### PR TITLE
[AOT] Prevent data race across different VM instance

### DIFF
--- a/include/ast/segment.h
+++ b/include/ast/segment.h
@@ -29,7 +29,7 @@ namespace AST {
 class Segment : public Base {
 public:
   /// Binary loading from file manager. Inheritted from Base.
-  virtual Expect<void> loadBinary(FileMgr &Mgr, const Configure &Conf) = 0;
+  Expect<void> loadBinary(FileMgr &Mgr, const Configure &Conf) override = 0;
 
   /// Getter of locals vector.
   InstrView getInstrs() const { return Expr.getInstrs(); }

--- a/include/runtime/instance/memory.h
+++ b/include/runtime/instance/memory.h
@@ -24,7 +24,6 @@
 #include <cstring>
 #include <fstream>
 #include <memory>
-#include <set>
 #include <utility>
 
 namespace WasmEdge {
@@ -32,7 +31,6 @@ namespace Runtime {
 namespace Instance {
 
 class MemoryInstance {
-
 public:
   static inline constexpr const uint64_t kPageSize = UINT64_C(65536);
   static inline constexpr const uint64_t k4G = UINT64_C(0x100000000);
@@ -95,14 +93,15 @@ public:
     if (HasMaxPage) {
       MaxPageCaped = std::min(MaxPage, MaxPageCaped);
     }
-    if (Count + MinPage > MaxPageCaped) {
+    if (Count > MaxPageCaped - MinPage) {
       return false;
     }
-    if (Count + MinPage > PageLimit) {
+    if (Count > PageLimit - MinPage) {
       spdlog::error("Memory grow page failed -- exceeded limit page size: {}",
                     PageLimit);
       return false;
     }
+
     if (Allocator::resize(DataPtr, MinPage, MinPage + Count) == nullptr) {
       return false;
     }

--- a/lib/aot/compiler.cpp
+++ b/lib/aot/compiler.cpp
@@ -4192,8 +4192,6 @@ void Compiler::compile(const AST::ImportSection &ImportSec) {
       Context->Globals.push_back(Type);
       break;
     }
-    default:
-      break;
     }
   }
 }

--- a/test/aot/AOTcoreTest.cpp
+++ b/test/aot/AOTcoreTest.cpp
@@ -25,8 +25,12 @@
 #include "gtest/gtest.h"
 
 #include <fstream>
+#include <future>
+#include <iostream>
 #include <memory>
 #include <string>
+#include <thread>
+#include <unordered_map>
 #include <vector>
 
 namespace {
@@ -39,10 +43,41 @@ static SpecTest T(std::filesystem::u8path("../spec/testSuites"sv));
 class CoreTest : public testing::TestWithParam<std::string> {};
 
 TEST_P(CoreTest, TestSuites) {
+  const auto kWorkerSize = std::thread::hardware_concurrency();
+  struct alignas(32) WorkerData {
+    std::packaged_task<size_t(size_t)> TaskReady{[](size_t I) { return I; }};
+    std::packaged_task<Expect<void>(WasmEdge::VM::VM &)> NormalTask;
+    std::packaged_task<Expect<std::vector<ValVariant>>(WasmEdge::VM::VM &)>
+        ExecuteTask;
+  };
   const auto [Proposal, Conf, UnitName] = T.resolve(GetParam());
-  WasmEdge::VM::VM VM(Conf);
-  WasmEdge::SpecTestModule SpecTestMod;
-  VM.registerModule(SpecTestMod);
+  std::vector<WorkerData> WData(kWorkerSize);
+  std::vector<std::thread> Workers;
+  Workers.reserve(kWorkerSize);
+  for (size_t I = 0; I < kWorkerSize; ++I) {
+    Workers.emplace_back([Conf = std::cref(Conf), &W = WData[I]]() {
+      WasmEdge::VM::VM VM(Conf);
+      WasmEdge::SpecTestModule SpecTestMod;
+      VM.registerModule(SpecTestMod);
+
+      while (true) {
+        auto TaskReady = W.TaskReady.get_future();
+        const auto Command = TaskReady.get();
+        W.TaskReady.reset();
+        switch (Command) {
+        case 0:
+          return;
+        case 1:
+          W.NormalTask(VM);
+          break;
+        case 2:
+          W.ExecuteTask(VM);
+          break;
+        }
+      }
+    });
+  }
+
   auto Compile = [&, Conf = std::cref(Conf)](
                      const std::string &Filename) -> Expect<std::string> {
     WasmEdge::Loader::Loader Loader(Conf);
@@ -64,78 +99,141 @@ TEST_P(CoreTest, TestSuites) {
     }
     return SOPath;
   };
-  T.onModule = [&VM, &Compile](const std::string &ModName,
-                               const std::string &Filename) -> Expect<void> {
+  auto CallVM = [&WData](std::function<Expect<void>(WasmEdge::VM::VM &)> Task)
+      -> Expect<void> {
+    std::vector<std::future<Expect<void>>> Futures;
+    Futures.reserve(WData.size());
+    for (auto &W : WData) {
+      W.NormalTask = std::packaged_task<Expect<void>(WasmEdge::VM::VM &)>(Task);
+      Futures.emplace_back(W.NormalTask.get_future());
+    }
+    for (auto &W : WData) {
+      W.TaskReady(1);
+    }
+    for (auto &Future : Futures) {
+      Future.wait();
+    }
+    std::vector<Expect<void>> Results;
+    Results.reserve(WData.size());
+    for (auto &Future : Futures) {
+      Results.push_back(Future.get());
+    }
+    return std::move(Results[0]);
+  };
+  auto ExecuteVM =
+      [&WData](
+          std::function<Expect<std::vector<ValVariant>>(WasmEdge::VM::VM &)>
+              Task) -> Expect<std::vector<ValVariant>> {
+    std::vector<std::future<Expect<std::vector<ValVariant>>>> Futures;
+    Futures.reserve(WData.size());
+    for (auto &W : WData) {
+      W.ExecuteTask = std::packaged_task<Expect<std::vector<ValVariant>>(
+          WasmEdge::VM::VM &)>(Task);
+      Futures.emplace_back(W.ExecuteTask.get_future());
+    }
+    for (auto &W : WData) {
+      W.TaskReady(2);
+    }
+    for (auto &Future : Futures) {
+      Future.wait();
+    }
+    std::vector<Expect<std::vector<ValVariant>>> Results;
+    Results.reserve(WData.size());
+    for (auto &Future : Futures) {
+      Results.push_back(Future.get());
+    }
+    return std::move(Results[0]);
+  };
+  T.onModule = [&CallVM, &Compile](const std::string &ModName,
+                                   const std::string &Filename) {
     return Compile(Filename).and_then(
-        [&VM, &ModName](const std::string &SOFilename) -> Expect<void> {
+        [&CallVM, &ModName](const std::string &SOFilename) {
+          return CallVM([&ModName, &SOFilename](WasmEdge::VM::VM &VM) {
+            if (!ModName.empty()) {
+              return VM.registerModule(ModName, SOFilename);
+            } else {
+              return VM.loadWasm(SOFilename)
+                  .and_then([&VM]() { return VM.validate(); })
+                  .and_then([&VM]() { return VM.instantiate(); });
+            }
+          });
+        });
+  };
+  T.onValidate = [&CallVM, &Compile](const std::string &Filename) {
+    return Compile(Filename).and_then([&CallVM](const std::string &SOFilename) {
+      return CallVM([&SOFilename](WasmEdge::VM::VM &VM) {
+        return VM.loadWasm(SOFilename).and_then([&VM]() {
+          return VM.validate();
+        });
+      });
+    });
+  };
+  T.onInstantiate = [&CallVM, &Compile](const std::string &Filename) {
+    return Compile(Filename).and_then([&CallVM](const std::string &SOFilename) {
+      return CallVM([&SOFilename](WasmEdge::VM::VM &VM) {
+        return VM.loadWasm(SOFilename)
+            .and_then([&VM]() { return VM.validate(); })
+            .and_then([&VM]() { return VM.instantiate(); });
+      });
+    });
+  };
+  /// Helper function to call functions.
+  T.onInvoke = [&ExecuteVM](const std::string &ModName,
+                            const std::string &Field,
+                            const std::vector<ValVariant> &Params,
+                            const std::vector<ValType> &ParamTypes)
+      -> Expect<std::vector<ValVariant>> {
+    return ExecuteVM(
+        [&ModName, &Field, &Params, &ParamTypes](WasmEdge::VM::VM &VM) {
           if (!ModName.empty()) {
-            return VM.registerModule(ModName, SOFilename);
+            /// Invoke function of named module. Named modules are registered in
+            /// Store Manager.
+            return VM.execute(ModName, Field, Params, ParamTypes);
           } else {
-            return VM.loadWasm(SOFilename)
-                .and_then([&VM]() { return VM.validate(); })
-                .and_then([&VM]() { return VM.instantiate(); });
+            /// Invoke function of anonymous module. Anonymous modules are
+            /// instantiated in VM.
+            return VM.execute(Field, Params, ParamTypes);
           }
         });
   };
-  T.onValidate = [&VM, &Compile](const std::string &Filename) -> Expect<void> {
-    return Compile(Filename)
-        .and_then([&](const std::string &SOFilename) -> Expect<void> {
-          return VM.loadWasm(SOFilename);
-        })
-        .and_then([&VM]() { return VM.validate(); });
-  };
-  T.onInstantiate = [&VM,
-                     &Compile](const std::string &Filename) -> Expect<void> {
-    return Compile(Filename)
-        .and_then([&](const std::string &SOFilename) -> Expect<void> {
-          return VM.loadWasm(SOFilename);
-        })
-        .and_then([&VM]() { return VM.validate(); })
-        .and_then([&VM]() { return VM.instantiate(); });
-  };
-  /// Helper function to call functions.
-  T.onInvoke = [&VM](const std::string &ModName, const std::string &Field,
-                     const std::vector<ValVariant> &Params,
-                     const std::vector<ValType> &ParamTypes)
-      -> Expect<std::vector<ValVariant>> {
-    if (!ModName.empty()) {
-      /// Invoke function of named module. Named modules are registered in
-      /// Store Manager.
-      return VM.execute(ModName, Field, Params, ParamTypes);
-    } else {
-      /// Invoke function of anonymous module. Anonymous modules are
-      /// instantiated in VM.
-      return VM.execute(Field, Params, ParamTypes);
-    }
-  };
   /// Helper function to get values.
-  T.onGet = [&VM](const std::string &ModName,
-                  const std::string &Field) -> Expect<std::vector<ValVariant>> {
-    /// Get module instance.
-    auto &Store = VM.getStoreManager();
-    WasmEdge::Runtime::Instance::ModuleInstance *ModInst = nullptr;
-    if (ModName.empty()) {
-      ModInst = *Store.getActiveModule();
-    } else {
-      if (auto Res = Store.findModule(ModName)) {
-        ModInst = *Res;
-      } else {
-        return Unexpect(Res);
-      }
-    }
+  T.onGet = [&ExecuteVM](const std::string &ModName, const std::string &Field) {
+    return ExecuteVM(
+        [&ModName,
+         &Field](WasmEdge::VM::VM &VM) -> Expect<std::vector<ValVariant>> {
+          /// Get module instance.
+          auto &Store = VM.getStoreManager();
+          WasmEdge::Runtime::Instance::ModuleInstance *ModInst = nullptr;
+          if (ModName.empty()) {
+            ModInst = *Store.getActiveModule();
+          } else {
+            if (auto Res = Store.findModule(ModName)) {
+              ModInst = *Res;
+            } else {
+              return Unexpect(Res);
+            }
+          }
 
-    /// Get global instance.
-    auto &Globs = ModInst->getGlobalExports();
-    if (Globs.find(Field) == Globs.cend()) {
-      return Unexpect(ErrCode::IncompatibleImportType);
-    }
-    uint32_t GlobAddr = Globs.find(Field)->second;
-    auto *GlobInst = *Store.getGlobal(GlobAddr);
+          /// Get global instance.
+          auto &Globs = ModInst->getGlobalExports();
+          if (Globs.find(Field) == Globs.cend()) {
+            return Unexpect(ErrCode::IncompatibleImportType);
+          }
+          uint32_t GlobAddr = Globs.find(Field)->second;
+          auto *GlobInst = *Store.getGlobal(GlobAddr);
 
-    return std::vector<WasmEdge::ValVariant>{GlobInst->getValue()};
+          return std::vector<WasmEdge::ValVariant>{GlobInst->getValue()};
+        });
   };
 
   T.run(Proposal, UnitName);
+
+  for (auto &W : WData) {
+    W.TaskReady(0);
+  }
+  for (size_t I = 0; I < kWorkerSize; ++I) {
+    Workers[I].join();
+  }
 }
 
 /// Initiate test suite.

--- a/test/externref/ExternrefTest.h
+++ b/test/externref/ExternrefTest.h
@@ -8,6 +8,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <set>
 
 /// Test: function to pass as function pointer
 uint32_t MulFunc(uint32_t A, uint32_t B) { return A * B; }


### PR DESCRIPTION
*VM execution is not fully thread-safe yet*.
* Make static pointer `This` as thread_local.
* Move all other static global to private member.
* Register signal handler on entering a compiled function.
* Use a merge-sort like algorithm for finding a usable memory region.
* Change AOT core test to a multi-thread version with different VM instance.