### PR TITLE
Minor fixes

### DIFF
--- a/cmake/FindFilesystem.cmake
+++ b/cmake/FindFilesystem.cmake
@@ -185,8 +185,7 @@ if(CXX_FILESYSTEM_HAVE_FS)
     ]] code @ONLY)
 
     # Try to compile a simple filesystem program without any linker flags
-    set(CXX_FILESYSTEM_NO_LINK_NEEDED off)
-    # check_cxx_source_compiles("${code}" CXX_FILESYSTEM_NO_LINK_NEEDED)
+    check_cxx_source_compiles("${code}" CXX_FILESYSTEM_NO_LINK_NEEDED)
 
     set(can_link ${CXX_FILESYSTEM_NO_LINK_NEEDED})
 

--- a/include/ast/instruction.h
+++ b/include/ast/instruction.h
@@ -106,7 +106,7 @@ private:
 ///
 /// Read OpCode byte(s) from file manager and return OpCode.
 ///
-/// \param FileMgr the file manager object to load bytes.
+/// \param Mgr the file manager object to load bytes.
 /// \param Conf the WasmEdge configuration reference.
 ///
 /// \returns OpCode if success, ErrCode when failed.
@@ -116,7 +116,7 @@ Expect<OpCode> loadOpCode(FileMgr &Mgr, const Configure &Conf);
 ///
 /// Read instructions until the End OpCode and return the vector.
 ///
-/// \param FileMgr the file manager object to load bytes.
+/// \param Mgr the file manager object to load bytes.
 /// \param Conf the WasmEdge configuration reference.
 ///
 /// \returns InstrVec if success, ErrCode when failed.

--- a/include/common/value.h
+++ b/include/common/value.h
@@ -28,7 +28,7 @@ using ValVariant =
 using Byte = uint8_t;
 
 /// Reference types helper functions.
-inline constexpr RefVariant genNullRef(const RefType Type) noexcept {
+inline constexpr RefVariant genNullRef(const RefType /*Type*/) noexcept {
   return UINT64_C(0);
 }
 inline constexpr RefVariant genFuncRef(const uint32_t Idx) noexcept {
@@ -88,6 +88,8 @@ inline constexpr ValVariant ValueFromType(ValType Type) noexcept {
     return genNullRef(RefType::FuncRef);
   case ValType::ExternRef:
     return genNullRef(RefType::ExternRef);
+  case ValType::None:
+    __builtin_unreachable();
   }
 }
 

--- a/include/experimental/expected.hpp
+++ b/include/experimental/expected.hpp
@@ -1541,13 +1541,13 @@ public:
   constexpr const_lvalue_reference_type operator*() const & {
     return impl_base::val();
   }
-  constexpr lvalue_reference_type operator*() & { return impl_base::val(); };
+  constexpr lvalue_reference_type operator*() & { return impl_base::val(); }
   constexpr const_rvalue_reference_type operator*() const && {
     return move(impl_base::val());
-  };
+  }
   constexpr rvalue_reference_type operator*() && {
     return move(impl_base::val());
-  };
+  }
   constexpr explicit operator bool() const noexcept { return has_value(); }
   using impl_base::error;
   using impl_base::has_value;

--- a/include/runtime/stackmgr.h
+++ b/include/runtime/stackmgr.h
@@ -57,7 +57,7 @@ public:
     ValueStack.reserve(2048U);
     LabelStack.reserve(64U);
     FrameStack.reserve(16U);
-  };
+  }
   ~StackManager() = default;
 
   /// Getter of stack size.

--- a/include/validator/formchecker.h
+++ b/include/validator/formchecker.h
@@ -66,7 +66,7 @@ public:
   void addLocal(const ValType &V);
   void addLocal(const VType &V);
 
-  std::vector<VType> result() { return ValStack; };
+  std::vector<VType> result() { return ValStack; }
   auto &getTypes() { return Types; }
   auto &getFunctions() { return Funcs; }
   auto &getTables() { return Tables; }

--- a/lib/aot/CMakeLists.txt
+++ b/lib/aot/CMakeLists.txt
@@ -22,6 +22,7 @@ llvm_add_library(wasmedgeAOT
   compiler.cpp
   LINK_LIBS
   wasmedgeCommon
+  wasmedgeAST
   utilBlake3
   ${LLD_SYSTEM}
   ${LLD_COMMON}
@@ -45,7 +46,7 @@ llvm_add_library(wasmedgeAOT
 target_include_directories(wasmedgeAOT
   SYSTEM
   PRIVATE
-  "${LLVM_INCLUDE_DIR}"
+  ${LLVM_INCLUDE_DIR}
 )
 
 target_include_directories(wasmedgeAOT

--- a/lib/aot/compiler.cpp
+++ b/lib/aot/compiler.cpp
@@ -2954,12 +2954,12 @@ private:
     StoreInst->setAlignment(Align(UINT64_C(1) << Alignment));
   }
   void compileSplatOp(llvm::VectorType *VectorTy) {
-    const uint32_t kZero = 0;
     auto *Undef = llvm::UndefValue::get(VectorTy);
     auto *Zeros = llvm::ConstantAggregateZero::get(llvm::VectorType::get(
         Context.Int32Ty, VectorTy->getElementCount().Min, false));
     auto *Value = Builder.CreateTrunc(Stack.back(), VectorTy->getElementType());
-    auto *Vector = Builder.CreateInsertElement(Undef, Value, kZero);
+    auto *Vector =
+        Builder.CreateInsertElement(Undef, Value, Builder.getInt64(0));
     Vector = Builder.CreateShuffleVector(Vector, Undef, Zeros);
 
     Stack.back() = Builder.CreateBitCast(Vector, Context.Int64x2Ty);

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -99,7 +99,7 @@ struct WasmEdge_ImportObjectContext {};
 /// WasmEdge_VMContext implementation.
 struct WasmEdge_VMContext {
   template <typename... Args>
-  WasmEdge_VMContext(Args &&... Vals) noexcept
+  WasmEdge_VMContext(Args &&...Vals) noexcept
       : VM(std::forward<Args>(Vals)...) {}
   WasmEdge::VM::VM VM;
 };
@@ -183,11 +183,11 @@ template <typename T> inline bool isContext(T *Cxt) noexcept {
   return (Cxt != nullptr);
 }
 template <typename T, typename... Args>
-inline bool isContext(T *Cxt, Args *... Cxts) noexcept {
+inline bool isContext(T *Cxt, Args *...Cxts) noexcept {
   return isContext(Cxt) && isContext(Cxts...);
 }
 template <typename T, typename U, typename... CxtT>
-inline WasmEdge_Result wrap(T &&Proc, U &&Then, CxtT *... Cxts) noexcept {
+inline WasmEdge_Result wrap(T &&Proc, U &&Then, CxtT *...Cxts) noexcept {
   if (isContext(Cxts...)) {
     if (auto Res = Proc()) {
       Then(Res);

--- a/lib/ast/CMakeLists.txt
+++ b/lib/ast/CMakeLists.txt
@@ -17,7 +17,7 @@ target_include_directories(wasmedgeAST
 )
 
 target_link_libraries(wasmedgeAST
-  PRIVATE
+  PUBLIC
   wasmedgeLoaderFileMgr
   wasmedgeCommon
 )

--- a/lib/host/wasmedge_process/CMakeLists.txt
+++ b/lib/host/wasmedge_process/CMakeLists.txt
@@ -6,8 +6,8 @@ add_library(wasmedgeHostModuleWasmEdgeProcess
 )
 
 target_link_libraries(wasmedgeHostModuleWasmEdgeProcess
-  PRIVATE
-  wasmedgeSystem
+  PUBLIC
+  wasmedgeAST
 )
 
 target_include_directories(wasmedgeHostModuleWasmEdgeProcess

--- a/lib/interpreter/CMakeLists.txt
+++ b/lib/interpreter/CMakeLists.txt
@@ -21,8 +21,9 @@ add_library(wasmedgeInterpreter
 )
 
 target_link_libraries(wasmedgeInterpreter
-  PRIVATE
+  PUBLIC
   wasmedgeCommon
+  wasmedgeAST
   wasmedgeSystem
 )
 

--- a/lib/loader/CMakeLists.txt
+++ b/lib/loader/CMakeLists.txt
@@ -7,16 +7,11 @@ add_library(wasmedgeLoaderFileMgr
 )
 
 target_link_libraries(wasmedgeLoaderFileMgr
-  PRIVATE
-  wasmedgeSystem
   PUBLIC
+  wasmedgeCommon
+  wasmedgeSystem
   dl
   std::filesystem
-)
-
-target_link_libraries(wasmedgeLoaderFileMgr
-  PRIVATE
-  wasmedgeCommon
 )
 
 target_include_directories(wasmedgeLoaderFileMgr
@@ -30,11 +25,10 @@ add_library(wasmedgeLoader
 )
 
 target_link_libraries(wasmedgeLoader
-  PRIVATE
+  PUBLIC
+  wasmedgeCommon
   wasmedgeAST
   wasmedgeLoaderFileMgr
-  wasmedgeCommon
-  PUBLIC
   std::filesystem
 )
 

--- a/lib/system/mmap.cpp
+++ b/lib/system/mmap.cpp
@@ -23,8 +23,10 @@
 #include <unistd.h>
 #elif MAP_WINAPI
 #include <boost/winapi/access_rights.hpp>
+#include <boost/winapi/file_management.hpp>
 #include <boost/winapi/file_mapping.hpp>
 #include <boost/winapi/handles.hpp>
+#include <boost/winapi/page_protection_flags.hpp>
 #endif
 
 namespace WasmEdge {
@@ -81,7 +83,7 @@ struct Implement {
     boost::winapi::LARGE_INTEGER_ Size;
     boost::winapi::GetFileSizeEx(File, &Size);
 
-    Map = boost::winapi::create_file_mapping(
+    Map = boost::winapi::CreateFileMappingW(
         File, nullptr, boost::winapi::PAGE_READONLY_, Size.HighPart,
         Size.LowPart, nullptr);
     if (Map == nullptr) {
@@ -100,10 +102,10 @@ struct Implement {
       boost::winapi::UnmapViewOfFile(Address);
     }
     if (Map) {
-      boost::winapi::close_handle(Map);
+      boost::winapi::CloseHandle(Map);
     }
     if (File) {
-      boost::winapi::close_handle(File);
+      boost::winapi::CloseHandle(File);
     }
   }
   bool ok() const noexcept { return Address != nullptr; }

--- a/lib/validator/CMakeLists.txt
+++ b/lib/validator/CMakeLists.txt
@@ -6,8 +6,9 @@ add_library(wasmedgeValidator
 )
 
 target_link_libraries(wasmedgeValidator
-  PRIVATE
+  PUBLIC
   wasmedgeCommon
+  wasmedgeAST
 )
 
 target_include_directories(wasmedgeValidator

--- a/test/aot/AOTCacheTest.cpp
+++ b/test/aot/AOTCacheTest.cpp
@@ -22,8 +22,8 @@ using namespace std::literals::string_literals;
 using namespace std::literals::string_view_literals;
 
 TEST(CacheTest, GlobalEmpty) {
-  const auto Path =
-      WasmEdge::AOT::Cache::getPath({}, WasmEdge::AOT::Cache::StorageScope::Global);
+  const auto Path = WasmEdge::AOT::Cache::getPath(
+      {}, WasmEdge::AOT::Cache::StorageScope::Global);
   EXPECT_TRUE(Path);
   auto Root = *Path;
   while (Root.filename().u8string() != "wasmedge"sv) {
@@ -39,8 +39,8 @@ TEST(CacheTest, GlobalEmpty) {
 }
 
 TEST(CacheTest, LocalEmpty) {
-  const auto Path =
-      WasmEdge::AOT::Cache::getPath({}, WasmEdge::AOT::Cache::StorageScope::Local);
+  const auto Path = WasmEdge::AOT::Cache::getPath(
+      {}, WasmEdge::AOT::Cache::StorageScope::Local);
   EXPECT_TRUE(Path);
   auto Root = *Path;
   while (Root.filename().u8string() != ".wasmedge"sv) {

--- a/test/aot/AOTcoreTest.cpp
+++ b/test/aot/AOTcoreTest.cpp
@@ -48,7 +48,8 @@ TEST_P(CoreTest, TestSuites) {
     WasmEdge::Loader::Loader Loader(Conf);
     WasmEdge::Validator::Validator ValidatorEngine(Conf);
     WasmEdge::AOT::Compiler Compiler;
-    Compiler.setOptimizationLevel(WasmEdge::AOT::Compiler::OptimizationLevel::O0);
+    Compiler.setOptimizationLevel(
+        WasmEdge::AOT::Compiler::OptimizationLevel::O0);
     Compiler.setDumpIR(true);
     auto Path = std::filesystem::u8path(Filename);
     Path.replace_extension(std::filesystem::u8path(".so"sv));

--- a/test/expected/constructors.cpp
+++ b/test/expected/constructors.cpp
@@ -13,7 +13,7 @@ struct takes_init_and_variadic {
   std::vector<int> v;
   std::tuple<int, int> t;
   template <class... Args>
-  takes_init_and_variadic(std::initializer_list<int> l, Args &&... args)
+  takes_init_and_variadic(std::initializer_list<int> l, Args &&...args)
       : v(l), t(std::forward<Args>(args)...) {}
 };
 

--- a/test/expected/emplace.cpp
+++ b/test/expected/emplace.cpp
@@ -13,7 +13,7 @@ struct takes_init_and_variadic {
   std::vector<int> v;
   std::tuple<int, int> t;
   template <class... Args>
-  takes_init_and_variadic(std::initializer_list<int> l, Args &&... args)
+  takes_init_and_variadic(std::initializer_list<int> l, Args &&...args)
       : v(l), t(std::forward<Args>(args)...) {}
 };
 } // namespace

--- a/test/externref/ExternrefTest.cpp
+++ b/test/externref/ExternrefTest.cpp
@@ -59,7 +59,8 @@ TEST(ExternRefTest, Ref__Functions) {
   EXPECT_EQ(std::get<uint32_t>((*Res3)[0]), 68161536U);
 
   /// Test 4: call sum and square -- (210 + 654)^2
-  FuncArgs = {WasmEdge::genExternRef(&AC), WasmEdge::genExternRef(&SS), 210U, 654U};
+  FuncArgs = {WasmEdge::genExternRef(&AC), WasmEdge::genExternRef(&SS), 210U,
+              654U};
   FuncArgTypes = {WasmEdge::ValType::ExternRef, WasmEdge::ValType::ExternRef,
                   WasmEdge::ValType::I32, WasmEdge::ValType::I32};
   auto Res4 = VM.execute("call_add_square", FuncArgs, FuncArgTypes);
@@ -107,7 +108,8 @@ TEST(ExternRefTest, Ref__STL) {
   /// Test 3: call map insert {key, val}
   STLStrKey = "one";
   STLStrVal = "1";
-  FuncArgs = {WasmEdge::genExternRef(&STLMap), WasmEdge::genExternRef(&STLStrKey),
+  FuncArgs = {WasmEdge::genExternRef(&STLMap),
+              WasmEdge::genExternRef(&STLStrKey),
               WasmEdge::genExternRef(&STLStrVal)};
   FuncArgTypes = {WasmEdge::ValType::ExternRef, WasmEdge::ValType::ExternRef,
                   WasmEdge::ValType::ExternRef};
@@ -119,7 +121,8 @@ TEST(ExternRefTest, Ref__STL) {
 
   /// Test 4: call map erase {key}
   STLStrKey = "one";
-  FuncArgs = {WasmEdge::genExternRef(&STLMap), WasmEdge::genExternRef(&STLStrKey)};
+  FuncArgs = {WasmEdge::genExternRef(&STLMap),
+              WasmEdge::genExternRef(&STLStrKey)};
   FuncArgTypes = {WasmEdge::ValType::ExternRef, WasmEdge::ValType::ExternRef};
   auto Res4 = VM.execute("call_map_erase", FuncArgs, FuncArgTypes);
   ASSERT_TRUE(Res4);

--- a/test/host/wasi/wasi.cpp
+++ b/test/host/wasi/wasi.cpp
@@ -249,23 +249,27 @@ TEST(WasiTest, Args) {
   Env.init({}, "test"s, {}, {});
   writeDummyMemoryContent(MemInst);
   EXPECT_TRUE(WasiArgsSizesGet.run(
-      &MemInst, std::array<WasmEdge::ValVariant, 2>{UINT32_C(65536), UINT32_C(4)},
+      &MemInst,
+      std::array<WasmEdge::ValVariant, 2>{UINT32_C(65536), UINT32_C(4)},
       Errno));
   EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), __WASI_ERRNO_FAULT);
   EXPECT_EQ(*MemInst.getPointer<const uint32_t *>(4), UINT32_C(0xa5a5a5a5));
   EXPECT_TRUE(WasiArgsSizesGet.run(
-      &MemInst, std::array<WasmEdge::ValVariant, 2>{UINT32_C(0), UINT32_C(65536)},
+      &MemInst,
+      std::array<WasmEdge::ValVariant, 2>{UINT32_C(0), UINT32_C(65536)},
       Errno));
   EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), __WASI_ERRNO_FAULT);
   EXPECT_EQ(*MemInst.getPointer<const uint32_t *>(0), UINT32_C(0xa5a5a5a5));
 
   EXPECT_TRUE(WasiArgsGet.run(
-      &MemInst, std::array<WasmEdge::ValVariant, 2>{UINT32_C(65536), UINT32_C(8)},
+      &MemInst,
+      std::array<WasmEdge::ValVariant, 2>{UINT32_C(65536), UINT32_C(8)},
       Errno));
   EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), __WASI_ERRNO_FAULT);
   EXPECT_EQ(*MemInst.getPointer<const uint32_t *>(8), UINT32_C(0xa5a5a5a5));
   EXPECT_TRUE(WasiArgsGet.run(
-      &MemInst, std::array<WasmEdge::ValVariant, 2>{UINT32_C(0), UINT32_C(65536)},
+      &MemInst,
+      std::array<WasmEdge::ValVariant, 2>{UINT32_C(0), UINT32_C(65536)},
       Errno));
   EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), __WASI_ERRNO_FAULT);
   EXPECT_EQ(*MemInst.getPointer<const uint32_t *>(0), UINT32_C(0xa5a5a5a5));
@@ -340,23 +344,27 @@ TEST(WasiTest, Envs) {
   Env.init({}, "test"s, {}, {});
   writeDummyMemoryContent(MemInst);
   EXPECT_TRUE(WasiEnvironSizesGet.run(
-      &MemInst, std::array<WasmEdge::ValVariant, 2>{UINT32_C(65536), UINT32_C(4)},
+      &MemInst,
+      std::array<WasmEdge::ValVariant, 2>{UINT32_C(65536), UINT32_C(4)},
       Errno));
   EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), __WASI_ERRNO_FAULT);
   EXPECT_EQ(*MemInst.getPointer<const uint32_t *>(4), UINT32_C(0xa5a5a5a5));
   EXPECT_TRUE(WasiEnvironSizesGet.run(
-      &MemInst, std::array<WasmEdge::ValVariant, 2>{UINT32_C(0), UINT32_C(65536)},
+      &MemInst,
+      std::array<WasmEdge::ValVariant, 2>{UINT32_C(0), UINT32_C(65536)},
       Errno));
   EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), __WASI_ERRNO_FAULT);
   EXPECT_EQ(*MemInst.getPointer<const uint32_t *>(0), UINT32_C(0xa5a5a5a5));
 
   EXPECT_TRUE(WasiEnvironGet.run(
-      &MemInst, std::array<WasmEdge::ValVariant, 2>{UINT32_C(65536), UINT32_C(8)},
+      &MemInst,
+      std::array<WasmEdge::ValVariant, 2>{UINT32_C(65536), UINT32_C(8)},
       Errno));
   EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), __WASI_ERRNO_FAULT);
   EXPECT_EQ(*MemInst.getPointer<const uint32_t *>(8), UINT32_C(0xa5a5a5a5));
   EXPECT_TRUE(WasiEnvironGet.run(
-      &MemInst, std::array<WasmEdge::ValVariant, 2>{UINT32_C(0), UINT32_C(65536)},
+      &MemInst,
+      std::array<WasmEdge::ValVariant, 2>{UINT32_C(0), UINT32_C(65536)},
       Errno));
   // success on zero-size write
   EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), __WASI_ERRNO_SUCCESS);
@@ -366,23 +374,27 @@ TEST(WasiTest, Envs) {
   Env.init({}, "test"s, {}, std::array{"a=b"s});
   writeDummyMemoryContent(MemInst);
   EXPECT_TRUE(WasiEnvironSizesGet.run(
-      &MemInst, std::array<WasmEdge::ValVariant, 2>{UINT32_C(65536), UINT32_C(4)},
+      &MemInst,
+      std::array<WasmEdge::ValVariant, 2>{UINT32_C(65536), UINT32_C(4)},
       Errno));
   EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), __WASI_ERRNO_FAULT);
   EXPECT_EQ(*MemInst.getPointer<const uint32_t *>(4), UINT32_C(0xa5a5a5a5));
   EXPECT_TRUE(WasiEnvironSizesGet.run(
-      &MemInst, std::array<WasmEdge::ValVariant, 2>{UINT32_C(0), UINT32_C(65536)},
+      &MemInst,
+      std::array<WasmEdge::ValVariant, 2>{UINT32_C(0), UINT32_C(65536)},
       Errno));
   EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), __WASI_ERRNO_FAULT);
   EXPECT_EQ(*MemInst.getPointer<const uint32_t *>(0), UINT32_C(0xa5a5a5a5));
 
   EXPECT_TRUE(WasiEnvironGet.run(
-      &MemInst, std::array<WasmEdge::ValVariant, 2>{UINT32_C(65536), UINT32_C(8)},
+      &MemInst,
+      std::array<WasmEdge::ValVariant, 2>{UINT32_C(65536), UINT32_C(8)},
       Errno));
   EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), __WASI_ERRNO_FAULT);
   EXPECT_EQ(*MemInst.getPointer<const uint32_t *>(8), UINT32_C(0xa5a5a5a5));
   EXPECT_TRUE(WasiEnvironGet.run(
-      &MemInst, std::array<WasmEdge::ValVariant, 2>{UINT32_C(0), UINT32_C(65536)},
+      &MemInst,
+      std::array<WasmEdge::ValVariant, 2>{UINT32_C(0), UINT32_C(65536)},
       Errno));
   EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), __WASI_ERRNO_FAULT);
   EXPECT_EQ(*MemInst.getPointer<const uint32_t *>(0), UINT32_C(0xa5a5a5a5));
@@ -411,7 +423,8 @@ TEST(WasiTest, ClockRes) {
         std::array<WasmEdge::ValVariant, 2>{
             static_cast<uint32_t>(__WASI_CLOCKID_REALTIME), UINT32_C(0)},
         Errno));
-    EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), convertErrno(SysErrno));
+    EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]),
+              convertErrno(SysErrno));
     if (SysErrno == 0) {
       const uint64_t Res = convertTimespec(Timespec);
       EXPECT_EQ(*MemInst.getPointer<const uint64_t *>(0), Res);
@@ -431,7 +444,8 @@ TEST(WasiTest, ClockRes) {
         std::array<WasmEdge::ValVariant, 2>{
             static_cast<uint32_t>(__WASI_CLOCKID_MONOTONIC), UINT32_C(0)},
         Errno));
-    EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), convertErrno(SysErrno));
+    EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]),
+              convertErrno(SysErrno));
     if (SysErrno == 0) {
       const uint64_t Res = convertTimespec(Timespec);
       EXPECT_EQ(*MemInst.getPointer<const uint64_t *>(0), Res);
@@ -452,7 +466,8 @@ TEST(WasiTest, ClockRes) {
             static_cast<uint32_t>(__WASI_CLOCKID_PROCESS_CPUTIME_ID),
             UINT32_C(0)},
         Errno));
-    EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), convertErrno(SysErrno));
+    EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]),
+              convertErrno(SysErrno));
     if (SysErrno == 0) {
       const uint64_t Res = convertTimespec(Timespec);
       EXPECT_EQ(*MemInst.getPointer<const uint64_t *>(0), Res);
@@ -473,7 +488,8 @@ TEST(WasiTest, ClockRes) {
             static_cast<uint32_t>(__WASI_CLOCKID_THREAD_CPUTIME_ID),
             UINT32_C(0)},
         Errno));
-    EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), convertErrno(SysErrno));
+    EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]),
+              convertErrno(SysErrno));
     if (SysErrno == 0) {
       const uint64_t Res = convertTimespec(Timespec);
       EXPECT_EQ(*MemInst.getPointer<const uint64_t *>(0), Res);
@@ -527,7 +543,8 @@ TEST(WasiTest, ClockTimeGet) {
                                  static_cast<uint32_t>(__WASI_CLOCKID_REALTIME),
                                  UINT64_C(0), UINT32_C(0)},
                              Errno));
-    EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), convertErrno(SysErrno));
+    EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]),
+              convertErrno(SysErrno));
     if (SysErrno == 0) {
       const uint64_t Time = convertTimespec(Timespec);
       EXPECT_NEAR(*MemInst.getPointer<const uint64_t *>(0), Time, 1000000);
@@ -548,7 +565,8 @@ TEST(WasiTest, ClockTimeGet) {
             static_cast<uint32_t>(__WASI_CLOCKID_MONOTONIC), UINT64_C(0),
             UINT32_C(0)},
         Errno));
-    EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), convertErrno(SysErrno));
+    EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]),
+              convertErrno(SysErrno));
     if (SysErrno == 0) {
       const uint64_t Time = convertTimespec(Timespec);
       EXPECT_NEAR(*MemInst.getPointer<const uint64_t *>(0), Time, 1000000);
@@ -569,7 +587,8 @@ TEST(WasiTest, ClockTimeGet) {
             static_cast<uint32_t>(__WASI_CLOCKID_PROCESS_CPUTIME_ID),
             UINT64_C(0), UINT32_C(0)},
         Errno));
-    EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), convertErrno(SysErrno));
+    EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]),
+              convertErrno(SysErrno));
     if (SysErrno == 0) {
       const uint64_t Time = convertTimespec(Timespec);
       EXPECT_NEAR(*MemInst.getPointer<const uint64_t *>(0), Time, 1000000);
@@ -590,7 +609,8 @@ TEST(WasiTest, ClockTimeGet) {
             static_cast<uint32_t>(__WASI_CLOCKID_THREAD_CPUTIME_ID),
             UINT64_C(0), UINT32_C(0)},
         Errno));
-    EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), convertErrno(SysErrno));
+    EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]),
+              convertErrno(SysErrno));
     if (SysErrno == 0) {
       const uint64_t Time = convertTimespec(Timespec);
       EXPECT_NEAR(*MemInst.getPointer<const uint64_t *>(0), Time, 1000000);
@@ -601,10 +621,10 @@ TEST(WasiTest, ClockTimeGet) {
   {
     Env.init({}, "test"s, {}, {});
     writeDummyMemoryContent(MemInst);
-    EXPECT_TRUE(WasiClockTimeGet.run(
-        &MemInst,
-        std::array<WasmEdge::ValVariant, 3>{UINT32_C(4), UINT64_C(0), UINT32_C(0)},
-        Errno));
+    EXPECT_TRUE(WasiClockTimeGet.run(&MemInst,
+                                     std::array<WasmEdge::ValVariant, 3>{
+                                         UINT32_C(4), UINT64_C(0), UINT32_C(0)},
+                                     Errno));
     EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), __WASI_ERRNO_INVAL);
   }
 
@@ -691,7 +711,8 @@ TEST(WasiTest, Random) {
   // invalid pointer, zero size
   Env.init({}, "test"s, {}, {});
   EXPECT_TRUE(WasiRandomGet.run(
-      &MemInst, std::array<WasmEdge::ValVariant, 2>{UINT32_C(65536), UINT32_C(0)},
+      &MemInst,
+      std::array<WasmEdge::ValVariant, 2>{UINT32_C(65536), UINT32_C(0)},
       Errno));
   EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), __WASI_ERRNO_SUCCESS);
   Env.fini();
@@ -699,7 +720,8 @@ TEST(WasiTest, Random) {
   // invalid pointer, non zero size
   Env.init({}, "test"s, {}, {});
   EXPECT_TRUE(WasiRandomGet.run(
-      &MemInst, std::array<WasmEdge::ValVariant, 2>{UINT32_C(65536), UINT32_C(1)},
+      &MemInst,
+      std::array<WasmEdge::ValVariant, 2>{UINT32_C(65536), UINT32_C(1)},
       Errno));
   EXPECT_EQ(WasmEdge::retrieveValue<int32_t>(Errno[0]), __WASI_ERRNO_FAULT);
   Env.fini();

--- a/test/po/po.cpp
+++ b/test/po/po.cpp
@@ -31,9 +31,12 @@ public:
         B(Description("b option"sv), DefaultValue<int>(-1)),
         C(Description("c option"sv), DefaultValue<int>(0), ZeroOrMore()),
         F(Description("f option"sv), ZeroOrMore()) {
-    Parser.add_option("a"sv, A).add_option("a-option"sv, A)
-        .add_option("b"sv, B).add_option("b_option"sv, B)
-        .add_option("c"sv, C).add_option("coption"sv, C)
+    Parser.add_option("a"sv, A)
+        .add_option("a-option"sv, A)
+        .add_option("b"sv, B)
+        .add_option("b_option"sv, B)
+        .add_option("c"sv, C)
+        .add_option("coption"sv, C)
         .add_option(F);
   }
   Option<Toggle> A;

--- a/tools/wasmedge/wasmedger.cpp
+++ b/tools/wasmedge/wasmedger.cpp
@@ -115,9 +115,10 @@ int main(int Argc, const char *Argv[]) {
     ProcMod->getEnv().AllowedCmd.insert(Str);
   }
 
-  WasiMod->getEnv().init(Dir.value(),
-                         InputPath.filename().replace_extension("wasm"sv),
-                         Args.value(), Env.value());
+  WasiMod->getEnv().init(
+      Dir.value(),
+      InputPath.filename().replace_extension(std::filesystem::u8path("wasm"sv)),
+      Args.value(), Env.value());
 
   if (!Reactor.value()) {
     // command mode

--- a/tools/wasmedge/wasmedger.cpp
+++ b/tools/wasmedge/wasmedger.cpp
@@ -171,7 +171,7 @@ int main(int Argc, const char *Argv[]) {
          I < FuncType.Params.size() && I + 1 < Args.value().size(); ++I) {
       switch (FuncType.Params[I]) {
       case WasmEdge::ValType::I32: {
-        const uint32_t Value = std::stoll(Args.value()[I + 1]);
+        const uint32_t Value = std::stol(Args.value()[I + 1]);
         FuncArgs.emplace_back(Value);
         FuncArgTypes.emplace_back(WasmEdge::ValType::I32);
         break;
@@ -183,7 +183,7 @@ int main(int Argc, const char *Argv[]) {
         break;
       }
       case WasmEdge::ValType::F32: {
-        const float Value = std::stod(Args.value()[I + 1]);
+        const float Value = std::stof(Args.value()[I + 1]);
         FuncArgs.emplace_back(Value);
         FuncArgTypes.emplace_back(WasmEdge::ValType::F32);
         break;


### PR DESCRIPTION
* Adjust library dependency
* Check for newer compilers in std::filesystem
* Add missing include files, fix typo
* Avoid helper function to prevent zero and pointer ambiguity
* Use u8path for path creation
* Run clang-format-11
* Remove extra semicolons
* Add unlisted enum entries in switch statements
* Use stof on float, stol on uint32_t
