### PR TITLE
[CI] Don't need to check the ninja-build again. It's built-in deps in our docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,10 +61,6 @@ jobs:
       env:
         CMAKE_BUILD_TYPE: ${{ matrix.build_type }}
       run: |
-        if ! command ninja; then
-          apt update
-          apt install -y ninja-build
-        fi
         cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DWASMEDGE_BUILD_TESTS=ON .
         cmake --build build
     - name: Test WasmEdge

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,10 +48,6 @@ jobs:
 
     - name: Build
       run: |
-        if ! command ninja; then
-          apt update
-          apt install -y ninja-build
-        fi
         cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug -DWASMEDGE_BUILD_TESTS=ON .
         cmake --build build
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,10 +34,6 @@ jobs:
 
     - name: Build WasmEdge using clang with Debug mode
       run: |
-        if ! command ninja; then
-          apt update
-          apt install -y ninja-build
-        fi
         cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIB=ON .
         cmake --build build
 


### PR DESCRIPTION
Signed-off-by: hydai <hydai@secondstate.io>