### PR TITLE
[WASI] Fix the signature error of `path_read_link`.

### DIFF
--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -693,11 +693,12 @@ public:
   /// @param[in] Path The path of the symbolic link from which to read.
   /// @param[out] Buffer The buffer to which to write the contents of the
   /// symbolic link.
+  /// @param[out] NRead The number of bytes read.
   /// @return Nothing or WASI error.
   WasiExpect<void> pathReadlink(__wasi_fd_t Fd, std::string_view Path,
-                                Span<char> Buffer) {
+                                Span<char> Buffer, __wasi_size_t &NRead) {
     auto Node = getNodeOrNull(Fd);
-    return VINode::pathReadlink(FS, std::move(Node), Path, Buffer);
+    return VINode::pathReadlink(FS, std::move(Node), Path, Buffer, NRead);
   }
 
   /// Remove a directory.

--- a/include/host/wasi/inode.h
+++ b/include/host/wasi/inode.h
@@ -414,9 +414,10 @@ public:
   /// @param[in] Path The path of the symbolic link from which to read.
   /// @param[out] Buffer The buffer to which to write the contents of the
   /// symbolic link.
+  /// @param[out] NRead The number of bytes read.
   /// @return Nothing or WASI error.
-  WasiExpect<void> pathReadlink(std::string Path,
-                                Span<char> Buffer) const noexcept;
+  WasiExpect<void> pathReadlink(std::string Path, Span<char> Buffer,
+                                __wasi_size_t &NRead) const noexcept;
 
   /// Remove a directory.
   ///

--- a/include/host/wasi/vinode.h
+++ b/include/host/wasi/vinode.h
@@ -453,10 +453,11 @@ public:
   /// @param[in] Path The path of the symbolic link from which to read.
   /// @param[out] Buffer The buffer to which to write the contents of the
   /// symbolic link.
+  /// @param[out] NRead The number of bytes read.
   /// @return Nothing or WASI error.
   static WasiExpect<void> pathReadlink(VFS &FS, std::shared_ptr<VINode> Fd,
-                                       std::string_view Path,
-                                       Span<char> Buffer);
+                                       std::string_view Path, Span<char> Buffer,
+                                       __wasi_size_t &NRead);
 
   /// Remove a directory.
   ///

--- a/include/host/wasi/wasifunc.h
+++ b/include/host/wasi/wasifunc.h
@@ -19,7 +19,8 @@ public:
   WasiArgsSizesGet(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst,
-                        uint32_t ArgcPtr, uint32_t ArgvBufSizePtr);
+                        uint32_t /* Out */ ArgcPtr,
+                        uint32_t /* Out */ ArgvBufSizePtr);
 };
 
 class WasiEnvironGet : public Wasi<WasiEnvironGet> {
@@ -35,7 +36,8 @@ public:
   WasiEnvironSizesGet(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst,
-                        uint32_t EnvCntPtr, uint32_t EnvBufSizePtr);
+                        uint32_t /* Out */ EnvCntPtr,
+                        uint32_t /* Out */ EnvBufSizePtr);
 };
 
 class WasiClockResGet : public Wasi<WasiClockResGet> {
@@ -43,7 +45,7 @@ public:
   WasiClockResGet(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst,
-                        uint32_t ClockId, uint32_t ResolutionPtr);
+                        uint32_t ClockId, uint32_t /* Out */ ResolutionPtr);
 };
 
 class WasiClockTimeGet : public Wasi<WasiClockTimeGet> {
@@ -51,7 +53,8 @@ public:
   WasiClockTimeGet(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst,
-                        uint32_t ClockId, uint64_t Precision, uint32_t TimePtr);
+                        uint32_t ClockId, uint64_t Precision,
+                        uint32_t /* Out */ TimePtr);
 };
 
 class WasiFdAdvise : public Wasi<WasiFdAdvise> {
@@ -89,7 +92,7 @@ public:
   WasiFdFdstatGet(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
-                        uint32_t FdStatPtr);
+                        uint32_t /* Out */ FdStatPtr);
 };
 
 class WasiFdFdstatSetFlags : public Wasi<WasiFdFdstatSetFlags> {
@@ -113,7 +116,7 @@ public:
   WasiFdFilestatGet(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
-                        uint32_t FilestatPtr);
+                        uint32_t /* Out */ FilestatPtr);
 };
 
 class WasiFdFilestatSetSize : public Wasi<WasiFdFilestatSetSize> {
@@ -138,7 +141,7 @@ public:
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
                         uint32_t IOVsPtr, uint32_t IOVsLen, uint64_t Offset,
-                        uint32_t NReadPtr);
+                        uint32_t /* Out */ NReadPtr);
 };
 
 class WasiFdPrestatGet : public Wasi<WasiFdPrestatGet> {
@@ -146,7 +149,7 @@ public:
   WasiFdPrestatGet(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
-                        uint32_t PreStatPtr);
+                        uint32_t /* Out */ PreStatPtr);
 };
 
 class WasiFdPrestatDirName : public Wasi<WasiFdPrestatDirName> {
@@ -163,7 +166,7 @@ public:
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
                         uint32_t IOVSPtr, uint32_t IOVSLen, uint64_t Offset,
-                        uint32_t NWrittenPtr);
+                        uint32_t /* Out */ NWrittenPtr);
 };
 
 class WasiFdRead : public Wasi<WasiFdRead> {
@@ -171,7 +174,8 @@ public:
   WasiFdRead(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
-                        uint32_t IOVSPtr, uint32_t IOVSLen, uint32_t NReadPtr);
+                        uint32_t IOVSPtr, uint32_t IOVSLen,
+                        uint32_t /* Out */ NReadPtr);
 };
 
 class WasiFdReadDir : public Wasi<WasiFdReadDir> {
@@ -180,7 +184,7 @@ public:
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
                         uint32_t BufPtr, uint32_t BufLen, uint64_t Cookie,
-                        uint32_t BufUsedSize);
+                        uint32_t /* Out */ NReadPtr);
 };
 
 class WasiFdRenumber : public Wasi<WasiFdRenumber> {
@@ -196,7 +200,8 @@ public:
   WasiFdSeek(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<int32_t> body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
-                       int64_t Offset, uint32_t Whence, uint32_t NewOffsetPtr);
+                       int64_t Offset, uint32_t Whence,
+                       uint32_t /* Out */ NewOffsetPtr);
 };
 
 class WasiFdSync : public Wasi<WasiFdSync> {
@@ -211,7 +216,7 @@ public:
   WasiFdTell(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
-                        uint32_t OffsetPtr);
+                        uint32_t /* Out */ OffsetPtr);
 };
 
 class WasiFdWrite : public Wasi<WasiFdWrite> {
@@ -220,7 +225,7 @@ public:
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
                         uint32_t IOVSPtr, uint32_t IOVSLen,
-                        uint32_t NWrittenPtr);
+                        uint32_t /* Out */ NWrittenPtr);
 };
 
 class WasiPathCreateDirectory : public Wasi<WasiPathCreateDirectory> {
@@ -237,7 +242,7 @@ public:
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
                         uint32_t Flags, uint32_t PathPtr, uint32_t PathLen,
-                        uint32_t FilestatPtr);
+                        uint32_t /* Out */ FilestatPtr);
 };
 
 class WasiPathFilestatSetTimes : public Wasi<WasiPathFilestatSetTimes> {
@@ -267,7 +272,7 @@ public:
                         int32_t DirFd, uint32_t DirFlags, uint32_t PathPtr,
                         uint32_t PathLen, uint32_t OFlags,
                         uint64_t FsRightsBase, uint64_t FsRightsInheriting,
-                        uint32_t FsFlags, uint32_t FdPtr);
+                        uint32_t FsFlags, uint32_t /* Out */ FdPtr);
 };
 
 class WasiPathReadLink : public Wasi<WasiPathReadLink> {
@@ -276,7 +281,7 @@ public:
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
                         uint32_t PathPtr, uint32_t PathLen, uint32_t BufPtr,
-                        uint32_t BufLen);
+                        uint32_t BufLen, uint32_t /* Out */ NReadPtr);
 };
 
 class WasiPathRemoveDirectory : public Wasi<WasiPathRemoveDirectory> {
@@ -319,7 +324,7 @@ public:
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst,
                         uint32_t InPtr, uint32_t OutPtr,
-                        uint32_t NSubscriptions, uint32_t NEventsPtr);
+                        uint32_t NSubscriptions, uint32_t /* Out */ NEventsPtr);
 };
 
 class WasiProcExit : public Wasi<WasiProcExit> {
@@ -338,6 +343,13 @@ public:
                         uint32_t Signal);
 };
 
+class WasiSchedYield : public Wasi<WasiSchedYield> {
+public:
+  WasiSchedYield(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+
+  Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst);
+};
+
 class WasiRandomGet : public Wasi<WasiRandomGet> {
 public:
   WasiRandomGet(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
@@ -346,19 +358,13 @@ public:
                         uint32_t BufPtr, uint32_t BufLen);
 };
 
-class WasiSchedYield : public Wasi<WasiSchedYield> {
-public:
-  WasiSchedYield(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
-
-  Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst);
-};
-
 class WasiSockOpen : public Wasi<WasiSockOpen> {
 public:
   WasiSockOpen(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst,
-                        int32_t AddressFamily, int32_t SockType, uint32_t RoFd);
+                        int32_t AddressFamily, int32_t SockType,
+                        uint32_t /* Out */ RoFdPtr);
 };
 
 class WasiSockBind : public Wasi<WasiSockBind> {
@@ -382,7 +388,7 @@ public:
   WasiSockAccept(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
-                        int32_t Port, uint32_t RoFdPtr);
+                        int32_t Port, uint32_t /* Out */ RoFdPtr);
 };
 
 class WasiSockConnect : public Wasi<WasiSockConnect> {
@@ -399,8 +405,8 @@ public:
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
                         uint32_t RiDataPtr, uint32_t RiDataLen,
-                        uint32_t RiFlags, uint32_t RoDataLenPtr,
-                        uint32_t RoFlagsPtr);
+                        uint32_t RiFlags, uint32_t /* Out */ RoDataLenPtr,
+                        uint32_t /* Out */ RoFlagsPtr);
 };
 
 class WasiSockRecvFrom : public Wasi<WasiSockRecvFrom> {
@@ -410,7 +416,7 @@ public:
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
                         uint32_t RiDataPtr, int32_t RiDataLen,
                         uint32_t AddressPtr, uint32_t RiFlags,
-                        uint32_t RoDataLenPtr);
+                        uint32_t /* Out */ RoDataLenPtr);
 };
 
 class WasiSockSend : public Wasi<WasiSockSend> {
@@ -419,7 +425,7 @@ public:
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
                         uint32_t SiDataPtr, uint32_t SiDataLen,
-                        uint32_t SiFlags, uint32_t SoDataLenPtr);
+                        uint32_t SiFlags, uint32_t /* Out */ SoDataLenPtr);
 };
 
 class WasiSockSendTo : public Wasi<WasiSockSendTo> {

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -691,11 +691,13 @@ WasiExpect<INode> INode::pathOpen(std::string Path, __wasi_oflags_t OpenFlags,
   }
 }
 
-WasiExpect<void> INode::pathReadlink(std::string Path,
-                                     Span<char> Buffer) const noexcept {
+WasiExpect<void> INode::pathReadlink(std::string Path, Span<char> Buffer,
+                                     __wasi_size_t &NRead) const noexcept {
   if (auto Res = ::readlinkat(Fd, Path.c_str(), Buffer.data(), Buffer.size());
       unlikely(Res < 0)) {
     return WasiUnexpect(fromErrNo(errno));
+  } else {
+    NRead = Res;
   }
 
   return {};

--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -648,11 +648,13 @@ WasiExpect<INode> INode::pathOpen(std::string Path, __wasi_oflags_t OpenFlags,
   }
 }
 
-WasiExpect<void> INode::pathReadlink(std::string Path,
-                                     Span<char> Buffer) const noexcept {
+WasiExpect<void> INode::pathReadlink(std::string Path, Span<char> Buffer,
+                                     __wasi_size_t &NRead) const noexcept {
   if (auto Res = ::readlinkat(Fd, Path.c_str(), Buffer.data(), Buffer.size());
       unlikely(Res < 0)) {
     return WasiUnexpect(fromErrNo(errno));
+  } else {
+    NRead = Res;
   }
 
   return {};

--- a/lib/host/wasi/inode-win.cpp
+++ b/lib/host/wasi/inode-win.cpp
@@ -156,7 +156,8 @@ WasiExpect<INode> INode::pathOpen(std::string, __wasi_oflags_t,
   return WasiUnexpect(__WASI_ERRNO_NOSYS);
 }
 
-WasiExpect<void> INode::pathReadlink(std::string, Span<char>) const noexcept {
+WasiExpect<void> INode::pathReadlink(std::string, Span<char>,
+                                     __wasi_size_t &) const noexcept {
   return WasiUnexpect(__WASI_ERRNO_NOSYS);
 }
 

--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -308,7 +308,8 @@ Expect<uint32_t> WasiArgsGet::body(Runtime::Instance::MemoryInstance *MemInst,
 
 Expect<uint32_t>
 WasiArgsSizesGet::body(Runtime::Instance::MemoryInstance *MemInst,
-                       uint32_t ArgcPtr, uint32_t ArgvBufSizePtr) {
+                       uint32_t /* Out */ ArgcPtr,
+                       uint32_t /* Out */ ArgvBufSizePtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -367,7 +368,8 @@ WasiEnvironGet::body(Runtime::Instance::MemoryInstance *MemInst,
 
 Expect<uint32_t>
 WasiEnvironSizesGet::body(Runtime::Instance::MemoryInstance *MemInst,
-                          uint32_t EnvCntPtr, uint32_t EnvBufSizePtr) {
+                          uint32_t /* Out */ EnvCntPtr,
+                          uint32_t /* Out */ EnvBufSizePtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -393,7 +395,7 @@ WasiEnvironSizesGet::body(Runtime::Instance::MemoryInstance *MemInst,
 
 Expect<uint32_t>
 WasiClockResGet::body(Runtime::Instance::MemoryInstance *MemInst,
-                      uint32_t ClockId, uint32_t ResolutionPtr) {
+                      uint32_t ClockId, uint32_t /* Out */ ResolutionPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -420,7 +422,8 @@ WasiClockResGet::body(Runtime::Instance::MemoryInstance *MemInst,
 
 Expect<uint32_t>
 WasiClockTimeGet::body(Runtime::Instance::MemoryInstance *MemInst,
-                       uint32_t ClockId, uint64_t Precision, uint32_t TimePtr) {
+                       uint32_t ClockId, uint64_t Precision,
+                       uint32_t /* Out */ TimePtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -503,7 +506,7 @@ Expect<uint32_t> WasiFdDatasync::body(Runtime::Instance::MemoryInstance *,
 
 Expect<uint32_t>
 WasiFdFdstatGet::body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
-                      uint32_t FdStatPtr) {
+                      uint32_t /* Out */ FdStatPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -569,7 +572,7 @@ WasiFdFdstatSetRights::body(Runtime::Instance::MemoryInstance *, int32_t Fd,
 
 Expect<uint32_t>
 WasiFdFilestatGet::body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
-                        uint32_t FilestatPtr) {
+                        uint32_t /* Out */ FilestatPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -625,7 +628,7 @@ WasiFdFilestatSetTimes::body(Runtime::Instance::MemoryInstance *, int32_t Fd,
 Expect<uint32_t> WasiFdPread::body(Runtime::Instance::MemoryInstance *MemInst,
                                    int32_t Fd, uint32_t IOVsPtr,
                                    uint32_t IOVsLen, uint64_t Offset,
-                                   uint32_t NReadPtr) {
+                                   uint32_t /* Out */ NReadPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -704,7 +707,7 @@ WasiFdPrestatDirName::body(Runtime::Instance::MemoryInstance *MemInst,
 
 Expect<uint32_t>
 WasiFdPrestatGet::body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
-                       uint32_t PreStatPtr) {
+                       uint32_t /* Out */ PreStatPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -727,7 +730,7 @@ WasiFdPrestatGet::body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
 Expect<uint32_t> WasiFdPwrite::body(Runtime::Instance::MemoryInstance *MemInst,
                                     int32_t Fd, uint32_t IOVsPtr,
                                     uint32_t IOVsLen, uint64_t Offset,
-                                    uint32_t NWrittenPtr) {
+                                    uint32_t /* Out */ NWrittenPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -786,7 +789,8 @@ Expect<uint32_t> WasiFdPwrite::body(Runtime::Instance::MemoryInstance *MemInst,
 
 Expect<uint32_t> WasiFdRead::body(Runtime::Instance::MemoryInstance *MemInst,
                                   int32_t Fd, uint32_t IOVsPtr,
-                                  uint32_t IOVsLen, uint32_t NReadPtr) {
+                                  uint32_t IOVsLen,
+                                  uint32_t /* Out */ NReadPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -842,7 +846,7 @@ Expect<uint32_t> WasiFdRead::body(Runtime::Instance::MemoryInstance *MemInst,
 Expect<uint32_t> WasiFdReadDir::body(Runtime::Instance::MemoryInstance *MemInst,
                                      int32_t Fd, uint32_t BufPtr,
                                      uint32_t BufLen, uint64_t Cookie,
-                                     uint32_t BufUsedSizePtr) {
+                                     uint32_t /* Out */ NReadPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -856,17 +860,15 @@ Expect<uint32_t> WasiFdReadDir::body(Runtime::Instance::MemoryInstance *MemInst,
     return __WASI_ERRNO_FAULT;
   }
 
-  auto *const BufUsedSize =
-      MemInst->getPointer<__wasi_size_t *>(BufUsedSizePtr);
-  if (unlikely(BufUsedSize == nullptr)) {
+  auto *const NRead = MemInst->getPointer<__wasi_size_t *>(NReadPtr);
+  if (unlikely(NRead == nullptr)) {
     return __WASI_ERRNO_FAULT;
   }
 
   const __wasi_fd_t WasiFd = Fd;
   const __wasi_dircookie_t WasiCookie = Cookie;
 
-  if (auto Res =
-          Env.fdReaddir(WasiFd, {Buf, WasiBufLen}, WasiCookie, *BufUsedSize);
+  if (auto Res = Env.fdReaddir(WasiFd, {Buf, WasiBufLen}, WasiCookie, *NRead);
       unlikely(!Res)) {
     return Res.error();
   }
@@ -886,7 +888,7 @@ Expect<uint32_t> WasiFdRenumber::body(Runtime::Instance::MemoryInstance *,
 
 Expect<int32_t> WasiFdSeek::body(Runtime::Instance::MemoryInstance *MemInst,
                                  int32_t Fd, int64_t Offset, uint32_t Whence,
-                                 uint32_t NewOffsetPtr) {
+                                 uint32_t /* Out */ NewOffsetPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -926,7 +928,7 @@ Expect<uint32_t> WasiFdSync::body(Runtime::Instance::MemoryInstance *,
 }
 
 Expect<uint32_t> WasiFdTell::body(Runtime::Instance::MemoryInstance *MemInst,
-                                  int32_t Fd, uint32_t OffsetPtr) {
+                                  int32_t Fd, uint32_t /* Out */ OffsetPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -949,7 +951,8 @@ Expect<uint32_t> WasiFdTell::body(Runtime::Instance::MemoryInstance *MemInst,
 
 Expect<uint32_t> WasiFdWrite::body(Runtime::Instance::MemoryInstance *MemInst,
                                    int32_t Fd, uint32_t IOVsPtr,
-                                   uint32_t IOVsLen, uint32_t NWrittenPtr) {
+                                   uint32_t IOVsLen,
+                                   uint32_t /* Out */ NWrittenPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -1031,7 +1034,7 @@ WasiPathCreateDirectory::body(Runtime::Instance::MemoryInstance *MemInst,
 Expect<uint32_t>
 WasiPathFilestatGet::body(Runtime::Instance::MemoryInstance *MemInst,
                           int32_t Fd, uint32_t Flags, uint32_t PathPtr,
-                          uint32_t PathLen, uint32_t FilestatPtr) {
+                          uint32_t PathLen, uint32_t /* Out */ FilestatPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -1159,7 +1162,8 @@ Expect<uint32_t> WasiPathOpen::body(Runtime::Instance::MemoryInstance *MemInst,
                                     uint32_t PathPtr, uint32_t PathLen,
                                     uint32_t OFlags, uint64_t FsRightsBase,
                                     uint64_t FsRightsInheriting,
-                                    uint32_t FsFlags, uint32_t FdPtr) {
+                                    uint32_t FsFlags,
+                                    uint32_t /* Out */ FdPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -1228,7 +1232,7 @@ Expect<uint32_t> WasiPathOpen::body(Runtime::Instance::MemoryInstance *MemInst,
 Expect<uint32_t>
 WasiPathReadLink::body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
                        uint32_t PathPtr, uint32_t PathLen, uint32_t BufPtr,
-                       uint32_t BufLen) {
+                       uint32_t BufLen, uint32_t /* Out */ NReadPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -1248,10 +1252,15 @@ WasiPathReadLink::body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
     return __WASI_ERRNO_FAULT;
   }
 
+  auto *const NRead = MemInst->getPointer<__wasi_size_t *>(NReadPtr);
+  if (unlikely(NRead == nullptr)) {
+    return __WASI_ERRNO_FAULT;
+  }
+
   const __wasi_fd_t WasiFd = Fd;
 
-  if (auto Res =
-          Env.pathReadlink(WasiFd, {Path, WasiPathLen}, {Buf, WasiBufLen});
+  if (auto Res = Env.pathReadlink(WasiFd, {Path, WasiPathLen},
+                                  {Buf, WasiBufLen}, *NRead);
       unlikely(!Res)) {
     return Res.error();
   }
@@ -1380,7 +1389,7 @@ WasiPathUnlinkFile::body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
 Expect<uint32_t>
 WasiPollOneoff::body(Runtime::Instance::MemoryInstance *MemInst, uint32_t InPtr,
                      uint32_t OutPtr, uint32_t NSubscriptions,
-                     uint32_t NEventsPtr) {
+                     uint32_t /* Out */ NEventsPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -1521,6 +1530,13 @@ Expect<uint32_t> WasiProcRaise::body(Runtime::Instance::MemoryInstance *,
   return __WASI_ERRNO_SUCCESS;
 }
 
+Expect<uint32_t> WasiSchedYield::body(Runtime::Instance::MemoryInstance *) {
+  if (auto Res = Env.schedYield(); unlikely(!Res)) {
+    return Res.error();
+  }
+  return __WASI_ERRNO_SUCCESS;
+}
+
 Expect<uint32_t> WasiRandomGet::body(Runtime::Instance::MemoryInstance *MemInst,
                                      uint32_t BufPtr, uint32_t BufLen) {
   /// Check memory instance from module.
@@ -1541,16 +1557,9 @@ Expect<uint32_t> WasiRandomGet::body(Runtime::Instance::MemoryInstance *MemInst,
   return __WASI_ERRNO_SUCCESS;
 }
 
-Expect<uint32_t> WasiSchedYield::body(Runtime::Instance::MemoryInstance *) {
-  if (auto Res = Env.schedYield(); unlikely(!Res)) {
-    return Res.error();
-  }
-  return __WASI_ERRNO_SUCCESS;
-}
-
 Expect<uint32_t> WasiSockOpen::body(Runtime::Instance::MemoryInstance *MemInst,
                                     int32_t AddressFamily, int32_t SockType,
-                                    uint32_t RoFdPtr) {
+                                    uint32_t /* Out */ RoFdPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -1630,7 +1639,7 @@ Expect<uint32_t> WasiSockListen::body(
 
 Expect<uint32_t>
 WasiSockAccept::body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
-                     int32_t Port, uint32_t RoFdPtr) {
+                     int32_t Port, uint32_t /* Out */ RoFdPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -1688,8 +1697,8 @@ WasiSockConnect::body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
 Expect<uint32_t> WasiSockRecv::body(Runtime::Instance::MemoryInstance *MemInst,
                                     int32_t Fd, uint32_t RiDataPtr,
                                     uint32_t RiDataLen, uint32_t RiFlags,
-                                    uint32_t RoDataLenPtr,
-                                    uint32_t RoFlagsPtr) {
+                                    uint32_t /* Out */ RoDataLenPtr,
+                                    uint32_t /* Out */ RoFlagsPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -1759,7 +1768,7 @@ Expect<uint32_t> WasiSockRecv::body(Runtime::Instance::MemoryInstance *MemInst,
 Expect<uint32_t> WasiSockSend::body(Runtime::Instance::MemoryInstance *MemInst,
                                     int32_t Fd, uint32_t SiDataPtr,
                                     uint32_t SiDataLen, uint32_t SiFlags,
-                                    uint32_t SoDataLenPtr) {
+                                    uint32_t /* Out */ SoDataLenPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;


### PR DESCRIPTION
1. Fix the signature error with the lost read size output.
2. Add the `Ret_` prefix for parameter names with receiving outputs.

Signed-off-by: YiYing He <yiying@secondstate.io>