### PR TITLE
[Misc] Include missing headers

### DIFF
--- a/include/common/int128.h
+++ b/include/common/int128.h
@@ -22,6 +22,8 @@ using uint128_t = unsigned __int128;
 
 #include <boost/predef/other/endian.h>
 #include <cstdint>
+#include <limits>
+#include <stdexcept>
 
 #if !BOOST_ENDIAN_LITTLE_BYTE
 #error unsupported endian!


### PR DESCRIPTION
Fix arm 32bit compile fail issue when C API is already disable
> Disabe `WASMEDGE_BUILD_AOT_RUNTIME` `WASMEDGE_BUILD_SHARED_LIB` `DWASMEDGE_BUILD_STATIC_LIB`

```bash
cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_AOT_RUNTIME=OFF -DWASMEDGE_BUILD_SHARED_LIB=OFF -DWASMEDGE_BUILD_STATIC_LIB=OFF .
cmake --build build
```