### PR TITLE
Add conf-header.py and fix wasmedge.h.in

### DIFF
--- a/.github/scripts/conf-header.py
+++ b/.github/scripts/conf-header.py
@@ -1,0 +1,106 @@
+import re
+import fnmatch
+import os
+import glob
+import sys
+
+
+def clean_list(l):
+    l = [x.strip() for x in l]
+    l = [x for x in l if x != ""]
+    return l
+
+def enum_line(line):
+    l = line.strip()
+    elems = clean_list(l.split(','))
+    if len(elems) <= 1 or elems[1].strip().startswith("//"):
+        return l
+    else:
+        for idx in range(len(elems)):
+            if idx != len(elems) - 1:
+                elems[idx] = elems[idx] + ","
+        return elems
+
+# Extract enum values from header file
+def get_enum_from(header, enum_name):
+    matches = glob.glob(header)    
+    if len(matches) == 0 or len(matches) > 1:
+        print "No single match for header: {0} {1}".format(header, enum_name)
+        print "Please specify right path for header"
+        exit(1)
+    header_file = matches[0]
+    content = ""
+    with open(header_file) as f:
+        content = f.read()
+    keyword = "enum class " + enum_name    
+    enum_start = content.index(keyword)
+    left = content.index("{", enum_start) + 1
+    right = content.index("}", left) - 1
+    enum_content = content[left:right]
+    enum_lines = enum_content.split("\n")
+    enum_lines = [enum_line(l) for l in enum_lines]
+    
+    result = []
+    for x in enum_lines:
+        if type(x) is list:
+            result.extend(x)
+        else:
+            result.append(x)
+    return clean_list(result)
+
+
+## Compare with header files enum value according marks in wasmedge.h.in
+## Generate new wasmedge.h.in if any difference found
+def sync_enums(force_update):
+    lines = []
+    with open('include/api/wasmedge.h.in') as f:
+        lines = f.readlines()
+    result = []
+    cur = 0
+    while cur < len(lines):
+        line = lines[cur]
+        if 'Gen Based:' in line:
+            result.append(line)
+            header = line.split(':')[-1].strip()
+            enum_line = lines[cur+1]
+            result.append(enum_line)
+            prefix = "WasmEdge_"
+            prev = lines[cur-1].strip()
+            if "Gen Prev:" in prev:
+                prefix = prev.split(':')[-1].strip()
+            enum_name = enum_line.replace("enum " + prefix, "").split()[0]
+            print "check .... ", enum_name
+            num = cur + 2
+            values = []
+            while num < len(lines):
+                l = lines[num]
+                if '};' in l:
+                    break
+                values.append(l.strip())
+                num += 1
+            header_values = get_enum_from(header, enum_name)
+            if len(values) != len(header_values):                
+                if not force_update:
+                    print "wasmedge.h.in is not synced"
+                    print "Please run conf-header.py with option --update and commit changes"
+                    exit(1)
+                print "update ... ", enum_name
+            for v in header_values:
+                if v.startswith("//"):
+                    result.append("  {0}\n".format(v))
+                else:
+                    t = "  {0}{1}_{2}\n".format(prefix, enum_name, v)
+                    result.append(t)
+            cur = num
+        else:
+            result.append(line)
+            cur += 1
+    if force_update:
+        with open('include/api/wasmedge.h.in', 'w') as f:
+            f.writelines(result)
+
+if __name__ == "__main__":
+    force_update = False
+    if len(sys.argv) >= 2 and sys.argv[1] == '--update':
+        force_update = True
+    sync_enums(force_update)

--- a/.github/scripts/conf-header.py
+++ b/.github/scripts/conf-header.py
@@ -81,7 +81,7 @@ def sync_enums(force_update):
             header_values = get_enum_from(header, enum_name)
             if len(values) != len(header_values):                
                 if not force_update:
-                    print "wasmedge.h.in is not synced"
+                    print "wasmedge.h.in is not synced: ", enum_name
                     print "Please run conf-header.py with option --update and commit changes"
                     exit(1)
                 print "update ... ", enum_name

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -35,4 +35,9 @@ jobs:
     - name: Run clang-format
       run: |
         bash ./.github/scripts/clang-format.sh `which clang-format-12`
+    - name: Run header check
+      run: |
+        apt update
+        apt install python
+        python ./.github/scripts/conf-header.py
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,6 +38,6 @@ jobs:
     - name: Run header check
       run: |
         apt update
-        apt install python
+        apt install python -y
         python ./.github/scripts/conf-header.py
 

--- a/include/api/wasmedge.h.in
+++ b/include/api/wasmedge.h.in
@@ -36,6 +36,7 @@
 #define WASMEDGE_VERSION_PATCH ${WASMEDGE_VERSION_PATCH}
 
 /// Error code enumeration.
+// Gen Based: include/common/errcode.h
 enum WasmEdge_ErrCode {
   WasmEdge_ErrCode_Success = 0x00,
   WasmEdge_ErrCode_Terminated = 0x01,        /// Exit and return success.
@@ -118,26 +119,29 @@ enum WasmEdge_ErrCode {
 };
 
 /// WASM Value type enumeration.
+// Gen Based: include/common/types.h
 enum WasmEdge_ValType {
-  WasmEdge_ValType_I32 = 0x7FU,
-  WasmEdge_ValType_I64 = 0x7EU,
-  WasmEdge_ValType_F32 = 0x7DU,
-  WasmEdge_ValType_F64 = 0x7CU,
-  WasmEdge_ValType_V128 = 0x7BU,
-  WasmEdge_ValType_FuncRef = 0x70U,
-  WasmEdge_ValType_ExternRef = 0x6FU
-};
-
-/// WASM Reference type enumeration.
-enum WasmEdge_RefType {
-  WasmEdge_RefType_FuncRef = 0x70U,
-  WasmEdge_RefType_ExternRef = 0x6FU
+  WasmEdge_ValType_None = 0x40,
+  WasmEdge_ValType_I32 = 0x7F,
+  WasmEdge_ValType_I64 = 0x7E,
+  WasmEdge_ValType_F32 = 0x7D,
+  WasmEdge_ValType_F64 = 0x7C,
+  WasmEdge_ValType_V128 = 0x7B,
+  WasmEdge_ValType_FuncRef = 0x70,
+  WasmEdge_ValType_ExternRef = 0x6F
 };
 
 /// WASM Mutability enumeration.
 enum WasmEdge_Mutability {
   WasmEdge_Mutability_Const = 0x00U,
   WasmEdge_Mutability_Var = 0x01U
+};
+
+/// WASM Reference type enumeration.
+// Gen Based: include/common/types.h
+enum WasmEdge_RefType {
+  WasmEdge_RefType_ExternRef = 0x6F,
+  WasmEdge_RefType_FuncRef = 0x70
 };
 
 /// WasmEdge WASM value struct.
@@ -179,6 +183,7 @@ typedef struct WasmEdge_Limit {
 /// WASM Proposal enumeration.
 /// This enum is copied from "include/common/configure.h" and should be the
 /// same.
+// Gen Based: include/common/configure.h
 enum WasmEdge_Proposal {
   WasmEdge_Proposal_BulkMemoryOperations = 0,
   WasmEdge_Proposal_ReferenceTypes,
@@ -188,16 +193,21 @@ enum WasmEdge_Proposal {
   WasmEdge_Proposal_Memory64,
   WasmEdge_Proposal_Threads,
   WasmEdge_Proposal_ExceptionHandling,
-  WasmEdge_Proposal_FunctionReferences
+  WasmEdge_Proposal_FunctionReferences,
+  WasmEdge_Proposal_Max
 };
 
 /// Host Module Registration enumeration.
+// Gen Based: include/common/configure.h
 enum WasmEdge_HostRegistration {
   WasmEdge_HostRegistration_Wasi = 0,
-  WasmEdge_HostRegistration_WasmEdge_Process
+  WasmEdge_HostRegistration_WasmEdge_Process,
+  WasmEdge_HostRegistration_Max
 };
 
 /// AOT compiler optimization level enumeration.
+// Gen Prev: WasmEdge_Compiler
+// Gen Based: include/common/configure.h
 enum WasmEdge_CompilerOptimizationLevel {
   /// Disable as many optimizations as possible.
   WasmEdge_CompilerOptimizationLevel_O0 = 0,

--- a/include/api/wasmedge.h.in
+++ b/include/api/wasmedge.h.in
@@ -137,13 +137,6 @@ enum WasmEdge_Mutability {
   WasmEdge_Mutability_Var = 0x01U
 };
 
-/// WASM Reference type enumeration.
-// Gen Based: include/common/types.h
-enum WasmEdge_RefType {
-  WasmEdge_RefType_ExternRef = 0x6F,
-  WasmEdge_RefType_FuncRef = 0x70
-};
-
 /// WasmEdge WASM value struct.
 typedef struct WasmEdge_Value {
   unsigned __int128 Value;

--- a/include/api/wasmedge.h.in
+++ b/include/api/wasmedge.h.in
@@ -131,6 +131,13 @@ enum WasmEdge_ValType {
   WasmEdge_ValType_ExternRef = 0x6F
 };
 
+// WASM Reference type enumeration.
+// Gen Based: include/common/types.h
+enum WasmEdge_RefType {
+  WasmEdge_RefType_ExternRef = 0x6F,
+  WasmEdge_RefType_FuncRef = 0x70
+};
+
 /// WASM Mutability enumeration.
 enum WasmEdge_Mutability {
   WasmEdge_Mutability_Const = 0x00U,

--- a/include/api/wasmedge.h.in
+++ b/include/api/wasmedge.h.in
@@ -39,160 +39,83 @@
 // Gen Based: include/common/errcode.h
 enum WasmEdge_ErrCode {
   WasmEdge_ErrCode_Success = 0x00,
-  /// Exit and return success.
-  WasmEdge_ErrCode_Terminated = 0x01,
-  /// Generic runtime error.
-  WasmEdge_ErrCode_RuntimeError = 0x02,
-  /// Exceeded cost limit (out of gas).
-  WasmEdge_ErrCode_CostLimitExceeded = 0x03,
-  /// Wrong VM's workflow
-  WasmEdge_ErrCode_WrongVMWorkflow = 0x04,
-  /// Wasm function not found
-  WasmEdge_ErrCode_FuncNotFound = 0x05,
-  /// AOT runtime is disabled
-  WasmEdge_ErrCode_AOTDisabled = 0x06,
-
+  WasmEdge_ErrCode_Terminated = 0x01,        /// Exit and return success.
+  WasmEdge_ErrCode_RuntimeError = 0x02,      /// Generic runtime error.
+  WasmEdge_ErrCode_CostLimitExceeded = 0x03, /// Exceeded cost limit (out of gas).
+  WasmEdge_ErrCode_WrongVMWorkflow = 0x04,   /// Wrong VM's workflow
+  WasmEdge_ErrCode_FuncNotFound = 0x05,      /// Wasm function not found
+  WasmEdge_ErrCode_AOTDisabled = 0x06,       /// AOT runtime is disabled
   /// Load phase
-  /// File not found
-  WasmEdge_ErrCode_InvalidPath = 0x20,
-  /// Error when reading
-  WasmEdge_ErrCode_ReadError = 0x21,
-  /// Reach end of file when reading
-  WasmEdge_ErrCode_UnexpectedEnd = 0x22,
-  /// Not detected magic header
-  WasmEdge_ErrCode_InvalidMagic = 0x23,
-  /// Unsupported version
-  WasmEdge_ErrCode_InvalidVersion = 0x24,
-  /// Malformed section ID
-  WasmEdge_ErrCode_InvalidSection = 0x25,
-  /// Section size mismatched
-  WasmEdge_ErrCode_SectionSizeMismatch = 0x26,
-  /// Name size out of bounds
-  WasmEdge_ErrCode_NameSizeOutOfBounds = 0x27,
-  /// Junk sections
-  WasmEdge_ErrCode_JunkSection = 0x28,
-  /// Incompatible function and code section
-  WasmEdge_ErrCode_IncompatibleFuncCode = 0x29,
-  /// Incompatible data and datacount section
-  WasmEdge_ErrCode_IncompatibleDataCount = 0x2A,
-  /// Datacount section required
-  WasmEdge_ErrCode_DataCountRequired = 0x2B,
-  /// Malformed import kind
-  WasmEdge_ErrCode_InvalidImportKind = 0x2C,
-  /// Malformed export kind
-  WasmEdge_ErrCode_InvalidExportKind = 0x2D,
-  /// Not loaded an expected zero byte
-  WasmEdge_ErrCode_ExpectedZeroByte = 0x2E,
-  /// Malformed mutability
-  WasmEdge_ErrCode_InvalidMut = 0x2F,
-  /// Local size too large
-  WasmEdge_ErrCode_TooManyLocals = 0x30,
-  /// Malformed value type
-  WasmEdge_ErrCode_InvalidValType = 0x31,
-  /// Malformed element type (Bulk-mem proposal)
-  WasmEdge_ErrCode_InvalidElemType = 0x32,
-  /// Malformed reference type (Ref-types proposal)
-  WasmEdge_ErrCode_InvalidRefType = 0x33,
-  /// Invalid utf-8 encoding
-  WasmEdge_ErrCode_InvalidUTF8 = 0x34,
-  /// Invalid too large integer
-  WasmEdge_ErrCode_IntegerTooLarge = 0x35,
-  /// Invalid presentation too long integer
-  WasmEdge_ErrCode_IntegerTooLong = 0x36,
-  /// Illegal OpCode
-  WasmEdge_ErrCode_InvalidOpCode = 0x37,
-  /// Parsing error
-  WasmEdge_ErrCode_InvalidGrammar = 0x38,
-
+  WasmEdge_ErrCode_InvalidPath = 0x20,           /// File not found
+  WasmEdge_ErrCode_ReadError = 0x21,             /// Error when reading
+  WasmEdge_ErrCode_UnexpectedEnd = 0x22,         /// Reach end of file when reading
+  WasmEdge_ErrCode_InvalidMagic = 0x23,          /// Not detected magic header
+  WasmEdge_ErrCode_InvalidVersion = 0x24,        /// Unsupported version
+  WasmEdge_ErrCode_InvalidSection = 0x25,        /// Malformed section ID
+  WasmEdge_ErrCode_SectionSizeMismatch = 0x26,   /// Section size mismatched
+  WasmEdge_ErrCode_NameSizeOutOfBounds = 0x27,   /// Name size out of bounds
+  WasmEdge_ErrCode_JunkSection = 0x28,           /// Junk sections
+  WasmEdge_ErrCode_IncompatibleFuncCode = 0x29,  /// Incompatible function and code section
+  WasmEdge_ErrCode_IncompatibleDataCount = 0x2A, /// Incompatible data and datacount section
+  WasmEdge_ErrCode_DataCountRequired = 0x2B,     /// Datacount section required
+  WasmEdge_ErrCode_InvalidImportKind = 0x2C,     /// Malformed import kind
+  WasmEdge_ErrCode_InvalidExportKind = 0x2D,     /// Malformed export kind
+  WasmEdge_ErrCode_ExpectedZeroByte = 0x2E,      /// Not loaded an expected zero byte
+  WasmEdge_ErrCode_InvalidMut = 0x2F,            /// Malformed mutability
+  WasmEdge_ErrCode_TooManyLocals = 0x30,         /// Local size too large
+  WasmEdge_ErrCode_InvalidValType = 0x31,        /// Malformed value type
+  WasmEdge_ErrCode_InvalidElemType = 0x32,       /// Malformed element type (Bulk-mem proposal)
+  WasmEdge_ErrCode_InvalidRefType = 0x33,  /// Malformed reference type (Ref-types proposal)
+  WasmEdge_ErrCode_InvalidUTF8 = 0x34,     /// Invalid utf-8 encoding
+  WasmEdge_ErrCode_IntegerTooLarge = 0x35, /// Invalid too large integer
+  WasmEdge_ErrCode_IntegerTooLong = 0x36,  /// Invalid presentation too long integer
+  WasmEdge_ErrCode_InvalidOpCode = 0x37,   /// Illegal OpCode
+  WasmEdge_ErrCode_InvalidGrammar = 0x38,  /// Parsing error
   /// Validation phase
-  /// Alignment > natural
-  WasmEdge_ErrCode_InvalidAlignment = 0x40,
-  /// Got unexpected type when checking
-  WasmEdge_ErrCode_TypeCheckFailed = 0x41,
-  /// Branch to unknown label index
-  WasmEdge_ErrCode_InvalidLabelIdx = 0x42,
-  /// Access unknown local index
-  WasmEdge_ErrCode_InvalidLocalIdx = 0x43,
-  /// Type index not defined
-  WasmEdge_ErrCode_InvalidFuncTypeIdx = 0x44,
-  /// Function index not defined
-  WasmEdge_ErrCode_InvalidFuncIdx = 0x45,
-  /// Table index not defined
-  WasmEdge_ErrCode_InvalidTableIdx = 0x46,
-  /// Memory index not defined
-  WasmEdge_ErrCode_InvalidMemoryIdx = 0x47,
-  /// Global index not defined
-  WasmEdge_ErrCode_InvalidGlobalIdx = 0x48,
-  /// Element segment index not defined
-  WasmEdge_ErrCode_InvalidElemIdx = 0x49,
-  /// Data segment index not defined
-  WasmEdge_ErrCode_InvalidDataIdx = 0x4A,
-  /// Undeclared reference
-  WasmEdge_ErrCode_InvalidRefIdx = 0x4B,
-  /// Should be constant expression
-  WasmEdge_ErrCode_ConstExprRequired = 0x4C,
-  /// Export name conflicted
-  WasmEdge_ErrCode_DupExportName = 0x4D,
-  /// Tried to store to const global value
-  WasmEdge_ErrCode_ImmutableGlobal = 0x4E,
-  /// Invalid result arity in select t* instruction
-  WasmEdge_ErrCode_InvalidResultArity = 0x4F,
-  /// #Tables > 1 (without Ref-types proposal)
-  WasmEdge_ErrCode_MultiTables = 0x50,
-  /// #Memories > 1
-  WasmEdge_ErrCode_MultiMemories = 0x51,
-  /// Invalid Limit grammar
-  WasmEdge_ErrCode_InvalidLimit = 0x52,
-  /// Memory pages > 65536
-  WasmEdge_ErrCode_InvalidMemPages = 0x53,
-  /// Invalid start function signature
-  WasmEdge_ErrCode_InvalidStartFunc = 0x54,
-  /// Invalid lane index
-  WasmEdge_ErrCode_InvalidLaneIdx = 0x55,
-
+  WasmEdge_ErrCode_InvalidAlignment = 0x40,   /// Alignment > natural
+  WasmEdge_ErrCode_TypeCheckFailed = 0x41,    /// Got unexpected type when checking
+  WasmEdge_ErrCode_InvalidLabelIdx = 0x42,    /// Branch to unknown label index
+  WasmEdge_ErrCode_InvalidLocalIdx = 0x43,    /// Access unknown local index
+  WasmEdge_ErrCode_InvalidFuncTypeIdx = 0x44, /// Type index not defined
+  WasmEdge_ErrCode_InvalidFuncIdx = 0x45,     /// Function index not defined
+  WasmEdge_ErrCode_InvalidTableIdx = 0x46,    /// Table index not defined
+  WasmEdge_ErrCode_InvalidMemoryIdx = 0x47,   /// Memory index not defined
+  WasmEdge_ErrCode_InvalidGlobalIdx = 0x48,   /// Global index not defined
+  WasmEdge_ErrCode_InvalidElemIdx = 0x49,     /// Element segment index not defined
+  WasmEdge_ErrCode_InvalidDataIdx = 0x4A,     /// Data segment index not defined
+  WasmEdge_ErrCode_InvalidRefIdx = 0x4B,      /// Undeclared reference
+  WasmEdge_ErrCode_ConstExprRequired = 0x4C,  /// Should be constant expression
+  WasmEdge_ErrCode_DupExportName = 0x4D,      /// Export name conflicted
+  WasmEdge_ErrCode_ImmutableGlobal = 0x4E,    /// Tried to store to const global value
+  WasmEdge_ErrCode_InvalidResultArity = 0x4F, /// Invalid result arity in select t* instruction
+  WasmEdge_ErrCode_MultiTables = 0x50,        /// #Tables > 1 (without Ref-types proposal)
+  WasmEdge_ErrCode_MultiMemories = 0x51,      /// #Memories > 1
+  WasmEdge_ErrCode_InvalidLimit = 0x52,       /// Invalid Limit grammar
+  WasmEdge_ErrCode_InvalidMemPages = 0x53,    /// Memory pages > 65536
+  WasmEdge_ErrCode_InvalidStartFunc = 0x54,   /// Invalid start function signature
+  WasmEdge_ErrCode_InvalidLaneIdx = 0x55,     /// Invalid lane index
   /// Instantiation phase
-  /// Module name conflicted when importing.
-  WasmEdge_ErrCode_ModuleNameConflict = 0x60,
-  /// Import matching failed
-  WasmEdge_ErrCode_IncompatibleImportType = 0x61,
-  /// Unknown import instances
-  WasmEdge_ErrCode_UnknownImport = 0x62,
-  /// Init failed when instantiating data segment
-  WasmEdge_ErrCode_DataSegDoesNotFit = 0x63,
-  /// Init failed when instantiating element segment
-  WasmEdge_ErrCode_ElemSegDoesNotFit = 0x64,
-
+  WasmEdge_ErrCode_ModuleNameConflict = 0x60,     /// Module name conflicted when importing.
+  WasmEdge_ErrCode_IncompatibleImportType = 0x61, /// Import matching failed
+  WasmEdge_ErrCode_UnknownImport = 0x62,          /// Unknown import instances
+  WasmEdge_ErrCode_DataSegDoesNotFit = 0x63,      /// Init failed when instantiating data segment
+  WasmEdge_ErrCode_ElemSegDoesNotFit = 0x64, /// Init failed when instantiating element segment
   /// Execution phase
-  /// Wrong access of instances addresses
-  WasmEdge_ErrCode_WrongInstanceAddress = 0x80,
-  /// Wrong access of instances indices
-  WasmEdge_ErrCode_WrongInstanceIndex = 0x81,
-  /// Instruction type not match
-  WasmEdge_ErrCode_InstrTypeMismatch = 0x82,
-  /// Function signature not match when invoking
-  WasmEdge_ErrCode_FuncSigMismatch = 0x83,
-  /// Divide by zero
-  WasmEdge_ErrCode_DivideByZero = 0x84,
-  /// Integer overflow
-  WasmEdge_ErrCode_IntegerOverflow = 0x85,
-  /// Cannot do convert to integer
-  WasmEdge_ErrCode_InvalidConvToInt = 0x86,
-  /// Out of bounds table access
-  WasmEdge_ErrCode_TableOutOfBounds = 0x87,
-  /// Out of bounds memory access
-  WasmEdge_ErrCode_MemoryOutOfBounds = 0x88,
-  /// Meet an unreachable instruction
-  WasmEdge_ErrCode_Unreachable = 0x89,
-  /// Uninitialized element in table instance
-  WasmEdge_ErrCode_UninitializedElement = 0x8A,
-  /// Access undefined element in table instances
-  WasmEdge_ErrCode_UndefinedElement = 0x8B,
-  /// Func type mismatch in call_indirect
-  WasmEdge_ErrCode_IndirectCallTypeMismatch = 0x8C,
-  /// Host function execution failed
-  WasmEdge_ErrCode_ExecutionFailed = 0x8D,
-  /// Reference type not match
-  WasmEdge_ErrCode_RefTypeMismatch = 0x8E
+  WasmEdge_ErrCode_WrongInstanceAddress = 0x80, /// Wrong access of instances addresses
+  WasmEdge_ErrCode_WrongInstanceIndex = 0x81,   /// Wrong access of instances indices
+  WasmEdge_ErrCode_InstrTypeMismatch = 0x82,    /// Instruction type not match
+  WasmEdge_ErrCode_FuncSigMismatch = 0x83,      /// Function signature not match when invoking
+  WasmEdge_ErrCode_DivideByZero = 0x84,         /// Divide by zero
+  WasmEdge_ErrCode_IntegerOverflow = 0x85,      /// Integer overflow
+  WasmEdge_ErrCode_InvalidConvToInt = 0x86,     /// Cannot do convert to integer
+  WasmEdge_ErrCode_TableOutOfBounds = 0x87,     /// Out of bounds table access
+  WasmEdge_ErrCode_MemoryOutOfBounds = 0x88,    /// Out of bounds memory access
+  WasmEdge_ErrCode_Unreachable = 0x89,          /// Meet an unreachable instruction
+  WasmEdge_ErrCode_UninitializedElement = 0x8A, /// Uninitialized element in table instance
+  WasmEdge_ErrCode_UndefinedElement = 0x8B,     /// Access undefined element in table instances
+  WasmEdge_ErrCode_IndirectCallTypeMismatch = 0x8C, /// Func type mismatch in call_indirect
+  WasmEdge_ErrCode_ExecutionFailed = 0x8D,          /// Host function execution failed
+  WasmEdge_ErrCode_RefTypeMismatch = 0x8E           /// Reference type not match
 };
 
 /// WASM Value type enumeration.

--- a/include/common/configure.h
+++ b/include/common/configure.h
@@ -47,7 +47,7 @@ public:
   /// AOT compiler optimization level enum class.
   enum class OptimizationLevel : uint8_t {
     /// Disable as many optimizations as possible.
-    O0,
+    O0 = 0,
     /// Optimize quickly without destroying debuggability.
     O1,
     /// Optimize for fast execution as much as possible without triggering


### PR DESCRIPTION
It's a little trivial than I thought. 
Workout a hacky version of Python script to check the enums. 

Mark format with:
```
Gen Based: include/common/errcode.h
```

The script will try to update the enum values according to headers.

close #349 