### PR TITLE
[Misc] Enable c api in 32-bit environment

### DIFF
--- a/include/api/wasmedge.h.in
+++ b/include/api/wasmedge.h.in
@@ -29,6 +29,25 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#if defined(__x86_64__) || defined(__aarch64__)
+
+typedef unsigned __int128 uint128_t;
+typedef __int128 int128_t;
+
+#else
+
+typedef struct uint128_t {
+  uint64_t Low;
+  uint64_t High;
+} uint128_t ;
+
+typedef struct int128_t {
+  uint64_t Low;
+  int64_t High;
+} int128_t;
+
+#endif
+
 /// WasmEdge version.
 #define WASMEDGE_VERSION "${CPACK_PACKAGE_VERSION}"
 #define WASMEDGE_VERSION_MAJOR ${WASMEDGE_VERSION_MAJOR}
@@ -219,7 +238,7 @@ enum WasmEdge_Mutability {
 
 /// WasmEdge WASM value struct.
 typedef struct WasmEdge_Value {
-  unsigned __int128 Value;
+  uint128_t Value;
   /// The value type is used in the parameters of invoking functions. For the
   /// return values of invoking functions, this member will always be
   /// `WasmEdge_ValType_I32`. Users should use APIs to retrieve the WASM
@@ -421,7 +440,7 @@ WasmEdge_ValueGenF64(const double Val);
 ///
 /// \returns WasmEdge_Value struct with the V128 value.
 WASMEDGE_CAPI_EXPORT extern WasmEdge_Value
-WasmEdge_ValueGenV128(const __int128 Val);
+WasmEdge_ValueGenV128(const int128_t Val);
 
 /// Generate the NULL reference WASM value.
 ///
@@ -495,7 +514,7 @@ WasmEdge_ValueGetF64(const WasmEdge_Value Val);
 /// \param Val the WasmEdge_Value struct.
 ///
 /// \returns V128 value in the input struct.
-WASMEDGE_CAPI_EXPORT extern __int128
+WASMEDGE_CAPI_EXPORT extern int128_t
 WasmEdge_ValueGetV128(const WasmEdge_Value Val);
 
 /// Specify the WASM value is a null reference or not.

--- a/include/common/int128.h
+++ b/include/common/int128.h
@@ -52,6 +52,7 @@ public:
   constexpr uint128_t(unsigned long V) noexcept : Low(V), High(0) {}
   constexpr uint128_t(unsigned long long V) noexcept : Low(V), High(0) {}
   constexpr uint128_t(int128_t V) noexcept;
+  constexpr uint128_t(uint64_t H, uint64_t L) noexcept : Low(L), High(H) {}
 
   constexpr operator bool() const noexcept {
     return static_cast<bool>(Low) || static_cast<bool>(High);
@@ -267,7 +268,6 @@ public:
   }
 
 private:
-  constexpr uint128_t(uint64_t H, uint64_t L) noexcept : Low(L), High(H) {}
   uint64_t Low = 0;
   uint64_t High = 0;
 };
@@ -291,6 +291,7 @@ public:
   constexpr int128_t(unsigned long long V) noexcept
       : Low(V), High(INT64_C(0)) {}
   constexpr int128_t(uint128_t V) noexcept;
+  constexpr int128_t(int64_t H, uint64_t L) noexcept : Low(L), High(H) {}
 
   constexpr int128_t &operator=(int V) noexcept { return *this = int128_t(V); }
   constexpr int128_t &operator=(long V) noexcept { return *this = int128_t(V); }
@@ -321,7 +322,6 @@ public:
   constexpr int64_t high() const noexcept { return High; }
 
 private:
-  constexpr int128_t(int64_t H, uint64_t L) noexcept : Low(L), High(H) {}
   uint64_t Low = 0;
   int64_t High = 0;
 };

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -110,20 +110,44 @@ inline constexpr WasmEdge_Result genWasmEdge_Result(ErrCode Code) noexcept {
   return WasmEdge_Result{.Code = static_cast<uint8_t>(Code)};
 }
 
+/// Helper function for returning a struct uint128_t / int128_t
+/// from class WasmEdge::uint128_t / WasmEdge::int128_t.
+template <typename C>
+inline constexpr ::uint128_t to_uint128_t(C Val) noexcept {
+#if defined(__x86_64__) || defined(__aarch64__)
+  return Val;
+#else
+  return {.Low = Val.low(), .High = static_cast<uint64_t>(Val.high())};
+#endif
+}
+template <typename C> inline constexpr ::int128_t to_int128_t(C Val) noexcept {
+#if defined(__x86_64__) || defined(__aarch64__)
+  return Val;
+#else
+  return {.Low = Val.low(), .High = Val.high()};
+#endif
+}
+
+/// Helper function for returning a class WasmEdge::uint128_t /
+/// WasmEdge::int128_t from struct uint128_t / int128_t.
+template <typename C, typename T>
+inline constexpr C to_WasmEdge_128_t(T Val) noexcept {
+#if defined(__x86_64__) || defined(__aarch64__)
+  return Val;
+#else
+  return C(Val.High, Val.Low);
+#endif
+}
+
 /// Helper functions for returning a WasmEdge_Value by various values.
 template <typename T> inline WasmEdge_Value genWasmEdge_Value(T Val) noexcept {
   return WasmEdge_Value{
-      .Value = ValVariant(Val).unwrap(),
+      .Value = to_uint128_t(ValVariant(Val).unwrap()),
       .Type = static_cast<WasmEdge_ValType>(WasmEdge::ValTypeFromType<T>())};
-}
-template <>
-inline constexpr WasmEdge_Value genWasmEdge_Value(__int128 Val) noexcept {
-  return WasmEdge_Value{.Value = static_cast<unsigned __int128>(Val),
-                        .Type = WasmEdge_ValType_V128};
 }
 inline WasmEdge_Value genWasmEdge_Value(ValVariant Val,
                                         WasmEdge_ValType T) noexcept {
-  return WasmEdge_Value{.Value = Val.unwrap(), .Type = T};
+  return WasmEdge_Value{.Value = to_uint128_t(Val.unwrap()), .Type = T};
 }
 
 /// Helper function for converting a WasmEdge_Value array to a ValVariant
@@ -141,25 +165,32 @@ genParamPair(const WasmEdge_Value *Val, const uint32_t Len) noexcept {
     TVec[I] = static_cast<ValType>(Val[I].Type);
     switch (TVec[I]) {
     case ValType::I32:
-      VVec[I] = ValVariant::wrap<uint32_t>(Val[I].Value);
+      VVec[I] = ValVariant::wrap<uint32_t>(
+          to_WasmEdge_128_t<WasmEdge::uint128_t>(Val[I].Value));
       break;
     case ValType::I64:
-      VVec[I] = ValVariant::wrap<uint64_t>(Val[I].Value);
+      VVec[I] = ValVariant::wrap<uint64_t>(
+          to_WasmEdge_128_t<WasmEdge::uint128_t>(Val[I].Value));
       break;
     case ValType::F32:
-      VVec[I] = ValVariant::wrap<float>(Val[I].Value);
+      VVec[I] = ValVariant::wrap<float>(
+          to_WasmEdge_128_t<WasmEdge::uint128_t>(Val[I].Value));
       break;
     case ValType::F64:
-      VVec[I] = ValVariant::wrap<double>(Val[I].Value);
+      VVec[I] = ValVariant::wrap<double>(
+          to_WasmEdge_128_t<WasmEdge::uint128_t>(Val[I].Value));
       break;
     case ValType::V128:
-      VVec[I] = ValVariant::wrap<unsigned __int128>(Val[I].Value);
+      VVec[I] = ValVariant::wrap<WasmEdge::uint128_t>(
+          to_WasmEdge_128_t<WasmEdge::uint128_t>(Val[I].Value));
       break;
     case ValType::FuncRef:
-      VVec[I] = ValVariant::wrap<FuncRef>(Val[I].Value);
+      VVec[I] = ValVariant::wrap<FuncRef>(
+          to_WasmEdge_128_t<WasmEdge::uint128_t>(Val[I].Value));
       break;
     case ValType::ExternRef:
-      VVec[I] = ValVariant::wrap<ExternRef>(Val[I].Value);
+      VVec[I] = ValVariant::wrap<ExternRef>(
+          to_WasmEdge_128_t<WasmEdge::uint128_t>(Val[I].Value));
       break;
     case ValType::None:
     default:
@@ -277,7 +308,7 @@ public:
     std::vector<WasmEdge_Value> Params(FuncType.Params.size()),
         Returns(FuncType.Returns.size());
     for (uint32_t I = 0; I < Args.size(); I++) {
-      Params[I].Value = Args[I].get<unsigned __int128>();
+      Params[I].Value = to_uint128_t(Args[I].get<WasmEdge::uint128_t>());
       Params[I].Type = static_cast<WasmEdge_ValType>(FuncType.Params[I]);
     }
     WasmEdge_Value *PPtr = Params.size() ? (&Params[0]) : nullptr;
@@ -292,7 +323,7 @@ public:
                   static_cast<uint32_t>(Returns.size()));
     }
     for (uint32_t I = 0; I < Rets.size(); I++) {
-      Rets[I] = Returns[I].Value;
+      Rets[I] = to_WasmEdge_128_t<WasmEdge::uint128_t>(Returns[I].Value);
     }
     if (!WasmEdge_ResultOK(Stat)) {
       return Unexpect(ErrCode::ExecutionFailed);
@@ -404,8 +435,9 @@ WASMEDGE_CAPI_EXPORT WasmEdge_Value WasmEdge_ValueGenF64(const double Val) {
   return genWasmEdge_Value(Val);
 }
 
-WASMEDGE_CAPI_EXPORT WasmEdge_Value WasmEdge_ValueGenV128(const __int128 Val) {
-  return genWasmEdge_Value(Val);
+WASMEDGE_CAPI_EXPORT WasmEdge_Value
+WasmEdge_ValueGenV128(const ::int128_t Val) {
+  return genWasmEdge_Value(to_WasmEdge_128_t<WasmEdge::uint128_t>(Val));
 }
 
 WASMEDGE_CAPI_EXPORT WasmEdge_Value
@@ -426,39 +458,52 @@ WASMEDGE_CAPI_EXPORT WasmEdge_Value WasmEdge_ValueGenExternRef(void *Ref) {
 }
 
 WASMEDGE_CAPI_EXPORT int32_t WasmEdge_ValueGetI32(const WasmEdge_Value Val) {
-  return WasmEdge::ValVariant::wrap<int32_t>(Val.Value).get<int32_t>();
+  return WasmEdge::ValVariant::wrap<int32_t>(
+             to_WasmEdge_128_t<WasmEdge::uint128_t>(Val.Value))
+      .get<int32_t>();
 }
 
 WASMEDGE_CAPI_EXPORT int64_t WasmEdge_ValueGetI64(const WasmEdge_Value Val) {
-  return WasmEdge::ValVariant::wrap<int64_t>(Val.Value).get<int64_t>();
+  return WasmEdge::ValVariant::wrap<int64_t>(
+             to_WasmEdge_128_t<WasmEdge::uint128_t>(Val.Value))
+      .get<int64_t>();
 }
 
 WASMEDGE_CAPI_EXPORT float WasmEdge_ValueGetF32(const WasmEdge_Value Val) {
-  return WasmEdge::ValVariant::wrap<float>(Val.Value).get<float>();
+  return WasmEdge::ValVariant::wrap<float>(
+             to_WasmEdge_128_t<WasmEdge::uint128_t>(Val.Value))
+      .get<float>();
 }
 
 WASMEDGE_CAPI_EXPORT double WasmEdge_ValueGetF64(const WasmEdge_Value Val) {
-  return WasmEdge::ValVariant::wrap<double>(Val.Value).get<double>();
+  return WasmEdge::ValVariant::wrap<double>(
+             to_WasmEdge_128_t<WasmEdge::uint128_t>(Val.Value))
+      .get<double>();
 }
 
-WASMEDGE_CAPI_EXPORT __int128 WasmEdge_ValueGetV128(const WasmEdge_Value Val) {
-  return WasmEdge::ValVariant::wrap<__int128>(Val.Value).get<__int128>();
+WASMEDGE_CAPI_EXPORT ::int128_t
+WasmEdge_ValueGetV128(const WasmEdge_Value Val) {
+  return to_int128_t(WasmEdge::ValVariant::wrap<WasmEdge::int128_t>(
+                         to_WasmEdge_128_t<WasmEdge::uint128_t>(Val.Value))
+                         .get<WasmEdge::int128_t>());
 }
 
 WASMEDGE_CAPI_EXPORT bool WasmEdge_ValueIsNullRef(const WasmEdge_Value Val) {
-  return WasmEdge::isNullRef(WasmEdge::ValVariant::wrap<UnknownRef>(Val.Value));
+  return WasmEdge::isNullRef(WasmEdge::ValVariant::wrap<UnknownRef>(
+      to_WasmEdge_128_t<WasmEdge::uint128_t>(Val.Value)));
 }
 
 WASMEDGE_CAPI_EXPORT uint32_t
 WasmEdge_ValueGetFuncIdx(const WasmEdge_Value Val) {
-  return WasmEdge::retrieveFuncIdx(
-      WasmEdge::ValVariant::wrap<FuncRef>(Val.Value));
+  return WasmEdge::retrieveFuncIdx(WasmEdge::ValVariant::wrap<FuncRef>(
+      to_WasmEdge_128_t<WasmEdge::uint128_t>(Val.Value)));
 }
 
 WASMEDGE_CAPI_EXPORT void *
 WasmEdge_ValueGetExternRef(const WasmEdge_Value Val) {
   return &WasmEdge::retrieveExternRef<uint32_t>(
-      WasmEdge::ValVariant::wrap<ExternRef>(Val.Value));
+      WasmEdge::ValVariant::wrap<ExternRef>(
+          to_WasmEdge_128_t<WasmEdge::uint128_t>(Val.Value)));
 }
 
 /// <<<<<<<< WasmEdge value functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -1443,7 +1488,9 @@ WasmEdge_TableInstanceSetData(WasmEdge_TableInstanceContext *Cxt,
           return Unexpect(WasmEdge::ErrCode::RefTypeMismatch);
         }
         return fromTabCxt(Cxt)->setRefAddr(
-            Offset, WasmEdge::ValVariant(Data.Value).get<UnknownRef>());
+            Offset, WasmEdge::ValVariant(
+                        to_WasmEdge_128_t<WasmEdge::uint128_t>(Data.Value))
+                        .get<UnknownRef>());
       },
       EmptyThen, Cxt);
 }
@@ -1563,7 +1610,8 @@ WasmEdge_GlobalInstanceCreate(const WasmEdge_Value Value,
                               const enum WasmEdge_Mutability Mut) {
   return toGlobCxt(new WasmEdge::Runtime::Instance::GlobalInstance(
       static_cast<WasmEdge::ValType>(Value.Type),
-      static_cast<WasmEdge::ValMut>(Mut), Value.Value));
+      static_cast<WasmEdge::ValMut>(Mut),
+      to_WasmEdge_128_t<WasmEdge::uint128_t>(Value.Value)));
 }
 
 WASMEDGE_CAPI_EXPORT enum WasmEdge_ValType
@@ -1591,7 +1639,7 @@ WasmEdge_GlobalInstanceGetValue(const WasmEdge_GlobalInstanceContext *Cxt) {
         static_cast<WasmEdge_ValType>(fromGlobCxt(Cxt)->getValType()));
   }
   return genWasmEdge_Value(
-      WasmEdge::ValVariant(static_cast<unsigned __int128>(0)),
+      WasmEdge::ValVariant(static_cast<WasmEdge::uint128_t>(0)),
       WasmEdge_ValType_I32);
 }
 
@@ -1601,7 +1649,8 @@ WasmEdge_GlobalInstanceSetValue(WasmEdge_GlobalInstanceContext *Cxt,
   if (Cxt && fromGlobCxt(Cxt)->getValMut() == WasmEdge::ValMut::Var &&
       static_cast<WasmEdge::ValType>(Value.Type) ==
           fromGlobCxt(Cxt)->getValType()) {
-    fromGlobCxt(Cxt)->getValue() = Value.Value;
+    fromGlobCxt(Cxt)->getValue() =
+        to_WasmEdge_128_t<WasmEdge::uint128_t>(Value.Value);
   }
 }
 

--- a/test/api/APIStepsCoreTest.cpp
+++ b/test/api/APIStepsCoreTest.cpp
@@ -185,8 +185,8 @@ TEST_P(CoreTest, TestSuites) {
     if (GlobCxt == nullptr) {
       return Unexpect(ErrCode::WrongInstanceAddress);
     }
-    return std::vector<ValVariant>{
-        WasmEdge_GlobalInstanceGetValue(GlobCxt).Value};
+    return convToValVec(std::vector<WasmEdge_Value>{
+        WasmEdge_GlobalInstanceGetValue(GlobCxt)});
   };
 
   T.run(Proposal, UnitName);

--- a/test/api/APIUnitTest.cpp
+++ b/test/api/APIUnitTest.cpp
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "api/wasmedge.h"
-
 #include "gtest/gtest.h"
 
 #include <cstdint>
@@ -262,9 +261,15 @@ TEST(APICoreTest, Value) {
   EXPECT_EQ(WasmEdge_ValueGetF32(Val), 1 / 0.0f);
   Val = WasmEdge_ValueGenF64(-1 / 0.0);
   EXPECT_EQ(WasmEdge_ValueGetF64(Val), -1 / 0.0);
-  Val = WasmEdge_ValueGenV128(static_cast<__int128>(INT64_MAX) * 2 + 1);
+#if defined(__x86_64__) || defined(__aarch64__)
+  Val = WasmEdge_ValueGenV128(static_cast<int128_t>(INT64_MAX) * 2 + 1);
   EXPECT_EQ(WasmEdge_ValueGetV128(Val),
-            static_cast<__int128>(INT64_MAX) * 2 + 1);
+            static_cast<int128_t>(INT64_MAX) * 2 + 1);
+#else
+  int128_t V = {.Low=UINT64_MAX, .High=INT64_MAX};
+  Val = WasmEdge_ValueGenV128(V);
+  EXPECT_TRUE( 0 == std::memcmp( &V, &Val, sizeof(V) ) );
+#endif
   Val = WasmEdge_ValueGenNullRef(WasmEdge_RefType_FuncRef);
   EXPECT_TRUE(WasmEdge_ValueIsNullRef(Val));
   Val = WasmEdge_ValueGenFuncRef(123U);

--- a/test/api/APIVMCoreTest.cpp
+++ b/test/api/APIVMCoreTest.cpp
@@ -162,8 +162,8 @@ TEST_P(CoreTest, TestSuites) {
     if (GlobCxt == nullptr) {
       return Unexpect(ErrCode::WrongInstanceAddress);
     }
-    return std::vector<ValVariant>{
-        WasmEdge_GlobalInstanceGetValue(GlobCxt).Value};
+    return convToValVec(std::vector<WasmEdge_Value>{
+        WasmEdge_GlobalInstanceGetValue(GlobCxt)});
   };
 
   T.run(Proposal, UnitName);

--- a/test/api/helper.cpp
+++ b/test/api/helper.cpp
@@ -44,15 +44,27 @@ std::vector<ValVariant> convToValVec(const std::vector<WasmEdge_Value> &CVals) {
   std::vector<ValVariant> Vals(CVals.size());
   std::transform(
       CVals.cbegin(), CVals.cend(), Vals.begin(),
-      [](const WasmEdge_Value &Val) { return ValVariant(Val.Value); });
+      [](const WasmEdge_Value &Val) {
+#if defined(__x86_64__) || defined(__aarch64__)
+        return ValVariant(Val.Value);
+#else
+        return ValVariant(WasmEdge::uint128_t(Val.Value.High, Val.Value.Low));
+#endif
+      });
   return Vals;
 }
 std::vector<WasmEdge_Value> convFromValVec(const std::vector<ValVariant> &Vals,
                                            const std::vector<ValType> &Types) {
   std::vector<WasmEdge_Value> CVals(Vals.size());
   for (uint32_t I = 0; I < Vals.size(); I++) {
-    CVals[I] = WasmEdge_Value{.Value = Vals[I].get<unsigned __int128>(),
+#if defined(__x86_64__) || defined(__aarch64__)
+    CVals[I] = WasmEdge_Value{.Value = Vals[I].get<WasmEdge::uint128_t>(),
                               .Type = static_cast<WasmEdge_ValType>(Types[I])};
+#else
+    WasmEdge::uint128_t Val= Vals[I].get<WasmEdge::uint128_t>();
+    CVals[I] = WasmEdge_Value{.Value = {.Low = Val.low(), .High = static_cast<uint64_t>(Val.high())},
+                              .Type = static_cast<WasmEdge_ValType>(Types[I])};
+#endif
   }
   return CVals;
 }

--- a/test/api/helper.h
+++ b/test/api/helper.h
@@ -15,6 +15,7 @@
 
 #include "../spec/spectest.h"
 #include "api/wasmedge.h"
+#include "common/int128.h"
 
 namespace WasmEdge {
 


### PR DESCRIPTION
1. Add struct int128_t / uint128_t in c api layer 
2. Add some help functions covert between  struct and class ( about int128_t / uint128_t)
3. Verify compile result done both 32bit and non 32bit env

**Test environment**

- docker image:
wasmedge/wasmedge:ubuntu2004_armv7l
- Install tool-chain manually: 
```bash
apt update && apt install -y python3 xz-utils libssl-dev rpm build-essential gcc g++ llvm-12-dev liblld-12-dev ninja-build git curl wget m4 gcc-multilib g++-multilib cmake libboost-all-dev
```
- Build commands:
```bash
cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_AOT_RUNTIME=OFF .
cmake --build build
```
