### PR TITLE
[Docs] Fix documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ WasmEdge (previously known as SSVM) is a lightweight, high-performance, and exte
 🚀 [Install](docs/install.md) WasmEdge \
 🤖 [Build](docs/build.md) and [contribute to](docs/CONTRIBUTING.md) WasmEdge \
 ⌨️ [Run](docs/run.md) a standalone Wasm program or a [JavaScript program](docs/run_javascript.md) from CLI \
-🔌 Embed a Wasm function in your [Node.js](https://www.secondstate.io/articles/getting-started-with-rust-function/), [Go](https://www.secondstate.io/articles/extend-golang-app-with-webassembly-rust/), or [Rust](https://github.com/super-node/WasmEdge/tree/master/wasmedge-rs) apps \
+🔌 Embed a Wasm function in your [Node.js](https://www.secondstate.io/articles/getting-started-with-rust-function/), [Go](https://www.secondstate.io/articles/extend-golang-app-with-webassembly-rust/), or [Rust](bindings/rust/wasmedge-rs) apps \
 🛠 Manage and orchestrate Wasm runtimes using [Docker tools](https://www.secondstate.io/articles/manage-webassembly-apps-in-wasmedge-using-docker-tools/), [data streaming frameworks](https://www.secondstate.io/articles/yomo-wasmedge-real-time-data-streams/), and [blockchains](https://medium.com/ethereum-on-steroids/running-ethereum-smart-contracts-in-a-substrate-blockchain-56fbc27fc95a)
 
 # Introduction
@@ -44,16 +44,16 @@ The WasmEdge Runtime provides a well-defined execution sandbox for its contained
 
 ## Features
 
-WasmEdge can run standard WebAssembly bytecode programs compiled from C/C++, Rust, Swift, AssemblyScript, or Kotlin source code. It also [runs JavaScript](docs/run_javascript.md) through an embedded [QuickJS engine](https://github.com/second-state/wasmedge-quickjs). WasmEdge supports all standard WebAssembly features and proposed extensions. It also supports a number of extensions tailored for cloud-native and edge computing uses (e.g., the [WasmEdge Tensorflow extension](https://www.secondstate.io/articles/wasi-tensorflow/)). 
+WasmEdge can run standard WebAssembly bytecode programs compiled from C/C++, Rust, Swift, AssemblyScript, or Kotlin source code. It also [runs JavaScript](https://www.secondstate.io/articles/run-javascript-in-webassembly-with-wasmedge/) through an embedded [QuickJS engine](https://github.com/second-state/wasmedge-quickjs). WasmEdge supports all standard WebAssembly features and proposed extensions. It also supports a number of extensions tailored for cloud-native and edge computing uses (e.g., the [WasmEdge Tensorflow extension](https://www.secondstate.io/articles/wasi-tensorflow/)). 
 
 * [WebAssembly standard extensions](docs/extensions.md#webassembly-standard-extensions)
 * [WasmEdge extensions](docs/extensions.md#wasmedge-extensions)
 
-WasmEdge extensions to WebAssembly are typically available to developers as Rust SDKs or [JavaScript APIs](docs/run_javascript.md). 
+WasmEdge extensions to WebAssembly are typically available to developers as Rust SDKs or [JavaScript APIs](https://www.secondstate.io/articles/run-javascript-in-webassembly-with-wasmedge/). 
 
 ## Integrations
 
-WasmEdge and its contained wasm program can be started from the [CLI](docs/run.md) as a new process, or from a existing process. If started from an existing process (e.g., from a running [Node.js](https://www.secondstate.io/articles/getting-started-with-rust-function/) or [Go](https://www.secondstate.io/articles/extend-golang-app-with-webassembly-rust/) or [Rust](https://github.com/super-node/WasmEdge/tree/master/wasmedge-rs) program), WasmEdge will simply run inside the process as a function. Currently, WasmEdge is not yet thread-safe. In order to use WasmEdge in your own application or cloud-native frameworks, please refer to the guides below.
+WasmEdge and its contained wasm program can be started from the [CLI](docs/run.md) as a new process, or from a existing process. If started from an existing process (e.g., from a running [Node.js](https://www.secondstate.io/articles/getting-started-with-rust-function/) or [Go](https://www.secondstate.io/articles/extend-golang-app-with-webassembly-rust/) or [Rust](bindings/rust/wasmedge-rs) program), WasmEdge will simply run inside the process as a function. Currently, WasmEdge is not yet thread-safe. In order to use WasmEdge in your own application or cloud-native frameworks, please refer to the guides below.
 
 * [Embed WasmEdge into a host application](docs/integrations.md#embed-wasmedge-into-a-host-application)
 * [Orchestrate and manage WasmEdge instances using container tools](docs/integrations.md#use-wasmedge-as-a-docker-like-container)

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -15,9 +15,11 @@
 * Tools: The runtime executables.
   * [WasmEdge-TensorFlow-Tools](https://github.com/second-state/WasmEdge-tensorflow-tools) are the released tools to execute WASM with accessing to `TensorFlow` or `TensorFlow-Lite`.
 * Language supports: The `WasmEdge` triggering in other languages.
-  * [SSVM-napi](https://github.com/second-state/SSVM-napi) is the Node.js addon project for `WASM` functions accessing.
-  * [SSVM-napi-extensions](https://github.com/second-state/SSVM-napi-extensions) is the Node.js addon project for `WASM` runtime with `ssvm-tensorflow`, `ssvm-image`, and `ssvm-storage` extensions.
-  * [WasmEdge-go](https://github.com/second-state/WasmEdge-go) is the [golang](https://golang.org/) binding for `WasmEdge` C API.
+  * The [C API](c_api.md) is embedded in the core release as a header file and shared library.
+  * [WasmEdge-core NAPI package](https://github.com/second-state/wasmedge-core) is the Node.js addon project for `WASM` functions.
+  * [WasmEdge-extensions NAPI package](https://github.com/second-state/wasmedge-extensions) is the Node.js addon project for `WASM` runtime with `wasmedge-tensorflow`, `wasmedge-image`, and `wasmedge-storage` extensions.
+  * [WasmEdge-go](https://github.com/second-state/WasmEdge-go) is the [Golang](https://golang.org/) binding for `WasmEdge` C API.
+  * [WasmEdge-rs](https://github.com/WasmEdge/WasmEdge/tree/master/bindings/rust) is the Rust binding for `WasmEdge` C API.
 
 ## Releasing Steps
 
@@ -29,5 +31,7 @@
     * [WasmEdge-EVMC](https://github.com/second-state/WasmEdge-evmc)
 3. Release a new version of tools.
     * [WasmEdge-TensorFlow-Tools](https://github.com/second-state/WasmEdge-tensorflow-tools)
-4. Release [SSVM-napi](https://github.com/second-state/SSVM-napi) with updating to the new `WasmEdge core`.
-5. Release [SSVM-napi-extensions](https://github.com/second-state/SSVM-napi-extensions) with updating to the new `WasmEdge core` and `SSVM-napi`.
+4. Release a new version of [Go SDK](https://github.com/second-state/WasmEdge-go)
+5. Release a new version of [Rust crate](https://github.com/WasmEdge/WasmEdge/tree/master/bindings/rust)
+6. Release [WasmEdge-core NAPI package](https://github.com/second-state/wasmedge-core) with updating to the new `WasmEdge core`.
+7. Release [WasmEdge-extensions NAPI package](https://github.com/second-state/wasmedge-extensions) with updating to the new extensions.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -4,7 +4,7 @@ WasmEdge is a "serverless" runtime for cloud native and edge computing applicati
 
 A major use case of WasmEdge is to start an VM instance from a host application. Depending on your host application's programming language, you can use WasmEdge SDKs to start and call WasmEdge functions.
 
-* Embed WasmEdge functions into a C-based application using the [WasmEdge C API](docs/c_api.md). Checkout the [quick start guide](docs/c_api_quick_start.md).
+* Embed WasmEdge functions into a C-based application using the [WasmEdge C API](c_api.md). Checkout the [quick start guide](c_api_quick_start.md).
 * Embed WasmEdge functions into a Go application using the [WasmEdge Go API](https://github.com/second-state/WasmEdge-go). Here is a [tutorial](https://www.secondstate.io/articles/extend-golang-app-with-webassembly-rust/) and are some [examples](https://github.com/second-state/WasmEdge-go-examples)!
 * Embed WasmEdge functions into a Rust application using the [WasmEdge Rust crate](../wasmedge-rs).
 * Embed WasmEdge functions into a Node.js application using the NAPI. Here is a [tutorial](https://www.secondstate.io/articles/getting-started-with-rust-function/).

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -6,9 +6,9 @@ A major use case of WasmEdge is to start an VM instance from a host application.
 
 * Embed WasmEdge functions into a C-based application using the [WasmEdge C API](c_api.md). Checkout the [quick start guide](c_api_quick_start.md).
 * Embed WasmEdge functions into a Go application using the [WasmEdge Go API](https://github.com/second-state/WasmEdge-go). Here is a [tutorial](https://www.secondstate.io/articles/extend-golang-app-with-webassembly-rust/) and are some [examples](https://github.com/second-state/WasmEdge-go-examples)!
-* Embed WasmEdge functions into a Rust application using the [WasmEdge Rust crate](../wasmedge-rs).
+* Embed WasmEdge functions into a Rust application using the [WasmEdge Rust crate](../bindings/rust/wasmedge-rs).
 * Embed WasmEdge functions into a Node.js application using the NAPI. Here is a [tutorial](https://www.secondstate.io/articles/getting-started-with-rust-function/).
-* Embed WasmEdge functions into any application by spawning a new process. See examples for [Vercel Serverless Functions](https://www.secondstate.io/articles/vercel-wasmedge-webassembly-rust/) and [AWS Lambda]().
+* Embed WasmEdge functions into any application by spawning a new process. See examples for [Vercel Serverless Functions](https://www.secondstate.io/articles/vercel-wasmedge-webassembly-rust/) and [AWS Lambda](https://www.cncf.io/blog/2021/08/25/webassembly-serverless-functions-in-aws-lambda/).
 
 However, the WebAssembly spec only supports very limited data types as input parameters and return values for the WebAssembly bytecode functions. In order to pass complex data types, such as a string of an array, as call arguments into Rust-based WasmEdge function, you should use the bindgen solution provided by the [rustwasmc](https://github.com/second-state/rustwasmc) toolchain. We currently supports bindgen in the [Node.js](https://www.secondstate.io/articles/getting-started-with-rust-function/) and in [Go](https://www.secondstate.io/articles/extend-golang-app-with-webassembly-rust/). We are working on [supporting interface types](https://github.com/WasmEdge/WasmEdge/issues/264) in place of bindgen for future releases.
 

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -24,7 +24,7 @@ WasmEdge is a cloud-native WebAssembly runtime hosted by the CNCF. It is widely 
 
 ## Cloud-native runtime (as a lightweight Docker alternative) 
 
-WasmEdge can be embedded into cloud-native infrastructure via its SDKs in [C](https://github.com/WasmEdge/WasmEdge/blob/master/docs/c_api.md), [Go](https://www.secondstate.io/articles/extend-golang-app-with-webassembly-rust/), [Rust](https://github.com/WasmEdge/WasmEdge/tree/master/wasmedge-rs), and [JavaScript](https://www.secondstate.io/articles/getting-started-with-rust-function/). It is also an OCI compliant runtime that can be directly [managed by CRI-O and Docker tools](https://www.secondstate.io/articles/manage-webassembly-apps-in-wasmedge-using-docker-tools/) as a lightweight and high-performance alternative to Docker. 
+WasmEdge can be embedded into cloud-native infrastructure via its SDKs in [C](c_api.md), [Go](https://www.secondstate.io/articles/extend-golang-app-with-webassembly-rust/), [Rust](../bindings/rust/wasmedge-rs), and [JavaScript](https://www.secondstate.io/articles/getting-started-with-rust-function/). It is also an OCI compliant runtime that can be directly [managed by CRI-O and Docker tools](https://www.secondstate.io/articles/manage-webassembly-apps-in-wasmedge-using-docker-tools/) as a lightweight and high-performance alternative to Docker. 
 
 ### Dapr (Distributed Application Runtime)
 


### PR DESCRIPTION
As we move docs and language binding SDKs, there are broken links in our system. We are fixing them as we encounter them.