### PR TITLE
[Utils] Install Script: macOS packaging change

### DIFF
--- a/utils/install.sh
+++ b/utils/install.sh
@@ -91,7 +91,7 @@ get_latest_release() {
     res=$(git ls-remote --refs --tags "https://github.com/$1.git" |
         cut -d '/' -f 3 |
         sort --version-sort |
-        grep -vE rc |
+        grep -e '^[0-9].[0-9].[0-9]$' |
         tail -1)
     echo "$res"
 }


### PR DESCRIPTION
* Packaging of macOS is now similar to linux

Fix for: #495 #482 

Testing:
```bash
wget -qO- https://raw.githubusercontent.com/SAtacker/WasmEdge/fix_install_script/utils/install.sh | bash -s -- -e all --version=0.8.2
```

Signed-off-by: Shreyas Atre <shreyasatre16@gmail.com>