### PR TITLE
[CI] Remove test branch name

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -14,7 +14,6 @@ on:
   push:
     branches:
       - master
-      - avinal/issue519
     paths-ignore:
       - 'docs/**'
       - '*.md'


### PR DESCRIPTION
## What is Changed?
- Removes redundant branch name mereged via PR #521

## Why?
 I apologize for this silly mistake. It just slipped through all our review. This PR fixes that.
 https://github.com/WasmEdge/WasmEdge/blob/b2a96f256b967031f013a01d6eaaefa9fb42418c/.github/workflows/static-code-analysis.yml#L17

Signed-off-by: Avinal Kumar <avinal.xlvii@gmail.com>