### PR TITLE
Return the results with types for execution.

### DIFF
--- a/docs/externref.md
+++ b/docs/externref.md
@@ -106,8 +106,12 @@ Noted that `MulFunc` is a function definition in above, which is: `uint32_t MulF
 ```cpp
 std::vector<WasmEdge::ValVariant> FuncArgs = {WasmEdge::genExternRef(MulFunc), 789U, 4321U};
 std::vector<WasmEdge::ValType> FuncArgTypes = {WasmEdge::ValType::ExternRef, WasmEdge::ValType::I32, WasmEdge::ValType::I32};
-std::vector<WasmEdge::ValVariant> Returns = *(VM.execute("call_mul", FuncArgs, FuncArgTypes));
-std::cout << Returns[0].get<uint32_t>(); // will print 3409269
+auto Result = VM.execute("call_mul", FuncArgs, FuncArgTypes);
+if (Result) {
+  std::vector<std::pair<WasmEdge::ValVariant, WasmEdge::ValType>> &Returns = *Result;
+  std::cout << Returns[0].first.get<uint32_t>(); // will print 3409269
+  // The `Returns[0].second` must be `WasmEdge::ValType::I32` because the `call_mul` returns an i32 value.
+}
 ```
 
 ## Passing Objects
@@ -132,8 +136,12 @@ Then users can pass the object into WasmEdge by using `WasmEdge::genExternRef()`
 ```cpp
 std::vector<WasmEdge::ValVariant> FuncArgs = {WasmEdge::genExternRef(&AC), 1234U, 5678U};
 std::vector<WasmEdge::ValType> FuncArgTypes = {WasmEdge::ValType::ExternRef, WasmEdge::ValType::I32, WasmEdge::ValType::I32};
-std::vector<WasmEdge::ValVariant> Returns = *(VM.execute("call_add", FuncArgs, FuncArgTypes));
-std::cout << Returns[0].get<uint32_t>(); // will print 6912
+auto Result = VM.execute("call_add", FuncArgs, FuncArgTypes);
+if (Result) {
+  std::pair<std::vector<WasmEdge::ValVariant>, std::vector<WasmEdge::ValType>> &Returns = *Result;
+  std::cout << Returns.first[0].get<uint32_t>(); // will print 6912
+  // The `Returns.second[0]` must be `WasmEdge::ValType::I32` because the `call_add` returns an i32 value.
+}
 ```
 
 In the host function which would access the object by reference, users can use "`retrieveExternRef`" API to retrieve the reference to the object.
@@ -168,8 +176,12 @@ Then users can pass the object into WasmEdge by using `WasmEdge::genExternRef()`
 ```cpp
 std::vector<WasmEdge::ValVariant> FuncArgs = {WasmEdge::genExternRef(&SS), 1024U};
 std::vector<WasmEdge::ValType> FuncArgTypes = {WasmEdge::ValType::ExternRef, WasmEdge::ValType::I32};
-std::vector<WasmEdge::ValVariant> Returns = *(VM.execute("call_square", FuncArgs, FuncArgTypes));
-std::cout << Returns[0].get<uint32_t>(); // will print 1048576
+auto Result = VM.execute("call_square", FuncArgs, FuncArgTypes);
+if (Result) {
+  std::pair<std::vector<WasmEdge::ValVariant>, std::vector<WasmEdge::ValType>> &Returns = *Result;
+  std::cout << Returns.first[0].get<uint32_t>(); // will print 1048576
+  // The `Returns.second[0]` must be `WasmEdge::ValType::I32` because the `call_square` returns an i32 value.
+}
 ```
 
 In the host function which would access the object by reference, users can use "`retrieveExternRef`" API to retrieve the reference to the object, and the reference is a functor.

--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -105,10 +105,9 @@ public:
                               const AST::Module &Mod, std::string_view Name);
 
   /// Invoke function by function address in Store manager.
-  Expect<std::vector<ValVariant>> invoke(Runtime::StoreManager &StoreMgr,
-                                         const uint32_t FuncAddr,
-                                         Span<const ValVariant> Params,
-                                         Span<const ValType> ParamTypes);
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
+  invoke(Runtime::StoreManager &StoreMgr, const uint32_t FuncAddr,
+         Span<const ValVariant> Params, Span<const ValType> ParamTypes);
 
 private:
   /// Run Wasm bytecode expression for initialization.

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -48,15 +48,15 @@ public:
   Expect<void> registerModule(const Runtime::ImportObject &Obj);
 
   /// Rapidly load, validate, instantiate, and run wasm function.
-  Expect<std::vector<ValVariant>>
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
   runWasmFile(const std::filesystem::path &Path, std::string_view Func,
               Span<const ValVariant> Params = {},
               Span<const ValType> ParamTypes = {});
-  Expect<std::vector<ValVariant>>
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
   runWasmFile(Span<const Byte> Code, std::string_view Func,
               Span<const ValVariant> Params = {},
               Span<const ValType> ParamTypes = {});
-  Expect<std::vector<ValVariant>>
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
   runWasmFile(const AST::Module &Module, std::string_view Func,
               Span<const ValVariant> Params = {},
               Span<const ValType> ParamTypes = {});
@@ -76,15 +76,15 @@ public:
 
   /// ======= Functions can be called after instantiated stage. =======
   /// Execute wasm with given input.
-  Expect<std::vector<ValVariant>> execute(std::string_view Func,
-                                          Span<const ValVariant> Params = {},
-                                          Span<const ValType> ParamTypes = {});
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
+  execute(std::string_view Func, Span<const ValVariant> Params = {},
+          Span<const ValType> ParamTypes = {});
 
   /// Execute function of registered module with given input.
-  Expect<std::vector<ValVariant>> execute(std::string_view Mod,
-                                          std::string_view Func,
-                                          Span<const ValVariant> Params = {},
-                                          Span<const ValType> ParamTypes = {});
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
+  execute(std::string_view Mod, std::string_view Func,
+          Span<const ValVariant> Params = {},
+          Span<const ValType> ParamTypes = {});
 
   /// ======= Functions which are stageless. =======
   /// Clean up VM status
@@ -109,7 +109,7 @@ private:
   void initVM();
 
   /// Helper function for execution.
-  Expect<std::vector<ValVariant>>
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
   execute(Runtime::Instance::ModuleInstance *ModInst, std::string_view Func,
           Span<const ValVariant> Params = {},
           Span<const ValType> ParamTypes = {});

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -217,14 +217,15 @@ inline std::string_view genStrView(const WasmEdge_String S) noexcept {
 
 /// Helper functions for converting a ValVariant vector to a WasmEdge_Value
 /// array.
-inline constexpr void fillWasmEdge_ValueArr(Span<const ValVariant> Vec,
-                                            WasmEdge_Value *Val,
-                                            const uint32_t Len) noexcept {
+inline constexpr void
+fillWasmEdge_ValueArr(Span<const std::pair<ValVariant, ValType>> Vec,
+                      WasmEdge_Value *Val, const uint32_t Len) noexcept {
   if (Val == nullptr) {
     return;
   }
   for (uint32_t I = 0; I < Len && I < Vec.size(); I++) {
-    Val[I] = genWasmEdge_Value(Vec[I], WasmEdge_ValType_I32);
+    Val[I] = genWasmEdge_Value(Vec[I].first,
+                               static_cast<WasmEdge_ValType>(Vec[I].second));
   }
 }
 
@@ -1431,7 +1432,9 @@ WASMEDGE_CAPI_EXPORT WasmEdge_Result WasmEdge_ExecutorInvoke(
   auto ParamPair = genParamPair(Params, ParamLen);
   auto FuncStr = genStrView(FuncName);
   return wrap(
-      [&]() -> WasmEdge::Expect<std::vector<WasmEdge::ValVariant>> {
+      [&]()
+          -> WasmEdge::Expect<
+              std::vector<std::pair<WasmEdge::ValVariant, WasmEdge::ValType>>> {
         /// Get module instance.
         WasmEdge::Runtime::Instance::ModuleInstance *ModInst;
         if (auto Res = fromStoreCxt(StoreCxt)->getActiveModule()) {
@@ -1466,7 +1469,9 @@ WASMEDGE_CAPI_EXPORT WasmEdge_Result WasmEdge_ExecutorInvokeRegistered(
   auto ModStr = genStrView(ModuleName);
   auto FuncStr = genStrView(FuncName);
   return wrap(
-      [&]() -> WasmEdge::Expect<std::vector<WasmEdge::ValVariant>> {
+      [&]()
+          -> WasmEdge::Expect<
+              std::vector<std::pair<WasmEdge::ValVariant, WasmEdge::ValType>>> {
         /// Get module instance.
         WasmEdge::Runtime::Instance::ModuleInstance *ModInst;
         if (auto Res = fromStoreCxt(StoreCxt)->findModule(ModStr)) {

--- a/lib/vm/vm.cpp
+++ b/lib/vm/vm.cpp
@@ -91,7 +91,7 @@ Expect<void> VM::registerModule(std::string_view Name,
   return ExecutorEngine.registerModule(StoreRef, Module, Name);
 }
 
-Expect<std::vector<ValVariant>>
+Expect<std::vector<std::pair<ValVariant, ValType>>>
 VM::runWasmFile(const std::filesystem::path &Path, std::string_view Func,
                 Span<const ValVariant> Params, Span<const ValType> ParamTypes) {
   if (Stage == VMStage::Instantiated) {
@@ -107,7 +107,7 @@ VM::runWasmFile(const std::filesystem::path &Path, std::string_view Func,
   }
 }
 
-Expect<std::vector<ValVariant>>
+Expect<std::vector<std::pair<ValVariant, ValType>>>
 VM::runWasmFile(Span<const Byte> Code, std::string_view Func,
                 Span<const ValVariant> Params, Span<const ValType> ParamTypes) {
   if (Stage == VMStage::Instantiated) {
@@ -123,7 +123,7 @@ VM::runWasmFile(Span<const Byte> Code, std::string_view Func,
   }
 }
 
-Expect<std::vector<ValVariant>>
+Expect<std::vector<std::pair<ValVariant, ValType>>>
 VM::runWasmFile(const AST::Module &Module, std::string_view Func,
                 Span<const ValVariant> Params, Span<const ValType> ParamTypes) {
   if (Stage == VMStage::Instantiated) {
@@ -204,9 +204,9 @@ Expect<void> VM::instantiate() {
   }
 }
 
-Expect<std::vector<ValVariant>> VM::execute(std::string_view Func,
-                                            Span<const ValVariant> Params,
-                                            Span<const ValType> ParamTypes) {
+Expect<std::vector<std::pair<ValVariant, ValType>>>
+VM::execute(std::string_view Func, Span<const ValVariant> Params,
+            Span<const ValType> ParamTypes) {
   /// Get module instance.
   if (auto Res = StoreRef.getActiveModule()) {
     /// Execute function and return values with the module instance.
@@ -218,10 +218,9 @@ Expect<std::vector<ValVariant>> VM::execute(std::string_view Func,
   }
 }
 
-Expect<std::vector<ValVariant>> VM::execute(std::string_view ModName,
-                                            std::string_view Func,
-                                            Span<const ValVariant> Params,
-                                            Span<const ValType> ParamTypes) {
+Expect<std::vector<std::pair<ValVariant, ValType>>>
+VM::execute(std::string_view ModName, std::string_view Func,
+            Span<const ValVariant> Params, Span<const ValType> ParamTypes) {
   /// Get module instance.
   if (auto Res = StoreRef.findModule(ModName)) {
     /// Execute function and return values with the module instance.
@@ -233,7 +232,7 @@ Expect<std::vector<ValVariant>> VM::execute(std::string_view ModName,
   }
 }
 
-Expect<std::vector<ValVariant>>
+Expect<std::vector<std::pair<ValVariant, ValType>>>
 VM::execute(Runtime::Instance::ModuleInstance *ModInst, std::string_view Func,
             Span<const ValVariant> Params, Span<const ValType> ParamTypes) {
   /// Get exports and find function.

--- a/test/aot/AOTcoreTest.cpp
+++ b/test/aot/AOTcoreTest.cpp
@@ -107,7 +107,7 @@ TEST_P(NativeCoreTest, TestSuites) {
   T.onInvoke = [&VM](const std::string &ModName, const std::string &Field,
                      const std::vector<ValVariant> &Params,
                      const std::vector<ValType> &ParamTypes)
-      -> Expect<std::vector<ValVariant>> {
+      -> Expect<std::vector<std::pair<ValVariant, ValType>>> {
     if (!ModName.empty()) {
       /// Invoke function of named module. Named modules are registered in
       /// Store Manager.
@@ -119,8 +119,8 @@ TEST_P(NativeCoreTest, TestSuites) {
     }
   };
   /// Helper function to get values.
-  T.onGet = [&VM](const std::string &ModName,
-                  const std::string &Field) -> Expect<std::vector<ValVariant>> {
+  T.onGet = [&VM](const std::string &ModName, const std::string &Field)
+      -> Expect<std::pair<ValVariant, ValType>> {
     /// Get module instance.
     auto &Store = VM.getStoreManager();
     WasmEdge::Runtime::Instance::ModuleInstance *ModInst = nullptr;
@@ -142,7 +142,8 @@ TEST_P(NativeCoreTest, TestSuites) {
     uint32_t GlobAddr = Globs.find(Field)->second;
     auto *GlobInst = *Store.getGlobal(GlobAddr);
 
-    return std::vector<WasmEdge::ValVariant>{GlobInst->getValue()};
+    return std::make_pair(GlobInst->getValue(),
+                          GlobInst->getGlobalType().getValType());
   };
 
   T.run(Proposal, UnitName);
@@ -213,7 +214,7 @@ TEST_P(CustomWasmCoreTest, TestSuites) {
   T.onInvoke = [&VM](const std::string &ModName, const std::string &Field,
                      const std::vector<ValVariant> &Params,
                      const std::vector<ValType> &ParamTypes)
-      -> Expect<std::vector<ValVariant>> {
+      -> Expect<std::vector<std::pair<ValVariant, ValType>>> {
     if (!ModName.empty()) {
       /// Invoke function of named module. Named modules are registered in
       /// Store Manager.
@@ -225,8 +226,8 @@ TEST_P(CustomWasmCoreTest, TestSuites) {
     }
   };
   /// Helper function to get values.
-  T.onGet = [&VM](const std::string &ModName,
-                  const std::string &Field) -> Expect<std::vector<ValVariant>> {
+  T.onGet = [&VM](const std::string &ModName, const std::string &Field)
+      -> Expect<std::pair<ValVariant, ValType>> {
     /// Get module instance.
     auto &Store = VM.getStoreManager();
     WasmEdge::Runtime::Instance::ModuleInstance *ModInst = nullptr;
@@ -248,7 +249,8 @@ TEST_P(CustomWasmCoreTest, TestSuites) {
     uint32_t GlobAddr = Globs.find(Field)->second;
     auto *GlobInst = *Store.getGlobal(GlobAddr);
 
-    return std::vector<WasmEdge::ValVariant>{GlobInst->getValue()};
+    return std::make_pair(GlobInst->getValue(),
+                          GlobInst->getGlobalType().getValType());
   };
 
   T.run(Proposal, UnitName);

--- a/test/api/APIAOTCoreTest.cpp
+++ b/test/api/APIAOTCoreTest.cpp
@@ -137,7 +137,7 @@ TEST_P(CoreTest, TestSuites) {
   T.onInvoke = [&VM](const std::string &ModName, const std::string &Field,
                      const std::vector<ValVariant> &Params,
                      const std::vector<ValType> &ParamTypes)
-      -> Expect<std::vector<ValVariant>> {
+      -> Expect<std::vector<std::pair<ValVariant, ValType>>> {
     WasmEdge_Result Res;
     std::vector<WasmEdge_Value> CParams = convFromValVec(Params, ParamTypes);
     std::vector<WasmEdge_Value> CReturns;
@@ -181,8 +181,8 @@ TEST_P(CoreTest, TestSuites) {
     return convToValVec(CReturns);
   };
   /// Helper function to get values.
-  T.onGet = [&VM](const std::string &ModName,
-                  const std::string &Field) -> Expect<std::vector<ValVariant>> {
+  T.onGet = [&VM](const std::string &ModName, const std::string &Field)
+      -> Expect<std::pair<ValVariant, ValType>> {
     /// Get global instance.
     WasmEdge_StoreContext *StoreCxt = WasmEdge_VMGetStoreContext(VM);
     WasmEdge_String ModStr = WasmEdge_StringWrap(
@@ -194,8 +194,9 @@ TEST_P(CoreTest, TestSuites) {
     if (GlobCxt == nullptr) {
       return Unexpect(ErrCode::WrongInstanceAddress);
     }
-    return std::vector<ValVariant>{
-        WasmEdge_GlobalInstanceGetValue(GlobCxt).Value};
+    WasmEdge_Value Val = WasmEdge_GlobalInstanceGetValue(GlobCxt);
+    return std::make_pair(ValVariant(Val.Value),
+                          static_cast<ValType>(Val.Type));
   };
 
   T.run(Proposal, UnitName);

--- a/test/api/APIStepsCoreTest.cpp
+++ b/test/api/APIStepsCoreTest.cpp
@@ -122,7 +122,7 @@ TEST_P(CoreTest, TestSuites) {
   T.onInvoke = [&](const std::string &ModName, const std::string &Field,
                    const std::vector<ValVariant> &Params,
                    const std::vector<ValType> &ParamTypes)
-      -> Expect<std::vector<ValVariant>> {
+      -> Expect<std::vector<std::pair<ValVariant, ValType>>> {
     WasmEdge_Result Res;
     std::vector<WasmEdge_Value> CParams = convFromValVec(Params, ParamTypes);
     std::vector<WasmEdge_Value> CReturns;
@@ -171,8 +171,9 @@ TEST_P(CoreTest, TestSuites) {
     return convToValVec(CReturns);
   };
   /// Helper function to get values.
-  T.onGet = [&](const std::string &ModName,
-                const std::string &Field) -> Expect<std::vector<ValVariant>> {
+  T.onGet =
+      [&](const std::string &ModName,
+          const std::string &Field) -> Expect<std::pair<ValVariant, ValType>> {
     /// Get global instance.
     WasmEdge_String ModStr = WasmEdge_StringWrap(
         ModName.data(), static_cast<uint32_t>(ModName.length()));
@@ -183,8 +184,9 @@ TEST_P(CoreTest, TestSuites) {
     if (GlobCxt == nullptr) {
       return Unexpect(ErrCode::WrongInstanceAddress);
     }
-    return convToValVec(
-        std::vector<WasmEdge_Value>{WasmEdge_GlobalInstanceGetValue(GlobCxt)});
+    WasmEdge_Value Val = WasmEdge_GlobalInstanceGetValue(GlobCxt);
+    return std::make_pair(ValVariant(Val.Value),
+                          static_cast<ValType>(Val.Type));
   };
 
   T.run(Proposal, UnitName);

--- a/test/api/APIUnitTest.cpp
+++ b/test/api/APIUnitTest.cpp
@@ -1068,7 +1068,9 @@ TEST(APICoreTest, ExecutorWithStatistics) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_ExecutorInvoke(ExecCxt, Store, FuncName, P, 2, R, 2)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   EXPECT_EQ(912, WasmEdge_ValueGetI32(R[1]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type);
   EXPECT_FALSE(WasmEdge_ResultOK(
       WasmEdge_ExecutorInvoke(nullptr, Store, FuncName, P, 2, R, 2)));
   EXPECT_FALSE(WasmEdge_ResultOK(
@@ -1095,6 +1097,7 @@ TEST(APICoreTest, ExecutorWithStatistics) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_ExecutorInvoke(ExecCxt, Store, FuncName, P, 2, R, 1)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   /// Discard result
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_ExecutorInvoke(ExecCxt, Store, FuncName, P, 2, nullptr, 0)));
@@ -1127,6 +1130,7 @@ TEST(APICoreTest, ExecutorWithStatistics) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_ExecutorInvoke(ExecCxt, Store, FuncName, P, 1, R, 1)));
   EXPECT_EQ(1000, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   WasmEdge_StringDelete(FuncName);
   /// Call sub: (123) - (456)
   FuncName = WasmEdge_StringCreateByCString("func-host-sub");
@@ -1135,6 +1139,7 @@ TEST(APICoreTest, ExecutorWithStatistics) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_ExecutorInvoke(ExecCxt, Store, FuncName, P, 1, R, 1)));
   EXPECT_EQ(-333, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   WasmEdge_StringDelete(FuncName);
   /// Call mul: (-30) * (-66)
   FuncName = WasmEdge_StringCreateByCString("func-host-mul");
@@ -1143,6 +1148,7 @@ TEST(APICoreTest, ExecutorWithStatistics) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_ExecutorInvoke(ExecCxt, Store, FuncName, P, 1, R, 1)));
   EXPECT_EQ(1980, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   WasmEdge_StringDelete(FuncName);
   /// Call div: (-9999) / (1234)
   FuncName = WasmEdge_StringCreateByCString("func-host-div");
@@ -1151,6 +1157,7 @@ TEST(APICoreTest, ExecutorWithStatistics) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_ExecutorInvoke(ExecCxt, Store, FuncName, P, 1, R, 1)));
   EXPECT_EQ(-8, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   WasmEdge_StringDelete(FuncName);
 
   /// Invoke functions of registered module
@@ -1164,6 +1171,7 @@ TEST(APICoreTest, ExecutorWithStatistics) {
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_ExecutorInvokeRegistered(
       ExecCxt, Store, ModName, FuncName, P, 2, R, 1)));
   EXPECT_EQ(6500, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   EXPECT_FALSE(WasmEdge_ResultOK(WasmEdge_ExecutorInvokeRegistered(
       nullptr, Store, ModName, FuncName, P, 2, R, 1)));
   EXPECT_FALSE(WasmEdge_ResultOK(WasmEdge_ExecutorInvokeRegistered(
@@ -1226,6 +1234,7 @@ TEST(APICoreTest, ExecutorWithStatistics) {
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_ExecutorInvokeRegistered(
       ExecCxt, Store, ModName, FuncName, P, 2, R, 1)));
   EXPECT_EQ(-266, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   WasmEdge_StringDelete(FuncName);
   FuncName = WasmEdge_StringCreateByCString("func-term");
   Res = WasmEdge_ExecutorInvokeRegistered(ExecCxt, Store, ModName, FuncName,
@@ -2058,7 +2067,9 @@ TEST(APICoreTest, VM) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMRunWasmFromFile(VM, TPath, FuncName, P, 2, R, 2)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   EXPECT_EQ(912, WasmEdge_ValueGetI32(R[1]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type);
   EXPECT_FALSE(WasmEdge_ResultOK(
       WasmEdge_VMRunWasmFromFile(nullptr, TPath, FuncName, P, 2, R, 2)));
   EXPECT_FALSE(WasmEdge_ResultOK(
@@ -2085,6 +2096,7 @@ TEST(APICoreTest, VM) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMRunWasmFromFile(VM, TPath, FuncName, P, 2, R, 1)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   /// Discard result
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMRunWasmFromFile(VM, TPath, FuncName, P, 2, nullptr, 0)));
@@ -2099,7 +2111,9 @@ TEST(APICoreTest, VM) {
       VM, Buf.data(), static_cast<uint32_t>(Buf.size()), FuncName, P, 2, R,
       2)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   EXPECT_EQ(912, WasmEdge_ValueGetI32(R[1]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type);
   EXPECT_FALSE(WasmEdge_ResultOK(WasmEdge_VMRunWasmFromBuffer(
       nullptr, Buf.data(), static_cast<uint32_t>(Buf.size()), FuncName, P, 2, R,
       2)));
@@ -2133,6 +2147,7 @@ TEST(APICoreTest, VM) {
       VM, Buf.data(), static_cast<uint32_t>(Buf.size()), FuncName, P, 2, R,
       1)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   /// Discard result
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_VMRunWasmFromBuffer(
       VM, Buf.data(), static_cast<uint32_t>(Buf.size()), FuncName, P, 2,
@@ -2148,7 +2163,9 @@ TEST(APICoreTest, VM) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMRunWasmFromASTModule(VM, Mod, FuncName, P, 2, R, 2)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   EXPECT_EQ(912, WasmEdge_ValueGetI32(R[1]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type);
   EXPECT_FALSE(WasmEdge_ResultOK(
       WasmEdge_VMRunWasmFromASTModule(nullptr, Mod, FuncName, P, 2, R, 2)));
   EXPECT_FALSE(WasmEdge_ResultOK(
@@ -2175,6 +2192,7 @@ TEST(APICoreTest, VM) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMRunWasmFromASTModule(VM, Mod, FuncName, P, 2, R, 1)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   /// Discard result
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMRunWasmFromASTModule(VM, Mod, FuncName, P, 2, nullptr, 0)));
@@ -2236,7 +2254,9 @@ TEST(APICoreTest, VM) {
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_VMInstantiate(VM)));
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_VMExecute(VM, FuncName, P, 2, R, 2)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   EXPECT_EQ(912, WasmEdge_ValueGetI32(R[1]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type);
   EXPECT_FALSE(
       WasmEdge_ResultOK(WasmEdge_VMExecute(nullptr, FuncName, P, 2, R, 2)));
   /// Function type mismatch
@@ -2258,6 +2278,7 @@ TEST(APICoreTest, VM) {
   R[0] = WasmEdge_ValueGenI32(0);
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_VMExecute(VM, FuncName, P, 2, R, 1)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   /// Discard result
   EXPECT_TRUE(
       WasmEdge_ResultOK(WasmEdge_VMExecute(VM, FuncName, P, 2, nullptr, 0)));
@@ -2272,7 +2293,9 @@ TEST(APICoreTest, VM) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMExecuteRegistered(VM, ModName, FuncName, P, 2, R, 2)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   EXPECT_EQ(912, WasmEdge_ValueGetI32(R[1]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type);
   EXPECT_FALSE(WasmEdge_ResultOK(
       WasmEdge_VMExecuteRegistered(nullptr, ModName, FuncName, P, 2, R, 2)));
   /// Function type mismatch
@@ -2300,6 +2323,7 @@ TEST(APICoreTest, VM) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMExecuteRegistered(VM, ModName, FuncName, P, 2, R, 1)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
+  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type);
   /// Discard result
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMExecuteRegistered(VM, ModName, FuncName, P, 2, nullptr, 0)));

--- a/test/api/APIVMCoreTest.cpp
+++ b/test/api/APIVMCoreTest.cpp
@@ -103,7 +103,7 @@ TEST_P(CoreTest, TestSuites) {
   T.onInvoke = [&VM](const std::string &ModName, const std::string &Field,
                      const std::vector<ValVariant> &Params,
                      const std::vector<ValType> &ParamTypes)
-      -> Expect<std::vector<ValVariant>> {
+      -> Expect<std::vector<std::pair<ValVariant, ValType>>> {
     WasmEdge_Result Res;
     std::vector<WasmEdge_Value> CParams = convFromValVec(Params, ParamTypes);
     std::vector<WasmEdge_Value> CReturns;
@@ -147,8 +147,8 @@ TEST_P(CoreTest, TestSuites) {
     return convToValVec(CReturns);
   };
   /// Helper function to get values.
-  T.onGet = [&VM](const std::string &ModName,
-                  const std::string &Field) -> Expect<std::vector<ValVariant>> {
+  T.onGet = [&VM](const std::string &ModName, const std::string &Field)
+      -> Expect<std::pair<ValVariant, ValType>> {
     /// Get global instance.
     WasmEdge_StoreContext *StoreCxt = WasmEdge_VMGetStoreContext(VM);
     WasmEdge_String ModStr = WasmEdge_StringWrap(
@@ -160,8 +160,9 @@ TEST_P(CoreTest, TestSuites) {
     if (GlobCxt == nullptr) {
       return Unexpect(ErrCode::WrongInstanceAddress);
     }
-    return convToValVec(
-        std::vector<WasmEdge_Value>{WasmEdge_GlobalInstanceGetValue(GlobCxt)});
+    WasmEdge_Value Val = WasmEdge_GlobalInstanceGetValue(GlobCxt);
+    return std::make_pair(ValVariant(Val.Value),
+                          static_cast<ValType>(Val.Type));
   };
 
   T.run(Proposal, UnitName);

--- a/test/api/helper.cpp
+++ b/test/api/helper.cpp
@@ -40,19 +40,23 @@ ErrCode convResult(WasmEdge_Result Res) {
   return static_cast<ErrCode>(Res.Code);
 }
 
-std::vector<ValVariant> convToValVec(const std::vector<WasmEdge_Value> &CVals) {
-  std::vector<ValVariant> Vals(CVals.size());
-  std::transform(
-      CVals.cbegin(), CVals.cend(), Vals.begin(),
-      [](const WasmEdge_Value &Val) {
+std::vector<std::pair<ValVariant, ValType>>
+convToValVec(const std::vector<WasmEdge_Value> &CVals) {
+  std::vector<std::pair<ValVariant, ValType>> Vals(CVals.size());
+  std::transform(CVals.cbegin(), CVals.cend(), Vals.begin(),
+                 [](const WasmEdge_Value &Val) {
 #if defined(__x86_64__) || defined(__aarch64__)
-        return ValVariant(Val.Value);
+                   return std::make_pair(ValVariant(Val.Value),
+                                         static_cast<ValType>(Val.Type));
 #else
-        return ValVariant(WasmEdge::uint128_t(Val.Value.High, Val.Value.Low));
+                   return std::make_pair(ValVariant(WasmEdge::uint128_t(
+                                             Val.Value.High, Val.Value.Low)),
+                                         static_cast<ValType>(Val.Type));
 #endif
-      });
+                 });
   return Vals;
 }
+
 std::vector<WasmEdge_Value> convFromValVec(const std::vector<ValVariant> &Vals,
                                            const std::vector<ValType> &Types) {
   std::vector<WasmEdge_Value> CVals(Vals.size());
@@ -61,9 +65,10 @@ std::vector<WasmEdge_Value> convFromValVec(const std::vector<ValVariant> &Vals,
     CVals[I] = WasmEdge_Value{.Value = Vals[I].get<WasmEdge::uint128_t>(),
                               .Type = static_cast<WasmEdge_ValType>(Types[I])};
 #else
-    WasmEdge::uint128_t Val= Vals[I].get<WasmEdge::uint128_t>();
-    CVals[I] = WasmEdge_Value{.Value = {.Low = Val.low(), .High = static_cast<uint64_t>(Val.high())},
-                              .Type = static_cast<WasmEdge_ValType>(Types[I])};
+    WasmEdge::uint128_t Val = Vals[I].get<WasmEdge::uint128_t>();
+    CVals[I] = WasmEdge_Value{
+        .Value = {.Low = Val.low(), .High = static_cast<uint64_t>(Val.high())},
+        .Type = static_cast<WasmEdge_ValType>(Types[I])};
 #endif
   }
   return CVals;

--- a/test/api/helper.h
+++ b/test/api/helper.h
@@ -23,7 +23,8 @@ WasmEdge_ConfigureContext *createConf(const Configure &Conf);
 
 ErrCode convResult(WasmEdge_Result Res);
 
-std::vector<ValVariant> convToValVec(const std::vector<WasmEdge_Value> &CVals);
+std::vector<std::pair<ValVariant, ValType>>
+convToValVec(const std::vector<WasmEdge_Value> &CVals);
 
 std::vector<WasmEdge_Value> convFromValVec(const std::vector<ValVariant> &Vals,
                                            const std::vector<ValType> &Types);

--- a/test/executor/ExecutorTest.cpp
+++ b/test/executor/ExecutorTest.cpp
@@ -63,7 +63,7 @@ TEST_P(CoreTest, TestSuites) {
   T.onInvoke = [&VM](const std::string &ModName, const std::string &Field,
                      const std::vector<ValVariant> &Params,
                      const std::vector<ValType> &ParamTypes)
-      -> Expect<std::vector<ValVariant>> {
+      -> Expect<std::vector<std::pair<ValVariant, ValType>>> {
     if (!ModName.empty()) {
       /// Invoke function of named module. Named modules are registered in
       /// Store Manager.
@@ -75,8 +75,8 @@ TEST_P(CoreTest, TestSuites) {
     }
   };
   /// Helper function to get values.
-  T.onGet = [&VM](const std::string &ModName,
-                  const std::string &Field) -> Expect<std::vector<ValVariant>> {
+  T.onGet = [&VM](const std::string &ModName, const std::string &Field)
+      -> Expect<std::pair<ValVariant, ValType>> {
     /// Get module instance.
     auto &Store = VM.getStoreManager();
     WasmEdge::Runtime::Instance::ModuleInstance *ModInst = nullptr;
@@ -98,7 +98,8 @@ TEST_P(CoreTest, TestSuites) {
     uint32_t GlobAddr = Globs.find(Field)->second;
     auto *GlobInst = *Store.getGlobal(GlobAddr);
 
-    return std::vector<WasmEdge::ValVariant>{GlobInst->getValue()};
+    return std::make_pair(GlobInst->getValue(),
+                          GlobInst->getGlobalType().getValType());
   };
 
   T.run(Proposal, UnitName);

--- a/test/externref/ExternrefTest.cpp
+++ b/test/externref/ExternrefTest.cpp
@@ -39,8 +39,9 @@ TEST(ExternRefTest, Ref__Functions) {
                   WasmEdge::ValType::I32};
   auto Res1 = VM.execute("call_add", FuncArgs, FuncArgTypes);
   ASSERT_TRUE(Res1);
-  EXPECT_EQ((*Res1).size(), 1U);
-  EXPECT_EQ((*Res1)[0].get<uint32_t>(), 6912U);
+  EXPECT_EQ(Res1->size(), 1U);
+  EXPECT_EQ((*Res1)[0].first.get<uint32_t>(), 6912U);
+  EXPECT_EQ((*Res1)[0].second, WasmEdge::ValType::I32);
 
   /// Test 2: call mul -- 789 * 4321
   FuncArgs = {WasmEdge::ExternRef(MulFunc), 789U, 4321U};
@@ -48,16 +49,18 @@ TEST(ExternRefTest, Ref__Functions) {
                   WasmEdge::ValType::I32};
   auto Res2 = VM.execute("call_mul", FuncArgs, FuncArgTypes);
   ASSERT_TRUE(Res2);
-  EXPECT_EQ((*Res1).size(), 1U);
-  EXPECT_EQ((*Res2)[0].get<uint32_t>(), 3409269U);
+  EXPECT_EQ(Res2->size(), 1U);
+  EXPECT_EQ((*Res2)[0].first.get<uint32_t>(), 3409269U);
+  EXPECT_EQ((*Res2)[0].second, WasmEdge::ValType::I32);
 
   /// Test 3: call square -- 8256^2
   FuncArgs = {WasmEdge::ExternRef(&SS), 8256U};
   FuncArgTypes = {WasmEdge::ValType::ExternRef, WasmEdge::ValType::I32};
   auto Res3 = VM.execute("call_square", FuncArgs, FuncArgTypes);
   ASSERT_TRUE(Res3);
-  EXPECT_EQ((*Res1).size(), 1U);
-  EXPECT_EQ((*Res3)[0].get<uint32_t>(), 68161536U);
+  EXPECT_EQ(Res3->size(), 1U);
+  EXPECT_EQ((*Res3)[0].first.get<uint32_t>(), 68161536U);
+  EXPECT_EQ((*Res3)[0].second, WasmEdge::ValType::I32);
 
   /// Test 4: call sum and square -- (210 + 654)^2
   FuncArgs = {WasmEdge::ExternRef(&AC), WasmEdge::ExternRef(&SS), 210U, 654U};
@@ -65,8 +68,9 @@ TEST(ExternRefTest, Ref__Functions) {
                   WasmEdge::ValType::I32, WasmEdge::ValType::I32};
   auto Res4 = VM.execute("call_add_square", FuncArgs, FuncArgTypes);
   ASSERT_TRUE(Res4);
-  EXPECT_EQ((*Res1).size(), 1U);
-  EXPECT_EQ((*Res4)[0].get<uint32_t>(), 746496U);
+  EXPECT_EQ(Res4->size(), 1U);
+  EXPECT_EQ((*Res4)[0].first.get<uint32_t>(), 746496U);
+  EXPECT_EQ((*Res4)[0].second, WasmEdge::ValType::I32);
 }
 
 TEST(ExternRefTest, Ref__STL) {
@@ -94,7 +98,7 @@ TEST(ExternRefTest, Ref__STL) {
   FuncArgTypes = {WasmEdge::ValType::ExternRef, WasmEdge::ValType::ExternRef};
   auto Res1 = VM.execute("call_ostream_str", FuncArgs, FuncArgTypes);
   ASSERT_TRUE(Res1);
-  EXPECT_EQ((*Res1).size(), 0U);
+  EXPECT_EQ(Res1->size(), 0U);
   EXPECT_EQ(STLSS.str(), "hello world!");
 
   /// Test 2: call ostream << uint32_t
@@ -102,7 +106,7 @@ TEST(ExternRefTest, Ref__STL) {
   FuncArgTypes = {WasmEdge::ValType::ExternRef, WasmEdge::ValType::I32};
   auto Res2 = VM.execute("call_ostream_u32", FuncArgs, FuncArgTypes);
   ASSERT_TRUE(Res2);
-  EXPECT_EQ((*Res2).size(), 0U);
+  EXPECT_EQ(Res2->size(), 0U);
   EXPECT_EQ(STLSS.str(), "hello world!123456");
 
   /// Test 3: call map insert {key, val}
@@ -114,7 +118,7 @@ TEST(ExternRefTest, Ref__STL) {
                   WasmEdge::ValType::ExternRef};
   auto Res3 = VM.execute("call_map_insert", FuncArgs, FuncArgTypes);
   ASSERT_TRUE(Res3);
-  EXPECT_EQ((*Res3).size(), 0U);
+  EXPECT_EQ(Res3->size(), 0U);
   EXPECT_NE(STLMap.find(STLStrKey), STLMap.end());
   EXPECT_EQ(STLMap.find(STLStrKey)->second, STLStrVal);
 
@@ -124,7 +128,7 @@ TEST(ExternRefTest, Ref__STL) {
   FuncArgTypes = {WasmEdge::ValType::ExternRef, WasmEdge::ValType::ExternRef};
   auto Res4 = VM.execute("call_map_erase", FuncArgs, FuncArgTypes);
   ASSERT_TRUE(Res4);
-  EXPECT_EQ((*Res4).size(), 0U);
+  EXPECT_EQ(Res4->size(), 0U);
   EXPECT_EQ(STLMap.find(STLStrKey), STLMap.end());
 
   /// Test 5: call set insert {key}
@@ -132,7 +136,7 @@ TEST(ExternRefTest, Ref__STL) {
   FuncArgTypes = {WasmEdge::ValType::ExternRef, WasmEdge::ValType::I32};
   auto Res5 = VM.execute("call_set_insert", FuncArgs, FuncArgTypes);
   ASSERT_TRUE(Res5);
-  EXPECT_EQ((*Res5).size(), 0U);
+  EXPECT_EQ(Res5->size(), 0U);
   EXPECT_NE(STLSet.find(3456U), STLSet.end());
 
   /// Test 6: call set erase {key}
@@ -140,7 +144,7 @@ TEST(ExternRefTest, Ref__STL) {
   FuncArgTypes = {WasmEdge::ValType::ExternRef, WasmEdge::ValType::I32};
   auto Res6 = VM.execute("call_set_erase", FuncArgs, FuncArgTypes);
   ASSERT_TRUE(Res6);
-  EXPECT_EQ((*Res6).size(), 0U);
+  EXPECT_EQ(Res6->size(), 0U);
   EXPECT_EQ(STLSet.find(3456U), STLSet.end());
 
   /// Test 7: call vector push {val}
@@ -149,7 +153,7 @@ TEST(ExternRefTest, Ref__STL) {
   FuncArgTypes = {WasmEdge::ValType::ExternRef, WasmEdge::ValType::I32};
   auto Res7 = VM.execute("call_vector_push", FuncArgs, FuncArgTypes);
   ASSERT_TRUE(Res7);
-  EXPECT_EQ((*Res7).size(), 0U);
+  EXPECT_EQ(Res7->size(), 0U);
   EXPECT_EQ(STLVec.size(), 10U);
   EXPECT_EQ(STLVec[9], 100U);
 
@@ -160,8 +164,9 @@ TEST(ExternRefTest, Ref__STL) {
   FuncArgTypes = {WasmEdge::ValType::ExternRef, WasmEdge::ValType::ExternRef};
   auto Res8 = VM.execute("call_vector_sum", FuncArgs, FuncArgTypes);
   ASSERT_TRUE(Res8);
-  EXPECT_EQ((*Res8).size(), 1U);
-  EXPECT_EQ((*Res8)[0].get<uint32_t>(), 40U + 50U + 60U + 70U + 80U);
+  EXPECT_EQ(Res8->size(), 1U);
+  EXPECT_EQ((*Res8)[0].first.get<uint32_t>(), 40U + 50U + 60U + 70U + 80U);
+  EXPECT_EQ((*Res8)[0].second, WasmEdge::ValType::I32);
 }
 
 } // namespace

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -239,180 +239,200 @@ SpecTest::resolve(std::string_view Params) const {
       Proposal.Path, Proposal.Conf, Params.substr(Pos + 1)};
 }
 
-bool SpecTest::compare(
+bool SpecTest::compare(const std::pair<std::string, std::string> &Expected,
+                       const std::pair<ValVariant, ValType> &Got) const {
+  const auto &TypeStr = Expected.first;
+  const auto &ValStr = Expected.second;
+  bool IsV128 = (std::string_view(TypeStr).substr(0, 4) == "v128"sv);
+  if (!IsV128 && ValStr.substr(0, 4) == "nan:"sv) {
+    /// Handle NaN case
+    /// TODO: nan:canonical and nan:arithmetic
+    if (TypeStr == "f32"sv) {
+      if (Got.second != ValType::F32) {
+        return false;
+      }
+      return std::isnan(Got.first.get<float>());
+    } else if (TypeStr == "f64"sv) {
+      if (Got.second != ValType::F64) {
+        return false;
+      }
+      return std::isnan(Got.first.get<double>());
+    }
+  } else if (TypeStr == "funcref"sv) {
+    if (Got.second != ValType::FuncRef) {
+      return false;
+    }
+    if (ValStr == "null"sv) {
+      return WasmEdge::isNullRef(Got.first);
+    } else {
+      if (WasmEdge::isNullRef(Got.first)) {
+        return false;
+      }
+      return WasmEdge::retrieveFuncIdx(Got.first) ==
+             static_cast<uint32_t>(std::stoul(ValStr));
+    }
+  } else if (TypeStr == "externref"sv) {
+    if (Got.second != ValType::ExternRef) {
+      return false;
+    }
+    if (ValStr == "null"sv) {
+      return WasmEdge::isNullRef(Got.first);
+    } else {
+      if (WasmEdge::isNullRef(Got.first)) {
+        return false;
+      }
+      return static_cast<uint32_t>(reinterpret_cast<uintptr_t>(
+                 &WasmEdge::retrieveExternRef<uint32_t>(Got.first))) ==
+             static_cast<uint32_t>(std::stoul(ValStr));
+    }
+  } else if (TypeStr == "i32"sv) {
+    if (Got.second != ValType::I32) {
+      return false;
+    }
+    return Got.first.get<uint32_t>() == uint32_t(std::stoul(ValStr));
+  } else if (TypeStr == "f32"sv) {
+    if (Got.second != ValType::F32) {
+      return false;
+    }
+    /// Compare the 32-bit pattern
+    return Got.first.get<uint32_t>() == uint32_t(std::stoul(ValStr));
+  } else if (TypeStr == "i64"sv) {
+    if (Got.second != ValType::I64) {
+      return false;
+    }
+    return Got.first.get<uint64_t>() == uint64_t(std::stoull(ValStr));
+  } else if (TypeStr == "f64"sv) {
+    if (Got.second != ValType::F64) {
+      return false;
+    }
+    /// Compare the 64-bit pattern
+    return Got.first.get<uint64_t>() == uint64_t(std::stoull(ValStr));
+  } else if (IsV128) {
+    std::vector<std::string_view> Parts;
+    std::string_view Ev = ValStr;
+    if (Got.second != ValType::V128) {
+      return false;
+    }
+    for (std::string::size_type Begin = 0, End = Ev.find(' ');
+         Begin != std::string::npos;
+         Begin = 1 + End, End = Ev.find(' ', Begin)) {
+      Parts.push_back(Ev.substr(Begin, End - Begin));
+      if (End == std::string::npos) {
+        break;
+      }
+    }
+    std::string_view LaneType = std::string_view(TypeStr).substr(4);
+    if (LaneType == "f32") {
+      using uint64x2_t [[gnu::vector_size(16)]] = uint64_t;
+      using floatx4_t [[gnu::vector_size(16)]] = float;
+      using uint32x4_t [[gnu::vector_size(16)]] = uint32_t;
+      const uint64x2_t V64 = {
+          static_cast<uint64_t>(Got.first.get<uint128_t>()),
+          static_cast<uint64_t>(Got.first.get<uint128_t>() >> 64U)};
+      const auto VF = reinterpret_cast<floatx4_t>(V64);
+      const auto VI = reinterpret_cast<uint32x4_t>(V64);
+      for (size_t I = 0; I < 4; ++I) {
+        if (Parts[I].substr(0, 4) == "nan:"sv) {
+          if (!std::isnan(VF[I])) {
+            return false;
+          }
+        } else {
+          const uint32_t V1 = VI[I];
+          const uint32_t V2 = std::stoull(std::string(Parts[I]));
+          if (V1 != V2) {
+            return false;
+          }
+        }
+      }
+    } else if (LaneType == "f64") {
+      using doublex2_t [[gnu::vector_size(16)]] = double;
+      using uint64x2_t [[gnu::vector_size(16)]] = uint64_t;
+      const uint64x2_t V64 = {
+          static_cast<uint64_t>(Got.first.get<uint128_t>()),
+          static_cast<uint64_t>(Got.first.get<uint128_t>() >> 64U)};
+      const auto VF = reinterpret_cast<doublex2_t>(V64);
+      const auto VI = reinterpret_cast<uint64x2_t>(V64);
+      for (size_t I = 0; I < 2; ++I) {
+        if (Parts[I].substr(0, 4) == "nan:"sv) {
+          if (!std::isnan(VF[I])) {
+            return false;
+          }
+        } else {
+          const uint64_t V1 = VI[I];
+          const uint64_t V2 = std::stoull(std::string(Parts[I]));
+          if (V1 != V2) {
+            return false;
+          }
+        }
+      }
+    } else if (LaneType == "i8") {
+      using uint8x16_t [[gnu::vector_size(16)]] = uint8_t;
+      const uint64x2_t V64 = {
+          static_cast<uint64_t>(Got.first.get<uint128_t>()),
+          static_cast<uint64_t>(Got.first.get<uint128_t>() >> 64U)};
+      const auto V = reinterpret_cast<uint8x16_t>(V64);
+      for (size_t I = 0; I < 16; ++I) {
+        const uint8_t V1 = V[I];
+        const uint8_t V2 = std::stoul(std::string(Parts[I]));
+        if (V1 != V2) {
+          return false;
+        }
+      }
+    } else if (LaneType == "i16") {
+      using uint16x8_t [[gnu::vector_size(16)]] = uint16_t;
+      const uint64x2_t V64 = {
+          static_cast<uint64_t>(Got.first.get<uint128_t>()),
+          static_cast<uint64_t>(Got.first.get<uint128_t>() >> 64U)};
+      const auto V = reinterpret_cast<uint16x8_t>(V64);
+      for (size_t I = 0; I < 8; ++I) {
+        const uint16_t V1 = V[I];
+        const uint16_t V2 = std::stoul(std::string(Parts[I]));
+        if (V1 != V2) {
+          return false;
+        }
+      }
+    } else if (LaneType == "i32") {
+      using uint32x4_t [[gnu::vector_size(16)]] = uint32_t;
+      const uint64x2_t V64 = {
+          static_cast<uint64_t>(Got.first.get<uint128_t>()),
+          static_cast<uint64_t>(Got.first.get<uint128_t>() >> 64U)};
+      const auto V = reinterpret_cast<uint32x4_t>(V64);
+      for (size_t I = 0; I < 4; ++I) {
+        const uint32_t V1 = V[I];
+        const uint32_t V2 = std::stoul(std::string(Parts[I]));
+        if (V1 != V2) {
+          return false;
+        }
+      }
+    } else if (LaneType == "i64") {
+      using uint64x2_t [[gnu::vector_size(16)]] = uint64_t;
+      const uint64x2_t V = {
+          static_cast<uint64_t>(Got.first.get<uint128_t>()),
+          static_cast<uint64_t>(Got.first.get<uint128_t>() >> 64U)};
+      for (size_t I = 0; I < 2; ++I) {
+        const uint64_t V1 = V[I];
+        const uint64_t V2 = std::stoull(std::string(Parts[I]));
+        if (V1 != V2) {
+          return false;
+        }
+      }
+    } else {
+      return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+bool SpecTest::compares(
     const std::vector<std::pair<std::string, std::string>> &Expected,
-    const std::vector<ValVariant> &Got) const {
+    const std::vector<std::pair<ValVariant, ValType>> &Got) const {
   if (Expected.size() != Got.size()) {
     return false;
   }
   for (size_t I = 0; I < Expected.size(); ++I) {
-    const auto &[Type, E] = Expected[I];
-    const auto &G = Got[I];
-    if (E.substr(0, 4) == "nan:"sv) {
-      /// Handle NaN case
-      /// TODO: nan:canonical and nan:arithmetic
-      if (Type == "f32"sv) {
-        const float F = G.get<float>();
-        if (!std::isnan(F)) {
-          return false;
-        }
-      } else if (Type == "f64"sv) {
-        const double D = G.get<double>();
-        if (!std::isnan(D)) {
-          return false;
-        }
-      }
-    } else if (Type == "funcref"sv) {
-      /// Handle reference value case
-      if (E == "null"sv) {
-        return WasmEdge::isNullRef(G);
-      } else {
-        if (WasmEdge::isNullRef(G)) {
-          return false;
-        }
-        uint32_t V1 = WasmEdge::retrieveFuncIdx(G);
-        uint32_t V2 = static_cast<uint32_t>(std::stoul(E));
-        if (V1 != V2) {
-          return false;
-        }
-      }
-    } else if (Type == "externref"sv) {
-      /// Handle reference value case
-      if (E == "null"sv) {
-        return WasmEdge::isNullRef(G);
-      } else {
-        if (WasmEdge::isNullRef(G)) {
-          return false;
-        }
-        /// The added 0x1 uint32_t prefix in externref index case will be
-        /// discarded
-        uint32_t V1 = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(
-            &WasmEdge::retrieveExternRef<uint32_t>(G)));
-        uint32_t V2 = static_cast<uint32_t>(std::stoul(E));
-        if (V1 != V2) {
-          return false;
-        }
-      }
-    } else if (Type == "i32"sv || Type == "f32"sv) {
-      const uint32_t V1 = uint32_t(std::stoul(E));
-      const uint32_t V2 = G.get<uint32_t>();
-      if (V1 != V2) {
-        return false;
-      }
-    } else if (Type == "i64"sv || Type == "f64"sv) {
-      const uint64_t V2 = uint64_t(std::stoull(E));
-      const uint64_t V1 = G.get<uint64_t>();
-      if (V1 != V2) {
-        return false;
-      }
-    } else if (std::string_view(Type).substr(0, 4) == "v128"sv) {
-      std::vector<std::string_view> Parts;
-      std::string_view Ev = E;
-      for (std::string::size_type Begin = 0, End = Ev.find(' ');
-           Begin != std::string::npos;
-           Begin = 1 + End, End = Ev.find(' ', Begin)) {
-        Parts.push_back(Ev.substr(Begin, End - Begin));
-        if (End == std::string::npos) {
-          break;
-        }
-      }
-      std::string_view LaneType = std::string_view(Type).substr(4);
-      if (LaneType == "f32") {
-        using uint64x2_t [[gnu::vector_size(16)]] = uint64_t;
-        using floatx4_t [[gnu::vector_size(16)]] = float;
-        using uint32x4_t [[gnu::vector_size(16)]] = uint32_t;
-        const uint64x2_t V64 = {
-            static_cast<uint64_t>(G.get<uint128_t>()),
-            static_cast<uint64_t>(G.get<uint128_t>() >> 64U)};
-        const auto VF = reinterpret_cast<floatx4_t>(V64);
-        const auto VI = reinterpret_cast<uint32x4_t>(V64);
-        for (size_t I = 0; I < 4; ++I) {
-          if (Parts[I].substr(0, 4) == "nan:"sv) {
-            if (!std::isnan(VF[I])) {
-              return false;
-            }
-          } else {
-            const uint32_t V2 = std::stoull(std::string(Parts[I]));
-            const uint32_t V1 = VI[I];
-            if (V1 != V2) {
-              return false;
-            }
-          }
-        }
-      } else if (LaneType == "f64") {
-        using doublex2_t [[gnu::vector_size(16)]] = double;
-        using uint64x2_t [[gnu::vector_size(16)]] = uint64_t;
-        const uint64x2_t V64 = {
-            static_cast<uint64_t>(G.get<uint128_t>()),
-            static_cast<uint64_t>(G.get<uint128_t>() >> 64U)};
-        const auto VF = reinterpret_cast<doublex2_t>(V64);
-        const auto VI = reinterpret_cast<uint64x2_t>(V64);
-        for (size_t I = 0; I < 2; ++I) {
-          if (Parts[I].substr(0, 4) == "nan:"sv) {
-            if (!std::isnan(VF[I])) {
-              return false;
-            }
-          } else {
-            const uint64_t V2 = std::stoull(std::string(Parts[I]));
-            const uint64_t V1 = VI[I];
-            if (V1 != V2) {
-              return false;
-            }
-          }
-        }
-      } else if (LaneType == "i8") {
-        using uint8x16_t [[gnu::vector_size(16)]] = uint8_t;
-        const uint64x2_t V64 = {
-            static_cast<uint64_t>(G.get<uint128_t>()),
-            static_cast<uint64_t>(G.get<uint128_t>() >> 64U)};
-        const auto V = reinterpret_cast<uint8x16_t>(V64);
-        for (size_t I = 0; I < 16; ++I) {
-          const uint8_t V2 = std::stoul(std::string(Parts[I]));
-          const uint8_t V1 = V[I];
-          if (V1 != V2) {
-            return false;
-          }
-        }
-      } else if (LaneType == "i16") {
-        using uint16x8_t [[gnu::vector_size(16)]] = uint16_t;
-        const uint64x2_t V64 = {
-            static_cast<uint64_t>(G.get<uint128_t>()),
-            static_cast<uint64_t>(G.get<uint128_t>() >> 64U)};
-        const auto V = reinterpret_cast<uint16x8_t>(V64);
-        for (size_t I = 0; I < 8; ++I) {
-          const uint16_t V2 = std::stoul(std::string(Parts[I]));
-          const uint16_t V1 = V[I];
-          if (V1 != V2) {
-            return false;
-          }
-        }
-      } else if (LaneType == "i32") {
-        using uint32x4_t [[gnu::vector_size(16)]] = uint32_t;
-        const uint64x2_t V64 = {
-            static_cast<uint64_t>(G.get<uint128_t>()),
-            static_cast<uint64_t>(G.get<uint128_t>() >> 64U)};
-        const auto V = reinterpret_cast<uint32x4_t>(V64);
-        for (size_t I = 0; I < 4; ++I) {
-          const uint32_t V2 = std::stoul(std::string(Parts[I]));
-          const uint32_t V1 = V[I];
-          if (V1 != V2) {
-            return false;
-          }
-        }
-      } else if (LaneType == "i64") {
-        using uint64x2_t [[gnu::vector_size(16)]] = uint64_t;
-        const uint64x2_t V = {static_cast<uint64_t>(G.get<uint128_t>()),
-                              static_cast<uint64_t>(G.get<uint128_t>() >> 64U)};
-        for (size_t I = 0; I < 2; ++I) {
-          const uint64_t V2 = std::stoull(std::string(Parts[I]));
-          const uint64_t V1 = V[I];
-          if (V1 != V2) {
-            return false;
-          }
-        }
-      }
-    } else {
-      assuming(false);
+    if (!compare(Expected[I], Got[I])) {
+      return false;
     }
   }
   return true;
@@ -466,11 +486,7 @@ void SpecTest::run(std::string_view Proposal, std::string_view UnitName) {
     /// Manager. Anonymous modules are instantiated in VM.
     if (auto Res = onInvoke(ModName, Field, Params.first, Params.second)) {
       /// Check value.
-      if (compare(Returns, *Res)) {
-        EXPECT_TRUE(true);
-      } else {
-        EXPECT_NE(LineNumber, LineNumber);
-      }
+      EXPECT_TRUE(compares(Returns, *Res));
     } else {
       EXPECT_NE(LineNumber, LineNumber);
     }
@@ -484,7 +500,7 @@ void SpecTest::run(std::string_view Proposal, std::string_view UnitName) {
 
     if (auto Res = onGet(ModName, Field)) {
       /// Check value.
-      EXPECT_TRUE(compare(Returns, *Res));
+      EXPECT_TRUE(compare(Returns[0], *Res));
     } else {
       EXPECT_NE(LineNumber, LineNumber);
     }

--- a/test/spec/spectest.h
+++ b/test/spec/spectest.h
@@ -47,8 +47,11 @@ public:
   std::vector<std::string> enumerate() const;
   std::tuple<std::string_view, WasmEdge::Configure, std::string>
   resolve(std::string_view Params) const;
-  bool compare(const std::vector<std::pair<std::string, std::string>> &Expected,
-               const std::vector<ValVariant> &Got) const;
+  bool compare(const std::pair<std::string, std::string> &Expected,
+               const std::pair<ValVariant, ValType> &Got) const;
+  bool
+  compares(const std::vector<std::pair<std::string, std::string>> &Expected,
+           const std::vector<std::pair<ValVariant, ValType>> &Got) const;
   bool stringContains(const std::string &Expected,
                       const std::string &Got) const;
 
@@ -67,13 +70,13 @@ public:
   using InstantiateCallback = Expect<void>(const std::string &Filename);
   std::function<InstantiateCallback> onInstantiate;
 
-  using InvokeCallback = Expect<std::vector<ValVariant>>(
+  using InvokeCallback = Expect<std::vector<std::pair<ValVariant, ValType>>>(
       const std::string &ModName, const std::string &Field,
       const std::vector<ValVariant> &Params,
       const std::vector<ValType> &ParamTypes);
   std::function<InvokeCallback> onInvoke;
 
-  using GetCallback = Expect<std::vector<ValVariant>>(
+  using GetCallback = Expect<std::pair<ValVariant, ValType>>(
       const std::string &ModName, const std::string &Field);
   std::function<GetCallback> onGet;
 

--- a/tools/wasmedge/wasmedger.cpp
+++ b/tools/wasmedge/wasmedger.cpp
@@ -271,19 +271,19 @@ int main(int Argc, const char *Argv[]) {
 
     if (auto Result = VM.execute(FuncName, FuncArgs, FuncArgTypes)) {
       /// Print results.
-      for (size_t I = 0; I < FuncType.getReturnTypes().size(); ++I) {
-        switch (FuncType.getReturnTypes()[I]) {
+      for (size_t I = 0; I < Result->size(); ++I) {
+        switch ((*Result)[I].second) {
         case WasmEdge::ValType::I32:
-          std::cout << (*Result)[I].get<uint32_t>() << '\n';
+          std::cout << (*Result)[I].first.get<uint32_t>() << '\n';
           break;
         case WasmEdge::ValType::I64:
-          std::cout << (*Result)[I].get<uint64_t>() << '\n';
+          std::cout << (*Result)[I].first.get<uint64_t>() << '\n';
           break;
         case WasmEdge::ValType::F32:
-          std::cout << (*Result)[I].get<float>() << '\n';
+          std::cout << (*Result)[I].first.get<float>() << '\n';
           break;
         case WasmEdge::ValType::F64:
-          std::cout << (*Result)[I].get<double>() << '\n';
+          std::cout << (*Result)[I].first.get<double>() << '\n';
           break;
         /// TODO: FuncRef and ExternRef
         default:


### PR DESCRIPTION
The SIMD opcode spec test failed.
Mentioned at #558 

The last commit can help to check the value comparison, and can be deleted after fixing.