### PR TITLE
Resolve the edge case for the nearby expressions in memory

### DIFF
--- a/include/ast/instruction.h
+++ b/include/ast/instruction.h
@@ -26,8 +26,6 @@ public:
   /// Constructor assigns the OpCode.
   Instruction(OpCode Byte, uint32_t Off = 0) noexcept
       : Code(Byte), Offset(Off) {}
-  /// Copy constructor.
-  Instruction(const Instruction &Instr) = default;
   /// Destructor.
   ~Instruction() noexcept = default;
 
@@ -84,8 +82,8 @@ public:
 private:
   /// \name Data of instructions.
   /// @{
-  const OpCode Code = OpCode::End;
-  const uint32_t Offset = 0;
+  OpCode Code = OpCode::End;
+  uint32_t Offset = 0;
   BlockType ResType = ValType::None;
   uint32_t JumpEnd = 0;
   uint32_t JumpElse = 0;

--- a/include/runtime/instance/function.h
+++ b/include/runtime/instance/function.h
@@ -100,10 +100,14 @@ public:
 private:
   struct WasmFunction {
     const std::vector<std::pair<uint32_t, ValType>> Locals;
-    const AST::InstrVec Instrs;
+    AST::InstrVec Instrs;
     WasmFunction(Span<const std::pair<uint32_t, ValType>> Locs,
                  AST::InstrView Expr) noexcept
-        : Locals(Locs.begin(), Locs.end()), Instrs(Expr.begin(), Expr.end()) {}
+        : Locals(Locs.begin(), Locs.end()) {
+      /// FIXME: Modify the capacity to prevent from connection of 2 vectors.
+      Instrs.reserve(Expr.size() + 1);
+      Instrs.assign(Expr.begin(), Expr.end());
+    }
   };
 
   /// \name Data of function instance.


### PR DESCRIPTION
On MacOS, there's a situation that after instantiation, the expression vector of function instance A is connected after the expression vector of function instance B in memory.
Therefore when iterating the instructions in interpreter mode through the program counter, the expression `PC != PCEnd` of the while loop may cause unexpected end because the `A.expr.end()` is right equal to `B.expr.begin()`.

closes #453
closes #454