### PR TITLE
[Utils] Add lost symbolic link: libpng.so -> libpng16.so.16.37.0

### DIFF
--- a/utils/install.sh
+++ b/utils/install.sh
@@ -77,6 +77,12 @@ _extracter() {
 
                         ln -sf "$IPATH/lib/$filtered" "$IPATH/lib/$_f4_"
                         echo "#$IPATH/lib/$_f4_" >>"$IPATH/env"
+
+                        # special case: libpng16.so.16.37.0 ---> libpng.so
+                        if [[ "$filtered" =~ "libpng16.so.16.37.0" ]]; then
+                            ln -sf "$IPATH/lib/$filtered" "$IPATH/lib/libpng.so"
+                            echo "#$IPATH/lib/libpng.so" >>"$IPATH/env"
+                        fi
                     fi
                 elif [[ "$2" =~ "bin" ]] && [[ ! "$IPATH/$filtered" =~ "/bin/" ]]; then
                     echo "#$IPATH/bin/$filtered" >>"$IPATH/env"


### PR DESCRIPTION
Sorry that lost of the linking of `libpng.so`.
We should add the `libpng.so` -> `libpng16.so`, or the `-lpng` will error.