### PR TITLE
[CI] Add inventory warning

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -1,0 +1,37 @@
+name: Warning of Inventorying Rust
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'bindings/rust/wasmedge-sys'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'bindings/rust/wasmedge-sys'
+
+jobs:
+  inventorying rust:
+    runs-on: ubuntu-latest
+    container:
+      image: wasmedge/wasmedge:ubuntu-build-clang
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install dependency
+      run: |
+        apt update
+        apt install -y ctags
+
+    - name: Inventory for rust-sys
+      run: |
+        for fn in `ctags -x --c-types=f+p include/api/wasmedge/wasmedge.h  | awk '/^WasmEdge_/{print $1}'`; do
+          grep -q ${fn} -R bindings/rust/wasmedge-sys || echo "${fn} is not used in rust-sys crate" >> /tmp/missing_api_in_rust.txt
+        done;
+        cat /tmp/missing_api_in_rust.txt || exit 0
+        exit `wc -l /tmp/missing_api_in_rust.txt | awk '{print $1}'`


### PR DESCRIPTION
Because there is no warning flow in GitHub CI, the prefix `Warning of` of the name of CI flow is used, such that developer can easily to know this CI flow is allowed to fail.
Fix #626 