### PR TITLE
[Docker] Update to the latest NAPI packages

### DIFF
--- a/utils/docker/Dockerfile.appdev_aarch64
+++ b/utils/docker/Dockerfile.appdev_aarch64
@@ -14,8 +14,6 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get install -y nodejs
 RUN npm install wasmedge-core@0.8.3
 
-RUN wget -qO- https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -e all -v 0.8.2
-
 RUN mkdir -p /root/examples
 WORKDIR /root/examples
 RUN wget https://github.com/WasmEdge/WasmEdge/raw/master/tools/wasmedge/examples/hello.wasm &&\

--- a/utils/docker/Dockerfile.appdev_x86_64
+++ b/utils/docker/Dockerfile.appdev_x86_64
@@ -14,8 +14,6 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get install -y nodejs
 RUN npm install wasmedge-extensions@0.8.3
 
-RUN wget -qO- https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -e all -v 0.8.2
-
 RUN mkdir -p /root/examples
 WORKDIR /root/examples
 RUN wget https://github.com/WasmEdge/WasmEdge/raw/master/tools/wasmedge/examples/hello.wasm &&\


### PR DESCRIPTION
The NAPI install script already calls the standard WasmEdge install script. There is no more need to call the standard script again.

Signed-off-by: Michael Yuan <michael@secondstate.io>