### PR TITLE
Remove Port from sockAccept implementation for INode

### DIFF
--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -857,11 +857,11 @@ public:
     }
   }
 
-  WasiExpect<__wasi_fd_t> sockAccept(__wasi_fd_t Fd, uint16_t Port) noexcept {
+  WasiExpect<__wasi_fd_t> sockAccept(__wasi_fd_t Fd) noexcept {
     auto Node = getNodeOrNull(Fd);
     std::shared_ptr<VINode> NewNode;
 
-    if (auto Res = Node->sockAccept(Port); unlikely(!Res)) {
+    if (auto Res = Node->sockAccept(); unlikely(!Res)) {
       return WasiUnexpect(Res);
     } else {
       NewNode = std::move(*Res);

--- a/include/host/wasi/inode.h
+++ b/include/host/wasi/inode.h
@@ -480,7 +480,7 @@ public:
 
   WasiExpect<void> sockListen(uint32_t Backlog) noexcept;
 
-  WasiExpect<INode> sockAccept(uint16_t Port) noexcept;
+  WasiExpect<INode> sockAccept() noexcept;
 
   WasiExpect<void> sockConnect(uint8_t *Address, uint8_t AddressLength,
                                uint16_t Port) noexcept;

--- a/include/host/wasi/vinode.h
+++ b/include/host/wasi/vinode.h
@@ -542,7 +542,7 @@ public:
     return Node.sockListen(Backlog);
   }
 
-  WasiExpect<std::shared_ptr<VINode>> sockAccept(uint16_t Port);
+  WasiExpect<std::shared_ptr<VINode>> sockAccept();
 
   WasiExpect<void> sockConnect(uint8_t *Address, uint8_t AddressLength,
                                uint16_t Port) noexcept {

--- a/include/host/wasi/wasifunc.h
+++ b/include/host/wasi/wasifunc.h
@@ -388,7 +388,7 @@ public:
   WasiSockAccept(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
-                        int32_t Port, uint32_t /* Out */ RoFdPtr);
+                        uint32_t /* Out */ RoFdPtr);
 };
 
 class WasiSockConnect : public Wasi<WasiSockConnect> {

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -828,11 +828,10 @@ WasiExpect<void> INode::sockListen(uint32_t Backlog) noexcept {
   return {};
 }
 
-WasiExpect<INode> INode::sockAccept(uint16_t Port) noexcept {
+WasiExpect<INode> INode::sockAccept() noexcept {
   struct sockaddr_in ServerSocketAddr;
   ServerSocketAddr.sin_family = AF_INET;
   ServerSocketAddr.sin_addr.s_addr = INADDR_ANY;
-  ServerSocketAddr.sin_port = htons(Port);
   socklen_t AddressLen = sizeof(ServerSocketAddr);
 
   if (auto NewFd =

--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -786,11 +786,10 @@ WasiExpect<void> INode::sockListen(uint32_t Backlog) noexcept {
   return {};
 }
 
-WasiExpect<INode> INode::sockAccept(uint16_t Port) noexcept {
+WasiExpect<INode> INode::sockAccept() noexcept {
   struct sockaddr_in ServerSocketAddr;
   ServerSocketAddr.sin_family = AF_INET;
   ServerSocketAddr.sin_addr.s_addr = INADDR_ANY;
-  ServerSocketAddr.sin_port = htons(Port);
   socklen_t AddressLen = sizeof(ServerSocketAddr);
 
   if (auto NewFd =

--- a/lib/host/wasi/vinode.cpp
+++ b/lib/host/wasi/vinode.cpp
@@ -335,8 +335,8 @@ VINode::sockOpen(VFS &FS, __wasi_address_family_t SysDomain,
   }
 }
 
-WasiExpect<std::shared_ptr<VINode>> VINode::sockAccept(uint16_t Port) {
-  if (auto Res = Node.sockAccept(Port); unlikely(!Res)) {
+WasiExpect<std::shared_ptr<VINode>> VINode::sockAccept() {
+  if (auto Res = Node.sockAccept(); unlikely(!Res)) {
     return WasiUnexpect(Res);
   } else {
     __wasi_rights_t Rights =

--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -1651,8 +1651,7 @@ WasiSockAccept::body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
   }
   const __wasi_fd_t WasiFd = Fd;
 
-  if (auto Res = Env.sockAccept(WasiFd);
-      unlikely(!Res)) {
+  if (auto Res = Env.sockAccept(WasiFd); unlikely(!Res)) {
     return Res.error();
   } else {
     *RoFd = *Res;

--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -1639,7 +1639,7 @@ Expect<uint32_t> WasiSockListen::body(
 
 Expect<uint32_t>
 WasiSockAccept::body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
-                     int32_t Port, uint32_t /* Out */ RoFdPtr) {
+                     uint32_t /* Out */ RoFdPtr) {
   /// Check memory instance from module.
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -1651,7 +1651,7 @@ WasiSockAccept::body(Runtime::Instance::MemoryInstance *MemInst, int32_t Fd,
   }
   const __wasi_fd_t WasiFd = Fd;
 
-  if (auto Res = Env.sockAccept(WasiFd, static_cast<uint16_t>(Port));
+  if (auto Res = Env.sockAccept(WasiFd);
       unlikely(!Res)) {
     return Res.error();
   } else {


### PR DESCRIPTION
As mentioned in #662, the sockAccept method does not require port parameter since it's not used from ServerSocketAddr. This pr is for removing the port parameter from the implementation and header file.