### PR TITLE
[Rust] Temp rm wasmedge-sdk

### DIFF
--- a/.github/workflows/rust-crate-release.yml
+++ b/.github/workflows/rust-crate-release.yml
@@ -36,18 +36,3 @@ jobs:
       with:
           path: './bindings/rust/wasmedge-sys'
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-    - name: Prepare wasmEdge-sdk
-      run: |
-        VERSION=`cat bindings/rust/wasmedge-sys/Cargo.toml | grep '^version' | awk -F\" '{print $2}'`
-        sed -i 's/wasmedge-sys =/wasmedge-sys = "'${VERSION}'"#/' bindings/rust/wasmedge-sdk/Cargo.toml
-        git config --global user.email "github_action@github.com"
-        git config --global user.name "GithubAction"
-        git add bindings/rust/wasmedge-sdk/Cargo.toml
-        git commit -m '[CI] wasmedge-sdk dependency'
-
-    - name: Publish wasmedge-sdk crate
-      uses: katyo/publish-crates@v1
-      with:
-          path: './bindings/rust/wasmedge-sdk'
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["wasmedge-sdk", "wasmedge-sys"]
+members = ["wasmedge-sys"]
 exclude = ["build/", "utils/"]

--- a/flake.nix
+++ b/flake.nix
@@ -20,20 +20,6 @@
           cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug -DWASMEDGE_BUILD_AOT_RUNTIME=OFF .
           cmake --build build
         '';
-        runRustSdkTest = pkgs.writeShellScriptBin "run-rust-sdk-test" ''
-          cd bindings/rust/
-          export WASMEDGE_DIR="$(pwd)/../../"
-          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
-          export LD_LIBRARY_PATH="$(pwd)/../../build/lib/api"
-          cargo test -p wasmedge-sdk --examples -- --nocapture
-        '';
-        runRustSdkExample = pkgs.writeShellScriptBin "run-rust-sdk-example" ''
-          cd bindings/rust/
-          export WASMEDGE_DIR="$(pwd)/../../"
-          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
-          export LD_LIBRARY_PATH="$(pwd)/../../build/lib/api"
-          cargo run -p wasmedge-sdk --example $1
-        '';
         runRustSysTest = pkgs.writeShellScriptBin "run-rust-sys-test" ''
           cd bindings/rust/
           export WASMEDGE_DIR="$(pwd)/../../"
@@ -66,8 +52,6 @@
             buildWasmEdgeNoAOT
             runRustSysTest
             runRustSysExample
-            runRustSdkTest
-            runRustSdkExample
           ];
 
           LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";


### PR DESCRIPTION
Currently, we keep working on `wasmedge-sys` crate, and `wasmedge-sdk` will more focus on how to fit the usage of application layer.  Besides, it will redesign and provide later, so `wasmedge-sdk` is temporally removed.

Signed-off-by: Antonio Yang <yanganto@gmail.com>