### PR TITLE
[Rust] Implement new APIs for Config

### DIFF
--- a/bindings/rust/wasmedge-sys/src/config.rs
+++ b/bindings/rust/wasmedge-sys/src/config.rs
@@ -1,4 +1,7 @@
-use crate::{wasmedge, Error, WasmEdgeResult};
+use crate::{
+    types::{CompilerOptimizationLevel, CompilerOutputFormat},
+    wasmedge, Error, WasmEdgeResult,
+};
 
 #[derive(Debug)]
 pub struct Config {
@@ -92,20 +95,43 @@ impl Config {
         self
     }
 
+    /// Set the maximum number of memory pages available to running modules.
+    pub fn set_max_memory_pages(self, num_pages: u32) -> Self {
+        unsafe { wasmedge::WasmEdge_ConfigureSetMaxMemoryPage(self.ctx, num_pages) };
+        self
+    }
+
+    /// Get the page limit of memory instances.
+    pub fn get_max_memory_pages(&self) -> u32 {
+        unsafe { wasmedge::WasmEdge_ConfigureGetMaxMemoryPage(self.ctx) }
+    }
+
     // For AOT compiler
 
     /// Set the optimization level of AOT compiler.
-    pub fn opt_level(self, opt_level: OptLevel) -> Self {
+    pub fn set_optimization_level(self, opt_level: CompilerOptimizationLevel) -> Self {
         unsafe {
             wasmedge::WasmEdge_ConfigureCompilerSetOptimizationLevel(self.ctx, opt_level as u32)
         };
         self
     }
 
-    /// Set the maximum number of memory pages available to running modules.
-    pub fn max_memory_pages(self, num_pages: u32) -> Self {
-        unsafe { wasmedge::WasmEdge_ConfigureSetMaxMemoryPage(self.ctx, num_pages) };
+    /// Get the optimization level of AOT compiler.
+    pub fn get_optimization_level(&self) -> CompilerOptimizationLevel {
+        let level = unsafe { wasmedge::WasmEdge_ConfigureCompilerGetOptimizationLevel(self.ctx) };
+        level.into()
+    }
+
+    /// Set the output binary format of AOT compiler.
+    pub fn set_compiler_output_format(self, format: CompilerOutputFormat) -> Self {
+        unsafe { wasmedge::WasmEdge_ConfigureCompilerSetOutputFormat(self.ctx, format as u32) };
         self
+    }
+
+    /// Get the output binary format of AOT compiler.
+    pub fn get_compiler_output_format(&self) -> CompilerOutputFormat {
+        let value = unsafe { wasmedge::WasmEdge_ConfigureCompilerGetOutputFormat(self.ctx) };
+        value.into()
     }
 
     /// Set the dump IR boolean value of AOT compiler.
@@ -114,10 +140,31 @@ impl Config {
         self
     }
 
+    /// Get the dump IR option of AOT compiler.
+    pub fn is_dump_ir(&self) -> bool {
+        unsafe { wasmedge::WasmEdge_ConfigureCompilerIsDumpIR(self.ctx) }
+    }
+
+    /// Set the generic binary option of AOT compiler.
+    pub fn generic_binary(self, enable: bool) -> Self {
+        unsafe { wasmedge::WasmEdge_ConfigureCompilerSetGenericBinary(self.ctx, enable) };
+        self
+    }
+
+    /// Get the generic binary option of AOT compiler.
+    pub fn is_generic_binary(&self) -> bool {
+        unsafe { wasmedge::WasmEdge_ConfigureCompilerIsGenericBinary(self.ctx) }
+    }
+
     /// Enable or disable instruction counting.
     pub fn count_instructions(self, enable: bool) -> Self {
         unsafe { wasmedge::WasmEdge_ConfigureStatisticsSetInstructionCounting(self.ctx, enable) };
         self
+    }
+
+    /// Get the instruction counting option.
+    pub fn is_instruction_counting(&self) -> bool {
+        unsafe { wasmedge::WasmEdge_ConfigureStatisticsIsInstructionCounting(self.ctx) }
     }
 
     /// Enable or disable cost cost measuring.
@@ -125,30 +172,22 @@ impl Config {
         unsafe { wasmedge::WasmEdge_ConfigureStatisticsSetCostMeasuring(self.ctx, enable) };
         self
     }
-}
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(u32)]
-pub enum OptLevel {
-    /// Disable as many optimizations as possible.
-    O0 = wasmedge::WasmEdge_CompilerOptimizationLevel_O0,
+    /// Get the cost measuring option.
+    pub fn is_cost_measuring(&self) -> bool {
+        unsafe { wasmedge::WasmEdge_ConfigureStatisticsIsCostMeasuring(self.ctx) }
+    }
 
-    /// Optimize quickly without destroying debuggability.
-    O1 = wasmedge::WasmEdge_CompilerOptimizationLevel_O1,
+    /// Set the time measuring option.
+    pub fn measure_time(self, enable: bool) -> Self {
+        unsafe { wasmedge::WasmEdge_ConfigureStatisticsSetTimeMeasuring(self.ctx, enable) };
+        self
+    }
 
-    /// Optimize for fast execution as much as possible without triggering
-    /// significant incremental compile time or code size growth.
-    O2 = wasmedge::WasmEdge_CompilerOptimizationLevel_O2,
-
-    ///  Optimize for fast execution as much as possible.
-    O3 = wasmedge::WasmEdge_CompilerOptimizationLevel_O3,
-
-    ///  Optimize for small code size as much as possible without triggering
-    ///  significant incremental compile time or execution time slowdowns.
-    Os = wasmedge::WasmEdge_CompilerOptimizationLevel_Os,
-
-    /// Optimize for small code size as much as possible.
-    Oz = wasmedge::WasmEdge_CompilerOptimizationLevel_Oz,
+    /// Get the cost measuring option.
+    pub fn is_time_measuring(&self) -> bool {
+        unsafe { wasmedge::WasmEdge_ConfigureStatisticsIsTimeMeasuring(self.ctx) }
+    }
 }
 
 // # TODO: WasmEdge_HostRegistration

--- a/bindings/rust/wasmedge-sys/src/lib.rs
+++ b/bindings/rust/wasmedge-sys/src/lib.rs
@@ -26,7 +26,7 @@ pub mod vm;
 pub mod wasi;
 
 pub use compiler::Compiler;
-pub use config::{Config, OptLevel};
+pub use config::Config;
 pub use error::{Error, WasmEdgeError, WasmEdgeResult};
 pub use executor::Executor;
 pub use import_obj::ImportObj;

--- a/bindings/rust/wasmedge-sys/src/types.rs
+++ b/bindings/rust/wasmedge-sys/src/types.rs
@@ -1,7 +1,6 @@
 use super::wasmedge;
 pub type WasmEdgeProposal = wasmedge::WasmEdge_Proposal;
 pub type HostRegistration = wasmedge::WasmEdge_HostRegistration;
-pub type CompilerOptimizationLevel = wasmedge::WasmEdge_CompilerOptimizationLevel;
 pub type HostFunc = wasmedge::WasmEdge_HostFunc_t;
 pub type WrapFunc = wasmedge::WasmEdge_WrapFunc_t;
 
@@ -102,6 +101,62 @@ impl From<wasmedge::WasmEdge_Mutability> for Mutability {
             wasmedge::WasmEdge_Mutability_Const => Mutability::Const,
             wasmedge::WasmEdge_Mutability_Var => Mutability::Var,
             _ => panic!("unknown Mutability value `{}`", mutable),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum CompilerOptimizationLevel {
+    /// Disable as many optimizations as possible.
+    O0 = wasmedge::WasmEdge_CompilerOptimizationLevel_O0,
+
+    /// Optimize quickly without destroying debuggability.
+    O1 = wasmedge::WasmEdge_CompilerOptimizationLevel_O1,
+
+    /// Optimize for fast execution as much as possible without triggering
+    /// significant incremental compile time or code size growth.
+    O2 = wasmedge::WasmEdge_CompilerOptimizationLevel_O2,
+
+    ///  Optimize for fast execution as much as possible.
+    O3 = wasmedge::WasmEdge_CompilerOptimizationLevel_O3,
+
+    ///  Optimize for small code size as much as possible without triggering
+    ///  significant incremental compile time or execution time slowdowns.
+    Os = wasmedge::WasmEdge_CompilerOptimizationLevel_Os,
+
+    /// Optimize for small code size as much as possible.
+    Oz = wasmedge::WasmEdge_CompilerOptimizationLevel_Oz,
+}
+impl From<u32> for CompilerOptimizationLevel {
+    fn from(val: u32) -> CompilerOptimizationLevel {
+        match val {
+            0 => CompilerOptimizationLevel::O0,
+            1 => CompilerOptimizationLevel::O1,
+            2 => CompilerOptimizationLevel::O2,
+            3 => CompilerOptimizationLevel::O3,
+            4 => CompilerOptimizationLevel::Os,
+            5 => CompilerOptimizationLevel::Oz,
+            _ => panic!("Unknown CompilerOptimizationLevel value: {}", val),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum CompilerOutputFormat {
+    /// Native dynamic library format.
+    Native = wasmedge::WasmEdge_CompilerOutputFormat_Native,
+
+    /// WebAssembly with AOT compiled codes in custom sections.
+    Wasm = wasmedge::WasmEdge_CompilerOutputFormat_Wasm,
+}
+impl From<u32> for CompilerOutputFormat {
+    fn from(val: u32) -> CompilerOutputFormat {
+        match val {
+            0 => CompilerOutputFormat::Native,
+            1 => CompilerOutputFormat::Wasm,
+            _ => panic!("Unknown CompilerOutputFormat value: {}", val),
         }
     }
 }


### PR DESCRIPTION
The following C-APIs are involved in this PR:
- Fix #691 
- Fix #692 
- Fix #693 
- Fix #696 
- Fix #697 
- Fix #698 
- Fix #699 
- WasmEdge_ConfigureCompilerIsGenericBinary
- WasmEdge_ConfigureCompilerSetGenericBinary
- WasmEdge_ConfigureCompilerGetOutputFormat
- WasmEdge_ConfigureCompilerSetOutputFormat