### PR TITLE
[Rust] Expose ImportType and ExportType; Implement new APIs for Module

### DIFF
--- a/bindings/rust/wasmedge-sys/src/module.rs
+++ b/bindings/rust/wasmedge-sys/src/module.rs
@@ -1,10 +1,14 @@
 use super::wasmedge;
 use crate::{
     error::{check, Error, WasmEdgeResult},
+    instance::function::FuncType,
+    instance::global::GlobalType,
+    instance::memory::MemType,
+    types::ExternalType,
     utils, Config,
 };
 use ::core::mem::MaybeUninit as MU;
-use std::path::Path;
+use std::{borrow::Cow, ffi::CStr, path::Path};
 
 #[derive(Debug)]
 pub struct Module {
@@ -81,6 +85,245 @@ impl Module {
             ctx,
             registered: false,
         })
+    }
+}
+
+#[derive(Debug)]
+pub struct ImportType {
+    pub(crate) ctx: *const wasmedge::WasmEdge_ImportTypeContext,
+}
+impl Drop for ImportType {
+    fn drop(&mut self) {
+        if !self.ctx.is_null() {
+            self.ctx = std::ptr::null();
+        }
+    }
+}
+impl ImportType {
+    /// Get the external type
+    pub fn external_type(&self) -> ExternalType {
+        let ty = unsafe { wasmedge::WasmEdge_ImportTypeGetExternalType(self.ctx) };
+        ty.into()
+    }
+
+    /// Get the module name
+    pub fn module_name(&self) -> Cow<'_, str> {
+        let c_name = unsafe {
+            let raw_name = wasmedge::WasmEdge_ImportTypeGetModuleName(self.ctx);
+            CStr::from_ptr(raw_name.Buf)
+        };
+        c_name.to_string_lossy()
+    }
+
+    /// Get the external name
+    pub fn external_name(&self) -> Cow<'_, str> {
+        let c_name = unsafe {
+            let raw_name = wasmedge::WasmEdge_ImportTypeGetExternalName(self.ctx);
+            CStr::from_ptr(raw_name.Buf)
+        };
+        c_name.to_string_lossy()
+    }
+
+    /// Get the external value (which is function type)
+    pub fn function_type(&self, module: &Module) -> WasmEdgeResult<FuncType> {
+        let external_ty = self.external_type();
+        if external_ty != ExternalType::Function {
+            return Err(Error::OperationError(format!(
+                "The external type should be 'function', but found '{}'",
+                external_ty
+            )));
+        }
+        let ctx_func_ty =
+            unsafe { wasmedge::WasmEdge_ImportTypeGetFunctionType(module.ctx, self.ctx) };
+        match ctx_func_ty.is_null() {
+            true => Err(Error::OperationError(String::from(
+                "fail to get the function type",
+            ))),
+            false => Ok(FuncType {
+                ctx: ctx_func_ty,
+                registered: true,
+            }),
+        }
+    }
+
+    /// Get the external value (which is table type)
+    pub fn table_type(&self, module: &Module) -> WasmEdgeResult<TableType> {
+        let external_ty = self.external_type();
+        if external_ty != ExternalType::Table {
+            return Err(Error::OperationError(format!(
+                "The external type should be 'table', but found '{}'",
+                external_ty
+            )));
+        }
+        let ctx_tab_ty = unsafe { wasmedge::WasmEdge_ImportTypeGetTableType(module.ctx, self.ctx) };
+        match ctx_tab_ty.is_null() {
+            true => Err(Error::OperationError(String::from(
+                "fail to get the table type",
+            ))),
+            false => Ok(TableType {
+                ctx: ctx_tab_ty,
+                registered: true,
+            }),
+        }
+    }
+
+    /// Get the external value (which is memory type)
+    pub fn memory_type(&self, module: &Module) -> WasmEdgeResult<MemType> {
+        let external_ty = self.external_type();
+        if external_ty != ExternalType::Memory {
+            return Err(Error::OperationError(format!(
+                "The external type should be 'memory', but found '{}'",
+                external_ty
+            )));
+        }
+        let ctx_mem_ty =
+            unsafe { wasmedge::WasmEdge_ImportTypeGetMemoryType(module.ctx, self.ctx) };
+        match ctx_mem_ty.is_null() {
+            true => Err(Error::OperationError(String::from(
+                "fail to get the memory type",
+            ))),
+            false => Ok(MemType {
+                ctx: ctx_mem_ty as *mut _,
+                registered: true,
+            }),
+        }
+    }
+
+    /// Get the external value (which is global type)
+    pub fn global_type(&self, module: &Module) -> WasmEdgeResult<GlobalType> {
+        let external_ty = self.external_type();
+        if external_ty != ExternalType::Global {
+            return Err(Error::OperationError(format!(
+                "The external type should be 'global', but found '{}'",
+                external_ty
+            )));
+        }
+        let ctx_global_ty =
+            unsafe { wasmedge::WasmEdge_ImportTypeGetGlobalType(module.ctx, self.ctx) };
+        match ctx_global_ty.is_null() {
+            true => Err(Error::OperationError(String::from(
+                "fail to get the global type",
+            ))),
+            false => Ok(GlobalType {
+                ctx: ctx_global_ty as *mut _,
+                registered: true,
+            }),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ExportType {
+    pub(crate) ctx: *const wasmedge::WasmEdge_ExportTypeContext,
+}
+impl Drop for ExportType {
+    fn drop(&mut self) {
+        if !self.ctx.is_null() {
+            self.ctx = std::ptr::null();
+        }
+    }
+}
+impl ExportType {
+    /// Get the external type
+    pub fn external_type(&self) -> ExternalType {
+        let ty = unsafe { wasmedge::WasmEdge_ExportTypeGetExternalType(self.ctx) };
+        ty.into()
+    }
+
+    /// Get the external name
+    pub fn external_name(&self) -> Cow<'_, str> {
+        let c_name = unsafe {
+            let raw_name = wasmedge::WasmEdge_ExportTypeGetExternalName(self.ctx);
+            CStr::from_ptr(raw_name.Buf)
+        };
+        c_name.to_string_lossy()
+    }
+
+    /// Get the external value (which is function type)
+    pub fn function_type(&self, module: &Module) -> WasmEdgeResult<FuncType> {
+        let external_ty = self.external_type();
+        if external_ty != ExternalType::Function {
+            return Err(Error::OperationError(format!(
+                "The external type should be 'function', but found '{}'",
+                external_ty
+            )));
+        }
+        let ctx_func_ty =
+            unsafe { wasmedge::WasmEdge_ExportTypeGetFunctionType(module.ctx, self.ctx) };
+        match ctx_func_ty.is_null() {
+            true => Err(Error::OperationError(String::from(
+                "fail to get the function type",
+            ))),
+            false => Ok(FuncType {
+                ctx: ctx_func_ty,
+                registered: true,
+            }),
+        }
+    }
+
+    /// Get the external value (which is table type)
+    pub fn table_type(&self, module: &Module) -> WasmEdgeResult<TableType> {
+        let external_ty = self.external_type();
+        if external_ty != ExternalType::Table {
+            return Err(Error::OperationError(format!(
+                "The external type should be 'table', but found '{}'",
+                external_ty
+            )));
+        }
+        let ctx_tab_ty = unsafe { wasmedge::WasmEdge_ExportTypeGetTableType(module.ctx, self.ctx) };
+        match ctx_tab_ty.is_null() {
+            true => Err(Error::OperationError(String::from(
+                "fail to get the table type",
+            ))),
+            false => Ok(TableType {
+                ctx: ctx_tab_ty,
+                registered: true,
+            }),
+        }
+    }
+
+    /// Get the external value (which is memory type)
+    pub fn memory_type(&self, module: &Module) -> WasmEdgeResult<MemType> {
+        let external_ty = self.external_type();
+        if external_ty != ExternalType::Memory {
+            return Err(Error::OperationError(format!(
+                "The external type should be 'memory', but found '{}'",
+                external_ty
+            )));
+        }
+        let ctx_mem_ty =
+            unsafe { wasmedge::WasmEdge_ExportTypeGetMemoryType(module.ctx, self.ctx) };
+        match ctx_mem_ty.is_null() {
+            true => Err(Error::OperationError(String::from(
+                "fail to get the function type",
+            ))),
+            false => Ok(MemType {
+                ctx: ctx_mem_ty as *mut _,
+                registered: true,
+            }),
+        }
+    }
+
+    /// Get the external value (which is global type)
+    pub fn global_type(&self, module: &Module) -> WasmEdgeResult<GlobalType> {
+        let external_ty = self.external_type();
+        if external_ty != ExternalType::Global {
+            return Err(Error::OperationError(format!(
+                "The external type should be 'global', but found '{}'",
+                external_ty
+            )));
+        }
+        let ctx_global_ty =
+            unsafe { wasmedge::WasmEdge_ExportTypeGetGlobalType(module.ctx, self.ctx) };
+        match ctx_global_ty.is_null() {
+            true => Err(Error::OperationError(String::from(
+                "fail to get the function type",
+            ))),
+            false => Ok(GlobalType {
+                ctx: ctx_global_ty as *mut _,
+                registered: true,
+            }),
+        }
     }
 }
 

--- a/bindings/rust/wasmedge-sys/src/module.rs
+++ b/bindings/rust/wasmedge-sys/src/module.rs
@@ -2,7 +2,7 @@ use super::wasmedge;
 use crate::{
     error::{check, Error, WasmEdgeResult},
     instance::{function::FuncType, global::GlobalType, memory::MemType, table::TableType},
-    types::ExternalType,
+    types::ExternType,
     utils, Config,
 };
 use ::core::mem::MaybeUninit as MU;
@@ -133,9 +133,18 @@ impl Drop for ImportType {
 }
 impl ImportType {
     /// Get the external type
-    pub fn external_type(&self) -> ExternalType {
+    pub fn ty(&self) -> ExternType {
         let ty = unsafe { wasmedge::WasmEdge_ImportTypeGetExternalType(self.ctx) };
         ty.into()
+    }
+
+    /// Get the external name
+    pub fn name(&self) -> Cow<'_, str> {
+        let c_name = unsafe {
+            let raw_name = wasmedge::WasmEdge_ImportTypeGetExternalName(self.ctx);
+            CStr::from_ptr(raw_name.Buf)
+        };
+        c_name.to_string_lossy()
     }
 
     /// Get the module name
@@ -147,19 +156,10 @@ impl ImportType {
         c_name.to_string_lossy()
     }
 
-    /// Get the external name
-    pub fn external_name(&self) -> Cow<'_, str> {
-        let c_name = unsafe {
-            let raw_name = wasmedge::WasmEdge_ImportTypeGetExternalName(self.ctx);
-            CStr::from_ptr(raw_name.Buf)
-        };
-        c_name.to_string_lossy()
-    }
-
     /// Get the external value (which is function type)
     pub fn function_type(&self, module: &Module) -> WasmEdgeResult<FuncType> {
-        let external_ty = self.external_type();
-        if external_ty != ExternalType::Function {
+        let external_ty = self.ty();
+        if external_ty != ExternType::Function {
             return Err(Error::OperationError(format!(
                 "The external type should be 'function', but found '{}'",
                 external_ty
@@ -180,8 +180,8 @@ impl ImportType {
 
     /// Get the external value (which is table type)
     pub fn table_type(&self, module: &Module) -> WasmEdgeResult<TableType> {
-        let external_ty = self.external_type();
-        if external_ty != ExternalType::Table {
+        let external_ty = self.ty();
+        if external_ty != ExternType::Table {
             return Err(Error::OperationError(format!(
                 "The external type should be 'table', but found '{}'",
                 external_ty
@@ -201,8 +201,8 @@ impl ImportType {
 
     /// Get the external value (which is memory type)
     pub fn memory_type(&self, module: &Module) -> WasmEdgeResult<MemType> {
-        let external_ty = self.external_type();
-        if external_ty != ExternalType::Memory {
+        let external_ty = self.ty();
+        if external_ty != ExternType::Memory {
             return Err(Error::OperationError(format!(
                 "The external type should be 'memory', but found '{}'",
                 external_ty
@@ -223,8 +223,8 @@ impl ImportType {
 
     /// Get the external value (which is global type)
     pub fn global_type(&self, module: &Module) -> WasmEdgeResult<GlobalType> {
-        let external_ty = self.external_type();
-        if external_ty != ExternalType::Global {
+        let external_ty = self.ty();
+        if external_ty != ExternType::Global {
             return Err(Error::OperationError(format!(
                 "The external type should be 'global', but found '{}'",
                 external_ty
@@ -257,13 +257,13 @@ impl Drop for ExportType {
 }
 impl ExportType {
     /// Get the external type
-    pub fn external_type(&self) -> ExternalType {
+    pub fn ty(&self) -> ExternType {
         let ty = unsafe { wasmedge::WasmEdge_ExportTypeGetExternalType(self.ctx) };
         ty.into()
     }
 
     /// Get the external name
-    pub fn external_name(&self) -> Cow<'_, str> {
+    pub fn name(&self) -> Cow<'_, str> {
         let c_name = unsafe {
             let raw_name = wasmedge::WasmEdge_ExportTypeGetExternalName(self.ctx);
             CStr::from_ptr(raw_name.Buf)
@@ -273,8 +273,8 @@ impl ExportType {
 
     /// Get the external value (which is function type)
     pub fn function_type(&self, module: &Module) -> WasmEdgeResult<FuncType> {
-        let external_ty = self.external_type();
-        if external_ty != ExternalType::Function {
+        let external_ty = self.ty();
+        if external_ty != ExternType::Function {
             return Err(Error::OperationError(format!(
                 "The external type should be 'function', but found '{}'",
                 external_ty
@@ -295,8 +295,8 @@ impl ExportType {
 
     /// Get the external value (which is table type)
     pub fn table_type(&self, module: &Module) -> WasmEdgeResult<TableType> {
-        let external_ty = self.external_type();
-        if external_ty != ExternalType::Table {
+        let external_ty = self.ty();
+        if external_ty != ExternType::Table {
             return Err(Error::OperationError(format!(
                 "The external type should be 'table', but found '{}'",
                 external_ty
@@ -316,8 +316,8 @@ impl ExportType {
 
     /// Get the external value (which is memory type)
     pub fn memory_type(&self, module: &Module) -> WasmEdgeResult<MemType> {
-        let external_ty = self.external_type();
-        if external_ty != ExternalType::Memory {
+        let external_ty = self.ty();
+        if external_ty != ExternType::Memory {
             return Err(Error::OperationError(format!(
                 "The external type should be 'memory', but found '{}'",
                 external_ty
@@ -338,8 +338,8 @@ impl ExportType {
 
     /// Get the external value (which is global type)
     pub fn global_type(&self, module: &Module) -> WasmEdgeResult<GlobalType> {
-        let external_ty = self.external_type();
-        if external_ty != ExternalType::Global {
+        let external_ty = self.ty();
+        if external_ty != ExternType::Global {
             return Err(Error::OperationError(format!(
                 "The external type should be 'global', but found '{}'",
                 external_ty

--- a/bindings/rust/wasmedge-sys/src/module.rs
+++ b/bindings/rust/wasmedge-sys/src/module.rs
@@ -1,9 +1,7 @@
 use super::wasmedge;
 use crate::{
     error::{check, Error, WasmEdgeResult},
-    instance::function::FuncType,
-    instance::global::GlobalType,
-    instance::memory::MemType,
+    instance::{function::FuncType, global::GlobalType, memory::MemType, table::TableType},
     types::ExternalType,
     utils, Config,
 };
@@ -174,7 +172,7 @@ impl ImportType {
                 "fail to get the function type",
             ))),
             false => Ok(FuncType {
-                ctx: ctx_func_ty,
+                ctx: ctx_func_ty as *mut _,
                 registered: true,
             }),
         }
@@ -195,7 +193,7 @@ impl ImportType {
                 "fail to get the table type",
             ))),
             false => Ok(TableType {
-                ctx: ctx_tab_ty,
+                ctx: ctx_tab_ty as *mut _,
                 registered: true,
             }),
         }
@@ -289,7 +287,7 @@ impl ExportType {
                 "fail to get the function type",
             ))),
             false => Ok(FuncType {
-                ctx: ctx_func_ty,
+                ctx: ctx_func_ty as *mut _,
                 registered: true,
             }),
         }
@@ -310,7 +308,7 @@ impl ExportType {
                 "fail to get the table type",
             ))),
             false => Ok(TableType {
-                ctx: ctx_tab_ty,
+                ctx: ctx_tab_ty as *mut _,
                 registered: true,
             }),
         }

--- a/bindings/rust/wasmedge-sys/src/module.rs
+++ b/bindings/rust/wasmedge-sys/src/module.rs
@@ -86,6 +86,40 @@ impl Module {
             registered: false,
         })
     }
+
+    /// Get the length of imports list
+    pub fn imports_len(&self) -> u32 {
+        unsafe { wasmedge::WasmEdge_ASTModuleListImportsLength(self.ctx) }
+    }
+
+    /// Get the imports
+    pub fn imports(&self) -> WasmEdgeResult<impl Iterator<Item = ImportType>> {
+        let size = self.imports_len();
+        let mut returns = Vec::with_capacity(size as usize);
+        unsafe {
+            wasmedge::WasmEdge_ASTModuleListImports(self.ctx, returns.as_mut_ptr(), size);
+            returns.set_len(size as usize);
+        }
+
+        Ok(returns.into_iter().map(|ctx| ImportType { ctx }))
+    }
+
+    /// Get the length of exports list
+    pub fn exports_len(&self) -> u32 {
+        unsafe { wasmedge::WasmEdge_ASTModuleListExportsLength(self.ctx) }
+    }
+
+    /// Get the exports
+    pub fn exports(&self) -> WasmEdgeResult<impl Iterator<Item = ExportType>> {
+        let size = self.exports_len();
+        let mut returns = Vec::with_capacity(size as usize);
+        unsafe {
+            wasmedge::WasmEdge_ASTModuleListExports(self.ctx, returns.as_mut_ptr(), size);
+            returns.set_len(size as usize);
+        }
+
+        Ok(returns.into_iter().map(|ctx| ExportType { ctx }))
+    }
 }
 
 #[derive(Debug)]

--- a/bindings/rust/wasmedge-sys/src/types.rs
+++ b/bindings/rust/wasmedge-sys/src/types.rs
@@ -1,4 +1,5 @@
 use super::wasmedge;
+use std::fmt;
 pub type WasmEdgeProposal = wasmedge::WasmEdge_Proposal;
 pub type HostFunc = wasmedge::WasmEdge_HostFunc_t;
 pub type WrapFunc = wasmedge::WasmEdge_WrapFunc_t;
@@ -185,5 +186,32 @@ impl From<HostRegistration> for wasmedge::WasmEdge_HostRegistration {
                 wasmedge::WasmEdge_HostRegistration_WasmEdge_Process
             }
         }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ExternalType {
+    Function = wasmedge::WasmEdge_ExternalType_Function,
+    Table = wasmedge::WasmEdge_ExternalType_Table,
+    Memory = wasmedge::WasmEdge_ExternalType_Memory,
+    Global = wasmedge::WasmEdge_ExternalType_Global,
+}
+impl From<u32> for ExternalType {
+    fn from(value: u32) -> Self {
+        match value {
+            0x00u32 => ExternalType::Function,
+        }
+    }
+}
+impl fmt::Display for ExternalType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            ExternalType::Function => "function",
+            ExternalType::Table => "table",
+            ExternalType::Memory => "memory",
+            ExternalType::Global => "global",
+        };
+        write!(f, "{}", message)
     }
 }

--- a/bindings/rust/wasmedge-sys/src/types.rs
+++ b/bindings/rust/wasmedge-sys/src/types.rs
@@ -191,30 +191,30 @@ impl From<HostRegistration> for wasmedge::WasmEdge_HostRegistration {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u32)]
-pub enum ExternalType {
+pub enum ExternType {
     Function = wasmedge::WasmEdge_ExternalType_Function,
     Table = wasmedge::WasmEdge_ExternalType_Table,
     Memory = wasmedge::WasmEdge_ExternalType_Memory,
     Global = wasmedge::WasmEdge_ExternalType_Global,
 }
-impl From<u32> for ExternalType {
+impl From<u32> for ExternType {
     fn from(val: u32) -> Self {
         match val {
-            0x00u32 => ExternalType::Function,
-            0x01u32 => ExternalType::Table,
-            0x02u32 => ExternalType::Memory,
-            0x03u32 => ExternalType::Global,
+            0x00u32 => ExternType::Function,
+            0x01u32 => ExternType::Table,
+            0x02u32 => ExternType::Memory,
+            0x03u32 => ExternType::Global,
             _ => panic!("Unknown ExternalType value: {}", val),
         }
     }
 }
-impl fmt::Display for ExternalType {
+impl fmt::Display for ExternType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let message = match self {
-            ExternalType::Function => "function",
-            ExternalType::Table => "table",
-            ExternalType::Memory => "memory",
-            ExternalType::Global => "global",
+            ExternType::Function => "function",
+            ExternType::Table => "table",
+            ExternType::Memory => "memory",
+            ExternType::Global => "global",
         };
         write!(f, "{}", message)
     }

--- a/bindings/rust/wasmedge-sys/src/types.rs
+++ b/bindings/rust/wasmedge-sys/src/types.rs
@@ -198,9 +198,13 @@ pub enum ExternalType {
     Global = wasmedge::WasmEdge_ExternalType_Global,
 }
 impl From<u32> for ExternalType {
-    fn from(value: u32) -> Self {
-        match value {
+    fn from(val: u32) -> Self {
+        match val {
             0x00u32 => ExternalType::Function,
+            0x01u32 => ExternalType::Table,
+            0x02u32 => ExternalType::Memory,
+            0x03u32 => ExternalType::Global,
+            _ => panic!("Unknown ExternalType value: {}", val),
         }
     }
 }


### PR DESCRIPTION
The following C-APIs are involved in this PR:
- ImportType
  - Fix #755 
  - Fix #759 
  - Fix #753 
  - Fix #756 
  - Fix #760 
  - Fix #758 
  - Fix #757 
- ExportType
  - Fix #710 
  - Fix #711 
  - Fix #712 
  - Fix #713 
  - Fix #716 
  - Fix #718 
  - Fix #724 
- ASTModule
  - Fix #687 
  - Fix #686 
  - Fix #685 
  - Fix #684 