### PR TITLE
[CI] Limit the MDBOOK action to merged book file updates

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -9,8 +9,8 @@ on:
         default: 'info'
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    paths:
+      - 'docs/book/**'
 
 jobs:
   build:

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -11,6 +11,10 @@ on:
     branches: [ master ]
     paths:
       - 'docs/book/**'
+  pull_request:
+    branches: [ master ]
+    paths:
+      - 'docs/book/**'
 
 jobs:
   build:
@@ -32,6 +36,7 @@ jobs:
           mdbook build
 
       - name: Publish EN version
+        if: ${{ github.event_name == 'push' }}
         uses: cpina/github-action-push-to-another-repository@main
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB_WWW }}


### PR DESCRIPTION
Auto triggers only occur when there is a push event in the docs/book folder

Signed-off-by: Michael Yuan <michael@michaelyuan.com>