### PR TITLE
[Misc] Beautify help information

### DIFF
--- a/include/po/argument_parser.h
+++ b/include/po/argument_parser.h
@@ -196,7 +196,7 @@ private:
 
     void usage() const noexcept {
       using std::cout;
-      cout << "\u001b[33mUSAGE\u001b[0m\n"sv;
+      cout << YELLOW_COLOR << "USAGE"sv << RESET_COLOR << '\n';
       for (const char *Part : ProgramNames) {
         cout << '\t' << Part;
       }
@@ -245,10 +245,10 @@ private:
 
       cout << '\n';
       if (!SubCommandList.empty()) {
-        cout << "\u001b[33mSubCommands\u001b[0m\n"sv;
+        cout << YELLOW_COLOR << "SubCommands"sv << RESET_COLOR << '\n';
         for (const auto Offset : SubCommandList) {
           cout << kIndent;
-          cout << "\u001b[32m"sv;
+          cout << GREEN_COLOR;
           bool First = true;
           for (const auto &Name : this[Offset].SubCommandNames) {
             if (!First) {
@@ -257,14 +257,14 @@ private:
             cout << Name;
             First = false;
           }
-          cout << "\u001b[0m\n"sv;
+          cout << RESET_COLOR << '\n';
           indent_output(kIndent, 2, 80, this[Offset].SC->description());
           cout << '\n';
         }
         cout << '\n';
       }
 
-      cout << "\u001b[33mOPTIONS\u001b[0m\n"sv;
+      cout << YELLOW_COLOR << "OPTIONS"sv << RESET_COLOR << '\n';
       for (const auto &Index : NonpositionalList) {
         const auto &Desc = ArgumentDescriptors[Index];
         if (Desc.hidden()) {
@@ -272,7 +272,7 @@ private:
         }
 
         cout << kIndent;
-        cout << "\u001b[32m"sv;
+        cout << GREEN_COLOR;
         bool First = true;
         for (const auto &Option : Desc.options()) {
           if (!First) {
@@ -285,7 +285,7 @@ private:
           }
           First = false;
         }
-        cout << "\u001b[0m\n"sv;
+        cout << RESET_COLOR << '\n';
         indent_output(kIndent, 2, 80, Desc.description());
         cout << '\n';
       }
@@ -395,6 +395,10 @@ private:
     std::vector<std::size_t> NonpositionalList;
     std::vector<std::size_t> PositionalList;
     std::unique_ptr<Option<Toggle>> HelpOpt;
+
+    static constexpr char YELLOW_COLOR[] = "\u001b[33m";
+    static constexpr char GREEN_COLOR[] = "\u001b[32m";
+    static constexpr char RESET_COLOR[] = "\u001b[0m";
   };
 
 public:

--- a/include/po/argument_parser.h
+++ b/include/po/argument_parser.h
@@ -196,40 +196,13 @@ private:
 
     void usage() const noexcept {
       using std::cout;
-      cout << "usage:"sv;
+      cout << "\u001b[33mUSAGE\u001b[0m\n"sv;
       for (const char *Part : ProgramNames) {
-        cout << ' ' << Part;
+        cout << '\t' << Part;
       }
-      for (const auto &Index : NonpositionalList) {
-        const auto &Desc = ArgumentDescriptors[Index];
-        if (Desc.hidden()) {
-          continue;
-        }
 
-        bool First = true;
-        cout << ' ' << '[';
-        for (const auto &Option : Desc.options()) {
-          if (!First) {
-            cout << '|';
-          }
-          if (Option.size() == 1) {
-            cout << '-' << Option;
-          } else {
-            cout << '-' << '-' << Option;
-          }
-          First = false;
-        }
-        switch (Desc.max_nargs()) {
-        case 0:
-          break;
-        case 1:
-          cout << ' ' << Desc.meta();
-          break;
-        default:
-          cout << ' ' << Desc.meta() << " ..."sv;
-          break;
-        }
-        cout << ']';
+      if (NonpositionalList.size() != 0) {
+        cout << " [OPTIONS]"sv;
       }
       bool First = true;
       for (const auto &Index : PositionalList) {
@@ -268,12 +241,14 @@ private:
     void help() const noexcept {
       usage();
       using std::cout;
-      const constexpr std::string_view kIndent = "  "sv;
+      const constexpr std::string_view kIndent = "\t"sv;
 
+      cout << '\n';
       if (!SubCommandList.empty()) {
-        cout << "SubCommands:\n"sv;
+        cout << "\u001b[33mSubCommands\u001b[0m\n"sv;
         for (const auto Offset : SubCommandList) {
           cout << kIndent;
+          cout << "\u001b[32m"sv;
           bool First = true;
           for (const auto &Name : this[Offset].SubCommandNames) {
             if (!First) {
@@ -282,13 +257,14 @@ private:
             cout << Name;
             First = false;
           }
-          cout << '\n';
+          cout << "\u001b[0m\n"sv;
           indent_output(kIndent, 2, 80, this[Offset].SC->description());
           cout << '\n';
         }
+        cout << '\n';
       }
 
-      cout << "Options:\n"sv;
+      cout << "\u001b[33mOPTIONS\u001b[0m\n"sv;
       for (const auto &Index : NonpositionalList) {
         const auto &Desc = ArgumentDescriptors[Index];
         if (Desc.hidden()) {
@@ -296,6 +272,7 @@ private:
         }
 
         cout << kIndent;
+        cout << "\u001b[32m"sv;
         bool First = true;
         for (const auto &Option : Desc.options()) {
           if (!First) {
@@ -308,7 +285,7 @@ private:
           }
           First = false;
         }
-        cout << '\n';
+        cout << "\u001b[0m\n"sv;
         indent_output(kIndent, 2, 80, Desc.description());
         cout << '\n';
       }


### PR DESCRIPTION
The output text of the current help command is too compact, making it difficult for the user to read. Hopefully, the formatting can be spruced up and ASNI color codes used.

This commit have change some code in `include/po/argument_parser.h`, here's the preview:

![2021-12-24_22-11.png](https://s2.loli.net/2021/12/24/3WnwfvCJH6UPEBm.png)