### PR TITLE
[Utils] Remove wget --show-progress option for supporting wget 1.14

### DIFF
--- a/utils/install.sh
+++ b/utils/install.sh
@@ -35,7 +35,7 @@ _downloader() {
             exit 1
         fi
     else
-        wget -q -c --directory-prefix="$TMP_DIR" --show-progress "$url"
+        wget -q -c --directory-prefix="$TMP_DIR" "$url"
     fi
 }
 


### PR DESCRIPTION
Some of our users are using CentOS 7, which only has wget 1.14.
The `--show-progress` is a "new" feature in wget 1.16, which is released in 2014/10. However, CentOS 7 doesn't support such a "new" version.