### PR TITLE
[Utils] Install Script: Changed first default and wget options

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -12,13 +12,13 @@
 The easiest way to install WasmEdge is to run the following command. Your system should have `git` and `wget` as prerequisites.
 
 ```bash
-wget -qO- https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash
+curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash
 ```
 
 If you would like to install WasmEdge with its [Tensorflow and image processing extensions](https://www.secondstate.io/articles/wasi-tensorflow/), please run the following command. It will attempt to install Tensorflow and image shared libraries on your system.
 
 ```bash
-wget -qO- https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -e all
+curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -e all
 ```
 
 Run the following command to make the installed binary available in the current session `source $HOME/.wasmedge/env`
@@ -30,13 +30,13 @@ Run the following command to make the installed binary available in the current 
 By default, WasmEdge is installed in the `$HOME/.wasmedge` directory. You can install it into a system directory, such as `/usr/local` to make it available to all users. To specify an install directory, you can run the `install.sh` script with the `-p` flag. You will need to run the following commands as the `root` user or `sudo` since they write into system directories.
 
 ```bash
-wget -qO- https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -p /usr/local
+curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -p /usr/local
 ```
 
 Or, with all extensions
 
 ```bash
-wget -qO- https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -e all -p /usr/local
+curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -e all -p /usr/local
 ```
 
 ## What's installed
@@ -56,19 +56,19 @@ After installation, you have the following directories and files. Here we assume
 To uninstall WasmEdge, you can run the following command.
 
 ```bash
-bash <(wget -qO- https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/uninstall.sh)
+bash <(curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/uninstall.sh)
 ```
 
 If `wasmedge` binary is not in `PATH` and it wasn't installed in the default `$HOME/.wasmedge` folder, then you must provide the installation path.
 
 ```bash
-bash <(wget -qO- https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/uninstall.sh) -p /path/to/parent/folder
+bash <(curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/uninstall.sh) -p /path/to/parent/folder
 ```
 
 If you wish to uninstall uninteractively, you can pass in the `--quick` or `-q` flag.
 
 ```bash
-bash <(wget -qO- https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/uninstall.sh) -q
+bash <(curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/uninstall.sh) -q
 ```
 
 > If a parent folder of the `wasmedge` binary contains `.wasmedge`, the folder will be considered for removal. For example, the script removes the default `$HOME/.wasmedge` folder altogether.

--- a/utils/install.sh
+++ b/utils/install.sh
@@ -25,17 +25,20 @@ _ldconfig() {
 
 _downloader() {
     local url=$1
-    if ! command -v wget &>/dev/null; then
-        if command -v curl &>/dev/null; then
-            pushd "$TMP_DIR"
-            curl -L -OC0 "$url" --progress-bar
-            popd
-        else
+    if ! command -v curl &>/dev/null; then
+        if ! command -v wget &>/dev/null; then
             echo "${RED}Please install wget or curl${NC}"
             exit 1
+        else
+            wget --help | grep -q '\--show-progress' &&
+                _PROGRESS_OPT="--show-progress" || _PROGRESS_OPT=""
+
+            wget q -c --directory-prefix="$TMP_DIR" "$_PROGRESS_OPT " "$url"
         fi
     else
-        wget -q -c --directory-prefix="$TMP_DIR" --show-progress "$url"
+        pushd "$TMP_DIR"
+        curl -L -OC0 "$url" --progress-bar
+        popd
     fi
 }
 

--- a/utils/install.sh
+++ b/utils/install.sh
@@ -566,7 +566,7 @@ main() {
 
     if [ "$REMOVE_OLD" == "1" ] || [[ "$REMOVE_OLD" =~ ^([yY][eE][sS]|[yY])$ ]]; then
         if [ -f "$IPATH/env" ]; then
-            bash <(wget -qO- https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/uninstall.sh) -p "$IPATH" -q
+            bash <(curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/uninstall.sh) -p "$IPATH" -q
         fi
     fi
 

--- a/utils/uninstall.sh
+++ b/utils/uninstall.sh
@@ -259,6 +259,8 @@ main() {
         echo "${YELLOW}Sourcing not found in ${__HOME__}/${_shell_rc} ${NC}"
         exit 1
     fi
+
+    exit 0
 }
 
 main "$@"


### PR DESCRIPTION
* [SAtacker] First checks if curl is installed else checks for wget
* [hydai] If wget has progress-bar option goes with it else it does not
* Suggestions from https://github.com/WasmEdge/WasmEdge/issues/966
and https://github.com/WasmEdge/WasmEdge/pull/958

Signed-off-by: Shreyas Atre <shreyasatre16@gmail.com>
Co-authored-by: hydai <hydai@secondstate.io>