### PR TITLE
[Rust] Refactored the Value enum and the relevant APIs

### DIFF
--- a/bindings/rust/wasmedge-sys/src/types.rs
+++ b/bindings/rust/wasmedge-sys/src/types.rs
@@ -287,19 +287,17 @@ pub enum Value {
     NullRef(RefType),
 }
 impl Value {
+    /// Returns a [`Value`] which implies a reference to an external object.
+    ///
+    /// # Argument
+    ///
+    /// - `extern_obj` specifies an external object.
     pub fn gen_extern_ref<T>(extern_obj: &mut T) -> Value {
         unsafe {
             let ptr = extern_obj as *mut T as *mut c_void;
             wasmedge::WasmEdge_ValueGenExternRef(ptr).into()
         }
     }
-
-    // pub fn gen_extern_ref(&mut self) -> Value {
-    //     unsafe {
-    //         let self_ptr: *mut c_void = self as *mut _ as *mut c_void;
-    //         wasmedge::WasmEdge_ValueGenExternRef(self_ptr).into()
-    //     }
-    // }
 
     pub fn ty(&self) -> ValType {
         match &self {


### PR DESCRIPTION
This PR refactored the `Value` enum and the relevant APIs. The following C APIs are involved:

- Fix #732 
- Fix #730
- Fix #738 
- Fix #739 
- Fix #723 
- Fix #734 
- Fix #728 
- Fix #715 
- Fix #714 
- Fix #720 
- Fix #719 
- Fix #707 
- Fix #717
- Fix #722 