### PR TITLE
Fix the memory data pointer getting timing

### DIFF
--- a/include/runtime/instance/module.h
+++ b/include/runtime/instance/module.h
@@ -188,7 +188,6 @@ public:
 
   /// \name Data for compiled functions.
   /// @{
-  uint8_t *MemoryPtr;
   std::vector<ValVariant *> GlobalsPtr;
   /// @}
 

--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -84,7 +84,10 @@ Executor::enterFunction(Runtime::StoreManager &StoreMgr,
     {
       CurrentStore = &StoreMgr;
       const auto &ModInst = **StoreMgr.getModule(Func.getModuleAddr());
-      ExecutionContext.Memory = ModInst.MemoryPtr;
+      ExecutionContext.Memory =
+          ModInst.getMemNum() > 0
+              ? (*StoreMgr.getMemory(*ModInst.getMemAddr(0)))->getDataPtr()
+              : nullptr;
       ExecutionContext.Globals = ModInst.GlobalsPtr.data();
     }
 

--- a/lib/executor/instantiate/module.cpp
+++ b/lib/executor/instantiate/module.cpp
@@ -141,16 +141,6 @@ Expect<void> Executor::instantiate(Runtime::StoreManager &StoreMgr,
   }
 
   // Prepare pointers for compiled functions
-  ModInst->MemoryPtr =
-      ModInst->getMemAddr(0)
-          .and_then([&StoreMgr](uint32_t MemAddr) {
-            return StoreMgr.getMemory(MemAddr);
-          })
-          .map([](const Runtime::Instance::MemoryInstance *MemInst) {
-            return MemInst->getDataPtr();
-          })
-          .value_or(nullptr);
-
   ModInst->GlobalsPtr.reserve(ModInst->getGlobalNum());
   for (uint32_t I = 0; I < static_cast<uint32_t>(ModInst->getGlobalNum());
        ++I) {


### PR DESCRIPTION
The data pointer of a memory instance may changed when memory growing:
https://github.com/WasmEdge/WasmEdge/blob/master/include/runtime/instance/memory.h#L107-L112

Therefore, it's better to retrieve the data pointer right before entering the compiled functions than in the instantiate phase.