### PR TITLE
[Rust] Refactored the function module

### DIFF
--- a/bindings/rust/wasmedge-sys/examples/hostfunc.rs
+++ b/bindings/rust/wasmedge-sys/examples/hostfunc.rs
@@ -64,16 +64,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut module =
         Module::create_from_file(&config, hostfunc_path).expect("funcs.wasm should be correct");
 
-    let mut vm = Vm::create(Some(&config), None)
+    let vm = Vm::create(Some(&config), None)
         .expect("fail to create VM instance")
         .register_wasm_from_import(&mut import_obj)
         .expect("import_obj should be regiestered")
         .load_wasm_from_module(&mut module)
-        .expect("funcs.wasm should be loaded")
-        .validate()
-        .expect("fail to validate vm")
-        .instantiate()
-        .expect("fail to instantiate vm");
+        .expect("funcs.wasm should be loaded");
+    vm.validate().expect("fail to validate vm");
+    vm.instantiate().expect("fail to instantiate vm");
 
     #[allow(clippy::type_complexity)]
     fn boxed_fn() -> Box<dyn Fn(Vec<Value>) -> Result<Vec<Value>, u8>> {

--- a/bindings/rust/wasmedge-sys/examples/hostfunc.rs
+++ b/bindings/rust/wasmedge-sys/examples/hostfunc.rs
@@ -52,7 +52,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut import_obj =
         ImportObj::create("extern_module").expect("fail to create ImportObj instance");
 
-    let result = FuncType::create(vec![ValType::I32; 2], vec![ValType::I32]);
+    let result = FuncType::create(
+        vec![ValType::ExternRef, ValType::I32, ValType::I32],
+        vec![ValType::I32],
+    );
     assert!(result.is_ok());
     let func_ty = result.unwrap();
     let result = Function::create(func_ty, Box::new(real_add), 0);

--- a/bindings/rust/wasmedge-sys/examples/hostfunc2.rs
+++ b/bindings/rust/wasmedge-sys/examples/hostfunc2.rs
@@ -65,7 +65,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::create().expect("fail to create Config instance");
     let mut import_obj = ImportObj::create("extern_module").unwrap();
 
-    let result = FuncType::create(vec![ValType::I32; 2], vec![ValType::I32]);
+    let result = FuncType::create(
+        vec![ValType::ExternRef, ValType::I32, ValType::I32],
+        vec![ValType::I32],
+    );
     assert!(result.is_ok());
     let func_ty = result.unwrap();
     let result = Function::create(func_ty, Box::new(real_add), 0);

--- a/bindings/rust/wasmedge-sys/examples/hostfunc2.rs
+++ b/bindings/rust/wasmedge-sys/examples/hostfunc2.rs
@@ -10,16 +10,12 @@
 //! generics of `Function::create_bindings::<I, O>`, wherein the I and O are the `WasmFnIO` traits
 //! base on the inputs and outputs of the real host function.
 //!
+
 use std::{
     fs::{self, File},
     io::Read,
 };
-
-use wasmedge_sys::{
-    instance::Function,
-    io::{I1, I2},
-    Config, ImportObj, Module, Value, Vm,
-};
+use wasmedge_sys::{Config, FuncType, Function, ImportObj, Module, ValType, Value, Vm};
 
 fn real_add(input: Vec<Value>) -> Result<Vec<Value>, u8> {
     println!("Rust: Entering Rust function real_add");
@@ -69,7 +65,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::create().expect("fail to create Config instance");
     let mut import_obj = ImportObj::create("extern_module").unwrap();
 
-    let result = Function::create_bindings::<I2<i32, i32>, I1<i32>>(Box::new(real_add));
+    let result = FuncType::create(vec![ValType::I32; 2], vec![ValType::I32]);
+    assert!(result.is_ok());
+    let func_ty = result.unwrap();
+    let result = Function::create(func_ty, Box::new(real_add), 0);
     assert!(result.is_ok());
     let mut host_func = result.unwrap();
     import_obj.add_func("add", &mut host_func);
@@ -78,14 +77,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut module =
         Module::create_from_buffer(&config, &wasm_binary).expect("funcs.wasm should be correct");
 
-    let vm = Vm::create(Some(&config), None)
+    let mut vm = Vm::create(Some(&config), None)
         .expect("fail to create VM instance")
         .register_wasm_from_import(&mut import_obj)
         .expect("import_obj should be regiestered")
         .load_wasm_from_module(&mut module)
-        .expect("funcs.wasm should be loaded");
-    vm.validate().expect("fail to validate vm");
-    vm.instantiate().expect("fail to instantiate vm");
+        .expect("funcs.wasm should be loaded")
+        .validate()
+        .expect("fail to validate vm")
+        .instantiate()
+        .expect("fail to instantiate vm");
 
     #[allow(clippy::type_complexity)]
     fn boxed_fn() -> Box<dyn Fn(Vec<Value>) -> Result<Vec<Value>, u8>> {

--- a/bindings/rust/wasmedge-sys/examples/hostfunc2.rs
+++ b/bindings/rust/wasmedge-sys/examples/hostfunc2.rs
@@ -78,16 +78,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut module =
         Module::create_from_buffer(&config, &wasm_binary).expect("funcs.wasm should be correct");
 
-    let mut vm = Vm::create(Some(&config), None)
+    let vm = Vm::create(Some(&config), None)
         .expect("fail to create VM instance")
         .register_wasm_from_import(&mut import_obj)
         .expect("import_obj should be regiestered")
         .load_wasm_from_module(&mut module)
-        .expect("funcs.wasm should be loaded")
-        .validate()
-        .expect("fail to validate vm")
-        .instantiate()
-        .expect("fail to instantiate vm");
+        .expect("funcs.wasm should be loaded");
+    vm.validate().expect("fail to validate vm");
+    vm.instantiate().expect("fail to instantiate vm");
 
     #[allow(clippy::type_complexity)]
     fn boxed_fn() -> Box<dyn Fn(Vec<Value>) -> Result<Vec<Value>, u8>> {

--- a/bindings/rust/wasmedge-sys/src/config.rs
+++ b/bindings/rust/wasmedge-sys/src/config.rs
@@ -143,7 +143,7 @@ impl Config {
         }
     }
 
-    /// Enables host registration wasi.
+    /// Enables or disables host registration wasi.
     pub fn enable_wasi(self, flag: bool) -> Self {
         unsafe {
             if flag && !self.wasi_enabled() {
@@ -181,7 +181,7 @@ impl Config {
         }
     }
 
-    /// Enables host registration WasmEdge process.
+    /// Enables or disables host registration WasmEdge process.
     pub fn enable_wasmedge_process(self, flag: bool) -> Self {
         unsafe {
             if flag && !self.wasmedge_process_enabled() {
@@ -323,6 +323,27 @@ impl Config {
     /// Checks if the cost measuring option turns on or not.
     pub fn is_time_measuring(&self) -> bool {
         unsafe { wasmedge::WasmEdge_ConfigureStatisticsIsTimeMeasuring(self.ctx) }
+    }
+
+    /// Enables or Disables the `Interruptible` option of AOT compiler.
+    ///
+    /// This option determines to generate interruptible binary or not when compilation in AOT compiler.
+    ///
+    /// # Argument
+    ///
+    /// - `flag` specifies if turn on the `Interruptible` option.
+    pub fn enable_interruptible(self, flag: bool) -> Self {
+        unsafe {
+            if (flag && !self.interruptible_enabled()) || (!flag && self.interruptible_enabled()) {
+                wasmedge::WasmEdge_ConfigureCompilerSetInterruptible(self.ctx, flag);
+            }
+        }
+        self
+    }
+
+    /// Checks if the `Interruptible` option of AOT Compiler turns on or not.
+    pub fn interruptible_enabled(&self) -> bool {
+        unsafe { wasmedge::WasmEdge_ConfigureCompilerIsInterruptible(self.ctx) }
     }
 }
 

--- a/bindings/rust/wasmedge-sys/src/config.rs
+++ b/bindings/rust/wasmedge-sys/src/config.rs
@@ -146,12 +146,12 @@ impl Config {
     /// Enables or disables host registration wasi.
     pub fn wasi(self, enable: bool) -> Self {
         unsafe {
-            if enable && !self.wasi_enabled() {
+            if enable {
                 wasmedge::WasmEdge_ConfigureAddHostRegistration(
                     self.ctx,
                     wasmedge::WasmEdge_HostRegistration_Wasi,
                 )
-            } else if !enable && self.wasi_enabled() {
+            } else {
                 wasmedge::WasmEdge_ConfigureRemoveHostRegistration(
                     self.ctx,
                     wasmedge::WasmEdge_HostRegistration_Wasi,
@@ -184,12 +184,12 @@ impl Config {
     /// Enables or disables host registration WasmEdge process.
     pub fn wasmedge_process(self, enable: bool) -> Self {
         unsafe {
-            if enable && !self.wasmedge_process_enabled() {
+            if enable {
                 wasmedge::WasmEdge_ConfigureAddHostRegistration(
                     self.ctx,
                     wasmedge::WasmEdge_HostRegistration_WasmEdge_Process,
                 )
-            } else if !enable && self.wasmedge_process_enabled() {
+            } else {
                 wasmedge::WasmEdge_ConfigureRemoveHostRegistration(
                     self.ctx,
                     wasmedge::WasmEdge_HostRegistration_WasmEdge_Process,

--- a/bindings/rust/wasmedge-sys/src/config.rs
+++ b/bindings/rust/wasmedge-sys/src/config.rs
@@ -144,14 +144,14 @@ impl Config {
     }
 
     /// Enables or disables host registration wasi.
-    pub fn enable_wasi(self, flag: bool) -> Self {
+    pub fn wasi(self, enable: bool) -> Self {
         unsafe {
-            if flag && !self.wasi_enabled() {
+            if enable && !self.wasi_enabled() {
                 wasmedge::WasmEdge_ConfigureAddHostRegistration(
                     self.ctx,
                     wasmedge::WasmEdge_HostRegistration_Wasi,
                 )
-            } else if !flag && self.wasi_enabled() {
+            } else if !enable && self.wasi_enabled() {
                 wasmedge::WasmEdge_ConfigureRemoveHostRegistration(
                     self.ctx,
                     wasmedge::WasmEdge_HostRegistration_Wasi,
@@ -182,14 +182,14 @@ impl Config {
     }
 
     /// Enables or disables host registration WasmEdge process.
-    pub fn enable_wasmedge_process(self, flag: bool) -> Self {
+    pub fn wasmedge_process(self, enable: bool) -> Self {
         unsafe {
-            if flag && !self.wasmedge_process_enabled() {
+            if enable && !self.wasmedge_process_enabled() {
                 wasmedge::WasmEdge_ConfigureAddHostRegistration(
                     self.ctx,
                     wasmedge::WasmEdge_HostRegistration_WasmEdge_Process,
                 )
-            } else if !flag && self.wasmedge_process_enabled() {
+            } else if !enable && self.wasmedge_process_enabled() {
                 wasmedge::WasmEdge_ConfigureRemoveHostRegistration(
                     self.ctx,
                     wasmedge::WasmEdge_HostRegistration_WasmEdge_Process,
@@ -332,10 +332,12 @@ impl Config {
     /// # Argument
     ///
     /// - `flag` specifies if turn on the `Interruptible` option.
-    pub fn enable_interruptible(self, flag: bool) -> Self {
+    pub fn interruptible(self, enable: bool) -> Self {
         unsafe {
-            if (flag && !self.interruptible_enabled()) || (!flag && self.interruptible_enabled()) {
-                wasmedge::WasmEdge_ConfigureCompilerSetInterruptible(self.ctx, flag);
+            if (enable && !self.interruptible_enabled())
+                || (!enable && self.interruptible_enabled())
+            {
+                wasmedge::WasmEdge_ConfigureCompilerSetInterruptible(self.ctx, enable);
             }
         }
         self

--- a/bindings/rust/wasmedge-sys/src/config.rs
+++ b/bindings/rust/wasmedge-sys/src/config.rs
@@ -144,12 +144,19 @@ impl Config {
     }
 
     /// Enables host registration wasi.
-    pub fn enable_wasi(self) -> Self {
+    pub fn enable_wasi(self, flag: bool) -> Self {
         unsafe {
-            wasmedge::WasmEdge_ConfigureAddHostRegistration(
-                self.ctx,
-                wasmedge::WasmEdge_HostRegistration_Wasi,
-            )
+            if flag && !self.wasi_enabled() {
+                wasmedge::WasmEdge_ConfigureAddHostRegistration(
+                    self.ctx,
+                    wasmedge::WasmEdge_HostRegistration_Wasi,
+                )
+            } else if !flag && self.wasi_enabled() {
+                wasmedge::WasmEdge_ConfigureRemoveHostRegistration(
+                    self.ctx,
+                    wasmedge::WasmEdge_HostRegistration_Wasi,
+                )
+            }
         };
         self
     }
@@ -175,12 +182,19 @@ impl Config {
     }
 
     /// Enables host registration WasmEdge process.
-    pub fn enable_wasmedge_process(self) -> Self {
+    pub fn enable_wasmedge_process(self, flag: bool) -> Self {
         unsafe {
-            wasmedge::WasmEdge_ConfigureAddHostRegistration(
-                self.ctx,
-                wasmedge::WasmEdge_HostRegistration_WasmEdge_Process,
-            )
+            if flag && !self.wasmedge_process_enabled() {
+                wasmedge::WasmEdge_ConfigureAddHostRegistration(
+                    self.ctx,
+                    wasmedge::WasmEdge_HostRegistration_WasmEdge_Process,
+                )
+            } else if !flag && self.wasmedge_process_enabled() {
+                wasmedge::WasmEdge_ConfigureRemoveHostRegistration(
+                    self.ctx,
+                    wasmedge::WasmEdge_HostRegistration_WasmEdge_Process,
+                )
+            }
         };
         self
     }

--- a/bindings/rust/wasmedge-sys/src/config.rs
+++ b/bindings/rust/wasmedge-sys/src/config.rs
@@ -334,11 +334,7 @@ impl Config {
     /// - `flag` specifies if turn on the `Interruptible` option.
     pub fn interruptible(self, enable: bool) -> Self {
         unsafe {
-            if (enable && !self.interruptible_enabled())
-                || (!enable && self.interruptible_enabled())
-            {
-                wasmedge::WasmEdge_ConfigureCompilerSetInterruptible(self.ctx, enable);
-            }
+            wasmedge::WasmEdge_ConfigureCompilerSetInterruptible(self.ctx, enable);
         }
         self
     }

--- a/bindings/rust/wasmedge-sys/src/error.rs
+++ b/bindings/rust/wasmedge-sys/src/error.rs
@@ -71,6 +71,8 @@ pub enum WasmEdgeError {
 pub enum FuncError {
     #[error("Fail to create Function instance")]
     Create,
+    #[error("{0}")]
+    CreateBinding(String),
     #[error("Fail to get the function type")]
     Type,
 }

--- a/bindings/rust/wasmedge-sys/src/executor.rs
+++ b/bindings/rust/wasmedge-sys/src/executor.rs
@@ -171,10 +171,7 @@ impl Executor {
             .collect::<Vec<_>>();
 
         // get the length of the function's returns
-        let returns_len = store
-            .find_func(func_name.as_ref())?
-            .get_type()?
-            .returns_len();
+        let returns_len = store.find_func(func_name.as_ref())?.ty()?.returns_len();
         let mut returns = Vec::with_capacity(returns_len);
 
         let func_name: WasmEdgeString = func_name.as_ref().into();
@@ -224,7 +221,7 @@ impl Executor {
         // get the length of the function's returns
         let returns_len = store
             .find_func_registered(mod_name.as_ref(), func_name.as_ref())?
-            .get_type()?
+            .ty()?
             .returns_len();
         let mut returns = Vec::with_capacity(returns_len);
 

--- a/bindings/rust/wasmedge-sys/src/executor.rs
+++ b/bindings/rust/wasmedge-sys/src/executor.rs
@@ -160,13 +160,14 @@ impl Executor {
     /// # Error
     ///
     /// If fail to invoke the function specified by `func_name`, then an error is returned.
-    pub fn invoke_function(
+    pub fn run_func(
         &self,
         store: &Store,
         func_name: impl AsRef<str>,
-        params: impl Iterator<Item = Value>,
+        params: impl IntoIterator<Item = Value>,
     ) -> WasmEdgeResult<impl Iterator<Item = Value>> {
         let raw_params = params
+            .into_iter()
             .map(wasmedge::WasmEdge_Value::from)
             .collect::<Vec<_>>();
 
@@ -207,14 +208,15 @@ impl Executor {
     ///
     /// If fail to invoke the target registered function, then an error is returned.
     ///
-    pub fn invoke_registered_function(
+    pub fn run_func_registered(
         &self,
         store: &Store,
         mod_name: impl AsRef<str>,
         func_name: impl AsRef<str>,
-        params: impl Iterator<Item = Value>,
+        params: impl IntoIterator<Item = Value>,
     ) -> WasmEdgeResult<impl Iterator<Item = Value>> {
         let raw_params = params
+            .into_iter()
             .map(wasmedge::WasmEdge_Value::from)
             .collect::<Vec<_>>();
 

--- a/bindings/rust/wasmedge-sys/src/instance/function.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/function.rs
@@ -293,13 +293,70 @@ mod tests {
     use crate::ValType;
 
     #[test]
+    fn test_func_type() {
+        // test FuncType with args and returns
+        {
+            let param_tys = vec![
+                ValType::I32,
+                ValType::I64,
+                ValType::F32,
+                ValType::F64,
+                ValType::V128,
+                ValType::ExternRef,
+            ];
+            let param_len = param_tys.len();
+            let ret_tys = vec![ValType::FuncRef, ValType::ExternRef, ValType::V128];
+            let ret_len = ret_tys.len();
+
+            // create FuncType
+            let result = FuncType::create(param_tys, ret_tys);
+            assert!(result.is_ok());
+            let func_ty = result.unwrap();
+
+            // check parameters
+            assert_eq!(func_ty.params_len(), param_len);
+            let param_tys = func_ty.params_type_iter().collect::<Vec<_>>();
+            assert_eq!(
+                param_tys,
+                vec![
+                    ValType::I32,
+                    ValType::I64,
+                    ValType::F32,
+                    ValType::F64,
+                    ValType::V128,
+                    ValType::ExternRef,
+                ]
+            );
+
+            // check returns
+            assert_eq!(func_ty.returns_len(), ret_len);
+            let return_tys = func_ty.returns_type_iter().collect::<Vec<_>>();
+            assert_eq!(
+                return_tys,
+                vec![ValType::FuncRef, ValType::ExternRef, ValType::V128]
+            );
+        }
+
+        // test FuncType without args and returns
+        {
+            // create FuncType
+            let result = FuncType::create([], []);
+            assert!(result.is_ok());
+            let func_ty = result.unwrap();
+
+            assert_eq!(func_ty.params_len(), 0);
+            assert_eq!(func_ty.returns_len(), 0);
+        }
+    }
+
+    #[test]
     fn test_func() {
         // create a FuncType
         let result = FuncType::create(vec![ValType::I32; 2], vec![ValType::I32]);
         assert!(result.is_ok());
         let func_ty = result.unwrap();
         // create a host function
-        let result = Function::create(func_ty, Box::new(real_add), 0); // Box::new(real_add), "read_add");
+        let result = Function::create(func_ty, Box::new(real_add), 0);
         assert!(result.is_ok());
         let host_func = result.unwrap();
 

--- a/bindings/rust/wasmedge-sys/src/instance/function.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/function.rs
@@ -88,7 +88,7 @@ impl Function {
     /// The example defines a host function `real_add`, and creates a [`Function`] binding to it by calling
     /// the `create_binding` method.
     ///
-    /// ```
+    /// ```rust
     /// use wasmedge_sys::{FuncType, Function, ValType, Value, WasmEdgeResult};
     ///
     /// fn real_add(input: Vec<Value>) -> Result<Vec<Value>, u8> {
@@ -118,12 +118,10 @@ impl Function {
     /// }
     ///
     /// // create a FuncType
-    /// let result = FuncType::create(vec![ValType::I32; 2], vec![ValType::I32]);
-    /// assert!(result.is_ok());
-    /// let func_ty = result.unwrap();
+    /// let func_ty = FuncType::create(vec![ValType::I32; 2], vec![ValType::I32]).expect("fail to create a FuncType");
     ///
-    /// let result = Function::create(func_ty, Box::new(real_add), 0); // Box::new(real_add), "read_add");
-    /// assert!(result.is_ok());
+    /// // create a Function instance
+    /// let func = Function::create(func_ty, Box::new(real_add), 0).expect("fail to create a Function instance");
     /// ```
     pub fn create(
         ty: FuncType,
@@ -217,7 +215,15 @@ impl FuncType {
     ///
     /// # Error
     ///
-    /// If fail to create a [`FuncType`], then an error is returned.
+    /// If fail to create a [`FuncType`], then a [WasmEdgeError::FuncTypeCreate](crate::error::WasmEdgeError::FuncTypeCreate) error is returned.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use wasmedge_sys::{FuncType, ValType};
+    ///
+    /// let func_ty = FuncType::create(vec![ValType::I32;2], vec![ValType::I32]).expect("fail to create a FuncType");
+    /// ```
     pub fn create<I: IntoIterator<Item = ValType>>(args: I, returns: I) -> WasmEdgeResult<Self> {
         let param_tys = args
             .into_iter()

--- a/bindings/rust/wasmedge-sys/src/lib.rs
+++ b/bindings/rust/wasmedge-sys/src/lib.rs
@@ -29,6 +29,7 @@ pub mod executor;
 #[doc(hidden)]
 pub mod import_obj;
 pub mod instance;
+#[doc(hidden)]
 pub mod io;
 #[doc(hidden)]
 pub mod loader;
@@ -65,8 +66,6 @@ pub use instance::{
     memory::{MemType, Memory},
     table::{Table, TableType},
 };
-#[doc(inline)]
-pub(crate) use io::WasmFnIO;
 #[doc(inline)]
 pub use loader::Loader;
 #[doc(inline)]

--- a/bindings/rust/wasmedge-sys/src/store.rs
+++ b/bindings/rust/wasmedge-sys/src/store.rs
@@ -646,13 +646,11 @@ mod tests {
         let mut import_obj = result.unwrap();
 
         // add host function
-        println!("*** register func: real_add");
         let result = FuncType::create(vec![ValType::I32; 2], vec![ValType::I32]);
         assert!(result.is_ok());
         let func_ty = result.unwrap();
         let result = Function::create(func_ty, Box::new(real_add), 0);
         assert!(result.is_ok());
-        println!("*** real_add registered");
         let mut host_func = result.unwrap();
         import_obj.add_func("add", &mut host_func);
         assert!(host_func.ctx.is_null() && host_func.registered);
@@ -746,7 +744,6 @@ mod tests {
         assert_eq!(val, Value::F32(3.5));
 
         // run the registered function
-        println!("*** first run");
         let result = executor.run_func_registered(
             &store,
             "extern_module",
@@ -754,11 +751,9 @@ mod tests {
             vec![Value::I32(12), Value::I32(21)],
         );
         assert!(result.is_ok());
-        println!("*** first run done");
         let returns = result.unwrap().collect::<Vec<_>>();
         assert_eq!(returns, vec![Value::I32(33)]);
 
-        println!("*** second run");
         let second_run = executor.run_func_registered(
             &store,
             "extern_module",

--- a/bindings/rust/wasmedge-sys/src/store.rs
+++ b/bindings/rust/wasmedge-sys/src/store.rs
@@ -615,9 +615,7 @@ mod tests {
     use super::Store;
     use crate::{
         instance::{Function, Global, GlobalType, Memory, Table, TableType},
-        io::{I1, I2},
-        types::{Mutability, RefType, ValType},
-        Config, Executor, ImportObj, Value,
+        Config, Executor, FuncType, ImportObj, Mutability, RefType, ValType, Value,
     };
 
     #[test]
@@ -648,8 +646,13 @@ mod tests {
         let mut import_obj = result.unwrap();
 
         // add host function
-        let result = Function::create_bindings::<I2<i32, i32>, I1<i32>>(Box::new(real_add));
+        println!("*** register func: real_add");
+        let result = FuncType::create(vec![ValType::I32; 2], vec![ValType::I32]);
         assert!(result.is_ok());
+        let func_ty = result.unwrap();
+        let result = Function::create(func_ty, Box::new(real_add), 0);
+        assert!(result.is_ok());
+        println!("*** real_add registered");
         let mut host_func = result.unwrap();
         import_obj.add_func("add", &mut host_func);
         assert!(host_func.ctx.is_null() && host_func.registered);
@@ -691,6 +694,7 @@ mod tests {
         let executor = result.unwrap();
         let result = executor.register_import_object(&mut store, &import_obj);
         assert!(result.is_ok());
+        let executor = result.unwrap();
 
         // check the module list after instantiation
         assert_eq!(store.reg_module_len(), 1);
@@ -739,9 +743,29 @@ mod tests {
         let global = result.unwrap();
         assert!(!global.ctx.is_null() && global.registered);
         let val = global.get_value();
-        let val = val.as_f32();
-        assert!(val.is_some());
-        assert!((val.unwrap() - 3.5).abs() < f32::EPSILON);
+        assert_eq!(val, Value::F32(3.5));
+
+        // run the registered function
+        println!("*** first run");
+        let result = executor.run_func_registered(
+            &store,
+            "extern_module",
+            "add",
+            vec![Value::I32(12), Value::I32(21)],
+        );
+        assert!(result.is_ok());
+        println!("*** first run done");
+        let returns = result.unwrap().collect::<Vec<_>>();
+        assert_eq!(returns, vec![Value::I32(33)]);
+
+        println!("*** second run");
+        let second_run = executor.run_func_registered(
+            &store,
+            "extern_module",
+            "add",
+            vec![Value::I32(12), Value::I32(21)],
+        );
+        assert!(second_run.is_ok());
     }
 
     fn real_add(input: Vec<Value>) -> Result<Vec<Value>, u8> {


### PR DESCRIPTION
This PR is to refactor the function module and add a unit test for FuncType. The C APIs involved are

- Fix #695 
- Support `WasmEdge_ConfigureCompilerIsInterruptible`
- Support `WasmEdge_ConfigureCompilerSetInterruptible`
