### PR TITLE
[Rust] Introduce the WasmEdgeString struct 

### DIFF
--- a/bindings/rust/wasmedge-sys/src/executor.rs
+++ b/bindings/rust/wasmedge-sys/src/executor.rs
@@ -101,7 +101,7 @@ impl Executor {
                 self.ctx,
                 store.ctx,
                 ast_mod.ctx,
-                mod_name.into_raw(),
+                mod_name.as_raw(),
             ))?;
             ast_mod.ctx = std::ptr::null_mut();
             ast_mod.registered = true;
@@ -182,7 +182,7 @@ impl Executor {
             check(wasmedge::WasmEdge_ExecutorInvoke(
                 self.ctx,
                 store.ctx,
-                func_name.into_raw(),
+                func_name.as_raw(),
                 raw_params.as_ptr(),
                 raw_params.len() as u32,
                 returns.as_mut_ptr(),
@@ -234,8 +234,8 @@ impl Executor {
             check(wasmedge::WasmEdge_ExecutorInvokeRegistered(
                 self.ctx,
                 store.ctx,
-                mod_name.into_raw(),
-                func_name.into_raw(),
+                mod_name.as_raw(),
+                func_name.as_raw(),
                 raw_params.as_ptr(),
                 raw_params.len() as u32,
                 returns.as_mut_ptr(),

--- a/bindings/rust/wasmedge-sys/src/executor.rs
+++ b/bindings/rust/wasmedge-sys/src/executor.rs
@@ -3,6 +3,7 @@
 use super::wasmedge;
 use crate::{
     error::{check, WasmEdgeError, WasmEdgeResult},
+    types::WasmEdgeString,
     Config, ImportObj, Module, Statistics, Store, Value,
 };
 use std::ptr;
@@ -94,12 +95,13 @@ impl Executor {
         ast_mod: &mut Module,
         mod_name: impl AsRef<str>,
     ) -> WasmEdgeResult<Self> {
+        let mod_name: WasmEdgeString = mod_name.as_ref().into();
         unsafe {
             check(wasmedge::WasmEdge_ExecutorRegisterModule(
                 self.ctx,
                 store.ctx,
                 ast_mod.ctx,
-                mod_name.into(),
+                mod_name.into_raw(),
             ))?;
             ast_mod.ctx = std::ptr::null_mut();
             ast_mod.registered = true;
@@ -175,11 +177,12 @@ impl Executor {
             .returns_len();
         let mut returns = Vec::with_capacity(returns_len);
 
+        let func_name: WasmEdgeString = func_name.as_ref().into();
         unsafe {
             check(wasmedge::WasmEdge_ExecutorInvoke(
                 self.ctx,
                 store.ctx,
-                func_name.into(),
+                func_name.into_raw(),
                 raw_params.as_ptr(),
                 raw_params.len() as u32,
                 returns.as_mut_ptr(),
@@ -225,12 +228,14 @@ impl Executor {
             .returns_len();
         let mut returns = Vec::with_capacity(returns_len);
 
+        let mod_name: WasmEdgeString = mod_name.as_ref().into();
+        let func_name: WasmEdgeString = func_name.as_ref().into();
         unsafe {
             check(wasmedge::WasmEdge_ExecutorInvokeRegistered(
                 self.ctx,
                 store.ctx,
-                mod_name.into(),
-                func_name.into(),
+                mod_name.into_raw(),
+                func_name.into_raw(),
                 raw_params.as_ptr(),
                 raw_params.len() as u32,
                 returns.as_mut_ptr(),

--- a/bindings/rust/wasmedge-sys/src/import_obj.rs
+++ b/bindings/rust/wasmedge-sys/src/import_obj.rs
@@ -3,6 +3,7 @@
 use super::wasmedge;
 use crate::{
     instance::{Function, Global, Memory, Table},
+    types::WasmEdgeString,
     utils::string_to_c_char,
     WasmEdgeError, WasmEdgeResult,
 };
@@ -27,8 +28,8 @@ impl ImportObj {
     ///
     /// If fail to create a host module, then an error is returned.
     pub fn create(name: impl AsRef<str>) -> WasmEdgeResult<Self> {
-        let raw_module_name = name.into();
-        let ctx = unsafe { wasmedge::WasmEdge_ImportObjectCreate(raw_module_name) };
+        let mod_name: WasmEdgeString = name.as_ref().into();
+        let ctx = unsafe { wasmedge::WasmEdge_ImportObjectCreate(mod_name.into_raw()) };
         match ctx.is_null() {
             true => Err(WasmEdgeError::ImportObjCreate),
             false => Ok(ImportObj {
@@ -231,9 +232,9 @@ impl ImportObj {
     ///
     /// - `func` specifies the host function instance to add.
     pub fn add_func(&mut self, name: impl AsRef<str>, func: &mut Function) {
-        let raw_func_name = name.into();
+        let func_name: WasmEdgeString = name.into();
         unsafe {
-            wasmedge::WasmEdge_ImportObjectAddFunction(self.ctx, raw_func_name, (*func).ctx);
+            wasmedge::WasmEdge_ImportObjectAddFunction(self.ctx, func_name.into_raw(), (*func).ctx);
         }
         func.registered = true;
         func.ctx = std::ptr::null_mut();
@@ -247,8 +248,9 @@ impl ImportObj {
     ///
     /// - `table` specifies the export table instance to add.
     pub fn add_table(&mut self, name: impl AsRef<str>, table: &mut Table) {
+        let table_name: WasmEdgeString = name.as_ref().into();
         unsafe {
-            wasmedge::WasmEdge_ImportObjectAddTable(self.ctx, name.into(), table.ctx);
+            wasmedge::WasmEdge_ImportObjectAddTable(self.ctx, table_name.into_raw(), table.ctx);
         }
         table.registered = true;
         table.ctx = std::ptr::null_mut();
@@ -262,8 +264,9 @@ impl ImportObj {
     ///
     /// - `memory` specifies the export memory instance to add.
     pub fn add_memory(&mut self, name: impl AsRef<str>, memory: &mut Memory) {
+        let mem_name: WasmEdgeString = name.as_ref().into();
         unsafe {
-            wasmedge::WasmEdge_ImportObjectAddMemory(self.ctx, name.into(), memory.ctx);
+            wasmedge::WasmEdge_ImportObjectAddMemory(self.ctx, mem_name.into_raw(), memory.ctx);
         }
         memory.registered = true;
         memory.ctx = std::ptr::null_mut();
@@ -277,8 +280,9 @@ impl ImportObj {
     ///
     /// `global` specifies the export global instance to add.
     pub fn add_global(&mut self, name: impl AsRef<str>, global: &mut Global) {
+        let global_name: WasmEdgeString = name.as_ref().into();
         unsafe {
-            wasmedge::WasmEdge_ImportObjectAddGlobal(self.ctx, name.into(), global.ctx);
+            wasmedge::WasmEdge_ImportObjectAddGlobal(self.ctx, global_name.into_raw(), global.ctx);
         }
         global.registered = true;
         global.ctx = std::ptr::null_mut();

--- a/bindings/rust/wasmedge-sys/src/import_obj.rs
+++ b/bindings/rust/wasmedge-sys/src/import_obj.rs
@@ -29,7 +29,7 @@ impl ImportObj {
     /// If fail to create a host module, then an error is returned.
     pub fn create(name: impl AsRef<str>) -> WasmEdgeResult<Self> {
         let mod_name: WasmEdgeString = name.as_ref().into();
-        let ctx = unsafe { wasmedge::WasmEdge_ImportObjectCreate(mod_name.into_raw()) };
+        let ctx = unsafe { wasmedge::WasmEdge_ImportObjectCreate(mod_name.as_raw()) };
         match ctx.is_null() {
             true => Err(WasmEdgeError::ImportObjCreate),
             false => Ok(ImportObj {
@@ -234,7 +234,7 @@ impl ImportObj {
     pub fn add_func(&mut self, name: impl AsRef<str>, func: &mut Function) {
         let func_name: WasmEdgeString = name.into();
         unsafe {
-            wasmedge::WasmEdge_ImportObjectAddFunction(self.ctx, func_name.into_raw(), (*func).ctx);
+            wasmedge::WasmEdge_ImportObjectAddFunction(self.ctx, func_name.as_raw(), (*func).ctx);
         }
         func.registered = true;
         func.ctx = std::ptr::null_mut();
@@ -250,7 +250,7 @@ impl ImportObj {
     pub fn add_table(&mut self, name: impl AsRef<str>, table: &mut Table) {
         let table_name: WasmEdgeString = name.as_ref().into();
         unsafe {
-            wasmedge::WasmEdge_ImportObjectAddTable(self.ctx, table_name.into_raw(), table.ctx);
+            wasmedge::WasmEdge_ImportObjectAddTable(self.ctx, table_name.as_raw(), table.ctx);
         }
         table.registered = true;
         table.ctx = std::ptr::null_mut();
@@ -266,7 +266,7 @@ impl ImportObj {
     pub fn add_memory(&mut self, name: impl AsRef<str>, memory: &mut Memory) {
         let mem_name: WasmEdgeString = name.as_ref().into();
         unsafe {
-            wasmedge::WasmEdge_ImportObjectAddMemory(self.ctx, mem_name.into_raw(), memory.ctx);
+            wasmedge::WasmEdge_ImportObjectAddMemory(self.ctx, mem_name.as_raw(), memory.ctx);
         }
         memory.registered = true;
         memory.ctx = std::ptr::null_mut();
@@ -282,7 +282,7 @@ impl ImportObj {
     pub fn add_global(&mut self, name: impl AsRef<str>, global: &mut Global) {
         let global_name: WasmEdgeString = name.as_ref().into();
         unsafe {
-            wasmedge::WasmEdge_ImportObjectAddGlobal(self.ctx, global_name.into_raw(), global.ctx);
+            wasmedge::WasmEdge_ImportObjectAddGlobal(self.ctx, global_name.as_raw(), global.ctx);
         }
         global.registered = true;
         global.ctx = std::ptr::null_mut();

--- a/bindings/rust/wasmedge-sys/src/store.rs
+++ b/bindings/rust/wasmedge-sys/src/store.rs
@@ -48,7 +48,7 @@ impl Store {
     /// If fail to find the target [function](crate::Function), then an error is returned.
     pub fn find_func(&self, name: impl AsRef<str>) -> WasmEdgeResult<Function> {
         let func_name: WasmEdgeString = name.as_ref().into();
-        let ctx = unsafe { wasmedge::WasmEdge_StoreFindFunction(self.ctx, func_name.into_raw()) };
+        let ctx = unsafe { wasmedge::WasmEdge_StoreFindFunction(self.ctx, func_name.as_raw()) };
         match ctx.is_null() {
             true => Err(WasmEdgeError::Store(StoreError::NotFoundFunc(
                 name.as_ref().to_string(),
@@ -83,8 +83,8 @@ impl Store {
             let func_name: WasmEdgeString = func_name.as_ref().into();
             wasmedge::WasmEdge_StoreFindFunctionRegistered(
                 self.ctx,
-                mod_name.into_raw(),
-                func_name.into_raw(),
+                mod_name.as_raw(),
+                func_name.as_raw(),
             )
         };
         match ctx.is_null() {
@@ -114,7 +114,7 @@ impl Store {
     /// If fail to find the target [table](crate::Table), then an error is returned.
     pub fn find_table(&self, name: impl AsRef<str>) -> WasmEdgeResult<Table> {
         let table_name: WasmEdgeString = name.as_ref().into();
-        let ctx = unsafe { wasmedge::WasmEdge_StoreFindTable(self.ctx, table_name.into_raw()) };
+        let ctx = unsafe { wasmedge::WasmEdge_StoreFindTable(self.ctx, table_name.as_raw()) };
         match ctx.is_null() {
             true => Err(WasmEdgeError::Store(StoreError::NotFoundGlobal(
                 name.as_ref().to_string(),
@@ -148,8 +148,8 @@ impl Store {
             let table_name: WasmEdgeString = table_name.as_ref().into();
             wasmedge::WasmEdge_StoreFindTableRegistered(
                 self.ctx,
-                mod_name.into_raw(),
-                table_name.into_raw(),
+                mod_name.as_raw(),
+                table_name.as_raw(),
             )
         };
         match ctx.is_null() {
@@ -178,7 +178,7 @@ impl Store {
     /// If fail to find the target [memory](crate::Memory), then an error is returned.
     pub fn find_memory(&self, name: impl AsRef<str>) -> WasmEdgeResult<Memory> {
         let mem_name: WasmEdgeString = name.as_ref().into();
-        let ctx = unsafe { wasmedge::WasmEdge_StoreFindMemory(self.ctx, mem_name.into_raw()) };
+        let ctx = unsafe { wasmedge::WasmEdge_StoreFindMemory(self.ctx, mem_name.as_raw()) };
         match ctx.is_null() {
             true => Err(WasmEdgeError::Store(StoreError::NotFoundMem(
                 name.as_ref().to_string(),
@@ -212,8 +212,8 @@ impl Store {
             let mem_name: WasmEdgeString = mem_name.as_ref().into();
             wasmedge::WasmEdge_StoreFindMemoryRegistered(
                 self.ctx,
-                mod_name.into_raw(),
-                mem_name.into_raw(),
+                mod_name.as_raw(),
+                mem_name.as_raw(),
             )
         };
         match ctx.is_null() {
@@ -242,7 +242,7 @@ impl Store {
     /// If fail to find the target [global](crate::Global), then an error is returned.
     pub fn find_global(&self, name: impl AsRef<str>) -> WasmEdgeResult<Global> {
         let global_name: WasmEdgeString = name.as_ref().into();
-        let ctx = unsafe { wasmedge::WasmEdge_StoreFindGlobal(self.ctx, global_name.into_raw()) };
+        let ctx = unsafe { wasmedge::WasmEdge_StoreFindGlobal(self.ctx, global_name.as_raw()) };
         match ctx.is_null() {
             true => Err(WasmEdgeError::Store(StoreError::NotFoundGlobal(
                 name.as_ref().to_string(),
@@ -276,8 +276,8 @@ impl Store {
             let global_name: WasmEdgeString = global_name.as_ref().into();
             wasmedge::WasmEdge_StoreFindGlobalRegistered(
                 self.ctx,
-                mod_name.into_raw(),
-                global_name.into_raw(),
+                mod_name.as_raw(),
+                global_name.as_raw(),
             )
         };
         match ctx.is_null() {
@@ -329,9 +329,7 @@ impl Store {
     /// - `mod_name` specifies the name of the registered module.
     pub fn reg_func_len(&self, mod_name: impl AsRef<str>) -> u32 {
         let mod_name: WasmEdgeString = mod_name.as_ref().into();
-        unsafe {
-            wasmedge::WasmEdge_StoreListFunctionRegisteredLength(self.ctx, mod_name.into_raw())
-        }
+        unsafe { wasmedge::WasmEdge_StoreListFunctionRegisteredLength(self.ctx, mod_name.as_raw()) }
     }
 
     /// Returns the names of the exported [functions](crate::Function) in the registered module.
@@ -348,7 +346,7 @@ impl Store {
                 unsafe {
                     wasmedge::WasmEdge_StoreListFunctionRegistered(
                         self.ctx,
-                        mod_name.into_raw(),
+                        mod_name.as_raw(),
                         func_names.as_mut_ptr(),
                         len_func_names,
                     );
@@ -402,7 +400,7 @@ impl Store {
     /// - `mod_name` specifies the name of the registered module.
     pub fn reg_table_len(&self, mod_name: impl AsRef<str>) -> u32 {
         let mod_name: WasmEdgeString = mod_name.as_ref().into();
-        unsafe { wasmedge::WasmEdge_StoreListTableRegisteredLength(self.ctx, mod_name.into_raw()) }
+        unsafe { wasmedge::WasmEdge_StoreListTableRegisteredLength(self.ctx, mod_name.as_raw()) }
     }
 
     /// Returns the names of the exported [tables](crate::Table) in the registered module.
@@ -419,7 +417,7 @@ impl Store {
                 unsafe {
                     wasmedge::WasmEdge_StoreListTableRegistered(
                         self.ctx,
-                        mod_name.into_raw(),
+                        mod_name.as_raw(),
                         table_names.as_mut_ptr(),
                         len_table_names,
                     );
@@ -473,7 +471,7 @@ impl Store {
     /// - `mod_name` specifies the name of the registered module.
     pub fn reg_global_len(&self, mod_name: impl AsRef<str>) -> u32 {
         let mod_name: WasmEdgeString = mod_name.as_ref().into();
-        unsafe { wasmedge::WasmEdge_StoreListGlobalRegisteredLength(self.ctx, mod_name.into_raw()) }
+        unsafe { wasmedge::WasmEdge_StoreListGlobalRegisteredLength(self.ctx, mod_name.as_raw()) }
     }
 
     /// Returns the names of all exported [globals](crate::Global) in the registered module.
@@ -490,7 +488,7 @@ impl Store {
                 unsafe {
                     wasmedge::WasmEdge_StoreListGlobalRegistered(
                         self.ctx,
-                        mod_name.into_raw(),
+                        mod_name.as_raw(),
                         global_names.as_mut_ptr(),
                         len_global_names,
                     );
@@ -544,7 +542,7 @@ impl Store {
     /// - `mod_name` specifies the name of the registered module.
     pub fn reg_mem_len(&self, mod_name: impl AsRef<str>) -> u32 {
         let mod_name: WasmEdgeString = mod_name.as_ref().into();
-        unsafe { wasmedge::WasmEdge_StoreListMemoryRegisteredLength(self.ctx, mod_name.into_raw()) }
+        unsafe { wasmedge::WasmEdge_StoreListMemoryRegisteredLength(self.ctx, mod_name.as_raw()) }
     }
 
     /// Returns the names of all exported [memories](crate::Memory) in the registered module.
@@ -557,7 +555,7 @@ impl Store {
                 unsafe {
                     wasmedge::WasmEdge_StoreListMemoryRegistered(
                         self.ctx,
-                        mod_name.into_raw(),
+                        mod_name.as_raw(),
                         mem_names.as_mut_ptr(),
                         len_mem_names,
                     );

--- a/bindings/rust/wasmedge-sys/src/store.rs
+++ b/bindings/rust/wasmedge-sys/src/store.rs
@@ -511,7 +511,7 @@ impl Store {
     }
 
     /// Returns the names of all exported [memories](crate::Memory) in the anonymous module.
-    pub fn mem_names_iter(&self) -> Option<Vec<String>> {
+    pub fn mem_names(&self) -> Option<Vec<String>> {
         let len_mem_names = self.mem_len();
         match len_mem_names > 0 {
             true => {

--- a/bindings/rust/wasmedge-sys/src/store.rs
+++ b/bindings/rust/wasmedge-sys/src/store.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     instance::{Function, Global, Memory, Table},
+    types::WasmEdgeString,
     wasmedge, StoreError, WasmEdgeError, WasmEdgeResult,
 };
 
@@ -46,7 +47,8 @@ impl Store {
     ///
     /// If fail to find the target [function](crate::Function), then an error is returned.
     pub fn find_func(&self, name: impl AsRef<str>) -> WasmEdgeResult<Function> {
-        let ctx = unsafe { wasmedge::WasmEdge_StoreFindFunction(self.ctx, name.as_ref().into()) };
+        let func_name: WasmEdgeString = name.as_ref().into();
+        let ctx = unsafe { wasmedge::WasmEdge_StoreFindFunction(self.ctx, func_name.into_raw()) };
         match ctx.is_null() {
             true => Err(WasmEdgeError::Store(StoreError::NotFoundFunc(
                 name.as_ref().to_string(),
@@ -77,10 +79,12 @@ impl Store {
         func_name: impl AsRef<str>,
     ) -> WasmEdgeResult<Function> {
         let ctx = unsafe {
+            let mod_name: WasmEdgeString = mod_name.as_ref().into();
+            let func_name: WasmEdgeString = func_name.as_ref().into();
             wasmedge::WasmEdge_StoreFindFunctionRegistered(
                 self.ctx,
-                mod_name.as_ref().into(),
-                func_name.as_ref().into(),
+                mod_name.into_raw(),
+                func_name.into_raw(),
             )
         };
         match ctx.is_null() {
@@ -109,7 +113,8 @@ impl Store {
     ///
     /// If fail to find the target [table](crate::Table), then an error is returned.
     pub fn find_table(&self, name: impl AsRef<str>) -> WasmEdgeResult<Table> {
-        let ctx = unsafe { wasmedge::WasmEdge_StoreFindTable(self.ctx, name.as_ref().into()) };
+        let table_name: WasmEdgeString = name.as_ref().into();
+        let ctx = unsafe { wasmedge::WasmEdge_StoreFindTable(self.ctx, table_name.into_raw()) };
         match ctx.is_null() {
             true => Err(WasmEdgeError::Store(StoreError::NotFoundGlobal(
                 name.as_ref().to_string(),
@@ -139,10 +144,12 @@ impl Store {
         table_name: impl AsRef<str>,
     ) -> WasmEdgeResult<Table> {
         let ctx = unsafe {
+            let mod_name: WasmEdgeString = mod_name.as_ref().into();
+            let table_name: WasmEdgeString = table_name.as_ref().into();
             wasmedge::WasmEdge_StoreFindTableRegistered(
                 self.ctx,
-                mod_name.as_ref().into(),
-                table_name.as_ref().into(),
+                mod_name.into_raw(),
+                table_name.into_raw(),
             )
         };
         match ctx.is_null() {
@@ -170,7 +177,8 @@ impl Store {
     ///
     /// If fail to find the target [memory](crate::Memory), then an error is returned.
     pub fn find_memory(&self, name: impl AsRef<str>) -> WasmEdgeResult<Memory> {
-        let ctx = unsafe { wasmedge::WasmEdge_StoreFindMemory(self.ctx, name.as_ref().into()) };
+        let mem_name: WasmEdgeString = name.as_ref().into();
+        let ctx = unsafe { wasmedge::WasmEdge_StoreFindMemory(self.ctx, mem_name.into_raw()) };
         match ctx.is_null() {
             true => Err(WasmEdgeError::Store(StoreError::NotFoundMem(
                 name.as_ref().to_string(),
@@ -200,10 +208,12 @@ impl Store {
         mem_name: impl AsRef<str>,
     ) -> WasmEdgeResult<Memory> {
         let ctx = unsafe {
+            let mod_name: WasmEdgeString = mod_name.as_ref().into();
+            let mem_name: WasmEdgeString = mem_name.as_ref().into();
             wasmedge::WasmEdge_StoreFindMemoryRegistered(
                 self.ctx,
-                mod_name.as_ref().into(),
-                mem_name.as_ref().into(),
+                mod_name.into_raw(),
+                mem_name.into_raw(),
             )
         };
         match ctx.is_null() {
@@ -231,7 +241,8 @@ impl Store {
     ///
     /// If fail to find the target [global](crate::Global), then an error is returned.
     pub fn find_global(&self, name: impl AsRef<str>) -> WasmEdgeResult<Global> {
-        let ctx = unsafe { wasmedge::WasmEdge_StoreFindGlobal(self.ctx, name.as_ref().into()) };
+        let global_name: WasmEdgeString = name.as_ref().into();
+        let ctx = unsafe { wasmedge::WasmEdge_StoreFindGlobal(self.ctx, global_name.into_raw()) };
         match ctx.is_null() {
             true => Err(WasmEdgeError::Store(StoreError::NotFoundGlobal(
                 name.as_ref().to_string(),
@@ -261,10 +272,12 @@ impl Store {
         global_name: impl AsRef<str>,
     ) -> WasmEdgeResult<Global> {
         let ctx = unsafe {
+            let mod_name: WasmEdgeString = mod_name.as_ref().into();
+            let global_name: WasmEdgeString = global_name.as_ref().into();
             wasmedge::WasmEdge_StoreFindGlobalRegistered(
                 self.ctx,
-                mod_name.as_ref().into(),
-                global_name.as_ref().into(),
+                mod_name.into_raw(),
+                global_name.into_raw(),
             )
         };
         match ctx.is_null() {
@@ -284,28 +297,29 @@ impl Store {
         unsafe { wasmedge::WasmEdge_StoreListFunctionLength(self.ctx) }
     }
 
-    /// Returns an iterator of names of the exported [functions](crate::Function) in the anonymous module.
-    pub fn func_names_iter(&self) -> Vec<String> {
-        let mut names: Vec<String> = vec![];
+    /// Returns the names of the exported [functions](crate::Function) in the anonymous module.
+    pub fn func_names(&self) -> Option<Vec<String>> {
         let len_func_names = self.func_len();
-        if len_func_names > 0 {
-            let mut func_names = Vec::with_capacity(len_func_names as usize);
-            unsafe {
-                wasmedge::WasmEdge_StoreListFunction(
-                    self.ctx,
-                    func_names.as_mut_ptr(),
-                    len_func_names,
-                );
-                func_names.set_len(len_func_names as usize);
-            }
+        match len_func_names > 0 {
+            true => {
+                let mut func_names = Vec::with_capacity(len_func_names as usize);
+                unsafe {
+                    wasmedge::WasmEdge_StoreListFunction(
+                        self.ctx,
+                        func_names.as_mut_ptr(),
+                        len_func_names,
+                    );
+                    func_names.set_len(len_func_names as usize);
+                }
 
-            for func_name in func_names {
-                let slice = unsafe { std::ffi::CStr::from_ptr(func_name.Buf as *const _) };
-                let name = slice.to_string_lossy().into_owned();
-                names.push(name);
+                let names = func_names
+                    .into_iter()
+                    .map(|x| x.into())
+                    .collect::<Vec<String>>();
+                Some(names)
             }
+            false => None,
         }
-        names
     }
 
     /// Returns the length of the exported [functions](crate::Function) in the registered module.
@@ -314,37 +328,41 @@ impl Store {
     ///
     /// - `mod_name` specifies the name of the registered module.
     pub fn reg_func_len(&self, mod_name: impl AsRef<str>) -> u32 {
-        unsafe { wasmedge::WasmEdge_StoreListFunctionRegisteredLength(self.ctx, mod_name.into()) }
+        let mod_name: WasmEdgeString = mod_name.as_ref().into();
+        unsafe {
+            wasmedge::WasmEdge_StoreListFunctionRegisteredLength(self.ctx, mod_name.into_raw())
+        }
     }
 
-    /// Returns an iterator of names of the exported [functions](crate::Function) in the registered module.
+    /// Returns the names of the exported [functions](crate::Function) in the registered module.
     ///
     /// # Argument
     ///
     /// - `mod_name` specifies the name of the registered module.
-    pub fn reg_func_names_iter(&self, mod_name: impl AsRef<str>) -> Vec<String> {
-        let mut names: Vec<String> = vec![];
+    pub fn reg_func_names(&self, mod_name: impl AsRef<str>) -> Option<Vec<String>> {
         let len_func_names = self.reg_func_len(mod_name.as_ref());
-        if len_func_names > 0 {
-            let mut func_names = Vec::with_capacity(len_func_names as usize);
-            unsafe {
-                wasmedge::WasmEdge_StoreListFunctionRegistered(
-                    self.ctx,
-                    mod_name.into(),
-                    func_names.as_mut_ptr(),
-                    len_func_names,
-                );
-                func_names.set_len(len_func_names as usize);
-            };
+        match len_func_names > 0 {
+            true => {
+                let mut func_names = Vec::with_capacity(len_func_names as usize);
+                let mod_name: WasmEdgeString = mod_name.as_ref().into();
+                unsafe {
+                    wasmedge::WasmEdge_StoreListFunctionRegistered(
+                        self.ctx,
+                        mod_name.into_raw(),
+                        func_names.as_mut_ptr(),
+                        len_func_names,
+                    );
+                    func_names.set_len(len_func_names as usize);
+                };
 
-            for func_name in func_names {
-                let slice = unsafe { std::ffi::CStr::from_ptr(func_name.Buf as *const _) };
-                let name = slice.to_string_lossy().into_owned();
-                names.push(name);
+                let names = func_names
+                    .into_iter()
+                    .map(|x| x.into())
+                    .collect::<Vec<String>>();
+                Some(names)
             }
+            false => None,
         }
-
-        names
     }
 
     /// Returns the length of the exported [tables](crate::Table) in the anonymous module.
@@ -352,27 +370,29 @@ impl Store {
         unsafe { wasmedge::WasmEdge_StoreListTableLength(self.ctx) }
     }
 
-    /// Returns an iterator of names of the exported [tables](crate::Table) in the anonynous module.
-    pub fn table_names_iter(&self) -> Vec<String> {
-        let mut names: Vec<String> = vec![];
+    /// Returns the names of the exported [tables](crate::Table) in the anonynous module.
+    pub fn table_names(&self) -> Option<Vec<String>> {
         let len_table_names = self.table_len();
-        if len_table_names > 0 {
-            let mut table_names = Vec::with_capacity(len_table_names as usize);
-            unsafe {
-                wasmedge::WasmEdge_StoreListTable(
-                    self.ctx,
-                    table_names.as_mut_ptr(),
-                    len_table_names,
-                );
-                table_names.set_len(len_table_names as usize);
-            }
+        match len_table_names > 0 {
+            true => {
+                let mut table_names = Vec::with_capacity(len_table_names as usize);
+                unsafe {
+                    wasmedge::WasmEdge_StoreListTable(
+                        self.ctx,
+                        table_names.as_mut_ptr(),
+                        len_table_names,
+                    );
+                    table_names.set_len(len_table_names as usize);
+                }
 
-            for table_name in table_names {
-                let slice = unsafe { std::ffi::CStr::from_ptr(table_name.Buf as *const _) };
-                names.push(slice.to_string_lossy().into_owned());
+                let names = table_names
+                    .into_iter()
+                    .map(|x| x.into())
+                    .collect::<Vec<String>>();
+                Some(names)
             }
+            false => None,
         }
-        names
     }
 
     /// Returns the length of the exported [tables](crate::Table) in the registered module.
@@ -381,35 +401,39 @@ impl Store {
     ///
     /// - `mod_name` specifies the name of the registered module.
     pub fn reg_table_len(&self, mod_name: impl AsRef<str>) -> u32 {
-        unsafe { wasmedge::WasmEdge_StoreListTableRegisteredLength(self.ctx, mod_name.into()) }
+        let mod_name: WasmEdgeString = mod_name.as_ref().into();
+        unsafe { wasmedge::WasmEdge_StoreListTableRegisteredLength(self.ctx, mod_name.into_raw()) }
     }
 
-    /// Returns an iterator of names of the exported [tables](crate::Table) in the registered module.
+    /// Returns the names of the exported [tables](crate::Table) in the registered module.
     ///
     /// # Argument
     ///
     /// - `mod_name` specifies the name of the registered module.
-    pub fn reg_table_names_iter(&self, mod_name: impl AsRef<str>) -> Vec<String> {
-        let mut names: Vec<String> = vec![];
+    pub fn reg_table_names(&self, mod_name: impl AsRef<str>) -> Option<Vec<String>> {
         let len_table_names = self.reg_table_len(mod_name.as_ref());
-        if len_table_names > 0 {
-            let mut table_names = Vec::with_capacity(len_table_names as usize);
-            unsafe {
-                wasmedge::WasmEdge_StoreListTableRegistered(
-                    self.ctx,
-                    mod_name.into(),
-                    table_names.as_mut_ptr(),
-                    len_table_names,
-                );
-                table_names.set_len(len_table_names as usize);
-            };
+        match len_table_names > 0 {
+            true => {
+                let mut table_names = Vec::with_capacity(len_table_names as usize);
+                let mod_name: WasmEdgeString = mod_name.as_ref().into();
+                unsafe {
+                    wasmedge::WasmEdge_StoreListTableRegistered(
+                        self.ctx,
+                        mod_name.into_raw(),
+                        table_names.as_mut_ptr(),
+                        len_table_names,
+                    );
+                    table_names.set_len(len_table_names as usize);
+                };
 
-            for table_name in table_names {
-                let slice = unsafe { std::ffi::CStr::from_ptr(table_name.Buf as *const _) };
-                names.push(slice.to_string_lossy().into_owned());
+                let names = table_names
+                    .into_iter()
+                    .map(|x| x.into())
+                    .collect::<Vec<String>>();
+                Some(names)
             }
+            false => None,
         }
-        names
     }
 
     /// Returns the length of the exported [globals](crate::Global) in the anonymous module.
@@ -417,27 +441,29 @@ impl Store {
         unsafe { wasmedge::WasmEdge_StoreListGlobalLength(self.ctx) }
     }
 
-    /// Returns an iterator of names of the exported [globals](crate::Global) in the anonymous module.
-    pub fn global_names_iter(&self) -> Vec<String> {
-        let mut names: Vec<String> = vec![];
+    /// Returns the names of the exported [globals](crate::Global) in the anonymous module.
+    pub fn global_names(&self) -> Option<Vec<String>> {
         let len_global_names = self.global_len();
-        if len_global_names > 0 {
-            let mut global_names = Vec::with_capacity(len_global_names as usize);
-            unsafe {
-                wasmedge::WasmEdge_StoreListGlobal(
-                    self.ctx,
-                    global_names.as_mut_ptr(),
-                    len_global_names,
-                );
-                global_names.set_len(len_global_names as usize);
-            }
+        match len_global_names > 0 {
+            true => {
+                let mut global_names = Vec::with_capacity(len_global_names as usize);
+                unsafe {
+                    wasmedge::WasmEdge_StoreListGlobal(
+                        self.ctx,
+                        global_names.as_mut_ptr(),
+                        len_global_names,
+                    );
+                    global_names.set_len(len_global_names as usize);
+                }
 
-            for global_name in global_names {
-                let slice = unsafe { std::ffi::CStr::from_ptr(global_name.Buf as *const _) };
-                names.push(slice.to_string_lossy().into_owned());
+                let names = global_names
+                    .into_iter()
+                    .map(|x| x.into())
+                    .collect::<Vec<String>>();
+                Some(names)
             }
+            false => None,
         }
-        names
     }
 
     /// Returns the length of the exported [globals](crate::Global) in the reigstered module.
@@ -446,35 +472,39 @@ impl Store {
     ///
     /// - `mod_name` specifies the name of the registered module.
     pub fn reg_global_len(&self, mod_name: impl AsRef<str>) -> u32 {
-        unsafe { wasmedge::WasmEdge_StoreListGlobalRegisteredLength(self.ctx, mod_name.into()) }
+        let mod_name: WasmEdgeString = mod_name.as_ref().into();
+        unsafe { wasmedge::WasmEdge_StoreListGlobalRegisteredLength(self.ctx, mod_name.into_raw()) }
     }
 
-    /// Returns an iterator of names of all exported [globals](crate::Global) in the registered module.
+    /// Returns the names of all exported [globals](crate::Global) in the registered module.
     ///
     /// # Argument
     ///
     /// - `mod_name` specifies the name of the registered module.
-    pub fn reg_global_names_iter(&self, mod_name: impl AsRef<str>) -> Vec<String> {
-        let mut names: Vec<String> = vec![];
+    pub fn reg_global_names(&self, mod_name: impl AsRef<str>) -> Option<Vec<String>> {
         let len_global_names = self.reg_global_len(mod_name.as_ref());
-        if len_global_names > 0 {
-            let mut global_names = Vec::with_capacity(len_global_names as usize);
-            unsafe {
-                wasmedge::WasmEdge_StoreListGlobalRegistered(
-                    self.ctx,
-                    mod_name.into(),
-                    global_names.as_mut_ptr(),
-                    len_global_names,
-                );
-                global_names.set_len(len_global_names as usize);
-            }
+        match len_global_names > 0 {
+            true => {
+                let mut global_names = Vec::with_capacity(len_global_names as usize);
+                let mod_name: WasmEdgeString = mod_name.as_ref().into();
+                unsafe {
+                    wasmedge::WasmEdge_StoreListGlobalRegistered(
+                        self.ctx,
+                        mod_name.into_raw(),
+                        global_names.as_mut_ptr(),
+                        len_global_names,
+                    );
+                    global_names.set_len(len_global_names as usize);
+                }
 
-            for global_name in global_names {
-                let slice = unsafe { std::ffi::CStr::from_ptr(global_name.Buf as *const _) };
-                names.push(slice.to_string_lossy().into_owned());
+                let names = global_names
+                    .into_iter()
+                    .map(|x| x.into())
+                    .collect::<Vec<String>>();
+                Some(names)
             }
+            false => None,
         }
-        names
     }
 
     /// Returns the length of the exported [memories](crate::Memory) in the anonymous module.
@@ -482,23 +512,29 @@ impl Store {
         unsafe { wasmedge::WasmEdge_StoreListMemoryLength(self.ctx) }
     }
 
-    /// Returns an iterator of names of all exported [memories](crate::Memory) in the anonymous module.
-    pub fn mem_names_iter(&self) -> Vec<String> {
-        let mut names: Vec<String> = vec![];
+    /// Returns the names of all exported [memories](crate::Memory) in the anonymous module.
+    pub fn mem_names_iter(&self) -> Option<Vec<String>> {
         let len_mem_names = self.mem_len();
-        if len_mem_names > 0 {
-            let mut mem_names = Vec::with_capacity(len_mem_names as usize);
-            unsafe {
-                wasmedge::WasmEdge_StoreListMemory(self.ctx, mem_names.as_mut_ptr(), len_mem_names);
-                mem_names.set_len(len_mem_names as usize);
-            }
+        match len_mem_names > 0 {
+            true => {
+                let mut mem_names = Vec::with_capacity(len_mem_names as usize);
+                unsafe {
+                    wasmedge::WasmEdge_StoreListMemory(
+                        self.ctx,
+                        mem_names.as_mut_ptr(),
+                        len_mem_names,
+                    );
+                    mem_names.set_len(len_mem_names as usize);
+                }
 
-            for mem_name in mem_names {
-                let slice = unsafe { std::ffi::CStr::from_ptr(mem_name.Buf as *const _) };
-                names.push(slice.to_string_lossy().into_owned());
+                let names = mem_names
+                    .into_iter()
+                    .map(|x| x.into())
+                    .collect::<Vec<String>>();
+                Some(names)
             }
+            false => None,
         }
-        names
     }
 
     /// Returns the length of the exported [memories](crate::Memory) in the registered module.
@@ -507,31 +543,35 @@ impl Store {
     ///
     /// - `mod_name` specifies the name of the registered module.
     pub fn reg_mem_len(&self, mod_name: impl AsRef<str>) -> u32 {
-        unsafe { wasmedge::WasmEdge_StoreListMemoryRegisteredLength(self.ctx, mod_name.into()) }
+        let mod_name: WasmEdgeString = mod_name.as_ref().into();
+        unsafe { wasmedge::WasmEdge_StoreListMemoryRegisteredLength(self.ctx, mod_name.into_raw()) }
     }
 
-    /// Returns an iterator of names of all exported [memories](crate::Memory) in the registered module.
-    pub fn reg_mem_names_iter(&self, mod_name: impl AsRef<str>) -> Vec<String> {
-        let mut names: Vec<String> = vec![];
+    /// Returns the names of all exported [memories](crate::Memory) in the registered module.
+    pub fn reg_mem_names(&self, mod_name: impl AsRef<str>) -> Option<Vec<String>> {
         let len_mem_names = self.reg_mem_len(mod_name.as_ref());
-        if len_mem_names > 0 {
-            let mut mem_names = Vec::with_capacity(len_mem_names as usize);
-            unsafe {
-                wasmedge::WasmEdge_StoreListMemoryRegistered(
-                    self.ctx,
-                    mod_name.into(),
-                    mem_names.as_mut_ptr(),
-                    len_mem_names,
-                );
-                mem_names.set_len(len_mem_names as usize);
-            }
+        match len_mem_names > 0 {
+            true => {
+                let mut mem_names = Vec::with_capacity(len_mem_names as usize);
+                let mod_name: WasmEdgeString = mod_name.as_ref().into();
+                unsafe {
+                    wasmedge::WasmEdge_StoreListMemoryRegistered(
+                        self.ctx,
+                        mod_name.into_raw(),
+                        mem_names.as_mut_ptr(),
+                        len_mem_names,
+                    );
+                    mem_names.set_len(len_mem_names as usize);
+                }
 
-            for mem_name in mem_names {
-                let slice = unsafe { std::ffi::CStr::from_ptr(mem_name.Buf as *const _) };
-                names.push(slice.to_string_lossy().into_owned());
+                let names = mem_names
+                    .into_iter()
+                    .map(|x| x.into())
+                    .collect::<Vec<String>>();
+                Some(names)
             }
+            false => None,
         }
-        names
     }
 
     /// Returns the length of the registered [modules](crate::Module).
@@ -540,22 +580,28 @@ impl Store {
     }
 
     /// Returns the names of all registered [modules](crate::Module).
-    pub fn reg_module_name_iter(&self) -> Vec<String> {
-        let mut names: Vec<String> = vec![];
+    pub fn reg_module_names(&self) -> Option<Vec<String>> {
         let len_mod_names = self.reg_module_len();
-        if len_mod_names > 0 {
-            let mut mod_names = Vec::with_capacity(len_mod_names as usize);
-            unsafe {
-                wasmedge::WasmEdge_StoreListModule(self.ctx, mod_names.as_mut_ptr(), len_mod_names);
-                mod_names.set_len(len_mod_names as usize);
-            };
+        match len_mod_names > 0 {
+            true => {
+                let mut mod_names = Vec::with_capacity(len_mod_names as usize);
+                unsafe {
+                    wasmedge::WasmEdge_StoreListModule(
+                        self.ctx,
+                        mod_names.as_mut_ptr(),
+                        len_mod_names,
+                    );
+                    mod_names.set_len(len_mod_names as usize);
+                };
 
-            for mod_name in mod_names {
-                let slice = unsafe { std::ffi::CStr::from_ptr(mod_name.Buf as *const _) };
-                names.push(slice.to_string_lossy().into_owned());
+                let names = mod_names
+                    .into_iter()
+                    .map(|x| x.into())
+                    .collect::<Vec<String>>();
+                Some(names)
             }
+            false => None,
         }
-        names
     }
 }
 impl Drop for Store {
@@ -596,7 +642,7 @@ mod tests {
         assert_eq!(store.mem_len(), 0);
         assert_eq!(store.reg_mem_len(module_name), 0);
         assert_eq!(store.reg_module_len(), 0);
-        assert_eq!(store.reg_module_name_iter().len(), 0);
+        assert!(store.reg_module_names().is_none());
 
         // create ImportObject instance
         let result = ImportObj::create(module_name);
@@ -650,19 +696,24 @@ mod tests {
 
         // check the module list after instantiation
         assert_eq!(store.reg_module_len(), 1);
-        assert_eq!(store.reg_module_name_iter()[0], module_name);
+        assert!(store.reg_module_names().is_some());
+        assert_eq!(store.reg_module_names().unwrap()[0], module_name);
         assert_eq!(store.func_len(), 0);
         assert_eq!(store.reg_func_len(module_name), 1);
-        assert_eq!(store.reg_func_names_iter(module_name)[0], "add");
+        assert!(store.reg_func_names(module_name).is_some());
+        assert_eq!(store.reg_func_names(module_name).unwrap()[0], "add");
         assert_eq!(store.table_len(), 0);
         assert_eq!(store.reg_table_len(module_name), 1);
-        assert_eq!(store.reg_table_names_iter(module_name)[0], "table");
+        assert!(store.reg_table_names(module_name).is_some());
+        assert_eq!(store.reg_table_names(module_name).unwrap()[0], "table");
         assert_eq!(store.global_len(), 0);
         assert_eq!(store.reg_global_len(module_name), 1);
-        assert_eq!(store.reg_global_names_iter(module_name)[0], "global");
+        assert!(store.reg_global_names(module_name).is_some());
+        assert_eq!(store.reg_global_names(module_name).unwrap()[0], "global");
         assert_eq!(store.mem_len(), 0);
         assert_eq!(store.reg_mem_len(module_name), 1);
-        assert_eq!(store.reg_mem_names_iter(module_name)[0], "mem");
+        assert!(store.reg_mem_names(module_name).is_some());
+        assert_eq!(store.reg_mem_names(module_name).unwrap()[0], "mem");
 
         // check the function list after instantiation
         let result = store.find_func("add");

--- a/bindings/rust/wasmedge-sys/src/types.rs
+++ b/bindings/rust/wasmedge-sys/src/types.rs
@@ -447,7 +447,7 @@ impl Drop for WasmEdgeString {
     }
 }
 impl WasmEdgeString {
-    pub(crate) fn into_raw(&self) -> wasmedge::WasmEdge_String {
+    pub(crate) fn as_raw(&self) -> wasmedge::WasmEdge_String {
         self.ctx
     }
 }

--- a/bindings/rust/wasmedge-sys/src/types.rs
+++ b/bindings/rust/wasmedge-sys/src/types.rs
@@ -455,7 +455,12 @@ impl<T: AsRef<str>> From<T> for WasmEdgeString {
     fn from(s: T) -> Self {
         let ctx = if s.as_ref().contains('\0') {
             let buffer = s.as_ref().as_bytes();
-            unsafe { wasmedge::WasmEdge_StringCreateByBuffer(buffer.as_ptr(), buffer.len() as u32) }
+            unsafe {
+                wasmedge::WasmEdge_StringCreateByBuffer(
+                    buffer.as_ptr() as *const _,
+                    buffer.len() as u32,
+                )
+            }
         } else {
             let cs = CString::new(s.as_ref()).expect(
                 "Failed to create a CString: the supplied bytes contain an internal 0 byte",

--- a/bindings/rust/wasmedge-sys/src/types.rs
+++ b/bindings/rust/wasmedge-sys/src/types.rs
@@ -439,9 +439,13 @@ impl_to_prim_conversions! {
 
 impl<T: AsRef<str>> From<T> for wasmedge::WasmEdge_String {
     fn from(s: T) -> Self {
-        let cs =
-            CString::new(s.as_ref()).expect("fail to convert a string slice to WasmEdge_String");
-        unsafe { wasmedge::WasmEdge_StringCreateByCString(cs.as_ptr()) }
+        if s.as_ref().contains('\0') {
+            let buffer = s.as_ref().as_bytes();
+            unsafe { wasmedge::WasmEdge_StringCreateByBuffer(buffer.as_ptr(), buffer.len() as u32) }
+        } else {
+            let cs = CString::new(s.as_ref()).unwrap();
+            unsafe { wasmedge::WasmEdge_StringCreateByCString(cs.as_ptr()) }
+        }
     }
 }
 

--- a/bindings/rust/wasmedge-sys/src/vm.rs
+++ b/bindings/rust/wasmedge-sys/src/vm.rs
@@ -80,7 +80,7 @@ impl Vm {
         unsafe {
             check(wasmedge::WasmEdge_VMRegisterModuleFromFile(
                 self.ctx,
-                mod_name.into_raw(),
+                mod_name.as_raw(),
                 path.as_ptr(),
             ))?
         };
@@ -148,7 +148,7 @@ impl Vm {
         unsafe {
             check(wasmedge::WasmEdge_VMRegisterModuleFromBuffer(
                 self.ctx,
-                mod_name.into_raw(),
+                mod_name.as_raw(),
                 buffer.as_ptr(),
                 buffer.len() as u32,
             ))?;
@@ -187,7 +187,7 @@ impl Vm {
         unsafe {
             check(wasmedge::WasmEdge_VMRegisterModuleFromASTModule(
                 self.ctx,
-                mod_name.into_raw(),
+                mod_name.as_raw(),
                 module.ctx,
             ))?;
         }
@@ -241,7 +241,7 @@ impl Vm {
             check(wasmedge::WasmEdge_VMRunWasmFromFile(
                 self.ctx,
                 path.as_ptr(),
-                func_name.into_raw(),
+                func_name.as_raw(),
                 raw_params.as_ptr(),
                 raw_params.len() as u32,
                 returns.as_mut_ptr(),
@@ -296,7 +296,7 @@ impl Vm {
                 self.ctx,
                 buffer.as_ptr(),
                 buffer.len() as u32,
-                func_name.into_raw(),
+                func_name.as_raw(),
                 raw_params.as_ptr(),
                 raw_params.len() as u32,
                 returns.as_mut_ptr(),
@@ -352,7 +352,7 @@ impl Vm {
             check(wasmedge::WasmEdge_VMRunWasmFromASTModule(
                 self.ctx,
                 module.ctx,
-                func_name.into_raw(),
+                func_name.as_raw(),
                 raw_params.as_ptr(),
                 raw_params.len() as u32,
                 returns.as_mut_ptr(),
@@ -497,7 +497,7 @@ impl Vm {
         unsafe {
             check(wasmedge::WasmEdge_VMExecute(
                 self.ctx,
-                func_name.into_raw(),
+                func_name.as_raw(),
                 raw_params.as_ptr(),
                 raw_params.len() as u32,
                 returns.as_mut_ptr(),
@@ -549,8 +549,8 @@ impl Vm {
         unsafe {
             check(wasmedge::WasmEdge_VMExecuteRegistered(
                 self.ctx,
-                mod_name.into_raw(),
-                func_name.into_raw(),
+                mod_name.as_raw(),
+                func_name.as_raw(),
                 raw_params.as_ptr(),
                 raw_params.len() as u32,
                 returns.as_mut_ptr(),
@@ -575,7 +575,7 @@ impl Vm {
     pub fn get_function_type(&self, func_name: impl AsRef<str>) -> WasmEdgeResult<FuncType> {
         let ty_ctx = unsafe {
             let func_name: WasmEdgeString = func_name.as_ref().into();
-            wasmedge::WasmEdge_VMGetFunctionType(self.ctx, func_name.into_raw())
+            wasmedge::WasmEdge_VMGetFunctionType(self.ctx, func_name.as_raw())
         };
         match ty_ctx.is_null() {
             true => Err(WasmEdgeError::Vm(VmError::NotFoundFuncType(
@@ -606,8 +606,8 @@ impl Vm {
             let func_name: WasmEdgeString = func_name.as_ref().into();
             wasmedge::WasmEdge_VMGetFunctionTypeRegistered(
                 self.ctx,
-                mod_name.into_raw(),
-                func_name.into_raw(),
+                mod_name.as_raw(),
+                func_name.as_raw(),
             )
         };
         match ty_ctx.is_null() {

--- a/bindings/rust/wasmedge-sys/src/vm.rs
+++ b/bindings/rust/wasmedge-sys/src/vm.rs
@@ -4,7 +4,7 @@ use super::wasmedge;
 use crate::{
     error::{check, VmError, WasmEdgeError, WasmEdgeResult},
     instance::function::FuncType,
-    types::HostRegistration,
+    types::{HostRegistration, WasmEdgeString},
     utils, Config, ImportObj, Module, Statistics, Store, Value,
 };
 use std::path::Path;
@@ -76,11 +76,11 @@ impl Vm {
         path: impl AsRef<Path>,
     ) -> WasmEdgeResult<Self> {
         let path = utils::path_to_cstring(path.as_ref())?;
-        let raw_mod_name = mod_name.into();
+        let mod_name: WasmEdgeString = mod_name.as_ref().into();
         unsafe {
             check(wasmedge::WasmEdge_VMRegisterModuleFromFile(
                 self.ctx,
-                raw_mod_name,
+                mod_name.into_raw(),
                 path.as_ptr(),
             ))?
         };
@@ -144,10 +144,11 @@ impl Vm {
         mod_name: impl AsRef<str>,
         buffer: &[u8],
     ) -> WasmEdgeResult<Self> {
+        let mod_name: WasmEdgeString = mod_name.as_ref().into();
         unsafe {
             check(wasmedge::WasmEdge_VMRegisterModuleFromBuffer(
                 self.ctx,
-                mod_name.into(),
+                mod_name.into_raw(),
                 buffer.as_ptr(),
                 buffer.len() as u32,
             ))?;
@@ -182,10 +183,11 @@ impl Vm {
         mod_name: impl AsRef<str>,
         module: &mut Module,
     ) -> WasmEdgeResult<Self> {
+        let mod_name: WasmEdgeString = mod_name.as_ref().into();
         unsafe {
             check(wasmedge::WasmEdge_VMRegisterModuleFromASTModule(
                 self.ctx,
-                mod_name.into(),
+                mod_name.into_raw(),
                 module.ctx,
             ))?;
         }
@@ -234,11 +236,12 @@ impl Vm {
         let returns_len = unsafe { wasmedge::WasmEdge_FunctionTypeGetReturnsLength(func_type.ctx) };
         let mut returns = Vec::with_capacity(returns_len as usize);
 
+        let func_name: WasmEdgeString = func_name.as_ref().into();
         unsafe {
             check(wasmedge::WasmEdge_VMRunWasmFromFile(
                 self.ctx,
                 path.as_ptr(),
-                func_name.as_ref().into(),
+                func_name.into_raw(),
                 raw_params.as_ptr(),
                 raw_params.len() as u32,
                 returns.as_mut_ptr(),
@@ -287,12 +290,13 @@ impl Vm {
         let returns_len = unsafe { wasmedge::WasmEdge_FunctionTypeGetReturnsLength(func_type.ctx) };
         let mut returns = Vec::with_capacity(returns_len as usize);
 
+        let func_name: WasmEdgeString = func_name.as_ref().into();
         unsafe {
             check(wasmedge::WasmEdge_VMRunWasmFromBuffer(
                 self.ctx,
                 buffer.as_ptr(),
                 buffer.len() as u32,
-                func_name.as_ref().into(),
+                func_name.into_raw(),
                 raw_params.as_ptr(),
                 raw_params.len() as u32,
                 returns.as_mut_ptr(),
@@ -343,11 +347,12 @@ impl Vm {
         let returns_len = unsafe { wasmedge::WasmEdge_FunctionTypeGetReturnsLength(func_type.ctx) };
         let mut returns = Vec::with_capacity(returns_len as usize);
 
+        let func_name: WasmEdgeString = func_name.as_ref().into();
         unsafe {
             check(wasmedge::WasmEdge_VMRunWasmFromASTModule(
                 self.ctx,
                 module.ctx,
-                func_name.as_ref().into(),
+                func_name.into_raw(),
                 raw_params.as_ptr(),
                 raw_params.len() as u32,
                 returns.as_mut_ptr(),
@@ -488,10 +493,11 @@ impl Vm {
         let returns_len = unsafe { wasmedge::WasmEdge_FunctionTypeGetReturnsLength(func_type.ctx) };
         let mut returns = Vec::with_capacity(returns_len as usize);
 
+        let func_name: WasmEdgeString = func_name.as_ref().into();
         unsafe {
             check(wasmedge::WasmEdge_VMExecute(
                 self.ctx,
-                func_name.as_ref().into(),
+                func_name.into_raw(),
                 raw_params.as_ptr(),
                 raw_params.len() as u32,
                 returns.as_mut_ptr(),
@@ -538,11 +544,13 @@ impl Vm {
         let returns_len = unsafe { wasmedge::WasmEdge_FunctionTypeGetReturnsLength(func_type.ctx) };
         let mut returns = Vec::with_capacity(returns_len as usize);
 
+        let mod_name: WasmEdgeString = mod_name.as_ref().into();
+        let func_name: WasmEdgeString = func_name.as_ref().into();
         unsafe {
             check(wasmedge::WasmEdge_VMExecuteRegistered(
                 self.ctx,
-                mod_name.as_ref().into(),
-                func_name.as_ref().into(),
+                mod_name.into_raw(),
+                func_name.into_raw(),
                 raw_params.as_ptr(),
                 raw_params.len() as u32,
                 returns.as_mut_ptr(),
@@ -565,8 +573,10 @@ impl Vm {
     ///
     /// If fail to get the function type, then an error is returned.
     pub fn get_function_type(&self, func_name: impl AsRef<str>) -> WasmEdgeResult<FuncType> {
-        let ty_ctx =
-            unsafe { wasmedge::WasmEdge_VMGetFunctionType(self.ctx, func_name.as_ref().into()) };
+        let ty_ctx = unsafe {
+            let func_name: WasmEdgeString = func_name.as_ref().into();
+            wasmedge::WasmEdge_VMGetFunctionType(self.ctx, func_name.into_raw())
+        };
         match ty_ctx.is_null() {
             true => Err(WasmEdgeError::Vm(VmError::NotFoundFuncType(
                 func_name.as_ref().to_string(),
@@ -592,10 +602,12 @@ impl Vm {
         func_name: impl AsRef<str>,
     ) -> WasmEdgeResult<FuncType> {
         let ty_ctx = unsafe {
+            let mod_name: WasmEdgeString = mod_name.as_ref().into();
+            let func_name: WasmEdgeString = func_name.as_ref().into();
             wasmedge::WasmEdge_VMGetFunctionTypeRegistered(
                 self.ctx,
-                mod_name.as_ref().into(),
-                func_name.as_ref().into(),
+                mod_name.into_raw(),
+                func_name.into_raw(),
             )
         };
         match ty_ctx.is_null() {


### PR DESCRIPTION
In this PR, the `WasmEdgeString` struct is introduced as a wrapper of `WasmEdge_String`. In addition, to support the new design, refactored some parts of the `store`, `vm`, `import_obj`, and `executor` modules.

The following C-APIs are involved:

- `WasmEdge_StringCreateByBuffer`
- `WasmEdge_StringIsEqual`