### PR TITLE
[Docs] Update .gitignore and fix python doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ docs/_build
 
 .direnv
 .envrc
+
+# mdbook build
+docs/book/*/book

--- a/docs/book/en/src/SUMMARY.md
+++ b/docs/book/en/src/SUMMARY.md
@@ -41,7 +41,8 @@
     - [AssemblyScript](dev/as.md)
     - [Kotlin](dev/kotlin.md)
     - [Grain](dev/grain.md)
-
+    - [Python](dev/python.md)
+    
 - [Embed WasmEdge functions](embed.md)
     - [C SDK](embed/c.md)
        - [API references](embed/c/ref.md)


### PR DESCRIPTION
Signed-off-by: KernelErr <45716019+KernelErr@users.noreply.github.com>