### PR TITLE
[Docs] Fix link anchor name in WasmEdge Book.

### DIFF
--- a/docs/book/en/src/embed/c/ref.md
+++ b/docs/book/en/src/embed/c/ref.md
@@ -2009,4 +2009,4 @@ enum WasmEdge_CompilerOutputFormat {
 };
 ```
 
-Please refer to the [AOT compiler options configuration](#Configurations) for details.
+Please refer to the [AOT compiler options configuration](#configurations) for details.


### PR DESCRIPTION
Capitalized anchor name doesn't work.