### PR TITLE
[Android] Add basic Anroid support

### DIFF
--- a/docs/book/zh/src/os/android.md
+++ b/docs/book/zh/src/os/android.md
@@ -1,0 +1,65 @@
+# ANDROID
+## 使用 ANDROID NDK 构建和测试 WasmEdge 命令行工具
+
+此教程指导使用 Android NDK 构建 Interpreter 模式的 WasmEdge，并在 Android 设备中测试 wasmedge 命令行工具。
+
+### 环境准备
+
+* [Android NDK 23b](https://developer.android.com/ndk/downloads)
+    * 下载到的 NDK 工具链需要解压到磁盘上
+* [CMake 3.21](https://cmake.org/download/) 及以上版本
+  * 如果本机已安装 cmake，请检查版本是否符合要求
+* [ADB](https://developer.android.com/studio/releases/platform-tools)
+  * 将下载到的 platform-tools 解压到磁盘上，adb 命令在 bin 目录中
+  * 如果您使用的是 debian/ubuntu 系统，可以通过 apt 安装 adb
+* 一台已经 [启用开发者选项和 USB 调试](https://developer.android.com/studio/debug/dev-options) 的 Android 设备, 最低系统版本为 Android 6.0    
+
+### 构建 WasmEdge
+
+1. 添加 NDK 目录路径到环境变量 `ANDROID_NDK_HOME=path/to/you/ndk/dir`
+2. 执行 WasmEdge 源码路径下的 `utils/android/standalone/build_for_android.sh` 命令行脚本，将自动执行构建，构建结果在 WasmEdge 目录中的 build 目录
+
+### 测试
+
+#### 推送到 Android 设备
+
+1. 将 Android 设备通过 USB 或 WLAN 连接到 PC 
+   您可以通过 `adb devices` 命令检查已连接的设备，可以获得类似如下显式：
+    ```
+    $ adb devices
+    List of devices attached
+    0a388e93      device
+    ```
+2. 使用 `adb push`命令推送 build/tools/wasmedge 到 Android 设备的 /data/local/tmp 目录
+   ```
+   $ cd build
+   $ adb push ./tools/wasmedge /data/local/tmp  
+   ```
+
+#### 在 Android 设备中执行 WasmEdge
+
+1. 使用 `adb shell` 命令进入 Android 设备
+2. 测试运行 wasmedge 程序
+    ```
+    $ cd /data/local/tmp/wasmedge/examples
+    $ ../wasmedge hello.wasm 1 2 3                                                           
+    hello
+    1
+    2
+    3
+    $ ../wasmedge --reactor add.wasm add 2 2
+    4
+    $ ../wasmedge --reactor fibonacci.wasm fib 8
+    34
+    $ ../wasmedge --reactor factorial.wasm fac 12
+    479001600
+    $
+    $ cd js
+    $ ./../wasmedge --dir .:. qjs.wasm hello.js 1 2 3
+    Hello 1 2 3
+    ```
+
+### 注意
+
+* Android 10 及以上系统版本，SELinux 限制普通 Android 应用程序使用 exec() 执行 home 目录中的可执行文件。[参考](https://android.googlesource.com/platform/system/sepolicy/+/08450264ae3f917f6b8e4091d6fedf84ef8d796f/private/untrusted_app_all.te#27)
+* Android SELinux 限制普通 Android 应用程序访问 /data/local/tmp 目录

--- a/lib/host/wasi/CMakeLists.txt
+++ b/lib/host/wasi/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(wasmedgeHostModuleWasi
   wasmedgeSystem
 )
 
-if(NOT APPLE AND NOT WIN32)
+if(NOT APPLE AND NOT WIN32 AND NOT ANDROID)
   target_link_libraries(wasmedgeHostModuleWasi
     PUBLIC
     rt

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -265,7 +265,7 @@ INode::fdFilestatSetSize(__wasi_filesize_t Size) const noexcept {
 WasiExpect<void>
 INode::fdFilestatSetTimes(__wasi_timestamp_t ATim, __wasi_timestamp_t MTim,
                           __wasi_fstflags_t FstFlags) const noexcept {
-#if __GLIBC_PREREQ(2, 6)
+#if __GLIBC_PREREQ(2, 6) || __BIONIC__
   timespec SysTimespec[2];
   if (FstFlags & __WASI_FSTFLAGS_ATIM) {
     SysTimespec[0] = toTimespec(ATim);
@@ -584,7 +584,7 @@ WasiExpect<void>
 INode::pathFilestatSetTimes(std::string Path, __wasi_timestamp_t ATim,
                             __wasi_timestamp_t MTim,
                             __wasi_fstflags_t FstFlags) const noexcept {
-#if __GLIBC_PREREQ(2, 6)
+#if __GLIBC_PREREQ(2, 6) || __BIONIC__
   timespec SysTimespec[2];
   if (FstFlags & __WASI_FSTFLAGS_ATIM) {
     SysTimespec[0] = toTimespec(ATim);

--- a/utils/android/standalone/build_for_android.sh
+++ b/utils/android/standalone/build_for_android.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ ! $ANDROID_NDK_HOME ]; then
+    echo "env var ANDROID_NDK_HOME not set"
+    exit 1
+else
+    echo "use ndk: $ANDROID_NDK_HOME"
+fi
+
+WASMEDGE_ROOT_PATH=$(dirname $(dirname $(dirname $(dirname $0))))
+
+cd ${WASMEDGE_ROOT_PATH}
+mkdir build
+cd build
+
+echo $(pwd)
+
+if ! cmake .. -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_AOT_RUNTIME=OFF -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=23 -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a -DCMAKE_ANDROID_NDK=$ANDROID_NDK_HOME -DCMAKE_ANDROID_STL_TYPE=c++_static; then
+    echo === CMakeOutput.log ===
+    cat build/CMakeFiles/CMakeOutput.log
+    echo === CMakeError.log ===
+    cat build/CMakeFiles/CMakeError.log
+    exit 1
+fi
+
+make -j
+
+echo "build finished"


### PR DESCRIPTION
* Add Android Binoic libc support, minimun Android API Level 23.
* Add build script for Android NDK.
* Add Android build tutorial.

Signed-off-by: HangedFish <bravohangedman@outlook.com>

----
It is a basic Android platform support that can be used to verify that WasmEdge works on the Android platform.

There is still a lot of work to be done to bring WasmEdge to Android application development. 