### PR TITLE
[C-API] Implemented new C-APIs

### DIFF
--- a/include/api/wasmedge/wasmedge.h
+++ b/include/api/wasmedge/wasmedge.h
@@ -2697,6 +2697,11 @@ WasmEdge_GlobalInstanceDelete(WasmEdge_GlobalInstanceContext *Cxt);
 WASMEDGE_CAPI_EXPORT extern WasmEdge_ImportObjectContext *
 WasmEdge_ImportObjectCreate(const WasmEdge_String ModuleName);
 
+/// Get the module name.
+///
+/// \param Cxt the target WasmEdge_ImportObjectContext.
+///
+/// \returns the name of the WasmEdge_ImportObjectContext.
 WASMEDGE_CAPI_EXPORT extern WasmEdge_String
 WasmEdge_ImportObjectGetModuleName(const WasmEdge_ImportObjectContext *Cxt);
 

--- a/include/api/wasmedge/wasmedge.h
+++ b/include/api/wasmedge/wasmedge.h
@@ -2697,25 +2697,27 @@ WasmEdge_GlobalInstanceDelete(WasmEdge_GlobalInstanceContext *Cxt);
 WASMEDGE_CAPI_EXPORT extern WasmEdge_ImportObjectContext *
 WasmEdge_ImportObjectCreate(const WasmEdge_String ModuleName);
 
+WASMEDGE_CAPI_EXPORT extern WasmEdge_String
+WasmEdge_ImportObjectGetModuleName(const WasmEdge_ImportObjectContext *Cxt);
+
 /// Creation of the WasmEdge_ImportObjectContext for the WASI specification.
 ///
 /// This function will create a WASI host module that contains the WASI host
 /// functions and initialize it. The caller owns the object and should call
 /// `WasmEdge_ImportObjectDelete` to free it.
 ///
-/// \param Args the command line arguments. The first argument suggests being
-/// the program name. NULL if the length is 0.
-/// \param ArgLen the length of the command line arguments.
-/// \param Envs the environment variables in the format `ENV=VALUE`. NULL if the
-/// length is 0.
-/// \param EnvLen the length of the environment variables.
-/// \param Preopens the directory paths to preopen. String format in
-/// `PATH1:PATH2` means the path mapping, or the same path will be mapped. NULL
-/// if the length is 0.
+/// \param Args the command line arguments. The first argument suggests
+/// being the program name. NULL if the length is 0. \param ArgLen the
+/// length of the command line arguments. \param Envs the environment
+/// variables in the format `ENV=VALUE`. NULL if the length is 0. \param
+/// EnvLen the length of the environment variables. \param Preopens the
+/// directory paths to preopen. String format in `PATH1:PATH2` means the
+/// path mapping, or the same path will be mapped. NULL if the length is 0.
 /// \param PreopenLen the length of the directory paths to preopen.
 ///
 /// \returns pointer to context, NULL if failed.
-WASMEDGE_CAPI_EXPORT extern WasmEdge_ImportObjectContext *
+WASMEDGE_CAPI_EXPORT
+extern WasmEdge_ImportObjectContext *
 WasmEdge_ImportObjectCreateWASI(const char *const *Args, const uint32_t ArgLen,
                                 const char *const *Envs, const uint32_t EnvLen,
                                 const char *const *Preopens,

--- a/include/api/wasmedge/wasmedge.h
+++ b/include/api/wasmedge/wasmedge.h
@@ -3512,6 +3512,42 @@ WasmEdge_VMGetStoreContext(WasmEdge_VMContext *Cxt);
 WASMEDGE_CAPI_EXPORT extern WasmEdge_StatisticsContext *
 WasmEdge_VMGetStatisticsContext(WasmEdge_VMContext *Cxt);
 
+/// Get the executor context used in the WasmEdge_VMContext.
+///
+/// The executor context links to the executor in the VM context and owned
+/// by the VM context. The caller should __NOT__ call the
+/// `WasmEdge_ExecutorDelete`.
+///
+/// \param Cxt the WasmEdge_VMContext.
+///
+/// \returns pointer to the executor context.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_ExecutorContext *
+WasmEdge_VMGetExecutorContext(WasmEdge_VMContext *Cxt);
+
+/// Get the validator context used in the WasmEdge_VMContext.
+///
+/// The validator context links to the validator in the VM context and owned
+/// by the VM context. The caller should __NOT__ call the
+/// `WasmEdge_ValidatorDelete`.
+///
+/// \param Cxt the WasmEdge_VMContext.
+///
+/// \returns pointer to the validator context.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_ValidatorContext *
+WasmEdge_VMGetValidatorContext(WasmEdge_VMContext *Cxt);
+
+/// Get the loader context used in the WasmEdge_VMContext.
+///
+/// The loader context links to the loader in the VM context and owned
+/// by the VM context. The caller should __NOT__ call the
+/// `WasmEdge_LoaderDelete`.
+///
+/// \param Cxt the WasmEdge_VMContext.
+///
+/// \returns pointer to the loader context.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_LoaderContext *
+WasmEdge_VMGetLoaderContext(WasmEdge_VMContext *Cxt);
+
 /// Deletion of the WasmEdge_VMContext.
 ///
 /// After calling this function, the context will be freed and should __NOT__ be

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -191,6 +191,15 @@ public:
   /// Getter of statistics.
   Statistics::Statistics &getStatistics() { return Stat; }
 
+  /// Getter of executor
+  Executor::Executor &getExecutor() { return ExecutorEngine; }
+
+  /// Getter of validator
+  Validator::Validator &getValidator() { return ValidatorEngine; }
+
+  /// Getter of loader
+  Loader::Loader &getLoader() { return LoaderEngine; }
+
 private:
   Expect<void> unsafeRegisterModule(std::string_view Name,
                                     const std::filesystem::path &Path);

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -2345,6 +2345,16 @@ WasmEdge_ImportObjectCreate(const WasmEdge_String ModuleName) {
       new WasmEdge::Runtime::ImportObject(genStrView(ModuleName)));
 }
 
+WASMEDGE_CAPI_EXPORT WasmEdge_String
+WasmEdge_ImportObjectGetModuleName(const WasmEdge_ImportObjectContext *Cxt) {
+  if (Cxt) {
+    auto StrView = fromImpObjCxt(Cxt)->getModuleName();
+    return WasmEdge_String{.Length = static_cast<uint32_t>(StrView.length()),
+                           .Buf = StrView.data()};
+  }
+  return WasmEdge_String{.Length = 0, .Buf = nullptr};
+}
+
 WASMEDGE_CAPI_EXPORT WasmEdge_ImportObjectContext *
 WasmEdge_ImportObjectCreateWASI(const char *const *Args, const uint32_t ArgLen,
                                 const char *const *Envs, const uint32_t EnvLen,

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -356,6 +356,9 @@ private:
   inline QUANT auto *to##SIMP##Cxt(QUANT INST *Cxt) noexcept {                 \
     return reinterpret_cast<QUANT WasmEdge_##NAME##Context *>(Cxt);            \
   }
+CONVTO(Ldr, Loader::Loader, Loader, )
+CONVTO(Valid, Validator::Validator, Validator, )
+CONVTO(Exec, Executor::Executor, Executor, )
 CONVTO(Stat, Statistics::Statistics, Statistics, )
 CONVTO(FuncType, AST::FunctionType, FunctionType, )
 CONVTO(FuncType, AST::FunctionType, FunctionType, const)
@@ -2857,6 +2860,30 @@ WASMEDGE_CAPI_EXPORT WasmEdge_StatisticsContext *
 WasmEdge_VMGetStatisticsContext(WasmEdge_VMContext *Cxt) {
   if (Cxt) {
     return toStatCxt(&Cxt->VM.getStatistics());
+  }
+  return nullptr;
+}
+
+WASMEDGE_CAPI_EXPORT WasmEdge_ExecutorContext *
+WasmEdge_VMGetExecutorContext(WasmEdge_VMContext *Cxt) {
+  if (Cxt) {
+    return toExecCxt(&Cxt->VM.getExecutor());
+  }
+  return nullptr;
+}
+
+WASMEDGE_CAPI_EXPORT WasmEdge_ValidatorContext *
+WasmEdge_VMGetValidatorContext(WasmEdge_VMContext *Cxt) {
+  if (Cxt) {
+    return toValidCxt(&Cxt->VM.getValidator());
+  }
+  return nullptr;
+}
+
+WASMEDGE_CAPI_EXPORT WasmEdge_LoaderContext *
+WasmEdge_VMGetLoaderContext(WasmEdge_VMContext *Cxt) {
+  if (Cxt) {
+    return toLdrCxt(&Cxt->VM.getLoader());
   }
   return nullptr;
 }

--- a/test/api/APIUnitTest.cpp
+++ b/test/api/APIUnitTest.cpp
@@ -2107,6 +2107,9 @@ TEST(APICoreTest, ImportObject) {
   ImpObj = WasmEdge_ImportObjectCreate(HostName);
   WasmEdge_StringDelete(HostName);
   EXPECT_NE(ImpObj, nullptr);
+  WasmEdge_String ExpectedHostName = WasmEdge_StringCreateByCString("extern");
+  WasmEdge_String ActualHostName = WasmEdge_ImportObjectGetModuleName(ImpObj);
+  EXPECT_TRUE(WasmEdge_StringIsEqual(ExpectedHostName, ActualHostName));
 
   // Add host function "func-add": {externref, i32} -> {i32}
   Param[0] = WasmEdge_ValType_ExternRef;
@@ -3221,6 +3224,18 @@ TEST(APICoreTest, VM) {
   // VM get statistics
   EXPECT_NE(WasmEdge_VMGetStatisticsContext(VM), nullptr);
   EXPECT_EQ(WasmEdge_VMGetStatisticsContext(nullptr), nullptr);
+
+  // VM get executor
+  EXPECT_NE(WasmEdge_VMGetExecutorContext(VM), nullptr);
+  EXPECT_EQ(WasmEdge_VMGetExecutorContext(nullptr), nullptr);
+
+  // VM get validator
+  EXPECT_NE(WasmEdge_VMGetValidatorContext(VM), nullptr);
+  EXPECT_EQ(WasmEdge_VMGetValidatorContext(nullptr), nullptr);
+
+  // VM get loader
+  EXPECT_NE(WasmEdge_VMGetLoaderContext(VM), nullptr);
+  EXPECT_EQ(WasmEdge_VMGetLoaderContext(nullptr), nullptr);
 
   WasmEdge_ASTModuleDelete(Mod);
   WasmEdge_ImportObjectDelete(ImpObj);


### PR DESCRIPTION
In this PR, new four C APIs are added, which are

* `WasmEdge_VMGetExecutorContext`
* `WasmEdge_VMGetValidatorContext`
* `WasmEdge_VMGetLoaderContext`
* `WasmEdge_ImportObjectGetModuleName`