### PR TITLE
[Rust] Supported ModuleInstance and the relevant C-APIs

### DIFF
--- a/bindings/rust/wasmedge-sys/Cargo.toml
+++ b/bindings/rust/wasmedge-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmedge-sys"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 links = "wasmedge_c"
 build = "build.rs"

--- a/bindings/rust/wasmedge-sys/src/error.rs
+++ b/bindings/rust/wasmedge-sys/src/error.rs
@@ -157,6 +157,12 @@ pub enum ExportError {
 pub enum InstanceError {
     #[error("Fail to find the target function ({0})")]
     NotFoundFunc(String),
+    #[error("Fail to find the target table ({0})")]
+    NotFoundTable(String),
+    #[error("Fail to find the target memory ({0})")]
+    NotFoundMem(String),
+    #[error("Fail to find the target global ({0})")]
+    NotFoundGlobal(String),
 }
 
 /// Defines the errors raised from [Store](crate::Store).

--- a/bindings/rust/wasmedge-sys/src/error.rs
+++ b/bindings/rust/wasmedge-sys/src/error.rs
@@ -56,6 +56,8 @@ pub enum WasmEdgeError {
     Import(ImportError),
     #[error("{0}")]
     Export(ExportError),
+    #[error("{0}")]
+    Instance(InstanceError),
 
     // std
     #[error("Found an interior nul byte")]
@@ -150,6 +152,13 @@ pub enum ExportError {
     GlobalType(String),
 }
 
+/// Defines the errors raised from [Instance](crate::Instance).
+#[derive(Error, Clone, Debug, PartialEq)]
+pub enum InstanceError {
+    #[error("Fail to find the target function ({0})")]
+    NotFoundFunc(String),
+}
+
 /// Defines the errors raised from [Store](crate::Store).
 #[derive(Error, Clone, Debug, PartialEq)]
 pub enum StoreError {
@@ -179,6 +188,8 @@ pub enum StoreError {
     },
     #[error("Not found the target module ({0})")]
     NotFoundModule(String),
+    #[error("Not found the active module")]
+    NotFoundActiveModule,
 }
 
 /// Defines the errors raised from [Vm](crate::Vm).

--- a/bindings/rust/wasmedge-sys/src/instance/instance.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/instance.rs
@@ -1,8 +1,10 @@
 //! Defines WasmEdge Instancestruct.
 
 use crate::{
-    error::InstanceError, types::WasmEdgeString, wasmedge, Function, Global, Memory, Store, Table,
-    WasmEdgeError, WasmEdgeResult,
+    error::InstanceError,
+    instance::{function::InnerFunc, global::InnerGlobal, memory::InnerMemory, table::InnerTable},
+    types::WasmEdgeString,
+    wasmedge, Function, Global, Memory, Store, Table, WasmEdgeError, WasmEdgeResult,
 };
 
 /// Struct of WasmEdge Instance.
@@ -45,7 +47,7 @@ impl<'store> Instance<'store> {
         let func_ctx = unsafe {
             wasmedge::WasmEdge_ModuleInstanceFindFunction(
                 self.inner.0,
-                self.store.ctx,
+                self.store.inner.0,
                 func_name.as_raw(),
             )
         };
@@ -54,7 +56,7 @@ impl<'store> Instance<'store> {
                 name.as_ref().to_string(),
             ))),
             false => Ok(Function {
-                ctx: func_ctx,
+                inner: InnerFunc(func_ctx),
                 registered: true,
             }),
         }
@@ -75,7 +77,7 @@ impl<'store> Instance<'store> {
         let ctx = unsafe {
             wasmedge::WasmEdge_ModuleInstanceFindTable(
                 self.inner.0,
-                self.store.ctx,
+                self.store.inner.0,
                 table_name.as_raw(),
             )
         };
@@ -84,7 +86,7 @@ impl<'store> Instance<'store> {
                 name.as_ref().to_string(),
             ))),
             false => Ok(Table {
-                ctx,
+                inner: InnerTable(ctx),
                 registered: true,
             }),
         }
@@ -105,7 +107,7 @@ impl<'store> Instance<'store> {
         let ctx = unsafe {
             wasmedge::WasmEdge_ModuleInstanceFindMemory(
                 self.inner.0,
-                self.store.ctx,
+                self.store.inner.0,
                 mem_name.as_raw(),
             )
         };
@@ -114,7 +116,7 @@ impl<'store> Instance<'store> {
                 name.as_ref().to_string(),
             ))),
             false => Ok(Memory {
-                ctx,
+                inner: InnerMemory(ctx),
                 registered: true,
             }),
         }
@@ -135,7 +137,7 @@ impl<'store> Instance<'store> {
         let ctx = unsafe {
             wasmedge::WasmEdge_ModuleInstanceFindGlobal(
                 self.inner.0,
-                self.store.ctx,
+                self.store.inner.0,
                 global_name.as_raw(),
             )
         };
@@ -144,7 +146,7 @@ impl<'store> Instance<'store> {
                 name.as_ref().to_string(),
             ))),
             false => Ok(Global {
-                ctx,
+                inner: InnerGlobal(ctx),
                 registered: true,
             }),
         }

--- a/bindings/rust/wasmedge-sys/src/instance/instance.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/instance.rs
@@ -353,6 +353,7 @@ mod tests {
         assert_eq!(global.mutability(), Mutability::Const);
     }
 
+    #[test]
     fn test_instance_find_names() {
         let vm = create_vm();
         let result = vm.store_mut();
@@ -381,7 +382,7 @@ mod tests {
         assert_eq!(instance.mem_len(), 1);
         let result = instance.mem_names();
         assert!(result.is_some());
-        assert_eq!(result.unwrap(), ["memory"]);
+        assert_eq!(result.unwrap(), ["mem"]);
 
         assert_eq!(instance.global_len(), 1);
         let result = instance.global_names();

--- a/bindings/rust/wasmedge-sys/src/instance/instance.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/instance.rs
@@ -4,8 +4,12 @@ use crate::{
     error::InstanceError, types::WasmEdgeString, wasmedge, Function, Global, Memory, Store, Table,
     WasmEdgeError, WasmEdgeResult,
 };
-// use std::marker::PhantomData;
 
+/// Struct of WasmEdge Instance.
+///
+/// An [`Instance`] represents an instantiated module. In the instantiation process, An [`Instance`] is created from a
+/// [`Module`](crate::Module). From an [`Instance`] the exported [functions](crate::Function), [tables](crate::Table),
+/// [memories](crate::Memory), and [globals](crate::Global) can be fetched.
 pub struct Instance<'store> {
     pub(crate) inner: InnerInstance,
     pub(crate) store: &'store Store,

--- a/bindings/rust/wasmedge-sys/src/instance/instance.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/instance.rs
@@ -1,0 +1,52 @@
+//! Defines WasmEdge Instancestruct.
+
+use crate::{
+    error::InstanceError, types::WasmEdgeString, wasmedge, Function, Store, WasmEdgeError,
+    WasmEdgeResult,
+};
+// use std::marker::PhantomData;
+
+pub struct Instance<'store> {
+    pub(crate) inner: InnerInstance,
+    pub(crate) store: &'store Store,
+}
+impl<'store> Instance<'store> {
+    /// Returns the name of this exported module instance.
+    ///
+    /// If this module is an active module, return None.
+    pub fn name(&self) -> Option<String> {
+        let name =
+            unsafe { wasmedge::WasmEdge_ModuleInstanceGetModuleName(self.inner.0 as *const _) };
+
+        let name: String = name.into();
+        if name.len() == 0 {
+            return None;
+        }
+
+        Some(name)
+    }
+
+    pub fn find_func(&self, name: impl AsRef<str>) -> WasmEdgeResult<Function> {
+        let func_name: WasmEdgeString = name.as_ref().into();
+        let func_ctx = unsafe {
+            wasmedge::WasmEdge_ModuleInstanceFindFunction(
+                self.inner.0,
+                self.store.ctx,
+                func_name.as_raw(),
+            )
+        };
+        match func_ctx.is_null() {
+            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundFunc(
+                name.as_ref().to_string(),
+            ))),
+            false => Ok(Function {
+                ctx: func_ctx,
+                registered: true,
+            }),
+        }
+    }
+}
+
+pub(crate) struct InnerInstance(pub(crate) *const wasmedge::WasmEdge_ModuleInstanceContext);
+unsafe impl Send for InnerInstance {}
+unsafe impl Sync for InnerInstance {}

--- a/bindings/rust/wasmedge-sys/src/instance/mod.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod function;
 pub mod global;
+pub mod instance;
 pub mod memory;
 pub mod table;
 
@@ -9,6 +10,8 @@ pub mod table;
 pub use function::{FuncType, Function};
 #[doc(inline)]
 pub use global::{Global, GlobalType};
+#[doc(inline)]
+pub use instance::Instance;
 #[doc(inline)]
 pub use memory::{MemType, Memory};
 #[doc(inline)]

--- a/bindings/rust/wasmedge-sys/src/instance/mod.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/mod.rs
@@ -2,8 +2,8 @@
 
 pub mod function;
 pub mod global;
-pub mod instance;
 pub mod memory;
+pub mod module;
 pub mod table;
 
 #[doc(inline)]
@@ -11,8 +11,8 @@ pub use function::{FuncType, Function};
 #[doc(inline)]
 pub use global::{Global, GlobalType};
 #[doc(inline)]
-pub use instance::Instance;
-#[doc(inline)]
 pub use memory::{MemType, Memory};
+#[doc(inline)]
+pub use module::Instance;
 #[doc(inline)]
 pub use table::{Table, TableType};

--- a/bindings/rust/wasmedge-sys/src/instance/module.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/module.rs
@@ -25,7 +25,7 @@ impl<'store> Instance<'store> {
             unsafe { wasmedge::WasmEdge_ModuleInstanceGetModuleName(self.inner.0 as *const _) };
 
         let name: String = name.into();
-        if name.len() == 0 {
+        if name.is_empty() {
             return None;
         }
 

--- a/bindings/rust/wasmedge-sys/src/lib.rs
+++ b/bindings/rust/wasmedge-sys/src/lib.rs
@@ -64,8 +64,8 @@ pub use import_obj::ImportObject;
 pub use instance::{
     function::{FuncType, Function},
     global::{Global, GlobalType},
-    instance::Instance,
     memory::{MemType, Memory},
+    module::Instance,
     table::{Table, TableType},
 };
 #[doc(inline)]

--- a/bindings/rust/wasmedge-sys/src/lib.rs
+++ b/bindings/rust/wasmedge-sys/src/lib.rs
@@ -64,6 +64,7 @@ pub use import_obj::ImportObject;
 pub use instance::{
     function::{FuncType, Function},
     global::{Global, GlobalType},
+    instance::Instance,
     memory::{MemType, Memory},
     table::{Table, TableType},
 };

--- a/bindings/rust/wasmedge-sys/src/module.rs
+++ b/bindings/rust/wasmedge-sys/src/module.rs
@@ -15,14 +15,10 @@ use std::{borrow::Cow, ffi::CStr, marker::PhantomData};
 
 /// Struct of WasmEdge AST (short for abstract syntax tree) Module.
 ///
-/// [`Module`] is the representation of WasmEdge AST Module concept, but not equivalent to
-/// *[W3C Module](https://www.w3.org/TR/wasm-core-1/#concepts%E2%91%A0)*.
-/// The initial state of a [`Module`] loaded from a file or buffer is a AST module; After the instantiation step,
-/// it "transform"s a module which is equivalent to W3C Module in semantics. The state transformation can be summarized
-/// as below:
-///
-/// `a WASM file ---<load>--> AST Module ---<instantiate>--> Module`
-///
+/// [`Module`] is also called `AST Module` in WasmEdge terminology. An `AST Module` is a compiled in-memory
+/// representation of an input WebAssembly binary. In the instantiation process, a [`Module`] is used to create a
+/// [module stance](crate::instance), from which the exported [functions](crate::Function), [tables](crate::Table),
+/// [memories](crate::Memory), and [globals](crate::Global) can be fetched.
 #[derive(Debug)]
 pub struct Module {
     pub(crate) inner: InnerModule,

--- a/bindings/rust/wasmedge-sys/src/store.rs
+++ b/bindings/rust/wasmedge-sys/src/store.rs
@@ -4,8 +4,8 @@ use crate::{
     instance::{
         function::{Function, InnerFunc},
         global::{Global, InnerGlobal},
-        instance::{InnerInstance, Instance},
         memory::{InnerMemory, Memory},
+        module::{InnerInstance, Instance},
         table::{InnerTable, Table},
     },
     types::WasmEdgeString,
@@ -619,7 +619,7 @@ impl Store {
     /// # Error
     ///
     /// If fail to find the target [module instance](crate::Instance), then an error is returned.
-    pub fn active_module<'a>(&'a self) -> WasmEdgeResult<Instance<'a>> {
+    pub fn active_module(&self) -> WasmEdgeResult<Instance<'_>> {
         let ctx = unsafe { wasmedge::WasmEdge_StoreGetActiveModule(self.inner.0) };
         match ctx.is_null() {
             true => Err(WasmEdgeError::Store(StoreError::NotFoundActiveModule)),
@@ -639,7 +639,7 @@ impl Store {
     /// # Error
     ///
     /// If fail to find the target [module instance](crate::Instance), then an error is returned.
-    pub fn named_module<'a>(&'a self, name: impl AsRef<str>) -> WasmEdgeResult<Instance<'a>> {
+    pub fn named_module(&self, name: impl AsRef<str>) -> WasmEdgeResult<Instance<'_>> {
         let mod_name: WasmEdgeString = name.as_ref().into();
         let ctx = unsafe { wasmedge::WasmEdge_StoreFindModule(self.inner.0, mod_name.as_raw()) };
         match ctx.is_null() {

--- a/bindings/rust/wasmedge-sys/src/store.rs
+++ b/bindings/rust/wasmedge-sys/src/store.rs
@@ -997,6 +997,7 @@ mod tests {
         handle.join().unwrap();
     }
 
+    #[test]
     fn test_store_active_module() {
         let result = Vm::create(None, None);
         assert!(result.is_ok());
@@ -1053,7 +1054,7 @@ mod tests {
         // create a Config context
         let result = Config::create();
         assert!(result.is_ok());
-        let config = result.unwrap();
+        let mut config = result.unwrap();
         config.bulk_memory_operations(true);
         assert!(config.bulk_memory_operations_enabled());
 

--- a/bindings/rust/wasmedge-sys/src/store.rs
+++ b/bindings/rust/wasmedge-sys/src/store.rs
@@ -120,7 +120,7 @@ impl Store {
         let table_name: WasmEdgeString = name.as_ref().into();
         let ctx = unsafe { wasmedge::WasmEdge_StoreFindTable(self.inner.0, table_name.as_raw()) };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Store(StoreError::NotFoundGlobal(
+            true => Err(WasmEdgeError::Store(StoreError::NotFoundTable(
                 name.as_ref().to_string(),
             ))),
             false => Ok(Table {


### PR DESCRIPTION
In this PR, the new `ModuleInstance` and the relevant C-APIs are supported in `wasmedge-sys`. Along with this PR, the version of `wasmedge-sys` comes to `0.4.1`.