### PR TITLE
[CI] Added workflow for publishing rustdoc.

### DIFF
--- a/.github/workflows/wasmedge-sys-docs.yml
+++ b/.github/workflows/wasmedge-sys-docs.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     tags:
-      - "wasmedge-sys/[0-9]+.[0-9]+.[0-9]+*"
+      - "rust/[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   rustdoc:

--- a/.github/workflows/wasmedge-sys-docs.yml
+++ b/.github/workflows/wasmedge-sys-docs.yml
@@ -1,7 +1,7 @@
 name: wasmedge-sys-docs
 
 concurrency:
-  group: rust-crate-release-${{ github.head_ref }}
+  group: wasmedge-sys-docs-${{ github.head_ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/wasmedge-sys-docs.yml
+++ b/.github/workflows/wasmedge-sys-docs.yml
@@ -1,0 +1,42 @@
+name: wasmedge-sys-docs
+
+concurrency:
+  group: rust-crate-release-${{ github.head_ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    tags:
+      - "wasmedge-sys/[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  rustdoc:
+    name: rustdoc
+    runs-on: ubuntu-latest
+    container:
+      image: wasmedge/wasmedge:ubuntu-build-clang
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - name: Build Documentation
+        run: |
+          cd bindings/rust/wasmedge-sys
+          cargo doc --all --no-deps --target-dir=./target
+          echo "<meta http-equiv=\"refresh\" content=\"0; url=wasmedge_sys\">" > target/doc/index.html
+
+      - name: Deploy Docs
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: bindings/rust/wasmedge-sys/target/doc
+          force_orphan: true


### PR DESCRIPTION
In this PR, a new CI workflow is implemented for publishing the rustdoc of  the `wasmedge-sys` crate to github pages.

To enable the Github Pages feature, it is required to specify the `Source` as shown in the red rectangle below:

<img width="1010" alt="image" src="https://user-images.githubusercontent.com/4726889/157251040-c683248d-1785-479a-b7a6-5a08e0378922.png">


### References
  - [actions-gh-pages](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-deploy-to-external-repository-external_repository)
  - [rust-analyzer rustdoc.yaml](https://github.com/rust-analyzer/rust-analyzer/blob/master/.github/workflows/rustdoc.yaml)
  - [Prepare your Rust API docs for Github Pages](https://dev.to/deciduously/prepare-your-rust-api-docs-for-github-pages-2n5i)