### PR TITLE
Pointer-based mechanism in store and module instance

### DIFF
--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -115,7 +115,8 @@ public:
 
   /// Invoke function by function address in Store manager.
   Expect<std::vector<std::pair<ValVariant, ValType>>>
-  invoke(Runtime::StoreManager &StoreMgr, const uint32_t FuncAddr,
+  invoke(Runtime::StoreManager &StoreMgr,
+         const Runtime::Instance::FunctionInstance &FuncInst,
          Span<const ValVariant> Params, Span<const ValType> ParamTypes);
 
   /// Register new thread
@@ -190,14 +191,12 @@ private:
                            const AST::ElementSection &ElemSec);
 
   /// Initialize table with Element Instances.
-  Expect<void> initTable(Runtime::StoreManager &StoreMgr,
-                         Runtime::StackManager &StackMgr,
+  Expect<void> initTable(Runtime::StackManager &StackMgr,
                          Runtime::Instance::ModuleInstance &ModInst,
                          const AST::ElementSection &ElemSec);
 
   /// Initialize memory with Data Instances.
-  Expect<void> initMemory(Runtime::StoreManager &StoreMgr,
-                          Runtime::StackManager &StackMgr,
+  Expect<void> initMemory(Runtime::StackManager &StackMgr,
                           Runtime::Instance::ModuleInstance &ModInst,
                           const AST::DataSection &DataSec);
 
@@ -232,28 +231,23 @@ private:
   /// @{
   /// Helper function for get table instance by index.
   Runtime::Instance::TableInstance *
-  getTabInstByIdx(Runtime::StoreManager &StoreMgr,
-                  Runtime::StackManager &StackMgr, const uint32_t Idx);
+  getTabInstByIdx(Runtime::StackManager &StackMgr, const uint32_t Idx) const;
 
   /// Helper function for get memory instance by index.
   Runtime::Instance::MemoryInstance *
-  getMemInstByIdx(Runtime::StoreManager &StoreMgr,
-                  Runtime::StackManager &StackMgr, const uint32_t Idx);
+  getMemInstByIdx(Runtime::StackManager &StackMgr, const uint32_t Idx) const;
 
   /// Helper function for get global instance by index.
   Runtime::Instance::GlobalInstance *
-  getGlobInstByIdx(Runtime::StoreManager &StoreMgr,
-                   Runtime::StackManager &StackMgr, const uint32_t Idx);
+  getGlobInstByIdx(Runtime::StackManager &StackMgr, const uint32_t Idx) const;
 
   /// Helper function for get element instance by index.
   Runtime::Instance::ElementInstance *
-  getElemInstByIdx(Runtime::StoreManager &StoreMgr,
-                   Runtime::StackManager &StackMgr, const uint32_t Idx);
+  getElemInstByIdx(Runtime::StackManager &StackMgr, const uint32_t Idx) const;
 
   /// Helper function for get data instance by index.
   Runtime::Instance::DataInstance *
-  getDataInstByIdx(Runtime::StoreManager &StoreMgr,
-                   Runtime::StackManager &StackMgr, const uint32_t Idx);
+  getDataInstByIdx(Runtime::StackManager &StackMgr, const uint32_t Idx) const;
   /// @}
 
   /// \name Run instructions functions
@@ -289,12 +283,10 @@ private:
                              uint32_t StackOffset) const noexcept;
   Expect<void> runLocalTeeOp(Runtime::StackManager &StackMgr,
                              uint32_t StackOffset) const noexcept;
-  Expect<void> runGlobalGetOp(Runtime::StoreManager &StoreMgr,
-                              Runtime::StackManager &StackMgr,
-                              const uint32_t Idx) noexcept;
-  Expect<void> runGlobalSetOp(Runtime::StoreManager &StoreMgr,
-                              Runtime::StackManager &StackMgr,
-                              const uint32_t Idx) noexcept;
+  Expect<void> runGlobalGetOp(Runtime::StackManager &StackMgr,
+                              uint32_t Idx) const noexcept;
+  Expect<void> runGlobalSetOp(Runtime::StackManager &StackMgr,
+                              uint32_t Idx) const noexcept;
   /// ======= Table instructions =======
   Expect<void> runTableGetOp(Runtime::StackManager &StackMgr,
                              Runtime::Instance::TableInstance &TabInst,

--- a/include/runtime/instance/module.h
+++ b/include/runtime/instance/module.h
@@ -201,6 +201,9 @@ public:
       // Error logging need to be handled in caller.
       return Unexpect(ErrCode::WrongInstanceIndex);
     }
+    return unsafeGetTable(Idx);
+  }
+  TableInstance *unsafeGetTable(const uint32_t Idx) const {
     return TabInsts[Idx];
   }
   Expect<MemoryInstance *> getMemory(const uint32_t Idx) const {
@@ -209,6 +212,9 @@ public:
       // Error logging need to be handled in caller.
       return Unexpect(ErrCode::WrongInstanceIndex);
     }
+    return unsafeGetMemory(Idx);
+  }
+  MemoryInstance *unsafeGetMemory(const uint32_t Idx) const {
     return MemInsts[Idx];
   }
   Expect<GlobalInstance *> getGlobal(const uint32_t Idx) const {
@@ -217,6 +223,9 @@ public:
       // Error logging need to be handled in caller.
       return Unexpect(ErrCode::WrongInstanceIndex);
     }
+    return unsafeGetGlobal(Idx);
+  }
+  GlobalInstance *unsafeGetGlobal(const uint32_t Idx) const {
     return GlobInsts[Idx];
   }
   Expect<ElementInstance *> getElem(const uint32_t Idx) const {
@@ -225,6 +234,9 @@ public:
       // Error logging need to be handled in caller.
       return Unexpect(ErrCode::WrongInstanceIndex);
     }
+    return unsafeGetElem(Idx);
+  }
+  ElementInstance *unsafeGetElem(const uint32_t Idx) const {
     return ElemInsts[Idx];
   }
   Expect<DataInstance *> getData(const uint32_t Idx) const {
@@ -233,6 +245,9 @@ public:
       // Error logging need to be handled in caller.
       return Unexpect(ErrCode::WrongInstanceIndex);
     }
+    return unsafeGetData(Idx);
+  }
+  DataInstance *unsafeGetData(const uint32_t Idx) const {
     return DataInsts[Idx];
   }
 

--- a/include/runtime/stackmgr.h
+++ b/include/runtime/stackmgr.h
@@ -14,11 +14,7 @@
 #pragma once
 
 #include "ast/instruction.h"
-#include "runtime/instance/function.h"
-#include "runtime/instance/global.h"
-#include "runtime/instance/memory.h"
 #include "runtime/instance/module.h"
-#include "runtime/instance/table.h"
 
 #include <optional>
 #include <vector>
@@ -30,10 +26,10 @@ class StackManager {
 public:
   struct Frame {
     Frame() = delete;
-    Frame(uint32_t Addr, uint32_t L, uint32_t A,
+    Frame(Instance::ModuleInstance *Mod, uint32_t L, uint32_t A,
           AST::InstrView::iterator FromIt, const bool Dummy = false) noexcept
-        : ModAddr(Addr), Locals(L), Arity(A), From(FromIt), IsDummy(Dummy) {}
-    uint32_t ModAddr;
+        : Module(Mod), Locals(L), Arity(A), From(FromIt), IsDummy(Dummy) {}
+    Instance::ModuleInstance *Module;
     uint32_t Locals;
     uint32_t Arity;
     AST::InstrView::iterator From;
@@ -81,16 +77,16 @@ public:
   }
 
   /// Push a new frame entry to stack.
-  void pushFrame(const uint32_t ModuleAddr, AST::InstrView::iterator From,
-                 const uint32_t LocalNum = 0,
+  void pushFrame(Instance::ModuleInstance *Module,
+                 AST::InstrView::iterator From, const uint32_t LocalNum = 0,
                  const uint32_t Arity = 0) noexcept {
-    FrameStack.emplace_back(ModuleAddr, LocalNum, Arity, From);
+    FrameStack.emplace_back(Module, LocalNum, Arity, From);
   }
 
   /// Push a dummy frame for invokation base.
   void pushDummyFrame() noexcept {
-    FrameStack.emplace_back(0, ValueStack.size(), 0, AST::InstrView::iterator{},
-                            true);
+    FrameStack.emplace_back(nullptr, ValueStack.size(), 0,
+                            AST::InstrView::iterator{}, true);
   }
 
   /// Unsafe pop top frame.
@@ -123,13 +119,13 @@ public:
   }
 
   /// Unsafe getter of module address.
-  uint32_t getModuleAddr() const noexcept {
+  Instance::ModuleInstance *getModule() const noexcept {
     assuming(!FrameStack.empty());
-    return FrameStack.back().ModAddr;
+    return FrameStack.back().Module;
   }
 
   /// Unsafe checker of top frame is a dummy frame.
-  bool isTopDummyFrame() noexcept {
+  bool isTopDummyFrame() const noexcept {
     assuming(!FrameStack.empty());
     return FrameStack.back().IsDummy;
   }

--- a/include/runtime/stackmgr.h
+++ b/include/runtime/stackmgr.h
@@ -27,13 +27,12 @@ public:
   struct Frame {
     Frame() = delete;
     Frame(Instance::ModuleInstance *Mod, uint32_t L, uint32_t A,
-          AST::InstrView::iterator FromIt, const bool Dummy = false) noexcept
-        : Module(Mod), Locals(L), Arity(A), From(FromIt), IsDummy(Dummy) {}
+          AST::InstrView::iterator FromIt) noexcept
+        : Module(Mod), Locals(L), Arity(A), From(FromIt) {}
     Instance::ModuleInstance *Module;
     uint32_t Locals;
     uint32_t Arity;
     AST::InstrView::iterator From;
-    bool IsDummy;
   };
 
   using Value = ValVariant;
@@ -83,12 +82,6 @@ public:
     FrameStack.emplace_back(Module, LocalNum, Arity, From);
   }
 
-  /// Push a dummy frame for invokation base.
-  void pushDummyFrame() noexcept {
-    FrameStack.emplace_back(nullptr, ValueStack.size(), 0,
-                            AST::InstrView::iterator{}, true);
-  }
-
   /// Unsafe pop top frame.
   AST::InstrView::iterator popFrame() noexcept {
     assuming(!FrameStack.empty());
@@ -122,12 +115,6 @@ public:
   Instance::ModuleInstance *getModule() const noexcept {
     assuming(!FrameStack.empty());
     return FrameStack.back().Module;
-  }
-
-  /// Unsafe checker of top frame is a dummy frame.
-  bool isTopDummyFrame() const noexcept {
-    assuming(!FrameStack.empty());
-    return FrameStack.back().IsDummy;
   }
 
   /// Reset stack.

--- a/include/runtime/storemgr.h
+++ b/include/runtime/storemgr.h
@@ -59,103 +59,120 @@ public:
   ~StoreManager() = default;
 
   /// Import instances and move owner to store manager.
-  template <typename... Args> uint32_t importModule(Args &&...Values) {
+  template <typename... Args>
+  Instance::ModuleInstance *importModule(Args &&...Values) {
     std::unique_lock Lock(Mutex);
-    uint32_t ModAddr = unsafeImportInstance(ImpModInsts, ModInsts,
-                                            std::forward<Args>(Values)...);
-    ModInsts.back()->Addr = ModAddr;
-    ModMap.emplace(ModInsts.back()->getModuleName(), ModAddr);
-    return ModAddr;
+    auto *ModInst = unsafeImportInstance(ImpModInsts, ModInsts,
+                                         std::forward<Args>(Values)...);
+    ModMap.emplace(ModInsts.back()->getModuleName(), ModInst);
+    return ModInst;
   }
-  template <typename... Args> uint32_t importFunction(Args &&...Values) {
+  template <typename... Args>
+  Instance::FunctionInstance *importFunction(Args &&...Values) {
     std::unique_lock Lock(Mutex);
-    return unsafeImportInstance(ImpFuncInsts, FuncInsts,
-                                std::forward<Args>(Values)...);
+    auto *FuncInst = unsafeImportInstance(ImpFuncInsts, FuncInsts,
+                                          std::forward<Args>(Values)...);
+    FuncInst->setAddr(static_cast<uint32_t>(FuncInsts.size() - 1));
+    return FuncInst;
   }
-  template <typename... Args> uint32_t importTable(Args &&...Values) {
+  template <typename... Args>
+  Instance::TableInstance *importTable(Args &&...Values) {
     std::unique_lock Lock(Mutex);
     return unsafeImportInstance(ImpTabInsts, TabInsts,
                                 std::forward<Args>(Values)...);
   }
-  template <typename... Args> uint32_t importMemory(Args &&...Values) {
+  template <typename... Args>
+  Instance::MemoryInstance *importMemory(Args &&...Values) {
     std::unique_lock Lock(Mutex);
     return unsafeImportInstance(ImpMemInsts, MemInsts,
                                 std::forward<Args>(Values)...);
   }
-  template <typename... Args> uint32_t importGlobal(Args &&...Values) {
+  template <typename... Args>
+  Instance::GlobalInstance *importGlobal(Args &&...Values) {
     std::unique_lock Lock(Mutex);
     return unsafeImportInstance(ImpGlobInsts, GlobInsts,
                                 std::forward<Args>(Values)...);
   }
-  template <typename... Args> uint32_t importElement(Args &&...Values) {
+  template <typename... Args>
+  Instance::ElementInstance *importElement(Args &&...Values) {
     std::unique_lock Lock(Mutex);
     return unsafeImportInstance(ImpElemInsts, ElemInsts,
                                 std::forward<Args>(Values)...);
   }
-  template <typename... Args> uint32_t importData(Args &&...Values) {
+  template <typename... Args>
+  Instance::DataInstance *importData(Args &&...Values) {
     std::unique_lock Lock(Mutex);
     return unsafeImportInstance(ImpDataInsts, DataInsts,
                                 std::forward<Args>(Values)...);
   }
 
   /// Import host instances but not move ownership.
-  uint32_t importHostFunction(Instance::FunctionInstance &Func) {
+  Instance::FunctionInstance *
+  importHostFunction(Instance::FunctionInstance &Func) {
     std::unique_lock Lock(Mutex);
+    Func.setAddr(static_cast<uint32_t>(FuncInsts.size()));
     return unsafeImportHostInstance(Func, FuncInsts);
   }
-  uint32_t importHostTable(Instance::TableInstance &Tab) {
+  Instance::TableInstance *importHostTable(Instance::TableInstance &Tab) {
     std::unique_lock Lock(Mutex);
     return unsafeImportHostInstance(Tab, TabInsts);
   }
-  uint32_t importHostMemory(Instance::MemoryInstance &Mem) {
+  Instance::MemoryInstance *importHostMemory(Instance::MemoryInstance &Mem) {
     std::unique_lock Lock(Mutex);
     return unsafeImportHostInstance(Mem, MemInsts);
   }
-  uint32_t importHostGlobal(Instance::GlobalInstance &Glob) {
+  Instance::GlobalInstance *importHostGlobal(Instance::GlobalInstance &Glob) {
     std::unique_lock Lock(Mutex);
     return unsafeImportHostInstance(Glob, GlobInsts);
   }
 
   /// Insert instances for instantiation and move ownership to store manager.
-  template <typename... Args> uint32_t pushModule(Args &&...Values) {
+  template <typename... Args>
+  Instance::ModuleInstance *pushModule(Args &&...Values) {
     std::unique_lock Lock(Mutex);
     ++NumMod;
-    uint32_t ModAddr = unsafeImportInstance(ImpModInsts, ModInsts,
-                                            std::forward<Args>(Values)...);
-    ModInsts.back()->Addr = ModAddr;
-    return ModAddr;
-  }
-  template <typename... Args> uint32_t pushFunction(Args &&...Values) {
-    std::unique_lock Lock(Mutex);
-    ++NumFunc;
-    return unsafeImportInstance(ImpFuncInsts, FuncInsts,
+    return unsafeImportInstance(ImpModInsts, ModInsts,
                                 std::forward<Args>(Values)...);
   }
-  template <typename... Args> uint32_t pushTable(Args &&...Values) {
+  template <typename... Args>
+  Instance::FunctionInstance *pushFunction(Args &&...Values) {
+    std::unique_lock Lock(Mutex);
+    ++NumFunc;
+    auto *FuncInst = unsafeImportInstance(ImpFuncInsts, FuncInsts,
+                                          std::forward<Args>(Values)...);
+    FuncInst->setAddr(static_cast<uint32_t>(FuncInsts.size() - 1));
+    return FuncInst;
+  }
+  template <typename... Args>
+  Instance::TableInstance *pushTable(Args &&...Values) {
     std::unique_lock Lock(Mutex);
     ++NumTab;
     return unsafeImportInstance(ImpTabInsts, TabInsts,
                                 std::forward<Args>(Values)...);
   }
-  template <typename... Args> uint32_t pushMemory(Args &&...Values) {
+  template <typename... Args>
+  Instance::MemoryInstance *pushMemory(Args &&...Values) {
     std::unique_lock Lock(Mutex);
     ++NumMem;
     return unsafeImportInstance(ImpMemInsts, MemInsts,
                                 std::forward<Args>(Values)...);
   }
-  template <typename... Args> uint32_t pushGlobal(Args &&...Values) {
+  template <typename... Args>
+  Instance::GlobalInstance *pushGlobal(Args &&...Values) {
     std::unique_lock Lock(Mutex);
     ++NumGlob;
     return unsafeImportInstance(ImpGlobInsts, GlobInsts,
                                 std::forward<Args>(Values)...);
   }
-  template <typename... Args> uint32_t pushElement(Args &&...Values) {
+  template <typename... Args>
+  Instance::ElementInstance *pushElement(Args &&...Values) {
     std::unique_lock Lock(Mutex);
     ++NumElem;
     return unsafeImportInstance(ImpElemInsts, ElemInsts,
                                 std::forward<Args>(Values)...);
   }
-  template <typename... Args> uint32_t pushData(Args &&...Values) {
+  template <typename... Args>
+  Instance::DataInstance *pushData(Args &&...Values) {
     std::unique_lock Lock(Mutex);
     ++NumData;
     return unsafeImportInstance(ImpDataInsts, DataInsts,
@@ -303,22 +320,20 @@ public:
 private:
   /// Helper function for importing instances and move ownership.
   template <typename T, typename... Args>
-  std::enable_if_t<IsInstanceV<T>, uint32_t>
+  std::enable_if_t<IsInstanceV<T>, T *>
   unsafeImportInstance(std::vector<std::unique_ptr<T>> &ImpInstsVec,
                        std::vector<T *> &InstsVec, Args &&...Values) {
-    const auto Addr = static_cast<uint32_t>(InstsVec.size());
     ImpInstsVec.push_back(std::make_unique<T>(std::forward<Args>(Values)...));
     InstsVec.push_back(ImpInstsVec.back().get());
-    return Addr;
+    return ImpInstsVec.back().get();
   }
 
   /// Helper function for importing host instances.
   template <typename T>
-  std::enable_if_t<IsImportEntityV<T>, uint32_t>
+  std::enable_if_t<IsImportEntityV<T>, T *>
   unsafeImportHostInstance(T &Inst, std::vector<T *> &InstsVec) {
-    const auto Addr = static_cast<uint32_t>(InstsVec.size());
     InstsVec.push_back(&Inst);
-    return Addr;
+    return InstsVec.back();
   }
 
   /// Helper function for getting instance from instance vector.
@@ -369,7 +384,7 @@ private:
 
   /// \name Module name mapping.
   /// @{
-  std::map<std::string, uint32_t, std::less<>> ModMap;
+  std::map<std::string, Instance::ModuleInstance *, std::less<>> ModMap;
   /// @}
 };
 

--- a/lib/executor/engine/controlInstr.cpp
+++ b/lib/executor/engine/controlInstr.cpp
@@ -87,9 +87,8 @@ Expect<void> Executor::runCallOp(Runtime::StoreManager &StoreMgr,
                                  const AST::Instruction &Instr,
                                  AST::InstrView::iterator &PC) noexcept {
   // Get Function address.
-  const auto *ModInst = *StoreMgr.getModule(StackMgr.getModuleAddr());
-  const uint32_t FuncAddr = *ModInst->getFuncAddr(Instr.getTargetIndex());
-  const auto *FuncInst = *StoreMgr.getFunction(FuncAddr);
+  const auto *ModInst = StackMgr.getModule();
+  const auto *FuncInst = *ModInst->getFunc(Instr.getTargetIndex());
   if (auto Res = enterFunction(StoreMgr, StackMgr, *FuncInst, PC + 1); !Res) {
     return Unexpect(Res);
   } else {
@@ -102,11 +101,10 @@ Expect<void> Executor::runCallIndirectOp(
     Runtime::StoreManager &StoreMgr, Runtime::StackManager &StackMgr,
     const AST::Instruction &Instr, AST::InstrView::iterator &PC) noexcept {
   // Get Table Instance
-  const auto *TabInst =
-      getTabInstByIdx(StoreMgr, StackMgr, Instr.getSourceIndex());
+  const auto *TabInst = getTabInstByIdx(StackMgr, Instr.getSourceIndex());
 
   // Get function type at index x.
-  const auto *ModInst = *StoreMgr.getModule(StackMgr.getModuleAddr());
+  const auto *ModInst = StackMgr.getModule();
   const auto *TargetFuncType = *ModInst->getFuncType(Instr.getTargetIndex());
 
   // Pop the value i32.const i from the Stack.

--- a/lib/executor/engine/engine.cpp
+++ b/lib/executor/engine/engine.cpp
@@ -136,9 +136,9 @@ Expect<void> Executor::execute(Runtime::StoreManager &StoreMgr,
       return {};
     }
     case OpCode::Ref__func: {
-      const auto *ModInst = *StoreMgr.getModule(StackMgr.getModuleAddr());
-      const uint32_t FuncAddr = *ModInst->getFuncAddr(Instr.getTargetIndex());
-      StackMgr.push<FuncRef>(FuncRef(FuncAddr));
+      const auto *ModInst = StackMgr.getModule();
+      const auto *FuncInst = *ModInst->getFunc(Instr.getTargetIndex());
+      StackMgr.push<FuncRef>(FuncRef(FuncInst->getAddr()));
       return {};
     }
 
@@ -170,176 +170,141 @@ Expect<void> Executor::execute(Runtime::StoreManager &StoreMgr,
     case OpCode::Local__tee:
       return runLocalTeeOp(StackMgr, Instr.getStackOffset());
     case OpCode::Global__get:
-      return runGlobalGetOp(StoreMgr, StackMgr, Instr.getTargetIndex());
+      return runGlobalGetOp(StackMgr, Instr.getTargetIndex());
     case OpCode::Global__set:
-      return runGlobalSetOp(StoreMgr, StackMgr, Instr.getTargetIndex());
+      return runGlobalSetOp(StackMgr, Instr.getTargetIndex());
 
     // Table Instructions
     case OpCode::Table__get:
       return runTableGetOp(
-          StackMgr,
-          *getTabInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getTabInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::Table__set:
       return runTableSetOp(
-          StackMgr,
-          *getTabInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getTabInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::Table__init:
       return runTableInitOp(
-          StackMgr,
-          *getTabInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()),
-          *getElemInstByIdx(StoreMgr, StackMgr, Instr.getSourceIndex()), Instr);
+          StackMgr, *getTabInstByIdx(StackMgr, Instr.getTargetIndex()),
+          *getElemInstByIdx(StackMgr, Instr.getSourceIndex()), Instr);
     case OpCode::Elem__drop:
-      return runElemDropOp(
-          *getElemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()));
+      return runElemDropOp(*getElemInstByIdx(StackMgr, Instr.getTargetIndex()));
     case OpCode::Table__copy:
       return runTableCopyOp(
-          StackMgr,
-          *getTabInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()),
-          *getTabInstByIdx(StoreMgr, StackMgr, Instr.getSourceIndex()), Instr);
+          StackMgr, *getTabInstByIdx(StackMgr, Instr.getTargetIndex()),
+          *getTabInstByIdx(StackMgr, Instr.getSourceIndex()), Instr);
     case OpCode::Table__grow:
-      return runTableGrowOp(StackMgr, *getTabInstByIdx(StoreMgr, StackMgr,
-                                                       Instr.getTargetIndex()));
+      return runTableGrowOp(StackMgr,
+                            *getTabInstByIdx(StackMgr, Instr.getTargetIndex()));
     case OpCode::Table__size:
-      return runTableSizeOp(StackMgr, *getTabInstByIdx(StoreMgr, StackMgr,
-                                                       Instr.getTargetIndex()));
+      return runTableSizeOp(StackMgr,
+                            *getTabInstByIdx(StackMgr, Instr.getTargetIndex()));
     case OpCode::Table__fill:
       return runTableFillOp(
-          StackMgr,
-          *getTabInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getTabInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
 
     // Memory Instructions
     case OpCode::I32__load:
       return runLoadOp<uint32_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::I64__load:
       return runLoadOp<uint64_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::F32__load:
       return runLoadOp<float>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::F64__load:
       return runLoadOp<double>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::I32__load8_s:
       return runLoadOp<int32_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr,
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr,
           8);
     case OpCode::I32__load8_u:
       return runLoadOp<uint32_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr,
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr,
           8);
     case OpCode::I32__load16_s:
       return runLoadOp<int32_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr,
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr,
           16);
     case OpCode::I32__load16_u:
       return runLoadOp<uint32_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr,
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr,
           16);
     case OpCode::I64__load8_s:
       return runLoadOp<int64_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr,
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr,
           8);
     case OpCode::I64__load8_u:
       return runLoadOp<uint64_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr,
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr,
           8);
     case OpCode::I64__load16_s:
       return runLoadOp<int64_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr,
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr,
           16);
     case OpCode::I64__load16_u:
       return runLoadOp<uint64_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr,
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr,
           16);
     case OpCode::I64__load32_s:
       return runLoadOp<int64_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr,
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr,
           32);
     case OpCode::I64__load32_u:
       return runLoadOp<uint64_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr,
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr,
           32);
     case OpCode::I32__store:
       return runStoreOp<uint32_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::I64__store:
       return runStoreOp<uint64_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::F32__store:
       return runStoreOp<float>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::F64__store:
       return runStoreOp<double>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::I32__store8:
       return runStoreOp<uint32_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr,
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr,
           8);
     case OpCode::I32__store16:
       return runStoreOp<uint32_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr,
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr,
           16);
     case OpCode::I64__store8:
       return runStoreOp<uint64_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr,
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr,
           8);
     case OpCode::I64__store16:
       return runStoreOp<uint64_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr,
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr,
           16);
     case OpCode::I64__store32:
       return runStoreOp<uint64_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr,
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr,
           32);
     case OpCode::Memory__grow:
       return runMemoryGrowOp(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()));
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()));
     case OpCode::Memory__size:
       return runMemorySizeOp(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()));
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()));
     case OpCode::Memory__init:
       return runMemoryInitOp(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()),
-          *getDataInstByIdx(StoreMgr, StackMgr, Instr.getSourceIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()),
+          *getDataInstByIdx(StackMgr, Instr.getSourceIndex()), Instr);
     case OpCode::Data__drop:
-      return runDataDropOp(
-          *getDataInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()));
+      return runDataDropOp(*getDataInstByIdx(StackMgr, Instr.getTargetIndex()));
     case OpCode::Memory__copy:
       return runMemoryCopyOp(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()),
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getSourceIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()),
+          *getMemInstByIdx(StackMgr, Instr.getSourceIndex()), Instr);
     case OpCode::Memory__fill:
       return runMemoryFillOp(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
 
     // Const numeric instructions
     case OpCode::I32__const:
@@ -780,94 +745,72 @@ Expect<void> Executor::execute(Runtime::StoreManager &StoreMgr,
     // SIMD Memory Instructions
     case OpCode::V128__load:
       return runLoadOp<uint128_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__load8x8_s:
       return runLoadExpandOp<int8_t, int16_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__load8x8_u:
       return runLoadExpandOp<uint8_t, uint16_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__load16x4_s:
       return runLoadExpandOp<int16_t, int32_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__load16x4_u:
       return runLoadExpandOp<uint16_t, uint32_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__load32x2_s:
       return runLoadExpandOp<int32_t, int64_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__load32x2_u:
       return runLoadExpandOp<uint32_t, uint64_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__load8_splat:
       return runLoadSplatOp<uint8_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__load16_splat:
       return runLoadSplatOp<uint16_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__load32_splat:
       return runLoadSplatOp<uint32_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__load64_splat:
       return runLoadSplatOp<uint64_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__load32_zero:
       return runLoadOp<uint128_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr,
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr,
           32);
     case OpCode::V128__load64_zero:
       return runLoadOp<uint128_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr,
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr,
           64);
     case OpCode::V128__store:
       return runStoreOp<uint128_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__load8_lane:
       return runLoadLaneOp<uint8_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__load16_lane:
       return runLoadLaneOp<uint16_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__load32_lane:
       return runLoadLaneOp<uint32_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__load64_lane:
       return runLoadLaneOp<uint64_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__store8_lane:
       return runStoreLaneOp<uint8_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__store16_lane:
       return runStoreLaneOp<uint16_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__store32_lane:
       return runStoreLaneOp<uint32_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
     case OpCode::V128__store64_lane:
       return runStoreLaneOp<uint64_t>(
-          StackMgr,
-          *getMemInstByIdx(StoreMgr, StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
 
     // SIMD Const Instructions
     case OpCode::V128__const:

--- a/lib/executor/engine/engine.cpp
+++ b/lib/executor/engine/engine.cpp
@@ -28,7 +28,7 @@ Executor::runFunction(Runtime::StoreManager &StoreMgr,
 
   // Reset and push a dummy frame into stack.
   StackMgr.reset();
-  StackMgr.pushDummyFrame();
+  StackMgr.pushFrame(nullptr, AST::InstrView::iterator(), 0, 0);
 
   // Push arguments.
   for (auto &Val : Params) {

--- a/lib/executor/engine/proxy.cpp
+++ b/lib/executor/engine/proxy.cpp
@@ -83,9 +83,8 @@ Expect<void> Executor::call(Runtime::StoreManager &StoreMgr,
                             Runtime::StackManager &StackMgr,
                             const uint32_t FuncIdx, const ValVariant *Args,
                             ValVariant *Rets) noexcept {
-  const auto *ModInst = *StoreMgr.getModule(StackMgr.getModuleAddr());
-  const uint32_t FuncAddr = *ModInst->getFuncAddr(FuncIdx);
-  const auto *FuncInst = *StoreMgr.getFunction(FuncAddr);
+  const auto *ModInst = StackMgr.getModule();
+  const auto *FuncInst = *ModInst->getFunc(FuncIdx);
   const auto &FuncType = FuncInst->getFuncType();
   const uint32_t ParamsSize =
       static_cast<uint32_t>(FuncType.getParamTypes().size());
@@ -120,7 +119,7 @@ Expect<void *> Executor::ptrFunc(Runtime::StoreManager &StoreMgr,
                                  const uint32_t TableIdx,
                                  const uint32_t FuncTypeIdx,
                                  const uint32_t FuncIdx) noexcept {
-  const auto *TabInst = getTabInstByIdx(StoreMgr, StackMgr, TableIdx);
+  const auto *TabInst = getTabInstByIdx(StackMgr, TableIdx);
   assuming(TabInst);
 
   if (unlikely(FuncIdx >= TabInst->getSize())) {
@@ -134,9 +133,9 @@ Expect<void *> Executor::ptrFunc(Runtime::StoreManager &StoreMgr,
   }
   const auto FuncAddr = retrieveFuncIdx(*Ref);
 
-  const auto ModInst = StoreMgr.getModule(StackMgr.getModuleAddr());
-  assuming(ModInst && *ModInst);
-  const auto TargetFuncType = (*ModInst)->getFuncType(FuncTypeIdx);
+  const auto *ModInst = StackMgr.getModule();
+  assuming(ModInst);
+  const auto TargetFuncType = ModInst->getFuncType(FuncTypeIdx);
   assuming(TargetFuncType && *TargetFuncType);
   const auto FuncInst = *StoreMgr.getFunction(FuncAddr);
   assuming(FuncInst);
@@ -157,7 +156,7 @@ Executor::callIndirect(Runtime::StoreManager &StoreMgr,
                        Runtime::StackManager &StackMgr, const uint32_t TableIdx,
                        const uint32_t FuncTypeIdx, const uint32_t FuncIdx,
                        const ValVariant *Args, ValVariant *Rets) noexcept {
-  const auto *TabInst = getTabInstByIdx(StoreMgr, StackMgr, TableIdx);
+  const auto *TabInst = getTabInstByIdx(StackMgr, TableIdx);
   assuming(TabInst);
 
   if (unlikely(FuncIdx >= TabInst->getSize())) {
@@ -171,9 +170,9 @@ Executor::callIndirect(Runtime::StoreManager &StoreMgr,
   }
   const auto FuncAddr = retrieveFuncIdx(*Ref);
 
-  const auto ModInst = StoreMgr.getModule(StackMgr.getModuleAddr());
-  assuming(ModInst && *ModInst);
-  const auto TargetFuncType = (*ModInst)->getFuncType(FuncTypeIdx);
+  const auto *ModInst = StackMgr.getModule();
+  assuming(ModInst);
+  const auto TargetFuncType = ModInst->getFuncType(FuncTypeIdx);
   assuming(TargetFuncType && *TargetFuncType);
   const auto FuncInst = StoreMgr.getFunction(FuncAddr);
   assuming(FuncInst && *FuncInst);
@@ -210,11 +209,11 @@ Executor::callIndirect(Runtime::StoreManager &StoreMgr,
   return {};
 }
 
-Expect<uint32_t> Executor::memGrow(Runtime::StoreManager &StoreMgr,
+Expect<uint32_t> Executor::memGrow(Runtime::StoreManager &,
                                    Runtime::StackManager &StackMgr,
                                    const uint32_t MemIdx,
                                    const uint32_t NewSize) noexcept {
-  auto *MemInst = getMemInstByIdx(StoreMgr, StackMgr, MemIdx);
+  auto *MemInst = getMemInstByIdx(StackMgr, MemIdx);
   assuming(MemInst);
   const uint32_t CurrPageSize = MemInst->getPageSize();
   if (MemInst->growPage(NewSize)) {
@@ -224,23 +223,23 @@ Expect<uint32_t> Executor::memGrow(Runtime::StoreManager &StoreMgr,
   }
 }
 
-Expect<uint32_t> Executor::memSize(Runtime::StoreManager &StoreMgr,
+Expect<uint32_t> Executor::memSize(Runtime::StoreManager &,
                                    Runtime::StackManager &StackMgr,
                                    const uint32_t MemIdx) noexcept {
-  auto *MemInst = getMemInstByIdx(StoreMgr, StackMgr, MemIdx);
+  auto *MemInst = getMemInstByIdx(StackMgr, MemIdx);
   assuming(MemInst);
   return MemInst->getPageSize();
 }
 
-Expect<void> Executor::memCopy(Runtime::StoreManager &StoreMgr,
+Expect<void> Executor::memCopy(Runtime::StoreManager &,
                                Runtime::StackManager &StackMgr,
                                const uint32_t DstMemIdx,
                                const uint32_t SrcMemIdx, const uint32_t DstOff,
                                const uint32_t SrcOff,
                                const uint32_t Len) noexcept {
-  auto *MemInstDst = getMemInstByIdx(StoreMgr, StackMgr, DstMemIdx);
+  auto *MemInstDst = getMemInstByIdx(StackMgr, DstMemIdx);
   assuming(MemInstDst);
-  auto *MemInstSrc = getMemInstByIdx(StoreMgr, StackMgr, SrcMemIdx);
+  auto *MemInstSrc = getMemInstByIdx(StackMgr, SrcMemIdx);
   assuming(MemInstSrc);
 
   if (auto Data = MemInstSrc->getBytes(SrcOff, Len); unlikely(!Data)) {
@@ -255,11 +254,11 @@ Expect<void> Executor::memCopy(Runtime::StoreManager &StoreMgr,
   return {};
 }
 
-Expect<void> Executor::memFill(Runtime::StoreManager &StoreMgr,
+Expect<void> Executor::memFill(Runtime::StoreManager &,
                                Runtime::StackManager &StackMgr,
                                const uint32_t MemIdx, const uint32_t Off,
                                const uint8_t Val, const uint32_t Len) noexcept {
-  auto *MemInst = getMemInstByIdx(StoreMgr, StackMgr, MemIdx);
+  auto *MemInst = getMemInstByIdx(StackMgr, MemIdx);
   assuming(MemInst);
   if (auto Res = MemInst->fillBytes(Val, Off, Len); unlikely(!Res)) {
     return Unexpect(Res);
@@ -268,14 +267,14 @@ Expect<void> Executor::memFill(Runtime::StoreManager &StoreMgr,
   return {};
 }
 
-Expect<void> Executor::memInit(Runtime::StoreManager &StoreMgr,
+Expect<void> Executor::memInit(Runtime::StoreManager &,
                                Runtime::StackManager &StackMgr,
                                const uint32_t MemIdx, const uint32_t DataIdx,
                                const uint32_t DstOff, const uint32_t SrcOff,
                                const uint32_t Len) noexcept {
-  auto *MemInst = getMemInstByIdx(StoreMgr, StackMgr, MemIdx);
+  auto *MemInst = getMemInstByIdx(StackMgr, MemIdx);
   assuming(MemInst);
-  auto *DataInst = getDataInstByIdx(StoreMgr, StackMgr, DataIdx);
+  auto *DataInst = getDataInstByIdx(StackMgr, DataIdx);
   assuming(DataInst);
 
   if (auto Res = MemInst->setBytes(DataInst->getData(), DstOff, SrcOff, Len);
@@ -286,21 +285,21 @@ Expect<void> Executor::memInit(Runtime::StoreManager &StoreMgr,
   return {};
 }
 
-Expect<void> Executor::dataDrop(Runtime::StoreManager &StoreMgr,
+Expect<void> Executor::dataDrop(Runtime::StoreManager &,
                                 Runtime::StackManager &StackMgr,
                                 const uint32_t DataIdx) noexcept {
-  auto *DataInst = getDataInstByIdx(StoreMgr, StackMgr, DataIdx);
+  auto *DataInst = getDataInstByIdx(StackMgr, DataIdx);
   assuming(DataInst);
   DataInst->clear();
 
   return {};
 }
 
-Expect<RefVariant> Executor::tableGet(Runtime::StoreManager &StoreMgr,
+Expect<RefVariant> Executor::tableGet(Runtime::StoreManager &,
                                       Runtime::StackManager &StackMgr,
                                       const uint32_t TableIdx,
                                       const uint32_t Off) noexcept {
-  auto *TabInst = getTabInstByIdx(StoreMgr, StackMgr, TableIdx);
+  auto *TabInst = getTabInstByIdx(StackMgr, TableIdx);
   assuming(TabInst);
   if (auto Res = TabInst->getRefAddr(Off); unlikely(!Res)) {
     return Unexpect(Res);
@@ -309,11 +308,11 @@ Expect<RefVariant> Executor::tableGet(Runtime::StoreManager &StoreMgr,
   }
 }
 
-Expect<void> Executor::tableSet(Runtime::StoreManager &StoreMgr,
+Expect<void> Executor::tableSet(Runtime::StoreManager &,
                                 Runtime::StackManager &StackMgr,
                                 const uint32_t TableIdx, const uint32_t Off,
                                 const RefVariant Ref) noexcept {
-  auto *TabInst = getTabInstByIdx(StoreMgr, StackMgr, TableIdx);
+  auto *TabInst = getTabInstByIdx(StackMgr, TableIdx);
   assuming(TabInst);
   if (auto Res = TabInst->setRefAddr(Off, Ref); unlikely(!Res)) {
     return Unexpect(Res);
@@ -322,15 +321,15 @@ Expect<void> Executor::tableSet(Runtime::StoreManager &StoreMgr,
   return {};
 }
 
-Expect<void> Executor::tableCopy(Runtime::StoreManager &StoreMgr,
+Expect<void> Executor::tableCopy(Runtime::StoreManager &,
                                  Runtime::StackManager &StackMgr,
                                  const uint32_t TableIdxDst,
                                  const uint32_t TableIdxSrc,
                                  const uint32_t DstOff, const uint32_t SrcOff,
                                  const uint32_t Len) noexcept {
-  auto *TabInstDst = getTabInstByIdx(StoreMgr, StackMgr, TableIdxDst);
+  auto *TabInstDst = getTabInstByIdx(StackMgr, TableIdxDst);
   assuming(TabInstDst);
-  auto *TabInstSrc = getTabInstByIdx(StoreMgr, StackMgr, TableIdxSrc);
+  auto *TabInstSrc = getTabInstByIdx(StackMgr, TableIdxSrc);
   assuming(TabInstSrc);
 
   if (auto Refs = TabInstSrc->getRefs(SrcOff, Len); unlikely(!Refs)) {
@@ -344,12 +343,12 @@ Expect<void> Executor::tableCopy(Runtime::StoreManager &StoreMgr,
   return {};
 }
 
-Expect<uint32_t> Executor::tableGrow(Runtime::StoreManager &StoreMgr,
+Expect<uint32_t> Executor::tableGrow(Runtime::StoreManager &,
                                      Runtime::StackManager &StackMgr,
                                      const uint32_t TableIdx,
                                      const RefVariant Val,
                                      const uint32_t NewSize) noexcept {
-  auto *TabInst = getTabInstByIdx(StoreMgr, StackMgr, TableIdx);
+  auto *TabInst = getTabInstByIdx(StackMgr, TableIdx);
   assuming(TabInst);
   const uint32_t CurrTableSize = TabInst->getSize();
   if (likely(TabInst->growTable(NewSize, Val))) {
@@ -359,20 +358,20 @@ Expect<uint32_t> Executor::tableGrow(Runtime::StoreManager &StoreMgr,
   }
 }
 
-Expect<uint32_t> Executor::tableSize(Runtime::StoreManager &StoreMgr,
+Expect<uint32_t> Executor::tableSize(Runtime::StoreManager &,
                                      Runtime::StackManager &StackMgr,
                                      const uint32_t TableIdx) noexcept {
-  auto *TabInst = getTabInstByIdx(StoreMgr, StackMgr, TableIdx);
+  auto *TabInst = getTabInstByIdx(StackMgr, TableIdx);
   assuming(TabInst);
   return TabInst->getSize();
 }
 
-Expect<void> Executor::tableFill(Runtime::StoreManager &StoreMgr,
+Expect<void> Executor::tableFill(Runtime::StoreManager &,
                                  Runtime::StackManager &StackMgr,
                                  const uint32_t TableIdx, const uint32_t Off,
                                  const RefVariant Ref,
                                  const uint32_t Len) noexcept {
-  auto *TabInst = getTabInstByIdx(StoreMgr, StackMgr, TableIdx);
+  auto *TabInst = getTabInstByIdx(StackMgr, TableIdx);
   assuming(TabInst);
   if (auto Res = TabInst->fillRefs(Ref, Off, Len); unlikely(!Res)) {
     return Unexpect(Res);
@@ -381,15 +380,15 @@ Expect<void> Executor::tableFill(Runtime::StoreManager &StoreMgr,
   return {};
 }
 
-Expect<void> Executor::tableInit(Runtime::StoreManager &StoreMgr,
+Expect<void> Executor::tableInit(Runtime::StoreManager &,
                                  Runtime::StackManager &StackMgr,
                                  const uint32_t TableIdx,
                                  const uint32_t ElemIdx, const uint32_t DstOff,
                                  const uint32_t SrcOff,
                                  const uint32_t Len) noexcept {
-  auto *TabInst = getTabInstByIdx(StoreMgr, StackMgr, TableIdx);
+  auto *TabInst = getTabInstByIdx(StackMgr, TableIdx);
   assuming(TabInst);
-  auto *ElemInst = getElemInstByIdx(StoreMgr, StackMgr, ElemIdx);
+  auto *ElemInst = getElemInstByIdx(StackMgr, ElemIdx);
   assuming(ElemInst);
   if (auto Res = TabInst->setRefs(ElemInst->getRefs(), DstOff, SrcOff, Len);
       unlikely(!Res)) {
@@ -399,24 +398,24 @@ Expect<void> Executor::tableInit(Runtime::StoreManager &StoreMgr,
   return {};
 }
 
-Expect<void> Executor::elemDrop(Runtime::StoreManager &StoreMgr,
+Expect<void> Executor::elemDrop(Runtime::StoreManager &,
                                 Runtime::StackManager &StackMgr,
                                 const uint32_t ElemIdx) noexcept {
-  auto *ElemInst = getElemInstByIdx(StoreMgr, StackMgr, ElemIdx);
+  auto *ElemInst = getElemInstByIdx(StackMgr, ElemIdx);
   assuming(ElemInst);
   ElemInst->clear();
 
   return {};
 }
 
-Expect<RefVariant> Executor::refFunc(Runtime::StoreManager &StoreMgr,
+Expect<RefVariant> Executor::refFunc(Runtime::StoreManager &,
                                      Runtime::StackManager &StackMgr,
                                      const uint32_t FuncIdx) noexcept {
-  const auto ModInst = StoreMgr.getModule(StackMgr.getModuleAddr());
-  assuming(ModInst && *ModInst);
-  const auto FuncAddr = (*ModInst)->getFuncAddr(FuncIdx);
-  assuming(FuncAddr);
-  return FuncRef(*FuncAddr);
+  const auto *ModInst = StackMgr.getModule();
+  assuming(ModInst);
+  const auto FuncInst = ModInst->getFunc(FuncIdx);
+  assuming(FuncInst && *FuncInst);
+  return FuncRef((*FuncInst)->getAddr());
 }
 
 } // namespace Executor

--- a/lib/executor/engine/variableInstr.cpp
+++ b/lib/executor/engine/variableInstr.cpp
@@ -27,19 +27,17 @@ Expect<void> Executor::runLocalTeeOp(Runtime::StackManager &StackMgr,
   return {};
 }
 
-Expect<void> Executor::runGlobalGetOp(Runtime::StoreManager &StoreMgr,
-                                      Runtime::StackManager &StackMgr,
-                                      const uint32_t Idx) noexcept {
-  auto *GlobInst = getGlobInstByIdx(StoreMgr, StackMgr, Idx);
+Expect<void> Executor::runGlobalGetOp(Runtime::StackManager &StackMgr,
+                                      uint32_t Idx) const noexcept {
+  auto *GlobInst = getGlobInstByIdx(StackMgr, Idx);
   assuming(GlobInst);
   StackMgr.push(GlobInst->getValue());
   return {};
 }
 
-Expect<void> Executor::runGlobalSetOp(Runtime::StoreManager &StoreMgr,
-                                      Runtime::StackManager &StackMgr,
-                                      const uint32_t Idx) noexcept {
-  auto *GlobInst = getGlobInstByIdx(StoreMgr, StackMgr, Idx);
+Expect<void> Executor::runGlobalSetOp(Runtime::StackManager &StackMgr,
+                                      uint32_t Idx) const noexcept {
+  auto *GlobInst = getGlobInstByIdx(StackMgr, Idx);
   assuming(GlobInst);
   GlobInst->getValue() = StackMgr.pop();
   return {};

--- a/lib/executor/executor.cpp
+++ b/lib/executor/executor.cpp
@@ -35,27 +35,26 @@ Expect<void> Executor::registerModule(Runtime::StoreManager &StoreMgr,
     spdlog::error(ErrInfo::InfoRegistering(Obj.getModuleName()));
     return Unexpect(ErrCode::ModuleNameConflict);
   }
-  auto ModInstAddr = StoreMgr.importModule(Obj.getModuleName());
-  auto *ModInst = *StoreMgr.getModule(ModInstAddr);
+  auto *ModInst = StoreMgr.importModule(Obj.getModuleName());
 
   for (auto &Func : Obj.getFuncs()) {
-    uint32_t Addr = StoreMgr.importHostFunction(*Func.second.get());
-    ModInst->addFuncAddr(Addr);
+    auto *Inst = StoreMgr.importHostFunction(*Func.second.get());
+    ModInst->addFunc(Inst);
     ModInst->exportFunction(Func.first, ModInst->getFuncNum() - 1);
   }
   for (auto &Tab : Obj.getTables()) {
-    uint32_t Addr = StoreMgr.importHostTable(*Tab.second.get());
-    ModInst->addTableAddr(Addr);
+    auto *Inst = StoreMgr.importHostTable(*Tab.second.get());
+    ModInst->addTable(Inst);
     ModInst->exportTable(Tab.first, ModInst->getTableNum() - 1);
   }
   for (auto &Mem : Obj.getMems()) {
-    uint32_t Addr = StoreMgr.importHostMemory(*Mem.second.get());
-    ModInst->addMemAddr(Addr);
+    auto *Inst = StoreMgr.importHostMemory(*Mem.second.get());
+    ModInst->addMemory(Inst);
     ModInst->exportMemory(Mem.first, ModInst->getMemNum() - 1);
   }
   for (auto &Glob : Obj.getGlobals()) {
-    uint32_t Addr = StoreMgr.importHostGlobal(*Glob.second.get());
-    ModInst->addGlobalAddr(Addr);
+    auto *Inst = StoreMgr.importHostGlobal(*Glob.second.get());
+    ModInst->addGlobal(Inst);
     ModInst->exportGlobal(Glob.first, ModInst->getGlobalNum() - 1);
   }
   return {};
@@ -81,19 +80,12 @@ Expect<void> Executor::registerModule(Runtime::StoreManager &StoreMgr,
 
 // Invoke function. See "include/executor/executor.h".
 Expect<std::vector<std::pair<ValVariant, ValType>>>
-Executor::invoke(Runtime::StoreManager &StoreMgr, const uint32_t FuncAddr,
+Executor::invoke(Runtime::StoreManager &StoreMgr,
+                 const Runtime::Instance::FunctionInstance &FuncInst,
                  Span<const ValVariant> Params,
                  Span<const ValType> ParamTypes) {
-  // Check and get function address from store manager.
-  Runtime::Instance::FunctionInstance *FuncInst;
-  if (auto Res = StoreMgr.getFunction(FuncAddr)) {
-    FuncInst = *Res;
-  } else {
-    return Unexpect(Res);
-  }
-
   // Check parameter and function type.
-  const auto &FuncType = FuncInst->getFuncType();
+  const auto &FuncType = FuncInst.getFuncType();
   const auto &PTypes = FuncType.getParamTypes();
   const auto &RTypes = FuncType.getReturnTypes();
   std::vector<ValType> GotParamTypes(ParamTypes.begin(), ParamTypes.end());
@@ -107,7 +99,7 @@ Executor::invoke(Runtime::StoreManager &StoreMgr, const uint32_t FuncAddr,
   Runtime::StackManager StackMgr;
 
   // Call runFunction.
-  if (auto Res = runFunction(StoreMgr, StackMgr, *FuncInst, Params); !Res) {
+  if (auto Res = runFunction(StoreMgr, StackMgr, FuncInst, Params); !Res) {
     return Unexpect(Res);
   }
 

--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -36,7 +36,13 @@ Executor::enterFunction(Runtime::StoreManager &StoreMgr,
     // Get memory instance from current frame.
     // It'll be nullptr if current frame is dummy frame or no memory instance
     // in current module.
-    auto *MemoryInst = getMemInstByIdx(StackMgr, 0);
+    const auto *ModInst = StackMgr.getModule();
+    Runtime::Instance::MemoryInstance *MemoryInst = nullptr;
+    if (ModInst != nullptr) {
+      if (auto Res = ModInst->getMemory(0); Res) {
+        MemoryInst = *Res;
+      }
+    }
 
     if (Stat) {
       // Check host function cost.
@@ -173,11 +179,7 @@ Executor::getTabInstByIdx(Runtime::StackManager &StackMgr,
   if (unlikely(ModInst == nullptr)) {
     return nullptr;
   }
-  if (auto Res = ModInst->getTable(Idx)) {
-    return *Res;
-  } else {
-    return nullptr;
-  }
+  return ModInst->unsafeGetTable(Idx);
 }
 
 Runtime::Instance::MemoryInstance *
@@ -188,11 +190,7 @@ Executor::getMemInstByIdx(Runtime::StackManager &StackMgr,
   if (unlikely(ModInst == nullptr)) {
     return nullptr;
   }
-  if (auto Res = ModInst->getMemory(Idx)) {
-    return *Res;
-  } else {
-    return nullptr;
-  }
+  return ModInst->unsafeGetMemory(Idx);
 }
 
 Runtime::Instance::GlobalInstance *
@@ -203,11 +201,7 @@ Executor::getGlobInstByIdx(Runtime::StackManager &StackMgr,
   if (unlikely(ModInst == nullptr)) {
     return nullptr;
   }
-  if (auto Res = ModInst->getGlobal(Idx)) {
-    return *Res;
-  } else {
-    return nullptr;
-  }
+  return ModInst->unsafeGetGlobal(Idx);
 }
 
 Runtime::Instance::ElementInstance *
@@ -218,11 +212,7 @@ Executor::getElemInstByIdx(Runtime::StackManager &StackMgr,
   if (unlikely(ModInst == nullptr)) {
     return nullptr;
   }
-  if (auto Res = ModInst->getElem(Idx)) {
-    return *Res;
-  } else {
-    return nullptr;
-  }
+  return ModInst->unsafeGetElem(Idx);
 }
 
 Runtime::Instance::DataInstance *
@@ -233,11 +223,7 @@ Executor::getDataInstByIdx(Runtime::StackManager &StackMgr,
   if (unlikely(ModInst == nullptr)) {
     return nullptr;
   }
-  if (auto Res = ModInst->getData(Idx)) {
-    return *Res;
-  } else {
-    return nullptr;
-  }
+  return ModInst->unsafeGetData(Idx);
 }
 
 } // namespace Executor

--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -168,11 +168,11 @@ Expect<void> Executor::branchToLabel(Runtime::StackManager &StackMgr,
 Runtime::Instance::TableInstance *
 Executor::getTabInstByIdx(Runtime::StackManager &StackMgr,
                           const uint32_t Idx) const {
+  const auto *ModInst = StackMgr.getModule();
   // When top frame is dummy frame, cannot find instance.
-  if (StackMgr.isTopDummyFrame()) {
+  if (unlikely(ModInst == nullptr)) {
     return nullptr;
   }
-  const auto *ModInst = StackMgr.getModule();
   if (auto Res = ModInst->getTable(Idx)) {
     return *Res;
   } else {
@@ -183,11 +183,11 @@ Executor::getTabInstByIdx(Runtime::StackManager &StackMgr,
 Runtime::Instance::MemoryInstance *
 Executor::getMemInstByIdx(Runtime::StackManager &StackMgr,
                           const uint32_t Idx) const {
+  const auto *ModInst = StackMgr.getModule();
   // When top frame is dummy frame, cannot find instance.
-  if (StackMgr.isTopDummyFrame()) {
+  if (unlikely(ModInst == nullptr)) {
     return nullptr;
   }
-  const auto *ModInst = StackMgr.getModule();
   if (auto Res = ModInst->getMemory(Idx)) {
     return *Res;
   } else {
@@ -198,11 +198,11 @@ Executor::getMemInstByIdx(Runtime::StackManager &StackMgr,
 Runtime::Instance::GlobalInstance *
 Executor::getGlobInstByIdx(Runtime::StackManager &StackMgr,
                            const uint32_t Idx) const {
+  const auto *ModInst = StackMgr.getModule();
   // When top frame is dummy frame, cannot find instance.
-  if (StackMgr.isTopDummyFrame()) {
+  if (unlikely(ModInst == nullptr)) {
     return nullptr;
   }
-  const auto *ModInst = StackMgr.getModule();
   if (auto Res = ModInst->getGlobal(Idx)) {
     return *Res;
   } else {
@@ -213,11 +213,11 @@ Executor::getGlobInstByIdx(Runtime::StackManager &StackMgr,
 Runtime::Instance::ElementInstance *
 Executor::getElemInstByIdx(Runtime::StackManager &StackMgr,
                            const uint32_t Idx) const {
+  const auto *ModInst = StackMgr.getModule();
   // When top frame is dummy frame, cannot find instance.
-  if (StackMgr.isTopDummyFrame()) {
+  if (unlikely(ModInst == nullptr)) {
     return nullptr;
   }
-  const auto *ModInst = StackMgr.getModule();
   if (auto Res = ModInst->getElem(Idx)) {
     return *Res;
   } else {
@@ -228,11 +228,11 @@ Executor::getElemInstByIdx(Runtime::StackManager &StackMgr,
 Runtime::Instance::DataInstance *
 Executor::getDataInstByIdx(Runtime::StackManager &StackMgr,
                            const uint32_t Idx) const {
+  const auto *ModInst = StackMgr.getModule();
   // When top frame is dummy frame, cannot find instance.
-  if (StackMgr.isTopDummyFrame()) {
+  if (unlikely(ModInst == nullptr)) {
     return nullptr;
   }
-  const auto *ModInst = StackMgr.getModule();
   if (auto Res = ModInst->getData(Idx)) {
     return *Res;
   } else {

--- a/lib/executor/instantiate/data.cpp
+++ b/lib/executor/instantiate/data.cpp
@@ -37,7 +37,7 @@ Expect<void> Executor::instantiate(Runtime::StoreManager &StoreMgr,
       if (!Conf.hasProposal(Proposal::ReferenceTypes) &&
           !Conf.hasProposal(Proposal::BulkMemoryOperations)) {
         // Memory index should be 0. Checked in validation phase.
-        auto *MemInst = getMemInstByIdx(StoreMgr, StackMgr, DataSeg.getIdx());
+        auto *MemInst = getMemInstByIdx(StackMgr, DataSeg.getIdx());
         // Check data fits.
         assuming(MemInst);
         if (!MemInst->checkAccessBound(
@@ -50,21 +50,20 @@ Expect<void> Executor::instantiate(Runtime::StoreManager &StoreMgr,
     }
 
     // Insert data instance to store manager.
-    uint32_t NewDataInstAddr;
+    Runtime::Instance::DataInstance *DataInst = nullptr;
     if (InsMode == InstantiateMode::Instantiate) {
-      NewDataInstAddr = StoreMgr.pushData(Offset, DataSeg.getData());
+      DataInst = StoreMgr.pushData(Offset, DataSeg.getData());
     } else {
-      NewDataInstAddr = StoreMgr.importData(Offset, DataSeg.getData());
+      DataInst = StoreMgr.importData(Offset, DataSeg.getData());
     }
-    ModInst.addDataAddr(NewDataInstAddr);
+    ModInst.addData(DataInst);
   }
   return {};
 }
 
 // Initialize memory with Data Instances. See
 // "include/executor/executor.h".
-Expect<void> Executor::initMemory(Runtime::StoreManager &StoreMgr,
-                                  Runtime::StackManager &StackMgr,
+Expect<void> Executor::initMemory(Runtime::StackManager &StackMgr,
                                   Runtime::Instance::ModuleInstance &,
                                   const AST::DataSection &DataSec) {
   // initialize memory.
@@ -73,10 +72,10 @@ Expect<void> Executor::initMemory(Runtime::StoreManager &StoreMgr,
     // Initialize memory if data mode is active.
     if (DataSeg.getMode() == AST::DataSegment::DataMode::Active) {
       // Memory index should be 0. Checked in validation phase.
-      auto *MemInst = getMemInstByIdx(StoreMgr, StackMgr, DataSeg.getIdx());
+      auto *MemInst = getMemInstByIdx(StackMgr, DataSeg.getIdx());
       assuming(MemInst);
 
-      auto *DataInst = getDataInstByIdx(StoreMgr, StackMgr, Idx);
+      auto *DataInst = getDataInstByIdx(StackMgr, Idx);
       assuming(DataInst);
       const uint32_t Off = DataInst->getOffset();
 

--- a/lib/executor/instantiate/elem.cpp
+++ b/lib/executor/instantiate/elem.cpp
@@ -49,7 +49,7 @@ Expect<void> Executor::instantiate(Runtime::StoreManager &StoreMgr,
       if (!Conf.hasProposal(Proposal::ReferenceTypes) &&
           !Conf.hasProposal(Proposal::BulkMemoryOperations)) {
         // Table index should be 0. Checked in validation phase.
-        auto *TabInst = getTabInstByIdx(StoreMgr, StackMgr, ElemSeg.getIdx());
+        auto *TabInst = getTabInstByIdx(StackMgr, ElemSeg.getIdx());
         // Check elements fits.
         assuming(TabInst);
         if (!TabInst->checkAccessBound(
@@ -62,33 +62,30 @@ Expect<void> Executor::instantiate(Runtime::StoreManager &StoreMgr,
     }
 
     // Insert element instance to store manager.
-    uint32_t NewElemInstAddr;
+    Runtime::Instance::ElementInstance *ElemInst = nullptr;
     if (InsMode == InstantiateMode::Instantiate) {
-      NewElemInstAddr =
-          StoreMgr.pushElement(Offset, ElemSeg.getRefType(), InitVals);
+      ElemInst = StoreMgr.pushElement(Offset, ElemSeg.getRefType(), InitVals);
     } else {
-      NewElemInstAddr =
-          StoreMgr.importElement(Offset, ElemSeg.getRefType(), InitVals);
+      ElemInst = StoreMgr.importElement(Offset, ElemSeg.getRefType(), InitVals);
     }
-    ModInst.addElemAddr(NewElemInstAddr);
+    ModInst.addElem(ElemInst);
   }
   return {};
 }
 
 // Initialize table with Element Instances. See
 // "include/executor/executor.h".
-Expect<void> Executor::initTable(Runtime::StoreManager &StoreMgr,
-                                 Runtime::StackManager &StackMgr,
+Expect<void> Executor::initTable(Runtime::StackManager &StackMgr,
                                  Runtime::Instance::ModuleInstance &,
                                  const AST::ElementSection &ElemSec) {
   // Initialize tables.
   uint32_t Idx = 0;
   for (const auto &ElemSeg : ElemSec.getContent()) {
-    auto *ElemInst = getElemInstByIdx(StoreMgr, StackMgr, Idx);
+    auto *ElemInst = getElemInstByIdx(StackMgr, Idx);
     assuming(ElemInst);
     if (ElemSeg.getMode() == AST::ElementSegment::ElemMode::Active) {
       // Table index is checked in validation phase.
-      auto *TabInst = getTabInstByIdx(StoreMgr, StackMgr, ElemSeg.getIdx());
+      auto *TabInst = getTabInstByIdx(StackMgr, ElemSeg.getIdx());
       assuming(TabInst);
       const uint32_t Off = ElemInst->getOffset();
 

--- a/lib/executor/instantiate/function.cpp
+++ b/lib/executor/instantiate/function.cpp
@@ -22,28 +22,28 @@ Expect<void> Executor::instantiate(Runtime::StoreManager &StoreMgr,
   // Iterate through code segments to make function instances.
   for (uint32_t I = 0; I < CodeSegs.size(); ++I) {
     // Insert function instance to store manager.
-    uint32_t NewFuncInstAddr;
+    Runtime::Instance::FunctionInstance *FuncInst = nullptr;
     auto *FuncType = *ModInst.getFuncType(TypeIdxs[I]);
     if (InsMode == InstantiateMode::Instantiate) {
       if (auto Symbol = CodeSegs[I].getSymbol()) {
-        NewFuncInstAddr =
-            StoreMgr.pushFunction(ModInst.Addr, *FuncType, std::move(Symbol));
+        FuncInst =
+            StoreMgr.pushFunction(&ModInst, *FuncType, std::move(Symbol));
       } else {
-        NewFuncInstAddr = StoreMgr.pushFunction(
-            ModInst.Addr, *FuncType, CodeSegs[I].getLocals(),
-            CodeSegs[I].getExpr().getInstrs());
+        FuncInst =
+            StoreMgr.pushFunction(&ModInst, *FuncType, CodeSegs[I].getLocals(),
+                                  CodeSegs[I].getExpr().getInstrs());
       }
     } else {
       if (auto Symbol = CodeSegs[I].getSymbol()) {
-        NewFuncInstAddr =
-            StoreMgr.importFunction(ModInst.Addr, *FuncType, std::move(Symbol));
+        FuncInst =
+            StoreMgr.importFunction(&ModInst, *FuncType, std::move(Symbol));
       } else {
-        NewFuncInstAddr = StoreMgr.importFunction(
-            ModInst.Addr, *FuncType, CodeSegs[I].getLocals(),
-            CodeSegs[I].getExpr().getInstrs());
+        FuncInst = StoreMgr.importFunction(&ModInst, *FuncType,
+                                           CodeSegs[I].getLocals(),
+                                           CodeSegs[I].getExpr().getInstrs());
       }
     }
-    ModInst.addFuncAddr(NewFuncInstAddr);
+    ModInst.addFunc(FuncInst);
   }
   return {};
 }

--- a/lib/executor/instantiate/import.cpp
+++ b/lib/executor/instantiate/import.cpp
@@ -16,19 +16,19 @@ namespace Executor {
 namespace {
 template <typename... Args>
 auto logMatchError(std::string_view ModName, std::string_view ExtName,
-                   ExternalType ExtType, ASTNodeAttr Node, Args &&...Values) {
+                   ExternalType ExtType, Args &&...Values) {
   spdlog::error(ErrCode::IncompatibleImportType);
   spdlog::error(ErrInfo::InfoMismatch(std::forward<Args>(Values)...));
   spdlog::error(ErrInfo::InfoLinking(ModName, ExtName, ExtType));
-  spdlog::error(ErrInfo::InfoAST(Node));
+  spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Desc_Import));
   return Unexpect(ErrCode::IncompatibleImportType);
 }
 
 auto logUnknownError(std::string_view ModName, std::string_view ExtName,
-                     ExternalType ExtType, ASTNodeAttr Node) {
+                     ExternalType ExtType) {
   spdlog::error(ErrCode::UnknownImport);
   spdlog::error(ErrInfo::InfoLinking(ModName, ExtName, ExtType));
-  spdlog::error(ErrInfo::InfoAST(Node));
+  spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Desc_Import));
   return Unexpect(ErrCode::UnknownImport);
 }
 
@@ -42,55 +42,54 @@ bool isLimitMatched(const AST::Limit &Lim1, const AST::Limit &Lim2) {
   return true;
 }
 
-Expect<uint32_t> getImportAddr(std::string_view ModName,
-                               std::string_view ExtName,
-                               const ExternalType ExtType, ASTNodeAttr Node,
-                               Runtime::Instance::ModuleInstance &ModInst) {
+Expect<void> checkImportMatched(std::string_view ModName,
+                                std::string_view ExtName,
+                                const ExternalType ExtType,
+                                Runtime::Instance::ModuleInstance &ModInst) {
   switch (ExtType) {
   case ExternalType::Function:
-    if (auto Res = ModInst.findFuncExports(ExtName); likely(Res.has_value())) {
-      return *Res;
+    if (auto Res = ModInst.findFuncExports(ExtName); likely(Res != nullptr)) {
+      return {};
     }
     break;
   case ExternalType::Table:
-    if (auto Res = ModInst.findTableExports(ExtName); likely(Res.has_value())) {
-      return *Res;
+    if (auto Res = ModInst.findTableExports(ExtName); likely(Res != nullptr)) {
+      return {};
     }
     break;
   case ExternalType::Memory:
-    if (auto Res = ModInst.findMemExports(ExtName); likely(Res.has_value())) {
-      return *Res;
+    if (auto Res = ModInst.findMemExports(ExtName); likely(Res != nullptr)) {
+      return {};
     }
     break;
   case ExternalType::Global:
-    if (auto Res = ModInst.findGlobalExports(ExtName);
-        likely(Res.has_value())) {
-      return *Res;
+    if (auto Res = ModInst.findGlobalExports(ExtName); likely(Res != nullptr)) {
+      return {};
     }
     break;
   default:
-    return logUnknownError(ModName, ExtName, ExtType, Node);
+    return logUnknownError(ModName, ExtName, ExtType);
   }
 
   // Check is error external type or unknown imports.
   if (ModInst.findFuncExports(ExtName)) {
-    return logMatchError(ModName, ExtName, ExtType, Node, ExtType,
+    return logMatchError(ModName, ExtName, ExtType, ExtType,
                          ExternalType::Function);
   }
   if (ModInst.findTableExports(ExtName)) {
-    return logMatchError(ModName, ExtName, ExtType, Node, ExtType,
+    return logMatchError(ModName, ExtName, ExtType, ExtType,
                          ExternalType::Table);
   }
   if (ModInst.findMemExports(ExtName)) {
-    return logMatchError(ModName, ExtName, ExtType, Node, ExtType,
+    return logMatchError(ModName, ExtName, ExtType, ExtType,
                          ExternalType::Memory);
   }
   if (ModInst.findGlobalExports(ExtName)) {
-    return logMatchError(ModName, ExtName, ExtType, Node, ExtType,
+    return logMatchError(ModName, ExtName, ExtType, ExtType,
                          ExternalType::Global);
   }
 
-  return logUnknownError(ModName, ExtName, ExtType, Node);
+  return logUnknownError(ModName, ExtName, ExtType);
 }
 } // namespace
 
@@ -105,17 +104,14 @@ Expect<void> Executor::instantiate(Runtime::StoreManager &StoreMgr,
     auto ModName = ImpDesc.getModuleName();
     auto ExtName = ImpDesc.getExternalName();
     Runtime::Instance::ModuleInstance *TargetModInst;
-    uint32_t TargetAddr;
     if (auto Res = StoreMgr.findModule(ModName)) {
       TargetModInst = *Res;
     } else {
-      return logUnknownError(ModName, ExtName, ExtType,
-                             ASTNodeAttr::Desc_Import);
+      return logUnknownError(ModName, ExtName, ExtType);
     }
-    if (auto Res = getImportAddr(ModName, ExtName, ExtType,
-                                 ASTNodeAttr::Desc_Import, *TargetModInst)) {
-      TargetAddr = *Res;
-    } else {
+    if (auto Res =
+            checkImportMatched(ModName, ExtName, ExtType, *TargetModInst);
+        unlikely(!Res)) {
       return Unexpect(Res);
     }
 
@@ -125,17 +121,17 @@ Expect<void> Executor::instantiate(Runtime::StoreManager &StoreMgr,
       // Get function type index. External type checked in validation.
       uint32_t TypeIdx = ImpDesc.getExternalFuncTypeIdx();
       // Import matching.
-      const auto *TargetInst = *StoreMgr.getFunction(TargetAddr);
+      auto *TargetInst = TargetModInst->findFuncExports(ExtName);
       const auto &TargetType = TargetInst->getFuncType();
       const auto *FuncType = *ModInst.getFuncType(TypeIdx);
       if (TargetType != *FuncType) {
         return logMatchError(
-            ModName, ExtName, ExtType, ASTNodeAttr::Desc_Import,
-            FuncType->getParamTypes(), FuncType->getReturnTypes(),
-            TargetType.getParamTypes(), TargetType.getReturnTypes());
+            ModName, ExtName, ExtType, FuncType->getParamTypes(),
+            FuncType->getReturnTypes(), TargetType.getParamTypes(),
+            TargetType.getReturnTypes());
       }
       // Set the matched function address to module instance.
-      ModInst.importFunction(TargetAddr);
+      ModInst.importFunction(TargetInst);
       break;
     }
     case ExternalType::Table: {
@@ -143,19 +139,18 @@ Expect<void> Executor::instantiate(Runtime::StoreManager &StoreMgr,
       const auto &TabType = ImpDesc.getExternalTableType();
       const auto &TabLim = TabType.getLimit();
       // Import matching.
-      const auto *TargetInst = *StoreMgr.getTable(TargetAddr);
+      auto *TargetInst = TargetModInst->findTableExports(ExtName);
       const auto &TargetType = TargetInst->getTableType();
       const auto &TargetLim = TargetType.getLimit();
       if (TargetType.getRefType() != TabType.getRefType() ||
           !isLimitMatched(TargetLim, TabLim)) {
-        return logMatchError(ModName, ExtName, ExtType,
-                             ASTNodeAttr::Desc_Import, TabType.getRefType(),
+        return logMatchError(ModName, ExtName, ExtType, TabType.getRefType(),
                              TabLim.hasMax(), TabLim.getMin(), TabLim.getMax(),
                              TargetType.getRefType(), TargetLim.hasMax(),
                              TargetLim.getMin(), TargetLim.getMax());
       }
       // Set the matched table address to module instance.
-      ModInst.importTable(TargetAddr);
+      ModInst.importTable(TargetInst);
       break;
     }
     case ExternalType::Memory: {
@@ -163,32 +158,31 @@ Expect<void> Executor::instantiate(Runtime::StoreManager &StoreMgr,
       const auto &MemType = ImpDesc.getExternalMemoryType();
       const auto &MemLim = MemType.getLimit();
       // Import matching.
-      const auto *TargetInst = *StoreMgr.getMemory(TargetAddr);
+      auto *TargetInst = TargetModInst->findMemExports(ExtName);
       const auto &TargetLim = TargetInst->getMemoryType().getLimit();
       if (!isLimitMatched(TargetLim, MemLim)) {
-        return logMatchError(
-            ModName, ExtName, ExtType, ASTNodeAttr::Desc_Import,
-            MemLim.hasMax(), MemLim.getMin(), MemLim.getMax(),
-            TargetLim.hasMax(), TargetLim.getMin(), TargetLim.getMax());
+        return logMatchError(ModName, ExtName, ExtType, MemLim.hasMax(),
+                             MemLim.getMin(), MemLim.getMax(),
+                             TargetLim.hasMax(), TargetLim.getMin(),
+                             TargetLim.getMax());
       }
       // Set the matched memory address to module instance.
-      ModInst.importMemory(TargetAddr);
+      ModInst.importMemory(TargetInst);
       break;
     }
     case ExternalType::Global: {
       // Get global type. External type checked in validation.
       const auto &GlobType = ImpDesc.getExternalGlobalType();
       // Import matching.
-      const auto *TargetInst = *StoreMgr.getGlobal(TargetAddr);
+      auto *TargetInst = TargetModInst->findGlobalExports(ExtName);
       const auto &TargetType = TargetInst->getGlobalType();
       if (TargetType != GlobType) {
-        return logMatchError(ModName, ExtName, ExtType,
-                             ASTNodeAttr::Desc_Import, GlobType.getValType(),
+        return logMatchError(ModName, ExtName, ExtType, GlobType.getValType(),
                              GlobType.getValMut(), TargetType.getValType(),
                              TargetType.getValMut());
       }
       // Set the matched global address to module instance.
-      ModInst.importGlobal(TargetAddr);
+      ModInst.importGlobal(TargetInst);
       break;
     }
     default:

--- a/lib/executor/instantiate/memory.cpp
+++ b/lib/executor/instantiate/memory.cpp
@@ -18,15 +18,15 @@ Expect<void> Executor::instantiate(Runtime::StoreManager &StoreMgr,
   // Iterate and istantiate memory types.
   for (const auto &MemType : MemSec.getContent()) {
     // Insert memory instance to store manager.
-    uint32_t NewMemInstAddr;
+    Runtime::Instance::MemoryInstance *MemInst = nullptr;
     if (InsMode == InstantiateMode::Instantiate) {
-      NewMemInstAddr = StoreMgr.pushMemory(
+      MemInst = StoreMgr.pushMemory(
           MemType, Conf.getRuntimeConfigure().getMaxMemoryPage());
     } else {
-      NewMemInstAddr = StoreMgr.importMemory(
+      MemInst = StoreMgr.importMemory(
           MemType, Conf.getRuntimeConfigure().getMaxMemoryPage());
     }
-    ModInst.addMemAddr(NewMemInstAddr);
+    ModInst.addMemory(MemInst);
   }
   return {};
 }

--- a/lib/executor/instantiate/table.cpp
+++ b/lib/executor/instantiate/table.cpp
@@ -15,13 +15,13 @@ Expect<void> Executor::instantiate(Runtime::StoreManager &StoreMgr,
   // Iterate and instantiate table types.
   for (const auto &TabType : TabSec.getContent()) {
     // Insert table instance to store manager.
-    uint32_t NewTabInstAddr;
+    Runtime::Instance::TableInstance *TabInst = nullptr;
     if (InsMode == InstantiateMode::Instantiate) {
-      NewTabInstAddr = StoreMgr.pushTable(TabType);
+      TabInst = StoreMgr.pushTable(TabType);
     } else {
-      NewTabInstAddr = StoreMgr.importTable(TabType);
+      TabInst = StoreMgr.importTable(TabType);
     }
-    ModInst.addTableAddr(NewTabInstAddr);
+    ModInst.addTable(TabInst);
   }
   return {};
 }

--- a/test/aot/AOTcoreTest.cpp
+++ b/test/aot/AOTcoreTest.cpp
@@ -146,15 +146,13 @@ TEST_P(NativeCoreTest, TestSuites) {
     }
 
     // Get global instance.
-    if (auto Res = ModInst->findGlobalExports(Field); unlikely(!Res)) {
+    WasmEdge::Runtime::Instance::GlobalInstance *GlobInst =
+        ModInst->findGlobalExports(Field);
+    if (unlikely(GlobInst == nullptr)) {
       return Unexpect(ErrCode::IncompatibleImportType);
-    } else {
-      uint32_t GlobAddr = *Res;
-      auto *GlobInst = *Store.getGlobal(GlobAddr);
-
-      return std::make_pair(GlobInst->getValue(),
-                            GlobInst->getGlobalType().getValType());
     }
+    return std::make_pair(GlobInst->getValue(),
+                          GlobInst->getGlobalType().getValType());
   };
 
   T.run(Proposal, UnitName);
@@ -251,15 +249,13 @@ TEST_P(CustomWasmCoreTest, TestSuites) {
     }
 
     // Get global instance.
-    if (auto Res = ModInst->findGlobalExports(Field); unlikely(!Res)) {
+    WasmEdge::Runtime::Instance::GlobalInstance *GlobInst =
+        ModInst->findGlobalExports(Field);
+    if (unlikely(GlobInst == nullptr)) {
       return Unexpect(ErrCode::IncompatibleImportType);
-    } else {
-      uint32_t GlobAddr = *Res;
-      auto *GlobInst = *Store.getGlobal(GlobAddr);
-
-      return std::make_pair(GlobInst->getValue(),
-                            GlobInst->getGlobalType().getValType());
     }
+    return std::make_pair(GlobInst->getValue(),
+                          GlobInst->getGlobalType().getValType());
   };
 
   T.run(Proposal, UnitName);

--- a/test/executor/ExecutorTest.cpp
+++ b/test/executor/ExecutorTest.cpp
@@ -100,15 +100,13 @@ TEST_P(CoreTest, TestSuites) {
     }
 
     // Get global instance.
-    if (auto Res = ModInst->findGlobalExports(Field); unlikely(!Res)) {
+    WasmEdge::Runtime::Instance::GlobalInstance *GlobInst =
+        ModInst->findGlobalExports(Field);
+    if (unlikely(GlobInst == nullptr)) {
       return Unexpect(ErrCode::IncompatibleImportType);
-    } else {
-      uint32_t GlobAddr = *Res;
-      auto *GlobInst = *Store.getGlobal(GlobAddr);
-
-      return std::make_pair(GlobInst->getValue(),
-                            GlobInst->getGlobalType().getValType());
     }
+    return std::make_pair(GlobInst->getValue(),
+                          GlobInst->getGlobalType().getValType());
   };
 
   T.run(Proposal, UnitName);


### PR DESCRIPTION
1. The instance real pointer (allocated as unique pointers) will not changed until destroyed. Therefore it's safe to use pointer to instances.
2. Record the pointers of instances in module instances rather than addresses in store manager.
3. Use the module instance pointer in stack manager.
4. Use the unsafe getter of instances in calling frames to avoid the thread-safe bottleneck.

After applying this PR, about the 35% execution time reduced when running the `miniruby` example in #1016 .