### PR TITLE
[Rust] wasmedge-types v0.1.0

### DIFF
--- a/.github/workflows/rust-types-crate-release.yml
+++ b/.github/workflows/rust-types-crate-release.yml
@@ -1,0 +1,43 @@
+name: wasmedge-types crate release
+
+concurrency:
+  group: wasmedge-types-crate-release-${{ github.head_ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    tags:
+      - "rust-types/[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  crate_release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    container:
+      image: wasmedge/wasmedge:ubuntu-build-clang
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install Stable Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Build WasmEdge using clang
+        run: |
+          cmake -Bbuild -GNinja -DWASMEDGE_BUILD_SHARED_LIB=ON  -DCMAKE_INSTALL_PREFIX:PATH=/usr .
+          cmake --build build --target install
+
+      - name: Publish wasmedge-types crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        shell: bash
+        run: |
+          cd ./bindings/rust/wasmedge-types
+          git config --global user.email "runner@gha.local"
+          git config --global user.name "Github Action"
+          cargo publish --dry-run
+          cargo publish

--- a/.github/workflows/rust-types-docs.yml
+++ b/.github/workflows/rust-types-docs.yml
@@ -1,0 +1,41 @@
+name: wasmedge-types-docs
+
+concurrency:
+  group: wasmedge-types-docs-${{ github.head_ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    tags:
+      - "rust-types/[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  rustdoc:
+    name: rustdoc
+    runs-on: ubuntu-latest
+    container:
+      image: wasmedge/wasmedge:ubuntu-build-clang
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - name: Build Documentation
+        run: |
+          cd bindings/rust/wasmedge-types
+          cargo doc --all --no-deps --target-dir=./target
+
+      - name: Deploy Docs
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: bindings/rust/wasmedge-types/target/doc
+          force_orphan: true

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["wasmedge-sys"]
+members = ["wasmedge-sys", "wasmedge-types"]
 exclude = ["build/", "utils/"]

--- a/bindings/rust/wasmedge-types/Cargo.toml
+++ b/bindings/rust/wasmedge-types/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "wasmedge-types"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/bindings/rust/wasmedge-types/Cargo.toml
+++ b/bindings/rust/wasmedge-types/Cargo.toml
@@ -7,6 +7,6 @@ license = "Apache-2.0"
 readme = "README.md"
 documentation = "https://wasmedge.github.io/WasmEdge/wasmedge_types/"
 repository = "https://github.com/WasmEdge/WasmEdge/tree/master/bindings/rust/wasmedge-types"
-categores = ["data-structures"]
+categories = ["data-structures"]
 
 [dependencies]

--- a/bindings/rust/wasmedge-types/Cargo.toml
+++ b/bindings/rust/wasmedge-types/Cargo.toml
@@ -2,7 +2,11 @@
 name = "wasmedge-types"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+description = "The common data structures for WasmEdge Rust bindings."
+license = "Apache-2.0"
+readme = "README.md"
+documentation = "https://wasmedge.github.io/WasmEdge/wasmedge_types/"
+repository = "https://github.com/WasmEdge/WasmEdge/tree/master/bindings/rust/wasmedge-types"
+categores = ["data-structures"]
 
 [dependencies]

--- a/bindings/rust/wasmedge-types/README.md
+++ b/bindings/rust/wasmedge-types/README.md
@@ -1,0 +1,7 @@
+# Overview
+
+The [wasmedge-types](https://crates.io/crates/wasmedge-types) crate defines a group of common data structures used by both [wasmedge-rs](https://crates.io/crates/wasmedge-sdk) and [wasmedge-sys](https://crates.io/crates/wasmedge-sys) crates.
+
+See also
+
+* [WasmEdge Runtime](https://wasmedge.org/)

--- a/bindings/rust/wasmedge-types/src/lib.rs
+++ b/bindings/rust/wasmedge-types/src/lib.rs
@@ -67,6 +67,20 @@ impl From<u32> for ValType {
         }
     }
 }
+impl From<ValType> for u32 {
+    fn from(value: ValType) -> Self {
+        match value {
+            ValType::I32 => 127,
+            ValType::I64 => 126,
+            ValType::F32 => 125,
+            ValType::F64 => 124,
+            ValType::V128 => 123,
+            ValType::FuncRef => 112,
+            ValType::ExternRef => 111,
+            ValType::None => 64,
+        }
+    }
+}
 
 /// Defines WasmEdge mutability values.
 ///

--- a/bindings/rust/wasmedge-types/src/lib.rs
+++ b/bindings/rust/wasmedge-types/src/lib.rs
@@ -1,11 +1,10 @@
+/// Defines WasmEdge reference types.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum RefType {
-    /// `FuncRef` denotes the infinite union of all references to [functions](crate::Function), regardless of their
-    /// [function types](crate::FuncType).
+    /// Refers to the infinite union of all references to host functions, regardless of their function types.
     FuncRef,
 
-    /// `ExternRef` denotes the infinite union of all references to objects owned by the [Vm](crate::Vm) and that can be
-    /// passed into WebAssembly under this type.
+    /// Refers to the infinite union of all references to objects and that can be passed into WebAssembly under this type.
     ExternRef,
 }
 impl From<u32> for RefType {
@@ -26,6 +25,7 @@ impl From<RefType> for u32 {
     }
 }
 
+/// Defines WasmEdge value types.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ValType {
     /// 32-bit integer.
@@ -45,9 +45,9 @@ pub enum ValType {
     /// The packed data can be interpreted as signed or unsigned integers, single or double precision floating-point
     /// values, or a single 128 bit type. The interpretation is determined by individual operations.
     V128,
-    /// A reference to [functions](crate::Function).
+    /// A reference to a host function.
     FuncRef,
-    /// A reference to object owned by the [Vm](crate::Vm).
+    /// A reference to object.
     ExternRef,
     /// Unknown.
     None,
@@ -82,14 +82,14 @@ impl From<ValType> for u32 {
     }
 }
 
-/// Defines WasmEdge mutability values.
+/// Defines the mutability property of WasmEdge Global variables.
 ///
-/// `Mutability` determines a [global](crate::Global) variable is either mutable or immutable.
+/// `Mutability` determines the mutability property of a WasmEdge Global variable is either mutable or immutable.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Mutability {
-    /// Identifies an immutable global variable
+    /// Identifies an immutable global variable.
     Const,
-    /// Identifies a mutable global variable
+    /// Identifies a mutable global variable.
     Var,
 }
 impl From<u32> for Mutability {
@@ -209,12 +209,16 @@ impl From<HostRegistration> for u32 {
     }
 }
 
-/// Defines WasmEdge ExternalType values.
+/// Defines the type of external WasmEdge instances.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExternalInstanceType {
+    /// A WasmEdge instance that is a WasmEdge Func.
     Func(FuncType),
+    /// A WasmEdge instance that is a WasmEdge Table.
     Table(TableType),
+    /// A WasmEdge instance that is a WasmEdge Memory.
     Memory(MemoryType),
+    /// A WasmEdge instance that is a WasmEdge Global.
     Global(GlobalType),
 }
 impl From<u32> for ExternalInstanceType {
@@ -243,12 +247,22 @@ impl std::fmt::Display for ExternalInstanceType {
     }
 }
 
+/// Struct of WasmEdge FuncType.
+///
+/// A [FuncType] is used to declare the types of the parameters and return values of a WasmEdge Func to be created.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct FuncType {
     args: Option<Vec<ValType>>,
     returns: Option<Vec<ValType>>,
 }
 impl FuncType {
+    /// Creates a new [FuncType] with the given types of arguments and returns.
+    ///
+    /// # Arguments
+    ///
+    /// * `args` - A vector of [ValType]s that represent the types of the arguments.
+    ///
+    /// * `returns` - A vector of [ValType]s that represent the types of the returns.
     pub fn new(args: Option<Vec<ValType>>, returns: Option<Vec<ValType>>) -> Self {
         Self { args, returns }
     }
@@ -261,6 +275,7 @@ impl FuncType {
         }
     }
 
+    /// Returns the number of the arguments of a host function.
     pub fn args_len(&self) -> u32 {
         match &self.args {
             Some(args) => args.len() as u32,
@@ -276,6 +291,7 @@ impl FuncType {
         }
     }
 
+    /// Returns the number of the returns of a host function.
     pub fn returns_len(&self) -> u32 {
         match &self.returns {
             Some(returns) => returns.len() as u32,
@@ -284,6 +300,9 @@ impl FuncType {
     }
 }
 
+/// Struct of WasmEdge TableType.
+///
+/// A [TableType] is used to declare the element type and the size range of a WasmEdge Table to be created.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TableType {
     elem_ty: RefType,
@@ -291,6 +310,15 @@ pub struct TableType {
     max: u32,
 }
 impl TableType {
+    /// Creates a new [TableType] with the given element type and the size range.
+    ///
+    /// # Arguments
+    ///
+    /// * `elem_ty` - The element type of the table to be created.
+    ///
+    /// * `min` - The minimum size of the table to be created.
+    ///
+    /// * `max` - The maximum size of the table to be created.    
     pub fn new(elem_ty: RefType, min: u32, max: Option<u32>) -> Self {
         let max = match max {
             Some(val) => val,
@@ -299,14 +327,17 @@ impl TableType {
         Self { elem_ty, min, max }
     }
 
+    /// Returns the element type defined in the [TableType].
     pub fn elem_ty(&self) -> RefType {
         self.elem_ty
     }
 
+    /// Returns the minimum size defined in the [TableType].
     pub fn minimum(&self) -> u32 {
         self.min
     }
 
+    /// Returns the maximum size defined in the [TableType].
     pub fn maximum(&self) -> u32 {
         self.max
     }
@@ -321,12 +352,22 @@ impl Default for TableType {
     }
 }
 
+/// Struct of WasmEdge MemoryType.
+///
+/// A [MemoryType] is used to declare the size range of a WasmEdge Memory to be created.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemoryType {
     min: u32,
     max: u32,
 }
 impl MemoryType {
+    /// Creates a new [MemoryType] with the given size range.
+    ///
+    /// # Arguments
+    ///
+    /// * `min` - The minimum size of the memory to be created.
+    ///
+    /// * `max` - The maximum size of the memory to be created.
     pub fn new(min: u32, max: Option<u32>) -> Self {
         let max = match max {
             Some(max) => max,
@@ -335,10 +376,12 @@ impl MemoryType {
         Self { min, max }
     }
 
+    /// Returns the minimum size defined in the [MemoryType].
     pub fn minimum(&self) -> u32 {
         self.min
     }
 
+    /// Returns the maximum size defined in the [MemoryType].
     pub fn maximum(&self) -> u32 {
         self.max
     }
@@ -353,20 +396,31 @@ impl Default for MemoryType {
 }
 
 /// Struct of WasmEdge GlobalType.
+///
+/// A [GlobalType] is used to declare the type of a WasmEdge Global to be created.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlobalType {
     ty: ValType,
     mutability: Mutability,
 }
 impl GlobalType {
+    /// Creates a new [GlobalType] with the given value type and mutability.
+    ///
+    /// # Arguments
+    ///
+    /// * `ty` - The value type of the global to be created.
+    ///
+    /// * `mutability` - The value mutability property of the global to be created.
     pub fn new(ty: ValType, mutability: Mutability) -> Self {
         Self { ty, mutability }
     }
 
+    /// Returns the value type defined in the [GlobalType].
     pub fn value_ty(&self) -> ValType {
         self.ty
     }
 
+    /// Returns the value mutability property defined in the [GlobalType].
     pub fn mutability(&self) -> Mutability {
         self.mutability
     }

--- a/bindings/rust/wasmedge-types/src/lib.rs
+++ b/bindings/rust/wasmedge-types/src/lib.rs
@@ -144,6 +144,7 @@ impl From<CompilerOptimizationLevel> for u32 {
     }
 }
 
+/// Defines WasmEdge AOT compiler output binary format.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CompilerOutputFormat {
     /// Native dynamic library format.
@@ -151,6 +152,23 @@ pub enum CompilerOutputFormat {
 
     /// WebAssembly with AOT compiled codes in custom sections.
     Wasm,
+}
+impl From<u32> for CompilerOutputFormat {
+    fn from(val: u32) -> CompilerOutputFormat {
+        match val {
+            0 => CompilerOutputFormat::Native,
+            1 => CompilerOutputFormat::Wasm,
+            _ => panic!("Unknown CompilerOutputFormat value: {}", val),
+        }
+    }
+}
+impl From<CompilerOutputFormat> for u32 {
+    fn from(val: CompilerOutputFormat) -> u32 {
+        match val {
+            CompilerOutputFormat::Native => 0,
+            CompilerOutputFormat::Wasm => 1,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/bindings/rust/wasmedge-types/src/lib.rs
+++ b/bindings/rust/wasmedge-types/src/lib.rs
@@ -1,0 +1,286 @@
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum RefType {
+    /// `FuncRef` denotes the infinite union of all references to [functions](crate::Function), regardless of their
+    /// [function types](crate::FuncType).
+    FuncRef,
+
+    /// `ExternRef` denotes the infinite union of all references to objects owned by the [Vm](crate::Vm) and that can be
+    /// passed into WebAssembly under this type.
+    ExternRef,
+}
+impl From<u32> for RefType {
+    fn from(value: u32) -> Self {
+        match value {
+            112 => RefType::FuncRef,
+            111 => RefType::ExternRef,
+            _ => panic!("[wasmedge-types] Invalid WasmEdge_RefType: {:#X}", value),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum ValType {
+    /// 32-bit integer.
+    ///
+    /// Integers are not inherently signed or unsigned, their interpretation is determined by individual operations.
+    I32,
+    /// 64-bit integer.
+    ///
+    /// Integers are not inherently signed or unsigned, their interpretation is determined by individual operations.
+    I64,
+    /// 32-bit floating-point data as defined by the [IEEE 754-2019](https://ieeexplore.ieee.org/document/8766229).
+    F32,
+    /// 64-bit floating-point data as defined by the [IEEE 754-2019](https://ieeexplore.ieee.org/document/8766229).
+    F64,
+    /// 128-bit vector of packed integer or floating-point data.
+    ///
+    /// The packed data can be interpreted as signed or unsigned integers, single or double precision floating-point
+    /// values, or a single 128 bit type. The interpretation is determined by individual operations.
+    V128,
+    /// A reference to [functions](crate::Function).
+    FuncRef,
+    /// A reference to object owned by the [Vm](crate::Vm).
+    ExternRef,
+    /// Unknown.
+    None,
+}
+impl From<u32> for ValType {
+    fn from(value: u32) -> Self {
+        match value {
+            127 => ValType::I32,
+            126 => ValType::I64,
+            125 => ValType::F32,
+            124 => ValType::F64,
+            123 => ValType::V128,
+            112 => ValType::FuncRef,
+            111 => ValType::ExternRef,
+            64 => ValType::None,
+            _ => panic!("[wasmedge-types] Invalid WasmEdge_ValType: {:#X}", value),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Mutability {
+    /// Identifies an immutable global variable
+    Const,
+    /// Identifies a mutable global variable
+    Var,
+}
+impl From<u32> for Mutability {
+    fn from(value: u32) -> Self {
+        match value {
+            0 => Mutability::Const,
+            1 => Mutability::Var,
+            _ => panic!("[wasmedge-types] Invalid WasmEdge_Mutability: {:#X}", value),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CompilerOptimizationLevel {
+    /// Disable as many optimizations as possible.
+    O0,
+
+    /// Optimize quickly without destroying debuggability.
+    O1,
+
+    /// Optimize for fast execution as much as possible without triggering significant incremental compile time or code size growth.
+    O2,
+
+    ///  Optimize for fast execution as much as possible.
+    O3,
+
+    ///  Optimize for small code size as much as possible without triggering
+    ///  significant incremental compile time or execution time slowdowns.
+    Os,
+
+    /// Optimize for small code size as much as possible.
+    Oz,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CompilerOutputFormat {
+    /// Native dynamic library format.
+    Native,
+
+    /// WebAssembly with AOT compiled codes in custom sections.
+    Wasm,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HostRegistration {
+    Wasi,
+    WasmEdgeProcess,
+}
+
+/// Defines WasmEdge ExternalType values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExternalInstanceType {
+    Func(FuncType),
+    Table(TableType),
+    Memory(MemoryType),
+    Global(GlobalType),
+}
+impl From<u32> for ExternalInstanceType {
+    fn from(value: u32) -> Self {
+        match value {
+            0 => ExternalInstanceType::Func(FuncType::default()),
+            1 => ExternalInstanceType::Table(TableType::default()),
+            2 => ExternalInstanceType::Memory(MemoryType::default()),
+            3 => ExternalInstanceType::Global(GlobalType::default()),
+            _ => panic!(
+                "[wasmedge-types] Invalid WasmEdge_ExternalType: {:#X}",
+                value
+            ),
+        }
+    }
+}
+impl std::fmt::Display for ExternalInstanceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            ExternalInstanceType::Func(_) => "function",
+            ExternalInstanceType::Table(_) => "table",
+            ExternalInstanceType::Memory(_) => "memory",
+            ExternalInstanceType::Global(_) => "global",
+        };
+        write!(f, "{}", message)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct FuncType {
+    args: Option<Vec<ValType>>,
+    returns: Option<Vec<ValType>>,
+}
+impl FuncType {
+    pub fn new(args: Option<Vec<ValType>>, returns: Option<Vec<ValType>>) -> Self {
+        Self { args, returns }
+    }
+
+    /// Returns the types of the arguments of a host function.
+    pub fn args(&self) -> Option<&[ValType]> {
+        match &self.args {
+            Some(args) => Some(args.as_ref()),
+            None => None,
+        }
+    }
+
+    pub fn args_len(&self) -> u32 {
+        match &self.args {
+            Some(args) => args.len() as u32,
+            None => 0,
+        }
+    }
+
+    /// Returns the types of the returns of a host function.
+    pub fn returns(&self) -> Option<&[ValType]> {
+        match &self.returns {
+            Some(returns) => Some(returns.as_ref()),
+            None => None,
+        }
+    }
+
+    pub fn returns_len(&self) -> u32 {
+        match &self.returns {
+            Some(returns) => returns.len() as u32,
+            None => 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableType {
+    elem_ty: RefType,
+    min: u32,
+    max: u32,
+}
+impl TableType {
+    pub fn new(elem_ty: RefType, min: u32, max: Option<u32>) -> Self {
+        let max = match max {
+            Some(val) => val,
+            None => u32::MAX,
+        };
+        Self { elem_ty, min, max }
+    }
+
+    pub fn elem_ty(&self) -> RefType {
+        self.elem_ty
+    }
+
+    pub fn minimum(&self) -> u32 {
+        self.min
+    }
+
+    pub fn maximum(&self) -> u32 {
+        self.max
+    }
+}
+impl Default for TableType {
+    fn default() -> Self {
+        Self {
+            elem_ty: RefType::FuncRef,
+            min: 0,
+            max: u32::MAX,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryType {
+    min: u32,
+    max: u32,
+}
+impl MemoryType {
+    pub fn new(min: u32, max: Option<u32>) -> Self {
+        let max = match max {
+            Some(max) => max,
+            None => u32::MAX,
+        };
+        Self { min, max }
+    }
+
+    pub fn minimum(&self) -> u32 {
+        self.min
+    }
+
+    pub fn maximum(&self) -> u32 {
+        self.max
+    }
+}
+impl Default for MemoryType {
+    fn default() -> Self {
+        Self {
+            min: 0,
+            max: u32::MAX,
+        }
+    }
+}
+
+/// Struct of WasmEdge GlobalType.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GlobalType {
+    ty: ValType,
+    mutability: Mutability,
+}
+impl GlobalType {
+    pub fn new(ty: ValType, mutability: Mutability) -> Self {
+        Self { ty, mutability }
+    }
+
+    pub fn value_ty(&self) -> ValType {
+        self.ty
+    }
+
+    pub fn mutability(&self) -> Mutability {
+        self.mutability
+    }
+}
+impl Default for GlobalType {
+    fn default() -> Self {
+        Self {
+            ty: ValType::I32,
+            mutability: Mutability::Var,
+        }
+    }
+}

--- a/bindings/rust/wasmedge-types/src/lib.rs
+++ b/bindings/rust/wasmedge-types/src/lib.rs
@@ -17,6 +17,14 @@ impl From<u32> for RefType {
         }
     }
 }
+impl From<RefType> for u32 {
+    fn from(value: RefType) -> Self {
+        match value {
+            RefType::FuncRef => 112,
+            RefType::ExternRef => 111,
+        }
+    }
+}
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ValType {

--- a/bindings/rust/wasmedge-types/src/lib.rs
+++ b/bindings/rust/wasmedge-types/src/lib.rs
@@ -60,6 +60,9 @@ impl From<u32> for ValType {
     }
 }
 
+/// Defines WasmEdge mutability values.
+///
+/// `Mutability` determines a [global](crate::Global) variable is either mutable or immutable.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Mutability {
     /// Identifies an immutable global variable
@@ -73,6 +76,14 @@ impl From<u32> for Mutability {
             0 => Mutability::Const,
             1 => Mutability::Var,
             _ => panic!("[wasmedge-types] Invalid WasmEdge_Mutability: {:#X}", value),
+        }
+    }
+}
+impl From<Mutability> for u32 {
+    fn from(value: Mutability) -> Self {
+        match value {
+            Mutability::Const => 0,
+            Mutability::Var => 1,
         }
     }
 }

--- a/bindings/rust/wasmedge-types/src/lib.rs
+++ b/bindings/rust/wasmedge-types/src/lib.rs
@@ -96,6 +96,7 @@ impl From<Mutability> for u32 {
     }
 }
 
+/// Defines WasmEdge AOT compiler optimization level.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CompilerOptimizationLevel {
     /// Disable as many optimizations as possible.
@@ -116,6 +117,31 @@ pub enum CompilerOptimizationLevel {
 
     /// Optimize for small code size as much as possible.
     Oz,
+}
+impl From<u32> for CompilerOptimizationLevel {
+    fn from(val: u32) -> CompilerOptimizationLevel {
+        match val {
+            0 => CompilerOptimizationLevel::O0,
+            1 => CompilerOptimizationLevel::O1,
+            2 => CompilerOptimizationLevel::O2,
+            3 => CompilerOptimizationLevel::O3,
+            4 => CompilerOptimizationLevel::Os,
+            5 => CompilerOptimizationLevel::Oz,
+            _ => panic!("Unknown CompilerOptimizationLevel value: {}", val),
+        }
+    }
+}
+impl From<CompilerOptimizationLevel> for u32 {
+    fn from(val: CompilerOptimizationLevel) -> u32 {
+        match val {
+            CompilerOptimizationLevel::O0 => 0,
+            CompilerOptimizationLevel::O1 => 1,
+            CompilerOptimizationLevel::O2 => 2,
+            CompilerOptimizationLevel::O3 => 3,
+            CompilerOptimizationLevel::Os => 4,
+            CompilerOptimizationLevel::Oz => 5,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/bindings/rust/wasmedge-types/src/lib.rs
+++ b/bindings/rust/wasmedge-types/src/lib.rs
@@ -171,10 +171,28 @@ impl From<CompilerOutputFormat> for u32 {
     }
 }
 
+/// Defines WasmEdge host module registration enum.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum HostRegistration {
     Wasi,
     WasmEdgeProcess,
+}
+impl From<u32> for HostRegistration {
+    fn from(val: u32) -> Self {
+        match val {
+            0 => HostRegistration::Wasi,
+            1 => HostRegistration::WasmEdgeProcess,
+            _ => panic!("Unknown WasmEdge_HostRegistration value: {}", val),
+        }
+    }
+}
+impl From<HostRegistration> for u32 {
+    fn from(val: HostRegistration) -> u32 {
+        match val {
+            HostRegistration::Wasi => 0,
+            HostRegistration::WasmEdgeProcess => 1,
+        }
+    }
 }
 
 /// Defines WasmEdge ExternalType values.

--- a/bindings/rust/wasmedge-types/src/lib.rs
+++ b/bindings/rust/wasmedge-types/src/lib.rs
@@ -1,3 +1,9 @@
+//! The [wasmedge-types](https://crates.io/crates/wasmedge-types) crate defines a group of common data structures used by both [wasmedge-rs](https://crates.io/crates/wasmedge-sdk) and [wasmedge-sys](https://crates.io/crates/wasmedge-sys) crates.
+//!
+//! See also
+//!
+//! * [WasmEdge Runtime](https://wasmedge.org/)
+
 /// Defines WasmEdge reference types.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum RefType {


### PR DESCRIPTION
In this PR, the `wasmedge-types` crate is created. This crate contains the data structures used in the future versions of both `wasmedge-sys` and `wasmedge-rs` crates.

* This PR should be tagged as `rust-types/0.1.0`.