### PR TITLE
[bug] fix Stat incorrect initialize value

### DIFF
--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -86,8 +86,15 @@ using TypeNN =
 class Executor {
 public:
   Executor(const Configure &Conf, Statistics::Statistics *S = nullptr) noexcept
-      : Conf(Conf), Stat(S) {
+      : Conf(Conf) {
     assuming(This == nullptr);
+    if (Conf.getStatisticsConfigure().isInstructionCounting() ||
+        Conf.getStatisticsConfigure().isCostMeasuring() ||
+        Conf.getStatisticsConfigure().isTimeMeasuring()) {
+      Stat = S;
+    } else {
+      Stat = nullptr;
+    }
     newThread();
     if (Stat) {
       Stat->setCostLimit(Conf.getStatisticsConfigure().getCostLimit());

--- a/lib/executor/engine/engine.cpp
+++ b/lib/executor/engine/engine.cpp
@@ -1614,8 +1614,8 @@ Expect<void> Executor::execute(Runtime::StoreManager &StoreMgr,
   };
 
   while (PC != PCEnd) {
-    OpCode Code = PC->getOpCode();
     if (Stat) {
+      OpCode Code = PC->getOpCode();
       if (Conf.getStatisticsConfigure().isInstructionCounting()) {
         Stat->incInstrCount();
       }


### PR DESCRIPTION
This PR is able to solve `Stat` incorrect values which will call atomic_bool::load to check
 (code position: [ lib/executor/engine/engine.cpp:1619L ](https://github.com/WasmEdge/WasmEdge/blob/master/lib/executor/engine/engine.cpp#L1618-L1621)).

* In Executor constructor: Set `Stat`  value `nullptr` if  default , and set `Stat` value `S` if collect statistics information. (the Value `S` refer to the [VM constructor](https://github.com/WasmEdge/WasmEdge/blob/master/lib/vm/vm.cpp#L16-L24) 
* Modify `PC->getOpCode()` into `if (Stat)` block since  it will only be called in this case.

Fixes #1381 
Signed-off-by: eat4toast <shihaohang@outlook.com>