### PR TITLE
[Rust] Defined wat2wasm in wasmedge-types.

### DIFF
--- a/bindings/rust/wasmedge-types/Cargo.toml
+++ b/bindings/rust/wasmedge-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmedge-types"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "The common data structures for WasmEdge Rust bindings."
 license = "Apache-2.0"
@@ -10,3 +10,4 @@ repository = "https://github.com/WasmEdge/WasmEdge/tree/master/bindings/rust/was
 categories = ["data-structures"]
 
 [dependencies]
+wat = "1.0"

--- a/bindings/rust/wasmedge-types/src/lib.rs
+++ b/bindings/rust/wasmedge-types/src/lib.rs
@@ -439,3 +439,6 @@ impl Default for GlobalType {
         }
     }
 }
+
+/// Parses in-memory bytes as either the [WebAssembly Text format](http://webassembly.github.io/spec/core/text/index.html), or a binary WebAssembly module.
+pub use wat::parse_bytes as wat2wasm;


### PR DESCRIPTION
In this PR, `wat2wasm` is introduced in `wasmedge-types`. The version of `wasmedge-types` comes to `v0.1.1`.