### PR TITLE
[Rust]: Add Clone trait to Function and Global.

### DIFF
--- a/bindings/rust/wasmedge-sys/Cargo.toml
+++ b/bindings/rust/wasmedge-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmedge-sys"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 links = "wasmedge_c"
 build = "build.rs"

--- a/bindings/rust/wasmedge-sys/src/instance/function.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/function.rs
@@ -61,7 +61,7 @@ extern "C" fn wraper_fn(
 /// A WasmEdge [Function] defines a host function described by its [FuncType]. A host function is a function defined outside WASM module and passed to it.
 ///
 /// In WasmEdge, developers can create [host functions](crate::Function) and other WasmEdge instances, such as [Memory](crate::Memory), and add them into a WasmEdge [ImportObject](crate::ImportObject) for registering into a WasmEdge [Vm](crate::Vm) or [Store](crate::Store).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Function {
     pub(crate) inner: InnerFunc,
     pub(crate) registered: bool,
@@ -199,7 +199,7 @@ impl Drop for Function {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct InnerFunc(pub(crate) *mut ffi::WasmEdge_FunctionInstanceContext);
 unsafe impl Send for InnerFunc {}
 unsafe impl Sync for InnerFunc {}

--- a/bindings/rust/wasmedge-sys/src/instance/global.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/global.rs
@@ -65,7 +65,7 @@ impl Drop for GlobalType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct InnerGlobal(pub(crate) *mut ffi::WasmEdge_GlobalInstanceContext);
 unsafe impl Send for InnerGlobal {}
 unsafe impl Sync for InnerGlobal {}
@@ -73,7 +73,7 @@ unsafe impl Sync for InnerGlobal {}
 /// Struct of WasmEdge Global.
 ///
 /// A WasmEdge [Global] defines a global variable, which stores a single value of the given [GlobalType].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Global {
     pub(crate) inner: InnerGlobal,
     pub(crate) registered: bool,


### PR DESCRIPTION
In this PR, the `Clone` trait is added for `Function` and `Global`. Crate `wasmedge-sys` version upgraded from v0.5.0 to v0.5.1.