### PR TITLE
[Tools] Fix the extension name for shared library format in AOT compiler

### DIFF
--- a/test/api/APIAOTCoreTest.cpp
+++ b/test/api/APIAOTCoreTest.cpp
@@ -14,11 +14,12 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "common/defines.h"
+#include "helper.h"
+#include "hostfunc_c.h"
 #include "wasmedge/wasmedge.h"
 
 #include "../spec/spectest.h"
-#include "helper.h"
-#include "hostfunc_c.h"
 
 #include <cstdint>
 #include <functional>
@@ -29,14 +30,11 @@
 #include <utility>
 #include <vector>
 
-#if defined(linux) || defined(__linux) || defined(__linux__) ||                \
-    defined(__gnu_linux__)
+#if WASMEDGE_OS_LINUX
 #define EXTENSION ".so"sv
-#elif defined(macintosh) || defined(Macintosh) ||                              \
-    (defined(__APPLE__) && defined(__MACH__))
+#elif WASMEDGE_OS_MACOS
 #define EXTENSION ".dylib"sv
-#elif defined(_WIN32) || defined(_WIN64) || defined(__WIN32__) ||              \
-    defined(__TOS_WIN__) || defined(__WINDOWS__)
+#elif WASMEDGE_OS_WINDOWS
 #define EXTENSION ".dll"sv
 #endif
 

--- a/tools/wasmedge/wasmedgec.cpp
+++ b/tools/wasmedge/wasmedgec.cpp
@@ -3,6 +3,7 @@
 
 #include "aot/compiler.h"
 #include "common/configure.h"
+#include "common/defines.h"
 #include "common/filesystem.h"
 #include "common/version.h"
 #include "loader/loader.h"
@@ -16,6 +17,14 @@
 #include <string_view>
 #include <utility>
 #include <vector>
+
+#if WASMEDGE_OS_LINUX
+#define EXTENSION ".so"sv
+#elif WASMEDGE_OS_MACOS
+#define EXTENSION ".dylib"sv
+#elif WASMEDGE_OS_WINDOWS
+#define EXTENSION ".dll"sv
+#endif
 
 int main(int Argc, const char *Argv[]) {
   namespace PO = WasmEdge::PO;
@@ -191,7 +200,7 @@ int main(int Argc, const char *Argv[]) {
     if (ConfGenericBinary.value()) {
       Conf.getCompilerConfigure().setGenericBinary(true);
     }
-    if (OutputPath.extension().u8string() == ".so"sv) {
+    if (OutputPath.extension().u8string() == EXTENSION) {
       Conf.getCompilerConfigure().setOutputFormat(
           WasmEdge::CompilerConfigure::OutputFormat::Native);
     }


### PR DESCRIPTION
on different platforms.

Signed-off-by: YiYing He <yiying@secondstate.io>