### PR TITLE
[WASI] fix(wasinnfunc): add backend flag for context

### DIFF
--- a/lib/host/wasi_nn/wasinnfunc.cpp
+++ b/lib/host/wasi_nn/wasinnfunc.cpp
@@ -194,7 +194,7 @@ WasiNNInitExecCtx::body(Runtime::Instance::MemoryInstance *MemInst,
 
     Ctx.ExecutionsNum = Ctx.OpenVINOInfers.size();
     Ctx.OpenVINOInfers.push_back(Session);
-    Ctx.GraphContextBackends.push_back(GraphId);
+    Ctx.GraphContextBackends.push_back(Ctx.GraphBackends[GraphId]);
     *Context = Ctx.ExecutionsNum;
 
     return static_cast<uint32_t>(WASINN::ErrNo::Success);


### PR DESCRIPTION
fix the bug : `WasiNNInitExecCtx` shouldn't push the `GraphId` to `GraphContextBackends` but the backend flag for this `GraphId`