### PR TITLE
[Rust] Introduce AsInstance trait in wasmedge-sys crate

### DIFF
--- a/bindings/rust/wasmedge-sys/Cargo.toml
+++ b/bindings/rust/wasmedge-sys/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
-name = "wasmedge-sys"
-version = "0.7.0"
-edition = "2021"
-links = "wasmedge_c"
 build = "build.rs"
-description = "WasmEdge Runtime is a high-performance, extensible, and hardware optimized WebAssembly Virtual Machine for automotive, cloud, AI, and blockchain applications."
-license = "Apache-2.0"
-readme = "README.md"
-documentation = "https://wasmedge.github.io/WasmEdge/wasmedge_sys/"
-repository = "https://github.com/WasmEdge/WasmEdge"
 categories = ["api-bindings", "wasm"]
+description = "WasmEdge Runtime is a high-performance, extensible, and hardware optimized WebAssembly Virtual Machine for automotive, cloud, AI, and blockchain applications."
+documentation = "https://wasmedge.github.io/WasmEdge/wasmedge_sys/"
+edition = "2021"
 exclude = ["tests/", "examples/"]
+license = "Apache-2.0"
+links = "wasmedge_c"
+name = "wasmedge-sys"
+readme = "README.md"
+repository = "https://github.com/WasmEdge/WasmEdge"
+version = "0.7.0"
 
 [dependencies]
+lazy_static = "1.4.0"
+libc = "0.2.94"
 paste = "1.0.5"
 rand = "0.8.4"
-libc = "0.2.94"
 thiserror = "1.0.30"
-lazy_static = "1.4.0"
-wasmedge-types = "0.1.2"
+wasmedge-types = "0.1"
 
 [build-dependencies]
-bindgen = { version = "0.59.1", default-features = false, features = ["runtime"] }
+bindgen = {version = "0.59.1", default-features = false, features = ["runtime"]}
 cmake = "0.1"
 
 [features]
+aot = []
 default = ["aot"]
 standalone = []
-aot = []

--- a/bindings/rust/wasmedge-sys/examples/func_call_across_different_modes.rs
+++ b/bindings/rust/wasmedge-sys/examples/func_call_across_different_modes.rs
@@ -152,6 +152,7 @@ fn aot_call_interpreter() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[cfg_attr(test, test)]
+#[cfg(not(target_os = "macos"))]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // The function in interpreter mode calls the functions in AOT mode
     interpreter_call_aot()?;

--- a/bindings/rust/wasmedge-sys/examples/func_call_across_different_modes.rs
+++ b/bindings/rust/wasmedge-sys/examples/func_call_across_different_modes.rs
@@ -151,8 +151,6 @@ fn aot_call_interpreter() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg_attr(test, test)]
-#[cfg(not(target_os = "macos"))]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // The function in interpreter mode calls the functions in AOT mode
     interpreter_call_aot()?;

--- a/bindings/rust/wasmedge-sys/src/lib.rs
+++ b/bindings/rust/wasmedge-sys/src/lib.rs
@@ -139,7 +139,8 @@ pub use instance::{
     global::{Global, GlobalType},
     memory::{MemType, Memory},
     module::{
-        ImportInstance, ImportModule, ImportObject, Instance, WasiModule, WasmEdgeProcessModule,
+        AsInstance, ImportInstance, ImportModule, ImportObject, Instance, WasiModule,
+        WasmEdgeProcessModule,
     },
     table::{Table, TableType},
 };

--- a/bindings/rust/wasmedge-sys/src/store.rs
+++ b/bindings/rust/wasmedge-sys/src/store.rs
@@ -90,27 +90,15 @@ impl Store {
     ///
     /// * `name` - The name of the module to search.
     ///
-    /// # Error
-    ///
-    /// If fail to find, then an error is returned.
-    pub fn contains(&self, name: impl AsRef<str>) -> WasmEdgeResult<()> {
+    pub fn contains(&self, name: impl AsRef<str>) -> bool {
         if self.module_len() == 0 {
-            return Err(WasmEdgeError::Store(StoreError::NotFoundModule(
-                name.as_ref().into(),
-            )));
+            return false;
         }
 
-        let result = self
-            .module_names()
-            .ok_or_else(|| WasmEdgeError::Store(StoreError::NotFoundModule(name.as_ref().into())));
-
-        let names = result.unwrap();
-        if names.iter().all(|x| x != name.as_ref()) {
-            return Err(WasmEdgeError::Store(StoreError::NotFoundModule(
-                name.as_ref().into(),
-            )));
+        match self.module_names() {
+            Some(names) => names.iter().any(|x| x == name.as_ref()),
+            None => false,
         }
-        Ok(())
     }
 }
 impl Drop for Store {


### PR DESCRIPTION
In this PR, the `AsInstance` trait is introduced into `wasmedge-sys` crate and implemented for WasiModule and WasmEdgeProcessModule.