### PR TITLE
[Rust] Used nightly channel of Rust

### DIFF
--- a/.github/workflows/rust-wasmedge-sdk-release.yml
+++ b/.github/workflows/rust-wasmedge-sdk-release.yml
@@ -21,10 +21,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Stable Rust
+      - name: Install Nightly Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
 
       - name: Build WasmEdge using clang
         run: |


### PR DESCRIPTION
In this PR, the `nightly` channel of Rust substitutes for the `stable` in `rust-wasmedge-sdk-release` workflow.

Signed-off-by: Xin Liu <sam@secondstate.io>