### PR TITLE
Fix #1497

### DIFF
--- a/utils/install.sh
+++ b/utils/install.sh
@@ -120,7 +120,7 @@ get_latest_release() {
     res=$(git ls-remote --refs --tags "https://github.com/$1.git" |
         cut -d '/' -f 3 |
         sort --version-sort |
-        grep -e '^[0-9].[0-9].[0-9]$' |
+        grep -e '^[0-9]\+.[0-9]\+.[0-9]\+$' |
         tail -1)
     echo "$res"
 }


### PR DESCRIPTION
Version more than 1 digit is excluded, so `0.10.0` is missing.