### PR TITLE
[Utils] Installer Script: Prevent writing relative path to login shell profile

### DIFF
--- a/utils/install.sh
+++ b/utils/install.sh
@@ -573,7 +573,7 @@ main() {
             VERBOSE=1
             ;;
         p | path)
-            IPATH="${OPTARG}"
+            IPATH="$(readlink  --canonicalize "${OPTARG}")"
             default=1
             ;;
         r | remove-old)

--- a/utils/install.sh
+++ b/utils/install.sh
@@ -24,6 +24,10 @@ _ldconfig() {
     fi
 }
 
+_realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
 _downloader() {
     local url=$1
     if ! command -v curl &>/dev/null; then
@@ -573,7 +577,7 @@ main() {
             VERBOSE=1
             ;;
         p | path)
-            IPATH="$(readlink  --canonicalize "${OPTARG}")"
+            IPATH="$(_realpath "${OPTARG}")"
             default=1
             ;;
         r | remove-old)


### PR DESCRIPTION
Previously `. "./wasmedge/env"` will be written to my .zshrc if `-p ./wasmedge` is specific.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>