### PR TITLE
[CI] Add workflow to test rust bindings on Windows

### DIFF
--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -18,6 +18,7 @@ on:
       - "docs/**"
       - "**.md"
 
+
 jobs:
   build_ubuntu:
     name: Ubuntu 20.04
@@ -88,6 +89,7 @@ jobs:
           export LD_LIBRARY_PATH="$(pwd)/../../build/lib/api"
           cargo +nightly test --lib --examples --locked
           cargo +nightly test --doc --locked
+
 
   build_macos:
     name: MacOS
@@ -166,3 +168,140 @@ jobs:
           export LD_LIBRARY_PATH="$(pwd)/../../build/lib/api"
           cargo +nightly test --lib --examples --locked
           cargo +nightly test --doc --locked
+
+
+  build_windows_standalone:
+    name: Windows [In Standalone Mode]
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install dependency
+      uses: crazy-max/ghaction-chocolatey@v1
+      with:
+        args: install cmake ninja vswhere
+
+    - uses: GuillaumeFalourd/setup-windows10-sdk-action@v1
+      with:
+        sdk-version: 19041
+
+    - name: Install Stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        components: rustfmt, clippy
+
+    - name: Install Nightly Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        components: rustfmt, clippy
+
+    - name: Rustfmt
+      run: |
+        cd bindings/rust/
+        cargo +nightly fmt --all -- --check
+
+    - name: Test wasmedge-sys in standalone mode
+      run: |
+        $vsPath = (vswhere -latest -property installationPath)
+        Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
+        Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
+        cd bindings/rust/
+        $WASMEDGE_DIR="$(pwd)/../../"
+        cargo +nightly test -p wasmedge-sys --lib --examples
+        cargo +nightly test -p wasmedge-sys --doc
+
+    - name: Clean up
+      run: |
+        cd bindings/rust/
+        cargo clean
+
+    - name: Test
+      run: |
+        $vsPath = (vswhere -latest -property installationPath)
+        Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
+        Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0" 
+        cd bindings/rust/
+        $WASMEDGE_DIR="$(pwd)/../../"
+        $WASMEDGE_BUILD_DIR="$(pwd)/../../build"
+        $WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
+        $LD_LIBRARY_PATH="$(pwd)/../../build/lib/api"
+        cargo +nightly test --lib --examples --locked
+        cargo +nightly test --doc --locked
+
+
+  build_windows_WASMEDGE_BUILD_DIR:
+    name: Windows [By Specifying WASMEDGE_BUILD_DIR]
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install dependency
+      uses: crazy-max/ghaction-chocolatey@v1
+      with:
+        args: install cmake ninja vswhere
+
+    - uses: GuillaumeFalourd/setup-windows10-sdk-action@v1
+      with:
+        sdk-version: 19041
+
+    - name: Install Stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        components: rustfmt, clippy
+
+    - name: Install Nightly Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        components: rustfmt, clippy
+
+    - name: Rustfmt
+      run: |
+        cd bindings/rust/
+        cargo +nightly fmt --all -- --check
+
+    - name: Build WasmEdge in Debug mode
+      run: |
+        $vsPath = (vswhere -latest -property installationPath)
+        Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
+        Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
+        $llvm = "LLVM-13.0.1-win64.zip"
+        curl -sLO https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-13.0.1/LLVM-13.0.1-win64.zip -o $llvm
+        Expand-Archive -Path $llvm
+        $llvm_dir = "$pwd\\LLVM-13.0.1-win64\\LLVM-13.0.1-win64\\lib\\cmake\\llvm"
+        $Env:CC = "clang-cl"
+        $Env:CXX = "clang-cl"
+        $cmake_sys_version = "10.0.19041.0"
+        cmake -Bbuild -GNinja "-DCMAKE_SYSTEM_VERSION=$cmake_sys_version" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL "-DLLVM_DIR=$llvm_dir" -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_PACKAGE="ZIP" .
+        cmake --build build
+
+    - name: Clippy
+      run: |
+        $vsPath = (vswhere -latest -property installationPath)
+        Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
+        Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
+        cd bindings/rust/
+        $WASMEDGE_DIR="$(pwd)/../../"
+        $WASMEDGE_BUILD_DIR="$(pwd)/../../build"
+        $WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
+        cargo +nightly clippy --profile test --lib --examples -- -D warnings -D clippy::dbg_macro
+
+    - name: Test
+      run: |
+        $vsPath = (vswhere -latest -property installationPath)
+        Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
+        Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0" 
+        cd bindings/rust/
+        $WASMEDGE_DIR="$(pwd)/../../"
+        $WASMEDGE_BUILD_DIR="$(pwd)/../../build"
+        $WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
+        $LD_LIBRARY_PATH="$(pwd)/../../build/lib/api"
+        cargo +nightly test --lib --examples --locked
+        cargo +nightly test --doc --locked


### PR DESCRIPTION
The workflow tests rust bindings on windows -
1. In the standalone mode
2. By specifying the WASMEDGE_BUILD_DIR variable

Resolves issue: #1504