### PR TITLE
Point to the right directoy for wasm examples

### DIFF
--- a/utils/android/app/lib/build.gradle
+++ b/utils/android/app/lib/build.gradle
@@ -23,7 +23,7 @@ android {
 
     sourceSets{
         main{
-            assets.srcDirs = ['../../../../tools/wasmedge/examples']
+            assets.srcDirs = ['../../../../examples/wasm']
         }
     }
 


### PR DESCRIPTION
Signed-off-by: yixingjia@gmail.com

Previous PR move the example out of the tools folder which will cause
the app cannot load the wasm file.