### PR TITLE
[Rust]: Fix errors in examples.

### DIFF
--- a/bindings/rust/wasmedge-sys/examples/hostfunc.rs
+++ b/bindings/rust/wasmedge-sys/examples/hostfunc.rs
@@ -23,14 +23,14 @@ fn real_add(input: Vec<WasmValue>) -> Result<Vec<WasmValue>, u8> {
         return Err(1);
     }
 
-    let a = if input[0].ty() == ValType::I32 {
-        input[0].to_i32()
+    let a = if input[1].ty() == ValType::I32 {
+        input[1].to_i32()
     } else {
         return Err(2);
     };
 
-    let b = if input[1].ty() == ValType::I32 {
-        input[1].to_i32()
+    let b = if input[2].ty() == ValType::I32 {
+        input[2].to_i32()
     } else {
         return Err(3);
     };

--- a/bindings/rust/wasmedge-sys/examples/hostfunc2.rs
+++ b/bindings/rust/wasmedge-sys/examples/hostfunc2.rs
@@ -27,14 +27,14 @@ fn real_add(input: Vec<WasmValue>) -> Result<Vec<WasmValue>, u8> {
         return Err(1);
     }
 
-    let a = if input[0].ty() == ValType::I32 {
-        input[0].to_i32()
+    let a = if input[1].ty() == ValType::I32 {
+        input[1].to_i32()
     } else {
         return Err(2);
     };
 
-    let b = if input[1].ty() == ValType::I32 {
-        input[1].to_i32()
+    let b = if input[2].ty() == ValType::I32 {
+        input[2].to_i32()
     } else {
         return Err(3);
     };


### PR DESCRIPTION
Fix errors in `hostfunc.rs` and `hostfunc2.rs`.