### PR TITLE
[CI] Add Fedora RPM spec file to release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -411,6 +411,18 @@ jobs:
         rpmbuild -ba rpm/wasmedge.spec
       env:
         VERSION: ${{ needs.create_release.outputs.version }}
+    - name: Upload Fedora spec file
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create_release.outputs.upload_url }}
+        asset_path: build/rpm/wasmedge.spec
+        asset_name: wasmedge.spec
+        asset_content_type: text/plain
+    - name: Sleep 5 second to avoid GitHub ECONNRESET error
+      run: |
+        sleep 5
     - name: Upload Fedora SRPM
       uses: actions/upload-release-asset@v1
       env:
@@ -418,5 +430,5 @@ jobs:
       with:
         upload_url: ${{ needs.create_release.outputs.upload_url }}
         asset_path: /github/home/rpmbuild/SRPMS/wasmedge-${{ env.srpm_version }}-1.fc37.src.rpm
-        asset_name: WasmEdge-${{ env.srpm_version }}-1.fc37.src.rpm
+        asset_name: wasmedge-${{ env.srpm_version }}-1.fc37.src.rpm
         asset_content_type: application/x-rpm


### PR DESCRIPTION
- Update files according to https://bugzilla.redhat.com/show_bug.cgi?id=2035222
  - Add `wasmedge.spec` to release assets
  - Add comment above `ExclusiveArch` in spec file
  - Rename SRPM and spec files to all lower cases
  - Remove `wasmedge-lib` package
- Test release workflow in my own fork: https://github.com/dm4/WasmEdge/runs/6916370789?check_suite_focus=true