### PR TITLE
[RPM] Update RPM spec file

### DIFF
--- a/rpm/wasmedge.spec.in
+++ b/rpm/wasmedge.spec.in
@@ -6,6 +6,7 @@ Name:    wasmedge
 Version: %{srpm_version}
 Release: %autorelease
 Summary: High performance WebAssembly Virtual Machine
+# The entire source code is ASL 2.0 except LICENSE.spdx which is CC0
 License: ASL 2.0 and CC0
 URL:     https://github.com/%{reponame}/%{reponame}
 Source0: %{url}/releases/download/%{gittag}/%{reponame}-%{gittag}-src.tar.gz

--- a/rpm/wasmedge.spec.in
+++ b/rpm/wasmedge.spec.in
@@ -21,6 +21,8 @@ Requires:      llvm
 # Currently wasmedge could only be built on specific arches
 ExclusiveArch: x86_64 aarch64
 Provides: %{reponame} = %{version}-%{release}
+Provides: bundled(blake3) = 1.2.0
+Provides: bundled(wasi-cpp-header) = 0.0.1
 
 %description
 High performance WebAssembly Virtual Machine

--- a/rpm/wasmedge.spec.in
+++ b/rpm/wasmedge.spec.in
@@ -27,6 +27,7 @@ High performance WebAssembly Virtual Machine
 
 %package devel
 Summary: %{reponame} development files
+Requires: %{name}%{?_isa} = %{version}-%{release}
 Provides: %{reponame}-devel = %{version}-%{release}
 
 %description devel
@@ -57,8 +58,6 @@ ln -s lib%{name}Plugin%{reponame}Process.so.%{gittag} %{buildroot}%{_libdir}/%{n
 %{_libdir}/%{name}/lib%{name}Plugin%{reponame}Process.so.%{gittag}
 
 %files devel
-%license LICENSE LICENSE.spdx
-%doc Changelog.md README.md SECURITY.md
 %dir %{_includedir}/%{name}
 %{_includedir}/%{name}/dense_enum_map.h
 %{_includedir}/%{name}/enum.inc

--- a/rpm/wasmedge.spec.in
+++ b/rpm/wasmedge.spec.in
@@ -37,14 +37,11 @@ This package contains necessary header files for %{reponame} development.
 [ -f VERSION ] || echo -n %{gittag} > VERSION
 
 %build
-mkdir -p build
-cd build
-cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWASMEDGE_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=%{_prefix} ..
-cmake --build .
+%cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=OFF -DWASMEDGE_BUILD_TESTS=OFF
+%cmake_build
 
 %install
-cd build
-DESTDIR=%{buildroot} cmake --build . --target install
+%cmake_install
 mv %{buildroot}%{_libdir}/lib%{name}_c.so %{buildroot}%{_libdir}/lib%{name}_c.so.%{gittag}
 mv %{buildroot}%{_libdir}/%{name}/lib%{name}Plugin%{reponame}Process.so %{buildroot}%{_libdir}/%{name}/lib%{name}Plugin%{reponame}Process.so.%{gittag}
 ln -s lib%{name}_c.so.%{gittag} %{buildroot}%{_libdir}/lib%{name}_c.so

--- a/rpm/wasmedge.spec.in
+++ b/rpm/wasmedge.spec.in
@@ -9,7 +9,14 @@ Summary: High performance WebAssembly Virtual Machine
 License: ASL 2.0 and CC0
 URL:     https://github.com/%{reponame}/%{reponame}
 Source0: %{url}/releases/download/%{gittag}/%{reponame}-%{gittag}-src.tar.gz
-BuildRequires: gcc-c++,cmake,ninja-build,boost-devel,spdlog-devel,llvm-devel,lld-devel,git
+BuildRequires: boost-devel
+BuildRequires: cmake
+BuildRequires: gcc-c++
+BuildRequires: git
+BuildRequires: lld-devel
+BuildRequires: llvm-devel
+BuildRequires: ninja-build
+BuildRequires: spdlog-devel
 Requires:      llvm
 # Currently wasmedge could only be built on specific arches
 ExclusiveArch: x86_64 aarch64

--- a/rpm/wasmedge.spec.in
+++ b/rpm/wasmedge.spec.in
@@ -53,7 +53,8 @@ ln -s lib%{name}Plugin%{reponame}Process.so.%{gittag} %{buildroot}%{_libdir}/%{n
 %files
 %license LICENSE LICENSE.spdx
 %doc Changelog.md README.md SECURITY.md
-%{_bindir}/*
+%{_bindir}/wasmedge
+%{_bindir}/wasmedgec
 %{_libdir}/lib%{name}_c.so.%{gittag}
 %dir %{_libdir}/%{name}
 %{_libdir}/%{name}/lib%{name}Plugin%{reponame}Process.so.%{gittag}
@@ -61,7 +62,16 @@ ln -s lib%{name}Plugin%{reponame}Process.so.%{gittag} %{buildroot}%{_libdir}/%{n
 %files devel
 %license LICENSE LICENSE.spdx
 %doc Changelog.md README.md SECURITY.md
-%{_includedir}/*
+%dir %{_includedir}/%{name}
+%{_includedir}/%{name}/dense_enum_map.h
+%{_includedir}/%{name}/enum.inc
+%{_includedir}/%{name}/enum_configure.h
+%{_includedir}/%{name}/enum_errcode.h
+%{_includedir}/%{name}/enum_types.h
+%{_includedir}/%{name}/int128.h
+%{_includedir}/%{name}/spare_enum_map.h
+%{_includedir}/%{name}/version.h
+%{_includedir}/%{name}/wasmedge.h
 %{_libdir}/lib%{name}_c.so
 %dir %{_libdir}/%{name}
 %{_libdir}/%{name}/lib%{name}Plugin%{reponame}Process.so


### PR DESCRIPTION
- Accroding to https://bugzilla.redhat.com/show_bug.cgi?id=2035222#c24 , we should:
  - [x] Split `BuildRequires:` lines
  - [x] Not use glob in `%files`
  - [x] Use `%cmake` macros
  - [x] `wasmedge-devel` should depend on base package 
  - [x] Include a licensing breakdown
  - [x] Add bundled dependencies