### PR TITLE
[CI] Refactor workflows, reduce duplicate codes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -18,3 +18,41 @@ flowchart LR
       <li>build on Fedora</li>
     </ul>")
 ```
+
+### macOS
+```json
+[
+  {
+    "name": "MacOS 11 (x86_64)",
+    "runner": "macos-11",
+    "darwin_version": 20
+  },
+  {
+    "name": "MacOS 12 (x86_64)",
+    "runner": "macos-12",
+    "darwin_version": 21
+  }
+]
+```
+
+### manylinux
+```json
+[
+  {
+    "runner": "ubuntu-latest",
+    "docker_tag": "manylinux2010_x86_64"
+  },
+  {
+    "runner": "ubuntu-latest",
+    "docker_tag": "manylinux1_x86_64"
+  },
+  {
+    "runner": "ubuntu-latest",
+    "docker_tag": "manylinux2014_x86_64"
+  },
+  {
+    "runner": "ARM64",
+    "docker_tag": "manylinux2014_aarch64"
+  }
+]
+```

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,11 +6,15 @@ This document has not yet covered all workflows.
 ```mermaid
 flowchart LR
     %% _ is the starting point of everything
-    _(( ))-->lint
-    lint-->|pass|build
+    _(( ))-->lint(lint)
+    lint-->|pass|build(build)
     lint-->|fail|reject(unable to merge)
-    build-->source(create source tarball fa:fa-link)
-    click source "reusable-create-source-tarball.yml"
-    build-->macos(build on macOS fa:fa-link)
-    click macos "reusable-build-on-macos.yml"
+    build-.->source(create source tarball)
+    build-.->oss("<ul>
+      <li>build on macOS</li>
+      <li>build on manylinux</li>
+      <li>build on Windows</li>
+      <li>build on Android</li>
+      <li>build on Fedora</li>
+    </ul>")
 ```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,13 @@ jobs:
     with:
       version: ${{ needs.get_version_v2.outputs.version }}
 
+  build_on_macos:
+    needs: [get_version_v2, lint]
+    uses: ./.github/workflows/reusable-build-on-macos.yml
+    with:
+      version: ${{ needs.get_version_v2.outputs.version }}
+      matrix: "[{'name':'MacOS 11 (x86_64)','runner':'macos-11','darwin_version':20},{'name':'MacOS 12 (x86_64)','runner':'macos-12','darwin_version':21}]"
+
   build_fedora:
     name: Fedora 35
     needs: get_version_v2
@@ -282,64 +289,6 @@ jobs:
       with:
         name: WasmEdge-${{ needs.get_version_v2.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
         path: build/WasmEdge-${{ needs.get_version_v2.outputs.version }}-Linux.tar.gz
-
-  build_macos:
-    strategy:
-      matrix:
-        include:
-          - name: MacOS 11
-            host_runner: macos-11
-            darwin_version: darwin_20
-          - name: MacOS 12
-            host_runner: macos-12
-            darwin_version: darwin_21
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.host_runner }}
-    needs: get_version_v2
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Build WasmEdge
-      run: |
-        brew install llvm ninja boost cmake
-        export PATH="/usr/local/opt/llvm/bin:$PATH"
-        export LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
-        export CPPFLAGS="-I/usr/local/opt/llvm/include"
-        export CC=clang
-        export CXX=clang++
-        cmake -Bbuild -GNinja -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_LINK_TOOLS_STATIC=ON -DWASMEDGE_BUILD_PACKAGE="TGZ" .
-        cmake --build build
-    - name: Test WasmEdge
-      continue-on-error: true
-      run: |
-        export DYLD_LIBRARY_PATH="$(pwd)/build/lib/api:$DYLD_LIBRARY_PATH"
-        cd build
-        ./tools/wasmedge/wasmedge -v
-        ctest
-        cd -
-    - name: Test WasmEdge Package
-      run: |
-        cmake --build build --target package
-    - name: Test Standalone WasmEdge without LLVM
-      run: |
-        brew uninstall llvm
-        export DYLD_LIBRARY_PATH="$(pwd)/build/lib/api:$DYLD_LIBRARY_PATH"
-        echo "otool -L ./build/tools/wasmedge/wasmedge:"
-        otool -L ./build/tools/wasmedge/wasmedge
-        echo "otool -L ./build/tools/wasmedge/wasmedgec:"
-        otool -L ./build/tools/wasmedge/wasmedgec
-        echo "otool -L ./build/lib/api/libwasmedge_c.dylib:"
-        otool -L ./build/lib/api/libwasmedge_c.dylib
-        echo "./build/tools/wasmedge/wasmedgec examples/wasm/fibonacci.wasm fib.dylib"
-        ./build/tools/wasmedge/wasmedgec examples/wasm/fibonacci.wasm fib.dylib
-        echo "./build/tools/wasmedge/wasmedge --reactor fib.dylib fib 20"
-        ./build/tools/wasmedge/wasmedge --reactor fib.dylib fib 20
-    - name: Upload artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: WasmEdge-${{ needs.get_version_v2.outputs.version }}-${{ matrix.darwin_version }}_x86_64.tar.gz
-        path: build/WasmEdge-${{ needs.get_version_v2.outputs.version }}-Darwin.tar.gz
 
   build_windows:
     name: Windows Server 2022

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,12 @@ jobs:
       legacy: false
       matrix: "[{'runner':'ubuntu-latest','docker_tag':'manylinux2014_x86_64'},{'runner':'ARM64','docker_tag':'manylinux2014_aarch64'}]"
 
+  build_on_windows:
+    needs: [get_version_v2, lint]
+    uses: ./.github/workflows/reusable-build-on-windows.yml
+    with:
+      version: ${{ needs.get_version_v2.outputs.version }}
+
   build_fedora:
     name: Fedora 35
     needs: get_version_v2
@@ -256,72 +262,6 @@ jobs:
         name: codecov-wasmedge
         fail_ci_if_error: true
         path_to_write_report: ./build/codecov_report.gz
-
-  build_windows:
-    name: Windows Server 2022
-    runs-on: windows-2022
-    needs: get_version_v2
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Install dependency
-      uses: crazy-max/ghaction-chocolatey@v1
-      with:
-        args: install cmake ninja vswhere
-    - uses: GuillaumeFalourd/setup-windows10-sdk-action@v1
-      with:
-        sdk-version: 19041
-    - name: Build WasmEdge
-      run: |
-        $vsPath = (vswhere -latest -property installationPath)
-        Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
-        Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
-        $llvm = "LLVM-13.0.1-win64.zip"
-        curl -sLO https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-13.0.1/LLVM-13.0.1-win64.zip -o $llvm
-        Expand-Archive -Path $llvm
-        $llvm_dir = "$pwd\\LLVM-13.0.1-win64\\LLVM-13.0.1-win64\\lib\\cmake\\llvm"
-        $Env:CC = "clang-cl"
-        $Env:CXX = "clang-cl"
-        $cmake_sys_version = "10.0.19041.0"
-        cmake -Bbuild -GNinja "-DCMAKE_SYSTEM_VERSION=$cmake_sys_version" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL "-DLLVM_DIR=$llvm_dir" -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_PACKAGE="ZIP" .
-        cmake --build build
-    - name: Test WasmEdge
-      continue-on-error: true
-      run: |
-        $vsPath = (vswhere -latest -property installationPath)
-        Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
-        Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
-        $Env:PATH += ";$pwd\\build\\lib\\api"
-        cd build
-        tools\wasmedge\wasmedge -v
-        ctest
-        cd -
-    - name: Test WasmEdge Package
-      run: |
-        $vsPath = (vswhere -latest -property installationPath)
-        Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
-        Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
-        cmake --build build --target package
-    - name: Check artifact
-      run: |
-        Get-ChildItem -Path "$pwd\\build"
-    - name: Upload artifact (v2)
-      uses: actions/upload-artifact@v2
-      with:
-        name: WasmEdge-${{ needs.get_version_v2.outputs.version }}-windows.zip
-        path: build\\WasmEdge-${{ needs.get_version_v2.outputs.version }}-Windows.zip
-    - name: Package Windows Installer
-      run: |
-        $Env:product_version = ("${{ needs.get_version_v2.outputs.version }}").split("-")[0]
-        . "$Env:WIX\bin\candle.exe" -arch x64 -o build\wasmedge.wixobj .github\scripts\wasmedge.wxs
-        . "$Env:WIX\bin\light.exe" -out build\WasmEdge-$Env:product_version-windows.msi build\wasmedge.wixobj
-        echo "product_version=$Env:product_version" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-    - name: Upload Windows Installer
-      uses: actions/upload-artifact@v2
-      with:
-        name: WasmEdge-${{ env.product_version }}-windows.msi
-        path: build\\WasmEdge-${{ env.product_version }}-windows.msi
 
   build_android:
     name: Android

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,81 +119,17 @@ jobs:
     with:
       version: ${{ needs.get_version_v2.outputs.version }}
 
-  build_fedora:
-    name: Fedora 35
-    needs: get_version_v2
-    runs-on: ubuntu-latest
-    container:
-      image: fedora:latest
-    steps:
-    - name: Install requirements
-      run: |
-        dnf update -y
-        dnf install -y cmake ninja-build boost llvm llvm-devel lld-devel clang git file rpm-build dpkg-dev
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Build WasmEdge with Release mode
-      run: |
-        git config --global --add safe.directory $(pwd)
-        cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_PACKAGE="TGZ;DEB;RPM" .
-        cmake --build build
-    - name: Test WasmEdge
-      run: |
-        export LD_LIBRARY_PATH="$(pwd)/build/lib/api:$LD_LIBRARY_PATH"
-        cd build
-        ./tools/wasmedge/wasmedge -v
-        ctest
-        cd -
-    - name: Test WasmEdge Package
-      run: |
-        cmake --build build --target package
-    - name: Upload artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: WasmEdge-${{ needs.get_version_v2.outputs.version }}-fedora35.tar.gz
-        path: build/WasmEdge-${{ needs.get_version_v2.outputs.version }}-Linux.tar.gz
+  build_on_fedora:
+    needs: [get_version_v2, lint]
+    uses: ./.github/workflows/reusable-build-on-fedora.yml
+    with:
+      version: ${{ needs.get_version_v2.outputs.version }}
 
   build_fedora_srpm:
-    name: Fedora SRPM
-    needs: [get_version_v2, create_source_tarball]
-    runs-on: ubuntu-latest
-    container:
-      image: fedora:rawhide
-    steps:
-    - name: Install requirements
-      run: |
-        dnf update -y
-        dnf install -y git gcc-c++ cmake ninja-build boost-devel spdlog-devel llvm-devel lld-devel rpm-build
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Prepare source tarball for SRPM
-      uses: actions/download-artifact@v3
-      with:
-        name: WasmEdge-${{ needs.get_version_v2.outputs.version }}-src.tar.gz
-        path: /github/home/rpmbuild/SOURCES
-    - name: Rename source tarball
-      working-directory: /github/home/rpmbuild/SOURCES
-      run: |
-        mv WasmEdge-${{ needs.get_version_v2.outputs.version }}.tar.gz WasmEdge-${{ needs.get_version_v2.outputs.version }}-src.tar.gz
-    - name: Prepare SRPM version
-      run: |
-        GIT_TAG=${{ needs.get_version_v2.outputs.version }}
-        SRPM_VERSION=$(echo $GIT_TAG | tr '-' '~')
-        echo "srpm_version=$SRPM_VERSION" >> $GITHUB_ENV
-    - name: Build WasmEdge SRPM
-      run: |
-        git config --global --add safe.directory $(pwd)
-        mkdir -p build
-        cd build
-        cmake ..
-        rpmbuild -ba rpm/wasmedge.spec
-    - name: Upload artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: WasmEdge-${{ env.srpm_version }}-1.fc37.src.rpm
-        path: /github/home/rpmbuild/SRPMS/wasmedge-${{ env.srpm_version }}-1.fc37.src.rpm
+    needs: [get_version_v2, create_source_tarball, lint]
+    uses: ./.github/workflows/reusable-build-srpm.yml
+    with:
+      version: ${{ needs.get_version_v2.outputs.version }}
 
   build_ubuntu:
     needs: lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,22 @@ jobs:
       version: ${{ needs.get_version_v2.outputs.version }}
       matrix: "[{'name':'MacOS 11 (x86_64)','runner':'macos-11','darwin_version':20},{'name':'MacOS 12 (x86_64)','runner':'macos-12','darwin_version':21}]"
 
+  build_on_manylinux_legacy:
+    needs: [get_version_v1, lint]
+    uses: ./.github/workflows/reusable-build-on-manylinux.yml
+    with:
+      version: ${{ needs.get_version_v1.outputs.version }}
+      legacy: true
+      matrix: "[{'runner':'ubuntu-latest','docker_tag':'manylinux2010_x86_64'},{'runner':'ubuntu-latest','docker_tag':'manylinux1_x86_64'}]"
+
+  build_on_manylinux_2014:
+    needs: [get_version_v2, lint]
+    uses: ./.github/workflows/reusable-build-on-manylinux.yml
+    with:
+      version: ${{ needs.get_version_v2.outputs.version }}
+      legacy: false
+      matrix: "[{'runner':'ubuntu-latest','docker_tag':'manylinux2014_x86_64'},{'runner':'ARM64','docker_tag':'manylinux2014_aarch64'}]"
+
   build_fedora:
     name: Fedora 35
     needs: get_version_v2
@@ -240,55 +256,6 @@ jobs:
         name: codecov-wasmedge
         fail_ci_if_error: true
         path_to_write_report: ./build/codecov_report.gz
-
-  build_manylinux:
-    strategy:
-      matrix:
-        include:
-          - name: manylinux2014 x86_64
-            host_runner: ubuntu-latest
-            docker_tag: manylinux2014_x86_64
-            checkout_version: v2
-          - name: manylinux2010 x86_64
-            host_runner: ubuntu-latest
-            docker_tag: manylinux2010_x86_64
-            checkout_version: v1
-          - name: manylinux1 x86_64
-            host_runner: ubuntu-latest
-            docker_tag: manylinux1_x86_64
-            checkout_version: v1
-          - name: manylinux2014 aarch64
-            host_runner: ARM64
-            docker_tag: manylinux2014_aarch64
-            checkout_version: v2
-    name: ${{ matrix.name }} platform
-    runs-on: ${{ matrix.host_runner }}
-    needs: [get_version_v1, get_version_v2]
-    container:
-      image: wasmedge/wasmedge:${{ matrix.docker_tag }}
-    steps:
-    - uses: actions/checkout@v1
-      if: ${{ matrix.checkout_version == 'v1' }}
-    - uses: actions/checkout@v2
-      if: ${{ matrix.checkout_version == 'v2' }}
-      with:
-        fetch-depth: 0
-    - name: Build ${{ matrix.name }} package
-      run: |
-        bash utils/docker/build-manylinux.sh
-        ./build/tools/wasmedge/wasmedge -v
-    - name: Upload artifact (v1)
-      uses: actions/upload-artifact@v1
-      if: ${{ matrix.checkout_version == 'v1' }}
-      with:
-        name: WasmEdge-${{ needs.get_version_v1.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
-        path: build/WasmEdge-${{ needs.get_version_v1.outputs.version }}-Linux.tar.gz
-    - name: Upload artifact (v2)
-      uses: actions/upload-artifact@v2
-      if: ${{ matrix.checkout_version == 'v2' }}
-      with:
-        name: WasmEdge-${{ needs.get_version_v2.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
-        path: build/WasmEdge-${{ needs.get_version_v2.outputs.version }}-Linux.tar.gz
 
   build_windows:
     name: Windows Server 2022

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,34 +79,10 @@ jobs:
         echo ::set-output name=version::$(git describe --match "[0-9].[0-9]*" --tag)
 
   create_source_tarball:
-    name: Create source tarball
-    runs-on: ubuntu-latest
-    needs: get_version_v2
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Propagate version information for tarball
-      run: |
-        echo -n $VERSION | tee VERSION
-      env:
-        VERSION: ${{ needs.get_version_v2.outputs.version }}
-    - name: Create source tarball
-      run: |
-        echo "Get version: $VERSION"
-        TEMPDIR=$(mktemp -d)
-        SRCDIR="$TEMPDIR/wasmedge/"
-        mkdir -p "$SRCDIR"
-        git checkout-index -a --prefix="$SRCDIR"
-        cp -v VERSION $SRCDIR
-        tar --owner 0 --group 0 -czf "$GITHUB_WORKSPACE/WasmEdge-$VERSION.tar.gz" -C "$TEMPDIR" "wasmedge"
-      env:
-        VERSION: ${{ needs.get_version_v2.outputs.version }}
-    - name: Upload artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: WasmEdge-${{ needs.get_version_v2.outputs.version }}-src.tar.gz
-        path: WasmEdge-${{ needs.get_version_v2.outputs.version }}.tar.gz
+    needs: [get_version_v2, lint]
+    uses: ./.github/workflows/reusable-create-source-tarball.yml
+    with:
+      version: ${{ needs.get_version_v2.outputs.version }}
 
   build_fedora:
     name: Fedora 35

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ on:
   pull_request:
     branches:
       - master
-      - 'proposal/**'
+      - "proposal/**"
     paths:
       - ".github/workflows/build.yml"
       - "include/**"
@@ -50,16 +50,16 @@ jobs:
     outputs:
       version: ${{ steps.prep.outputs.version }}
     steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 0
-    - name: Get version
-      id: prep
-      run: |
-        # Retrieve annotated tags. Details: https://github.com/actions/checkout/issues/290
-        git fetch --tags --force
-        echo "Set version: $(git describe --match "[0-9].[0-9]*" --tag)"
-        echo ::set-output name=version::$(git describe --match "[0-9].[0-9]*" --tag)
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 0
+      - name: Get version
+        id: prep
+        run: |
+          # Retrieve annotated tags. Details: https://github.com/actions/checkout/issues/290
+          git fetch --tags --force
+          echo "Set version: $(git describe --match "[0-9].[0-9]*" --tag)"
+          echo ::set-output name=version::$(git describe --match "[0-9].[0-9]*" --tag)
   get_version_v2:
     needs: lint
     name: Retrieve version information (v2)
@@ -67,16 +67,16 @@ jobs:
     outputs:
       version: ${{ steps.prep.outputs.version }}
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Get version
-      id: prep
-      run: |
-        # Retrieve annotated tags. Details: https://github.com/actions/checkout/issues/290
-        git fetch --tags --force
-        echo "Set version: $(git describe --match "[0-9].[0-9]*" --tag)"
-        echo ::set-output name=version::$(git describe --match "[0-9].[0-9]*" --tag)
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get version
+        id: prep
+        run: |
+          # Retrieve annotated tags. Details: https://github.com/actions/checkout/issues/290
+          git fetch --tags --force
+          echo "Set version: $(git describe --match "[0-9].[0-9]*" --tag)"
+          echo ::set-output name=version::$(git describe --match "[0-9].[0-9]*" --tag)
 
   create_source_tarball:
     needs: [get_version_v2, lint]
@@ -166,41 +166,41 @@ jobs:
     container:
       image: wasmedge/wasmedge:${{ matrix.docker_tag }}
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Build WasmEdge using ${{ matrix.compiler }} with ${{ matrix.build_type }} mode
-      if: ${{ ! matrix.coverage }}
-      env:
-        CMAKE_BUILD_TYPE: ${{ matrix.build_type }}
-      run: |
-        git config --global --add safe.directory $(pwd)
-        cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DWASMEDGE_BUILD_TESTS=ON .
-        cmake --build build
-    - name: Test WasmEdge
-      if: ${{ ! matrix.coverage }}
-      run: |
-        export LD_LIBRARY_PATH="$(pwd)/build/lib/api:$LD_LIBRARY_PATH"
-        cd build
-        ./tools/wasmedge/wasmedge -v
-        ctest
-        cd -
-    - name: Build WasmEdge using ${{ matrix.compiler }} with Coverage mode
-      if: ${{ matrix.coverage }}
-      run: |
-        apt update
-        apt install -y gcovr
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --target wasm32-wasi
-        git config --global --add safe.directory $(pwd)
-        cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_COVERAGE=ON .
-        cmake --build build
-        LD_LIBRARY_PATH=$(pwd)/build/lib/api cmake --build build --target codecov
-    - name: Create and upload coverage report to Codecov
-      if: ${{ matrix.coverage }}
-      uses: codecov/codecov-action@v2
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./build/codecov.xml
-        name: codecov-wasmedge
-        fail_ci_if_error: true
-        path_to_write_report: ./build/codecov_report.gz
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Build WasmEdge using ${{ matrix.compiler }} with ${{ matrix.build_type }} mode
+        if: ${{ ! matrix.coverage }}
+        env:
+          CMAKE_BUILD_TYPE: ${{ matrix.build_type }}
+        run: |
+          git config --global --add safe.directory $(pwd)
+          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DWASMEDGE_BUILD_TESTS=ON .
+          cmake --build build
+      - name: Test WasmEdge
+        if: ${{ ! matrix.coverage }}
+        run: |
+          export LD_LIBRARY_PATH="$(pwd)/build/lib/api:$LD_LIBRARY_PATH"
+          cd build
+          ./tools/wasmedge/wasmedge -v
+          ctest
+          cd -
+      - name: Build WasmEdge using ${{ matrix.compiler }} with Coverage mode
+        if: ${{ matrix.coverage }}
+        run: |
+          apt update
+          apt install -y gcovr
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --target wasm32-wasi
+          git config --global --add safe.directory $(pwd)
+          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_COVERAGE=ON .
+          cmake --build build
+          LD_LIBRARY_PATH=$(pwd)/build/lib/api cmake --build build --target codecov
+      - name: Create and upload coverage report to Codecov
+        if: ${{ matrix.coverage }}
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./build/codecov.xml
+          name: codecov-wasmedge
+          fail_ci_if_error: true
+          path_to_write_report: ./build/codecov_report.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
     with:
       version: ${{ needs.get_version_v2.outputs.version }}
 
-  build_ubuntu:
+  build_coverage_check:
     needs: lint
     strategy:
       matrix:
@@ -161,7 +161,7 @@ jobs:
             docker_tag: ubuntu-build-gcc
             build_type: Debug
             coverage: true
-    name: Ubuntu 20.04 with ${{ matrix.name }}
+    name: Build on Ubuntu with ${{ matrix.name }}
     runs-on: ubuntu-latest
     container:
       image: wasmedge/wasmedge:${{ matrix.docker_tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,12 @@ jobs:
     with:
       version: ${{ needs.get_version_v2.outputs.version }}
 
+  build_on_android:
+    needs: [get_version_v2, lint]
+    uses: ./.github/workflows/reusable-build-on-android.yml
+    with:
+      version: ${{ needs.get_version_v2.outputs.version }}
+
   build_fedora:
     name: Fedora 35
     needs: get_version_v2
@@ -262,37 +268,3 @@ jobs:
         name: codecov-wasmedge
         fail_ci_if_error: true
         path_to_write_report: ./build/codecov_report.gz
-
-  build_android:
-    name: Android
-    runs-on: ubuntu-latest
-    needs: get_version_v2
-    container:
-      image: wasmedge/wasmedge:latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Install dependency
-      run: |
-        apt update && apt install -y unzip
-        apt remove -y cmake
-        curl -sLO https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2-linux-x86_64.tar.gz
-        tar -zxf cmake-3.22.2-linux-x86_64.tar.gz
-        cp -r cmake-3.22.2-linux-x86_64/bin /usr/local
-        cp -r cmake-3.22.2-linux-x86_64/share /usr/local
-        curl -sLO https://dl.google.com/android/repository/android-ndk-r23b-linux.zip
-        unzip -q android-ndk-r23b-linux.zip
-    - name: Build WasmEdge for Android
-      run: |
-        git config --global --add safe.directory $(pwd)
-        export ANDROID_NDK_HOME=$(pwd)/android-ndk-r23b/
-        cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_PACKAGE="TGZ" -DWASMEDGE_BUILD_AOT_RUNTIME=OFF -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=23 -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a -DCMAKE_ANDROID_NDK=$ANDROID_NDK_HOME -DCMAKE_ANDROID_STL_TYPE=c++_static
-        cmake --build build
-        cmake --build build --target package
-    - name: Upload artifact (v2)
-      uses: actions/upload-artifact@v2
-      with:
-        name: WasmEdge-${{ needs.get_version_v2.outputs.version }}-android_aarch64.tar.gz
-        path: build/WasmEdge-${{ needs.get_version_v2.outputs.version }}-Android.tar.gz
-        

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,42 +47,13 @@ jobs:
           prerelease: true
 
   create_source_tarball:
-    name: Create source tarball
-    runs-on: ubuntu-latest
     needs: create_release
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Propagate version information for tarball
-      run: |
-        echo -n $VERSION | tee VERSION
-      env:
-        VERSION: ${{ needs.create_release.outputs.version }}
-    - name: Create source tarball
-      run: |
-        TEMPDIR=$(mktemp -d)
-        SRCDIR="$TEMPDIR/wasmedge/"
-        mkdir -p "$SRCDIR"
-        git checkout-index -a --prefix="$SRCDIR"
-        cp -v VERSION $SRCDIR
-        tar --owner 0 --group 0 -czf "$GITHUB_WORKSPACE/WasmEdge-$VERSION.tar.gz" -C "$TEMPDIR" "wasmedge"
-      env:
-        VERSION: ${{ needs.create_release.outputs.version }}
-    - name: Upload artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: WasmEdge-${{ needs.create_release.outputs.version }}-src.tar.gz
-        path: WasmEdge-${{ needs.create_release.outputs.version }}.tar.gz
-    - name: Upload source tarball
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create_release.outputs.upload_url }}
-        asset_name: WasmEdge-${{ needs.create_release.outputs.version }}-src.tar.gz
-        asset_path: WasmEdge-${{ needs.create_release.outputs.version }}.tar.gz
-        asset_content_type: application/x-gzip
+    uses: ./.github/workflows/reusable-create-source-tarball.yml
+    with:
+      version: ${{ needs.create_release.outputs.version }}
+      release: true
+      upload_asset_url: ${{ needs.create_release.outputs.upload_url }}
+    secrets: inherit
 
   build_on_macos:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,39 +56,14 @@ jobs:
     secrets: inherit
 
   build_on_macos:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: macos x86_64
-            os: darwin
-    name: Build and upload WasmEdge on ${{ matrix.name }} platform
     needs: create_release
-    runs-on: macos-11
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Build package
-        run: |
-          brew install llvm ninja boost cmake
-          export PATH="/usr/local/opt/llvm/bin:$PATH"
-          export LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
-          export CPPFLAGS="-I/usr/local/opt/llvm/include"
-          export CC=clang
-          export CXX=clang++
-          rm -rf build
-          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_LINK_TOOLS_STATIC=ON -DWASMEDGE_BUILD_PACKAGE="TGZ" .
-          cmake --build build
-          cmake --build build --target package
-      - name: Upload tar.gz package
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: build/WasmEdge-${{ needs.create_release.outputs.version }}-Darwin.tar.gz
-          asset_name: WasmEdge-${{ needs.create_release.outputs.version }}-${{ matrix.os }}_x86_64.tar.gz
-          asset_content_type: application/x-gzip
+    uses: ./.github/workflows/reusable-build-on-macos.yml
+    with:
+      version: ${{ needs.create_release.outputs.version }}
+      matrix: "[{'name':'MacOS 11 (x86_64)','runner':'macos-11','darwin_version':20}]"
+      release: true
+      upload_asset_url: ${{ needs.create_release.outputs.upload_url }}
+    secrets: inherit
 
   build_on_manylinux_legacy:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,15 @@ jobs:
       upload_asset_url: ${{ needs.create_release.outputs.upload_url }}
     secrets: inherit
 
+  build_on_windows:
+    needs: create_release
+    uses: ./.github/workflows/reusable-build-on-windows.yml
+    with:
+      version: ${{ needs.create_release.outputs.version }}
+      release: true
+      upload_asset_url: ${{ needs.create_release.outputs.upload_url }}
+    secrets: inherit
+
   build_and_upload_plugin_ubuntu:
     strategy:
       matrix:
@@ -193,64 +202,6 @@ jobs:
           asset_path: plugin.tar.gz
           asset_name: WasmEdge-plugin-${{ matrix.tar_name }}-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
           asset_content_type: application/x-gzip
-
-  build_windows:
-    name: Windows server 2022
-    runs-on: windows-2022
-    needs: create_release
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Install dependency
-      uses: crazy-max/ghaction-chocolatey@v1
-      with:
-        args: install cmake ninja vswhere
-    - uses: GuillaumeFalourd/setup-windows10-sdk-action@v1
-      with:
-        sdk-version: 19041
-    - name: Build WasmEdge
-      run: |
-        $vsPath = (vswhere -latest -property installationPath)
-        Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
-        Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
-        $llvm = "LLVM-13.0.1-win64.zip"
-        curl -sLO https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-13.0.1/LLVM-13.0.1-win64.zip -o $llvm
-        Expand-Archive -Path $llvm
-        $llvm_dir = "$pwd\\LLVM-13.0.1-win64\\LLVM-13.0.1-win64\\lib\\cmake\\llvm"
-        $Env:CC = "clang-cl"
-        $Env:CXX = "clang-cl"
-        cmake -Bbuild -GNinja -DCMAKE_SYSTEM_VERSION=10.0.19041.0 -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL "-DLLVM_DIR=$llvm_dir" -DWASMEDGE_BUILD_PACKAGE="ZIP" .
-        cmake --build build
-    - name: Create WasmEdge Package
-      run: |
-        $vsPath = (vswhere -latest -property installationPath)
-        Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
-        Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
-        cmake --build build --target package
-    - name: Upload Windows 10 zip package
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create_release.outputs.upload_url }}
-        asset_path: build\\WasmEdge-${{ needs.create_release.outputs.version }}-Windows.zip
-        asset_name: WasmEdge-${{ needs.create_release.outputs.version }}-windows.zip
-        asset_content_type: application/zip
-    - name: Package Windows Installer
-      run: |
-        $Env:product_version = ("${{ needs.create_release.outputs.version }}").split("-")[0]
-        . "$Env:WIX\bin\candle.exe" -arch x64 -o build\wasmedge.wixobj .github\scripts\wasmedge.wxs
-        . "$Env:WIX\bin\light.exe" -out build\WasmEdge-${{ needs.create_release.outputs.version }}-windows.msi build\wasmedge.wixobj
-    - name: Upload Windows Installer
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create_release.outputs.upload_url }}
-        asset_path: build\\WasmEdge-${{ needs.create_release.outputs.version }}-windows.msi
-        asset_name: WasmEdge-${{ needs.create_release.outputs.version }}-windows.msi
-        asset_content_type: application/octet-stream
 
   build_android:
     name: Android

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       logLevel:
-        description: 'Log level'
+        description: "Log level"
         required: true
-        default: 'info'
+        default: "info"
   push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+*"
@@ -251,48 +251,49 @@ jobs:
             artifact_name: build_manylinux2014_runtime_only
             include_bin: "--include-bin /usr/local/bin/wasmedge"
     name: Build DockerSlim Images
-    needs: [create_release, build_on_manylinux2014, build_manylinux2014_runtime_only]
+    needs:
+      [create_release, build_on_manylinux2014, build_manylinux2014_runtime_only]
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Prepare tarball
-      uses: actions/download-artifact@v3
-      with:
-        name: ${{ matrix.artifact_name }}
-        path: utils/docker
-    - name: Install requirements
-      run: |
-        curl -sL https://raw.githubusercontent.com/docker-slim/docker-slim/master/scripts/install-dockerslim.sh | sudo -E bash -
-    - name: Prepare docker env
-      id: docker_env
-      run: |
-        echo ::set-output name=docker_image::wasmedge/wasmedge:${{ matrix.name }}
-        echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Login to DockerHub
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-    - name: Run docker-slim
-      run: |
-        docker-slim build \
-          --dockerfile Dockerfile.release \
-          --dockerfile-context utils/docker \
-          --tag ${{ steps.docker_env.outputs.docker_image }} \
-          --http-probe-off \
-          ${{ matrix.include_bin }} \
-          --cbo-build-arg VERSION="${{ needs.create_release.outputs.version }}" \
-          --cbo-label org.opencontainers.image.title="${{ github.event.repository.name }}" \
-          --cbo-label org.opencontainers.image.description="${{ github.event.repository.description }}" \
-          --cbo-label org.opencontainers.image.url="${{ github.event.repository.html_url }}" \
-          --cbo-label org.opencontainers.image.source="${{ github.event.repository.clone_url }}" \
-          --cbo-label org.opencontainers.image.version="${{ needs.create_release.outputs.version }}" \
-          --cbo-label org.opencontainers.image.created="${{ steps.docker_env.outputs.created }}" \
-          --cbo-label org.opencontainers.image.revision="${{ github.sha }}" \
-          --cbo-label org.opencontainers.image.licenses="${{ github.event.repository.license.spdx_id }}"
-    - name: Push to DockerHub
-      run: |
-        docker push ${{ steps.docker_env.outputs.docker_image }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Prepare tarball
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: utils/docker
+      - name: Install requirements
+        run: |
+          curl -sL https://raw.githubusercontent.com/docker-slim/docker-slim/master/scripts/install-dockerslim.sh | sudo -E bash -
+      - name: Prepare docker env
+        id: docker_env
+        run: |
+          echo ::set-output name=docker_image::wasmedge/wasmedge:${{ matrix.name }}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+      - name: Run docker-slim
+        run: |
+          docker-slim build \
+            --dockerfile Dockerfile.release \
+            --dockerfile-context utils/docker \
+            --tag ${{ steps.docker_env.outputs.docker_image }} \
+            --http-probe-off \
+            ${{ matrix.include_bin }} \
+            --cbo-build-arg VERSION="${{ needs.create_release.outputs.version }}" \
+            --cbo-label org.opencontainers.image.title="${{ github.event.repository.name }}" \
+            --cbo-label org.opencontainers.image.description="${{ github.event.repository.description }}" \
+            --cbo-label org.opencontainers.image.url="${{ github.event.repository.html_url }}" \
+            --cbo-label org.opencontainers.image.source="${{ github.event.repository.clone_url }}" \
+            --cbo-label org.opencontainers.image.version="${{ needs.create_release.outputs.version }}" \
+            --cbo-label org.opencontainers.image.created="${{ steps.docker_env.outputs.created }}" \
+            --cbo-label org.opencontainers.image.revision="${{ github.sha }}" \
+            --cbo-label org.opencontainers.image.licenses="${{ github.event.repository.license.spdx_id }}"
+      - name: Push to DockerHub
+        run: |
+          docker push ${{ steps.docker_env.outputs.docker_image }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,143 +66,26 @@ jobs:
     secrets: inherit
 
   build_on_manylinux_legacy:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: manylinux1_x86_64
-            docker_tag: manylinux1_x86_64
-          - name: manylinux2010_x86_64
-            docker_tag: manylinux2010_x86_64
-    name: Build on ${{ matrix.name }} platform
     needs: create_release
-    runs-on: ubuntu-latest
-    container:
-      image: wasmedge/wasmedge:${{ matrix.docker_tag }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v1
-      - name: Build ${{ matrix.name }} package
-        run: |
-          bash utils/docker/build-manylinux.sh
-      - name: Upload ${{ matrix.name }} rpm package to artifact
-        uses: actions/upload-artifact@v1
-        with:
-          name: WasmEdge-${{ needs.create_release.outputs.version }}-${{ matrix.name }}.rpm
-          path: build/WasmEdge-${{ needs.create_release.outputs.version }}-Linux.rpm
-      - name: Upload ${{ matrix.name }} tar.gz package to artifact
-        uses: actions/upload-artifact@v1
-        with:
-          name: WasmEdge-${{ needs.create_release.outputs.version }}-${{ matrix.name }}.tar.gz
-          path: build/WasmEdge-${{ needs.create_release.outputs.version }}-Linux.tar.gz
-      - name: Upload ${{ matrix.name }} tar.xz package to artifact
-        uses: actions/upload-artifact@v1
-        with:
-          name: WasmEdge-${{ needs.create_release.outputs.version }}-${{ matrix.name }}.tar.xz
-          path: build/WasmEdge-${{ needs.create_release.outputs.version }}-Linux.tar.xz
+    uses: ./.github/workflows/reusable-build-on-manylinux.yml
+    with:
+      version: ${{ needs.create_release.outputs.version }}
+      legacy: true
+      matrix: "[{'runner':'ubuntu-latest','docker_tag':'manylinux2010_x86_64'},{'runner':'ubuntu-latest','docker_tag':'manylinux1_x86_64'}]"
+      release: true
+      upload_asset_url: ${{ needs.create_release.outputs.upload_url }}
+    secrets: inherit
 
   build_on_manylinux2014:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: manylinux2014_x86_64
-            docker_tag: manylinux2014_x86_64
-            host_runner: ubuntu-latest
-          - name: manylinux2014_aarch64
-            docker_tag: manylinux2014_aarch64
-            host_runner: ARM64
-    name: Build on ${{ matrix.name }} platform
     needs: create_release
-    runs-on: ${{ matrix.host_runner }}
-    container:
-      image: wasmedge/wasmedge:${{ matrix.docker_tag }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Build ${{ matrix.name }} package
-        run: |
-          bash utils/docker/build-manylinux.sh
-      - name: Upload ${{ matrix.name }} rpm package to artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: WasmEdge-${{ needs.create_release.outputs.version }}-${{ matrix.name }}.rpm
-          path: build/WasmEdge-${{ needs.create_release.outputs.version }}-Linux.rpm
-      - name: Upload ${{ matrix.name }} tar.gz package to artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: WasmEdge-${{ needs.create_release.outputs.version }}-${{ matrix.name }}.tar.gz
-          path: build/WasmEdge-${{ needs.create_release.outputs.version }}-Linux.tar.gz
-      - name: Upload ${{ matrix.name }} tar.xz package to artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: WasmEdge-${{ needs.create_release.outputs.version }}-${{ matrix.name }}.tar.xz
-          path: build/WasmEdge-${{ needs.create_release.outputs.version }}-Linux.tar.xz
-
-  upload_manylinux:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: manylinux1_x86_64
-          - name: manylinux2010_x86_64
-          - name: manylinux2014_x86_64
-          - name: manylinux2014_aarch64
-    name: Upload WasmEdge ${{ matrix.name }} package
-    needs: [create_release, build_on_manylinux_legacy, build_on_manylinux2014]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Download ${{ matrix.name }} rpm artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: WasmEdge-${{ needs.create_release.outputs.version }}-${{ matrix.name }}.rpm
-      - name: Verify the arifact
-        run: |
-          ls -alh .
-          ls -alh WasmEdge-${{ needs.create_release.outputs.version }}-${{ matrix.name }}.rpm
-      - name: Upload ${{ matrix.name }} rpm package
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: WasmEdge-${{ needs.create_release.outputs.version }}-${{ matrix.name }}.rpm/WasmEdge-${{ needs.create_release.outputs.version }}-Linux.rpm
-          asset_name: WasmEdge-${{ needs.create_release.outputs.version }}-${{ matrix.name }}.rpm
-          asset_content_type: application/x-rpm
-      - name: Download ${{ matrix.name }} tar.gz artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: WasmEdge-${{ needs.create_release.outputs.version }}-${{ matrix.name }}.tar.gz
-      - name: Sleep 5 second to avoid GitHub ECONNRESET error
-        run: |
-          sleep 5
-      - name: Upload ${{ matrix.name }} tar.gz package
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: WasmEdge-${{ needs.create_release.outputs.version }}-${{ matrix.name }}.tar.gz/WasmEdge-${{ needs.create_release.outputs.version }}-Linux.tar.gz
-          asset_name: WasmEdge-${{ needs.create_release.outputs.version }}-${{ matrix.name }}.tar.gz
-          asset_content_type: application/x-gzip
-      - name: Download ${{ matrix.name }} tar.xz artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: WasmEdge-${{ needs.create_release.outputs.version }}-${{ matrix.name }}.tar.xz
-      - name: Sleep 5 second to avoid GitHub ECONNRESET error
-        run: |
-          sleep 5
-      - name: Upload ${{ matrix.name }} tar.xz package
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: WasmEdge-${{ needs.create_release.outputs.version }}-${{ matrix.name }}.tar.xz/WasmEdge-${{ needs.create_release.outputs.version }}-Linux.tar.xz
-          asset_name: WasmEdge-${{ needs.create_release.outputs.version }}-${{ matrix.name }}.tar.xz
-          asset_content_type: application/x-xz
+    uses: ./.github/workflows/reusable-build-on-manylinux.yml
+    with:
+      version: ${{ needs.create_release.outputs.version }}
+      legacy: false
+      matrix: "[{'runner':'ubuntu-latest','docker_tag':'manylinux2014_x86_64'},{'runner':'ARM64','docker_tag':'manylinux2014_aarch64'}]"
+      release: true
+      upload_asset_url: ${{ needs.create_release.outputs.upload_url }}
+    secrets: inherit
 
   build_and_upload_plugin_ubuntu:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,15 @@ jobs:
       upload_asset_url: ${{ needs.create_release.outputs.upload_url }}
     secrets: inherit
 
+  build_on_android:
+    needs: create_release
+    uses: ./.github/workflows/reusable-build-on-android.yml
+    with:
+      version: ${{ needs.create_release.outputs.version }}
+      release: true
+      upload_asset_url: ${{ needs.create_release.outputs.upload_url }}
+    secrets: inherit
+
   build_and_upload_plugin_ubuntu:
     strategy:
       matrix:
@@ -202,43 +211,6 @@ jobs:
           asset_path: plugin.tar.gz
           asset_name: WasmEdge-plugin-${{ matrix.tar_name }}-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
           asset_content_type: application/x-gzip
-
-  build_android:
-    name: Android
-    runs-on: ubuntu-latest
-    needs: create_release
-    container:
-      image: wasmedge/wasmedge:latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Install dependency
-      run: |
-        apt update && apt install -y unzip
-        apt remove -y cmake
-        curl -sLO https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2-linux-x86_64.tar.gz
-        tar -zxf cmake-3.22.2-linux-x86_64.tar.gz
-        cp -r cmake-3.22.2-linux-x86_64/bin /usr/local
-        cp -r cmake-3.22.2-linux-x86_64/share /usr/local
-        curl -sLO https://dl.google.com/android/repository/android-ndk-r23b-linux.zip
-        unzip -q android-ndk-r23b-linux.zip
-    - name: Build WasmEdge for Android
-      run: |
-        git config --global --add safe.directory $(pwd)
-        export ANDROID_NDK_HOME=$(pwd)/android-ndk-r23b/
-        cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_PACKAGE="TGZ" -DWASMEDGE_BUILD_AOT_RUNTIME=OFF -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=23 -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a -DCMAKE_ANDROID_NDK=$ANDROID_NDK_HOME -DCMAKE_ANDROID_STL_TYPE=c++_static
-        cmake --build build
-        cmake --build build --target package
-    - name: Upload tar.gz package
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create_release.outputs.upload_url }}
-        asset_path: build/WasmEdge-${{ needs.create_release.outputs.version }}-Android.tar.gz
-        asset_name: WasmEdge-${{ needs.create_release.outputs.version }}-android_aarch64.tar.gz
-        asset_content_type: application/x-gzip
 
   build_fedora_srpm:
     name: Build and upload WasmEdge Fedora SRPM

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,16 @@ jobs:
       upload_asset_url: ${{ needs.create_release.outputs.upload_url }}
     secrets: inherit
 
+  build_fedora_srpm:
+    needs: [create_release, create_source_tarball]
+    uses: ./.github/workflows/reusable-build-srpm.yml
+    with:
+      version: ${{ needs.create_release.outputs.version }}
+      artifact: ${{ needs.create_source_tarball.outputs.artifact }}
+      release: true
+      upload_asset_url: ${{ needs.create_release.outputs.upload_url }}
+    secrets: inherit
+
   build_and_upload_plugin_ubuntu:
     strategy:
       matrix:
@@ -211,63 +221,6 @@ jobs:
           asset_path: plugin.tar.gz
           asset_name: WasmEdge-plugin-${{ matrix.tar_name }}-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
           asset_content_type: application/x-gzip
-
-  build_fedora_srpm:
-    name: Build and upload WasmEdge Fedora SRPM
-    needs: [create_release, create_source_tarball]
-    runs-on: ubuntu-latest
-    container:
-      image: fedora:rawhide
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Install requirements
-      run: |
-        dnf update -y
-        dnf install -y git gcc-c++ cmake ninja-build boost-devel spdlog-devel llvm-devel lld-devel rpm-build
-    - name: Prepare source tarball for SRPM
-      uses: actions/download-artifact@v3
-      with:
-        name: WasmEdge-${{ needs.create_release.outputs.version }}-src.tar.gz
-        path: /github/home/rpmbuild/SOURCES
-    - name: Rename source tarball
-      working-directory: /github/home/rpmbuild/SOURCES
-      run: |
-        mv WasmEdge-${{ needs.create_release.outputs.version }}.tar.gz WasmEdge-${{ needs.create_release.outputs.version }}-src.tar.gz
-    - name: Prepare SRPM version
-      run: |
-        VERSION=${{ needs.create_release.outputs.version }}
-        SRPM_VERSION=$(echo $VERSION | tr '-' '~')
-        echo "srpm_version=$SRPM_VERSION" >> $GITHUB_ENV
-    - name: Build WasmEdge SRPM
-      run: |
-        git config --global --add safe.directory $(pwd)
-        echo -n ${{ needs.create_release.outputs.version }} | tee VERSION
-        mkdir -p build
-        cd build
-        cmake ..
-        rpmbuild -ba rpm/wasmedge.spec
-    - name: Upload Fedora spec file
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create_release.outputs.upload_url }}
-        asset_path: build/rpm/wasmedge.spec
-        asset_name: wasmedge.spec
-        asset_content_type: text/plain
-    - name: Sleep 5 second to avoid GitHub ECONNRESET error
-      run: |
-        sleep 5
-    - name: Upload Fedora SRPM
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create_release.outputs.upload_url }}
-        asset_path: /github/home/rpmbuild/SRPMS/wasmedge-${{ env.srpm_version }}-1.fc37.src.rpm
-        asset_name: wasmedge-${{ env.srpm_version }}-1.fc37.src.rpm
-        asset_content_type: application/x-rpm
 
   build_manylinux2014_runtime_only:
     name: Build runtime only on manylinux2014 platform

--- a/.github/workflows/reusable-build-on-android.yml
+++ b/.github/workflows/reusable-build-on-android.yml
@@ -1,0 +1,56 @@
+name: Build on Android
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+      release:
+        type: boolean
+      upload_asset_url:
+        type: string
+
+jobs:
+  build_on_android:
+    name: Build on Android
+    runs-on: ubuntu-latest
+    container:
+      image: wasmedge/wasmedge:latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install dependency
+        run: |
+          apt update && apt install -y unzip
+          apt remove -y cmake
+          curl -sLO https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2-linux-x86_64.tar.gz
+          tar -zxf cmake-3.22.2-linux-x86_64.tar.gz
+          cp -r cmake-3.22.2-linux-x86_64/bin /usr/local
+          cp -r cmake-3.22.2-linux-x86_64/share /usr/local
+          curl -sLO https://dl.google.com/android/repository/android-ndk-r23b-linux.zip
+          unzip -q android-ndk-r23b-linux.zip
+      - name: Build WasmEdge
+        run: |
+          git config --global --add safe.directory $(pwd)
+          export ANDROID_NDK_HOME=$(pwd)/android-ndk-r23b/
+          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_PACKAGE="TGZ" -DWASMEDGE_BUILD_AOT_RUNTIME=OFF -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=23 -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a -DCMAKE_ANDROID_NDK=$ANDROID_NDK_HOME -DCMAKE_ANDROID_STL_TYPE=c++_static
+          cmake --build build
+          cmake --build build --target package
+      - name: Upload artifact
+        if: ${{ !inputs.release }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: WasmEdge-${{ inputs.version }}-android_aarch64.tar.gz
+          path: build/WasmEdge-${{ inputs.version }}-Android.tar.gz
+      - name: Upload tar.gz package
+        if: ${{ inputs.release }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_asset_url }}
+          asset_name: WasmEdge-${{ inputs.version }}-android_aarch64.tar.gz
+          asset_path: build/WasmEdge-${{ inputs.version }}-Android.tar.gz
+          asset_content_type: application/x-gzip

--- a/.github/workflows/reusable-build-on-fedora.yml
+++ b/.github/workflows/reusable-build-on-fedora.yml
@@ -1,0 +1,48 @@
+name: Build on Fedora
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+      release:
+        type: boolean
+      upload_asset_url:
+        type: string
+
+jobs:
+  build_fedora:
+    name: Fedora 35
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+    steps:
+      - name: Install dependency
+        run: |
+          dnf update -y
+          dnf install -y cmake ninja-build boost llvm llvm-devel lld-devel clang git file rpm-build dpkg-dev
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Build WasmEdge
+        run: |
+          git config --global --add safe.directory $(pwd)
+          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_PACKAGE="TGZ;DEB;RPM" .
+          cmake --build build
+      - name: Test WasmEdge
+        run: |
+          export LD_LIBRARY_PATH="$(pwd)/build/lib/api:$LD_LIBRARY_PATH"
+          cd build
+          ./tools/wasmedge/wasmedge -v
+          ctest
+          cd -
+      - name: Create package tarball
+        run: |
+          cmake --build build --target package
+      - name: Upload artifact
+        if: ${{ !inputs.release }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: WasmEdge-${{ inputs.version }}-fedora35.tar.gz
+          path: build/WasmEdge-${{ inputs.version }}-Linux.tar.gz

--- a/.github/workflows/reusable-build-on-macos.yml
+++ b/.github/workflows/reusable-build-on-macos.yml
@@ -1,0 +1,90 @@
+name: Build on MacOS
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+      matrix: # [ { name, runner, darwin_version }, ... ]
+        type: string
+        required: true
+      release:
+        type: boolean
+      upload_asset_url:
+        type: string
+
+jobs:
+  build_on_macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(inputs.matrix) }}
+    name: Build on ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    env:
+      BUILD_TESTS: ON
+      BUILD_TYPE: Debug
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup build environment
+        run: |
+          brew install llvm ninja boost cmake
+      - name: Set environment variables for release
+        if: ${{ inputs.release }}
+        run: |
+          echo "BUILD_TESTS=OFF" | tee -a $GITHUB_ENV
+          echo "BUILD_TYPE=Release" | tee -a $GITHUB_ENV
+      - name: Build WasmEdge
+        run: |
+          export PATH="/usr/local/opt/llvm/bin:$PATH"
+          export LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
+          export CPPFLAGS="-I/usr/local/opt/llvm/include"
+          export CC=clang
+          export CXX=clang++
+          rm -rf build
+          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWASMEDGE_BUILD_TESTS=$BUILD_TESTS -DWASMEDGE_LINK_TOOLS_STATIC=ON -DWASMEDGE_BUILD_PACKAGE="TGZ" .
+          cmake --build build
+      - name: Test WasmEdge
+        continue-on-error: true
+        run: |
+          export DYLD_LIBRARY_PATH="$(pwd)/build/lib/api:$DYLD_LIBRARY_PATH"
+          cd build
+          ./tools/wasmedge/wasmedge -v
+          ctest
+          cd -
+      - name: Create package tarball
+        run: |
+          cmake --build build --target package
+      - name: Test Standalone WasmEdge without LLVM
+        run: |
+          brew uninstall llvm
+          export DYLD_LIBRARY_PATH="$(pwd)/build/lib/api:$DYLD_LIBRARY_PATH"
+          echo "otool -L ./build/tools/wasmedge/wasmedge:"
+          otool -L ./build/tools/wasmedge/wasmedge
+          echo "otool -L ./build/tools/wasmedge/wasmedgec:"
+          otool -L ./build/tools/wasmedge/wasmedgec
+          echo "otool -L ./build/lib/api/libwasmedge_c.dylib:"
+          otool -L ./build/lib/api/libwasmedge_c.dylib
+          echo "./build/tools/wasmedge/wasmedgec examples/wasm/fibonacci.wasm fib.dylib"
+          ./build/tools/wasmedge/wasmedgec examples/wasm/fibonacci.wasm fib.dylib
+          echo "./build/tools/wasmedge/wasmedge --reactor fib.dylib fib 20"
+          ./build/tools/wasmedge/wasmedge --reactor fib.dylib fib 20
+      - name: Upload artifact
+        if: ${{ !inputs.release }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: WasmEdge-${{ inputs.version }}-darwin_${{ matrix.darwin_version }}_x86_64.tar.gz
+          path: build/WasmEdge-${{ inputs.version }}-Darwin.tar.gz
+      - name: Upload package tarball
+        if: ${{ inputs.release }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_asset_url }}
+          asset_name: WasmEdge-${{ inputs.version }}-darwin_${{ matrix.darwin_version }}_x86_64.tar.gz
+          asset_path: build/WasmEdge-${{ inputs.version }}-Darwin.tar.gz
+          asset_content_type: application/x-gzip

--- a/.github/workflows/reusable-build-on-manylinux.yml
+++ b/.github/workflows/reusable-build-on-manylinux.yml
@@ -1,0 +1,81 @@
+name: Build on manylinux
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+      legacy:
+        type: boolean
+        required: true
+      matrix: # [ { runner, docker_tag }, ... ]
+        type: string
+        required: true
+      release:
+        type: boolean
+      upload_asset_url:
+        type: string
+
+jobs:
+  build_on_manylinux:
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(inputs.matrix) }}
+    name: Build on ${{ matrix.docker_tag }}
+    runs-on: ${{ matrix.runner }}
+    container: wasmedge/wasmedge:${{ matrix.docker_tag }}
+    steps:
+      - uses: actions/checkout@v1
+        if: ${{ inputs.legacy }}
+      - uses: actions/checkout@v2
+        if: ${{ !inputs.legacy }}
+        with:
+          fetch-depth: 0
+      - name: Build ${{ matrix.docker_tag }} package
+        run: |
+          bash utils/docker/build-manylinux.sh
+          ./build/tools/wasmedge/wasmedge -v
+      - name: Upload artifact (v1)
+        if: ${{ inputs.legacy && !inputs.release }}
+        uses: actions/upload-artifact@v1
+        with:
+          name: WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.tar.gz
+          path: build/WasmEdge-${{ inputs.version }}-Linux.tar.gz
+      - name: Upload artifact (v2)
+        if: ${{ !inputs.legacy && !inputs.release }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.tar.gz
+          path: build/WasmEdge-${{ inputs.version }}-Linux.tar.gz
+      - name: Upload rpm package
+        if: ${{ inputs.release }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_asset_url }}
+          asset_name: WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.rpm
+          asset_path: WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.rpm/WasmEdge-${{ inputs.version }}-Linux.rpm
+          asset_content_type: application/x-rpm
+      - name: Upload tar.gz package
+        if: ${{ inputs.release }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_asset_url }}
+          asset_path: WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.tar.gz/WasmEdge-${{ inputs.version }}-Linux.tar.gz
+          asset_name: WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.tar.gz
+          asset_content_type: application/x-gzip
+      - name: Upload tar.xz package
+        if: ${{ inputs.release }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.tar.xz/WasmEdge-${{ inputs.version }}-Linux.tar.xz
+          asset_name: WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.tar.xz
+          asset_content_type: application/x-xz

--- a/.github/workflows/reusable-build-on-windows.yml
+++ b/.github/workflows/reusable-build-on-windows.yml
@@ -1,0 +1,104 @@
+name: Build on Windows
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+      release:
+        type: boolean
+      upload_asset_url:
+        type: string
+
+jobs:
+  build_on_windows:
+    name: Build on Windows Server 2022
+    runs-on: windows-2022
+    env:
+      build_tests: ON
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install dependency
+        uses: crazy-max/ghaction-chocolatey@v1
+        with:
+          args: install cmake ninja vswhere
+      - uses: GuillaumeFalourd/setup-windows10-sdk-action@v1
+        with:
+          sdk-version: 19041
+      - name: Set environment variables for release
+        if: ${{ inputs.release }}
+        run: |
+          echo "build_tests=OFF" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Build WasmEdge
+        run: |
+          $vsPath = (vswhere -latest -property installationPath)
+          Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
+          Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
+          $llvm = "LLVM-13.0.1-win64.zip"
+          curl -sLO https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-13.0.1/LLVM-13.0.1-win64.zip -o $llvm
+          Expand-Archive -Path $llvm
+          $llvm_dir = "$pwd\\LLVM-13.0.1-win64\\LLVM-13.0.1-win64\\lib\\cmake\\llvm"
+          $Env:CC = "clang-cl"
+          $Env:CXX = "clang-cl"
+          $cmake_sys_version = "10.0.19041.0"
+          cmake -Bbuild -GNinja "-DCMAKE_SYSTEM_VERSION=$cmake_sys_version" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL "-DLLVM_DIR=$llvm_dir" "-DWASMEDGE_BUILD_TESTS=$Env:build_tests" -DWASMEDGE_BUILD_PACKAGE="ZIP" .
+          cmake --build build
+      - name: Test WasmEdge
+        continue-on-error: true
+        run: |
+          $vsPath = (vswhere -latest -property installationPath)
+          Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
+          Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
+          $Env:PATH += ";$pwd\\build\\lib\\api"
+          cd build
+          tools\wasmedge\wasmedge -v
+          ctest
+          cd -
+      - name: Create WasmEdge package
+        run: |
+          $vsPath = (vswhere -latest -property installationPath)
+          Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
+          Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
+          cmake --build build --target package
+          Get-ChildItem -Path "$pwd\\build"
+      - name: Generate product version and package Windows installer
+        run: |
+          $Env:product_version = ("${{ inputs.version }}").split("-")[0]
+          . "$Env:WIX\bin\candle.exe" -arch x64 -o build\wasmedge.wixobj .github\scripts\wasmedge.wxs
+          . "$Env:WIX\bin\light.exe" -out build\WasmEdge-$Env:product_version-windows.msi build\wasmedge.wixobj
+          echo "product_version=$Env:product_version" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Upload artifact
+        if: ${{ !inputs.release }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: WasmEdge-${{ inputs.version }}-windows.zip
+          path: build\\WasmEdge-${{ inputs.version }}-Windows.zip
+      - name: Upload Windows installer
+        if: ${{ !inputs.release }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: WasmEdge-${{ env.product_version }}-windows.msi
+          path: build\\WasmEdge-${{ env.product_version }}-windows.msi
+      - name: Upload Windows 10 zip package
+        if: ${{ inputs.release }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_asset_url }}
+          asset_name: WasmEdge-${{ env.product_version }}-windows.zip
+          asset_path: build\\WasmEdge-${{ env.product_version }}-Windows.zip
+          asset_content_type: application/zip
+      - name: Upload Windows installer
+        if: ${{ inputs.release }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_asset_url }}
+          asset_name: WasmEdge-${{ env.product_version }}-windows.msi
+          asset_path: build\\WasmEdge-${{ env.product_version }}-windows.msi
+          asset_content_type: application/octet-stream

--- a/.github/workflows/reusable-build-srpm.yml
+++ b/.github/workflows/reusable-build-srpm.yml
@@ -1,0 +1,74 @@
+name: Build SRPM on Fedora
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+      release:
+        type: boolean
+      upload_asset_url:
+        type: string
+
+jobs:
+  build_srpm:
+    name: Build SRPM on Fedora
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:rawhide
+    steps:
+      - name: Install dependency
+        run: |
+          dnf update -y
+          dnf install -y git gcc-c++ cmake ninja-build boost-devel spdlog-devel llvm-devel lld-devel rpm-build
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Prepare source tarball for SRPM
+        uses: actions/download-artifact@v3
+        with:
+          name: WasmEdge-${{ inputs.version }}-src.tar.gz
+          path: /github/home/rpmbuild/SOURCES
+      - name: Rename source tarball
+        working-directory: /github/home/rpmbuild/SOURCES
+        run: |
+          mv WasmEdge-${{ inputs.version }}.tar.gz WasmEdge-${{ inputs.version }}-src.tar.gz
+      - name: Prepare SRPM version
+        run: |
+          GIT_TAG=${{ inputs.version }}
+          SRPM_VERSION=$(echo $GIT_TAG | tr '-' '~')
+          echo "srpm_version=$SRPM_VERSION" >> $GITHUB_ENV
+      - name: Build WasmEdge SRPM
+        run: |
+          git config --global --add safe.directory $(pwd)
+          mkdir -p build
+          cd build
+          cmake ..
+          rpmbuild -ba rpm/wasmedge.spec
+      - name: Upload artifact
+        if: ${{ !inputs.release }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: WasmEdge-${{ env.srpm_version }}-1.fc37.src.rpm
+          path: /github/home/rpmbuild/SRPMS/wasmedge-${{ env.srpm_version }}-1.fc37.src.rpm
+      - name: Upload Fedora spec file
+        if: ${{ inputs.release }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_asset_url }}
+          asset_name: wasmedge.spec
+          asset_path: build/rpm/wasmedge.spec
+          asset_content_type: text/plain
+      - name: Upload Fedora SRPM
+        if: ${{ inputs.release }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_asset_url }}
+          asset_name: wasmedge-${{ env.srpm_version }}-1.fc37.src.rpm
+          asset_path: /github/home/rpmbuild/SRPMS/wasmedge-${{ env.srpm_version }}-1.fc37.src.rpm
+          asset_content_type: application/x-rpm

--- a/.github/workflows/reusable-create-source-tarball.yml
+++ b/.github/workflows/reusable-create-source-tarball.yml
@@ -1,0 +1,53 @@
+name: Create Source Tarball
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+      release:
+        type: boolean
+      upload_asset_url:
+        type: string
+
+jobs:
+  create_source_tarball:
+    name: Create source tarball
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Propagate version information
+        run: |
+          echo -n $VERSION | tee VERSION
+        env:
+          VERSION: ${{ inputs.version }}
+      - name: Create source tarball
+        run: |
+          echo "Get version: $VERSION"
+          TEMPDIR=$(mktemp -d)
+          SRCDIR="$TEMPDIR/wasmedge/"
+          mkdir -p "$SRCDIR"
+          git checkout-index -a --prefix="$SRCDIR"
+          cp -v VERSION $SRCDIR
+          tar --owner 0 --group 0 -czf "$GITHUB_WORKSPACE/WasmEdge-$VERSION.tar.gz" -C "$TEMPDIR" "wasmedge"
+        env:
+          VERSION: ${{ inputs.version }}
+      - name: Upload artifact
+        if: ${{ !inputs.release }} # Only for non-release
+        uses: actions/upload-artifact@v2
+        with:
+          name: WasmEdge-${{ inputs.version }}-src.tar.gz
+          path: WasmEdge-${{ inputs.version }}.tar.gz
+      - name: Upload source tarball
+        if: ${{ inputs.release }} # Only for release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_asset_url }}
+          asset_name: WasmEdge-${{ inputs.version }}-src.tar.gz
+          asset_path: WasmEdge-${{ inputs.version }}.tar.gz
+          asset_content_type: application/x-gzip


### PR DESCRIPTION
This PR aims to fix #1464.

[README]: .github/workflows/README.md
[build.yml]: .github/workflows/build.yml
[build-extensions.yml]: .github/workflows/build-extensions.yml
[linter.yml]: .github/workflows/linter.yml

# List of TODOs
- [ ] [README] for workflows
- [x] run [build.yml] only if [linter.yml] has passed #1702 
- [x] replace duplicate parts in [build.yml] and [linter.yml] with [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows) #1750 
  - [x] lint #1738 
  - [x] create source tarball
  - [x] build on macOS
  - [x] build on manylinux
  - [x] build on Fedora
  - [x] build on Windows (Windows Server 2022 `windows-2022`)
  - [x] build on Android
- [ ] [build-extensions.yml]
  - [ ] ... (WIP)