### PR TITLE
[Rust] Updated WasmEdge Book with new examples.

### DIFF
--- a/bindings/rust/wasmedge-sdk/examples/hello_world.rs
+++ b/bindings/rust/wasmedge-sdk/examples/hello_world.rs
@@ -7,24 +7,6 @@ use wasmedge_types::wat2wasm;
 
 #[cfg_attr(test, test)]
 fn main() -> anyhow::Result<()> {
-    let wasm_bytes = wat2wasm(
-        br#"
-(module
-  ;; First we define a type with no parameters and no results.
-  (type $no_args_no_rets_t (func (param) (result)))
-
-  ;; Then we declare that we want to import a function named "env" "say_hello" with
-  ;; that type signature.
-  (import "env" "say_hello" (func $say_hello (type $no_args_no_rets_t)))
-
-  ;; Finally we create an entrypoint that calls our imported function.
-  (func $run (type $no_args_no_rets_t)
-    (call $say_hello))
-  ;; And mark it as an exported function named "run".
-  (export "run" (func $run)))
-"#,
-    )?;
-
     // We define a function to act as our "env" "say_hello" function imported in the
     // Wasm program above.
     fn say_hello_world(_inputs: Vec<WasmValue>) -> Result<Vec<WasmValue>, u8> {
@@ -38,6 +20,24 @@ fn main() -> anyhow::Result<()> {
         .with_func::<(), ()>("say_hello", say_hello_world)?
         .build("env")?;
 
+    let wasm_bytes = wat2wasm(
+        br#"
+    (module
+      ;; First we define a type with no parameters and no results.
+      (type $no_args_no_rets_t (func (param) (result)))
+    
+      ;; Then we declare that we want to import a function named "env" "say_hello" with
+      ;; that type signature.
+      (import "env" "say_hello" (func $say_hello (type $no_args_no_rets_t)))
+    
+      ;; Finally we create an entrypoint that calls our imported function.
+      (func $run (type $no_args_no_rets_t)
+        (call $say_hello))
+      ;; And mark it as an exported function named "run".
+      (export "run" (func $run)))
+    "#,
+    )?;
+
     // loads a wasm module from the given in-memory bytes
     let module = Module::from_bytes(None, &wasm_bytes)?;
 
@@ -49,6 +49,8 @@ fn main() -> anyhow::Result<()> {
 
     // register the module into the store
     store.register_import_module(&mut executor, &import)?;
+
+    // register the compiled module into the store and get an module instance
     let extern_instance = store.register_named_module(&mut executor, "extern", &module)?;
 
     // get the exported function "run"

--- a/bindings/rust/wasmedge-sdk/src/externals/memory.rs
+++ b/bindings/rust/wasmedge-sdk/src/externals/memory.rs
@@ -54,7 +54,7 @@ impl Memory {
         Ok(ty.into())
     }
 
-    /// Returns the size, in WebAssembly pages, of this memory.
+    /// Returns the size, in WebAssembly pages (64 KiB of each page), of this memory.
     pub fn size(&self) -> u32 {
         self.inner.size()
     }

--- a/docs/book/en/src/SUMMARY.md
+++ b/docs/book/en/src/SUMMARY.md
@@ -64,6 +64,7 @@
     - [Run a WebAssembly function with WasmEdge low-level APIs](embed/rust/sys_run_host_func.md)
     - [Compute Fibonacci numbers concurrently](embed/rust/concurrent_fib.md)
     - [Usage of WasmEdge module instances](embed/rust/how_to_use_module_instance.md)
+    - [Hello World!](embed/rust/say_hello.md)
   - [Python SDK](embed/python.md)
 
 - [WasmEdge in Kubernetes](kubernetes.md)

--- a/docs/book/en/src/SUMMARY.md
+++ b/docs/book/en/src/SUMMARY.md
@@ -63,6 +63,7 @@
   - [Rust SDK](embed/rust.md)
     - [Hello World!](embed/rust/say_hello.md)
     - [Memory Manipulation](embed/rust/memory_manipulation.md)
+    - [Table and FuncRef](embed/rust/table_and_funcref.md)
     - [Run a WebAssembly function with WasmEdge low-level APIs](embed/rust/sys_run_host_func.md)
     - [Compute Fibonacci numbers concurrently](embed/rust/concurrent_fib.md)
     - [Usage of WasmEdge module instances](embed/rust/how_to_use_module_instance.md)

--- a/docs/book/en/src/SUMMARY.md
+++ b/docs/book/en/src/SUMMARY.md
@@ -61,10 +61,11 @@
       - [Upgrade to 0.10.0](embed/go/0.9.1/upgrade_to_0.10.0.md)
   - [Node.js SDK](embed/node.md)
   - [Rust SDK](embed/rust.md)
+    - [Hello World!](embed/rust/say_hello.md)
+    - [Memory Manipulation](embed/rust/memory_manipulation.md)
     - [Run a WebAssembly function with WasmEdge low-level APIs](embed/rust/sys_run_host_func.md)
     - [Compute Fibonacci numbers concurrently](embed/rust/concurrent_fib.md)
     - [Usage of WasmEdge module instances](embed/rust/how_to_use_module_instance.md)
-    - [Hello World!](embed/rust/say_hello.md)
   - [Python SDK](embed/python.md)
 
 - [WasmEdge in Kubernetes](kubernetes.md)

--- a/docs/book/en/src/embed/rust.md
+++ b/docs/book/en/src/embed/rust.md
@@ -1,10 +1,6 @@
 
 # WasmEdge Rust SDK
 
-<!-- @import "[TOC]" {cmd="toc" depthFrom=1 depthTo=6 orderedList=false} -->
-
-<!-- code_chunk_output -->
-
 - [WasmEdge Rust SDK](#wasmedge-rust-sdk)
   - [Introduction](#introduction)
   - [`wasmedge-sdk` crate](#wasmedge-sdk-crate)
@@ -14,9 +10,9 @@
   - [`wasmedge-sys` crate](#wasmedge-sys-crate)
     - [Build in `non-standalone` mode](#build-in-non-standalone-mode)
   - [Docker image](#docker-image)
-    - [Examples](#examples)
-
-<!-- /code_chunk_output -->
+  - [Examples](#examples)
+    - [`wasmedge-sdk` Examples](#wasmedge-sdk-examples)
+    - [`wasmedge-sys` Examples](#wasmedge-sys-examples)
 
 ## Introduction
 
@@ -202,7 +198,13 @@ With the required `WasmEdge` library, you can then choose one of the following w
 
 For those who would like to dev in Docker environment, you can reference the [Use Docker](/src/start/docker.md) section of this book, which details how to use Docker for `WasmEdge` application development.
 
-### Examples
+## Examples
+
+### `wasmedge-sdk` Examples
+
+- [[wasmedge-sdk] Hello World!](rust/say_hello.md)
+
+### `wasmedge-sys` Examples
 
 - [[wasmedge-sys] Run a WebAssembly function with WasmEdge low-level APIs](rust/sys_run_host_func.md)
 

--- a/docs/book/en/src/embed/rust.md
+++ b/docs/book/en/src/embed/rust.md
@@ -1,22 +1,43 @@
-# Rust Bindings
 
-You can also embed WasmEdge into your Rust application via the WasmEdge Rust SDK.
+# WasmEdge Rust SDK
 
-The definitions of WasmEdge Rust SDK involve two Rust crates, [wasmedge-sys](https://crates.io/crates/wasmedge-sys) and [wasmedge-sdk](https://crates.io/crates/wasmedge-sdk). They are designed based on different principles and for different purposes. The `wasmedge-sys` crate defines a group of low-level Rust APIs, which simply wrap WasmEdge C APIs and provide the safe counterpart, while the `wasmedge-sdk` crate provides more elegant and ergonomic APIs, which are more suitable for application development.
+<!-- @import "[TOC]" {cmd="toc" depthFrom=1 depthTo=6 orderedList=false} -->
 
-* The [wasmedge-sys](https://crates.io/crates/wasmedge-sys) crate defines a group of low-level Rust APIs, which simply wrap WasmEdge C APIs and provide the safe counterparts. The APIs in [wasmedge-sys](https://crates.io/crates/wasmedge-sys) should be used to construct high-level libraries. For the details of the APIs, please visit [wasmedge-sys API documentation](https://wasmedge.github.io/WasmEdge/wasmedge_sys/).
+<!-- code_chunk_output -->
 
-* The [wasmedge-sdk](https://crates.io/crates/wasmedge-sdk) crate is based on the wasmedge-sys crate and provides a more elegant and idiomatic Rust APIs. These APIs are more suitable for business-oriented design and development. The wasmedge-sdk crate is still under active development and coming soon.
+- [WasmEdge Rust SDK](#wasmedge-rust-sdk)
+  - [Introduction](#introduction)
+  - [`wasmedge-sdk` crate](#wasmedge-sdk-crate)
+  - [`wasmedge-sys` crate](#wasmedge-sys-crate)
+    - [Build](#build)
+    - [Examples](#examples)
 
-## The `wasmedge-sys` crate
+<!-- /code_chunk_output -->
+
+## Introduction
+
+`WasmEdge` supports embedding into Rust applications via WasmEdge Rust SDK. WasmEdge Rust SDK consists of three crates:
+
+- [wasmedge-sdk](https://crates.io/crates/wasmedge-sdk) crate. It defines a group of safe, ergonomic high-level APIs, which are used to build up business applications.
+  - [API documentation](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/)
+
+- [wasmedge-sys](https://crates.io/crates/wasmedge-sys) crate. It defines a group of low-level Rust APIs, which simply wrap WasmEdge C-API and provide the safe counterparts. It is not recommended to use it directly to build up application.
+  - [API documentation](https://wasmedge.github.io/WasmEdge/wasmedge_sys/)
+
+- [wasmedge-types](https://crates.io/crates/wasmedge-types) crate. The data structures that are commonly used in `wasmedge-sdk` and `wasmedge-sys` are defined in this crate.
+  - [API documentation](https://wasmedge.github.io/WasmEdge/wasmedge_types/)
+
+## `wasmedge-sdk` crate
+
+## `wasmedge-sys` crate
 
 ### Build
 
 `wasmedge-sys` depends on the dynamic library and the header files of `WasmEdge`. To `cargo build` `wasmedge-sys` there are several choices to specify the dependencies:
 
-* By specifying `WASMEDGE_INCLUDE_DIR` and `WASMEDGE_LIB_DIR`
+- By specifying `WASMEDGE_INCLUDE_DIR` and `WASMEDGE_LIB_DIR`
 
-  * Suppose that you have already downloaded the `Wasmedge-0.9.1` binary package from [WasmEdge Releases](https://github.com/WasmEdge/WasmEdge/releases) and put it in the `~/workspace/me/` directory. The directory structure of the released package is shown below.
+  - Suppose that you have already downloaded the `Wasmedge-0.9.1` binary package from [WasmEdge Releases](https://github.com/WasmEdge/WasmEdge/releases) and put it in the `~/workspace/me/` directory. The directory structure of the released package is shown below.
 
     ```bash
     root@0a877562f39e:~/workspace/me/WasmEdge-0.9.1-Linux# pwd
@@ -41,7 +62,7 @@ The definitions of WasmEdge Rust SDK involve two Rust crates, [wasmedge-sys](htt
     4 directories, 9 files
     ```
 
-  * Set `WASMEDGE_INCLUDE_DIR` and `WASMEDGE_LIB_DIR` environment variables to specify the `include` and `lib` (or `lib64`) directories. After that, go to the `wasmedge-sys` directory and `cargo build` the crate.
+  - Set `WASMEDGE_INCLUDE_DIR` and `WASMEDGE_LIB_DIR` environment variables to specify the `include` and `lib` (or `lib64`) directories. After that, go to the `wasmedge-sys` directory and `cargo build` the crate.
 
     ```bash
     root@0a877562f39e:~/workspace/me/WasmEdge/bindings/rust/wasmedge-sys# export WASMEDGE_INCLUDE_DIR=/root/workspace/me/WasmEdge-0.9.1-Linux/include/wasmedge
@@ -49,21 +70,21 @@ The definitions of WasmEdge Rust SDK involve two Rust crates, [wasmedge-sys](htt
     root@0a877562f39e:~/workspace/me/WasmEdge/bindings/rust/wasmedge-sys# export WASMEDGE_LIB_DIR=/root/workspace/me/WasmEdge-0.9.1-Linux/lib64
     ```
 
-* By specifying `WASMEDGE_BUILD_DIR`
+- By specifying `WASMEDGE_BUILD_DIR`
 
-  * Suppose that you `git clone` WasmEdge repo in `~/workspace/me/WasmEdge`, and follow the [instructions](https://wasmedge.org/book/en/extend/build.html) to build WasmEdge native library. The generated `include` and `lib` directories should be in `~/workspace/me/WasmEdge/build`.
+  - Suppose that you `git clone` WasmEdge repo in `~/workspace/me/WasmEdge`, and follow the [instructions](https://wasmedge.org/book/en/extend/build.html) to build WasmEdge native library. The generated `include` and `lib` directories should be in `~/workspace/me/WasmEdge/build`.
 
-  * Then, set `WASMEDGE_BUILD_DIR` environment variable to specify the `build` directory. After that, go to the `wasmedge-sys` directory and `cargo build` the crate.
+  - Then, set `WASMEDGE_BUILD_DIR` environment variable to specify the `build` directory. After that, go to the `wasmedge-sys` directory and `cargo build` the crate.
 
     ```bash
     root@0a877562f39e:~/workspace/me/WasmEdge# export WASMEDGE_BUILD_DIR=/root/workspace/me/WasmEdge/build
     ```
 
-* By the `standalone` mode
+- By the `standalone` mode
 
   Besides the two methods mentioned above, the `standalone` mode enables building `WasmEdge` native library directly before building the crate itself.
 
-  * Suppose that you `git clone` WasmEdge repo in `~/workspace/me/WasmEdge`. Go to the `wasmedge-sys` directory, and follow the instructions shown below:
+  - Suppose that you `git clone` WasmEdge repo in `~/workspace/me/WasmEdge`. Go to the `wasmedge-sys` directory, and follow the instructions shown below:
 
     ```bash
     // set WASMEDGE_DIR
@@ -73,14 +94,14 @@ The definitions of WasmEdge Rust SDK involve two Rust crates, [wasmedge-sys](htt
     root@0a877562f39e:~/workspace/me/WasmEdge/bindings/rust/wasmedge-sys# cargo build --features standalone
     ```
 
-* By WasmEdge docker image
+- By WasmEdge docker image
 
   If you choose WasmEdge docker image to build your own container for development, the pre-built WasmEdge binary package is located in `$HOME/.wasmedge` directory by default. The build script (`build.rs`) of `wasmedge-sys` crate can detect the package and build the crate automatically.
 
 ### Examples
 
-* [[wasmedge-sys] Run a WebAssembly function with WasmEdge low-level APIs](rust/sys_run_host_func.md)
+- [[wasmedge-sys] Run a WebAssembly function with WasmEdge low-level APIs](rust/sys_run_host_func.md)
 
-* [[wasmedge-sys] Compute Fibonacci numbers concurrently](rust/concurrent_fib.md)
+- [[wasmedge-sys] Compute Fibonacci numbers concurrently](rust/concurrent_fib.md)
 
-* [[wasmedge-sys] The usage of WasmEdge module instances](rust/how_to_use_module_instance.md)
+- [[wasmedge-sys] The usage of WasmEdge module instances](rust/how_to_use_module_instance.md)

--- a/docs/book/en/src/embed/rust.md
+++ b/docs/book/en/src/embed/rust.md
@@ -82,6 +82,8 @@ For those who are interesting in building `wasmedge-sdk` from source, as mention
 wasmedge-sys = [version = "0.7.0", features = ["standalone"]]
 ```
 
+*For Windows users, duo to [issue 1527](https://github.com/WasmEdge/WasmEdge/issues/1527), the current version of `wasmedge-sys` does not support `standalone` mode on Windows platform. Please choose to use our [docker image](#docker-image). We'll fix the issue as soon as possible.*
+
 For those who want to build `wasmedge-sys` from source in terminal, just go to the `wasmedge-sys` directory and type `cargo build --features standalone` command that will compile the `wasmedge-sys` crate in `standalone` mode.
 
 ### Build in `non-standalone` mode

--- a/docs/book/en/src/embed/rust.md
+++ b/docs/book/en/src/embed/rust.md
@@ -8,8 +8,12 @@
 - [WasmEdge Rust SDK](#wasmedge-rust-sdk)
   - [Introduction](#introduction)
   - [`wasmedge-sdk` crate](#wasmedge-sdk-crate)
+    - [Usage](#usage)
+      - [Embedding](#embedding)
+      - [Build](#build)
   - [`wasmedge-sys` crate](#wasmedge-sys-crate)
-    - [Build](#build)
+    - [Build in `non-standalone` mode](#build-in-non-standalone-mode)
+  - [Docker image](#docker-image)
     - [Examples](#examples)
 
 <!-- /code_chunk_output -->
@@ -29,74 +33,174 @@
 
 ## `wasmedge-sdk` crate
 
+### Usage
+
+#### Embedding
+
+To use `wasmedge-sdk` in your Rust crate, simple add it to your `Cargo.toml`:
+
+```toml
+[dependencies]
+wasmedge-sdk = "0.1.0"
+```
+
+N.B. that since the `WasmEdge` library is a dependency of WasmEdge Rust SDK, it is required that `WasmEdge` is deployed first on your target system. The required header files, library and plugins should be placed in `$HOME/.wasmedge/` directory. The directory structure on Linux looks like below:
+
+```bash
+// $HOME/.wasmedge/
+.
+├── bin
+│   ├── wasmedge
+│   └── wasmedgec
+├── include
+│   └── wasmedge
+│       ├── dense_enum_map.h
+│       ├── enum.inc
+│       ├── enum_configure.h
+│       ├── enum_errcode.h
+│       ├── enum_types.h
+│       ├── int128.h
+│       ├── spare_enum_map.h
+│       ├── version.h
+│       └── wasmedge.h
+└── lib64
+    ├── libwasmedge_c.so
+    └── wasmedge
+        └── libwasmedgePluginWasmEdgeProcess.so
+
+5 directories, 13 files
+```
+
+In the future version, WasmEdge Rust SDK will support the `standalone` mode that supports automatic deployment of the `WasmEdge` library.
+
+#### Build
+
+For those who are interesting in building `wasmedge-sdk` from source, as mentioned before, the `WasmEdge` library should be deployed on your target system before you can build the `wasmedge-sdk` crate.
+
 ## `wasmedge-sys` crate
 
-### Build
+`wasmedge-sys` serves as a wraper layer of `WasmEdge` C-API, and provides a group of safe low-level Rust interfaces. For those who are interested in using `wasmedge-sys` in their projects, two modes are avaible: one is `standalone` mode, the other `non-standalone`. The `standalone` mode is recommended for most of the projects. To enable the `standalone` mode, simply put the following lines in your `Cargo.toml`:
 
-`wasmedge-sys` depends on the dynamic library and the header files of `WasmEdge`. To `cargo build` `wasmedge-sys` there are several choices to specify the dependencies:
+```toml
+[dependencies]
+wasmedge-sys = [version = "0.7.0", features = ["standalone"]]
+```
+
+For those who want to build `wasmedge-sys` from source in terminal, just go to the `wasmedge-sys` directory and type `cargo build --features standalone` command that will compile the `wasmedge-sys` crate in `standalone` mode.
+
+### Build in `non-standalone` mode
+
+For those who would like to use `wasmedge-sys` in the `non-standalone` mode, you should first guarantee that the `WasmEdge` binary is downloaded and deployed in your local environment. The directory structure on `Ubuntu-20.04` looks like below:
+
+```bash
+.
+├── bin
+│   ├── wasmedge
+│   └── wasmedgec
+├── include
+│   └── wasmedge
+│       ├── dense_enum_map.h
+│       ├── enum.inc
+│       ├── enum_configure.h
+│       ├── enum_errcode.h
+│       ├── enum_types.h
+│       ├── int128.h
+│       ├── spare_enum_map.h
+│       ├── version.h
+│       └── wasmedge.h
+└── lib64
+    ├── libwasmedge_c.so
+    └── wasmedge
+        └── libwasmedgePluginWasmEdgeProcess.so
+
+5 directories, 13 files
+```
+
+With the required `WasmEdge` library, you can then choose one of the following ways to build `wasmedge-sys`:
 
 - By specifying `WASMEDGE_INCLUDE_DIR` and `WASMEDGE_LIB_DIR`
 
-  - Suppose that you have already downloaded the `Wasmedge-0.9.1` binary package from [WasmEdge Releases](https://github.com/WasmEdge/WasmEdge/releases) and put it in the `~/workspace/me/` directory. The directory structure of the released package is shown below.
+  N.B. that it is strongly recommended to use this way if you'd like to use `wasmedge-sys` crate in your Rust project, but not want to enable the `standalone` feature.
+
+  - Suppose that you have already downloaded the `Wasmedge-0.10.0` binary package from [WasmEdge Releases](https://github.com/WasmEdge/WasmEdge/releases/tag/0.10.0) to a local directory, for example, `~/workspace/me/`. The directory structure of the released package should looks like below:
 
     ```bash
-    root@0a877562f39e:~/workspace/me/WasmEdge-0.9.1-Linux# pwd
-    /root/workspace/me/WasmEdge-0.9.1-Linux
-
-    root@0a877562f39e:~/workspace/me/WasmEdge-0.9.1-Linux# tree .
+    root@0a877562f39e:~/workspace/me/WasmEdge-0.10.0-Linux# tree .
     .
-    |-- bin
-    |   |-- wasmedge
-    |   `-- wasmedgec
-    |-- include
-    |   `-- wasmedge
-    |       |-- enum_configure.h
-    |       |-- enum_errcode.h
-    |       |-- enum_types.h
-    |       |-- int128.h
-    |       |-- version.h
-    |       `-- wasmedge.h
-    `-- lib64
-        `-- libwasmedge_c.so
+    ├── bin
+    │   ├── wasmedge
+    │   └── wasmedgec
+    ├── include
+    │   └── wasmedge
+    │       ├── dense_enum_map.h
+    │       ├── enum.inc
+    │       ├── enum_configure.h
+    │       ├── enum_errcode.h
+    │       ├── enum_types.h
+    │       ├── int128.h
+    │       ├── spare_enum_map.h
+    │       ├── version.h
+    │       └── wasmedge.h
+    └── lib64
+        ├── libwasmedge_c.so
+        └── wasmedge
+            └── libwasmedgePluginWasmEdgeProcess.so
 
-    4 directories, 9 files
+    5 directories, 13 files
     ```
 
-  - Set `WASMEDGE_INCLUDE_DIR` and `WASMEDGE_LIB_DIR` environment variables to specify the `include` and `lib` (or `lib64`) directories. After that, go to the `wasmedge-sys` directory and `cargo build` the crate.
+  - Use `WASMEDGE_INCLUDE_DIR` and `WASMEDGE_LIB_DIR` environment variables to specify the `include` and `lib` (or `lib64`) directories. After that, you can run `cargo build` command in terminal to build `wasmedge-sys`.
 
     ```bash
-    root@0a877562f39e:~/workspace/me/WasmEdge/bindings/rust/wasmedge-sys# export WASMEDGE_INCLUDE_DIR=/root/workspace/me/WasmEdge-0.9.1-Linux/include/wasmedge
+    root@0a877562f39e:~/workspace/me/WasmEdge/bindings/rust/wasmedge-sys# export WASMEDGE_INCLUDE_DIR=/root/workspace/me/WasmEdge-0.10.0-Linux/include/wasmedge
     
-    root@0a877562f39e:~/workspace/me/WasmEdge/bindings/rust/wasmedge-sys# export WASMEDGE_LIB_DIR=/root/workspace/me/WasmEdge-0.9.1-Linux/lib64
+    root@0a877562f39e:~/workspace/me/WasmEdge/bindings/rust/wasmedge-sys# export WASMEDGE_LIB_DIR=/root/workspace/me/WasmEdge-0.10.0-Linux/lib64
     ```
 
 - By specifying `WASMEDGE_BUILD_DIR`
 
-  - Suppose that you `git clone` WasmEdge repo in `~/workspace/me/WasmEdge`, and follow the [instructions](https://wasmedge.org/book/en/extend/build.html) to build WasmEdge native library. The generated `include` and `lib` directories should be in `~/workspace/me/WasmEdge/build`.
+  N.B. that it is strongly recommended to use this way if you'd like to build the `WasmEdge` binary from the master branch in person.
 
-  - Then, set `WASMEDGE_BUILD_DIR` environment variable to specify the `build` directory. After that, go to the `wasmedge-sys` directory and `cargo build` the crate.
+  - Suppose that you `git clone` WasmEdge repo in your local directory, for example, `~/workspace/me/WasmEdge`, and follow the [instructions](https://wasmedge.org/book/en/extend/build.html) to build WasmEdge native library. After that, you should find the generated `include` and `lib` directories in `~/workspace/me/WasmEdge/build`.
+
+  - Then, use `WASMEDGE_BUILD_DIR` environment variable to specify the `build` directory. After that, you can run `cargo build` command in terminal to build `wasmedge-sys`.
 
     ```bash
     root@0a877562f39e:~/workspace/me/WasmEdge# export WASMEDGE_BUILD_DIR=/root/workspace/me/WasmEdge/build
     ```
 
-- By the `standalone` mode
+- By default location
 
-  Besides the two methods mentioned above, the `standalone` mode enables building `WasmEdge` native library directly before building the crate itself.
+  For those who do not want to define environment variables, you can put the downloaded `WasmEdge` binary package in the default location `$HOME/.wasmedge/`. The directory structure of the default location should looks like below (for example, on `Ubuntu-20.04`):
 
-  - Suppose that you `git clone` WasmEdge repo in `~/workspace/me/WasmEdge`. Go to the `wasmedge-sys` directory, and follow the instructions shown below:
+  ```bash
+  // $HOME/.wasmedge/
+  .
+  ├── bin
+  │   ├── wasmedge
+  │   └── wasmedgec
+  ├── include
+  │   └── wasmedge
+  │       ├── dense_enum_map.h
+  │       ├── enum.inc
+  │       ├── enum_configure.h
+  │       ├── enum_errcode.h
+  │       ├── enum_types.h
+  │       ├── int128.h
+  │       ├── spare_enum_map.h
+  │       ├── version.h
+  │       └── wasmedge.h
+  └── lib64
+      ├── libwasmedge_c.so
+      └── wasmedge
+          └── libwasmedgePluginWasmEdgeProcess.so
 
-    ```bash
-    // set WASMEDGE_DIR
-    root@0a877562f39e:~/workspace/me/WasmEdge/bindings/rust/wasmedge-sys# export WASMEDGE_DIR=/root/workspace/me/WasmEdge
+  5 directories, 13 files
+  ```
+  
+## Docker image
 
-    // cargo build with standalone feature
-    root@0a877562f39e:~/workspace/me/WasmEdge/bindings/rust/wasmedge-sys# cargo build --features standalone
-    ```
-
-- By WasmEdge docker image
-
-  If you choose WasmEdge docker image to build your own container for development, the pre-built WasmEdge binary package is located in `$HOME/.wasmedge` directory by default. The build script (`build.rs`) of `wasmedge-sys` crate can detect the package and build the crate automatically.
+For those who would like to dev in Docker environment, you can reference the [Use Docker](/src/start/docker.md) section of this book, which details how to use Docker for `WasmEdge` application development.
 
 ### Examples
 

--- a/docs/book/en/src/embed/rust.md
+++ b/docs/book/en/src/embed/rust.md
@@ -206,6 +206,8 @@ For those who would like to dev in Docker environment, you can reference the [Us
 
 - [[wasmedge-sdk] Memory manipulation](rust/memory_manipulation.md)
 
+- [[wasmedge-sdk] Table and FuncRef](rust/table_and_funcref.md)
+
 ### `wasmedge-sys` Examples
 
 - [[wasmedge-sys] Run a WebAssembly function with WasmEdge low-level APIs](rust/sys_run_host_func.md)

--- a/docs/book/en/src/embed/rust.md
+++ b/docs/book/en/src/embed/rust.md
@@ -1,18 +1,22 @@
 
 # WasmEdge Rust SDK
 
+<!-- @import "[TOC]" {cmd="toc" depthFrom=1 depthTo=6 orderedList=false} -->
+
+<!-- code_chunk_output -->
+
 - [WasmEdge Rust SDK](#wasmedge-rust-sdk)
   - [Introduction](#introduction)
+  - [Versioning Table](#versioning-table)
   - [`wasmedge-sdk` crate](#wasmedge-sdk-crate)
-    - [Usage](#usage)
-      - [Embedding](#embedding)
-      - [Build](#build)
   - [`wasmedge-sys` crate](#wasmedge-sys-crate)
-    - [Build in `non-standalone` mode](#build-in-non-standalone-mode)
   - [Docker image](#docker-image)
+    - [Windows Users](#windows-users)
   - [Examples](#examples)
     - [`wasmedge-sdk` Examples](#wasmedge-sdk-examples)
     - [`wasmedge-sys` Examples](#wasmedge-sys-examples)
+
+<!-- /code_chunk_output -->
 
 ## Introduction
 
@@ -27,103 +31,28 @@
 - [wasmedge-types](https://crates.io/crates/wasmedge-types) crate. The data structures that are commonly used in `wasmedge-sdk` and `wasmedge-sys` are defined in this crate.
   - [API documentation](https://wasmedge.github.io/WasmEdge/wasmedge_types/)
 
+## Versioning Table
+
+  The following table provides the versioning information about each release of `wasmedge-sdk` crate and its dependencies.
+
+  | wasmedge-sdk  | WasmEdge lib                                                       | wasmedge-sys  | wasmedge-types|
+  | :-----------: | :----------------------------------------------------------------: | :-----------: | :-----------: |
+  | 0.1.0         | [0.10.0](https://github.com/WasmEdge/WasmEdge/releases/tag/0.10.0) | 0.7           | 0.1           |
+
 ## `wasmedge-sdk` crate
 
-### Usage
+To use `wasmedge-sdk` in your project, you should finish the followign two steps before building your project:
 
-#### Embedding
+- First, deploy `WasmEdge` library on your local system.
 
-To use `wasmedge-sdk` in your Rust crate, simple add it to your `Cargo.toml`:
+  You can reference the versiong table and download `WasmEdge` library from [WasmEdge Releases Page](https://github.com/WasmEdge/WasmEdge/releases). After download the `WasmEdge` library, you can choose one of the following three ways to specify the locations of the required files:
+  
+  - By default location
 
-```toml
-[dependencies]
-wasmedge-sdk = "0.1.0"
-```
-
-N.B. that since the `WasmEdge` library is a dependency of WasmEdge Rust SDK, it is required that `WasmEdge` is deployed first on your target system. The required header files, library and plugins should be placed in `$HOME/.wasmedge/` directory. The directory structure on Linux looks like below:
-
-```bash
-// $HOME/.wasmedge/
-.
-├── bin
-│   ├── wasmedge
-│   └── wasmedgec
-├── include
-│   └── wasmedge
-│       ├── dense_enum_map.h
-│       ├── enum.inc
-│       ├── enum_configure.h
-│       ├── enum_errcode.h
-│       ├── enum_types.h
-│       ├── int128.h
-│       ├── spare_enum_map.h
-│       ├── version.h
-│       └── wasmedge.h
-└── lib64
-    ├── libwasmedge_c.so
-    └── wasmedge
-        └── libwasmedgePluginWasmEdgeProcess.so
-
-5 directories, 13 files
-```
-
-In the future version, WasmEdge Rust SDK will support the `standalone` mode that supports automatic deployment of the `WasmEdge` library.
-
-#### Build
-
-For those who are interesting in building `wasmedge-sdk` from source, as mentioned before, the `WasmEdge` library should be deployed on your target system before you can build the `wasmedge-sdk` crate.
-
-## `wasmedge-sys` crate
-
-`wasmedge-sys` serves as a wraper layer of `WasmEdge` C-API, and provides a group of safe low-level Rust interfaces. For those who are interested in using `wasmedge-sys` in their projects, two modes are avaible: one is `standalone` mode, the other `non-standalone`. The `standalone` mode is recommended for most of the projects. To enable the `standalone` mode, simply put the following lines in your `Cargo.toml`:
-
-```toml
-[dependencies]
-wasmedge-sys = [version = "0.7.0", features = ["standalone"]]
-```
-
-*For Windows users, duo to [issue 1527](https://github.com/WasmEdge/WasmEdge/issues/1527), the current version of `wasmedge-sys` does not support `standalone` mode on Windows platform. Please choose to use our [docker image](#docker-image). We'll fix the issue as soon as possible.*
-
-For those who want to build `wasmedge-sys` from source in terminal, just go to the `wasmedge-sys` directory and type `cargo build --features standalone` command that will compile the `wasmedge-sys` crate in `standalone` mode.
-
-### Build in `non-standalone` mode
-
-For those who would like to use `wasmedge-sys` in the `non-standalone` mode, you should first guarantee that the `WasmEdge` binary is downloaded and deployed in your local environment. The directory structure on `Ubuntu-20.04` looks like below:
-
-```bash
-.
-├── bin
-│   ├── wasmedge
-│   └── wasmedgec
-├── include
-│   └── wasmedge
-│       ├── dense_enum_map.h
-│       ├── enum.inc
-│       ├── enum_configure.h
-│       ├── enum_errcode.h
-│       ├── enum_types.h
-│       ├── int128.h
-│       ├── spare_enum_map.h
-│       ├── version.h
-│       └── wasmedge.h
-└── lib64
-    ├── libwasmedge_c.so
-    └── wasmedge
-        └── libwasmedgePluginWasmEdgeProcess.so
-
-5 directories, 13 files
-```
-
-With the required `WasmEdge` library, you can then choose one of the following ways to build `wasmedge-sys`:
-
-- By specifying `WASMEDGE_INCLUDE_DIR` and `WASMEDGE_LIB_DIR`
-
-  N.B. that it is strongly recommended to use this way if you'd like to use `wasmedge-sys` crate in your Rust project, but not want to enable the `standalone` feature.
-
-  - Suppose that you have already downloaded the `Wasmedge-0.10.0` binary package from [WasmEdge Releases](https://github.com/WasmEdge/WasmEdge/releases/tag/0.10.0) to a local directory, for example, `~/workspace/me/`. The directory structure of the released package should looks like below:
+    For those who do not want to define environment variables, you can put the downloaded `WasmEdge` binary package in the default location `$HOME/.wasmedge/`. The directory structure of the default location should looks like below:
 
     ```bash
-    root@0a877562f39e:~/workspace/me/WasmEdge-0.10.0-Linux# tree .
+    // $HOME/.wasmedge/ on Ubuntu-20.04
     .
     ├── bin
     │   ├── wasmedge
@@ -147,60 +76,113 @@ With the required `WasmEdge` library, you can then choose one of the following w
     5 directories, 13 files
     ```
 
-  - Use `WASMEDGE_INCLUDE_DIR` and `WASMEDGE_LIB_DIR` environment variables to specify the `include` and `lib` (or `lib64`) directories. After that, you can run `cargo build` command in terminal to build `wasmedge-sys`.
-
     ```bash
-    root@0a877562f39e:~/workspace/me/WasmEdge/bindings/rust/wasmedge-sys# export WASMEDGE_INCLUDE_DIR=/root/workspace/me/WasmEdge-0.10.0-Linux/include/wasmedge
-    
-    root@0a877562f39e:~/workspace/me/WasmEdge/bindings/rust/wasmedge-sys# export WASMEDGE_LIB_DIR=/root/workspace/me/WasmEdge-0.10.0-Linux/lib64
+    // $HOME/.wasmedge/ on macOS-12
+    .
+    ├── bin
+    │   ├── wasmedge
+    │   └── wasmedgec
+    ├── include
+    │   └── wasmedge
+    │       ├── dense_enum_map.h
+    │       ├── enum.inc
+    │       ├── enum_configure.h
+    │       ├── enum_errcode.h
+    │       ├── enum_types.h
+    │       ├── int128.h
+    │       ├── spare_enum_map.h
+    │       ├── version.h
+    │       └── wasmedge.h
+    └── lib
+        └── libwasmedge_c.dylib
+
+    4 directories, 12 files
     ```
 
-- By specifying `WASMEDGE_BUILD_DIR`
+  - By specifying `WASMEDGE_INCLUDE_DIR` and `WASMEDGE_LIB_DIR`.
 
-  N.B. that it is strongly recommended to use this way if you'd like to build the `WasmEdge` binary from the master branch in person.
+    - `WASMEDGE_INCLUDE_DIR` is used to specify the directory in which the header files are.
 
-  - Suppose that you `git clone` WasmEdge repo in your local directory, for example, `~/workspace/me/WasmEdge`, and follow the [instructions](https://wasmedge.org/book/en/extend/build.html) to build WasmEdge native library. After that, you should find the generated `include` and `lib` directories in `~/workspace/me/WasmEdge/build`.
+    - `WASMEDGE_LIB_DIR` is used to specify the directory in which the `wasmedge_c` library is.
 
-  - Then, use `WASMEDGE_BUILD_DIR` environment variable to specify the `build` directory. After that, you can run `cargo build` command in terminal to build `wasmedge-sys`.
+    - For example, suppose that you have already downloaded the `Wasmedge-0.10.0` binary package from [WasmEdge Releases](https://github.com/WasmEdge/WasmEdge/releases/tag/0.10.0) and placed it into a local directory, for example, `~/workspace/me/`. The directory structure of the released package should looks like below:
 
-    ```bash
-    root@0a877562f39e:~/workspace/me/WasmEdge# export WASMEDGE_BUILD_DIR=/root/workspace/me/WasmEdge/build
-    ```
+      ```bash
+      root@0a877562f39e:~/workspace/me/WasmEdge-0.10.0-Linux# tree .
+      .
+      ├── bin
+      │   ├── wasmedge
+      │   └── wasmedgec
+      ├── include
+      │   └── wasmedge
+      │       ├── dense_enum_map.h
+      │       ├── enum.inc
+      │       ├── enum_configure.h
+      │       ├── enum_errcode.h
+      │       ├── enum_types.h
+      │       ├── int128.h
+      │       ├── spare_enum_map.h
+      │       ├── version.h
+      │       └── wasmedge.h
+      └── lib64
+          ├── libwasmedge_c.so
+          └── wasmedge
+              └── libwasmedgePluginWasmEdgeProcess.so
 
-- By default location
+      5 directories, 13 files
+      ```
 
-  For those who do not want to define environment variables, you can put the downloaded `WasmEdge` binary package in the default location `$HOME/.wasmedge/`. The directory structure of the default location should looks like below (for example, on `Ubuntu-20.04`):
+    Then set `WASMEDGE_INCLUDE_DIR` and `WASMEDGE_LIB_DIR` environment variables to specify the `include` and `lib` (here is `lib64`) directories.
 
-  ```bash
-  // $HOME/.wasmedge/
-  .
-  ├── bin
-  │   ├── wasmedge
-  │   └── wasmedgec
-  ├── include
-  │   └── wasmedge
-  │       ├── dense_enum_map.h
-  │       ├── enum.inc
-  │       ├── enum_configure.h
-  │       ├── enum_errcode.h
-  │       ├── enum_types.h
-  │       ├── int128.h
-  │       ├── spare_enum_map.h
-  │       ├── version.h
-  │       └── wasmedge.h
-  └── lib64
-      ├── libwasmedge_c.so
-      └── wasmedge
-          └── libwasmedgePluginWasmEdgeProcess.so
+      ```bash
+      root@0a877562f39e:~/workspace/me/WasmEdge/bindings/rust/wasmedge-sys# export WASMEDGE_INCLUDE_DIR=/root/workspace/me/WasmEdge-0.10.0-Linux/include/wasmedge
+      
+      root@0a877562f39e:~/workspace/me/WasmEdge/bindings/rust/wasmedge-sys# export WASMEDGE_LIB_DIR=/root/workspace/me/WasmEdge-0.10.0-Linux/lib64
+      ```
 
-  5 directories, 13 files
-  ```
-  
+  - By specifying `WASMEDGE_BUILD_DIR`
+
+    You can choose this way if you'd like to use the latest code in the `master` branch of the `WasmEdge` github repo. For example,
+
+    - Suppose that you `git clone` WasmEdge repo in your local directory, for example, `~/workspace/me/WasmEdge`, and follow the [instructions](https://wasmedge.org/book/en/extend/build.html) to build WasmEdge native library. After that, you should find the generated `include` and `lib` directories in `~/workspace/me/WasmEdge/build`.
+
+    - Then, set `WASMEDGE_BUILD_DIR` environment variable to specify the `build` directory.
+
+      ```bash
+      root@0a877562f39e:~/workspace/me/WasmEdge# export WASMEDGE_BUILD_DIR=/root/workspace/me/WasmEdge/build
+      ```
+
+- Second, after deploy the `WasmEdge` library on your local system, copy/paste the following code into the `Cargo.toml` file of your project. Now, you can use `cargo build` command to build your project.
+
+```toml
+[dependencies]
+wasmedge-sdk = "0.1"
+```
+
+## `wasmedge-sys` crate
+
+`wasmedge-sys` serves as a wraper layer of `WasmEdge` C-API, and provides a group of safe low-level Rust interfaces. For those who are interested in using `wasmedge-sys` in their projects, you should also deploy the `WasmEdge` library on your local system as described in the [wasmedge-sdk crate](#wasmedge-sdk-crate) section. Then, copy/paste the following code in the `Cargo.toml` file of your project.
+
+```toml
+[dependencies]
+wasmedge-sys = "0.7"
+```
+
+*For Windows users, duo to [issue 1527](https://github.com/WasmEdge/WasmEdge/issues/1527), the current version of `wasmedge-sys` does not support `standalone` mode on Windows platform. Please choose to use our [docker image](#docker-image). We'll fix the issue as soon as possible.*
+
+For those who want to build `wasmedge-sys` from source in terminal, just go to the `wasmedge-sys` directory and type `cargo build --features standalone` command that will compile the `wasmedge-sys` crate in `standalone` mode.
+
 ## Docker image
 
 For those who would like to dev in Docker environment, you can reference the [Use Docker](/src/start/docker.md) section of this book, which details how to use Docker for `WasmEdge` application development.
 
+### Windows Users
+
+Duo to [issue 1527](https://github.com/WasmEdge/WasmEdge/issues/1527), WasmEdger Rust bindings can not be used directly on Windows platform for now. Please choose to use our [docker image](#docker-image). We'll fix the issue as soon as possible.
+
 ## Examples
+
+For helping you get familiar with WasmEdge Rust bindings, the following quick examples demonstrate how to use the APIs defined in `wasmedge-sdk` and `wasmedge-sys`, respectively. In addition, we'll add more examples continuously. Please file an issue [here](https://github.com/WasmEdge/WasmEdge/issues) and let us know if you have any problems with the API usage.
 
 ### `wasmedge-sdk` Examples
 

--- a/docs/book/en/src/embed/rust.md
+++ b/docs/book/en/src/embed/rust.md
@@ -204,6 +204,8 @@ For those who would like to dev in Docker environment, you can reference the [Us
 
 - [[wasmedge-sdk] Hello World!](rust/say_hello.md)
 
+- [[wasmedge-sdk] Memory manipulation](rust/memory_manipulation.md)
+
 ### `wasmedge-sys` Examples
 
 - [[wasmedge-sys] Run a WebAssembly function with WasmEdge low-level APIs](rust/sys_run_host_func.md)

--- a/docs/book/en/src/embed/rust/memory_manipulation.md
+++ b/docs/book/en/src/embed/rust/memory_manipulation.md
@@ -152,4 +152,4 @@ assert_eq!(returns[0].to_i32(), val);
 
 The comments in the code explain the meaning of the code sample above, so we don't describe more.
 
-The complete example can be found [here](https://github.com/WasmEdge/WasmEdge/blob/master/bindings/rust/wasmedge-sdk/examples/memory.rs).
+The complete code of this example can be found [here](https://github.com/WasmEdge/WasmEdge/blob/master/bindings/rust/wasmedge-sdk/examples/memory.rs).

--- a/docs/book/en/src/embed/rust/memory_manipulation.md
+++ b/docs/book/en/src/embed/rust/memory_manipulation.md
@@ -6,9 +6,36 @@ N.B. In this example, `wasmedge-sdk v0.1.1`, `wasmedge-sys v0.7.1` and `wasmedge
 
 ## Wasm module
 
-Before talk about the code, let's first see the wasm module we use in this example.
+Before talk about the code, let's first see the wasm module we use in this example. In the wasm module, a linear memory of 1-page (64KiB) size is defined; in addition, three functions are exported from this module: `get_at`, `set_at`, and `mem_size`.
 
-(to do ...)
+```wasm
+(module
+  (type $mem_size_t (func (result i32)))
+  (type $get_at_t (func (param i32) (result i32)))
+  (type $set_at_t (func (param i32) (param i32)))
+
+  # A memory with initial size of 1 page
+  (memory $mem 1)
+
+  (func $get_at (type $get_at_t) (param $idx i32) (result i32)
+    (i32.load (local.get $idx)))
+
+  (func $set_at (type $set_at_t) (param $idx i32) (param $val i32)
+    (i32.store (local.get $idx) (local.get $val)))
+
+  (func $mem_size (type $mem_size_t) (result i32)
+    (memory.size))
+  
+  # Exported functions
+  (export "get_at" (func $get_at))
+  (export "set_at" (func $set_at))
+  (export "mem_size" (func $mem_size))
+  (export "memory" (memory $mem)))
+```
+
+Next, we'll demonstrate how to manipulate the linear memory by calling the exported functions.
+
+## Load Module
 
 Let's start off by getting all imports right away so you can follow along
 
@@ -20,3 +47,57 @@ use wasmedge_sdk::{params, Executor, ImportObjectBuilder, Module, Store};
 use wasmedge_sys::WasmValue;
 use wasmedge_types::wat2wasm;
 ```
+
+To load a `Module`, `wasmedge-sdk` defines two methods:
+
+- [from_file](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Module.html#method.from_file) loads a wasm module from a file, and meanwhile, validates the loaded wasm module.
+
+- [from_bytes](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Module.html#method.from_bytes) loads a wasm module from an array of in-memory bytes, and meanwhile, validates the loaded wasm module.
+
+Here we use `Module::from_bytes` method to load our wasm module from an array of in-memory bytes.
+
+```rust
+let wasm_bytes = wat2wasm(
+        r#"
+(module
+  (type $mem_size_t (func (result i32)))
+  (type $get_at_t (func (param i32) (result i32)))
+  (type $set_at_t (func (param i32) (param i32)))
+
+  (memory $mem 1)
+
+  (func $get_at (type $get_at_t) (param $idx i32) (result i32)
+    (i32.load (local.get $idx)))
+
+  (func $set_at (type $set_at_t) (param $idx i32) (param $val i32)
+    (i32.store (local.get $idx) (local.get $val)))
+
+  (func $mem_size (type $mem_size_t) (result i32)
+    (memory.size))
+
+  (export "get_at" (func $get_at))
+  (export "set_at" (func $set_at))
+  (export "mem_size" (func $mem_size))
+  (export "memory" (memory $mem)))
+"#
+    .as_bytes(),
+)?;
+
+// loads a wasm module from the given in-memory bytes
+let module = Module::from_bytes(None, &wasm_bytes)?;
+```
+
+The module returned by `Module::from_bytes` is a compiled module, also called AST Module in WasmEdge terminology. To use it in WasmEdge runtime environment, we need to instantiate the AST module. We use [Store::register_named_module](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Store.html#method.register_named_module) API to achieve the goal.
+
+```rust
+// create an executor
+let mut executor = Executor::new(None, None)?;
+
+// create a store
+let mut store = Store::new()?;
+
+// register the module into the store
+let extern_instance = store.register_named_module(&mut executor, "extern", &module)?;
+```
+
+In the code above, we register the AST module into a `Store`, in which the module is instantiated, and as a result, a [module instance](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Instance.html) is returned.

--- a/docs/book/en/src/embed/rust/memory_manipulation.md
+++ b/docs/book/en/src/embed/rust/memory_manipulation.md
@@ -1,0 +1,22 @@
+# Memory Manipulation
+
+In this example, we'll present how to manipulate the linear memory with the APIs defined in [wasmedge_sdk::Memory](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Memory.html).
+
+N.B. In this example, `wasmedge-sdk v0.1.1`, `wasmedge-sys v0.7.1` and `wasmedge-types v0.1.3` are used.
+
+## Wasm module
+
+Before talk about the code, let's first see the wasm module we use in this example.
+
+(to do ...)
+
+Let's start off by getting all imports right away so you can follow along
+
+```rust
+// please add this feature if you're using rust of version < 1.63
+// #![feature(explicit_generic_args_with_impl_trait)]
+
+use wasmedge_sdk::{params, Executor, ImportObjectBuilder, Module, Store};
+use wasmedge_sys::WasmValue;
+use wasmedge_types::wat2wasm;
+```

--- a/docs/book/en/src/embed/rust/say_hello.md
+++ b/docs/book/en/src/embed/rust/say_hello.md
@@ -115,4 +115,4 @@ Any one of these two methods requires that you have to get a [function instance]
 
 In addition, [Vm](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Vm.html#) defines a group of methods which can invoke host function in different ways. For details, please reference [Vm](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Vm.html#).
 
-The complete code can be found [here](https://github.com/WasmEdge/WasmEdge/blob/master/bindings/rust/wasmedge-sdk/examples/hello_world.rs).
+The complete example can be found [here](https://github.com/WasmEdge/WasmEdge/blob/master/bindings/rust/wasmedge-sdk/examples/hello_world.rs).

--- a/docs/book/en/src/embed/rust/say_hello.md
+++ b/docs/book/en/src/embed/rust/say_hello.md
@@ -1,0 +1,14 @@
+# Hello World
+
+N.B. In this example, `wasmedge-sdk v0.1.0`, `wasmedge-sys v0.7.0` and `wasmedge-types v0.1.3` are used.
+
+Let's start off by getting all our imports right away so you can follow along
+
+```rust
+// please add this feature if you're using rust of version < 1.63
+// #![feature(explicit_generic_args_with_impl_trait)]
+
+use wasmedge_sdk::{params, Executor, ImportObjectBuilder, Module, Store};
+use wasmedge_sys::WasmValue;
+use wasmedge_types::wat2wasm;
+```

--- a/docs/book/en/src/embed/rust/say_hello.md
+++ b/docs/book/en/src/embed/rust/say_hello.md
@@ -1,8 +1,10 @@
 # Hello World
 
-N.B. In this example, `wasmedge-sdk v0.1.0`, `wasmedge-sys v0.7.0` and `wasmedge-types v0.1.3` are used.
+In this example, we'll use a wasm module, in which a function `run` is exported and it will call a function `say_hello` from an import module named `env`. The imported function `say_hello` has no inputs and outputs, and only prints a greeting message out.
 
-Let's start off by getting all our imports right away so you can follow along
+N.B. In this example, `wasmedge-sdk v0.1.1`, `wasmedge-sys v0.7.1` and `wasmedge-types v0.1.3` are used.
+
+Let's start off by getting all imports right away so you can follow along
 
 ```rust
 // please add this feature if you're using rust of version < 1.63
@@ -12,3 +14,105 @@ use wasmedge_sdk::{params, Executor, ImportObjectBuilder, Module, Store};
 use wasmedge_sys::WasmValue;
 use wasmedge_types::wat2wasm;
 ```
+
+## Step 1: Define a native function and Create an ImportObject
+
+First, let's define a native function named `say_hello_world` that prints out `Hello, World!`.
+
+```rust
+fn say_hello_world(_inputs: Vec<WasmValue>) -> Result<Vec<WasmValue>, u8> {
+    println!("Hello, world!");
+
+    Ok(vec![])
+}
+```
+
+To use the native function as an import function in the `WasmEdge` runtime, we need an `ImportObject`. `wasmedge-sdk` defines a [ImportObjectBuilder](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.ImportObjectBuilder.html), which provides a group of chaining methods used to create an `ImportObject`. Let's see how to do it.
+
+```rust
+// create an import module
+let import = ImportObjectBuilder::new()
+    .with_func::<(), ()>("say_hello", say_hello_world)?
+    .build("env")?; 
+```
+
+Now, we have an import module named `env` which holds a host function `say_hello`. As you may notice, the names we used for the import module and the host function are exactly the same as the ones appearing in the wasm module. You can find the wasm module in [Step 2](#step-2-load-a-wasm-module).
+
+## Step 2: Load a wasm module
+
+Now, let's load a wasm module. `wasmedge-sdk` defines two methods in `Module`:
+
+- [from_file](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Module.html#method.from_file) loads a wasm module from a file, and meanwhile, validates the loaded wasm module.
+
+- [from_bytes](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Module.html#method.from_bytes) loads a wasm module from an array of in-memory bytes, and meanwhile, validates the loaded wasm module.
+
+Here we choose `Module::from_bytes` method to load our wasm module from an array of in-memory bytes.
+
+```rust
+let wasm_bytes = wat2wasm(
+    br#"
+(module
+    ;; First we define a type with no parameters and no results.
+    (type $no_args_no_rets_t (func (param) (result)))
+
+    ;; Then we declare that we want to import a function named "env" "say_hello" with
+    ;; that type signature.
+    (import "env" "say_hello" (func $say_hello (type $no_args_no_rets_t)))
+
+    ;; Finally we create an entrypoint that calls our imported function.
+    (func $run (type $no_args_no_rets_t)
+    (call $say_hello))
+    ;; And mark it as an exported function named "run".
+    (export "run" (func $run)))
+"#,
+)?;
+
+// loads a wasm module from the given in-memory bytes and returns a compiled module
+let module = Module::from_bytes(None, &wasm_bytes)?;
+```
+
+## Step 3: Register import module and compiled module
+
+To register a compiled module, we need to check if it has dependency on some import modules. In the wasm module this statement `(import "env" "say_hello" (func $say_hello (type $no_args_no_rets_t)))` tells us that it depends on an import module named `env`. Therefore, we need to register the import module first before registering the compiled wasm module.
+
+```rust
+// create an executor
+let mut executor = Executor::new(None, None)?;
+
+// create a store
+let mut store = Store::new()?;
+
+// register the import module into the store
+store.register_import_module(&mut executor, &import)?;
+
+// register the compiled module into the store and get an module instance
+let extern_instance = store.register_named_module(&mut executor, "extern", &module)?;
+```
+
+In the code above we use [Executor](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Executor.html) and [Store](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Store.html) to register the import module and the compiled module. `wasmedge-sdk` also provides alternative APIs to do the same thing: [Vm::register_import_module](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Vm.html#method.register_import_module) and [Vm::register_module_from_bytes](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Vm.html#method.register_module_from_bytes).
+
+## Step 4: Run the exported function
+
+Now we are ready to run the exported function.
+
+```rust
+// get the exported function "run"
+let run = extern_instance
+    .func("run")
+    .ok_or_else(|| anyhow::Error::msg("Not found exported function named 'run'."))?;
+
+// run host function
+run.call(&mut executor, params!())?;
+```
+
+In this example we created an instance of `Executor`, hence, we have two choices to call a [function instance](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Func.html):
+
+- [Func::call](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Func.html#method.call)
+
+- [Executor::run_func](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/trait.Engine.html#tymethod.run_func)
+
+Any one of these two methods requires that you have to get a [function instance](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Func.html).
+
+In addition, [Vm](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Vm.html#) defines a group of methods which can invoke host function in different ways. For details, please reference [Vm](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Vm.html#).
+
+The complete code can be found [here](https://github.com/WasmEdge/WasmEdge/blob/master/bindings/rust/wasmedge-sdk/examples/hello_world.rs).

--- a/docs/book/en/src/embed/rust/table_and_funcref.md
+++ b/docs/book/en/src/embed/rust/table_and_funcref.md
@@ -1,0 +1,123 @@
+# Table and FuncRef
+
+In this example, we'll present how to use [Table](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.Table.html) and [FuncRef](https://wasmedge.github.io/WasmEdge/wasmedge_sdk/struct.FuncRef.html) stored in a slot of a `Table` instance to implement indirect function invocation.
+
+## Prerequisite
+
+In this example we defines a native function `real_add` that takes two numbers and returns their sum. This function will be registered as a host function into WasmEdge runtime environment
+
+```rust
+fn real_add(input: Vec<WasmValue>) -> Result<Vec<WasmValue>, u8> {
+    println!("Rust: Entering Rust function real_add");
+
+    if input.len() != 2 {
+        return Err(1);
+    }
+
+    let a = if input[0].ty() == ValType::I32 {
+        input[0].to_i32()
+    } else {
+        return Err(2);
+    };
+
+    let b = if input[1].ty() == ValType::I32 {
+        input[1].to_i32()
+    } else {
+        return Err(3);
+    };
+
+    let c = a + b;
+    println!("Rust: calcuating in real_add c: {:?}", c);
+
+    println!("Rust: Leaving Rust function real_add");
+    Ok(vec![WasmValue::from_i32(c)])
+}
+```
+
+In addition, the following imports are used in this example.
+
+```rust
+use wasmedge_sdk::{
+    config::{CommonConfigOptions, ConfigBuilder},
+    params,
+    types::Val,
+    Executor, Func, ImportObjectBuilder, Store, Table, WasmVal,
+};
+use wasmedge_sys::WasmValue;
+use wasmedge_types::{RefType, TableType, ValType};
+```
+
+## Register Table instance
+
+The first thing we need to do is to create a `Table` instance. After that, we register the table instance along with an import module into the WasmEdge runtime environment. Now let's see the code.
+
+```rust
+// create an executor
+let config = ConfigBuilder::new(CommonConfigOptions::default()).build()?;
+let mut executor = Executor::new(Some(&config), None)?;
+
+// create a store
+let mut store = Store::new()?;
+
+// create a table instance
+let result = Table::new(TableType::new(RefType::FuncRef, 10, Some(20)));
+assert!(result.is_ok());
+let table = result.unwrap();
+
+// create an import object
+let import = ImportObjectBuilder::new()
+    .with_table("my-table", table)?
+    .build("extern")?;
+
+// register the import object into the store
+store.register_import_module(&mut executor, &import)?;
+```
+
+In the code snippet above, we create a `Table` instance with the initial size of `10` and the maximum size of 20. The element type of the `Table` instance is `reference to function`.
+
+## Store a function reference into Table
+
+In the previous steps, we defined a native function `real_add` and registered a `Table` instance named `my-table` into the runtime environment. Now we'll save a reference to `read_add` function to a slot of `my-table`.
+
+```rust
+// get the exported table instance
+let mut table = instance
+    .table("my-table")
+    .expect("Not found table instance named 'my-table'");
+
+// create a host function
+let host_func = Func::wrap::<(i32, i32), i32>(Box::new(real_add))?;
+
+// store the reference to host_func at the given index of the table instance
+table.set(3, Val::FuncRef(Some(host_func.as_ref())))?;
+```
+
+We save the reference to `host_func` into the third slot of `my-table`. Next, we can retrieve the function reference from the table instance by index and call the function via its reference.
+
+## Call native function via `FuncRef`
+
+```rust
+// retrieve the function reference at the given index of the table instance
+let value = table.get(3)?;
+if let Val::FuncRef(Some(func_ref)) = value {
+    // get the function type by func_ref
+    let func_ty = func_ref.ty()?;
+
+    // arguments
+    assert_eq!(func_ty.args_len(), 2);
+    let param_tys = func_ty.args().unwrap();
+    assert_eq!(param_tys, [ValType::I32, ValType::I32]);
+
+    // returns
+    assert_eq!(func_ty.returns_len(), 1);
+    let return_tys = func_ty.returns().unwrap();
+    assert_eq!(return_tys, [ValType::I32]);
+
+    // call the function by func_ref
+    let returns = func_ref.call(&mut executor, params!(1, 2))?;
+    assert_eq!(returns.len(), 1);
+    assert_eq!(returns[0].to_i32(), 3);
+}
+```
+
+The complete code of this example can be found [here](https://github.com/WasmEdge/WasmEdge/blob/master/bindings/rust/wasmedge-sdk/examples/table_and_funcref.rs).

--- a/docs/book/en/src/extend/plugin/externref.md
+++ b/docs/book/en/src/extend/plugin/externref.md
@@ -1,6 +1,6 @@
 # Customized External References
 
-[External References](https://webassembly.github.io/reference-types/core/syntax/types.html#syntax-reftype) denotes an opaque and unforgeable reference to a host object. A new `externref` type can be passed into a Wasm module or return from it. The Wasm module cannot reveal an `externref` value's bit pattern, nor create a fake host reference by an integer value.
+[External References](https://webassembly.github.io/reference-types/core/syntax/types.html#syntax-reftype) denotes an opaque and unforgetable reference to a host object. A new `externref` type can be passed into a Wasm module or return from it. The Wasm module cannot reveal an `externref` value's bit pattern, nor create a fake host reference by an integer value.
 
 ## Tutorial
 

--- a/docs/book/en/src/extend/plugin/loadable.md
+++ b/docs/book/en/src/extend/plugin/loadable.md
@@ -1,6 +1,6 @@
 # Loadable plugin
 
-Loadable plugin is a stand-along `.so`/`.dylib`/`.dll` file that WasmEdge can load during runtime environment, and provide modules to be imported. The following steps give an example of making a loadable plugin.
+Loadable plugin is a standalone `.so`/`.dylib`/`.dll` file that WasmEdge can load during runtime environment, and provide modules to be imported. The following steps give an example of making a loadable plugin.
 
 ## Example code
 


### PR DESCRIPTION
In this PR, new examples for demonstrating `wasmedge-sdk` are added; in addition, the sections about the `standalone` build mode are removed.