### PR TITLE
[Compiler] lld on macho requires -arch and -platform_version to always be specified

### DIFF
--- a/lib/aot/compiler.cpp
+++ b/lib/aot/compiler.cpp
@@ -4687,6 +4687,12 @@ Expect<void> outputNativeLibrary(const std::filesystem::path &OutputPath,
 #else
 #error Unsupported platform!
 #endif
+#if LLVM_VERSION_MAJOR >= 14
+            // LLVM 14 replaces the older mach_o lld implementation with the new
+            // one. And it require -arch and -platform_version to always be
+            // specified. Reference: https://reviews.llvm.org/D97799
+            "-platform_version", "macos", "10", "11",
+#endif
             "-dylib", "-demangle", "-macosx_version_min", "10.0.0",
             "-sdk_version", "11.3", "-syslibroot",
             "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",


### PR DESCRIPTION
Reference: https://reviews.llvm.org/D97799