### PR TITLE
[Docs] Fix outdated contributing page

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -29,35 +29,11 @@ Notes: Note the WasmEdge team builds lots of extensions of Server-side WebAssemb
 
 The WasmEdge is developed on Ubuntu 20.04 to take advantage of advanced LLVM features for the AOT compiler. The WasmEdge team also builds and releases statically linked WasmEdge binaries for older Linux distributions.
 
-Our development environment requires libLLVM-10 and >=GLIBCXX_3.4.26.
+Our development environment requires libLLVM-12 and >=GLIBCXX_3.4.26.
 
 If you are using an operating system older than Ubuntu 20.04, please use our special docker image to build WasmEdge. If you are looking for the pre-built binaries for the older operating system, we also provide several pre-built binaries based on manylinux* distribution.
 
-### Docker image
-
-```bash
-docker pull wasmedge/wasmedge
-```
-
-### Setup the environment manually
-
-```bash
-# Tools and libraries
-sudo apt install -y \
-    software-properties-common \
-    cmake \
-    libboost-all-dev
-
-# And you will need to install llvm for wasmedgec tool
-sudo apt install -y \
-    llvm-12-dev \
-    liblld-12-dev
-
-# WasmEdge supports both clang++ and g++ compilers
-# You can choose one of them for building this project
-sudo apt install -y gcc g++
-sudo apt install -y clang
-```
+Build WasmEdge please refer to: [Build WasmEdge from source](https://wasmedge.org/book/en/extend/build.html).
 
 ## Contribute Workflow
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -47,11 +47,14 @@ sudo apt install -y \
     software-properties-common \
     cmake \
     libboost-all-dev
+
 # And you will need to install llvm for wasmedgec tool
 sudo apt install -y \
-    llvm-dev \
-    liblld-10-dev
-# WasmEdge supports both clang++ and g++ compilers# You can choose one of them for building this project
+    llvm-12-dev \
+    liblld-12-dev
+
+# WasmEdge supports both clang++ and g++ compilers
+# You can choose one of them for building this project
 sudo apt install -y gcc g++
 sudo apt install -y clang
 ```
@@ -74,7 +77,14 @@ Changes should be made on your own fork in a new branch. The branch should be na
 
 ### Develop, Build and Test
 
-Write code on the new branch in your fork.
+Write code on the new branch in your fork, and build from source code:
+
+```bash
+cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_TESTS=ON
+cmake --build build
+```
+
+If you using Docker as development environment:
 
 ```bash
 # After pulling our wasmedge docker image

--- a/utils/docker/Dockerfile.ubuntu2004_x86_64
+++ b/utils/docker/Dockerfile.ubuntu2004_x86_64
@@ -13,8 +13,8 @@ RUN apt update && apt upgrade -y \
 	git \
 	dpkg-dev \
 	libboost-all-dev \
-	llvm-10-dev \
-	liblld-10-dev \
+	llvm-12-dev \
+	liblld-12-dev \
 	gcc \
 	rpm \
 	dpkg-dev \


### PR DESCRIPTION
Following with outdated contribute page will get this error:

```
-- Linker detection: GNU ld
CMake Error at lib/aot/CMakeLists.txt:9 (find_package):
  Could not find a package configuration file provided by "LLD" with any of
  the following names:

    LLDConfig.cmake
    lld-config.cmake

  Add the installation prefix of "LLD" to CMAKE_PREFIX_PATH or set "LLD_DIR"
  to a directory containing one of the above files.  If "LLD" provides a
  separate development package or SDK, be sure it has been installed.


-- Configuring incomplete, errors occurred!
See also "/home/cat/WasmEdge/build/CMakeFiles/CMakeOutput.log".
See also "/home/cat/WasmEdge/build/CMakeFiles/CMakeError.log".
```

llvm-12 is required.

Or a better option is to link the build section to [https://wasmedge.org/book/en/extend/build.html](https://wasmedge.org/book/en/extend/build.html) ?
So we won't need to maintain duplicated parts.
