### PR TITLE
Fix uninitialized variable warning

### DIFF
--- a/lib/aot/compiler.cpp
+++ b/lib/aot/compiler.cpp
@@ -4877,7 +4877,7 @@ Expect<void> outputWasmLibrary(const std::filesystem::path &OutputPath,
       } else if (Name == SYMBOL("intrinsics"sv)) {
         IntrinsicsAddress = Address;
       } else if (startsWith(Name, SYMBOL("t"sv))) {
-        uint64_t Index;
+        uint64_t Index = 0;
         std::from_chars(Name.data() + SYMBOL("t"sv).size(),
                         Name.data() + Name.size(), Index);
         if (Types.size() < Index + 1) {
@@ -4885,7 +4885,7 @@ Expect<void> outputWasmLibrary(const std::filesystem::path &OutputPath,
         }
         Types[Index] = Address;
       } else if (startsWith(Name, SYMBOL("f"sv))) {
-        uint64_t Index;
+        uint64_t Index = 0;
         std::from_chars(Name.data() + SYMBOL("f"sv).size(),
                         Name.data() + Name.size(), Index);
         if (Codes.size() < Index + 1) {


### PR DESCRIPTION
Hi WasmEdge team

We're building WasmEdge statically inside another existing build system and this system is using `-Werror=uninitialized`.  As a result we're getting an error at the two lines fixed by this commit. We could hot patch in the build engine but better to PR this. Thanks! 😇