### PR TITLE
spelling: infomation -> information

### DIFF
--- a/include/common/errinfo.h
+++ b/include/common/errinfo.h
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file contains the enumerations of WasmEdge error infomation.
+/// This file contains the enumerations of WasmEdge error information.
 ///
 //===----------------------------------------------------------------------===//
 #pragma once

--- a/include/po/argument_parser.h
+++ b/include/po/argument_parser.h
@@ -202,7 +202,7 @@ private:
 public:
   ArgumentParser() noexcept
       : SubCommandDescriptors(1), CurrentSubCommandId(0),
-        VerOpt(Description("Show version infomation"sv)) {
+        VerOpt(Description("Show version information"sv)) {
     SubCommandDescriptors.front().add_option("v"sv, VerOpt);
     SubCommandDescriptors.front().add_option("version"sv, VerOpt);
   }


### PR DESCRIPTION
Caught by Debian's lintian.

Signed-off-by: Faidon Liambotis <paravoid@debian.org>