### PR TITLE
[Tools] Add the lost WASI-NN host function registration in tools.

### DIFF
--- a/lib/driver/tool.cpp
+++ b/lib/driver/tool.cpp
@@ -212,6 +212,7 @@ int Tool(int Argc, const char *Argv[]) noexcept {
 
   Conf.addHostRegistration(HostRegistration::Wasi);
   Conf.addHostRegistration(HostRegistration::WasmEdge_Process);
+  Conf.addHostRegistration(HostRegistration::WasiNN);
   const auto InputPath = std::filesystem::absolute(SoName.value());
   VM::VM VM(Conf);
 


### PR DESCRIPTION
Signed-off-by: YiYing He <yiying@secondstate.io>