### PR TITLE
[CI] Fix the wasi-crypto upload path in release CI.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,7 +351,8 @@ jobs:
           cd build
           cd ${{ matrix.output_path }}
           make -j
-          cd -
+      - name: Prepare the WasmEdge ${{ matrix.name }} plugin tar.gz package
+        run: |
           cp build/${{ matrix.output_path }}/${{ matrix.output_bin }} ${{ matrix.output_bin }}
           tar -zcvf plugin.tar.gz ${{ matrix.output_bin }}
       - name: Upload WasmEdge ${{ matrix.name }} plugin tar.gz package


### PR DESCRIPTION
Signed-off-by: YiYing He <yiying@secondstate.io>