### PR TITLE
[Rust][CI] Refactored workflows related to Rust bindings for publishing crates.

### DIFF
--- a/.github/workflows/rust-wasmedge-sdk-docs.yml
+++ b/.github/workflows/rust-wasmedge-sdk-docs.yml
@@ -7,7 +7,6 @@ concurrency:
 on:
   push:
     branches:
-      - "master"
       - "rust/*"
     tags:
       - "rust-sdk/[0-9]+.[0-9]+.[0-9]+*"
@@ -30,14 +29,12 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Build WasmEdge using clang with Debug mode
+      - name: Build WasmEdge with Release mode
         run: |
-          apt-get update
-          apt-get install -y make
-          mkdir -p build
-          cd build
-          cmake -DCMAKE_BUILD_TYPE=Debug -DWASMEDGE_BUILD_TESTS=ON ..
-          make -j
+          apt update
+          apt install -y software-properties-common libboost-all-dev llvm-12-dev liblld-12-dev ninja-build
+          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_TESTS=ON .
+          cmake --build build
 
       - name: Build Documentation
         run: |

--- a/.github/workflows/rust-wasmedge-sdk-docs.yml
+++ b/.github/workflows/rust-wasmedge-sdk-docs.yml
@@ -6,6 +6,9 @@ concurrency:
 
 on:
   push:
+    branches:
+      - "master"
+      - "rust/*"
     tags:
       - "rust-sdk/[0-9]+.[0-9]+.[0-9]+*"
 

--- a/.github/workflows/rust-wasmedge-sdk-release.yml
+++ b/.github/workflows/rust-wasmedge-sdk-release.yml
@@ -47,8 +47,8 @@ jobs:
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"
-          cargo publish --dry-run
-          cargo publish
+          cargo publish -p wasmedge-sdk --dry-run
+          cargo publish -p wasmedge-sdk
 
       - name: Dry run wasmedge-sdk crate
         if: github.ref_type == 'branch'
@@ -62,4 +62,4 @@ jobs:
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"
-          cargo publish --dry-run
+          cargo publish -p wasmedge-sdk --dry-run

--- a/.github/workflows/rust-wasmedge-sdk-release.yml
+++ b/.github/workflows/rust-wasmedge-sdk-release.yml
@@ -28,10 +28,12 @@ jobs:
         with:
           toolchain: nightly
 
-      - name: Build WasmEdge using clang
+      - name: Build WasmEdge with Release mode
         run: |
-          cmake -Bbuild -GNinja -DWASMEDGE_BUILD_SHARED_LIB=ON  -DCMAKE_INSTALL_PREFIX:PATH=/usr .
-          cmake --build build --target install
+          apt update
+          apt install -y software-properties-common libboost-all-dev llvm-12-dev liblld-12-dev ninja-build
+          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_TESTS=ON .
+          cmake --build build
 
       - name: Publish wasmedge-sdk crate
         if: github.ref_type == 'tag'
@@ -40,6 +42,9 @@ jobs:
         shell: bash
         run: |
           cd bindings/rust/wasmedge-sdk
+          export WASMEDGE_DIR="$(pwd)/../../"
+          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
+          export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"
           cargo publish --dry-run
@@ -52,6 +57,9 @@ jobs:
         shell: bash
         run: |
           cd bindings/rust/wasmedge-sdk
+          export WASMEDGE_DIR="$(pwd)/../../"
+          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
+          export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"
           cargo publish --dry-run

--- a/.github/workflows/rust-wasmedge-sdk-release.yml
+++ b/.github/workflows/rust-wasmedge-sdk-release.yml
@@ -6,12 +6,14 @@ concurrency:
 
 on:
   push:
+    branches:
+      - "master"
+      - "rust/*"
     tags:
       - "rust-sdk/[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
-  crate_release:
-    name: Create Release
+  build-release-publish:
     runs-on: ubuntu-latest
     container:
       image: wasmedge/wasmedge:ubuntu-build-clang
@@ -32,6 +34,7 @@ jobs:
           cmake --build build --target install
 
       - name: Publish wasmedge-sdk crate
+        if: github.ref_type == 'tag'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         shell: bash
@@ -41,3 +44,14 @@ jobs:
           git config --global user.name "Github Action"
           cargo publish --dry-run
           cargo publish
+
+      - name: Dry run wasmedge-sdk crate
+        if: github.ref_type == 'branch'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        shell: bash
+        run: |
+          cd bindings/rust/wasmedge-sdk
+          git config --global user.email "runner@gha.local"
+          git config --global user.name "Github Action"
+          cargo publish --dry-run

--- a/.github/workflows/rust-wasmedge-sdk-release.yml
+++ b/.github/workflows/rust-wasmedge-sdk-release.yml
@@ -41,10 +41,10 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         shell: bash
         run: |
-          cd bindings/rust/wasmedge-sdk
-          export WASMEDGE_DIR="$(pwd)/../../../"
-          export WASMEDGE_BUILD_DIR="$(WASMEDGE_DIR)/build"
-          export WASMEDGE_PLUGIN_PATH="$(WASMEDGE_DIR)/build/plugins/wasmedge_process"
+          cd bindings/rust/
+          export WASMEDGE_DIR="$(pwd)/../../"
+          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
+          export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"
           cargo publish --dry-run
@@ -56,10 +56,10 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         shell: bash
         run: |
-          cd bindings/rust/wasmedge-sdk
-          export WASMEDGE_DIR="$(pwd)/../../../"
-          export WASMEDGE_BUILD_DIR="$(WASMEDGE_DIR)/build"
-          export WASMEDGE_PLUGIN_PATH="$(WASMEDGE_DIR)/build/plugins/wasmedge_process"
+          cd bindings/rust/
+          export WASMEDGE_DIR="$(pwd)/../../"
+          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
+          export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"
           cargo publish --dry-run

--- a/.github/workflows/rust-wasmedge-sdk-release.yml
+++ b/.github/workflows/rust-wasmedge-sdk-release.yml
@@ -42,9 +42,9 @@ jobs:
         shell: bash
         run: |
           cd bindings/rust/wasmedge-sdk
-          export WASMEDGE_DIR="$(pwd)/../../"
-          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
-          export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
+          export WASMEDGE_DIR="$(pwd)/../../../"
+          export WASMEDGE_BUILD_DIR="$(WASMEDGE_DIR)/build"
+          export WASMEDGE_PLUGIN_PATH="$(WASMEDGE_DIR)/build/plugins/wasmedge_process"
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"
           cargo publish --dry-run
@@ -57,9 +57,9 @@ jobs:
         shell: bash
         run: |
           cd bindings/rust/wasmedge-sdk
-          export WASMEDGE_DIR="$(pwd)/../../"
-          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
-          export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
+          export WASMEDGE_DIR="$(pwd)/../../../"
+          export WASMEDGE_BUILD_DIR="$(WASMEDGE_DIR)/build"
+          export WASMEDGE_PLUGIN_PATH="$(WASMEDGE_DIR)/build/plugins/wasmedge_process"
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"
           cargo publish --dry-run

--- a/.github/workflows/rust-wasmedge-sys-docs.yml
+++ b/.github/workflows/rust-wasmedge-sys-docs.yml
@@ -6,6 +6,9 @@ concurrency:
 
 on:
   push:
+    branches:
+      - "master"
+      - "rust/*"
     tags:
       - "rust/[0-9]+.[0-9]+.[0-9]+*"
 

--- a/.github/workflows/rust-wasmedge-sys-docs.yml
+++ b/.github/workflows/rust-wasmedge-sys-docs.yml
@@ -7,7 +7,6 @@ concurrency:
 on:
   push:
     branches:
-      - "master"
       - "rust/*"
     tags:
       - "rust/[0-9]+.[0-9]+.[0-9]+*"
@@ -30,9 +29,20 @@ jobs:
           profile: minimal
           override: true
 
+      - name: Build WasmEdge with Release mode
+        run: |
+          apt update
+          apt install -y software-properties-common libboost-all-dev llvm-12-dev liblld-12-dev ninja-build
+          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_TESTS=ON .
+          cmake --build build
+
       - name: Build Documentation
         run: |
           cd bindings/rust/wasmedge-sys
+          export WASMEDGE_DIR="$(pwd)/../../../"
+          export WASMEDGE_BUILD_DIR="$(pwd)/../../../build"
+          export WASMEDGE_PLUGIN_PATH="$(pwd)/../../../build/plugins/wasmedge_process"
+          export LD_LIBRARY_PATH="$(pwd)/../../../build/lib/api"
           cargo doc --all --no-deps --target-dir=./target
           echo "<meta http-equiv=\"refresh\" content=\"0; url=wasmedge_sys\">" > target/doc/index.html
 

--- a/.github/workflows/rust-wasmedge-sys-release.yml
+++ b/.github/workflows/rust-wasmedge-sys-release.yml
@@ -24,15 +24,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Stable Rust
+      - name: Install Nightly Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
 
-      - name: Build WasmEdge using clang
+      - name: Build WasmEdge with Release mode
         run: |
-          cmake -Bbuild -GNinja -DWASMEDGE_BUILD_SHARED_LIB=ON  -DCMAKE_INSTALL_PREFIX:PATH=/usr .
-          cmake --build build --target install
+          apt update
+          apt install -y software-properties-common libboost-all-dev llvm-12-dev liblld-12-dev ninja-build
+          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_TESTS=ON .
+          cmake --build build
 
       - name: Publish wasmedge-sys crate
         if: github.ref_type == 'tag'
@@ -41,6 +43,9 @@ jobs:
         shell: bash
         run: |
           cd ./bindings/rust/wasmedge-sys
+          export WASMEDGE_DIR="$(pwd)/../../"
+          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
+          export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"
           cargo publish --dry-run
@@ -53,6 +58,9 @@ jobs:
         shell: bash
         run: |
           cd ./bindings/rust/wasmedge-sys
+          export WASMEDGE_DIR="$(pwd)/../../"
+          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
+          export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"
           cargo publish --dry-run

--- a/.github/workflows/rust-wasmedge-sys-release.yml
+++ b/.github/workflows/rust-wasmedge-sys-release.yml
@@ -6,6 +6,9 @@ concurrency:
 
 on:
   push:
+    branches:
+      - "master"
+      - "rust/*"
     tags:
       - "rust/[0-9]+.[0-9]+.[0-9]+*"
 
@@ -32,6 +35,19 @@ jobs:
           cmake --build build --target install
 
       - name: Publish wasmedge-sys crate
+        if: github.ref_type == 'tag'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        shell: bash
+        run: |
+          cd ./bindings/rust/wasmedge-sys
+          git config --global user.email "runner@gha.local"
+          git config --global user.name "Github Action"
+          cargo publish --dry-run
+          cargo publish
+
+      - name: Dry run wasmedge-sys crate
+        if: github.ref_type == 'branch'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         shell: bash

--- a/.github/workflows/rust-wasmedge-sys-release.yml
+++ b/.github/workflows/rust-wasmedge-sys-release.yml
@@ -48,8 +48,8 @@ jobs:
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"
-          cargo publish --dry-run
-          cargo publish
+          cargo publish -p wasmedge-sys --dry-run
+          cargo publish -p wasmedge-sys
 
       - name: Dry run wasmedge-sys crate
         if: github.ref_type == 'branch'
@@ -63,5 +63,4 @@ jobs:
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"
-          cargo publish --dry-run
-          cargo publish
+          cargo publish -p wasmedge-sys --dry-run

--- a/.github/workflows/rust-wasmedge-sys-release.yml
+++ b/.github/workflows/rust-wasmedge-sys-release.yml
@@ -43,9 +43,9 @@ jobs:
         shell: bash
         run: |
           cd ./bindings/rust/wasmedge-sys
-          export WASMEDGE_DIR="$(pwd)/../../"
-          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
-          export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
+          export WASMEDGE_DIR="$(pwd)/../../../"
+          export WASMEDGE_BUILD_DIR="$(WASMEDGE_DIR)/build"
+          export WASMEDGE_PLUGIN_PATH="$(WASMEDGE_DIR)/build/plugins/wasmedge_process"
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"
           cargo publish --dry-run
@@ -58,9 +58,9 @@ jobs:
         shell: bash
         run: |
           cd ./bindings/rust/wasmedge-sys
-          export WASMEDGE_DIR="$(pwd)/../../"
-          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
-          export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
+          export WASMEDGE_DIR="$(pwd)/../../../"
+          export WASMEDGE_BUILD_DIR="$(WASMEDGE_DIR)/build"
+          export WASMEDGE_PLUGIN_PATH="$(WASMEDGE_DIR)/build/plugins/wasmedge_process"
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"
           cargo publish --dry-run

--- a/.github/workflows/rust-wasmedge-sys-release.yml
+++ b/.github/workflows/rust-wasmedge-sys-release.yml
@@ -13,7 +13,7 @@ on:
       - "rust/[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
-  crate_release:
+  build-release-publish:
     name: Create Release
     runs-on: ubuntu-latest
     container:
@@ -42,10 +42,10 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         shell: bash
         run: |
-          cd ./bindings/rust/wasmedge-sys
-          export WASMEDGE_DIR="$(pwd)/../../../"
-          export WASMEDGE_BUILD_DIR="$(WASMEDGE_DIR)/build"
-          export WASMEDGE_PLUGIN_PATH="$(WASMEDGE_DIR)/build/plugins/wasmedge_process"
+          cd bindings/rust/
+          export WASMEDGE_DIR="$(pwd)/../../"
+          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
+          export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"
           cargo publish --dry-run
@@ -57,10 +57,10 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         shell: bash
         run: |
-          cd ./bindings/rust/wasmedge-sys
-          export WASMEDGE_DIR="$(pwd)/../../../"
-          export WASMEDGE_BUILD_DIR="$(WASMEDGE_DIR)/build"
-          export WASMEDGE_PLUGIN_PATH="$(WASMEDGE_DIR)/build/plugins/wasmedge_process"
+          cd ./bindings/rust/
+          export WASMEDGE_DIR="$(pwd)/../../"
+          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
+          export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"
           cargo publish --dry-run

--- a/.github/workflows/rust-wasmedge-types-docs.yml
+++ b/.github/workflows/rust-wasmedge-types-docs.yml
@@ -6,6 +6,9 @@ concurrency:
 
 on:
   push:
+    branches:
+      - "master"
+      - "rust/*"
     tags:
       - "rust-types/[0-9]+.[0-9]+.[0-9]+*"
 

--- a/.github/workflows/rust-wasmedge-types-docs.yml
+++ b/.github/workflows/rust-wasmedge-types-docs.yml
@@ -30,9 +30,20 @@ jobs:
           profile: minimal
           override: true
 
+      - name: Build WasmEdge with Release mode
+        run: |
+          apt update
+          apt install -y software-properties-common libboost-all-dev llvm-12-dev liblld-12-dev ninja-build
+          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_TESTS=ON .
+          cmake --build build
+
       - name: Build Documentation
         run: |
           cd bindings/rust/wasmedge-types
+          export WASMEDGE_DIR="$(pwd)/../../../"
+          export WASMEDGE_BUILD_DIR="$(pwd)/../../../build"
+          export WASMEDGE_PLUGIN_PATH="$(pwd)/../../../build/plugins/wasmedge_process"
+          export LD_LIBRARY_PATH="$(pwd)/../../../build/lib/api"
           cargo doc --all --no-deps --target-dir=./target
 
       - name: Deploy Docs


### PR DESCRIPTION
In this PR, `rust-wasmedge-sys-release` and `rust-wasmedge-sdk-release` workflows are refactored for publishing. In addition, `rust-wasmedge-types-docs`, `rust-wasmedge-sys-docs`, and `rust-wasmedge-sdk-docs` are also refactored.