### PR TITLE
[Docs] use the annotation "module.wasm.image/variant: compat-smart" instead of "module.wasm.image/variant: compat"

### DIFF
--- a/docs/book/en/src/kubernetes/cri/containerd.md
+++ b/docs/book/en/src/kubernetes/cri/containerd.md
@@ -67,7 +67,7 @@ sudo ctr i pull docker.io/hydai/wasm-wasi-example:with-wasm-annotation
 Now, you can run the example in just one line with ctr (the containerd cli).
 
 ```bash
-sudo ctr run --rm --runc-binary crun --runtime io.containerd.runc.v2 --label module.wasm.image/variant=compat docker.io/hydai/wasm-wasi-example:with-wasm-annotation wasm-example /wasi_example_main.wasm 50000000
+sudo ctr run --rm --runc-binary crun --runtime io.containerd.runc.v2 --label module.wasm.image/variant=compat-smart docker.io/hydai/wasm-wasi-example:with-wasm-annotation wasm-example /wasi_example_main.wasm 50000000
 ```
 
 Starting the container would execute the WebAssembly program. You can see the output in the console.
@@ -102,7 +102,7 @@ sudo ctr i pull docker.io/avengermojo/http_server:with-wasm-annotation
 Now, you can run the example in just one line with ctr (the containerd cli). Notice that we are running the container with `--net-host` so that the HTTP server inside the WasmEdge container is accessible from the outside shell.
 
 ```bash
-sudo ctr run --rm --net-host --runc-binary crun --runtime io.containerd.runc.v2 --label module.wasm.image/variant=compat docker.io/avengermojo/http_server:with-wasm-annotation http-server-example /http_server.wasm
+sudo ctr run --rm --net-host --runc-binary crun --runtime io.containerd.runc.v2 --label module.wasm.image/variant=compat-smart docker.io/avengermojo/http_server:with-wasm-annotation http-server-example /http_server.wasm
 ```
 
 Starting the container would execute the WebAssembly program. You can see the output in the console.

--- a/docs/book/en/src/kubernetes/demo/server.md
+++ b/docs/book/en/src/kubernetes/demo/server.md
@@ -66,9 +66,9 @@ CMD ["/http_server.wasm"]
 
 > Please note that adding self-defined annotation is still a new feature in buildah.
 
-The `crun` container runtime can start the above WebAssembly-based container image. But it requires the `module.wasm.image/variant=compat` annotation on the container image to indicate that it is a WebAssembly application without a guest OS. You can find the details in [Official crun repo](https://github.com/containers/crun/blob/main/docs/wasm-wasi-example.md).
+The `crun` container runtime can start the above WebAssembly-based container image. But it requires the `module.wasm.image/variant=compat-smart` annotation on the container image to indicate that it is a WebAssembly application without a guest OS. You can find the details in [Official crun repo](https://github.com/containers/crun/blob/main/docs/wasm-wasi-example.md).
 
-To add `module.wasm.image/variant=compat` annotation in the container image, you will need the latest [buildah](https://buildah.io/). Currently, Docker does not support this feature. Please follow [the install instructions of buildah](https://github.com/containers/buildah/blob/main/install.md) to build the latest buildah binary.
+To add `module.wasm.image/variant=compat-smart` annotation in the container image, you will need the latest [buildah](https://buildah.io/). Currently, Docker does not support this feature. Please follow [the install instructions of buildah](https://github.com/containers/buildah/blob/main/install.md) to build the latest buildah binary.
 
 ### Build and install the latest buildah on Ubuntu
 
@@ -106,7 +106,7 @@ buildah --help
 In the `target/wasm32-wasi/release/` folder, do the following.
 
 ```bash
-sudo buildah build --annotation "module.wasm.image/variant=compat" -t http_server .
+sudo buildah build --annotation "module.wasm.image/variant=compat-smart" -t http_server .
 
 #
 # make sure docker is install and running

--- a/docs/book/en/src/kubernetes/demo/wasi.md
+++ b/docs/book/en/src/kubernetes/demo/wasi.md
@@ -44,9 +44,9 @@ CMD ["/wasi_example_main.wasm"]
 
 > Please note that adding self-defined annotation is still a new feature in buildah.
 
-The `crun` container runtime can start the above WebAssembly-based container image. But it requires the `module.wasm.image/variant=compat` annotation on the container image to indicate that it is a WebAssembly application without a guest OS. You can find the details in [Official crun repo](https://github.com/containers/crun/blob/main/docs/wasm-wasi-example.md).
+The `crun` container runtime can start the above WebAssembly-based container image. But it requires the `module.wasm.image/variant=compat-smart` annotation on the container image to indicate that it is a WebAssembly application without a guest OS. You can find the details in [Official crun repo](https://github.com/containers/crun/blob/main/docs/wasm-wasi-example.md).
 
-To add `module.wasm.image/variant=compat` annotation in the container image, you will need the latest [buildah](https://buildah.io/). Currently, Docker does not support this feature. Please follow [the install instructions of buildah](https://github.com/containers/buildah/blob/main/install.md) to build the latest buildah binary.
+To add `module.wasm.image/variant=compat-smart` annotation in the container image, you will need the latest [buildah](https://buildah.io/). Currently, Docker does not support this feature. Please follow [the install instructions of buildah](https://github.com/containers/buildah/blob/main/install.md) to build the latest buildah binary.
 
 ### Build and install the latest buildah on Ubuntu
 
@@ -83,7 +83,7 @@ buildah --help
 In the `target/wasm32-wasi/release/` folder, do the following.
 
 ```bash
-$ sudo buildah build --annotation "module.wasm.image/variant=compat" -t wasm-wasi-example .
+$ sudo buildah build --annotation "module.wasm.image/variant=compat-smart" -t wasm-wasi-example .
 # make sure docker is install and running
 # systemctl status docker
 # to make sure regular user can use docker

--- a/docs/book/en/src/kubernetes/kubernetes/kind.md
+++ b/docs/book/en/src/kubernetes/kubernetes/kind.md
@@ -12,7 +12,7 @@ If KinD is installed we can directly start with the example from [here](https://
 # Create a "WASM in KinD" Cluster
 kind create cluster --image ghcr.io/liquid-reply/kind-crun-wasm:v1.23.0
 # Run the example
-kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat" /wasi_example_main.wasm 50000000
+kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat-smart" /wasi_example_main.wasm 50000000
 ```
 
 In the rest of this section, we will explain how to create a KinD node image with wasmedge support.
@@ -79,5 +79,5 @@ Finally we can build a new `node-wasmedge` image. To test it, we create a kind c
 docker build -t node-wasmedge .
 kind create cluster --image node-wasmedge
 # Now you can run the example to validate your cluster
-kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat" /wasi_example_main.wasm 50000000
+kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat-smart" /wasi_example_main.wasm 50000000
 ```

--- a/docs/book/en/src/kubernetes/kubernetes/kubeedge.md
+++ b/docs/book/en/src/kubernetes/kubernetes/kubeedge.md
@@ -265,7 +265,7 @@ We can run the WebAssembly-based image from Docker Hub in the Kubernetes cluster
 ### Cloud Side
 
 ```bash
-$ kubectl run -it --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat" /wasi_example_main.wasm 50000000
+$ kubectl run -it --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat-smart" /wasi_example_main.wasm 50000000
 
 Random number: -1694733782
 Random bytes: [6, 226, 176, 126, 136, 114, 90, 2, 216, 17, 241, 217, 143, 189, 123, 197, 17, 60, 49, 37, 71, 69, 67, 108, 66, 39, 105, 9, 6, 72, 232, 238, 102, 5, 148, 243, 249, 183, 52, 228, 54, 176, 63, 249, 216, 217, 46, 74, 88, 204, 130, 191, 182, 19, 118, 193, 77, 35, 189, 6, 139, 68, 163, 214, 231, 100, 138, 246, 185, 47, 37, 49, 3, 7, 176, 97, 68, 124, 20, 235, 145, 166, 142, 159, 114, 163, 186, 46, 161, 144, 191, 211, 69, 19, 179, 241, 8, 207, 8, 112, 80, 170, 33, 51, 251, 33, 105, 0, 178, 175, 129, 225, 112, 126, 102, 219, 106, 77, 242, 104, 198, 238, 193, 247, 23, 47, 22, 29]
@@ -289,7 +289,7 @@ Priority:     0
 Node:         edge/192.168.122.229
 Start Time:   Mon, 06 Dec 2021 15:45:34 +0000
 Labels:       run=wasi-demo
-Annotations:  module.wasm.image/variant: compat
+Annotations:  module.wasm.image/variant: compat-smart
 Status:       Succeeded
 IP:           
 IPs:          <none>

--- a/docs/book/en/src/kubernetes/kubernetes/kubernetes-containerd.md
+++ b/docs/book/en/src/kubernetes/kubernetes/kubernetes-containerd.md
@@ -81,7 +81,7 @@ To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
 Run the WebAssembly-based image from Docker Hub in the Kubernetes cluster as follows.
 
 ```bash
-sudo cluster/kubectl.sh run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}' /wasi_example_main.wasm 50000000
+sudo cluster/kubectl.sh run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat-smart" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}' /wasi_example_main.wasm 50000000
 ```
 
 The output from the containerized application is printed into the console.
@@ -105,7 +105,7 @@ pod "wasi-demo-2" deleted
 Run the WebAssembly-based image from Docker Hub in the Kubernetes cluster as follows.
 
 ```bash
-sudo cluster/kubectl.sh run --restart=Never http-server --image=avengermojo/http_server:with-wasm-annotation --annotations="module.wasm.image/variant=compat" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}'
+sudo cluster/kubectl.sh run --restart=Never http-server --image=avengermojo/http_server:with-wasm-annotation --annotations="module.wasm.image/variant=compat-smart" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}'
 ```
 
 Since we are using `hostNetwork` in the `kubectl run` command, the HTTP server image is running on the local network with IP address `127.0.0.1`.

--- a/docs/book/en/src/kubernetes/kubernetes/kubernetes-crio.md
+++ b/docs/book/en/src/kubernetes/kubernetes/kubernetes-crio.md
@@ -81,7 +81,7 @@ To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
 Run the WebAssembly-based image from Docker Hub in the Kubernetes cluster as follows.
 
 ```bash
-sudo cluster/kubectl.sh run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat" /wasi_example_main.wasm 50000000
+sudo cluster/kubectl.sh run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat-smart" /wasi_example_main.wasm 50000000
 ```
 
 The output from the containerized application is printed into the console.
@@ -111,7 +111,7 @@ metadata:
   name: http-server
   namespace: default
   annotations:
-    module.wasm.image/variant: compat
+    module.wasm.image/variant: compat-smart
 spec:
   hostNetwork: true
   containers:

--- a/docs/book/en/src/kubernetes/kubernetes/openyurt.md
+++ b/docs/book/en/src/kubernetes/kubernetes/openyurt.md
@@ -200,10 +200,10 @@ One thing is to note that because the kubectl run (version 1.18.9 ) missed annot
 
 ```bash
 // kubectl 1.18.9
-$ sudo kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation  --overrides='{"kind":"Pod","metadata":{"annotations":{"module.wasm.image/variant":"compat"}} , "apiVersion":"v1", "spec": {"hostNetwork": true}}' /wasi_example_main.wasm 50000000
+$ sudo kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation  --overrides='{"kind":"Pod","metadata":{"annotations":{"module.wasm.image/variant":"compat-smart"}} , "apiVersion":"v1", "spec": {"hostNetwork": true}}' /wasi_example_main.wasm 50000000
 
 // kubectl 1.20.11
-$ sudo kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}' /wasi_example_main.wasm 50000000
+$ sudo kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat-smart" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}' /wasi_example_main.wasm 50000000
 
 ```
 

--- a/docs/book/en/src/kubernetes/kubernetes/superedge.md
+++ b/docs/book/en/src/kubernetes/kubernetes/superedge.md
@@ -115,7 +115,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    module.wasm.image/variant: compat
+    module.wasm.image/variant: compat-smart
   labels:
     run: wasi-demo
   name: wasi-demo

--- a/docs/book/zh/src/kubernetes/cri/containerd.md
+++ b/docs/book/zh/src/kubernetes/cri/containerd.md
@@ -64,7 +64,7 @@ sudo ctr i pull docker.io/hydai/wasm-wasi-example:with-wasm-annotation
 现在，您可以使用 ctr（containerd cli 工具）运行此示例。
 
 ```bash
-sudo ctr run --rm --runc-binary crun --runtime io.containerd.runc.v2 --label module.wasm.image/variant=compat docker.io/hydai/wasm-wasi-example:with-wasm-annotation wasm-example /wasi_example_main.wasm 50000000
+sudo ctr run --rm --runc-binary crun --runtime io.containerd.runc.v2 --label module.wasm.image/variant=compat-smart docker.io/hydai/wasm-wasi-example:with-wasm-annotation wasm-example /wasi_example_main.wasm 50000000
 ```
 
 启动容器会执行 WebAssembly 程序， 您可以在控制台中看到输出。
@@ -97,7 +97,7 @@ sudo ctr i pull docker.io/avengermojo/http_server:with-wasm-annotation
 现在，您可以使用 ctr（containerd cli 工具）运行该示例。（请注意，我们需要加上 `--net-host` 参数来运行容器，以便可以从外部访问 WasmEdge 容器内的 HTTP server。）
 
 ```bash
-sudo ctr run --rm --net-host --runc-binary crun --runtime io.containerd.runc.v2 --label module.wasm.image/variant=compat docker.io/avengermojo/http_server:with-wasm-annotation http-server-example /http_server.wasm
+sudo ctr run --rm --net-host --runc-binary crun --runtime io.containerd.runc.v2 --label module.wasm.image/variant=compat-smart docker.io/avengermojo/http_server:with-wasm-annotation http-server-example /http_server.wasm
 ```
 
 启动容器会执行 WebAssembly 程序， 您可以在控制台中看到输出。

--- a/docs/book/zh/src/kubernetes/demo/server.md
+++ b/docs/book/zh/src/kubernetes/demo/server.md
@@ -68,9 +68,9 @@ CMD ["/http_server.wasm"]
 
 > 请注意，添加自定义注释仍然是 buildah 中的新功能。
 
-`crun` 容器运行时可以启动上述基于 WebAssembly 的容器镜像。但它需要容器镜像上的 `module.wasm.image/variant=compat` 注释来表明它是一个没有客人操作系统（安装在虚拟机上的系统）的 WebAssembly 应用程序。你可以在[官方 crun repo](https://github.com/containers/crun/blob/main/docs/wasm-wasi-example.md) 中找到详细信息。
+`crun` 容器运行时可以启动上述基于 WebAssembly 的容器镜像。但它需要容器镜像上的 `module.wasm.image/variant=compat-smart` 注释来表明它是一个没有客人操作系统（安装在虚拟机上的系统）的 WebAssembly 应用程序。你可以在[官方 crun repo](https://github.com/containers/crun/blob/main/docs/wasm-wasi-example.md) 中找到详细信息。
 
-要在容器镜像中添加 `module.wasm.image/variant=compat` 注释，你需要最新的 [buildah](https://buildah.io/)。 目前，Docker 不支持此功能。请按照 [buildah 的安装说明](https://github.com/containers/buildah/blob/main/install.md) 构建最新的 buildah 二进制文件。
+要在容器镜像中添加 `module.wasm.image/variant=compat-smart` 注释，你需要最新的 [buildah](https://buildah.io/)。 目前，Docker 不支持此功能。请按照 [buildah 的安装说明](https://github.com/containers/buildah/blob/main/install.md) 构建最新的 buildah 二进制文件。
 
 ### 在 Ubuntu 上编译并安装最新的 buildah
 
@@ -108,7 +108,7 @@ buildah --help
 在 `target/wasm32-wasi/release/` 文件夹下，执行下列指令。
 
 ```bash
-$ sudo buildah build --annotation "module.wasm.image/variant=compat" -t http_server .
+$ sudo buildah build --annotation "module.wasm.image/variant=compat-smart" -t http_server .
 
 #
 # make sure docker is install and running

--- a/docs/book/zh/src/kubernetes/demo/wasi.md
+++ b/docs/book/zh/src/kubernetes/demo/wasi.md
@@ -44,9 +44,9 @@ CMD ["/wasi_example_main.wasm"]
 
 > 请注意，添加自定义注释仍然是 buildah 中的新功能。
 
-`crun` 容器运行时可以启动上述基于 WebAssembly 的容器镜像。但它需要容器镜像上的 `module.wasm.image/variant=compat` 注释来表明它是一个没有客人操作系统（安装在虚拟机上的系统）的 WebAssembly 应用程序。你可以在[官方 crun repo](https://github.com/containers/crun/blob/main/docs/wasm-wasi-example.md) 中找到详细信息。
+`crun` 容器运行时可以启动上述基于 WebAssembly 的容器镜像。但它需要容器镜像上的 `module.wasm.image/variant=compat-smart` 注释来表明它是一个没有客人操作系统（安装在虚拟机上的系统）的 WebAssembly 应用程序。你可以在[官方 crun repo](https://github.com/containers/crun/blob/main/docs/wasm-wasi-example.md) 中找到详细信息。
 
-要在容器镜像中添加 `module.wasm.image/variant=compat` 注释，你需要最新的 [buildah](https://buildah.io/)。 目前，Docker 不支持此功能。请按照 [buildah 的安装说明](https://github.com/containers/buildah/blob/main/install.md) 构建最新的 buildah 二进制文件。
+要在容器镜像中添加 `module.wasm.image/variant=compat-smart` 注释，你需要最新的 [buildah](https://buildah.io/)。 目前，Docker 不支持此功能。请按照 [buildah 的安装说明](https://github.com/containers/buildah/blob/main/install.md) 构建最新的 buildah 二进制文件。
 
 ### 在 Ubuntu 上编译并安装最新的 buildah
 
@@ -83,7 +83,7 @@ buildah --help
 在 `target/wasm32-wasi/release/` 文件夹下，执行下列指令。
 
 ```bash
-$ sudo buildah build --annotation "module.wasm.image/variant=compat" -t wasm-wasi-example .
+$ sudo buildah build --annotation "module.wasm.image/variant=compat-smart" -t wasm-wasi-example .
 # make sure docker is install and running
 # systemctl status docker
 # to make sure regular user can use docker

--- a/docs/book/zh/src/kubernetes/kubernetes/kind.md
+++ b/docs/book/zh/src/kubernetes/kubernetes/kind.md
@@ -12,7 +12,7 @@ KinD 是在 Docker 内部运行的 Kubernetes 发行版，非常适合本地开�
 # Create a "WASM in KinD" Cluster
 kind create cluster --image ghcr.io/liquid-reply/kind-crun-wasm:v1.23.0
 # Run the example
-kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat" /wasi_example_main.wasm 50000000
+kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat-smart" /wasi_example_main.wasm 50000000
 ```
 
 在这个章节的剩余部分，我们会介绍如何去创建一个带有 wasmedge 的支持 KinD 的节点镜像。
@@ -77,5 +77,5 @@ RUN echo "Installing Packages ..." \
 $ docker build -t node-wasmedge .
 $ kind create cluster --image node-wasmedge
 # Now you can run the example to validate your cluster
-$ kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat" /wasi_example_main.wasm 50000000
+$ kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat-smart" /wasi_example_main.wasm 50000000
 ```

--- a/docs/book/zh/src/kubernetes/kubernetes/kubeedge.md
+++ b/docs/book/zh/src/kubernetes/kubernetes/kubeedge.md
@@ -265,7 +265,7 @@ master     Ready     control-plane,master   68m   v1.21.0
 ### 云端
 
 ```bash
-$ kubectl run -it --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat" /wasi_example_main.wasm 50000000
+$ kubectl run -it --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat-smart" /wasi_example_main.wasm 50000000
 
 Random number: -1694733782
 Random bytes: [6, 226, 176, 126, 136, 114, 90, 2, 216, 17, 241, 217, 143, 189, 123, 197, 17, 60, 49, 37, 71, 69, 67, 108, 66, 39, 105, 9, 6, 72, 232, 238, 102, 5, 148, 243, 249, 183, 52, 228, 54, 176, 63, 249, 216, 217, 46, 74, 88, 204, 130, 191, 182, 19, 118, 193, 77, 35, 189, 6, 139, 68, 163, 214, 231, 100, 138, 246, 185, 47, 37, 49, 3, 7, 176, 97, 68, 124, 20, 235, 145, 166, 142, 159, 114, 163, 186, 46, 161, 144, 191, 211, 69, 19, 179, 241, 8, 207, 8, 112, 80, 170, 33, 51, 251, 33, 105, 0, 178, 175, 129, 225, 112, 126, 102, 219, 106, 77, 242, 104, 198, 238, 193, 247, 23, 47, 22, 29]
@@ -289,7 +289,7 @@ Priority:     0
 Node:         edge/192.168.122.229
 Start Time:   Mon, 06 Dec 2021 15:45:34 +0000
 Labels:       run=wasi-demo
-Annotations:  module.wasm.image/variant: compat
+Annotations:  module.wasm.image/variant: compat-smart
 Status:       Succeeded
 IP:           
 IPs:          <none>

--- a/docs/book/zh/src/kubernetes/kubernetes/kubernetes-containerd.md
+++ b/docs/book/zh/src/kubernetes/kubernetes/kubernetes-containerd.md
@@ -79,7 +79,7 @@ To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
 在 Kubernetes 集群中运行 Docker Hub 中基于 WebAssembly 的镜像，方法如下。
 
 ```bash
-sudo cluster/kubectl.sh run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}' /wasi_example_main.wasm 50000000
+sudo cluster/kubectl.sh run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat-smart" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}' /wasi_example_main.wasm 50000000
 ```
 
 容器化应用程序的输出被打印到控制台。
@@ -103,7 +103,7 @@ pod "wasi-demo-2" deleted
 在 Kubernetes 集群中运行 Docker Hub 中基于 WebAssembly 的镜像，方法如下。
 
 ```bash
-sudo cluster/kubectl.sh run --restart=Never http-server --image=avengermojo/http_server:with-wasm-annotation --annotations="module.wasm.image/variant=compat" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}'
+sudo cluster/kubectl.sh run --restart=Never http-server --image=avengermojo/http_server:with-wasm-annotation --annotations="module.wasm.image/variant=compat-smart" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}'
 ```
 
 由于我们在 `kubectl run` 命令中使用了 `hostNetwork` ，HTTP 服务器镜像运行在本地网络上，IP 地址是 `127.0.0.1` 。

--- a/docs/book/zh/src/kubernetes/kubernetes/kubernetes-crio.md
+++ b/docs/book/zh/src/kubernetes/kubernetes/kubernetes-crio.md
@@ -78,7 +78,7 @@ To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
 [这篇文章](../demo/wasi.md) 描述了如何编译、打包一个简单的 WebAssembly WASI 程序，以及将它以容器镜像的形式发布到 Docker hub 的完整过程。
 
 ```bash
-sudo cluster/kubectl.sh run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat" /wasi_example_main.wasm 50000000
+sudo cluster/kubectl.sh run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat-smart" /wasi_example_main.wasm 50000000
 ```
 
 容器化后的应用程序的输出会被打印到控制台上。
@@ -107,7 +107,7 @@ metadata:
   name: http-server
   namespace: default
   annotations:
-    module.wasm.image/variant: compat
+    module.wasm.image/variant: compat-smart
 spec:
   hostNetwork: true
   containers:

--- a/docs/book/zh/src/kubernetes/kubernetes/openyurt.md
+++ b/docs/book/zh/src/kubernetes/kubernetes/openyurt.md
@@ -200,9 +200,9 @@ yurtctl convert --deploy-yurttunnel --cloud-nodes oy-master --provider kubeadm\
 
 ```bash
 // kubectl 1.18.9
-$ sudo kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation  --overrides='{"kind":"Pod","metadata":{"annotations":{"module.wasm.image/variant":"compat"}} , "apiVersion":"v1", "spec": {"hostNetwork": true}}' /wasi_example_main.wasm 50000000
+$ sudo kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation  --overrides='{"kind":"Pod","metadata":{"annotations":{"module.wasm.image/variant":"compat-smart"}} , "apiVersion":"v1", "spec": {"hostNetwork": true}}' /wasi_example_main.wasm 50000000
 // kubectl 1.20.11
-$ sudo kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}' /wasi_example_main.wasm 50000000
+$ sudo kubectl run -it --rm --restart=Never wasi-demo --image=hydai/wasm-wasi-example:with-wasm-annotation --annotations="module.wasm.image/variant=compat-smart" --overrides='{"kind":"Pod", "apiVersion":"v1", "spec": {"hostNetwork": true}}' /wasi_example_main.wasm 50000000
 ```
 
 容器化应用的结果将会在控制台上输出，对应不同 Kubernetes 版本，得到的结果都是相同的。


### PR DESCRIPTION
As mentioned by #1692 and #1338,
in case only wasm apps are used the module.wasm.image/variant: compat-smart annotation should behave exactly like the module.wasm.image/variant: compat annotation. It should only make a difference when standard OCI containers and wasm apps are in the same pod.
So we can update all examples to compat-smart.