### PR TITLE
[CI] Check markdown format for pr (all rules in markdownlint)

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -14,24 +14,43 @@ on:
   push:
     branches: [ master ]
     paths:
-      - 'docs/book/**'
+      - 'docs/**'
   pull_request:
     branches: [ master ]
     paths:
-      - 'docs/book/**'
+      - 'docs/**'
 
 jobs:
-  build:
-
+  lint-markdown:
+    if: ${{ github.event_name != 'push' }}
     runs-on: ubuntu-20.04
-
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Lint markdown format
+        uses: github/super-linter@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BRANCH: master
+          FILTER_REGEX_INCLUDE: .*docs/.*md$
+          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_MARKDOWN: true
+
+  build-mdbook:
+    needs: lint-markdown
+    if: |
+      always() 
+      && (needs.lint-markdown.result == 'success' || needs.lint-markdown.result == 'skipped')
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          # mdbook-version: '0.4.10'
           mdbook-version: 'latest'
           
       - name: Create work dir


### PR DESCRIPTION
Fixes #1723

The modified workflow works as described below:

- PRs: first check the markdown format, lint or start building mdbook

<img width="493" alt="Screen Shot 2022-08-05 at 23 51 10" src="https://user-images.githubusercontent.com/49837965/183114414-9ccaac57-2654-4527-b35b-6e1714e261ef.png">


- Pulls: skip the format check (to prevent it breaks releasing the latest version of mdbook)

<img width="614" alt="Screen Shot 2022-08-05 at 23 52 30" src="https://user-images.githubusercontent.com/49837965/183114669-0dc6af1a-5890-402e-b789-daceaf227cd4.png">


The only uncertain thing is, build-mdbook will be triggered even if the changed files are `docs/**` && `!docs/book/**`, should I separate the format check into a new workflow? any good suggestion?
