### PR TITLE
[Rust] Refactored Memory::write method in `wasmedge-sdk`

### DIFF
--- a/bindings/rust/wasmedge-sdk/src/externals/memory.rs
+++ b/bindings/rust/wasmedge-sdk/src/externals/memory.rs
@@ -91,7 +91,7 @@ impl Memory {
     /// # Error
     ///
     /// If fail to write to the memory, then an error is returned.
-    pub fn write(&mut self, data: impl IntoIterator<Item = u8>, offset: u32) -> WasmEdgeResult<()> {
+    pub fn write(&mut self, data: impl AsRef<[u8]>, offset: u32) -> WasmEdgeResult<()> {
         self.inner.set_data(data, offset)?;
         Ok(())
     }
@@ -207,7 +207,10 @@ mod tests {
         assert_eq!(data, vec![0; 10]);
 
         // write data
-        let result = memory.write(vec![1; 10], 10);
+        // ! debug
+        let data = vec![1; 10];
+        let result = memory.write(data.as_slice(), 10);
+        // let result = memory.write(vec![1; 10], 10);
         assert!(result.is_ok());
         // read data after write data
         let result = memory.read(10, 10);

--- a/bindings/rust/wasmedge-sys/src/instance/memory.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/memory.rs
@@ -145,18 +145,13 @@ impl Memory {
     /// assert_eq!(data, vec![1; 10]);
     /// ```
     ///
-    pub fn set_data(
-        &mut self,
-        data: impl IntoIterator<Item = u8>,
-        offset: u32,
-    ) -> WasmEdgeResult<()> {
-        let data = data.into_iter().collect::<Vec<u8>>();
+    pub fn set_data(&mut self, data: impl AsRef<[u8]>, offset: u32) -> WasmEdgeResult<()> {
         unsafe {
             check(ffi::WasmEdge_MemoryInstanceSetData(
                 self.inner.0,
-                data.as_ptr() as *mut _,
+                data.as_ref().as_ptr(),
                 offset,
-                data.len() as u32,
+                data.as_ref().len() as u32,
             ))
         }
     }


### PR DESCRIPTION
This PR is to refactor `Memory::write` method in `wasmedge-sdk` and `Memory::set_data` method in `wasmedge-sys`.

- Fixed #1728 