### PR TITLE
Expose two helper functions in C API

### DIFF
--- a/include/api/wasmedge/wasmedge.h
+++ b/include/api/wasmedge/wasmedge.h
@@ -1316,6 +1316,22 @@ WASMEDGE_CAPI_EXPORT extern WasmEdge_Result
 WasmEdge_CompilerCompile(WasmEdge_CompilerContext *Cxt, const char *InPath,
                          const char *OutPath);
 
+/// Compile the input WASM from the given binary array.
+///
+/// The compiler compiles the WASM from the given binary array for the
+/// ahead-of-time mode and store the result to the output file path.
+///
+/// \param Cxt the WasmEdge_CompilerContext.
+/// \param InArray the input WASM binary array.
+/// \param InArrayLen the length of the input WASM binary array.
+/// \param OutPath the output WASM file path.
+///
+/// \returns WasmEdge_Result. Call `WasmEdge_ResultGetMessage` for the error
+/// message.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_Result WasmEdge_CompilerCompileFromArray(
+    WasmEdge_CompilerContext *Cxt, const uint8_t *InArray,
+    const uint64_t InArrayLen, const char *OutPath);
+
 /// Deletion of the WasmEdge_CompilerContext.
 ///
 /// After calling this function, the context will be destroyed and should

--- a/include/api/wasmedge/wasmedge.h
+++ b/include/api/wasmedge/wasmedge.h
@@ -1705,6 +1705,23 @@ WASMEDGE_CAPI_EXPORT extern void WasmEdge_ModuleInstanceInitWASI(
 WASMEDGE_CAPI_EXPORT extern uint32_t WasmEdge_ModuleInstanceWASIGetExitCode(
     const WasmEdge_ModuleInstanceContext *Cxt);
 
+/// Get the native handler from the WASI mapped FD/Handler.
+///
+/// This function will return the raw FD/Handler from a given mapped Fd
+/// or Handler.
+///
+/// \param Cxt the WasmEdge_ModuleInstanceContext of WASI import object.
+/// \param Fd the WASI mapped Fd.
+/// \param [out] NativeHandler the raw Fd/Handler.
+///
+/// \returns the error code. Return `0` if the Native Handler is found.
+/// Return `1` if the `Cxt` is `NULL`.
+/// Return `2` if the given mapped Fd/handler is not found.
+WASMEDGE_CAPI_EXPORT extern uint32_t
+WasmEdge_ModuleInstanceWASIGetNativeHandler(
+    const WasmEdge_ModuleInstanceContext *Cxt, int32_t Fd,
+    uint64_t *NativeHandler);
+
 /// Creation of the WasmEdge_ModuleInstanceContext for the wasi_nn
 /// specification.
 ///

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -1703,6 +1703,26 @@ WASMEDGE_CAPI_EXPORT void WasmEdge_ModuleInstanceInitWASI(
   WasiEnv.init(DirVec, ProgName, ArgVec, EnvVec);
 }
 
+WASMEDGE_CAPI_EXPORT extern uint32_t
+WasmEdge_ModuleInstanceWASIGetNativeHandler(
+    const WasmEdge_ModuleInstanceContext *Cxt, int32_t Fd,
+    uint64_t *NativeHandler) {
+  if (!Cxt) {
+    return 1;
+  }
+  auto *WasiMod =
+      dynamic_cast<const WasmEdge::Host::WasiModule *>(fromModCxt(Cxt));
+  if (!WasiMod) {
+    return 2;
+  }
+  auto Handler = WasiMod->getEnv().getNativeHandler(Fd);
+  if (!Handler) {
+    return 2;
+  }
+  *NativeHandler = *Handler;
+  return 0;
+}
+
 WASMEDGE_CAPI_EXPORT uint32_t WasmEdge_ModuleInstanceWASIGetExitCode(
     const WasmEdge_ModuleInstanceContext *Cxt) {
   if (!Cxt) {

--- a/test/api/APIAOTCoreTest.cpp
+++ b/test/api/APIAOTCoreTest.cpp
@@ -22,8 +22,10 @@
 #include "../spec/spectest.h"
 
 #include <cstdint>
+#include <fstream>
 #include <functional>
 #include <gtest/gtest.h>
+#include <iterator>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -36,9 +38,10 @@ using namespace WasmEdge;
 static SpecTest T(std::filesystem::u8path("../spec/testSuites"sv));
 
 // Parameterized testing class.
-class CoreTest : public testing::TestWithParam<std::string> {};
+class CoreCompileTest : public testing::TestWithParam<std::string> {};
+class CoreCompileArrayTest : public testing::TestWithParam<std::string> {};
 
-TEST_P(CoreTest, TestSuites) {
+TEST_P(CoreCompileTest, TestSuites) {
   const auto [Proposal, Conf, UnitName] = T.resolve(GetParam());
   WasmEdge_ConfigureContext *ConfCxt = createConf(Conf);
   WasmEdge_VMContext *VM = WasmEdge_VMCreate(ConfCxt, nullptr);
@@ -224,8 +227,228 @@ TEST_P(CoreTest, TestSuites) {
   WasmEdge_CompilerDelete(CompilerCxt);
 }
 
+TEST_P(CoreCompileArrayTest, TestSuites) {
+  const auto [Proposal, Conf, UnitName] = T.resolve(GetParam());
+  WasmEdge_ConfigureContext *ConfCxt = createConf(Conf);
+  WasmEdge_VMContext *VM = WasmEdge_VMCreate(ConfCxt, nullptr);
+  WasmEdge_ConfigureCompilerSetOptimizationLevel(
+      ConfCxt, WasmEdge_CompilerOptimizationLevel_O0);
+  WasmEdge_ConfigureCompilerSetOutputFormat(
+      ConfCxt, WasmEdge_CompilerOutputFormat_Native);
+  WasmEdge_CompilerContext *CompilerCxt = WasmEdge_CompilerCreate(ConfCxt);
+  WasmEdge_ConfigureDelete(ConfCxt);
+  WasmEdge_ModuleInstanceContext *TestModCxt = createSpecTestModule();
+  WasmEdge_VMRegisterModuleFromImport(VM, TestModCxt);
+
+  auto Compile = [&, Conf = std::cref(Conf)](
+                     const std::string &Filename) -> Expect<std::string> {
+    auto Path = std::filesystem::u8path(Filename);
+    auto InputPath = std::filesystem::u8path(Filename);
+    Path.replace_extension(std::filesystem::u8path(WASMEDGE_LIB_EXTENSION));
+    const auto SOPath = Path.u8string();
+
+    std::error_code EC;
+    size_t FileSize = std::filesystem::file_size(InputPath, EC);
+    if (EC) {
+      return Unexpect(ErrCode::Value::IllegalPath);
+    }
+
+    std::ifstream Fin(InputPath, std::ios::in | std::ios::binary);
+    if (!Fin) {
+      return Unexpect(ErrCode::Value::IllegalPath);
+    }
+
+    std::vector<Byte> Data(FileSize);
+    size_t Index = 0;
+    while (FileSize > 0) {
+      const uint32_t BlockSize = static_cast<uint32_t>(
+          std::min<size_t>(FileSize, std::numeric_limits<uint32_t>::max()));
+      Fin.read(reinterpret_cast<char *>(Data.data()) + Index, BlockSize);
+      const uint32_t ReadCount = static_cast<uint32_t>(Fin.gcount());
+      if (ReadCount != BlockSize) {
+        if (Fin.eof()) {
+          return Unexpect(ErrCode::Value::UnexpectedEnd);
+        } else {
+          return Unexpect(ErrCode::Value::ReadError);
+        }
+      }
+      Index += static_cast<size_t>(BlockSize);
+      FileSize -= static_cast<size_t>(BlockSize);
+    }
+
+    WasmEdge_Result Res = WasmEdge_CompilerCompileFromArray(
+        CompilerCxt, Data.data(), Data.size(), SOPath.c_str());
+    if (!WasmEdge_ResultOK(Res)) {
+      return Unexpect(convResult(Res));
+    }
+    return SOPath;
+  };
+  T.onModule = [&VM, &Compile](const std::string &ModName,
+                               const std::string &Filename) -> Expect<void> {
+    return Compile(Filename).and_then(
+        [&VM, &ModName](const std::string &SOFilename) -> Expect<void> {
+          WasmEdge_Result Res;
+          if (!ModName.empty()) {
+            WasmEdge_String ModStr = WasmEdge_StringWrap(
+                ModName.data(), static_cast<uint32_t>(ModName.length()));
+            Res = WasmEdge_VMRegisterModuleFromFile(VM, ModStr,
+                                                    SOFilename.c_str());
+          } else {
+            Res = WasmEdge_VMLoadWasmFromFile(VM, SOFilename.c_str());
+            if (!WasmEdge_ResultOK(Res)) {
+              return Unexpect(convResult(Res));
+            }
+            Res = WasmEdge_VMValidate(VM);
+            if (!WasmEdge_ResultOK(Res)) {
+              return Unexpect(convResult(Res));
+            }
+            Res = WasmEdge_VMInstantiate(VM);
+          }
+          if (!WasmEdge_ResultOK(Res)) {
+            return Unexpect(convResult(Res));
+          }
+          return {};
+        });
+  };
+  T.onLoad = [&VM, &Compile](const std::string &Filename) -> Expect<void> {
+    return Compile(Filename).and_then(
+        [&](const std::string &SOFilename) -> Expect<void> {
+          WasmEdge_Result Res =
+              WasmEdge_VMLoadWasmFromFile(VM, SOFilename.c_str());
+          if (!WasmEdge_ResultOK(Res)) {
+            return Unexpect(convResult(Res));
+          }
+          return {};
+        });
+  };
+  T.onValidate = [&VM, &Compile](const std::string &Filename) -> Expect<void> {
+    return Compile(Filename).and_then(
+        [&](const std::string &SOFilename) -> Expect<void> {
+          WasmEdge_Result Res =
+              WasmEdge_VMLoadWasmFromFile(VM, SOFilename.c_str());
+          if (!WasmEdge_ResultOK(Res)) {
+            return Unexpect(convResult(Res));
+          }
+          Res = WasmEdge_VMValidate(VM);
+          if (!WasmEdge_ResultOK(Res)) {
+            return Unexpect(convResult(Res));
+          }
+          return {};
+        });
+  };
+  T.onInstantiate = [&VM,
+                     &Compile](const std::string &Filename) -> Expect<void> {
+    return Compile(Filename).and_then(
+        [&](const std::string &SOFilename) -> Expect<void> {
+          WasmEdge_Result Res =
+              WasmEdge_VMLoadWasmFromFile(VM, SOFilename.c_str());
+          if (!WasmEdge_ResultOK(Res)) {
+            return Unexpect(convResult(Res));
+          }
+          Res = WasmEdge_VMValidate(VM);
+          if (!WasmEdge_ResultOK(Res)) {
+            return Unexpect(convResult(Res));
+          }
+          Res = WasmEdge_VMInstantiate(VM);
+          if (!WasmEdge_ResultOK(Res)) {
+            return Unexpect(convResult(Res));
+          }
+          return {};
+        });
+  };
+  // Helper function to call functions.
+  T.onInvoke = [&VM](const std::string &ModName, const std::string &Field,
+                     const std::vector<ValVariant> &Params,
+                     const std::vector<ValType> &ParamTypes)
+      -> Expect<std::vector<std::pair<ValVariant, ValType>>> {
+    WasmEdge_Result Res;
+    std::vector<WasmEdge_Value> CParams = convFromValVec(Params, ParamTypes);
+    std::vector<WasmEdge_Value> CReturns;
+    WasmEdge_String FieldStr = WasmEdge_StringWrap(
+        Field.data(), static_cast<uint32_t>(Field.length()));
+    if (!ModName.empty()) {
+      // Invoke function of named module. Named modules are registered in Store
+      // Manager. Get the function type to specify the return nums.
+      WasmEdge_String ModStr = WasmEdge_StringWrap(
+          ModName.data(), static_cast<uint32_t>(ModName.length()));
+      const WasmEdge_FunctionTypeContext *FuncType =
+          WasmEdge_VMGetFunctionTypeRegistered(VM, ModStr, FieldStr);
+      if (FuncType == nullptr) {
+        return Unexpect(ErrCode::Value::FuncNotFound);
+      }
+      CReturns.resize(WasmEdge_FunctionTypeGetReturnsLength(FuncType));
+      // Execute.
+      Res = WasmEdge_VMExecuteRegistered(
+          VM, ModStr, FieldStr, &CParams[0],
+          static_cast<uint32_t>(CParams.size()), &CReturns[0],
+          static_cast<uint32_t>(CReturns.size()));
+    } else {
+      // Invoke function of anonymous module. Anonymous modules are instantiated
+      // in VM. Get function type to specify the return nums.
+      const WasmEdge_FunctionTypeContext *FuncType =
+          WasmEdge_VMGetFunctionType(VM, FieldStr);
+      if (FuncType == nullptr) {
+        return Unexpect(ErrCode::Value::FuncNotFound);
+      }
+      CReturns.resize(WasmEdge_FunctionTypeGetReturnsLength(FuncType));
+      // Execute.
+      Res = WasmEdge_VMExecute(
+          VM, FieldStr, &CParams[0], static_cast<uint32_t>(CParams.size()),
+          &CReturns[0], static_cast<uint32_t>(CReturns.size()));
+    }
+    if (!WasmEdge_ResultOK(Res)) {
+      return Unexpect(convResult(Res));
+    }
+    return convToValVec(CReturns);
+  };
+  // Helper function to get values.
+  T.onGet = [&VM](const std::string &ModName, const std::string &Field)
+      -> Expect<std::pair<ValVariant, ValType>> {
+    // Get module instance.
+    const WasmEdge_ModuleInstanceContext *ModCxt = nullptr;
+    WasmEdge_StoreContext *StoreCxt = WasmEdge_VMGetStoreContext(VM);
+    if (ModName.empty()) {
+      ModCxt = WasmEdge_VMGetActiveModule(VM);
+    } else {
+      WasmEdge_String ModStr = WasmEdge_StringWrap(
+          ModName.data(), static_cast<uint32_t>(ModName.length()));
+      ModCxt = WasmEdge_StoreFindModule(StoreCxt, ModStr);
+    }
+    if (ModCxt == nullptr) {
+      return Unexpect(ErrCode::Value::WrongInstanceAddress);
+    }
+
+    // Get global instance.
+    WasmEdge_String FieldStr = WasmEdge_StringWrap(
+        Field.data(), static_cast<uint32_t>(Field.length()));
+    WasmEdge_GlobalInstanceContext *GlobCxt =
+        WasmEdge_ModuleInstanceFindGlobal(ModCxt, FieldStr);
+    if (GlobCxt == nullptr) {
+      return Unexpect(ErrCode::Value::WrongInstanceAddress);
+    }
+    WasmEdge_Value Val = WasmEdge_GlobalInstanceGetValue(GlobCxt);
+#if defined(__x86_64__) || defined(__aarch64__)
+    return std::make_pair(ValVariant(Val.Value),
+                          static_cast<ValType>(Val.Type));
+#else
+    return std::make_pair(
+        ValVariant(WasmEdge::uint128_t(Val.Value.High, Val.Value.Low)),
+        static_cast<ValType>(Val.Type));
+#endif
+  };
+
+  T.run(Proposal, UnitName);
+
+  WasmEdge_VMDelete(VM);
+  WasmEdge_ModuleInstanceDelete(TestModCxt);
+  WasmEdge_CompilerDelete(CompilerCxt);
+}
+
 // Initiate test suite.
-INSTANTIATE_TEST_SUITE_P(TestUnit, CoreTest, testing::ValuesIn(T.enumerate()));
+INSTANTIATE_TEST_SUITE_P(TestUnit, CoreCompileTest,
+                         testing::ValuesIn(T.enumerate()));
+INSTANTIATE_TEST_SUITE_P(TestUnit, CoreCompileArrayTest,
+                         testing::ValuesIn(T.enumerate()));
 
 } // namespace
 

--- a/test/api/APIUnitTest.cpp
+++ b/test/api/APIUnitTest.cpp
@@ -1992,6 +1992,39 @@ TEST(APICoreTest, ModuleInstance) {
   WasmEdge_ModuleInstanceDelete(HostMod);
   HostMod = WasmEdge_ModuleInstanceCreateWASI(Args, 0, Envs, 3, Preopens, 5);
   EXPECT_NE(HostMod, nullptr);
+  // Check the Native Handler
+  {
+    // STDIN
+    uint64_t NativeHandler = 100;
+    auto RetStatus =
+        WasmEdge_ModuleInstanceWASIGetNativeHandler(HostMod, 0, &NativeHandler);
+    EXPECT_EQ(RetStatus, 0);
+    EXPECT_EQ(NativeHandler, 0);
+  }
+  {
+    // STDOUT
+    uint64_t NativeHandler = 100;
+    auto RetStatus =
+        WasmEdge_ModuleInstanceWASIGetNativeHandler(HostMod, 1, &NativeHandler);
+    EXPECT_EQ(RetStatus, 0);
+    EXPECT_EQ(NativeHandler, 1);
+  }
+  {
+    // STDERR
+    uint64_t NativeHandler = 100;
+    auto RetStatus =
+        WasmEdge_ModuleInstanceWASIGetNativeHandler(HostMod, 2, &NativeHandler);
+    EXPECT_EQ(RetStatus, 0);
+    EXPECT_EQ(NativeHandler, 2);
+  }
+  {
+    // non-existed fd
+    uint64_t NativeHandler = 100;
+    auto RetStatus = WasmEdge_ModuleInstanceWASIGetNativeHandler(
+        HostMod, 9527, &NativeHandler);
+    EXPECT_EQ(RetStatus, 2);
+    EXPECT_EQ(NativeHandler, 100);
+  }
   // Get WASI exit code.
   EXPECT_EQ(WasmEdge_ModuleInstanceWASIGetExitCode(HostMod), EXIT_SUCCESS);
   EXPECT_EQ(WasmEdge_ModuleInstanceWASIGetExitCode(nullptr), EXIT_FAILURE);

--- a/test/api/hostfunc_c.c
+++ b/test/api/hostfunc_c.c
@@ -25,50 +25,48 @@ WasmEdge_Result SpecTestPrint(void *Data __attribute__((unused)),
   return WasmEdge_Result_Success;
 }
 
-WasmEdge_Result SpecTestPrintI32(void *Data __attribute__((unused)),
-                                 const WasmEdge_CallingFrameContext *CallFrameCxt
-                                 __attribute__((unused)),
-                                 const WasmEdge_Value *In
-                                 __attribute__((unused)),
-                                 WasmEdge_Value *Out __attribute__((unused))) {
+WasmEdge_Result
+SpecTestPrintI32(void *Data __attribute__((unused)),
+                 const WasmEdge_CallingFrameContext *CallFrameCxt
+                 __attribute__((unused)),
+                 const WasmEdge_Value *In __attribute__((unused)),
+                 WasmEdge_Value *Out __attribute__((unused))) {
   return WasmEdge_Result_Success;
 }
 
-WasmEdge_Result SpecTestPrintF32(void *Data __attribute__((unused)),
-                                 const WasmEdge_CallingFrameContext *CallFrameCxt
-                                 __attribute__((unused)),
-                                 const WasmEdge_Value *In
-                                 __attribute__((unused)),
-                                 WasmEdge_Value *Out __attribute__((unused))) {
+WasmEdge_Result
+SpecTestPrintF32(void *Data __attribute__((unused)),
+                 const WasmEdge_CallingFrameContext *CallFrameCxt
+                 __attribute__((unused)),
+                 const WasmEdge_Value *In __attribute__((unused)),
+                 WasmEdge_Value *Out __attribute__((unused))) {
   return WasmEdge_Result_Success;
 }
 
-WasmEdge_Result SpecTestPrintF64(void *Data __attribute__((unused)),
-                                 const WasmEdge_CallingFrameContext *CallFrameCxt
-                                 __attribute__((unused)),
-                                 const WasmEdge_Value *In
-                                 __attribute__((unused)),
-                                 WasmEdge_Value *Out __attribute__((unused))) {
+WasmEdge_Result
+SpecTestPrintF64(void *Data __attribute__((unused)),
+                 const WasmEdge_CallingFrameContext *CallFrameCxt
+                 __attribute__((unused)),
+                 const WasmEdge_Value *In __attribute__((unused)),
+                 WasmEdge_Value *Out __attribute__((unused))) {
   return WasmEdge_Result_Success;
 }
 
-WasmEdge_Result SpecTestPrintI32F32(void *Data __attribute__((unused)),
-                                    const WasmEdge_CallingFrameContext *CallFrameCxt
-                                    __attribute__((unused)),
-                                    const WasmEdge_Value *In
-                                    __attribute__((unused)),
-                                    WasmEdge_Value *Out
-                                    __attribute__((unused))) {
+WasmEdge_Result
+SpecTestPrintI32F32(void *Data __attribute__((unused)),
+                    const WasmEdge_CallingFrameContext *CallFrameCxt
+                    __attribute__((unused)),
+                    const WasmEdge_Value *In __attribute__((unused)),
+                    WasmEdge_Value *Out __attribute__((unused))) {
   return WasmEdge_Result_Success;
 }
 
-WasmEdge_Result SpecTestPrintF64F64(void *Data __attribute__((unused)),
-                                    const WasmEdge_CallingFrameContext *CallFrameCxt
-                                    __attribute__((unused)),
-                                    const WasmEdge_Value *In
-                                    __attribute__((unused)),
-                                    WasmEdge_Value *Out
-                                    __attribute__((unused))) {
+WasmEdge_Result
+SpecTestPrintF64F64(void *Data __attribute__((unused)),
+                    const WasmEdge_CallingFrameContext *CallFrameCxt
+                    __attribute__((unused)),
+                    const WasmEdge_Value *In __attribute__((unused)),
+                    WasmEdge_Value *Out __attribute__((unused))) {
   return WasmEdge_Result_Success;
 }
 


### PR DESCRIPTION
* Compile a wasm byte array into the native binary.
* Get the native handler from a given WASI mapped fd or handler.