### PR TITLE
[CAPI] Use 'FromBuffer' instead of 'FromArray'

### DIFF
--- a/.CurrentChangelog.md
+++ b/.CurrentChangelog.md
@@ -49,7 +49,7 @@ Features:
 * Added a new API for looking up the native handler from a given WASI mapped Fd/Handler.
   * Added `WasmEdge_ModuleInstanceWASIGetNativeHandler` to get the native handler.
 * Added a new API for compiling a given WASM byte array.
-  * Added `WasmEdge_CompilerCompileFromArray` to compile from buffer.
+  * Added `WasmEdge_CompilerCompileFromBuffer` to compile from buffer.
 * Added `httpsreq` plugin on Linux platforms.
 
 Fixed issues:

--- a/Changelog.md
+++ b/Changelog.md
@@ -49,7 +49,7 @@ Features:
 * Added a new API for looking up the native handler from a given WASI mapped Fd/Handler.
   * Added `WasmEdge_ModuleInstanceWASIGetNativeHandler` to get the native handler.
 * Added a new API for compiling a given WASM byte array.
-  * Added `WasmEdge_CompilerCompileFromArray` to compile from buffer.
+  * Added `WasmEdge_CompilerCompileFromBuffer` to compile from buffer.
 * Added `httpsreq` plugin on Linux platforms.
 
 Fixed issues:

--- a/include/api/wasmedge/wasmedge.h
+++ b/include/api/wasmedge/wasmedge.h
@@ -1316,21 +1316,21 @@ WASMEDGE_CAPI_EXPORT extern WasmEdge_Result
 WasmEdge_CompilerCompile(WasmEdge_CompilerContext *Cxt, const char *InPath,
                          const char *OutPath);
 
-/// Compile the input WASM from the given binary array.
+/// Compile the input WASM from the given buffer.
 ///
-/// The compiler compiles the WASM from the given binary array for the
+/// The compiler compiles the WASM from the given buffer for the
 /// ahead-of-time mode and store the result to the output file path.
 ///
 /// \param Cxt the WasmEdge_CompilerContext.
-/// \param InArray the input WASM binary array.
-/// \param InArrayLen the length of the input WASM binary array.
+/// \param InBuffer the input WASM binary buffer.
+/// \param InBufferLen the length of the input WASM binary buffer.
 /// \param OutPath the output WASM file path.
 ///
 /// \returns WasmEdge_Result. Call `WasmEdge_ResultGetMessage` for the error
 /// message.
-WASMEDGE_CAPI_EXPORT extern WasmEdge_Result WasmEdge_CompilerCompileFromArray(
-    WasmEdge_CompilerContext *Cxt, const uint8_t *InArray,
-    const uint64_t InArrayLen, const char *OutPath);
+WASMEDGE_CAPI_EXPORT extern WasmEdge_Result WasmEdge_CompilerCompileFromBuffer(
+    WasmEdge_CompilerContext *Cxt, const uint8_t *InBuffer,
+    const uint64_t InBufferLen, const char *OutPath);
 
 /// Deletion of the WasmEdge_CompilerContext.
 ///

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -1424,16 +1424,16 @@ WASMEDGE_CAPI_EXPORT WasmEdge_Result WasmEdge_CompilerCompile(
 #endif
 }
 
-WASMEDGE_CAPI_EXPORT WasmEdge_Result WasmEdge_CompilerCompileFromArray(
+WASMEDGE_CAPI_EXPORT WasmEdge_Result WasmEdge_CompilerCompileFromBuffer(
     WasmEdge_CompilerContext *Cxt [[maybe_unused]],
-    const uint8_t *InArray [[maybe_unused]],
-    const uint64_t InArrayLen [[maybe_unused]],
+    const uint8_t *InBuffer [[maybe_unused]],
+    const uint64_t InBufferLen [[maybe_unused]],
     const char *OutPath [[maybe_unused]]) {
 #ifdef WASMEDGE_BUILD_AOT_RUNTIME
   return wrap(
       [&]() -> WasmEdge::Expect<void> {
         std::filesystem::path OutputPath = std::filesystem::absolute(OutPath);
-        std::vector<WasmEdge::Byte> Data(InArray, InArray + InArrayLen);
+        std::vector<WasmEdge::Byte> Data(InBuffer, InBuffer + InBufferLen);
         std::unique_ptr<WasmEdge::AST::Module> Module;
         if (auto Res = Cxt->Load.parseModule(Data)) {
           Module = std::move(*Res);

--- a/test/api/APIUnitTest.cpp
+++ b/test/api/APIUnitTest.cpp
@@ -973,7 +973,7 @@ TEST(APICoreTest, Compiler) {
     Index += static_cast<size_t>(BlockSize);
     FileSize -= static_cast<size_t>(BlockSize);
   }
-  EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_CompilerCompileFromArray(
+  EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_CompilerCompileFromBuffer(
       Compiler, Data.data(), Data.size(), "test_aot" WASMEDGE_LIB_EXTENSION)));
   // Check the header of the output files.
   OutFile.open("test_aot" WASMEDGE_LIB_EXTENSION, std::ios::binary);


### PR DESCRIPTION
Signed-off-by: hydai <hydai@secondstate.io>