### PR TITLE
[Misc] Fix fdReaddir on large numbers of entries

### DIFF
--- a/include/host/wasi/inode.h
+++ b/include/host/wasi/inode.h
@@ -107,8 +107,9 @@ struct DirHolder {
     Dir = NewDir;
   }
 
+  const static uint64_t DIRCOOKIE_START = 0;
   DIR *Dir = nullptr;
-  uint64_t Cookie = 0;
+  uint64_t Cookie = DIRCOOKIE_START;
   std::vector<uint8_t, boost::alignment::aligned_allocator<
                            uint8_t, alignof(__wasi_dirent_t)>>
       Buffer;

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -488,8 +488,7 @@ WasiExpect<void> INode::fdReaddir(Span<uint8_t> Buffer,
     }
   }
 
-  if (unlikely(Cookie != Dir.Cookie)) {
-    Dir.Buffer.clear();
+  if (unlikely(Cookie != DirHolder::DIRCOOKIE_START)) {
     seekdir(Dir.Dir, Cookie);
   }
 

--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -460,8 +460,7 @@ WasiExpect<void> INode::fdReaddir(Span<uint8_t> Buffer,
     }
   }
 
-  if (unlikely(Cookie != Dir.Cookie)) {
-    Dir.Buffer.clear();
+  if (unlikely(Cookie != DirHolder::DIRCOOKIE_START)) {
     seekdir(Dir.Dir, Cookie);
   }
 


### PR DESCRIPTION
Fix #1711

The definition of arguments for `fdReaddir` are too ambiguous, I am not sure the excepted behavior.

some discussion: https://github.com/WebAssembly/wasi-filesystem/issues/3
definition: https://docs.rs/wasi/0.9.0+wasi-snapshot-preview1/wasi/fn.fd_readdir.html

Signed-off-by: LFsWang <tnst92002@gmail.com>