### PR TITLE
[Plugin] Support openssl3 on wasi-crypto plugin

### DIFF
--- a/plugins/wasi_crypto/CMakeLists.txt
+++ b/plugins/wasi_crypto/CMakeLists.txt
@@ -53,6 +53,7 @@ wasmedge_add_library(wasmedgePluginWasiCrypto
 target_compile_options(wasmedgePluginWasiCrypto
   PUBLIC
   -DWASMEDGE_PLUGIN
+  -DOPENSSL_API_COMPAT=0x10100000L
 )
 
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")

--- a/plugins/wasi_crypto/asymmetric_common/ecdsa.h
+++ b/plugins/wasi_crypto/asymmetric_common/ecdsa.h
@@ -127,7 +127,7 @@ public:
     static WasiCryptoExpect<EvpPkeyPtr> checkValid(EvpPkeyPtr Ctx,
                                                    bool) noexcept {
       ensureOrReturn(Ctx, __WASI_CRYPTO_ERRNO_INVALID_KEY);
-      EC_KEY *EcCtx = EVP_PKEY_get0_EC_KEY(Ctx.get());
+      const EC_KEY *EcCtx = EVP_PKEY_get0_EC_KEY(Ctx.get());
       ensureOrReturn(EcCtx, __WASI_CRYPTO_ERRNO_INVALID_KEY);
 
       const EC_GROUP *Group = EC_KEY_get0_group(EcCtx);
@@ -139,7 +139,7 @@ public:
 
     WasiCryptoExpect<std::vector<uint8_t>>
     exportSec(bool Compressed) const noexcept {
-      EC_KEY *EcCtx = EVP_PKEY_get0_EC_KEY(Ctx.get());
+      const EC_KEY *EcCtx = EVP_PKEY_get0_EC_KEY(Ctx.get());
       std::vector<uint8_t> Res(getRawPkSize(Compressed));
       opensslCheck(EC_POINT_point2oct(
           EC_KEY_get0_group(EcCtx), EC_KEY_get0_public_key(EcCtx),
@@ -149,16 +149,18 @@ public:
 
     WasiCryptoExpect<std::vector<uint8_t>>
     exportPem(bool Compressed) const noexcept {
-      EC_KEY_set_conv_form(EVP_PKEY_get0_EC_KEY(Ctx.get()),
-                           getForm(Compressed));
+      EC_KEY_set_conv_form(
+          const_cast<EC_KEY *>(EVP_PKEY_get0_EC_KEY(Ctx.get())),
+          getForm(Compressed));
 
       return pemWritePUBKEY(Ctx.get());
     }
 
     WasiCryptoExpect<std::vector<uint8_t>>
     exportPkcs8(bool Compressed) const noexcept {
-      EC_KEY_set_conv_form(EVP_PKEY_get0_EC_KEY(Ctx.get()),
-                           getForm(Compressed));
+      EC_KEY_set_conv_form(
+          const_cast<EC_KEY *>(EVP_PKEY_get0_EC_KEY(Ctx.get())),
+          getForm(Compressed));
 
       return i2dPUBKEY(Ctx.get());
     }
@@ -239,7 +241,7 @@ public:
 
     static WasiCryptoExpect<EvpPkeyPtr> checkValid(EvpPkeyPtr Ctx) noexcept {
       ensureOrReturn(Ctx, __WASI_CRYPTO_ERRNO_INVALID_KEY);
-      EC_KEY *EcCtx = EVP_PKEY_get0_EC_KEY(Ctx.get());
+      const EC_KEY *EcCtx = EVP_PKEY_get0_EC_KEY(Ctx.get());
       ensureOrReturn(EcCtx, __WASI_CRYPTO_ERRNO_INVALID_KEY);
 
       const EC_GROUP *Group = EC_KEY_get0_group(EcCtx);
@@ -367,7 +369,7 @@ public:
     static WasiCryptoExpect<EvpPkeyPtr> checkValid(EvpPkeyPtr Ctx,
                                                    bool) noexcept {
       ensureOrReturn(Ctx, __WASI_CRYPTO_ERRNO_INVALID_KEY);
-      EC_KEY *EcCtx = EVP_PKEY_get0_EC_KEY(Ctx.get());
+      const EC_KEY *EcCtx = EVP_PKEY_get0_EC_KEY(Ctx.get());
       ensureOrReturn(EcCtx, __WASI_CRYPTO_ERRNO_INVALID_KEY);
 
       // Curve id check.

--- a/plugins/wasi_crypto/signatures/rsa.cpp
+++ b/plugins/wasi_crypto/signatures/rsa.cpp
@@ -43,7 +43,7 @@ template <int PadMode, int KeyBits, int ShaNid>
 WasiCryptoExpect<EvpPkeyPtr>
 Rsa<PadMode, KeyBits, ShaNid>::PublicKey::checkValid(EvpPkeyPtr Ctx) noexcept {
   ensureOrReturn(Ctx, __WASI_CRYPTO_ERRNO_INVALID_KEY);
-  RSA *RsaKey = EVP_PKEY_get0_RSA(Ctx.get());
+  const RSA *RsaKey = EVP_PKEY_get0_RSA(Ctx.get());
   ensureOrReturn(RsaKey, __WASI_CRYPTO_ERRNO_INVALID_KEY);
   ensureOrReturn(RSA_bits(RsaKey) == KeyBits, __WASI_CRYPTO_ERRNO_INVALID_KEY);
   return {std::move(Ctx)};
@@ -128,7 +128,7 @@ template <int PadMode, int KeyBits, int ShaNid>
 WasiCryptoExpect<EvpPkeyPtr>
 Rsa<PadMode, KeyBits, ShaNid>::SecretKey::checkValid(EvpPkeyPtr Ctx) noexcept {
   ensureOrReturn(Ctx, __WASI_CRYPTO_ERRNO_INVALID_KEY);
-  RSA *RsaKey = EVP_PKEY_get0_RSA(Ctx.get());
+  const RSA *RsaKey = EVP_PKEY_get0_RSA(Ctx.get());
   ensureOrReturn(RsaKey, __WASI_CRYPTO_ERRNO_INVALID_KEY);
   ensureOrReturn(RSA_bits(RsaKey) == KeyBits, __WASI_CRYPTO_ERRNO_INVALID_KEY);
   return {std::move(Ctx)};
@@ -207,7 +207,7 @@ template <int PadMode, int KeyBits, int ShaNid>
 WasiCryptoExpect<EvpPkeyPtr>
 Rsa<PadMode, KeyBits, ShaNid>::KeyPair::checkValid(EvpPkeyPtr Ctx) noexcept {
   ensureOrReturn(Ctx, __WASI_CRYPTO_ERRNO_INVALID_KEY);
-  RSA *RsaKey = EVP_PKEY_get0_RSA(Ctx.get());
+  const RSA *RsaKey = EVP_PKEY_get0_RSA(Ctx.get());
   ensureOrReturn(RsaKey, __WASI_CRYPTO_ERRNO_INVALID_KEY);
   ensureOrReturn(RSA_bits(RsaKey) == KeyBits, __WASI_CRYPTO_ERRNO_INVALID_KEY);
   return {std::move(Ctx)};

--- a/plugins/wasi_crypto/signatures/rsa.h
+++ b/plugins/wasi_crypto/signatures/rsa.h
@@ -194,10 +194,7 @@ public:
 private:
   static constexpr size_t getSigSize() { return KeyBits / 8; }
 
-  static void *getShaCtx() {
-    return static_cast<void *>(
-        const_cast<EVP_MD *>(EVP_get_digestbynid(ShaNid)));
-  }
+  static const EVP_MD *getShaCtx() { return EVP_get_digestbynid(ShaNid); }
 };
 
 using RSA_PKCS1_2048_SHA256 = Rsa<RSA_PKCS1_PADDING, 2048, NID_sha256>;

--- a/plugins/wasi_crypto/symmetric/kdf.cpp
+++ b/plugins/wasi_crypto/symmetric/kdf.cpp
@@ -24,8 +24,9 @@ template <int ShaNid> constexpr uint32_t Hkdf<ShaNid>::getKeySize() noexcept {
     return 64;
 }
 
-template <int ShaNid> constexpr void *Hkdf<ShaNid>::getShaCtx() noexcept {
-  return static_cast<void *>(const_cast<EVP_MD *>(EVP_get_digestbynid(ShaNid)));
+template <int ShaNid>
+constexpr const EVP_MD *Hkdf<ShaNid>::getShaCtx() noexcept {
+  return EVP_get_digestbynid(ShaNid);
 }
 
 template <int ShaNid>

--- a/plugins/wasi_crypto/symmetric/kdf.h
+++ b/plugins/wasi_crypto/symmetric/kdf.h
@@ -232,7 +232,7 @@ public:
 private:
   constexpr static uint32_t getKeySize() noexcept;
 
-  constexpr static void *getShaCtx() noexcept;
+  constexpr static const EVP_MD *getShaCtx() noexcept;
 
   static WasiCryptoExpect<EvpPkeyCtxPtr> openStateImpl(Span<const uint8_t> Key,
                                                        int Mode) noexcept;

--- a/plugins/wasi_crypto/utils/evp_wrapper.h
+++ b/plugins/wasi_crypto/utils/evp_wrapper.h
@@ -21,11 +21,13 @@
 #include "common/span.h"
 
 #include <openssl/bio.h>
+#include <openssl/bn.h>
 #include <openssl/ec.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 #include <openssl/rand.h>
+#include <openssl/rsa.h>
 #include <openssl/x509.h>
 
 #include <cstdint>


### PR DESCRIPTION
* Use `OPENSSL_API_COMPAT` macro for old api interface

Signed-off-by: Shen-Ta Hsieh <beststeve@secondstate.io>