### PR TITLE
[Rust] Fixed the issue 1816

### DIFF
--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -71,6 +71,7 @@ jobs:
           export WASMEDGE_DIR="$(pwd)/../../"
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
+          cargo +nightly clippy -V
           cargo +nightly clippy --profile test --lib --examples -- -D warnings -D clippy::dbg_macro
           cd -
 
@@ -127,6 +128,7 @@ jobs:
           export WASMEDGE_DIR="$(pwd)/../../"
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
+          cargo +nightly clippy -V
           cargo +nightly clippy --profile test --lib --examples -- -D warnings -D clippy::dbg_macro
           cd -
 
@@ -207,6 +209,7 @@ jobs:
           Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
           cd bindings/rust/
+          cargo +nightly clippy -V
           cargo +nightly clippy --verbose --profile test --lib --examples -- -D warnings -D clippy::dbg_macro
 
       - name: Test Rust Bindings

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 exclude = ["build/", "utils/", "wasmedge-sys/examples/wasi_print_env"]
-members = ["wasmedge-sys", "wasmedge-types", "wasmedge-sdk"]
+members = ["wasmedge-sys", "wasmedge-types", "wasmedge-sdk", "wasmedge-macro"]

--- a/bindings/rust/wasmedge-macro/Cargo.toml
+++ b/bindings/rust/wasmedge-macro/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+edition = "2021"
+name = "wasmedge-macro"
+version = "0.1.0"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.43"
+quote = "1"
+syn = {version = "1.0", features = ["full", "extra-traits"]}

--- a/bindings/rust/wasmedge-macro/src/lib.rs
+++ b/bindings/rust/wasmedge-macro/src/lib.rs
@@ -2,6 +2,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, spanned::Spanned, FnArg, Item, Pat, PatType};
 
+/// Expand a synchronous host function defined with `wasmedge-sdk` crate.
 #[proc_macro_attribute]
 pub fn host_function(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let body_ast = parse_macro_input!(item as Item);

--- a/bindings/rust/wasmedge-macro/src/lib.rs
+++ b/bindings/rust/wasmedge-macro/src/lib.rs
@@ -1,0 +1,111 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, spanned::Spanned, FnArg, Item, Pat, PatType};
+
+#[proc_macro_attribute]
+pub fn host_function(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let body_ast = parse_macro_input!(item as Item);
+    if let Item::Fn(item_fn) = body_ast {
+        match expand_host_func(&item_fn) {
+            Ok(token_stream) => token_stream.into(),
+            Err(err) => err.to_compile_error().into(),
+        }
+    } else {
+        TokenStream::new()
+    }
+}
+
+fn expand_host_func(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2::TokenStream> {
+    let outer_fn_name_ident = &item_fn.sig.ident;
+    let outer_fn_name_literal = outer_fn_name_ident.to_string();
+    let outer_fn_inputs = &item_fn.sig.inputs;
+    let outer_fn_return = &item_fn.sig.output;
+    let args = outer_fn_inputs.iter().map(|fn_arg| match fn_arg {
+        FnArg::Typed(PatType { pat, .. }) => match &**pat {
+            Pat::Ident(ident) => ident,
+            _ => panic!("argument pattern is not a simple ident"),
+        },
+        FnArg::Receiver(_) => panic!("argument is a receiver"),
+    });
+    let inner_fn_name_literal = format!("inner_{}", outer_fn_name_literal);
+    let inner_fn_name_ident = syn::Ident::new(&inner_fn_name_literal, item_fn.sig.span());
+    let inner_fn_inputs = &item_fn.sig.inputs;
+    let inner_fn_return = &item_fn.sig.output;
+    let inner_fn_block = &item_fn.block;
+
+    let ret = match &item_fn.sig.asyncness {
+        Some(inner_asyncness) => {
+            quote!(
+                fn #outer_fn_name_ident (#outer_fn_inputs) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = Result<Vec<WasmValue>, HostFuncError>> + '_>> {
+                    #inner_asyncness fn #inner_fn_name_ident (#inner_fn_inputs) #inner_fn_return {
+                        #inner_fn_block
+                    }
+                    Box::pin(#inner_fn_name_ident(#(#args),*))
+                }
+            )
+        }
+        None => {
+            quote!(
+                fn #outer_fn_name_ident (#outer_fn_inputs) #outer_fn_return {
+                    fn #inner_fn_name_ident (#inner_fn_inputs) #inner_fn_return {
+                        #inner_fn_block
+                    }
+                    #inner_fn_name_ident(#(#args),*)
+                }
+            )
+        }
+    };
+
+    Ok(ret)
+}
+
+#[proc_macro_attribute]
+pub fn async_host_function2(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let body_ast = parse_macro_input!(item as Item);
+    if let Item::Fn(item_fn) = body_ast {
+        match expand_async_host_func2(&item_fn) {
+            Ok(token_stream) => token_stream.into(),
+            Err(err) => err.to_compile_error().into(),
+        }
+    } else {
+        TokenStream::new()
+    }
+}
+
+fn expand_async_host_func2(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2::TokenStream> {
+    let outer_fn_name_ident = &item_fn.sig.ident;
+    let outer_fn_name_literal = outer_fn_name_ident.to_string();
+    let outer_fn_inputs = &item_fn.sig.inputs;
+    let args = outer_fn_inputs.iter().map(|fn_arg| match fn_arg {
+        FnArg::Typed(PatType { pat, .. }) => match &**pat {
+            Pat::Ident(ident) => ident,
+            _ => panic!("argument pattern is not a simple ident"),
+        },
+        FnArg::Receiver(_) => panic!("argument is a receiver"),
+    });
+    let inner_fn_name_literal = format!("inner_{}", outer_fn_name_literal);
+    let inner_fn_name_ident = syn::Ident::new(&inner_fn_name_literal, item_fn.sig.span());
+    let inner_fn_inputs = &item_fn.sig.inputs;
+    let inner_fn_return = &item_fn.sig.output;
+    let inner_fn_block = &item_fn.block;
+
+    let ret = quote!(
+        fn #outer_fn_name_ident (#outer_fn_inputs) -> wasmedge_sys::WasmEdgeHostFuncFuture {
+            async fn #inner_fn_name_ident (#inner_fn_inputs) #inner_fn_return {
+                #inner_fn_block
+            }
+
+            let stack = switcher2::stack::EightMbStack::new().unwrap();
+            AsyncWasmEdgeResult::<switcher2::stack::EightMbStack, wasmedge_sys::WasmEdgeHostFuncResult<Vec<wasmedge_sys::WasmValue>>, fn()>::new(
+                stack,
+                |mut yielder| -> Result<Vec<wasmedge_sys::WasmValue>, wasmedge_types::error::HostFuncError> {
+                    yielder.async_suspend(#inner_fn_name_ident(#(#args),*))
+                },
+            )
+            .unwrap()
+        }
+    );
+
+    Ok(ret)
+}

--- a/bindings/rust/wasmedge-macro/src/lib.rs
+++ b/bindings/rust/wasmedge-macro/src/lib.rs
@@ -109,3 +109,111 @@ fn expand_async_host_func2(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2::To
 
     Ok(ret)
 }
+
+#[proc_macro_attribute]
+pub fn sys_async_host_function(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let body_ast = parse_macro_input!(item as Item);
+    if let Item::Fn(item_fn) = body_ast {
+        match sys_async_expand_host_func(&item_fn) {
+            Ok(token_stream) => token_stream.into(),
+            Err(err) => err.to_compile_error().into(),
+        }
+    } else {
+        TokenStream::new()
+    }
+}
+
+fn sys_async_expand_host_func(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2::TokenStream> {
+    let outer_fn_name_ident = &item_fn.sig.ident;
+    let outer_fn_name_literal = outer_fn_name_ident.to_string();
+    let outer_fn_inputs = &item_fn.sig.inputs;
+    let outer_fn_return = &item_fn.sig.output;
+    let args = outer_fn_inputs.iter().map(|fn_arg| match fn_arg {
+        FnArg::Typed(PatType { pat, .. }) => match &**pat {
+            Pat::Ident(ident) => ident,
+            _ => panic!("argument pattern is not a simple ident"),
+        },
+        FnArg::Receiver(_) => panic!("argument is a receiver"),
+    });
+    let inner_fn_name_literal = format!("inner_{}", outer_fn_name_literal);
+    let inner_fn_name_ident = syn::Ident::new(&inner_fn_name_literal, item_fn.sig.span());
+    let inner_fn_inputs = &item_fn.sig.inputs;
+    let inner_fn_return = &item_fn.sig.output;
+    let inner_fn_block = &item_fn.block;
+
+    let ret = match &item_fn.sig.asyncness {
+        Some(inner_asyncness) => {
+            quote!(
+                fn #outer_fn_name_ident (#outer_fn_inputs) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = Result<Vec<WasmValue>, HostFuncError>> + '_>> {
+                    #inner_asyncness fn #inner_fn_name_ident (#inner_fn_inputs) #inner_fn_return {
+                        #inner_fn_block
+                    }
+                    Box::pin(#inner_fn_name_ident(#(#args),*))
+                }
+            )
+        }
+        None => {
+            quote!(
+                fn #outer_fn_name_ident (#outer_fn_inputs) #outer_fn_return {
+                    fn #inner_fn_name_ident (#inner_fn_inputs) #inner_fn_return {
+                        #inner_fn_block
+                    }
+                    #inner_fn_name_ident(#(#args),*)
+                }
+            )
+        }
+    };
+
+    Ok(ret)
+}
+
+#[proc_macro_attribute]
+pub fn sys_async_host_function2(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let body_ast = parse_macro_input!(item as Item);
+    if let Item::Fn(item_fn) = body_ast {
+        match sys_expand_async_host_func2(&item_fn) {
+            Ok(token_stream) => token_stream.into(),
+            Err(err) => err.to_compile_error().into(),
+        }
+    } else {
+        TokenStream::new()
+    }
+}
+
+fn sys_expand_async_host_func2(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2::TokenStream> {
+    let outer_fn_name_ident = &item_fn.sig.ident;
+    let outer_fn_name_literal = outer_fn_name_ident.to_string();
+    let outer_fn_inputs = &item_fn.sig.inputs;
+    let args = outer_fn_inputs.iter().map(|fn_arg| match fn_arg {
+        FnArg::Typed(PatType { pat, .. }) => match &**pat {
+            Pat::Ident(ident) => ident,
+            _ => panic!("argument pattern is not a simple ident"),
+        },
+        FnArg::Receiver(_) => panic!("argument is a receiver"),
+    });
+    let inner_fn_name_literal = format!("inner_{}", outer_fn_name_literal);
+    let inner_fn_name_ident = syn::Ident::new(&inner_fn_name_literal, item_fn.sig.span());
+    let inner_fn_inputs = &item_fn.sig.inputs;
+    let inner_fn_return = &item_fn.sig.output;
+    let inner_fn_block = &item_fn.block;
+
+    let ret = quote!(
+        fn #outer_fn_name_ident (#outer_fn_inputs) -> wasmedge_sys::WasmEdgeHostFuncFuture {
+            async fn #inner_fn_name_ident (#inner_fn_inputs) #inner_fn_return {
+                #inner_fn_block
+            }
+
+            let stack = switcher2::stack::EightMbStack::new().unwrap();
+            AsyncWasmEdgeResult::<switcher2::stack::EightMbStack, wasmedge_sys::WasmEdgeHostFuncResult<Vec<wasmedge_sys::WasmValue>>, fn()>::new(
+                stack,
+                |mut yielder| -> Result<Vec<wasmedge_sys::WasmValue>, wasmedge_types::error::HostFuncError> {
+                    yielder.async_suspend(#inner_fn_name_ident(#(#args),*))
+                },
+            )
+            .unwrap()
+        }
+    );
+
+    Ok(ret)
+}

--- a/bindings/rust/wasmedge-sdk/Cargo.toml
+++ b/bindings/rust/wasmedge-sdk/Cargo.toml
@@ -8,14 +8,14 @@ license = "Apache-2.0"
 name = "wasmedge-sdk"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/WasmEdge/bindings/rust/wasmedge-sdk"
-version = "0.4.1"
+version = "0.5.0"
 
 [dependencies]
 anyhow = "1.0"
 thiserror = "1.0.30"
 wasmedge-macro = {path = "../wasmedge-macro", version = "0.1.0"}
-wasmedge-sys = {path = "../wasmedge-sys", version = "0.9.1"}
-wasmedge-types = {path = "../wasmedge-types", version = "0.2.1"}
+wasmedge-sys = {path = "../wasmedge-sys", version = "0.10.0"}
+wasmedge-types = {path = "../wasmedge-types", version = "0.3.0"}
 wat = "1.0"
 
 [features]

--- a/bindings/rust/wasmedge-sdk/Cargo.toml
+++ b/bindings/rust/wasmedge-sdk/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "wasmedge-sdk"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/WasmEdge/bindings/rust/wasmedge-sdk"
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
 anyhow = "1.0"

--- a/bindings/rust/wasmedge-sdk/Cargo.toml
+++ b/bindings/rust/wasmedge-sdk/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.4.0"
 [dependencies]
 anyhow = "1.0"
 thiserror = "1.0.30"
+wasmedge-macro = {path = "../wasmedge-macro", version = "0.1.0"}
 wasmedge-sys = {path = "../wasmedge-sys", version = "0.9.1"}
 wasmedge-types = {path = "../wasmedge-types", version = "0.2.1"}
 wat = "1.0"

--- a/bindings/rust/wasmedge-sdk/Cargo.toml
+++ b/bindings/rust/wasmedge-sdk/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.4.0"
 [dependencies]
 anyhow = "1.0"
 thiserror = "1.0.30"
-wasmedge-sys = {path = "../wasmedge-sys", version = "0.9.0"}
+wasmedge-sys = {path = "../wasmedge-sys", version = "0.9.1"}
 wasmedge-types = {path = "../wasmedge-types", version = "0.2.1"}
 wat = "1.0"
 

--- a/bindings/rust/wasmedge-sdk/src/caller.rs
+++ b/bindings/rust/wasmedge-sdk/src/caller.rs
@@ -1,0 +1,46 @@
+use crate::{Executor, Instance, Memory};
+use wasmedge_sys::CallingFrame;
+
+#[derive(Debug)]
+pub struct Caller<'a> {
+    inner: Option<&'a CallingFrame>,
+}
+impl<'a> Caller<'a> {
+    pub fn new(frame: &'a CallingFrame) -> Self {
+        Self { inner: Some(frame) }
+    }
+
+    pub fn executor(&self) -> Option<Executor> {
+        match self.inner {
+            Some(frame) => match frame.executor_mut() {
+                Some(inner) => Some(Executor { inner }),
+                None => None,
+            },
+            None => None,
+        }
+    }
+
+    pub fn instance(&self) -> Option<Instance> {
+        match self.inner {
+            Some(frame) => match frame.module_instance() {
+                Some(inner) => Some(Instance { inner }),
+                None => None,
+            },
+            None => None,
+        }
+    }
+
+    pub fn memory(&self, idx: usize) -> Option<Memory> {
+        match self.inner {
+            Some(frame) => match frame.memory_mut(idx as u32) {
+                Some(inner) => Some(Memory {
+                    inner,
+                    name: None,
+                    mod_name: None,
+                }),
+                None => None,
+            },
+            None => None,
+        }
+    }
+}

--- a/bindings/rust/wasmedge-sdk/src/caller.rs
+++ b/bindings/rust/wasmedge-sdk/src/caller.rs
@@ -21,10 +21,7 @@ impl<'a> Caller<'a> {
     /// Returns the [executor instance](crate::Executor) from this caller.
     pub fn executor(&self) -> Option<Executor> {
         match self.inner {
-            Some(frame) => match frame.executor_mut() {
-                Some(inner) => Some(Executor { inner }),
-                None => None,
-            },
+            Some(frame) => frame.executor_mut().map(|inner| Executor { inner }),
             None => None,
         }
     }
@@ -32,10 +29,7 @@ impl<'a> Caller<'a> {
     /// Returns the [module instance](crate::Instance) in this caller.
     pub fn instance(&self) -> Option<Instance> {
         match self.inner {
-            Some(frame) => match frame.module_instance() {
-                Some(inner) => Some(Instance { inner }),
-                None => None,
-            },
+            Some(frame) => frame.module_instance().map(|inner| Instance { inner }),
             None => None,
         }
     }
@@ -54,14 +48,11 @@ impl<'a> Caller<'a> {
     ///
     pub fn memory(&self, idx: usize) -> Option<Memory> {
         match self.inner {
-            Some(frame) => match frame.memory_mut(idx as u32) {
-                Some(inner) => Some(Memory {
-                    inner,
-                    name: None,
-                    mod_name: None,
-                }),
-                None => None,
-            },
+            Some(frame) => frame.memory_mut(idx as u32).map(|inner| Memory {
+                inner,
+                name: None,
+                mod_name: None,
+            }),
             None => None,
         }
     }

--- a/bindings/rust/wasmedge-sdk/src/externals/global.rs
+++ b/bindings/rust/wasmedge-sdk/src/externals/global.rs
@@ -179,7 +179,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
-            WasmEdgeError::Global(GlobalError::ModifyConst)
+            Box::new(WasmEdgeError::Global(GlobalError::ModifyConst))
         );
 
         // get the Var global from the store of vm

--- a/bindings/rust/wasmedge-sdk/src/import.rs
+++ b/bindings/rust/wasmedge-sdk/src/import.rs
@@ -663,9 +663,9 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
-            WasmEdgeError::Core(CoreError::Instantiation(
+            Box::new(WasmEdgeError::Core(CoreError::Instantiation(
                 CoreInstantiationError::ModuleNameConflict
-            ))
+            )))
         );
     }
 
@@ -718,9 +718,9 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
-            WasmEdgeError::Core(CoreError::Instantiation(
+            Box::new(WasmEdgeError::Core(CoreError::Instantiation(
                 CoreInstantiationError::ModuleNameConflict
-            ))
+            )))
         );
     }
 
@@ -931,7 +931,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
-            WasmEdgeError::Global(GlobalError::ModifyConst)
+            Box::new(WasmEdgeError::Global(GlobalError::ModifyConst))
         );
 
         // get the Var global from the store of vm

--- a/bindings/rust/wasmedge-sdk/src/lib.rs
+++ b/bindings/rust/wasmedge-sdk/src/lib.rs
@@ -144,6 +144,7 @@
 //! * [wasmedge-types: WasmEdge Types](https://crates.io/crates/wasmedge-types)
 //!
 
+pub mod caller;
 #[doc(hidden)]
 #[cfg(feature = "aot")]
 mod compiler;
@@ -164,6 +165,7 @@ pub mod utils;
 pub mod vm;
 pub mod wasi;
 
+pub use caller::Caller;
 #[doc(inline)]
 #[cfg(feature = "aot")]
 pub use compiler::Compiler;

--- a/bindings/rust/wasmedge-sdk/src/lib.rs
+++ b/bindings/rust/wasmedge-sdk/src/lib.rs
@@ -144,6 +144,7 @@
 //! * [wasmedge-types: WasmEdge Types](https://crates.io/crates/wasmedge-types)
 //!
 
+#[doc(hidden)]
 pub mod caller;
 #[doc(hidden)]
 #[cfg(feature = "aot")]

--- a/bindings/rust/wasmedge-sdk/src/module.rs
+++ b/bindings/rust/wasmedge-sdk/src/module.rs
@@ -191,7 +191,9 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
-            WasmEdgeError::Core(CoreError::Load(CoreLoadError::IllegalPath))
+            Box::new(WasmEdgeError::Core(CoreError::Load(
+                CoreLoadError::IllegalPath
+            )))
         );
     }
 
@@ -211,7 +213,9 @@ mod tests {
         let result = Module::from_bytes(None, &[]);
         assert_eq!(
             result.unwrap_err(),
-            WasmEdgeError::Core(CoreError::Load(CoreLoadError::UnexpectedEnd)),
+            Box::new(WasmEdgeError::Core(CoreError::Load(
+                CoreLoadError::UnexpectedEnd
+            ))),
         );
     }
 }

--- a/bindings/rust/wasmedge-sdk/src/module.rs
+++ b/bindings/rust/wasmedge-sdk/src/module.rs
@@ -210,7 +210,7 @@ mod tests {
         assert!(result.is_ok());
 
         // attempt to load an empty buffer
-        let result = Module::from_bytes(None, &[]);
+        let result = Module::from_bytes(None, []);
         assert_eq!(
             result.unwrap_err(),
             Box::new(WasmEdgeError::Core(CoreError::Load(

--- a/bindings/rust/wasmedge-sys/Cargo.toml
+++ b/bindings/rust/wasmedge-sys/Cargo.toml
@@ -10,7 +10,7 @@ links = "wasmedge"
 name = "wasmedge-sys"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/WasmEdge"
-version = "0.9.0"
+version = "0.9.1"
 
 [dependencies]
 lazy_static = "1.4.0"

--- a/bindings/rust/wasmedge-sys/Cargo.toml
+++ b/bindings/rust/wasmedge-sys/Cargo.toml
@@ -10,7 +10,7 @@ links = "wasmedge"
 name = "wasmedge-sys"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/WasmEdge"
-version = "0.9.1"
+version = "0.10.0"
 
 [dependencies]
 lazy_static = "1.4.0"
@@ -19,10 +19,10 @@ parking_lot = "0.12.1"
 paste = "1.0.5"
 rand = "0.8.4"
 thiserror = "1.0.30"
-wasmedge-types = {path = "../wasmedge-types", version = "0.2.1"}
+wasmedge-types = {path = "../wasmedge-types", version = "0.3.0"}
 
 [build-dependencies]
-bindgen = {version = "0.59.1", default-features = false, features = ["runtime"]}
+bindgen = {version = "0.60.1", default-features = false, features = ["runtime"]}
 cmake = "0.1"
 
 [features]

--- a/bindings/rust/wasmedge-sys/examples/hostfunc2.rs
+++ b/bindings/rust/wasmedge-sys/examples/hostfunc2.rs
@@ -48,8 +48,8 @@ fn real_add(_: &CallingFrame, input: Vec<WasmValue>) -> Result<Vec<WasmValue>, H
 }
 
 fn load_file_as_byte_vec(filename: &str) -> Vec<u8> {
-    let mut f = File::open(&filename).expect("no file found");
-    let metadata = fs::metadata(&filename).expect("unable to read metadata");
+    let mut f = File::open(filename).expect("no file found");
+    let metadata = fs::metadata(filename).expect("unable to read metadata");
     let mut buffer = vec![0; metadata.len() as usize];
     f.read_exact(&mut buffer)
         .expect("buffer should be the same size");

--- a/bindings/rust/wasmedge-sys/examples/wasi_module.rs
+++ b/bindings/rust/wasmedge-sys/examples/wasi_module.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
-            WasmEdgeError::Vm(VmError::NotFoundWasiModule)
+            Box::new(WasmEdgeError::Vm(VmError::NotFoundWasiModule))
         );
 
         // *** try to add a Wasi module.
@@ -70,7 +70,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
-            WasmEdgeError::Vm(VmError::NotFoundWasiModule)
+            Box::new(WasmEdgeError::Vm(VmError::NotFoundWasiModule))
         );
 
         // get store from vm
@@ -109,9 +109,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
-            WasmEdgeError::Core(CoreError::Instantiation(
+            Box::new(WasmEdgeError::Core(CoreError::Instantiation(
                 CoreInstantiationError::ModuleNameConflict
-            ))
+            )))
         );
     }
 

--- a/bindings/rust/wasmedge-sys/examples/wasmedge_process_module.rs
+++ b/bindings/rust/wasmedge-sys/examples/wasmedge_process_module.rs
@@ -52,9 +52,9 @@ fn create_wasmedge_process_module_implicitly() -> Result<(), Box<dyn std::error:
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err(),
-        WasmEdgeError::Core(CoreError::Instantiation(
+        Box::new(WasmEdgeError::Core(CoreError::Instantiation(
             CoreInstantiationError::ModuleNameConflict
-        ))
+        )))
     );
 
     Ok(())
@@ -75,7 +75,7 @@ fn create_wasmedge_process_module_explicitly() -> Result<(), Box<dyn std::error:
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err(),
-        WasmEdgeError::Vm(VmError::NotFoundWasmEdgeProcessModule)
+        Box::new(WasmEdgeError::Vm(VmError::NotFoundWasmEdgeProcessModule))
     );
 
     // *** try to add a WasmEdgeProcess module.
@@ -119,7 +119,7 @@ fn create_wasmedge_process_module_explicitly() -> Result<(), Box<dyn std::error:
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err(),
-        WasmEdgeError::Vm(VmError::NotFoundWasmEdgeProcessModule)
+        Box::new(WasmEdgeError::Vm(VmError::NotFoundWasmEdgeProcessModule))
     );
 
     // get store from vm

--- a/bindings/rust/wasmedge-sys/src/ast_module.rs
+++ b/bindings/rust/wasmedge-sys/src/ast_module.rs
@@ -108,9 +108,9 @@ impl<'module> ImportType<'module> {
                     )
                 };
                 match ctx_func_ty.is_null() {
-                    true => Err(WasmEdgeError::Import(ImportError::FuncType(
+                    true => Err(Box::new(WasmEdgeError::Import(ImportError::FuncType(
                         "Fail to get the function type".into(),
-                    ))),
+                    )))),
                     false => {
                         // get types of the arguments
                         let args_len = unsafe {
@@ -154,9 +154,9 @@ impl<'module> ImportType<'module> {
                     ffi::WasmEdge_ImportTypeGetGlobalType(self.module.inner.0, self.inner.0)
                 };
                 match ctx_global_ty.is_null() {
-                    true => Err(WasmEdgeError::Import(ImportError::MemType(
+                    true => Err(Box::new(WasmEdgeError::Import(ImportError::MemType(
                         "Fail to get the global type".into(),
-                    ))),
+                    )))),
                     false => {
                         // get the value type
                         let val = unsafe { ffi::WasmEdge_GlobalTypeGetValType(ctx_global_ty) };
@@ -177,9 +177,9 @@ impl<'module> ImportType<'module> {
                     ffi::WasmEdge_ImportTypeGetMemoryType(self.module.inner.0, self.inner.0)
                 };
                 match ctx_mem_ty.is_null() {
-                    true => Err(WasmEdgeError::Import(ImportError::MemType(
+                    true => Err(Box::new(WasmEdgeError::Import(ImportError::MemType(
                         "Fail to get the memory type".into(),
-                    ))),
+                    )))),
                     false => {
                         let limit = unsafe { ffi::WasmEdge_MemoryTypeGetLimit(ctx_mem_ty) };
                         let limit: WasmEdgeLimit = limit.into();
@@ -197,9 +197,9 @@ impl<'module> ImportType<'module> {
                     ffi::WasmEdge_ImportTypeGetTableType(self.module.inner.0, self.inner.0)
                 };
                 match ctx_tab_ty.is_null() {
-                    true => Err(WasmEdgeError::Import(ImportError::TableType(
+                    true => Err(Box::new(WasmEdgeError::Import(ImportError::TableType(
                         "Fail to get the table type".into(),
-                    ))),
+                    )))),
                     false => {
                         // get the element type
                         let elem_ty = unsafe { ffi::WasmEdge_TableTypeGetRefType(ctx_tab_ty) };
@@ -268,9 +268,9 @@ impl<'module> ExportType<'module> {
                     ffi::WasmEdge_ExportTypeGetFunctionType(self.module.inner.0, self.inner.0)
                 };
                 match ctx_func_ty.is_null() {
-                    true => Err(WasmEdgeError::Export(ExportError::FuncType(
+                    true => Err(Box::new(WasmEdgeError::Export(ExportError::FuncType(
                         "Fail to get the function type".into(),
-                    ))),
+                    )))),
                     false => {
                         // get types of the arguments
                         let args_len = unsafe {
@@ -314,9 +314,9 @@ impl<'module> ExportType<'module> {
                     ffi::WasmEdge_ExportTypeGetTableType(self.module.inner.0, self.inner.0)
                 };
                 match ctx_tab_ty.is_null() {
-                    true => Err(WasmEdgeError::Export(ExportError::TableType(
+                    true => Err(Box::new(WasmEdgeError::Export(ExportError::TableType(
                         "Fail to get the function type".into(),
-                    ))),
+                    )))),
                     false => {
                         // get the element type
                         let elem_ty = unsafe { ffi::WasmEdge_TableTypeGetRefType(ctx_tab_ty) };
@@ -339,9 +339,9 @@ impl<'module> ExportType<'module> {
                     ffi::WasmEdge_ExportTypeGetMemoryType(self.module.inner.0, self.inner.0)
                 };
                 match ctx_mem_ty.is_null() {
-                    true => Err(WasmEdgeError::Export(ExportError::MemType(
+                    true => Err(Box::new(WasmEdgeError::Export(ExportError::MemType(
                         "Fail to get the function type".into(),
-                    ))),
+                    )))),
                     false => {
                         let limit = unsafe { ffi::WasmEdge_MemoryTypeGetLimit(ctx_mem_ty) };
                         let limit: WasmEdgeLimit = limit.into();
@@ -359,9 +359,9 @@ impl<'module> ExportType<'module> {
                     ffi::WasmEdge_ExportTypeGetGlobalType(self.module.inner.0, self.inner.0)
                 };
                 match ctx_global_ty.is_null() {
-                    true => Err(WasmEdgeError::Export(ExportError::GlobalType(
+                    true => Err(Box::new(WasmEdgeError::Export(ExportError::GlobalType(
                         "Fail to get the function type".into(),
-                    ))),
+                    )))),
                     false => {
                         // get the value type
                         let val = unsafe { ffi::WasmEdge_GlobalTypeGetValType(ctx_global_ty) };

--- a/bindings/rust/wasmedge-sys/src/compiler.rs
+++ b/bindings/rust/wasmedge-sys/src/compiler.rs
@@ -34,7 +34,7 @@ impl Compiler {
         };
 
         match ctx.is_null() {
-            true => Err(WasmEdgeError::CompilerCreate),
+            true => Err(Box::new(WasmEdgeError::CompilerCreate)),
             false => Ok(Self {
                 inner: InnerCompiler(ctx),
             }),
@@ -166,7 +166,9 @@ mod tests {
             assert!(result.is_err());
             assert_eq!(
                 result.unwrap_err(),
-                WasmEdgeError::Core(CoreError::Load(CoreLoadError::IllegalPath))
+                Box::new(WasmEdgeError::Core(CoreError::Load(
+                    CoreLoadError::IllegalPath
+                )))
             );
         }
 

--- a/bindings/rust/wasmedge-sys/src/config.rs
+++ b/bindings/rust/wasmedge-sys/src/config.rs
@@ -144,7 +144,7 @@ impl Config {
     pub fn create() -> WasmEdgeResult<Self> {
         let ctx = unsafe { ffi::WasmEdge_ConfigureCreate() };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::ConfigCreate),
+            true => Err(Box::new(WasmEdgeError::ConfigCreate)),
             false => Ok(Self {
                 inner: InnerConfig(ctx),
             }),

--- a/bindings/rust/wasmedge-sys/src/executor.rs
+++ b/bindings/rust/wasmedge-sys/src/executor.rs
@@ -52,7 +52,7 @@ impl Executor {
         };
 
         match ctx.is_null() {
-            true => Err(WasmEdgeError::ExecutorCreate),
+            true => Err(Box::new(WasmEdgeError::ExecutorCreate)),
             false => Ok(Executor {
                 inner: InnerExecutor(ctx),
                 registered: false,

--- a/bindings/rust/wasmedge-sys/src/frame.rs
+++ b/bindings/rust/wasmedge-sys/src/frame.rs
@@ -9,17 +9,26 @@ use crate::{
 
 #[derive(Debug)]
 pub struct CallingFrame {
-    pub(crate) ctx: *const ffi::WasmEdge_CallingFrameContext,
+    pub(crate) inner: InnerCallingFrame,
+}
+impl Drop for CallingFrame {
+    fn drop(&mut self) {
+        if !self.inner.0.is_null() {
+            self.inner.0 = std::ptr::null();
+        }
+    }
 }
 impl CallingFrame {
     /// Creates a CallingFrame instance.
     pub(crate) fn create(ctx: *const ffi::WasmEdge_CallingFrameContext) -> Self {
-        Self { ctx }
+        Self {
+            inner: InnerCallingFrame(ctx),
+        }
     }
 
     /// Returns the [executor instance](crate::Executor) from this calling frame.
     pub fn executor_mut(&self) -> Option<Executor> {
-        let ctx = unsafe { ffi::WasmEdge_CallingFrameGetExecutor(self.ctx) };
+        let ctx = unsafe { ffi::WasmEdge_CallingFrameGetExecutor(self.inner.0) };
 
         match ctx.is_null() {
             false => Some(Executor {
@@ -39,7 +48,7 @@ impl CallingFrame {
     /// context will record that module instance.
     ///
     pub fn module_instance(&self) -> Option<Instance> {
-        let ctx = unsafe { ffi::WasmEdge_CallingFrameGetModuleInstance(self.ctx) };
+        let ctx = unsafe { ffi::WasmEdge_CallingFrameGetModuleInstance(self.inner.0) };
 
         match ctx.is_null() {
             false => Some(Instance {
@@ -63,7 +72,7 @@ impl CallingFrame {
     /// * idx - The index of the memory instance.
     ///
     pub fn memory_mut(&self, idx: u32) -> Option<Memory> {
-        let ctx = unsafe { ffi::WasmEdge_CallingFrameGetMemoryInstance(self.ctx, idx) };
+        let ctx = unsafe { ffi::WasmEdge_CallingFrameGetMemoryInstance(self.inner.0, idx) };
 
         match ctx.is_null() {
             false => Some(Memory {
@@ -74,3 +83,8 @@ impl CallingFrame {
         }
     }
 }
+
+#[derive(Debug)]
+pub(crate) struct InnerCallingFrame(pub(crate) *const ffi::WasmEdge_CallingFrameContext);
+unsafe impl Send for InnerCallingFrame {}
+unsafe impl Sync for InnerCallingFrame {}

--- a/bindings/rust/wasmedge-sys/src/frame.rs
+++ b/bindings/rust/wasmedge-sys/src/frame.rs
@@ -7,6 +7,7 @@ use crate::{
     Executor, Instance, Memory,
 };
 
+/// Represents a calling frame on top of stack.
 #[derive(Debug)]
 pub struct CallingFrame {
     pub(crate) inner: InnerCallingFrame,

--- a/bindings/rust/wasmedge-sys/src/instance/function.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/function.rs
@@ -205,9 +205,11 @@ impl Function {
     pub fn create(ty: &FuncType, real_fn: BoxedFn, cost: u64) -> WasmEdgeResult<Self> {
         let mut host_functions = HOST_FUNCS.write();
         if host_functions.len() >= host_functions.capacity() {
-            return Err(WasmEdgeError::Func(FuncError::CreateBinding(format!(
-                "The number of the host functions reaches the upper bound: {}",
-                host_functions.capacity()
+            return Err(Box::new(WasmEdgeError::Func(FuncError::CreateBinding(
+                format!(
+                    "The number of the host functions reaches the upper bound: {}",
+                    host_functions.capacity()
+                ),
             ))));
         }
 
@@ -230,7 +232,7 @@ impl Function {
         };
 
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Func(FuncError::Create)),
+            true => Err(Box::new(WasmEdgeError::Func(FuncError::Create))),
             false => Ok(Self {
                 inner: InnerFunc(ctx),
                 registered: false,
@@ -292,7 +294,7 @@ impl Function {
         };
 
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Func(FuncError::Create)),
+            true => Err(Box::new(WasmEdgeError::Func(FuncError::Create))),
             false => Ok(Self {
                 inner: InnerFunc(ctx),
                 registered: false,
@@ -309,7 +311,7 @@ impl Function {
     pub fn ty(&self) -> WasmEdgeResult<FuncType> {
         let ty = unsafe { ffi::WasmEdge_FunctionInstanceGetFunctionType(self.inner.0) };
         match ty.is_null() {
-            true => Err(WasmEdgeError::Func(FuncError::Type)),
+            true => Err(Box::new(WasmEdgeError::Func(FuncError::Type))),
             false => Ok(FuncType {
                 inner: InnerFuncType(ty as *mut _),
                 registered: true,
@@ -463,7 +465,7 @@ impl FuncType {
             )
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::FuncTypeCreate),
+            true => Err(Box::new(WasmEdgeError::FuncTypeCreate)),
             false => Ok(Self {
                 inner: InnerFuncType(ctx),
                 registered: false,
@@ -577,7 +579,7 @@ impl FuncRef {
     pub fn ty(&self) -> WasmEdgeResult<FuncType> {
         let ty = unsafe { ffi::WasmEdge_FunctionInstanceGetFunctionType(self.inner.0 as *mut _) };
         match ty.is_null() {
-            true => Err(WasmEdgeError::Func(FuncError::Type)),
+            true => Err(Box::new(WasmEdgeError::Func(FuncError::Type))),
             false => Ok(FuncType {
                 inner: InnerFuncType(ty as *mut _),
                 registered: true,

--- a/bindings/rust/wasmedge-sys/src/instance/memory.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/memory.rs
@@ -46,7 +46,7 @@ impl Memory {
         let ctx = unsafe { ffi::WasmEdge_MemoryInstanceCreate(ty.inner.0 as *const _) };
 
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Mem(MemError::Create)),
+            true => Err(Box::new(WasmEdgeError::Mem(MemError::Create))),
             false => Ok(Memory {
                 inner: InnerMemory(ctx),
                 registered: false,
@@ -63,7 +63,7 @@ impl Memory {
     pub fn ty(&self) -> WasmEdgeResult<MemType> {
         let ty_ctx = unsafe { ffi::WasmEdge_MemoryInstanceGetMemoryType(self.inner.0) };
         match ty_ctx.is_null() {
-            true => Err(WasmEdgeError::Mem(MemError::Type)),
+            true => Err(Box::new(WasmEdgeError::Mem(MemError::Type))),
             false => Ok(MemType {
                 inner: InnerMemType(ty_ctx as *mut _),
                 registered: true,
@@ -122,7 +122,7 @@ impl Memory {
     /// // set data and the data length is larger than the data size in the memory
     /// let result = mem.set_data(vec![1; 10], u32::pow(2, 16) - 9);
     /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err(), WasmEdgeError::Core(CoreError::Execution(CoreExecutionError::MemoryOutOfBounds)));
+    /// assert_eq!(result.unwrap_err(), Box::new(WasmEdgeError::Core(CoreError::Execution(CoreExecutionError::MemoryOutOfBounds))));
     /// ```
     ///
     /// # Example
@@ -173,12 +173,12 @@ impl Memory {
     pub fn data_pointer(&self, offset: u32, len: u32) -> WasmEdgeResult<&u8> {
         let ptr = unsafe { ffi::WasmEdge_MemoryInstanceGetPointerConst(self.inner.0, offset, len) };
         match ptr.is_null() {
-            true => Err(WasmEdgeError::Mem(MemError::ConstPtr)),
+            true => Err(Box::new(WasmEdgeError::Mem(MemError::ConstPtr))),
             false => {
                 let result = unsafe { ptr.as_ref() };
                 match result {
                     Some(ptr) => Ok(ptr),
-                    None => Err(WasmEdgeError::Mem(MemError::Ptr2Ref)),
+                    None => Err(Box::new(WasmEdgeError::Mem(MemError::Ptr2Ref))),
                 }
             }
         }
@@ -199,12 +199,12 @@ impl Memory {
     pub fn data_pointer_mut(&mut self, offset: u32, len: u32) -> WasmEdgeResult<&mut u8> {
         let ptr = unsafe { ffi::WasmEdge_MemoryInstanceGetPointer(self.inner.0, offset, len) };
         match ptr.is_null() {
-            true => Err(WasmEdgeError::Mem(MemError::MutPtr)),
+            true => Err(Box::new(WasmEdgeError::Mem(MemError::MutPtr))),
             false => {
                 let result = unsafe { ptr.as_mut() };
                 match result {
                     Some(ptr) => Ok(ptr),
-                    None => Err(WasmEdgeError::Mem(MemError::Ptr2Ref)),
+                    None => Err(Box::new(WasmEdgeError::Mem(MemError::Ptr2Ref))),
                 }
             }
         }
@@ -288,12 +288,12 @@ impl MemType {
     ///
     pub fn create(min: u32, max: Option<u32>, shared: bool) -> WasmEdgeResult<Self> {
         if shared && max.is_none() {
-            return Err(WasmEdgeError::Mem(MemError::CreateSharedType));
+            return Err(Box::new(WasmEdgeError::Mem(MemError::CreateSharedType)));
         }
         let ctx =
             unsafe { ffi::WasmEdge_MemoryTypeCreate(WasmEdgeLimit::new(min, max, shared).into()) };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::MemTypeCreate),
+            true => Err(Box::new(WasmEdgeError::MemTypeCreate)),
             false => Ok(Self {
                 inner: InnerMemType(ctx),
                 registered: false,
@@ -453,7 +453,9 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
-            WasmEdgeError::Core(CoreError::Execution(CoreExecutionError::MemoryOutOfBounds))
+            Box::new(WasmEdgeError::Core(CoreError::Execution(
+                CoreExecutionError::MemoryOutOfBounds
+            )))
         );
 
         // grow the memory size

--- a/bindings/rust/wasmedge-sys/src/instance/module.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/module.rs
@@ -64,8 +64,8 @@ impl Instance {
             ffi::WasmEdge_ModuleInstanceFindFunction(self.inner.0 as *const _, func_name.as_raw())
         };
         match func_ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundFunc(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
                 inner: InnerFunc(func_ctx),
@@ -89,8 +89,8 @@ impl Instance {
             ffi::WasmEdge_ModuleInstanceFindTable(self.inner.0 as *const _, table_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundTable(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
                 inner: InnerTable(ctx),
@@ -114,8 +114,8 @@ impl Instance {
             ffi::WasmEdge_ModuleInstanceFindMemory(self.inner.0 as *const _, mem_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundMem(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
                 inner: InnerMemory(ctx),
@@ -139,8 +139,8 @@ impl Instance {
             ffi::WasmEdge_ModuleInstanceFindGlobal(self.inner.0 as *const _, global_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundGlobal(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
                 inner: InnerGlobal(ctx),
@@ -447,7 +447,9 @@ impl ImportModule {
         let ctx = unsafe { ffi::WasmEdge_ModuleInstanceCreate(raw_name.as_raw()) };
 
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::CreateImportModule)),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::CreateImportModule,
+            ))),
             false => Ok(Self {
                 inner: InnerInstance(ctx),
                 registered: false,
@@ -588,7 +590,7 @@ impl WasiModule {
             )
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::ImportObjCreate),
+            true => Err(Box::new(WasmEdgeError::ImportObjCreate)),
             false => Ok(Self {
                 inner: InnerInstance(ctx),
                 registered: false,
@@ -688,9 +690,9 @@ impl WasiModule {
 
         match code {
             0 => Ok(handler),
-            _ => Err(WasmEdgeError::Instance(
+            _ => Err(Box::new(WasmEdgeError::Instance(
                 InstanceError::NotFoundMappedFdHandler,
-            )),
+            ))),
         }
     }
 }
@@ -701,8 +703,8 @@ impl AsInstance for WasiModule {
             ffi::WasmEdge_ModuleInstanceFindFunction(self.inner.0 as *const _, func_name.as_raw())
         };
         match func_ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundFunc(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
                 inner: InnerFunc(func_ctx),
@@ -717,8 +719,8 @@ impl AsInstance for WasiModule {
             ffi::WasmEdge_ModuleInstanceFindTable(self.inner.0 as *const _, table_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundTable(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
                 inner: InnerTable(ctx),
@@ -733,8 +735,8 @@ impl AsInstance for WasiModule {
             ffi::WasmEdge_ModuleInstanceFindMemory(self.inner.0 as *const _, mem_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundMem(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
                 inner: InnerMemory(ctx),
@@ -749,8 +751,8 @@ impl AsInstance for WasiModule {
             ffi::WasmEdge_ModuleInstanceFindGlobal(self.inner.0 as *const _, global_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundGlobal(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
                 inner: InnerGlobal(ctx),
@@ -996,7 +998,7 @@ impl WasmEdgeProcessModule {
             )
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::ImportObjCreate),
+            true => Err(Box::new(WasmEdgeError::ImportObjCreate)),
             false => Ok(Self {
                 inner: InnerInstance(ctx),
                 registered: false,
@@ -1041,8 +1043,8 @@ impl AsInstance for WasmEdgeProcessModule {
             ffi::WasmEdge_ModuleInstanceFindFunction(self.inner.0 as *const _, func_name.as_raw())
         };
         match func_ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundFunc(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
                 inner: InnerFunc(func_ctx),
@@ -1057,8 +1059,8 @@ impl AsInstance for WasmEdgeProcessModule {
             ffi::WasmEdge_ModuleInstanceFindTable(self.inner.0 as *const _, table_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundTable(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
                 inner: InnerTable(ctx),
@@ -1073,8 +1075,8 @@ impl AsInstance for WasmEdgeProcessModule {
             ffi::WasmEdge_ModuleInstanceFindMemory(self.inner.0 as *const _, mem_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundMem(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
                 inner: InnerMemory(ctx),
@@ -1089,8 +1091,8 @@ impl AsInstance for WasmEdgeProcessModule {
             ffi::WasmEdge_ModuleInstanceFindGlobal(self.inner.0 as *const _, global_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundGlobal(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
                 inner: InnerGlobal(ctx),
@@ -1286,7 +1288,7 @@ impl WasiNnModule {
     pub fn create() -> WasmEdgeResult<Self> {
         let ctx = unsafe { ffi::WasmEdge_ModuleInstanceCreateWasiNN() };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::ImportObjCreate),
+            true => Err(Box::new(WasmEdgeError::ImportObjCreate)),
             false => Ok(Self {
                 inner: InnerInstance(ctx),
                 registered: false,
@@ -1301,8 +1303,8 @@ impl AsInstance for WasiNnModule {
             ffi::WasmEdge_ModuleInstanceFindFunction(self.inner.0 as *const _, func_name.as_raw())
         };
         match func_ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundFunc(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
                 inner: InnerFunc(func_ctx),
@@ -1317,8 +1319,8 @@ impl AsInstance for WasiNnModule {
             ffi::WasmEdge_ModuleInstanceFindTable(self.inner.0 as *const _, table_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundTable(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
                 inner: InnerTable(ctx),
@@ -1333,8 +1335,8 @@ impl AsInstance for WasiNnModule {
             ffi::WasmEdge_ModuleInstanceFindMemory(self.inner.0 as *const _, mem_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundMem(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
                 inner: InnerMemory(ctx),
@@ -1349,8 +1351,8 @@ impl AsInstance for WasiNnModule {
             ffi::WasmEdge_ModuleInstanceFindGlobal(self.inner.0 as *const _, global_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundGlobal(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
                 inner: InnerGlobal(ctx),
@@ -1545,7 +1547,7 @@ impl WasiCryptoCommonModule {
     pub fn create() -> WasmEdgeResult<Self> {
         let ctx = unsafe { ffi::WasmEdge_ModuleInstanceCreateWasiCryptoCommon() };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::ImportObjCreate),
+            true => Err(Box::new(WasmEdgeError::ImportObjCreate)),
             false => Ok(Self {
                 inner: InnerInstance(ctx),
                 registered: false,
@@ -1560,8 +1562,8 @@ impl AsInstance for WasiCryptoCommonModule {
             ffi::WasmEdge_ModuleInstanceFindFunction(self.inner.0 as *const _, func_name.as_raw())
         };
         match func_ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundFunc(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
                 inner: InnerFunc(func_ctx),
@@ -1576,8 +1578,8 @@ impl AsInstance for WasiCryptoCommonModule {
             ffi::WasmEdge_ModuleInstanceFindTable(self.inner.0 as *const _, table_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundTable(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
                 inner: InnerTable(ctx),
@@ -1592,8 +1594,8 @@ impl AsInstance for WasiCryptoCommonModule {
             ffi::WasmEdge_ModuleInstanceFindMemory(self.inner.0 as *const _, mem_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundMem(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
                 inner: InnerMemory(ctx),
@@ -1608,8 +1610,8 @@ impl AsInstance for WasiCryptoCommonModule {
             ffi::WasmEdge_ModuleInstanceFindGlobal(self.inner.0 as *const _, global_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundGlobal(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
                 inner: InnerGlobal(ctx),
@@ -1804,7 +1806,7 @@ impl WasiCryptoAsymmetricCommonModule {
     pub fn create() -> WasmEdgeResult<Self> {
         let ctx = unsafe { ffi::WasmEdge_ModuleInstanceCreateWasiCryptoAsymmetricCommon() };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::ImportObjCreate),
+            true => Err(Box::new(WasmEdgeError::ImportObjCreate)),
             false => Ok(Self {
                 inner: InnerInstance(ctx),
                 registered: false,
@@ -1819,8 +1821,8 @@ impl AsInstance for WasiCryptoAsymmetricCommonModule {
             ffi::WasmEdge_ModuleInstanceFindFunction(self.inner.0 as *const _, func_name.as_raw())
         };
         match func_ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundFunc(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
                 inner: InnerFunc(func_ctx),
@@ -1835,8 +1837,8 @@ impl AsInstance for WasiCryptoAsymmetricCommonModule {
             ffi::WasmEdge_ModuleInstanceFindTable(self.inner.0 as *const _, table_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundTable(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
                 inner: InnerTable(ctx),
@@ -1851,8 +1853,8 @@ impl AsInstance for WasiCryptoAsymmetricCommonModule {
             ffi::WasmEdge_ModuleInstanceFindMemory(self.inner.0 as *const _, mem_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundMem(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
                 inner: InnerMemory(ctx),
@@ -1867,8 +1869,8 @@ impl AsInstance for WasiCryptoAsymmetricCommonModule {
             ffi::WasmEdge_ModuleInstanceFindGlobal(self.inner.0 as *const _, global_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundGlobal(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
                 inner: InnerGlobal(ctx),
@@ -2063,7 +2065,7 @@ impl WasiCryptoSymmetricModule {
     pub fn create() -> WasmEdgeResult<Self> {
         let ctx = unsafe { ffi::WasmEdge_ModuleInstanceCreateWasiCryptoSymmetric() };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::ImportObjCreate),
+            true => Err(Box::new(WasmEdgeError::ImportObjCreate)),
             false => Ok(Self {
                 inner: InnerInstance(ctx),
                 registered: false,
@@ -2078,8 +2080,8 @@ impl AsInstance for WasiCryptoSymmetricModule {
             ffi::WasmEdge_ModuleInstanceFindFunction(self.inner.0 as *const _, func_name.as_raw())
         };
         match func_ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundFunc(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
                 inner: InnerFunc(func_ctx),
@@ -2094,8 +2096,8 @@ impl AsInstance for WasiCryptoSymmetricModule {
             ffi::WasmEdge_ModuleInstanceFindTable(self.inner.0 as *const _, table_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundTable(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
                 inner: InnerTable(ctx),
@@ -2110,8 +2112,8 @@ impl AsInstance for WasiCryptoSymmetricModule {
             ffi::WasmEdge_ModuleInstanceFindMemory(self.inner.0 as *const _, mem_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundMem(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
                 inner: InnerMemory(ctx),
@@ -2126,8 +2128,8 @@ impl AsInstance for WasiCryptoSymmetricModule {
             ffi::WasmEdge_ModuleInstanceFindGlobal(self.inner.0 as *const _, global_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundGlobal(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
                 inner: InnerGlobal(ctx),
@@ -2322,7 +2324,7 @@ impl WasiCryptoKxModule {
     pub fn create() -> WasmEdgeResult<Self> {
         let ctx = unsafe { ffi::WasmEdge_ModuleInstanceCreateWasiCryptoKx() };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::ImportObjCreate),
+            true => Err(Box::new(WasmEdgeError::ImportObjCreate)),
             false => Ok(Self {
                 inner: InnerInstance(ctx),
                 registered: false,
@@ -2337,8 +2339,8 @@ impl AsInstance for WasiCryptoKxModule {
             ffi::WasmEdge_ModuleInstanceFindFunction(self.inner.0 as *const _, func_name.as_raw())
         };
         match func_ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundFunc(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
                 inner: InnerFunc(func_ctx),
@@ -2353,8 +2355,8 @@ impl AsInstance for WasiCryptoKxModule {
             ffi::WasmEdge_ModuleInstanceFindTable(self.inner.0 as *const _, table_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundTable(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
                 inner: InnerTable(ctx),
@@ -2369,8 +2371,8 @@ impl AsInstance for WasiCryptoKxModule {
             ffi::WasmEdge_ModuleInstanceFindMemory(self.inner.0 as *const _, mem_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundMem(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
                 inner: InnerMemory(ctx),
@@ -2385,8 +2387,8 @@ impl AsInstance for WasiCryptoKxModule {
             ffi::WasmEdge_ModuleInstanceFindGlobal(self.inner.0 as *const _, global_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundGlobal(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
                 inner: InnerGlobal(ctx),
@@ -2581,7 +2583,7 @@ impl WasiCryptoSignaturesModule {
     pub fn create() -> WasmEdgeResult<Self> {
         let ctx = unsafe { ffi::WasmEdge_ModuleInstanceCreateWasiCryptoSignatures() };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::ImportObjCreate),
+            true => Err(Box::new(WasmEdgeError::ImportObjCreate)),
             false => Ok(Self {
                 inner: InnerInstance(ctx),
                 registered: false,
@@ -2596,8 +2598,8 @@ impl AsInstance for WasiCryptoSignaturesModule {
             ffi::WasmEdge_ModuleInstanceFindFunction(self.inner.0 as *const _, func_name.as_raw())
         };
         match func_ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundFunc(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
                 inner: InnerFunc(func_ctx),
@@ -2612,8 +2614,8 @@ impl AsInstance for WasiCryptoSignaturesModule {
             ffi::WasmEdge_ModuleInstanceFindTable(self.inner.0 as *const _, table_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundTable(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
                 inner: InnerTable(ctx),
@@ -2628,8 +2630,8 @@ impl AsInstance for WasiCryptoSignaturesModule {
             ffi::WasmEdge_ModuleInstanceFindMemory(self.inner.0 as *const _, mem_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundMem(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
                 inner: InnerMemory(ctx),
@@ -2644,8 +2646,8 @@ impl AsInstance for WasiCryptoSignaturesModule {
             ffi::WasmEdge_ModuleInstanceFindGlobal(self.inner.0 as *const _, global_name.as_raw())
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Instance(InstanceError::NotFoundGlobal(
-                name.as_ref().to_string(),
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
                 inner: InnerGlobal(ctx),

--- a/bindings/rust/wasmedge-sys/src/instance/table.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/table.rs
@@ -49,7 +49,7 @@ impl Table {
         let ctx = unsafe { ffi::WasmEdge_TableInstanceCreate(ty.inner.0) };
 
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Table(TableError::Create)),
+            true => Err(Box::new(WasmEdgeError::Table(TableError::Create))),
             false => Ok(Table {
                 inner: InnerTable(ctx),
                 registered: false,
@@ -65,7 +65,7 @@ impl Table {
     pub fn ty(&self) -> WasmEdgeResult<TableType> {
         let ty_ctx = unsafe { ffi::WasmEdge_TableInstanceGetTableType(self.inner.0) };
         match ty_ctx.is_null() {
-            true => Err(WasmEdgeError::Table(TableError::Type)),
+            true => Err(Box::new(WasmEdgeError::Table(TableError::Type))),
             false => Ok(TableType {
                 inner: InnerTableType(ty_ctx as *mut _),
                 registered: true,
@@ -210,7 +210,7 @@ impl TableType {
             )
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::TableTypeCreate),
+            true => Err(Box::new(WasmEdgeError::TableTypeCreate)),
             false => Ok(Self {
                 inner: InnerTableType(ctx),
                 registered: false,

--- a/bindings/rust/wasmedge-sys/src/loader.rs
+++ b/bindings/rust/wasmedge-sys/src/loader.rs
@@ -36,7 +36,7 @@ impl Loader {
         };
 
         match ctx.is_null() {
-            true => Err(WasmEdgeError::LoaderCreate),
+            true => Err(Box::new(WasmEdgeError::LoaderCreate)),
             false => Ok(Self {
                 inner: InnerLoader(ctx),
                 registered: false,
@@ -72,7 +72,7 @@ impl Loader {
         }
 
         match mod_ctx.is_null() {
-            true => Err(WasmEdgeError::ModuleCreate),
+            true => Err(Box::new(WasmEdgeError::ModuleCreate)),
             false => Ok(Module {
                 inner: InnerModule(mod_ctx),
             }),
@@ -127,7 +127,7 @@ impl Loader {
         }
 
         match mod_ctx.is_null() {
-            true => Err(WasmEdgeError::ModuleCreate),
+            true => Err(Box::new(WasmEdgeError::ModuleCreate)),
             false => Ok(Module {
                 inner: InnerModule(mod_ctx),
             }),
@@ -192,14 +192,18 @@ mod tests {
             assert!(result.is_err());
             assert_eq!(
                 result.unwrap_err(),
-                WasmEdgeError::Core(CoreError::Load(CoreLoadError::MalformedMagic))
+                Box::new(WasmEdgeError::Core(CoreError::Load(
+                    CoreLoadError::MalformedMagic
+                )))
             );
 
             let result = loader.from_file("not_exist_file");
             assert!(result.is_err());
             assert_eq!(
                 result.unwrap_err(),
-                WasmEdgeError::Core(CoreError::Load(CoreLoadError::IllegalPath))
+                Box::new(WasmEdgeError::Core(CoreError::Load(
+                    CoreLoadError::IllegalPath
+                )))
             );
         }
 
@@ -216,7 +220,9 @@ mod tests {
             assert!(result.is_err());
             assert_eq!(
                 result.unwrap_err(),
-                WasmEdgeError::Core(CoreError::Load(CoreLoadError::MalformedMagic))
+                Box::new(WasmEdgeError::Core(CoreError::Load(
+                    CoreLoadError::MalformedMagic
+                )))
             );
 
             // empty is not accepted
@@ -224,7 +230,9 @@ mod tests {
             assert!(result.is_err());
             assert_eq!(
                 result.unwrap_err(),
-                WasmEdgeError::Core(CoreError::Load(CoreLoadError::UnexpectedEnd))
+                Box::new(WasmEdgeError::Core(CoreError::Load(
+                    CoreLoadError::UnexpectedEnd
+                )))
             );
         }
     }

--- a/bindings/rust/wasmedge-sys/src/loader.rs
+++ b/bindings/rust/wasmedge-sys/src/loader.rs
@@ -210,7 +210,7 @@ mod tests {
         // load from buffer
         {
             let buffer = b"\0asm\x01\0\0\0";
-            let result = loader.from_bytes(&buffer);
+            let result = loader.from_bytes(buffer);
             assert!(result.is_ok());
             let module = result.unwrap();
             assert!(!module.inner.0.is_null());
@@ -226,7 +226,7 @@ mod tests {
             );
 
             // empty is not accepted
-            let result = loader.from_bytes(&[]);
+            let result = loader.from_bytes([]);
             assert!(result.is_err());
             assert_eq!(
                 result.unwrap_err(),

--- a/bindings/rust/wasmedge-sys/src/statistics.rs
+++ b/bindings/rust/wasmedge-sys/src/statistics.rs
@@ -17,7 +17,7 @@ impl Statistics {
     pub fn create() -> WasmEdgeResult<Self> {
         let ctx = unsafe { ffi::WasmEdge_StatisticsCreate() };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::StatisticsCreate),
+            true => Err(Box::new(WasmEdgeError::StatisticsCreate)),
             false => Ok(Statistics {
                 inner: InnerStat(ctx),
                 registered: false,

--- a/bindings/rust/wasmedge-sys/src/store.rs
+++ b/bindings/rust/wasmedge-sys/src/store.rs
@@ -23,7 +23,7 @@ impl Store {
     pub fn create() -> WasmEdgeResult<Self> {
         let ctx = unsafe { ffi::WasmEdge_StoreCreate() };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Store(StoreError::Create)),
+            true => Err(Box::new(WasmEdgeError::Store(StoreError::Create))),
             false => Ok(Store {
                 inner: InnerStore(ctx),
                 registered: false,
@@ -74,9 +74,9 @@ impl Store {
         let mod_name: WasmEdgeString = name.as_ref().into();
         let ctx = unsafe { ffi::WasmEdge_StoreFindModule(self.inner.0, mod_name.as_raw()) };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::Store(StoreError::NotFoundModule(
+            true => Err(Box::new(WasmEdgeError::Store(StoreError::NotFoundModule(
                 name.as_ref().to_string(),
-            ))),
+            )))),
             false => Ok(Instance {
                 inner: InnerInstance(ctx as *mut _),
                 registered: true,

--- a/bindings/rust/wasmedge-sys/src/utils.rs
+++ b/bindings/rust/wasmedge-sys/src/utils.rs
@@ -16,16 +16,17 @@ use std::{
 #[cfg(unix)]
 pub(crate) fn path_to_cstring(path: &Path) -> WasmEdgeResult<CString> {
     use std::os::unix::ffi::OsStrExt;
-    Ok(CString::new(path.as_os_str().as_bytes())?)
+    Ok(CString::new(path.as_os_str().as_bytes())
+        .map_err(|err| Box::new(WasmEdgeError::FoundNulByte(err)))?)
 }
 
 #[cfg(windows)]
 pub(crate) fn path_to_cstring(path: &Path) -> WasmEdgeResult<CString> {
     match path.to_str() {
         Some(s) => Ok(CString::new(s)?),
-        None => Err(WasmEdgeError::WindowsPathConversion(
+        None => Err(Box::new(WasmEdgeError::WindowsPathConversion(
             path.to_string_lossy().to_string(),
-        )),
+        ))),
     }
 }
 
@@ -51,7 +52,7 @@ pub(crate) fn check(result: WasmEdge_Result) -> WasmEdgeResult<()> {
     };
 
     match category {
-        ffi::WasmEdge_ErrCategory_UserLevelError => Err(WasmEdgeError::User(code)),
+        ffi::WasmEdge_ErrCategory_UserLevelError => Err(Box::new(WasmEdgeError::User(code))),
         ffi::WasmEdge_ErrCategory_WASM => gen_runtime_error(code),
         _ => panic!("Invalid category value: {}", category),
     }
@@ -63,245 +64,245 @@ fn gen_runtime_error(code: u32) -> WasmEdgeResult<()> {
         0x00 | 0x01 => Ok(()),
 
         // Common errors
-        0x02 => Err(WasmEdgeError::Core(CoreError::Common(
+        0x02 => Err(Box::new(WasmEdgeError::Core(CoreError::Common(
             CoreCommonError::RuntimeError,
-        ))),
-        0x03 => Err(WasmEdgeError::Core(CoreError::Common(
+        )))),
+        0x03 => Err(Box::new(WasmEdgeError::Core(CoreError::Common(
             CoreCommonError::CostLimitExceeded,
-        ))),
-        0x04 => Err(WasmEdgeError::Core(CoreError::Common(
+        )))),
+        0x04 => Err(Box::new(WasmEdgeError::Core(CoreError::Common(
             CoreCommonError::WrongVMWorkflow,
-        ))),
-        0x05 => Err(WasmEdgeError::Core(CoreError::Common(
+        )))),
+        0x05 => Err(Box::new(WasmEdgeError::Core(CoreError::Common(
             CoreCommonError::FuncNotFound,
-        ))),
-        0x06 => Err(WasmEdgeError::Core(CoreError::Common(
+        )))),
+        0x06 => Err(Box::new(WasmEdgeError::Core(CoreError::Common(
             CoreCommonError::AOTDisabled,
-        ))),
-        0x07 => Err(WasmEdgeError::Core(CoreError::Common(
+        )))),
+        0x07 => Err(Box::new(WasmEdgeError::Core(CoreError::Common(
             CoreCommonError::Interrupted,
-        ))),
-        0x08 => Err(WasmEdgeError::Core(CoreError::Common(
+        )))),
+        0x08 => Err(Box::new(WasmEdgeError::Core(CoreError::Common(
             CoreCommonError::NotValidated,
-        ))),
-        0x09 => Err(WasmEdgeError::Core(CoreError::Common(
+        )))),
+        0x09 => Err(Box::new(WasmEdgeError::Core(CoreError::Common(
             CoreCommonError::UserDefError,
-        ))),
+        )))),
 
         // Load phase
-        0x20 => Err(WasmEdgeError::Core(CoreError::Load(
+        0x20 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::IllegalPath,
-        ))),
-        0x21 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x21 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::ReadError,
-        ))),
-        0x22 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x22 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::UnexpectedEnd,
-        ))),
-        0x23 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x23 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::MalformedMagic,
-        ))),
-        0x24 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x24 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::MalformedVersion,
-        ))),
-        0x25 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x25 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::MalformedSection,
-        ))),
-        0x26 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x26 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::SectionSizeMismatch,
-        ))),
-        0x27 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x27 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::NameSizeOutOfBounds,
-        ))),
-        0x28 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x28 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::JunkSection,
-        ))),
-        0x29 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x29 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::IncompatibleFuncCode,
-        ))),
-        0x2A => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x2A => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::IncompatibleDataCount,
-        ))),
-        0x2B => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x2B => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::DataCountRequired,
-        ))),
-        0x2C => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x2C => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::MalformedImportKind,
-        ))),
-        0x2D => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x2D => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::MalformedExportKind,
-        ))),
-        0x2E => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x2E => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::ExpectedZeroByte,
-        ))),
-        0x2F => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x2F => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::InvalidMut,
-        ))),
-        0x30 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x30 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::TooManyLocals,
-        ))),
-        0x31 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x31 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::MalformedValType,
-        ))),
-        0x32 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x32 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::MalformedElemType,
-        ))),
-        0x33 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x33 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::MalformedRefType,
-        ))),
-        0x34 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x34 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::MalformedUTF8,
-        ))),
-        0x35 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x35 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::IntegerTooLarge,
-        ))),
-        0x36 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x36 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::IntegerTooLong,
-        ))),
-        0x37 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x37 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::IllegalOpCode,
-        ))),
-        0x38 => Err(WasmEdgeError::Core(CoreError::Load(
+        )))),
+        0x38 => Err(Box::new(WasmEdgeError::Core(CoreError::Load(
             CoreLoadError::IllegalGrammar,
-        ))),
+        )))),
 
         // Validation phase
-        0x40 => Err(WasmEdgeError::Core(CoreError::Validation(
+        0x40 => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::InvalidAlignment,
-        ))),
-        0x41 => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x41 => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::TypeCheckFailed,
-        ))),
-        0x42 => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x42 => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::InvalidLabelIdx,
-        ))),
-        0x43 => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x43 => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::InvalidLocalIdx,
-        ))),
-        0x44 => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x44 => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::InvalidFuncTypeIdx,
-        ))),
-        0x45 => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x45 => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::InvalidFuncIdx,
-        ))),
-        0x46 => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x46 => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::InvalidTableIdx,
-        ))),
-        0x47 => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x47 => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::InvalidMemoryIdx,
-        ))),
-        0x48 => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x48 => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::InvalidGlobalIdx,
-        ))),
-        0x49 => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x49 => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::InvalidElemIdx,
-        ))),
-        0x4A => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x4A => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::InvalidDataIdx,
-        ))),
-        0x4B => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x4B => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::InvalidRefIdx,
-        ))),
-        0x4C => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x4C => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::ConstExprRequired,
-        ))),
-        0x4D => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x4D => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::DupExportName,
-        ))),
-        0x4E => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x4E => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::ImmutableGlobal,
-        ))),
-        0x4F => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x4F => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::InvalidResultArity,
-        ))),
-        0x50 => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x50 => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::MultiTables,
-        ))),
-        0x51 => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x51 => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::MultiMemories,
-        ))),
-        0x52 => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x52 => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::InvalidLimit,
-        ))),
-        0x53 => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x53 => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::InvalidMemPages,
-        ))),
-        0x54 => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x54 => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::InvalidStartFunc,
-        ))),
-        0x55 => Err(WasmEdgeError::Core(CoreError::Validation(
+        )))),
+        0x55 => Err(Box::new(WasmEdgeError::Core(CoreError::Validation(
             CoreValidationError::InvalidLaneIdx,
-        ))),
+        )))),
 
         // Instantiation phase
-        0x60 => Err(WasmEdgeError::Core(CoreError::Instantiation(
+        0x60 => Err(Box::new(WasmEdgeError::Core(CoreError::Instantiation(
             CoreInstantiationError::ModuleNameConflict,
-        ))),
-        0x61 => Err(WasmEdgeError::Core(CoreError::Instantiation(
+        )))),
+        0x61 => Err(Box::new(WasmEdgeError::Core(CoreError::Instantiation(
             CoreInstantiationError::IncompatibleImportType,
-        ))),
-        0x62 => Err(WasmEdgeError::Core(CoreError::Instantiation(
+        )))),
+        0x62 => Err(Box::new(WasmEdgeError::Core(CoreError::Instantiation(
             CoreInstantiationError::UnknownImport,
-        ))),
-        0x63 => Err(WasmEdgeError::Core(CoreError::Instantiation(
+        )))),
+        0x63 => Err(Box::new(WasmEdgeError::Core(CoreError::Instantiation(
             CoreInstantiationError::DataSegDoesNotFit,
-        ))),
-        0x64 => Err(WasmEdgeError::Core(CoreError::Instantiation(
+        )))),
+        0x64 => Err(Box::new(WasmEdgeError::Core(CoreError::Instantiation(
             CoreInstantiationError::ElemSegDoesNotFit,
-        ))),
+        )))),
 
         // Execution phase
-        0x80 => Err(WasmEdgeError::Core(CoreError::Execution(
+        0x80 => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
             CoreExecutionError::WrongInstanceAddress,
-        ))),
-        0x81 => Err(WasmEdgeError::Core(CoreError::Execution(
+        )))),
+        0x81 => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
             CoreExecutionError::WrongInstanceIndex,
-        ))),
-        0x82 => Err(WasmEdgeError::Core(CoreError::Execution(
+        )))),
+        0x82 => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
             CoreExecutionError::InstrTypeMismatch,
-        ))),
-        0x83 => Err(WasmEdgeError::Core(CoreError::Execution(
+        )))),
+        0x83 => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
             CoreExecutionError::FuncTypeMismatch,
-        ))),
-        0x84 => Err(WasmEdgeError::Core(CoreError::Execution(
+        )))),
+        0x84 => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
             CoreExecutionError::DivideByZero,
-        ))),
-        0x85 => Err(WasmEdgeError::Core(CoreError::Execution(
+        )))),
+        0x85 => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
             CoreExecutionError::IntegerOverflow,
-        ))),
-        0x86 => Err(WasmEdgeError::Core(CoreError::Execution(
+        )))),
+        0x86 => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
             CoreExecutionError::InvalidConvToInt,
-        ))),
-        0x87 => Err(WasmEdgeError::Core(CoreError::Execution(
+        )))),
+        0x87 => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
             CoreExecutionError::TableOutOfBounds,
-        ))),
-        0x88 => Err(WasmEdgeError::Core(CoreError::Execution(
+        )))),
+        0x88 => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
             CoreExecutionError::MemoryOutOfBounds,
-        ))),
-        0x89 => Err(WasmEdgeError::Core(CoreError::Execution(
+        )))),
+        0x89 => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
             CoreExecutionError::Unreachable,
-        ))),
-        0x8A => Err(WasmEdgeError::Core(CoreError::Execution(
+        )))),
+        0x8A => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
             CoreExecutionError::UninitializedElement,
-        ))),
-        0x8B => Err(WasmEdgeError::Core(CoreError::Execution(
+        )))),
+        0x8B => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
             CoreExecutionError::UndefinedElement,
-        ))),
-        0x8C => Err(WasmEdgeError::Core(CoreError::Execution(
+        )))),
+        0x8C => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
             CoreExecutionError::IndirectCallTypeMismatch,
-        ))),
-        0x8D => Err(WasmEdgeError::Core(CoreError::Execution(
+        )))),
+        0x8D => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
             CoreExecutionError::HostFuncFailed,
-        ))),
-        0x8E => Err(WasmEdgeError::Core(CoreError::Execution(
+        )))),
+        0x8E => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
             CoreExecutionError::RefTypeMismatch,
-        ))),
-        0x8F => Err(WasmEdgeError::Core(CoreError::Execution(
+        )))),
+        0x8F => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
             CoreExecutionError::UnalignedAtomicAccess,
-        ))),
-        0x90 => Err(WasmEdgeError::Core(CoreError::Execution(
+        )))),
+        0x90 => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
             CoreExecutionError::WaitOnUnsharedMemory,
-        ))),
+        )))),
 
         _ => panic!("unknown error code: {}", code),
     }

--- a/bindings/rust/wasmedge-sys/src/utils.rs
+++ b/bindings/rust/wasmedge-sys/src/utils.rs
@@ -23,7 +23,7 @@ pub(crate) fn path_to_cstring(path: &Path) -> WasmEdgeResult<CString> {
 #[cfg(windows)]
 pub(crate) fn path_to_cstring(path: &Path) -> WasmEdgeResult<CString> {
     match path.to_str() {
-        Some(s) => Ok(CString::new(s)?),
+        Some(s) => CString::new(s).map_err(|err| Box::new(WasmEdgeError::FoundNulByte(err))),
         None => Err(Box::new(WasmEdgeError::WindowsPathConversion(
             path.to_string_lossy().to_string(),
         ))),

--- a/bindings/rust/wasmedge-sys/src/utils.rs
+++ b/bindings/rust/wasmedge-sys/src/utils.rs
@@ -16,8 +16,8 @@ use std::{
 #[cfg(unix)]
 pub(crate) fn path_to_cstring(path: &Path) -> WasmEdgeResult<CString> {
     use std::os::unix::ffi::OsStrExt;
-    Ok(CString::new(path.as_os_str().as_bytes())
-        .map_err(|err| Box::new(WasmEdgeError::FoundNulByte(err)))?)
+    CString::new(path.as_os_str().as_bytes())
+        .map_err(|err| Box::new(WasmEdgeError::FoundNulByte(err)))
 }
 
 #[cfg(windows)]

--- a/bindings/rust/wasmedge-sys/src/validator.rs
+++ b/bindings/rust/wasmedge-sys/src/validator.rs
@@ -28,7 +28,7 @@ impl Validator {
             None => unsafe { ffi::WasmEdge_ValidatorCreate(std::ptr::null_mut()) },
         };
         match ctx.is_null() {
-            true => Err(WasmEdgeError::CompilerCreate),
+            true => Err(Box::new(WasmEdgeError::CompilerCreate)),
             false => Ok(Self {
                 inner: InnerValidator(ctx),
                 registered: false,

--- a/bindings/rust/wasmedge-sys/tests/executor_with_statistics.rs
+++ b/bindings/rust/wasmedge-sys/tests/executor_with_statistics.rs
@@ -120,7 +120,9 @@ fn test_executor_with_statistics() {
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err(),
-        WasmEdgeError::Core(CoreError::Execution(CoreExecutionError::FuncTypeMismatch))
+        Box::new(WasmEdgeError::Core(CoreError::Execution(
+            CoreExecutionError::FuncTypeMismatch
+        )))
     );
 
     // function type mismatched
@@ -131,7 +133,9 @@ fn test_executor_with_statistics() {
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err(),
-        WasmEdgeError::Core(CoreError::Execution(CoreExecutionError::FuncTypeMismatch))
+        Box::new(WasmEdgeError::Core(CoreError::Execution(
+            CoreExecutionError::FuncTypeMismatch
+        )))
     );
 
     // try to get non-existent exported function
@@ -139,7 +143,9 @@ fn test_executor_with_statistics() {
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err(),
-        WasmEdgeError::Instance(InstanceError::NotFoundFunc("func-mul-3".into()))
+        Box::new(WasmEdgeError::Instance(InstanceError::NotFoundFunc(
+            "func-mul-3".into()
+        )))
     );
 
     // call host function by using external reference
@@ -230,7 +236,9 @@ fn test_executor_with_statistics() {
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err(),
-        WasmEdgeError::Core(CoreError::Execution(CoreExecutionError::FuncTypeMismatch))
+        Box::new(WasmEdgeError::Core(CoreError::Execution(
+            CoreExecutionError::FuncTypeMismatch
+        )))
     );
     // Function type mismatch
     let result = executor.run_func(
@@ -243,21 +251,27 @@ fn test_executor_with_statistics() {
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err(),
-        WasmEdgeError::Core(CoreError::Execution(CoreExecutionError::FuncTypeMismatch))
+        Box::new(WasmEdgeError::Core(CoreError::Execution(
+            CoreExecutionError::FuncTypeMismatch
+        )))
     );
     // Module not found
     let result = store.module("error-name");
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err(),
-        WasmEdgeError::Store(StoreError::NotFoundModule("error-name".into()))
+        Box::new(WasmEdgeError::Store(StoreError::NotFoundModule(
+            "error-name".into()
+        )))
     );
     // Function not found
     let result = extern_instance.get_func("func-add2");
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err(),
-        WasmEdgeError::Instance(InstanceError::NotFoundFunc("func-add2".into()))
+        Box::new(WasmEdgeError::Instance(InstanceError::NotFoundFunc(
+            "func-add2".into()
+        )))
     );
 
     // get the exported host function named "func-term"
@@ -277,5 +291,5 @@ fn test_executor_with_statistics() {
     // Invoke host function to fail execution
     let result = executor.run_func(&func_fail, []);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), WasmEdgeError::User(2));
+    assert_eq!(result.unwrap_err(), Box::new(WasmEdgeError::User(2)));
 }

--- a/bindings/rust/wasmedge-types/Cargo.toml
+++ b/bindings/rust/wasmedge-types/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "wasmedge-types"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/WasmEdge/tree/master/bindings/rust/wasmedge-types"
-version = "0.2.1"
+version = "0.3.0"
 
 [dependencies]
 thiserror = "1.0.30"

--- a/bindings/rust/wasmedge-types/src/lib.rs
+++ b/bindings/rust/wasmedge-types/src/lib.rs
@@ -496,7 +496,9 @@ impl MemoryType {
     /// * `shared` - Enables shared memory if true.
     pub fn new(min: u32, max: Option<u32>, shared: bool) -> WasmEdgeResult<Self> {
         if shared && max.is_none() {
-            return Err(error::WasmEdgeError::Mem(error::MemError::CreateSharedType));
+            return Err(Box::new(error::WasmEdgeError::Mem(
+                error::MemError::CreateSharedType,
+            )));
         }
         Ok(Self { min, max, shared })
     }
@@ -560,4 +562,4 @@ impl Default for GlobalType {
 pub use wat::parse_bytes as wat2wasm;
 
 /// The WasmEdge result type.
-pub type WasmEdgeResult<T> = Result<T, error::WasmEdgeError>;
+pub type WasmEdgeResult<T> = Result<T, Box<error::WasmEdgeError>>;


### PR DESCRIPTION
This PR is to fix #1816. Duo to `cargo nightly clippy` updated to `v0.1.65` in CI, in addition, some new clippy issues are also fixed in this PR.