### PR TITLE
[Rust SDK] chore, fix crate repository link

### DIFF
--- a/bindings/rust/wasmedge-sdk/Cargo.toml
+++ b/bindings/rust/wasmedge-sdk/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["examples/"]
 license = "Apache-2.0"
 name = "wasmedge-sdk"
 readme = "README.md"
-repository = "https://github.com/WasmEdge/WasmEdge/bindings/rust/wasmedge-sdk"
+repository = "https://github.com/WasmEdge/WasmEdge/blob/master/bindings/rust/wasmedge-sdk"
 version = "0.5.0"
 
 [dependencies]


### PR DESCRIPTION
Current link returns 404, so replacing it.
- as-is : https://github.com/WasmEdge/WasmEdge/bindings/rust/wasmedge-sdk
- to-be : https://github.com/WasmEdge/WasmEdge/blob/master/bindings/rust/wasmedge-sdk

---

Signed-off-by: Yeongju Kang <46637297+yeongjukang@users.noreply.github.com>

