### PR TITLE
[Socket] Adjust kSaDataLen on IPv6 case

### DIFF
--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -31,7 +31,9 @@ namespace WASI {
 
 inline namespace detail {
 inline constexpr const int32_t kIOVMax = 1024;
-inline constexpr const int32_t kSaDataLen = 14;
+// Large enough to store SaData in sockaddr_in6
+// = sizeof(sockaddr_in6) - sizeof(sockaddr_in6::sin6_family)
+inline constexpr const int32_t kMaxSaDataLen = 26;
 } // namespace detail
 
 class EVPoller;

--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -1325,9 +1325,19 @@ WasiExpect<void> INode::getAddrinfo(std::string_view Node,
           fromAddressFamily(SysResItem->ai_addr->sa_family);
 
       // process sa_data in socket address
-      std::memcpy(AiAddrSaDataArray[Idx], SysResItem->ai_addr->sa_data,
-                  WASI::kSaDataLen);
-      CurSockaddr->sa_data_len = WASI::kSaDataLen;
+      size_t SaSize = 0;
+      switch (CurSockaddr->sa_family) {
+      case __wasi_address_family_t::__WASI_ADDRESS_FAMILY_INET4:
+        SaSize = sizeof(sockaddr_in) - sizeof(sockaddr_in::sin_family);
+        break;
+      case __wasi_address_family_t::__WASI_ADDRESS_FAMILY_INET6:
+        SaSize = sizeof(sockaddr_in6) - sizeof(sockaddr_in6::sin6_family);
+        break;
+      default:
+        assumingUnreachable();
+      }
+      std::memcpy(AiAddrSaDataArray[Idx], SysResItem->ai_addr->sa_data, SaSize);
+      CurSockaddr->sa_data_len = __wasi_size_t(SaSize);
     }
     // process ai_next in addrinfo
     SysResItem = SysResItem->ai_next;

--- a/lib/host/wasi/inode-win.cpp
+++ b/lib/host/wasi/inode-win.cpp
@@ -307,9 +307,19 @@ WasiExpect<void> INode::getAddrinfo(std::string_view Node,
           fromAddressFamily(SysResItem->ai_addr->sa_family);
 
       // process sa_data in socket address
-      std::memcpy(AiAddrSaDataArray[Idx], SysResItem->ai_addr->sa_data,
-                  WASI::kSaDataLen);
-      CurSockaddr->sa_data_len = WASI::kSaDataLen;
+      size_t SaSize = 0;
+      switch (CurSockaddr->sa_family) {
+      case __wasi_address_family_t::__WASI_ADDRESS_FAMILY_INET4:
+        SaSize = sizeof(sockaddr_in) - sizeof(sockaddr_in::sin_family);
+        break;
+      case __wasi_address_family_t::__WASI_ADDRESS_FAMILY_INET6:
+        SaSize = sizeof(sockaddr_in6) - sizeof(sockaddr_in6::sin6_family);
+        break;
+      default:
+        assumingUnreachable();
+      }
+      std::memcpy(AiAddrSaDataArray[Idx], SysResItem->ai_addr->sa_data, SaSize);
+      CurSockaddr->sa_data_len = __wasi_size_t(SaSize);
     }
     // process ai_next in addrinfo
     SysResItem = SysResItem->ai_next;

--- a/test/host/socket/wasi_socket.cpp
+++ b/test/host/socket/wasi_socket.cpp
@@ -114,7 +114,7 @@ void allocateAddrinfoArray(WasmEdge::Runtime::Instance::MemoryInstance &MemInst,
     Base += ResItemPtr->ai_addrlen;
     // allocate sockaddr sa_data.
     Sockaddr->sa_data = Base;
-    Sockaddr->sa_data_len = WasmEdge::Host::WASI::kSaDataLen;
+    Sockaddr->sa_data_len = WasmEdge::Host::WASI::kMaxSaDataLen;
     Base += Sockaddr->sa_data_len;
     // allocate ai_canonname
     ResItemPtr->ai_canonname = Base;


### PR DESCRIPTION
Fix #1372
* Breaking change: remove `kSaDataLen`, use `kMaxSaDataLen` instead.

Signed-off-by: LFsWang <tnst92002@gmail.com>