### PR TITLE
Port the "parse_json" example to the newer API

### DIFF
--- a/examples/capi/host_functions/parse_json/Makefile
+++ b/examples/capi/host_functions/parse_json/Makefile
@@ -1,0 +1,12 @@
+CC = gcc
+
+all: host_function parse-json.wasm
+
+host_function: host_function.c
+	$(CC) $^ -ljson-c -lwasmedge -o $@
+
+%.wasm: %.wat
+	wat2wasm --enable-all $^ -o $@
+
+clean:
+	rm -f host_function parse-json.wasm

--- a/examples/capi/host_functions/parse_json/README.md
+++ b/examples/capi/host_functions/parse_json/README.md
@@ -18,7 +18,7 @@ sudo apt install -y libjson-c-dev
 
 ```bash
 # Compilation
-$ gcc host_function.c -l json-c -o host_function
+$ gcc host_function.c -ljson-c -lwasmedge -o host_function
 $ ./host_function
 Got the result: Success
 ```

--- a/examples/capi/host_functions/parse_json/host_function.c
+++ b/examples/capi/host_functions/parse_json/host_function.c
@@ -2,7 +2,8 @@
 #include <stdio.h>
 #include <wasmedge/wasmedge.h>
 
-WasmEdge_Result parseJson(void *Data, WasmEdge_MemoryInstanceContext *MemCxt,
+WasmEdge_Result parseJson(void *Data,
+                          const WasmEdge_CallingFrameContext *CallingFrameCxt,
                           const WasmEdge_Value *In, WasmEdge_Value *Out) {
   FILE *Fp = fopen("test.json", "r");
   char Buffer[1024];
@@ -25,8 +26,8 @@ int main() {
 
   /* Create the import object. */
   WasmEdge_String ExportName = WasmEdge_StringCreateByCString("extern");
-  WasmEdge_ImportObjectContext *ImpObj =
-      WasmEdge_ImportObjectCreate(ExportName);
+  WasmEdge_ModuleInstanceContext *ImpObj =
+      WasmEdge_ModuleInstanceCreate(ExportName);
   enum WasmEdge_ValType ParamList[1] = {WasmEdge_ValType_ExternRef};
   enum WasmEdge_ValType ReturnList[1] = {WasmEdge_ValType_ExternRef};
   WasmEdge_FunctionTypeContext *HostFType =
@@ -36,7 +37,7 @@ int main() {
   WasmEdge_FunctionTypeDelete(HostFType);
   WasmEdge_String HostFuncName =
       WasmEdge_StringCreateByCString("func-parse-json");
-  WasmEdge_ImportObjectAddFunction(ImpObj, HostFuncName, HostFunc);
+  WasmEdge_ModuleInstanceAddFunction(ImpObj, HostFuncName, HostFunc);
   WasmEdge_StringDelete(HostFuncName);
 
   WasmEdge_VMRegisterModuleFromImport(VMCxt, ImpObj);
@@ -58,6 +59,6 @@ int main() {
   /* Resources deallocations. */
   WasmEdge_VMDelete(VMCxt);
   WasmEdge_StringDelete(FuncName);
-  WasmEdge_ImportObjectDelete(ImpObj);
+  WasmEdge_ModuleInstanceDelete(ImpObj);
   return 0;
 }


### PR DESCRIPTION
Port the "parse_json" example to the 0.10 and 0.11 API. This entails porting WasmEdge_ImportObject* to WasmEdge_ModuleInstance*, as well as WasmEdge_MemoryInstanceContext -> WasmEdge_CallingFrameContext.

While at it, add a Makefile and adjust the README.

Signed-off-by: Faidon Liambotis <paravoid@debian.org>