### PR TITLE
[Loader] Revert commit 19895708eb867e3f193f69e3b5420a6586d2a6e3

### DIFF
--- a/include/loader/loader.h
+++ b/include/loader/loader.h
@@ -155,10 +155,6 @@ private:
     // Read the vector size.
     if (auto Res = FMgr.readU32()) {
       VecCnt = *Res;
-      if (VecCnt / 2 > FMgr.getRemainSize()) {
-        return logLoadError(ErrCode::Value::IntegerTooLong,
-                            FMgr.getLastOffset(), NodeAttrFromAST<T>());
-      }
       Sec.getContent().resize(VecCnt);
     } else {
       return logLoadError(Res.error(), FMgr.getLastOffset(),

--- a/lib/loader/ast/instruction.cpp
+++ b/lib/loader/ast/instruction.cpp
@@ -220,7 +220,7 @@ Expect<void> Loader::loadInstruction(AST::Instruction &Instr) {
     if (auto Res = readU32(VecCnt); unlikely(!Res)) {
       return Unexpect(Res);
     }
-    if (VecCnt / 2 > FMgr.getRemainSize()) {
+    if (VecCnt == std::numeric_limits<uint32_t>::max()) {
       // Too many label for Br_table.
       return logLoadError(ErrCode::Value::IntegerTooLong, FMgr.getLastOffset(),
                           ASTNodeAttr::Instruction);
@@ -289,10 +289,6 @@ Expect<void> Loader::loadInstruction(AST::Instruction &Instr) {
     uint32_t VecCnt;
     if (auto Res = readU32(VecCnt); unlikely(!Res)) {
       return Unexpect(Res);
-    }
-    if (VecCnt / 2 > FMgr.getRemainSize()) {
-      return logLoadError(ErrCode::Value::IntegerTooLong, FMgr.getLastOffset(),
-                          ASTNodeAttr::Instruction);
     }
     Instr.setValTypeListSize(VecCnt);
     for (uint32_t I = 0; I < VecCnt; ++I) {

--- a/lib/loader/ast/module.cpp
+++ b/lib/loader/ast/module.cpp
@@ -60,9 +60,6 @@ Expect<std::unique_ptr<AST::Module>> Loader::loadModule() {
       } else {
         break;
       }
-      if (ContentSize > FMgr.getRemainSize()) {
-        break;
-      }
 
       // Load the section name.
       auto StartOffset = FMgr.getOffset();

--- a/lib/loader/ast/section.cpp
+++ b/lib/loader/ast/section.cpp
@@ -266,13 +266,7 @@ Expect<void> Loader::loadSection(FileMgr &VecMgr, AST::AOTSection &Sec) {
     spdlog::error("    AOT types size read error:{}", Res.error());
     return Unexpect(Res);
   } else {
-    const uint64_t Size = *Res;
-    if (Size > VecMgr.getRemainSize()) {
-      spdlog::error(ErrCode::Value::IntegerTooLong);
-      spdlog::error("    AOT types size too large");
-      return Unexpect(ErrCode::Value::IntegerTooLong);
-    }
-    Sec.getTypesAddress().resize(Size);
+    Sec.getTypesAddress().resize(*Res);
   }
   for (size_t I = 0; I < Sec.getTypesAddress().size(); ++I) {
     if (auto Res = VecMgr.readU64(); unlikely(!Res)) {
@@ -288,13 +282,7 @@ Expect<void> Loader::loadSection(FileMgr &VecMgr, AST::AOTSection &Sec) {
     spdlog::error("    AOT code size read error:{}", Res.error());
     return Unexpect(Res);
   } else {
-    const uint64_t Size = *Res;
-    if (Size > VecMgr.getRemainSize()) {
-      spdlog::error(ErrCode::Value::IntegerTooLong);
-      spdlog::error("    AOT code size too large");
-      return Unexpect(ErrCode::Value::IntegerTooLong);
-    }
-    Sec.getCodesAddress().resize(Size);
+    Sec.getCodesAddress().resize(*Res);
   }
   for (size_t I = 0; I < Sec.getCodesAddress().size(); ++I) {
     if (auto Res = VecMgr.readU64(); unlikely(!Res)) {
@@ -302,13 +290,7 @@ Expect<void> Loader::loadSection(FileMgr &VecMgr, AST::AOTSection &Sec) {
       spdlog::error("    AOT code address read error:{}", Res.error());
       return Unexpect(Res);
     } else {
-      const uint64_t Address = *Res;
-      if (Address > VecMgr.getRemainSize()) {
-        spdlog::error(ErrCode::Value::IntegerTooLong);
-        spdlog::error("    AOT code address too large");
-        return Unexpect(ErrCode::Value::IntegerTooLong);
-      }
-      Sec.getCodesAddress()[I] = Address;
+      Sec.getCodesAddress()[I] = *Res;
     }
   }
 
@@ -317,13 +299,7 @@ Expect<void> Loader::loadSection(FileMgr &VecMgr, AST::AOTSection &Sec) {
     spdlog::error("    AOT section count read error:{}", Res.error());
     return Unexpect(Res);
   } else {
-    const uint32_t Size = *Res;
-    if (Size > VecMgr.getRemainSize()) {
-      spdlog::error(ErrCode::Value::IntegerTooLong);
-      spdlog::error("    AOT section count too large");
-      return Unexpect(ErrCode::Value::IntegerTooLong);
-    }
-    Sec.getSections().resize(Size);
+    Sec.getSections().resize(*Res);
   }
 
   for (auto &Section : Sec.getSections()) {
@@ -355,16 +331,6 @@ Expect<void> Loader::loadSection(FileMgr &VecMgr, AST::AOTSection &Sec) {
       return Unexpect(Res);
     } else {
       ContentSize = *Res;
-      if (ContentSize > VecMgr.getRemainSize()) {
-        spdlog::error(ErrCode::Value::IntegerTooLong);
-        spdlog::error("    AOT section data size is too large");
-        return Unexpect(ErrCode::Value::IntegerTooLong);
-      }
-      if (std::get<2>(Section) < ContentSize) {
-        spdlog::error(ErrCode::Value::IntegerTooLong);
-        spdlog::error("    AOT section data size is larger then section size");
-        return Unexpect(ErrCode::Value::IntegerTooLong);
-      }
     }
     if (auto Res = VecMgr.readBytes(ContentSize); unlikely(!Res)) {
       spdlog::error(Res.error());

--- a/lib/loader/ast/segment.cpp
+++ b/lib/loader/ast/segment.cpp
@@ -193,10 +193,6 @@ Expect<void> Loader::loadSegment(AST::ElementSegment &ElemSeg) {
                           ASTNodeAttr::Seg_Element);
     } else {
       VecCnt = *Res;
-      if (VecCnt / 2 > FMgr.getRemainSize()) {
-        return logLoadError(ErrCode::Value::IntegerTooLong,
-                            FMgr.getLastOffset(), ASTNodeAttr::Seg_Element);
-      }
     }
     ElemSeg.getInitExprs().clear();
     ElemSeg.getInitExprs().reserve(VecCnt);
@@ -233,11 +229,6 @@ Expect<void> Loader::loadSegment(AST::CodeSegment &CodeSeg) {
   uint32_t VecCnt = 0;
   if (auto Res = FMgr.readU32()) {
     VecCnt = *Res;
-    if (VecCnt / 2 > FMgr.getRemainSize()) {
-      return logLoadError(ErrCode::Value::IntegerTooLong, FMgr.getLastOffset(),
-                          ASTNodeAttr::Seg_Code);
-    }
-
     CodeSeg.getLocals().clear();
     CodeSeg.getLocals().reserve(VecCnt);
   } else {
@@ -350,10 +341,6 @@ Expect<void> Loader::loadSegment(AST::DataSegment &DataSeg) {
     uint32_t VecCnt = 0;
     if (auto Res = FMgr.readU32()) {
       VecCnt = *Res;
-      if (VecCnt / 2 > FMgr.getRemainSize()) {
-        return logLoadError(ErrCode::Value::IntegerTooLong,
-                            FMgr.getLastOffset(), ASTNodeAttr::Seg_Data);
-      }
     } else {
       return logLoadError(Res.error(), FMgr.getLastOffset(),
                           ASTNodeAttr::Seg_Data);

--- a/lib/loader/ast/type.cpp
+++ b/lib/loader/ast/type.cpp
@@ -82,10 +82,6 @@ Expect<void> Loader::loadType(AST::FunctionType &FuncType) {
   // Read vector of parameter types.
   if (auto Res = FMgr.readU32()) {
     VecCnt = *Res;
-    if (VecCnt / 2 > FMgr.getRemainSize()) {
-      return logLoadError(ErrCode::Value::IntegerTooLong, FMgr.getLastOffset(),
-                          ASTNodeAttr::Type_Function);
-    }
     FuncType.getParamTypes().clear();
     FuncType.getParamTypes().reserve(VecCnt);
   } else {
@@ -110,10 +106,6 @@ Expect<void> Loader::loadType(AST::FunctionType &FuncType) {
   // Read vector of result types.
   if (auto Res = FMgr.readU32()) {
     VecCnt = *Res;
-    if (VecCnt / 2 > FMgr.getRemainSize()) {
-      return logLoadError(ErrCode::Value::IntegerTooLong, FMgr.getLastOffset(),
-                          ASTNodeAttr::Type_Function);
-    }
     FuncType.getReturnTypes().clear();
     FuncType.getReturnTypes().reserve(VecCnt);
   } else {

--- a/lib/loader/shared_library.cpp
+++ b/lib/loader/shared_library.cpp
@@ -82,9 +82,8 @@ Expect<void> SharedLibrary::load(const std::filesystem::path &Path) noexcept {
 Expect<void> SharedLibrary::load(const AST::AOTSection &AOTSec) noexcept {
   BinarySize = 0;
   for (const auto &Section : AOTSec.getSections()) {
-    const auto Offset = std::get<1>(Section);
-    const auto Size = std::get<2>(Section);
-    BinarySize = std::max(BinarySize, Offset + Size);
+    BinarySize =
+        std::max(BinarySize, std::get<1>(Section) + std::get<2>(Section));
   }
   BinarySize = roundUpPageBoundary(BinarySize);
 
@@ -99,7 +98,6 @@ Expect<void> SharedLibrary::load(const AST::AOTSection &AOTSec) noexcept {
     const auto Offset = std::get<1>(Section);
     const auto Size = std::get<2>(Section);
     const auto &Content = std::get<3>(Section);
-    assuming(Content.size() <= Size);
     std::copy(Content.begin(), Content.end(), Binary + Offset);
     switch (std::get<0>(Section)) {
     case 1: { // Text


### PR DESCRIPTION
1. This will cause universal WASM fail.
2. The error code of load fail case may be incorrect if the syntax error occurs before reach the file end.

Signed-off-by: YiYing He <yiying@secondstate.io>