### PR TITLE
[Rust] wasmedge-types v0.3.0

### DIFF
--- a/.github/workflows/rust-wasmedge-macro-release.yml
+++ b/.github/workflows/rust-wasmedge-macro-release.yml
@@ -9,8 +9,17 @@ on:
     branches:
       - "master"
       - "rust/release-wasmedge-macro"
+    paths:
+      - ".github/workflows/rust-wasmedge-macro-release.yml"
+      - "bindings/rust/wasmedge-macro/**"
     tags:
       - "rust-macro/[0-9]+.[0-9]+.[0-9]+*"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/rust-wasmedge-macro-release.yml"
+      - "bindings/rust/wasmedge-macro/**"
 
 jobs:
   crate_release:

--- a/.github/workflows/rust-wasmedge-types-docs.yml
+++ b/.github/workflows/rust-wasmedge-types-docs.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - "master"
-      - "release/rust-types/*"
+      - "rust/release-wasmedge-types"
     paths:
       - ".github/workflows/rust-wasmedge-types-docs.yml"
       - "bindings/rust/wasmedge-types/**"
@@ -56,7 +56,6 @@ jobs:
           cargo doc --all --no-deps --target-dir=./target
 
       - name: Deploy Docs
-        if: github.ref_type == 'tag'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust-wasmedge-types-release.yml
+++ b/.github/workflows/rust-wasmedge-types-release.yml
@@ -9,8 +9,17 @@ on:
     branches:
       - "master"
       - "rust/release-wasmedge-types"
+    paths:
+      - ".github/workflows/rust-wasmedge-types-release.yml"
+      - "bindings/rust/wasmedge-types/**"
     tags:
       - "rust-types/[0-9]+.[0-9]+.[0-9]+*"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/rust-wasmedge-types-release.yml"
+      - "bindings/rust/wasmedge-types/**"
 
 jobs:
   crate_release:

--- a/.github/workflows/rust-wasmedge-types-release.yml
+++ b/.github/workflows/rust-wasmedge-types-release.yml
@@ -7,7 +7,8 @@ concurrency:
 on:
   push:
     branches:
-      - "release/rust/*"
+      - "master"
+      - "rust/release-wasmedge-types"
     tags:
       - "rust-types/[0-9]+.[0-9]+.[0-9]+*"
 
@@ -23,10 +24,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Stable Rust
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
+          profile: minimal
+          override: true
 
       - name: Dry run wasmedge-types crate
         if: github.ref_type == 'branch'

--- a/bindings/rust/wasmedge-macro/Cargo.toml
+++ b/bindings/rust/wasmedge-macro/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+description = "The procedural macros for WasmEdge Rust bindings."
 documentation = "https://wasmedge.github.io/WasmEdge/wasmedge_macro/"
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
In this PR, `wasmedge-types v0.3.0` is ready to release. The tag for this release is `rust-types/0.3.0`.