### PR TITLE
[WIP][Socket] unify socket address size with breaking api

### DIFF
--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -1039,24 +1039,22 @@ public:
   }
 
   WasiExpect<void> sockGetLoaclAddr(__wasi_fd_t Fd, uint8_t *Address,
-                                    uint32_t *AddrTypePtr,
                                     uint32_t *PortPtr) const noexcept {
     auto Node = getNodeOrNull(Fd);
     if (unlikely(!Node)) {
       return WasiUnexpect(__WASI_ERRNO_BADF);
     } else {
-      return Node->sockGetLoaclAddr(Address, AddrTypePtr, PortPtr);
+      return Node->sockGetLoaclAddr(Address, PortPtr);
     }
   }
 
   WasiExpect<void> sockGetPeerAddr(__wasi_fd_t Fd, uint8_t *Address,
-                                   uint32_t *AddrTypePtr,
                                    uint32_t *PortPtr) const noexcept {
     auto Node = getNodeOrNull(Fd);
     if (unlikely(!Node)) {
       return WasiUnexpect(__WASI_ERRNO_BADF);
     } else {
-      return Node->sockGetPeerAddr(Address, AddrTypePtr, PortPtr);
+      return Node->sockGetPeerAddr(Address, PortPtr);
     }
   }
 

--- a/include/host/wasi/inode.h
+++ b/include/host/wasi/inode.h
@@ -601,10 +601,10 @@ public:
                               __wasi_sock_opt_so_t SockOptName, void *FlagPtr,
                               uint32_t FlagSizePtr) const noexcept;
 
-  WasiExpect<void> sockGetLoaclAddr(uint8_t *Address, uint32_t *AddrTypePtr,
+  WasiExpect<void> sockGetLoaclAddr(uint8_t *Address,
                                     uint32_t *PortPtr) const noexcept;
 
-  WasiExpect<void> sockGetPeerAddr(uint8_t *Address, uint32_t *AddrTypePtr,
+  WasiExpect<void> sockGetPeerAddr(uint8_t *Address,
                                    uint32_t *PortPtr) const noexcept;
 
   /// File type.

--- a/include/host/wasi/vinode.h
+++ b/include/host/wasi/vinode.h
@@ -664,14 +664,14 @@ public:
     return Node.sockSetOpt(SockOptLevel, SockOptName, FlagPtr, FlagSizePtr);
   }
 
-  WasiExpect<void> sockGetLoaclAddr(uint8_t *Address, uint32_t *AddrTypePtr,
+  WasiExpect<void> sockGetLoaclAddr(uint8_t *Address,
                                     uint32_t *PortPtr) const noexcept {
-    return Node.sockGetLoaclAddr(Address, AddrTypePtr, PortPtr);
+    return Node.sockGetLoaclAddr(Address, PortPtr);
   }
 
-  WasiExpect<void> sockGetPeerAddr(uint8_t *Address, uint32_t *AddrTypePtr,
+  WasiExpect<void> sockGetPeerAddr(uint8_t *Address,
                                    uint32_t *PortPtr) const noexcept {
-    return Node.sockGetPeerAddr(Address, AddrTypePtr, PortPtr);
+    return Node.sockGetPeerAddr(Address, PortPtr);
   }
 
   __wasi_rights_t fsRightsBase() const noexcept { return FsRightsBase; }

--- a/include/host/wasi/wasifunc.h
+++ b/include/host/wasi/wasifunc.h
@@ -471,8 +471,7 @@ public:
   WasiSockGetLocalAddr(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
-                        uint32_t AddressPtr, uint32_t AddressTypePtr,
-                        uint32_t PortPtr);
+                        uint32_t AddressPtr, uint32_t PortPtr);
 };
 
 class WasiSockGetPeerAddr : public Wasi<WasiSockGetPeerAddr> {
@@ -480,8 +479,7 @@ public:
   WasiSockGetPeerAddr(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
-                        uint32_t AddressPtr, uint32_t AddressTypePtr,
-                        uint32_t PortPtr);
+                        uint32_t AddressPtr, uint32_t PortPtr);
 };
 
 class WasiGetAddrinfo : public Wasi<WasiGetAddrinfo> {

--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -2298,7 +2298,6 @@ Expect<uint32_t> WasiGetAddrinfo::body(const Runtime::CallingFrame &Frame,
 
 Expect<uint32_t> WasiSockGetLocalAddr::body(const Runtime::CallingFrame &Frame,
                                             int32_t Fd, uint32_t AddressPtr,
-                                            uint32_t AddressTypePtr,
                                             uint32_t PortPtr) {
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -2310,19 +2309,13 @@ Expect<uint32_t> WasiSockGetLocalAddr::body(const Runtime::CallingFrame &Frame,
     return __WASI_ERRNO_FAULT;
   }
 
-  if (InnerAddress->buf_len != 16) {
+  if (InnerAddress->buf_len != 128) {
     return __WASI_ERRNO_INVAL;
   }
 
   uint8_t *AddressBuf =
       MemInst->getPointer<uint8_t *>(InnerAddress->buf, InnerAddress->buf_len);
   if (AddressBuf == nullptr) {
-    return __WASI_ERRNO_FAULT;
-  }
-
-  uint32_t *const RoAddressType =
-      MemInst->getPointer<uint32_t *>(AddressTypePtr);
-  if (RoAddressType == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
 
@@ -2333,8 +2326,7 @@ Expect<uint32_t> WasiSockGetLocalAddr::body(const Runtime::CallingFrame &Frame,
 
   const __wasi_fd_t WasiFd = Fd;
 
-  if (auto Res =
-          Env.sockGetLoaclAddr(WasiFd, AddressBuf, RoAddressType, RoPort);
+  if (auto Res = Env.sockGetLoaclAddr(WasiFd, AddressBuf, RoPort);
       unlikely(!Res)) {
     return Res.error();
   }
@@ -2343,7 +2335,6 @@ Expect<uint32_t> WasiSockGetLocalAddr::body(const Runtime::CallingFrame &Frame,
 
 Expect<uint32_t> WasiSockGetPeerAddr::body(const Runtime::CallingFrame &Frame,
                                            int32_t Fd, uint32_t AddressPtr,
-                                           uint32_t AddressTypePtr,
                                            uint32_t PortPtr) {
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -2365,12 +2356,6 @@ Expect<uint32_t> WasiSockGetPeerAddr::body(const Runtime::CallingFrame &Frame,
     return __WASI_ERRNO_FAULT;
   }
 
-  uint32_t *const RoAddressType =
-      MemInst->getPointer<uint32_t *>(AddressTypePtr);
-  if (RoAddressType == nullptr) {
-    return __WASI_ERRNO_FAULT;
-  }
-
   uint32_t *const RoPort = MemInst->getPointer<uint32_t *>(PortPtr);
   if (RoPort == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -2378,7 +2363,7 @@ Expect<uint32_t> WasiSockGetPeerAddr::body(const Runtime::CallingFrame &Frame,
 
   const __wasi_fd_t WasiFd = Fd;
 
-  if (auto Res = Env.sockGetPeerAddr(WasiFd, AddressBuf, RoAddressType, RoPort);
+  if (auto Res = Env.sockGetPeerAddr(WasiFd, AddressBuf, RoPort);
       unlikely(!Res)) {
     return Res.error();
   }


### PR DESCRIPTION
Cannot be merged until #1599

#### Breaking changes (Api)
* ```sockGetLoaclAddr(Fd, Address, AddrTypePtr, PortPtr)``` to ```sockGetLoaclAddr(Fd, Address, PortPtr)``` 
  * remove AddrTypePtr 
* ```sockGetPeerAddr(Fd, Address, AddrTypePtr, PortPtr)``` to ```sockGetPeerAddr(Fd, Address, PortPtr)``` 
  * remove AddrTypePtr 

Signed-off-by: LFsWang <tnst92002@gmail.com>