### PR TITLE
[Misc] Add off log system api

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -50,6 +50,7 @@ jobs:
           WasmEdge_VMRunWasmFromBuffer
           WasmEdge_VMRunWasmFromFile
           WasmEdge_StringWrap
+          WasmEdge_Plugin_GetDescriptor
           EOF
           echo "===Allowlist==="
           cat allowlist.txt

--- a/bindings/rust/wasmedge-sys/src/instance/memory.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/memory.rs
@@ -164,7 +164,7 @@ impl Memory {
     ///
     /// * `len` - The requested data length. If the size of `offset` + `len` is larger
     /// than the data size in the [Memory]
-    ///   
+    ///
     ///
     /// # Errors
     ///
@@ -212,7 +212,7 @@ impl Memory {
 
     /// Returns the size, in WebAssembly pages (64 KiB of each page), of this wasm memory.
     pub fn size(&self) -> u32 {
-        unsafe { ffi::WasmEdge_MemoryInstanceGetPageSize(self.inner.0) as u32 }
+        unsafe { ffi::WasmEdge_MemoryInstanceGetPageSize(self.inner.0) }
     }
 
     /// Grows this WebAssembly memory by `count` pages.
@@ -301,7 +301,7 @@ impl MemType {
         }
     }
 
-    /// Returns the initial size of a [Memory].    
+    /// Returns the initial size of a [Memory].
     pub fn min(&self) -> u32 {
         let limit = unsafe { ffi::WasmEdge_MemoryTypeGetLimit(self.inner.0) };
         let limit: WasmEdgeLimit = limit.into();

--- a/bindings/rust/wasmedge-sys/src/utils.rs
+++ b/bindings/rust/wasmedge-sys/src/utils.rs
@@ -40,6 +40,11 @@ pub fn log_error_info() {
     unsafe { ffi::WasmEdge_LogSetErrorLevel() }
 }
 
+/// Logs off.
+pub fn log_off() {
+    unsafe { ffi::WasmEdge_LogOff() }
+}
+
 // Checks the result of a `FFI` function.
 pub(crate) fn check(result: WasmEdge_Result) -> WasmEdgeResult<()> {
     let category = unsafe { ffi::WasmEdge_ResultGetCategory(result) };

--- a/include/api/wasmedge/wasmedge.h
+++ b/include/api/wasmedge/wasmedge.h
@@ -239,6 +239,9 @@ WASMEDGE_CAPI_EXPORT extern void WasmEdge_LogSetErrorLevel(void);
 /// Set the logging system to filter to debug level.
 WASMEDGE_CAPI_EXPORT extern void WasmEdge_LogSetDebugLevel(void);
 
+/// Set the logging system off.
+WASMEDGE_CAPI_EXPORT extern void WasmEdge_LogOff(void);
+
 // <<<<<<<< WasmEdge logging functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 // >>>>>>>> WasmEdge value functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

--- a/include/common/log.h
+++ b/include/common/log.h
@@ -20,6 +20,8 @@
 namespace WasmEdge {
 namespace Log {
 
+void setLogOff();
+
 void setDebugLoggingLevel();
 
 void setInfoLoggingLevel();

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -454,6 +454,8 @@ WASMEDGE_CAPI_EXPORT void WasmEdge_LogSetDebugLevel(void) {
   WasmEdge::Log::setDebugLoggingLevel();
 }
 
+WASMEDGE_CAPI_EXPORT void WasmEdge_LogOff(void) { WasmEdge::Log::setLogOff(); }
+
 // <<<<<<<< WasmEdge logging functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 // >>>>>>>> WasmEdge value functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

--- a/lib/common/log.cpp
+++ b/lib/common/log.cpp
@@ -6,6 +6,8 @@
 namespace WasmEdge {
 namespace Log {
 
+void setLogOff() { spdlog::set_level(spdlog::level::off); }
+
 void setDebugLoggingLevel() { spdlog::set_level(spdlog::level::debug); }
 
 void setInfoLoggingLevel() { spdlog::set_level(spdlog::level::info); }

--- a/test/api/APIUnitTest.cpp
+++ b/test/api/APIUnitTest.cpp
@@ -300,6 +300,8 @@ TEST(APICoreTest, Log) {
   EXPECT_TRUE(true);
   WasmEdge_LogSetErrorLevel();
   EXPECT_TRUE(true);
+  WasmEdge_LogOff();
+  EXPECT_TRUE(true);
 }
 
 TEST(APICoreTest, Value) {


### PR DESCRIPTION
avoid some error log confuse users when migrate wasmedge into other production

> I think the error (ex. interrupt) msg should be able hide thus avoid scare user (?

Signed-off-by: vincent <vincent@secondstate.io>