### PR TITLE
[Rust] Implement LogManager

### DIFF
--- a/bindings/rust/wasmedge-sdk/src/lib.rs
+++ b/bindings/rust/wasmedge-sdk/src/lib.rs
@@ -160,6 +160,8 @@ mod import;
 mod instance;
 #[doc(hidden)]
 pub mod io;
+#[doc(hidden)]
+pub mod log;
 mod module;
 #[doc(hidden)]
 pub mod plugin;
@@ -188,6 +190,8 @@ pub use instance::WasmEdgeProcessInstance;
 pub use instance::{AsInstance, Instance};
 #[doc(inline)]
 pub use io::{WasmVal, WasmValType, WasmValTypeList};
+#[doc(inline)]
+pub use log::LogManager;
 #[doc(inline)]
 pub use module::{ExportType, ImportType, Module};
 #[doc(inline)]

--- a/bindings/rust/wasmedge-sdk/src/log.rs
+++ b/bindings/rust/wasmedge-sdk/src/log.rs
@@ -1,0 +1,23 @@
+//! Defines WasmEdge LogManager struct
+
+use wasmedge_sys as sys;
+
+/// Manipulates the runtime logger.
+#[derive(Debug)]
+pub struct LogManager {}
+impl LogManager {
+    /// Logs the debug information.
+    pub fn log_debug_info() {
+        sys::utils::log_debug_info()
+    }
+
+    /// Logs the error information.
+    pub fn log_error_info() {
+        sys::utils::log_error_info()
+    }
+
+    /// Sets the logging system off.
+    pub fn log_off() {
+        sys::utils::log_off()
+    }
+}

--- a/bindings/rust/wasmedge-sys/src/utils.rs
+++ b/bindings/rust/wasmedge-sys/src/utils.rs
@@ -40,7 +40,7 @@ pub fn log_error_info() {
     unsafe { ffi::WasmEdge_LogSetErrorLevel() }
 }
 
-/// Logs off.
+/// Sets the logging system off.
 pub fn log_off() {
     unsafe { ffi::WasmEdge_LogOff() }
 }


### PR DESCRIPTION
In this PR, a new `LogManager` is introduced into `wasmedge-sdk` crate.