### PR TITLE
[Rust] Remove the deprecated APIs

### DIFF
--- a/bindings/rust/wasmedge-sdk/src/externals/function.rs
+++ b/bindings/rust/wasmedge-sdk/src/externals/function.rs
@@ -142,37 +142,6 @@ impl Func {
         })
     }
 
-    /// Creates a host function by wrapping a native function.
-    ///
-    /// N.B. that this function is used for single-threaded scenarios. If you would like to use hostfunc call chaining design, you should use this method to create a [Func] instance.
-    ///
-    /// # Arguments
-    ///
-    /// * `real_func` - The native function to be wrapped.
-    ///
-    /// # Error
-    ///
-    /// If fail to create the host function, then an error is returned.
-    pub fn wrap_single_thread<Args, Rets>(
-        real_func: impl Fn(&CallingFrame, Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError>
-            + 'static,
-    ) -> WasmEdgeResult<Self>
-    where
-        Args: WasmValTypeList,
-        Rets: WasmValTypeList,
-    {
-        let boxed_func = Box::new(real_func);
-        let args = Args::wasm_types();
-        let returns = Rets::wasm_types();
-        let ty = FuncType::new(Some(args.to_vec()), Some(returns.to_vec()));
-        let inner = sys::Function::create_single_thread(&ty.into(), boxed_func, 0)?;
-        Ok(Self {
-            inner,
-            name: None,
-            mod_name: None,
-        })
-    }
-
     /// Returns the exported name of this function.
     ///
     /// Notice that this field is meaningful only if this host function is used as an exported instance.

--- a/bindings/rust/wasmedge-sdk/src/import.rs
+++ b/bindings/rust/wasmedge-sdk/src/import.rs
@@ -172,38 +172,6 @@ impl ImportObjectBuilder {
         Ok(self)
     }
 
-    /// Adds a [host function](crate::Func) to the [ImportObject] to create.
-    ///
-    /// N.B. that this function is used for single-threaded scenarios. If you would like to use hostfunc call chaining design, you should use this method to create a [Func](crate::Func) instance.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The exported name of the [host function](crate::Func) to add.
-    ///
-    /// * `real_func` - The native function.
-    ///
-    /// # error
-    ///
-    /// If fail to create or add the [host function](crate::Func), then an error is returned.
-    pub fn with_func_single_thread<Args, Rets>(
-        mut self,
-        name: impl AsRef<str>,
-        real_func: impl Fn(&CallingFrame, Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError>
-            + 'static,
-    ) -> WasmEdgeResult<Self>
-    where
-        Args: WasmValTypeList,
-        Rets: WasmValTypeList,
-    {
-        let boxed_func = Box::new(real_func);
-        let args = Args::wasm_types();
-        let returns = Rets::wasm_types();
-        let ty = FuncType::new(Some(args.to_vec()), Some(returns.to_vec()));
-        let inner_func = sys::Function::create_single_thread(&ty.into(), boxed_func, 0)?;
-        self.funcs.push((name.as_ref().to_owned(), inner_func));
-        Ok(self)
-    }
-
     /// Adds a [global](crate::Global) to the [ImportObject] to create.
     ///
     /// # Arguments

--- a/bindings/rust/wasmedge-sys/src/instance/function.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/function.rs
@@ -2,8 +2,7 @@
 
 use crate::{
     error::{FuncError, HostFuncError, WasmEdgeError},
-    ffi, BoxedFn, BoxedFnSingle, CallingFrame, Engine, WasmEdgeResult, WasmValue, HOST_FUNCS,
-    HOST_FUNCS_SINGLE,
+    ffi, BoxedFn, CallingFrame, Engine, WasmEdgeResult, WasmValue, HOST_FUNCS,
 };
 use core::ffi::c_void;
 use parking_lot::Mutex;
@@ -68,65 +67,6 @@ extern "C" fn wraper_fn(
                 },
             }
         }
-    }
-}
-
-// Wrapper function for single-threaded scenarios.
-extern "C" fn wraper_fn_single(
-    key_ptr: *mut c_void,
-    _data: *mut c_void,
-    call_frame_ctx: *const ffi::WasmEdge_CallingFrameContext,
-    params: *const ffi::WasmEdge_Value,
-    param_len: u32,
-    returns: *mut ffi::WasmEdge_Value,
-    return_len: u32,
-) -> ffi::WasmEdge_Result {
-    let frame = CallingFrame::create(call_frame_ctx);
-
-    let key = key_ptr as *const usize as usize;
-    let mut result = Err(HostFuncError::Runtime(0));
-
-    let input = {
-        let raw_input = unsafe {
-            std::slice::from_raw_parts(
-                params,
-                param_len
-                    .try_into()
-                    .expect("len of params should not greater than usize"),
-            )
-        };
-        raw_input.iter().map(|r| (*r).into()).collect::<Vec<_>>()
-    };
-
-    let return_len = return_len
-        .try_into()
-        .expect("len of returns should not greater than usize");
-    let raw_returns = unsafe { std::slice::from_raw_parts_mut(returns, return_len) };
-
-    HOST_FUNCS_SINGLE.with(|f| {
-        let host_functions = f.borrow();
-        let real_fn = host_functions
-            .get(&key)
-            .expect("host function should be there");
-        result = real_fn(&frame, input);
-    });
-
-    match result {
-        Ok(v) => {
-            assert!(v.len() == return_len);
-            for (idx, item) in v.into_iter().enumerate() {
-                raw_returns[idx] = item.as_raw();
-            }
-            ffi::WasmEdge_Result { Code: 0 }
-        }
-        Err(err) => match err {
-            HostFuncError::User(code) => unsafe {
-                ffi::WasmEdge_ResultGen(ffi::WasmEdge_ErrCategory_UserLevelError, code)
-            },
-            HostFuncError::Runtime(code) => unsafe {
-                ffi::WasmEdge_ResultGen(ffi::WasmEdge_ErrCategory_WASM, code)
-            },
-        },
     }
 }
 
@@ -246,68 +186,6 @@ impl Function {
                 Some(wraper_fn),
                 key as *const usize as *mut c_void,
                 data,
-                cost,
-            )
-        };
-
-        match ctx.is_null() {
-            true => Err(Box::new(WasmEdgeError::Func(FuncError::Create))),
-            false => Ok(Self {
-                inner: InnerFunc(ctx),
-                registered: false,
-            }),
-        }
-    }
-
-    /// Creates a [host function](crate::Function) with the given function type.
-    ///
-    /// N.B. that this function is used for single-threaded scenarios. If you would like to use hostfunc call chaining design, you should use this method to create a [Function] instance. You can find the example of hostfunc call chaining in the `examples` directory of `wasmedge-sys`.
-    ///
-    /// # Arguments
-    ///
-    /// * `ty` - The types of the arguments and returns of the target function.
-    ///
-    /// * `real_fn` - The pointer to the target function.
-    ///
-    /// * `cost` - The function cost in the [Statistics](crate::Statistics). Pass 0 if the calculation is not needed.
-    ///
-    /// # Error
-    ///
-    /// If fail to create a [Function], then an error is returned.
-    ///
-    pub fn create_single_thread(
-        ty: &FuncType,
-        real_fn: BoxedFnSingle,
-        cost: u64,
-    ) -> WasmEdgeResult<Self> {
-        let mut key = 0usize;
-
-        HOST_FUNCS_SINGLE.with(|f| {
-            let mut host_functions = f.borrow_mut();
-            if host_functions.len() >= host_functions.capacity() {
-                return Err(WasmEdgeError::Func(FuncError::CreateBinding(format!(
-                    "The number of the host functions reaches the upper bound: {}",
-                    host_functions.capacity()
-                ))));
-            }
-
-            // generate key for the coming host function
-            let mut rng = rand::thread_rng();
-            key = rng.gen::<usize>();
-            while host_functions.contains_key(&key) {
-                key = rng.gen::<usize>();
-            }
-            host_functions.insert(key, real_fn);
-
-            Ok(())
-        })?;
-
-        let ctx = unsafe {
-            ffi::WasmEdge_FunctionInstanceCreateBinding(
-                ty.inner.0,
-                Some(wraper_fn_single),
-                key as *const usize as *mut c_void,
-                std::ptr::null_mut(),
                 cost,
             )
         };

--- a/bindings/rust/wasmedge-sys/src/lib.rs
+++ b/bindings/rust/wasmedge-sys/src/lib.rs
@@ -143,7 +143,7 @@
 extern crate lazy_static;
 
 use parking_lot::{Mutex, RwLock};
-use std::{cell::RefCell, collections::HashMap, env, sync::Arc};
+use std::{collections::HashMap, env, sync::Arc};
 
 #[doc(hidden)]
 #[allow(warnings)]
@@ -245,21 +245,6 @@ lazy_static! {
                 .map(|s| s
                     .parse::<usize>()
                     .expect("MAX_HOST_FUNC_LENGTH should be a positive integer."))
-                .unwrap_or(500)
-        ));
-}
-
-/// Type alias for a boxed native function. This type is used in non-thread-safe cases.
-pub type BoxedFnSingle =
-    Box<dyn Fn(&CallingFrame, Vec<WasmValue>) -> Result<Vec<WasmValue>, error::HostFuncError>>;
-
-thread_local! {
-    static HOST_FUNCS_SINGLE: RefCell<HashMap<usize, BoxedFnSingle>> =
-        RefCell::new(HashMap::with_capacity(
-            env::var("MAX_HOST_FUNC_SINGLE_LENGTH")
-                .map(|s| s
-                    .parse::<usize>()
-                    .expect("MAX_HOST_FUNC_SINGLE_LENGTH should be a number"))
                 .unwrap_or(500)
         ));
 }


### PR DESCRIPTION
In this PR, the following deprecated APIs are removed from Rust bindings:

- `wasmedge_sdk::Func::wrap_single_thread`
- `wasmedge_sdk::ImportBuilder::with_func_single_thread`
- `wasmedge_sys::Function::create_single_thread`

In addition, those test cases affected by the changes are also updated.
