### PR TITLE
[CI] Add network libs into slim images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -362,6 +362,11 @@ jobs:
             --dockerfile-context utils/docker \
             --tag ${{ steps.docker_env.outputs.docker_image }} \
             --http-probe-off \
+            --include-bin /usr/lib/x86_64-linux-gnu/libnss_compat.so.2 \
+            --include-bin /usr/lib/x86_64-linux-gnu/libnss_dns.so.2 \
+            --include-bin /usr/lib/x86_64-linux-gnu/libnss_files.so.2 \
+            --include-bin /usr/lib/x86_64-linux-gnu/libresolv.so.2 \
+            --include-path /etc/services \
             ${{ matrix.include_bin }} \
             --cbo-build-arg VERSION="${{ needs.create_release.outputs.version }}" \
             --cbo-label org.opencontainers.image.title="${{ github.event.repository.name }}" \

--- a/utils/docker/Dockerfile.release
+++ b/utils/docker/Dockerfile.release
@@ -1,6 +1,7 @@
 FROM ubuntu:20.04
 ARG VERSION
 
+RUN apt-get update && apt-get install -y netbase
 ADD WasmEdge-$VERSION-Linux.tar.gz /tmp/
 RUN cp -rf /tmp/WasmEdge-$VERSION-Linux/bin/* /usr/local/bin && \
     cp -rf /tmp/WasmEdge-$VERSION-Linux/lib64/* /usr/local/lib && \


### PR DESCRIPTION
Fix #1987. 

- Install netbase for `/etc/services` file.
- Preserve network related libs.
- Steps to verify (use http-client.wasm from #1987. for testing):

```
git clone https://github.com/WasmEdge/WasmEdge.git -b fix-1987
cd WasmEdge/
curl -Lo utils/docker/WasmEdge-0.11.1-Linux.tar.gz https://github.com/WasmEdge/WasmEdge/releases/download/0.11.1/WasmEdge-0.11.1-manylinux2014_x86_64.tar.gz
docker-slim build \
  --dockerfile Dockerfile.release \
  --dockerfile-context utils/docker \
  --tag wasmedge/fix-1987 \
  --http-probe-off \
  --include-bin /usr/lib/x86_64-linux-gnu/libnss_compat.so.2 \
  --include-bin /usr/lib/x86_64-linux-gnu/libnss_dns.so.2 \
  --include-bin /usr/lib/x86_64-linux-gnu/libnss_files.so.2 \
  --include-bin /usr/lib/x86_64-linux-gnu/libresolv.so.2 \
  --include-path /etc/services \
  --include-bin /usr/local/bin/wasmedge \
  --include-bin /usr/local/bin/wasmedgec \
  --cbo-build-arg VERSION=0.11.1
```

- Result:

```
$ docker images wasmedge/fix-1987
REPOSITORY          TAG       IMAGE ID       CREATED         SIZE
wasmedge/fix-1987   latest    e3a5a78cd6f2   9 minutes ago   55.8MB

$ docker run --rm -v $PWD:/app wasmedge/fix-1987 wasmedge http-client.wasm
address: 54.166.148.227:80
```