### PR TITLE
[CI] Refactor the release workflows for Rust SDK

### DIFF
--- a/.github/workflows/rust-wasmedge-sdk-release.yml
+++ b/.github/workflows/rust-wasmedge-sdk-release.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Set up build environment
         run: |
           sudo apt-get update
-          sudo apt-get install -y software-properties-common cmake libboost-all-dev llvm-12-dev liblld-12-dev ninja-build
-          sudo apt-get install -y gcc g++ clang-12
+          sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
+          sudo apt-get install -y llvm-14-dev liblld-14-dev clang-14
+          sudo apt-get install -y gcc g++
           sudo apt-get install -y libssl-dev pkg-config gh
 
       - name: Install Rust toolchain

--- a/.github/workflows/rust-wasmedge-sys-release.yml
+++ b/.github/workflows/rust-wasmedge-sys-release.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Set up build environment
         run: |
           sudo apt-get update
-          sudo apt-get install -y software-properties-common cmake libboost-all-dev llvm-12-dev liblld-12-dev ninja-build
-          sudo apt-get install -y gcc g++ clang-12
+          sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
+          sudo apt-get install -y llvm-14-dev liblld-14-dev clang-14
+          sudo apt-get install -y gcc g++
           sudo apt-get install -y libssl-dev pkg-config gh
 
       - name: Install Rust toolchain


### PR DESCRIPTION
In this PR, we replaced `llvm-12` with `llvm-14` in the release workflows for `wasmedge-sys` and `wasmedge-sdk`.

Using `llvm-12` causes the same issue as #1821. 