### PR TITLE
feat: remove none type from val type

### DIFF
--- a/bindings/java/wasmedge-jni/lib/ValueType.c
+++ b/bindings/java/wasmedge-jni/lib/ValueType.c
@@ -41,9 +41,6 @@ WasmEdge_Value JavaValueToWasmEdgeValue(JNIEnv *env, jobject jVal) {
   case WasmEdge_ValType_FuncRef:
     return WasmEdge_ValueGenFuncRef(
         (WasmEdge_FunctionInstanceContext *)getLongVal(env, jVal));
-    // TODO handle none type
-  case WasmEdge_ValType_None:
-    return WasmEdge_ValueGenNullRef(WasmEdge_RefType_ExternRef);
   }
 }
 
@@ -71,9 +68,6 @@ jobject WasmEdgeValueToJavaValue(JNIEnv *env, WasmEdge_Value value) {
   case WasmEdge_ValType_FuncRef:
     valClassName = "org/wasmedge/WasmEdgeFuncRef";
     break;
-    // TODO handle valtype none.
-  case WasmEdge_ValType_None:
-    return NULL;
   }
   jclass valClass = (*env)->FindClass(env, valClassName);
 

--- a/bindings/rust/wasmedge-sdk/src/types.rs
+++ b/bindings/rust/wasmedge-sdk/src/types.rs
@@ -75,7 +75,6 @@ impl From<WasmValue> for Val {
                     Val::ExternRef(Some(ExternRef { inner: value }))
                 }
             }
-            _ => panic!("unsupported value type"),
         }
     }
 }

--- a/bindings/rust/wasmedge-sys/src/types.rs
+++ b/bindings/rust/wasmedge-sys/src/types.rs
@@ -331,10 +331,6 @@ impl From<ffi::WasmEdge_Value> for WasmValue {
                 ctx: raw_val,
                 ty: ValType::ExternRef,
             },
-            ffi::WasmEdge_ValType_None => Self {
-                ctx: raw_val,
-                ty: ValType::None,
-            },
             _ => panic!("unknown WasmEdge_ValType `{}`", raw_val.Type),
         }
     }

--- a/bindings/rust/wasmedge-types/src/lib.rs
+++ b/bindings/rust/wasmedge-types/src/lib.rs
@@ -74,8 +74,6 @@ pub enum ValType {
     FuncRef,
     /// A reference to object.
     ExternRef,
-    /// Unknown.
-    None,
 }
 impl From<u32> for ValType {
     fn from(value: u32) -> Self {
@@ -87,7 +85,6 @@ impl From<u32> for ValType {
             123 => ValType::V128,
             112 => ValType::FuncRef,
             111 => ValType::ExternRef,
-            64 => ValType::None,
             _ => panic!("[wasmedge-types] Invalid WasmEdge_ValType: {value:#X}"),
         }
     }
@@ -102,7 +99,6 @@ impl From<ValType> for u32 {
             ValType::V128 => 123,
             ValType::FuncRef => 112,
             ValType::ExternRef => 111,
-            ValType::None => 64,
         }
     }
 }
@@ -116,7 +112,6 @@ impl From<i32> for ValType {
             123 => ValType::V128,
             112 => ValType::FuncRef,
             111 => ValType::ExternRef,
-            64 => ValType::None,
             _ => panic!("[wasmedge-types] Invalid WasmEdge_ValType: {value:#X}"),
         }
     }
@@ -131,7 +126,6 @@ impl From<ValType> for i32 {
             ValType::V128 => 123,
             ValType::FuncRef => 112,
             ValType::ExternRef => 111,
-            ValType::None => 64,
         }
     }
 }

--- a/include/ast/instruction.h
+++ b/include/ast/instruction.h
@@ -94,6 +94,7 @@ public:
     Data.Blocks.ResType.setData(VType);
   }
   void setBlockType(uint32_t Idx) noexcept { Data.Blocks.ResType.setData(Idx); }
+  void setEmptyBlockType() noexcept { Data.Blocks.ResType.setEmpty(); }
 
   /// Getter and setter of jump count to End instruction.
   uint32_t getJumpEnd() const noexcept { return Data.Blocks.JumpEnd; }

--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -908,7 +908,6 @@ I(Lane, "lane")
 #ifdef UseValType
 #define V Line
 
-V(None, 0x40, "none")
 V(I32, 0x7F, "i32")
 V(I64, 0x7E, "i64")
 V(F32, 0x7D, "f32")

--- a/include/common/types.h
+++ b/include/common/types.h
@@ -87,13 +87,14 @@ using ValVariant =
             int16x8_t, uint8x16_t, int8x16_t, floatx4_t, doublex2_t, UnknownRef,
             FuncRef, ExternRef>;
 
-__inline__ const uint8_t BLOCK_TYPE_EMPTY_BIT_MASK = 1;
-__inline__ const uint8_t BLOCK_TYPE_VAL_TYPE_BIT_MASK = 1 << 1;
-__inline__ const uint8_t BLOCK_TYPE_IDX_BIT_MASK = 1 << 2;
-
 /// BlockType definition.
 struct BlockType {
-  uint8_t TypeFlag;
+  enum class TypeEnum : uint8_t {
+    Empty,
+    ValType,
+    TypeIdx,
+  };
+  TypeEnum TypeFlag;
   union {
     ValType Type;
     uint32_t Idx;
@@ -101,17 +102,17 @@ struct BlockType {
   BlockType() = default;
   BlockType(ValType VType) { setData(VType); }
   BlockType(uint32_t Idx) { setData(Idx); }
-  void setEmpty() { TypeFlag = BLOCK_TYPE_EMPTY_BIT_MASK; }
+  void setEmpty() { TypeFlag = TypeEnum::Empty; }
   void setData(ValType VType) {
-    TypeFlag = BLOCK_TYPE_VAL_TYPE_BIT_MASK;
+    TypeFlag = TypeEnum::ValType;
     Data.Type = VType;
   }
   void setData(uint32_t Idx) {
-    TypeFlag = BLOCK_TYPE_IDX_BIT_MASK;
+    TypeFlag = TypeEnum::TypeIdx;
     Data.Idx = Idx;
   }
-  bool isEmpty() const { return TypeFlag == BLOCK_TYPE_EMPTY_BIT_MASK; }
-  bool isValType() const { return TypeFlag == BLOCK_TYPE_VAL_TYPE_BIT_MASK; }
+  bool isEmpty() const { return TypeFlag == TypeEnum::Empty; }
+  bool isValType() const { return TypeFlag == TypeEnum::ValType; }
 };
 
 /// NumType and RefType conversions.

--- a/include/common/types.h
+++ b/include/common/types.h
@@ -87,9 +87,13 @@ using ValVariant =
             int16x8_t, uint8x16_t, int8x16_t, floatx4_t, doublex2_t, UnknownRef,
             FuncRef, ExternRef>;
 
+__inline__ const uint8_t BLOCK_TYPE_EMPTY_BIT_MASK = 1;
+__inline__ const uint8_t BLOCK_TYPE_VAL_TYPE_BIT_MASK = 1 << 1;
+__inline__ const uint8_t BLOCK_TYPE_IDX_BIT_MASK = 1 << 2;
+
 /// BlockType definition.
 struct BlockType {
-  bool IsValType;
+  uint8_t TypeFlag;
   union {
     ValType Type;
     uint32_t Idx;
@@ -97,14 +101,17 @@ struct BlockType {
   BlockType() = default;
   BlockType(ValType VType) { setData(VType); }
   BlockType(uint32_t Idx) { setData(Idx); }
+  void setEmpty() { TypeFlag = BLOCK_TYPE_EMPTY_BIT_MASK; }
   void setData(ValType VType) {
-    IsValType = true;
+    TypeFlag = BLOCK_TYPE_VAL_TYPE_BIT_MASK;
     Data.Type = VType;
   }
   void setData(uint32_t Idx) {
-    IsValType = false;
+    TypeFlag = BLOCK_TYPE_IDX_BIT_MASK;
     Data.Idx = Idx;
   }
+  bool isEmpty() const { return TypeFlag == BLOCK_TYPE_EMPTY_BIT_MASK; }
+  bool isValType() const { return TypeFlag == BLOCK_TYPE_VAL_TYPE_BIT_MASK; }
 };
 
 /// NumType and RefType conversions.
@@ -269,7 +276,6 @@ inline constexpr ValVariant ValueFromType(ValType Type) noexcept {
   case ValType::FuncRef:
   case ValType::ExternRef:
     return UnknownRef();
-  case ValType::None:
   default:
     assumingUnreachable();
   }

--- a/include/loader/loader.h
+++ b/include/loader/loader.h
@@ -112,8 +112,7 @@ private:
     spdlog::error(ErrInfo::InfoAST(Node));
     return Unexpect(Code);
   }
-  Expect<ValType> checkValTypeProposals(ValType VType,
-                                        uint64_t Off,
+  Expect<ValType> checkValTypeProposals(ValType VType, uint64_t Off,
                                         ASTNodeAttr Node) const noexcept;
   Expect<RefType> checkRefTypeProposals(RefType RType, uint64_t Off,
                                         ASTNodeAttr Node) const noexcept;

--- a/include/loader/loader.h
+++ b/include/loader/loader.h
@@ -112,7 +112,7 @@ private:
     spdlog::error(ErrInfo::InfoAST(Node));
     return Unexpect(Code);
   }
-  Expect<ValType> checkValTypeProposals(ValType VType, bool AcceptNone,
+  Expect<ValType> checkValTypeProposals(ValType VType,
                                         uint64_t Off,
                                         ASTNodeAttr Node) const noexcept;
   Expect<RefType> checkRefTypeProposals(RefType RType, uint64_t Off,

--- a/lib/aot/compiler.cpp
+++ b/lib/aot/compiler.cpp
@@ -434,10 +434,10 @@ struct WasmEdge::AOT::Compiler::CompileContext {
   resolveBlockType(const BlockType &BType) const {
     using VecT = std::vector<ValType>;
     using RetT = std::pair<VecT, VecT>;
-    if (BType.IsValType) {
-      if (BType.Data.Type == ValType::None) {
-        return RetT{};
-      }
+    if (BType.isEmpty()) {
+      return RetT{};
+    }
+    if (BType.isValType()) {
       return RetT{{}, {BType.Data.Type}};
     } else {
       // Type index case. t2* = type[index].returns
@@ -455,8 +455,7 @@ namespace {
 using namespace WasmEdge;
 
 static bool isVoidReturn(Span<const WasmEdge::ValType> ValTypes) {
-  return ValTypes.empty() ||
-         (ValTypes.size() == 1 && ValTypes.front() == ValType::None);
+  return ValTypes.empty();
 }
 
 static llvm::Type *toLLVMType(llvm::LLVMContext &LLContext,

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -212,7 +212,6 @@ genParamPair(const WasmEdge_Value *Val, const uint32_t Len) noexcept {
       VVec[I] = ValVariant::wrap<ExternRef>(
           to_WasmEdge_128_t<WasmEdge::uint128_t>(Val[I].Value));
       break;
-    case ValType::None:
     default:
       // TODO: Return error
       assumingUnreachable();

--- a/lib/common/errinfo.cpp
+++ b/lib/common/errinfo.cpp
@@ -195,9 +195,6 @@ std::ostream &operator<<(std::ostream &OS, const struct InfoInstruction &Rhs) {
     OS << " , Args: [";
     for (uint32_t I = 0; I < Rhs.Args.size(); ++I) {
       switch (Rhs.ArgsTypes[I]) {
-      case ValType::None:
-        OS << "none";
-        break;
       case ValType::I32:
         if (Rhs.IsSigned) {
           OS << Rhs.Args[I].get<int32_t>();

--- a/lib/loader/ast/segment.cpp
+++ b/lib/loader/ast/segment.cpp
@@ -247,7 +247,7 @@ Expect<void> Loader::loadSegment(AST::CodeSegment &CodeSeg) {
   uint32_t TotalLocalCnt = 0;
   for (uint32_t I = 0; I < VecCnt; ++I) {
     uint32_t LocalCnt = 0;
-    ValType LocalType = ValType::None;
+    ValType LocalType;
     if (auto Res = FMgr.readU32(); unlikely(!Res)) {
       return logLoadError(Res.error(), FMgr.getLastOffset(),
                           ASTNodeAttr::Seg_Code);
@@ -267,7 +267,7 @@ Expect<void> Loader::loadSegment(AST::CodeSegment &CodeSeg) {
     } else {
       LocalType = static_cast<ValType>(*Res);
     }
-    if (auto Res = checkValTypeProposals(LocalType, false, FMgr.getLastOffset(),
+    if (auto Res = checkValTypeProposals(LocalType, FMgr.getLastOffset(),
                                          ASTNodeAttr::Seg_Code);
         unlikely(!Res)) {
       return Unexpect(Res);

--- a/lib/loader/ast/type.cpp
+++ b/lib/loader/ast/type.cpp
@@ -95,7 +95,7 @@ Expect<void> Loader::loadType(AST::FunctionType &FuncType) {
   for (uint32_t I = 0; I < VecCnt; ++I) {
     if (auto Res = FMgr.readByte()) {
       ValType Type = static_cast<ValType>(*Res);
-      if (auto Check = checkValTypeProposals(Type, false, FMgr.getLastOffset(),
+      if (auto Check = checkValTypeProposals(Type, FMgr.getLastOffset(),
                                              ASTNodeAttr::Type_Function);
           !Check) {
         return Unexpect(Check);
@@ -128,7 +128,7 @@ Expect<void> Loader::loadType(AST::FunctionType &FuncType) {
   for (uint32_t I = 0; I < VecCnt; ++I) {
     if (auto Res = FMgr.readByte()) {
       ValType Type = static_cast<ValType>(*Res);
-      if (auto Check = checkValTypeProposals(Type, false, FMgr.getLastOffset(),
+      if (auto Check = checkValTypeProposals(Type, FMgr.getLastOffset(),
                                              ASTNodeAttr::Type_Function);
           !Check) {
         return Unexpect(Check);
@@ -181,9 +181,9 @@ Expect<void> Loader::loadType(AST::GlobalType &GlobType) {
   // Read value type.
   if (auto Res = FMgr.readByte()) {
     GlobType.setValType(static_cast<ValType>(*Res));
-    if (auto Check = checkValTypeProposals(GlobType.getValType(), false,
-                                           FMgr.getLastOffset(),
-                                           ASTNodeAttr::Type_Global);
+    if (auto Check =
+            checkValTypeProposals(GlobType.getValType(), FMgr.getLastOffset(),
+                                  ASTNodeAttr::Type_Global);
         !Check) {
       return Unexpect(Check);
     }

--- a/lib/loader/filemgr.cpp
+++ b/lib/loader/filemgr.cpp
@@ -205,7 +205,7 @@ template <typename RetType, size_t N> Expect<RetType> FileMgr::readSN() {
           Payload = Byte;
           Payload -= (1 << 7);
         } else {
-          Status = ErrCode::Value::IntegerTooLong;
+          Status = ErrCode::Value::IntegerTooLarge;
           return Unexpect(Status);
         }
       } else {
@@ -214,7 +214,7 @@ template <typename RetType, size_t N> Expect<RetType> FileMgr::readSN() {
         if (Byte < (1 << (EffectiveBits - 1))) {
           Payload = Byte;
         } else {
-          Status = ErrCode::Value::IntegerTooLong;
+          Status = ErrCode::Value::IntegerTooLarge;
           return Unexpect(Status);
         }
       }

--- a/lib/loader/filemgr.cpp
+++ b/lib/loader/filemgr.cpp
@@ -170,10 +170,10 @@ template <typename RetType, size_t N> Expect<RetType> FileMgr::readSN() {
     // In the rest logic, RemainingBits must be at least 1.
 
     WasmEdge::Byte Byte;
-    if (auto Res = testRead(1); unlikely(!Res)) {
+    if (auto Res = readByte(); unlikely(!Res)) {
       return Unexpect(Res);
     } else {
-      Byte = Data[Pos++];
+      Byte = *Res;
     }
 
     const WasmEdge::Byte HighestBitMask = 1 << 7;
@@ -205,7 +205,7 @@ template <typename RetType, size_t N> Expect<RetType> FileMgr::readSN() {
           Payload = Byte;
           Payload -= (1 << 7);
         } else {
-          Status = ErrCode::Value::IntegerTooLarge;
+          Status = ErrCode::Value::IntegerTooLong;
           return Unexpect(Status);
         }
       } else {
@@ -214,7 +214,7 @@ template <typename RetType, size_t N> Expect<RetType> FileMgr::readSN() {
         if (Byte < (1 << (EffectiveBits - 1))) {
           Payload = Byte;
         } else {
-          Status = ErrCode::Value::IntegerTooLarge;
+          Status = ErrCode::Value::IntegerTooLong;
           return Unexpect(Status);
         }
       }
@@ -287,8 +287,8 @@ Expect<std::string> FileMgr::readName() {
   if (unlikely(Status != ErrCode::Value::Success)) {
     return Unexpect(Status);
   }
-  // If UTF-8 validation or readU32() or readBytes() failed, the last succeeded
-  // reading offset will be at the start of `Name`.
+  // If UTF-8 validation or readU32() or readBytes() failed, the last
+  // succeeded reading offset will be at the start of `Name`.
   LastPos = Pos;
 
   // Read the name size.
@@ -423,7 +423,8 @@ Expect<void> FileMgr::jumpContent() {
   return {};
 }
 
-// Helper function for reading number of bytes. See "include/loader/filemgr.h".
+// Helper function for reading number of bytes. See
+// "include/loader/filemgr.h".
 Expect<void> FileMgr::readBytes(Span<Byte> Buffer) {
   if (unlikely(Status != ErrCode::Value::Success)) {
     return Unexpect(Status);

--- a/lib/loader/filemgr.cpp
+++ b/lib/loader/filemgr.cpp
@@ -170,10 +170,10 @@ template <typename RetType, size_t N> Expect<RetType> FileMgr::readSN() {
     // In the rest logic, RemainingBits must be at least 1.
 
     WasmEdge::Byte Byte;
-    if (auto Res = readByte(); unlikely(!Res)) {
+    if (auto Res = testRead(1); unlikely(!Res)) {
       return Unexpect(Res);
     } else {
-      Byte = *Res;
+      Byte = Data[Pos++];
     }
 
     const WasmEdge::Byte HighestBitMask = 1 << 7;

--- a/lib/loader/filemgr.cpp
+++ b/lib/loader/filemgr.cpp
@@ -287,8 +287,8 @@ Expect<std::string> FileMgr::readName() {
   if (unlikely(Status != ErrCode::Value::Success)) {
     return Unexpect(Status);
   }
-  // If UTF-8 validation or readU32() or readBytes() failed, the last
-  // succeeded reading offset will be at the start of `Name`.
+  // If UTF-8 validation or readU32() or readBytes() failed, the last succeeded
+  // reading offset will be at the start of `Name`.
   LastPos = Pos;
 
   // Read the name size.
@@ -423,8 +423,7 @@ Expect<void> FileMgr::jumpContent() {
   return {};
 }
 
-// Helper function for reading number of bytes. See
-// "include/loader/filemgr.h".
+// Helper function for reading number of bytes. See "include/loader/filemgr.h".
 Expect<void> FileMgr::readBytes(Span<Byte> Buffer) {
   if (unlikely(Status != ErrCode::Value::Success)) {
     return Unexpect(Status);

--- a/lib/loader/loader.cpp
+++ b/lib/loader/loader.cpp
@@ -172,8 +172,7 @@ Loader::parseModule(Span<const uint8_t> Code) {
 }
 
 // Helper function of checking the valid value types.
-Expect<ValType> Loader::checkValTypeProposals(ValType VType, bool AcceptNone,
-                                              uint64_t Off,
+Expect<ValType> Loader::checkValTypeProposals(ValType VType, uint64_t Off,
                                               ASTNodeAttr Node) const noexcept {
   if (VType == ValType::V128 && !Conf.hasProposal(Proposal::SIMD)) {
     return logNeedProposal(ErrCode::Value::MalformedValType, Proposal::SIMD,
@@ -196,11 +195,6 @@ Expect<ValType> Loader::checkValTypeProposals(ValType VType, bool AcceptNone,
   case ValType::ExternRef:
   case ValType::FuncRef:
     return VType;
-  case ValType::None:
-    if (AcceptNone) {
-      return VType;
-    }
-    [[fallthrough]];
   default:
     return logLoadError(ErrCode::Value::MalformedValType, Off, Node);
   }

--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -208,13 +208,14 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
                                const BlockType &BType)
       -> Expect<std::pair<Span<const VType>, Span<const VType>>> {
     using ReturnType = std::pair<Span<const VType>, Span<const VType>>;
-    if (BType.IsValType) {
+    if (BType.isEmpty()) {
+      return ReturnType{{}, Buffer};
+    }
+    if (BType.isValType()) {
       // ValType case. t2* = valtype | none
-      if (BType.Data.Type != ValType::None) {
-        Buffer.clear();
-        Buffer.reserve(1);
-        Buffer.push_back(ASTToVType(BType.Data.Type));
-      }
+      Buffer.clear();
+      Buffer.reserve(1);
+      Buffer.push_back(ASTToVType(BType.Data.Type));
       return ReturnType{{}, Buffer};
     } else {
       // Type index case. t2* = type[index].returns

--- a/test/errinfo/errinfoTest.cpp
+++ b/test/errinfo/errinfoTest.cpp
@@ -101,7 +101,7 @@ TEST(ErrInfoTest, Info__Mismatch) {
       {WasmEdge::ValType::I64, WasmEdge::ValType::F64},
       {WasmEdge::ValType::F64, WasmEdge::ValType::ExternRef,
        WasmEdge::ValType::V128},
-      {WasmEdge::ValType::None, WasmEdge::ValType::V128});
+      {WasmEdge::ValType::V128});
   std::cout << Info6 << std::endl;
   WasmEdge::ErrInfo::InfoMismatch Info7(WasmEdge::RefType::ExternRef, true, 10,
                                         20, WasmEdge::RefType::FuncRef, true,
@@ -131,10 +131,9 @@ TEST(ErrInfoTest, Info__Instruction) {
       WasmEdge::FuncRef(
           reinterpret_cast<WasmEdge::Runtime::Instance::FunctionInstance *>(
               100))};
-  WasmEdge::ErrInfo::InfoInstruction Info1(WasmEdge::OpCode::Block, 255, Args,
-                                           {WasmEdge::ValType::None,
-                                            WasmEdge::ValType::None,
-                                            WasmEdge::ValType::None});
+  WasmEdge::ErrInfo::InfoInstruction Info1(
+      WasmEdge::OpCode::Block, 255, Args,
+      {WasmEdge::ValType::I32, WasmEdge::ValType::I32, WasmEdge::ValType::I32});
   std::cout << Info1 << std::endl;
   WasmEdge::ErrInfo::InfoInstruction Info2(
       WasmEdge::OpCode::Block, 255, Args,


### PR DESCRIPTION
This PR fixes #2029.

It is based on #2030, and currently include the change in #2030. Should be after #2030.