### PR TITLE
[Rust] Fix a bug in wasmedge_sys::Compiler

### DIFF
--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -79,8 +79,7 @@ jobs:
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           export LD_LIBRARY_PATH="$(pwd)/../../build/lib/api"
-          cargo +nightly test --lib --examples --locked
-          cargo +nightly test --doc --locked
+          cargo +nightly test --workspace --examples --locked
 
   build_macos:
     name: MacOS
@@ -142,8 +141,7 @@ jobs:
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           export DYLD_LIBRARY_PATH="$(pwd)/../../build/lib/api"
-          cargo +nightly test --lib --examples --locked
-          cargo +nightly test --doc --locked
+          cargo +nightly test --workspace --examples --locked
 
   build_windows:
     name: Windows
@@ -221,5 +219,4 @@ jobs:
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
           $env:Path="$env:Path;C:\Users\runneradmin\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\bin;D:\a\WasmEdge\WasmEdge\build\lib\api"
           cd bindings\rust
-          cargo +nightly test -p wasmedge-sys --all-targets
-          cargo +nightly test -p wasmedge-sdk --all-targets
+          cargo +nightly test --workspace --examples --locked

--- a/bindings/rust/wasmedge-macro/src/lib.rs
+++ b/bindings/rust/wasmedge-macro/src/lib.rs
@@ -37,6 +37,8 @@ fn expand_host_func(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2::TokenStre
     );
     // return type of wrapper function
     let wrapper_fn_return = item_fn.sig.output.clone();
+    // visibility of wrapper function
+    let wrapper_visibility = item_fn.vis.clone();
 
     // * define the signature of inner function
     // name of inner function
@@ -53,7 +55,7 @@ fn expand_host_func(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2::TokenStre
     let ret = match item_fn.sig.inputs.len() {
         2 => {
             quote!(
-                fn #wrapper_fn_name_ident (#wrapper_fn_inputs) #wrapper_fn_return {
+                # wrapper_visibility fn #wrapper_fn_name_ident (#wrapper_fn_inputs) #wrapper_fn_return {
                     // define inner function
                     fn #inner_fn_name_ident (#inner_fn_inputs) #inner_fn_return {
                         #inner_fn_block
@@ -120,7 +122,7 @@ fn expand_host_func(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2::TokenStre
 
             // generate token stream
             quote!(
-                fn #wrapper_fn_name_ident (#wrapper_fn_inputs) #wrapper_fn_return {
+                # wrapper_visibility fn #wrapper_fn_name_ident (#wrapper_fn_inputs) #wrapper_fn_return {
                     // define inner function
                     fn #inner_fn_name_ident (#inner_fn_inputs) #inner_fn_return {
                         #inner_fn_block
@@ -277,6 +279,7 @@ fn expand_async_host_func(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2::Tok
 
 fn expand_async_host_func_with_two_args(item_fn: &syn::ItemFn) -> proc_macro2::TokenStream {
     let fn_name_ident = &item_fn.sig.ident;
+    let fn_visibility = &item_fn.vis;
 
     // * prepare the function arguments
     let mut fn_inputs = item_fn.sig.inputs.clone();
@@ -302,7 +305,7 @@ fn expand_async_host_func_with_two_args(item_fn: &syn::ItemFn) -> proc_macro2::T
 
     // compose the final function
     quote!(
-        fn #fn_name_ident (#fn_inputs) -> Box<(dyn std::future::Future<Output = Result<Vec<WasmValue>, HostFuncError>> + Send + 'static)> {
+        #fn_visibility fn #fn_name_ident (#fn_inputs) -> Box<(dyn std::future::Future<Output = Result<Vec<WasmValue>, HostFuncError>> + Send + 'static)> {
             Box::new(async move {
                 let #original_first_arg_ident = Caller::new(frame);
                 #fn_block
@@ -446,6 +449,8 @@ fn sys_expand_host_func(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2::Token
     let wrapper_fn_name_literal = wrapper_fn_name_ident.to_string();
     // return type of wrapper function
     let wrapper_fn_return = item_fn.sig.output.clone();
+    // visiblity of wrapper function
+    let wrapper_fn_visibility = item_fn.vis.clone();
 
     // * define the signature of inner function
     // name of inner function
@@ -484,7 +489,7 @@ fn sys_expand_host_func(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2::Token
             wrapper_fn_inputs.push(parse_quote!(_data: *mut std::os::raw::c_void));
 
             quote!(
-                fn #wrapper_fn_name_ident (#wrapper_fn_inputs) #wrapper_fn_return {
+                #wrapper_fn_visibility fn #wrapper_fn_name_ident (#wrapper_fn_inputs) #wrapper_fn_return {
                     // define inner function
                     fn #inner_fn_name_ident (#inner_fn_inputs) #inner_fn_return {
                         #inner_fn_block
@@ -553,7 +558,7 @@ fn sys_expand_host_func(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2::Token
 
             // generate token stream
             quote!(
-                fn #wrapper_fn_name_ident (#wrapper_fn_inputs) #wrapper_fn_return {
+                #wrapper_fn_visibility fn #wrapper_fn_name_ident (#wrapper_fn_inputs) #wrapper_fn_return {
                     // define inner function
                     fn #inner_fn_name_ident (#inner_fn_inputs) #inner_fn_return {
                         #inner_fn_block
@@ -597,6 +602,7 @@ fn sys_expand_async_host_func(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2:
 
 fn sys_expand_async_host_func_with_two_args(item_fn: &syn::ItemFn) -> proc_macro2::TokenStream {
     let fn_name_ident = &item_fn.sig.ident;
+    let fn_visibility = &item_fn.vis;
 
     // insert the third argument
     let mut fn_inputs = item_fn.sig.inputs.clone();
@@ -605,7 +611,7 @@ fn sys_expand_async_host_func_with_two_args(item_fn: &syn::ItemFn) -> proc_macro
     let fn_block = &item_fn.block;
 
     let ret = quote!(
-        fn #fn_name_ident (#fn_inputs) -> Box<(dyn std::future::Future<Output = Result<Vec<WasmValue>, HostFuncError>> + Send + 'static)> {
+        #fn_visibility fn #fn_name_ident (#fn_inputs) -> Box<(dyn std::future::Future<Output = Result<Vec<WasmValue>, HostFuncError>> + Send + 'static)> {
             Box::new(async move {
                 #fn_block
             })

--- a/bindings/rust/wasmedge-sdk/Cargo.toml
+++ b/bindings/rust/wasmedge-sdk/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "wasmedge-sdk"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/WasmEdge/blob/master/bindings/rust/wasmedge-sdk"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/bindings/rust/wasmedge-sdk/examples/hello_world.rs
+++ b/bindings/rust/wasmedge-sdk/examples/hello_world.rs
@@ -10,7 +10,7 @@ use wasmedge_sdk::{
 // We define a function to act as our "env" "say_hello" function imported in the
 // Wasm program above.
 #[host_function]
-fn say_hello(caller: Caller, _args: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
+pub fn say_hello(caller: Caller, _args: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
     println!("Hello, world!");
 
     // get executor from caller

--- a/bindings/rust/wasmedge-sdk/examples/run_func_in_aot_mode.rs
+++ b/bindings/rust/wasmedge-sdk/examples/run_func_in_aot_mode.rs
@@ -1,0 +1,37 @@
+use wasmedge_sdk::{
+    config::{
+        CommonConfigOptions, CompilerConfigOptions, ConfigBuilder, HostRegistrationConfigOptions,
+    },
+    params, Compiler, CompilerOutputFormat, Vm, WasmVal,
+};
+
+#[cfg_attr(test, test)]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // create a Config context
+    let config = ConfigBuilder::new(CommonConfigOptions::new().bulk_memory_operations(true))
+        .with_compiler_config(
+            CompilerConfigOptions::new()
+                .interruptible(true)
+                .out_format(CompilerOutputFormat::Native),
+        )
+        .with_host_registration_config(HostRegistrationConfigOptions::default().wasi(true))
+        .build()?;
+
+    let wasm_file = std::path::PathBuf::from(env!("WASMEDGE_DIR"))
+        .join("bindings/rust/wasmedge-sys/tests/data/fibonacci.wasm");
+    let aot_file = std::path::PathBuf::from("fibonacci.wasm.so");
+
+    // compile wasm to so for runing in the `aot` mode
+    let compiler = Compiler::new(Some(&config))?;
+    compiler.compile_from_file(wasm_file, &aot_file)?;
+    assert!(&aot_file.exists());
+
+    let vm = Vm::new(Some(config))?;
+
+    let res = vm.run_func_from_file(&aot_file, "fib", params!(5))?;
+    println!("fib(5): {}", res[0].to_i32());
+
+    // remove the generated aot file
+    assert!(std::fs::remove_file(&aot_file).is_ok());
+    Ok(())
+}

--- a/bindings/rust/wasmedge-sdk/examples/run_func_in_aot_mode.rs
+++ b/bindings/rust/wasmedge-sdk/examples/run_func_in_aot_mode.rs
@@ -5,7 +5,6 @@ use wasmedge_sdk::{
     params, Compiler, CompilerOutputFormat, Vm, WasmVal,
 };
 
-#[cfg_attr(test, test)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // create a Config context
     let config = ConfigBuilder::new(CommonConfigOptions::new().bulk_memory_operations(true))

--- a/bindings/rust/wasmedge-sdk/examples/run_func_in_aot_mode.rs
+++ b/bindings/rust/wasmedge-sdk/examples/run_func_in_aot_mode.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let wasm_file = std::path::PathBuf::from(env!("WASMEDGE_DIR"))
         .join("bindings/rust/wasmedge-sys/tests/data/fibonacci.wasm");
-    let aot_file = std::path::PathBuf::from("fibonacci.wasm.so");
+    let aot_file = std::path::PathBuf::from("aot-fibonacci.wasm");
 
     // compile wasm to so for runing in the `aot` mode
     let compiler = Compiler::new(Some(&config))?;

--- a/bindings/rust/wasmedge-sdk/examples/run_func_in_aot_mode.rs
+++ b/bindings/rust/wasmedge-sdk/examples/run_func_in_aot_mode.rs
@@ -6,7 +6,6 @@ use wasmedge_sdk::{
     params, Compiler, CompilerOutputFormat, Vm, WasmVal,
 };
 
-#[cfg(target_family = "unix")]
 #[cfg_attr(test, test)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // create a Config context
@@ -32,6 +31,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert!(aot_file_path.ends_with("example_aot_fibonacci.dylib"));
     #[cfg(target_os = "linux")]
     assert!(aot_file_path.ends_with("example_aot_fibonacci.so"));
+    #[cfg(target_os = "windows")]
+    assert!(aot_file_path.ends_with("example_aot_fibonacci.dll"));
 
     let vm = Vm::new(Some(config))?;
 

--- a/bindings/rust/wasmedge-sdk/examples/run_func_in_aot_mode.rs
+++ b/bindings/rust/wasmedge-sdk/examples/run_func_in_aot_mode.rs
@@ -22,16 +22,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let wasm_file = std::path::PathBuf::from(env!("WASMEDGE_DIR"))
         .join("bindings/rust/wasmedge-sys/tests/data/fibonacci.wasm");
     let out_dir = std::env::current_dir()?;
-    let aot_filename = "aot_fibonacci";
+    let aot_filename = "example_aot_fibonacci";
 
     // compile wasm to so for runing in the `aot` mode
     let compiler = Compiler::new(Some(&config))?;
     let aot_file_path = compiler.compile_from_file(wasm_file, aot_filename, out_dir)?;
     assert!(&aot_file_path.exists());
     #[cfg(target_os = "macos")]
-    assert!(aot_file_path.ends_with("aot_fibonacci.dylib"));
+    assert!(aot_file_path.ends_with("example_aot_fibonacci.dylib"));
     #[cfg(target_os = "linux")]
-    assert!(aot_file_path.ends_with("aot_fibonacci.so"));
+    assert!(aot_file_path.ends_with("example_aot_fibonacci.so"));
 
     let vm = Vm::new(Some(config))?;
 

--- a/bindings/rust/wasmedge-sdk/examples/run_func_in_aot_mode.rs
+++ b/bindings/rust/wasmedge-sdk/examples/run_func_in_aot_mode.rs
@@ -1,3 +1,4 @@
+#[cfg(target_family = "unix")]
 use wasmedge_sdk::{
     config::{
         CommonConfigOptions, CompilerConfigOptions, ConfigBuilder, HostRegistrationConfigOptions,
@@ -5,6 +6,7 @@ use wasmedge_sdk::{
     params, Compiler, CompilerOutputFormat, Vm, WasmVal,
 };
 
+#[cfg(target_family = "unix")]
 #[cfg_attr(test, test)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // create a Config context

--- a/bindings/rust/wasmedge-sdk/examples/run_func_in_aot_mode.rs
+++ b/bindings/rust/wasmedge-sdk/examples/run_func_in_aot_mode.rs
@@ -1,4 +1,3 @@
-#[cfg(target_family = "unix")]
 use wasmedge_sdk::{
     config::{
         CommonConfigOptions, CompilerConfigOptions, ConfigBuilder, HostRegistrationConfigOptions,

--- a/bindings/rust/wasmedge-sdk/src/compiler.rs
+++ b/bindings/rust/wasmedge-sdk/src/compiler.rs
@@ -54,7 +54,7 @@ impl Compiler {
             .join(format!("{}.{}", filename.as_ref(), extension));
         self.inner.compile_from_file(wasm_file, &aot_file)?;
 
-        Ok(aot_file.to_path_buf())
+        Ok(aot_file)
     }
 
     /// Compiles the given wasm bytes into a shared library file (*.so in Linux, *.dylib in macOS, or *.dll in Windows). The file path of the generated shared library file will be returned if the method works successfully.
@@ -87,7 +87,7 @@ impl Compiler {
             .join(format!("{}.{}", filename.as_ref(), extension));
         self.inner.compile_from_bytes(bytes, &aot_file)?;
 
-        Ok(aot_file.to_path_buf())
+        Ok(aot_file)
     }
 }
 
@@ -122,7 +122,7 @@ mod tests {
         // read buffer
         let mut aot_file = std::fs::File::open(&aot_file_path)?;
         let mut buffer = [0u8; 4];
-        aot_file.read(&mut buffer)?;
+        aot_file.read_exact(&mut buffer)?;
         let wasm_magic: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];
         assert_ne!(buffer, wasm_magic);
 
@@ -224,7 +224,7 @@ mod tests {
         // read buffer
         let mut aot_file = std::fs::File::open(&aot_file_path)?;
         let mut buffer = [0u8; 4];
-        aot_file.read(&mut buffer)?;
+        aot_file.read_exact(&mut buffer)?;
         let wasm_magic: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];
         assert_ne!(buffer, wasm_magic);
 

--- a/bindings/rust/wasmedge-sdk/src/compiler.rs
+++ b/bindings/rust/wasmedge-sdk/src/compiler.rs
@@ -92,6 +92,7 @@ impl Compiler {
 }
 
 #[cfg(feature = "aot")]
+#[cfg(target_family = "unix")]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -114,10 +115,8 @@ mod tests {
         let wasm_file = std::path::PathBuf::from(env!("WASMEDGE_DIR"))
             .join("bindings/rust/wasmedge-sys/tests/data/fibonacci.wasm");
         let out_dir = std::env::current_dir()?;
-        let aot_filename = "aot_fibonacci";
+        let aot_filename = "aot_fibonacci_1";
         let aot_file_path = compiler.compile_from_file(wasm_file, aot_filename, out_dir)?;
-        assert!(aot_file_path.exists());
-        assert!(aot_file_path.ends_with("aot_fibonacci.dylib"));
 
         // read buffer
         let mut aot_file = std::fs::File::open(&aot_file_path)?;
@@ -148,15 +147,13 @@ mod tests {
         let wasm_file = std::path::PathBuf::from(env!("WASMEDGE_DIR"))
             .join("bindings/rust/wasmedge-sys/tests/data/fibonacci.wasm");
         let out_dir = std::env::current_dir()?;
-        let aot_filename = "aot_fibonacci";
+        let aot_filename = "aot_fibonacci_1";
         let aot_file_path = compiler.compile_from_file(wasm_file, aot_filename, out_dir)?;
-        assert!(aot_file_path.exists());
-        assert!(aot_file_path.ends_with("aot_fibonacci.so"));
 
         // read buffer
         let mut aot_file = std::fs::File::open(&aot_file_path)?;
         let mut buffer = [0u8; 4];
-        aot_file.read(&mut buffer)?;
+        aot_file.read_exact(&mut buffer)?;
         let wasm_magic: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];
         assert_ne!(buffer, wasm_magic);
 
@@ -216,10 +213,8 @@ mod tests {
 
         // compile wasm bytes into a shared library file
         let out_dir = std::env::current_dir()?;
-        let aot_filename = "aot_fibonacci";
+        let aot_filename = "aot_fibonacci_2";
         let aot_file_path = compiler.compile_from_bytes(wasm_bytes, aot_filename, out_dir)?;
-        assert!(aot_file_path.exists());
-        assert!(aot_file_path.ends_with("aot_fibonacci.dylib"));
 
         // read buffer
         let mut aot_file = std::fs::File::open(&aot_file_path)?;
@@ -284,15 +279,13 @@ mod tests {
 
         // compile wasm bytes into a shared library file
         let out_dir = std::env::current_dir()?;
-        let aot_filename = "aot_fibonacci";
+        let aot_filename = "aot_fibonacci_2";
         let aot_file_path = compiler.compile_from_bytes(wasm_bytes, aot_filename, out_dir)?;
-        assert!(aot_file_path.exists());
-        assert!(aot_file_path.ends_with("aot_fibonacci.so"));
 
         // read buffer
         let mut aot_file = std::fs::File::open(&aot_file_path)?;
         let mut buffer = [0u8; 4];
-        aot_file.read(&mut buffer)?;
+        aot_file.read_exact(&mut buffer)?;
         let wasm_magic: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];
         assert_ne!(buffer, wasm_magic);
 

--- a/bindings/rust/wasmedge-sys/Cargo.toml
+++ b/bindings/rust/wasmedge-sys/Cargo.toml
@@ -10,7 +10,7 @@ links = "wasmedge"
 name = "wasmedge-sys"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/WasmEdge/blob/master/bindings/rust/wasmedge-sys"
-version = "0.11.0"
+version = "0.11.1"
 
 [dependencies]
 lazy_static = "1.4.0"

--- a/bindings/rust/wasmedge-sys/src/compiler.rs
+++ b/bindings/rust/wasmedge-sys/src/compiler.rs
@@ -155,6 +155,8 @@ mod tests {
             #[cfg(target_os = "macos")]
             let out_path = std::path::PathBuf::from("test_aot.dylib");
             assert!(!out_path.exists());
+            #[cfg(target_os = "windows")]
+            let out_path = std::path::PathBuf::from("test_aot.dll");
             let result = compiler.compile_from_file(in_path, &out_path);
             assert!(result.is_ok());
             assert!(out_path.exists());
@@ -187,6 +189,8 @@ mod tests {
             let out_path = std::path::PathBuf::from("test_aot_from_file.so");
             #[cfg(target_os = "macos")]
             let out_path = std::path::PathBuf::from("test_aot_from_file.dylib");
+            #[cfg(target_os = "windows")]
+            let out_path = std::path::PathBuf::from("test_aot_from_file.dll");
             assert!(!out_path.exists());
             let result = compiler.compile_from_file(in_path, &out_path);
             assert!(result.is_ok());
@@ -256,6 +260,8 @@ mod tests {
             let out_path = std::path::PathBuf::from("test_aot_from_bytes.so");
             #[cfg(target_os = "macos")]
             let out_path = std::path::PathBuf::from("test_aot_from_bytes.dylib");
+            #[cfg(target_os = "windows")]
+            let out_path = std::path::PathBuf::from("test_aot_from_bytes.dll");
             assert!(!out_path.exists());
             let result = compiler.compile_from_bytes(wasm_bytes, &out_path);
             assert!(result.is_ok());
@@ -291,6 +297,8 @@ mod tests {
             let out_path = std::path::PathBuf::from("test_aot_fib_send.so");
             #[cfg(target_os = "macos")]
             let out_path = std::path::PathBuf::from("test_aot_fib_send.dylib");
+            #[cfg(target_os = "windows")]
+            let out_path = std::path::PathBuf::from("test_aot_fib_send.dll");
             assert!(!out_path.exists());
             let result = compiler.compile_from_file(in_path, &out_path);
             assert!(result.is_ok());
@@ -346,6 +354,8 @@ mod tests {
             let out_path = std::path::PathBuf::from("test_aot_fib_sync.so");
             #[cfg(target_os = "macos")]
             let out_path = std::path::PathBuf::from("test_aot_fib_sync.dylib");
+            #[cfg(target_os = "windows")]
+            let out_path = std::path::PathBuf::from("test_aot_fib_sync.dll");
             assert!(!out_path.exists());
             let result = compiler_main.compile_from_file(in_path, &out_path);
             assert!(result.is_ok());

--- a/bindings/rust/wasmedge-sys/src/compiler.rs
+++ b/bindings/rust/wasmedge-sys/src/compiler.rs
@@ -150,7 +150,10 @@ mod tests {
             // compile a file for universal WASM output format
             let in_path = std::path::PathBuf::from(env!("WASMEDGE_DIR"))
                 .join("bindings/rust/wasmedge-sys/tests/data/test.wasm");
-            let out_path = std::path::PathBuf::from("test_aot.wasm");
+            #[cfg(target_os = "linux")]
+            let out_path = std::path::PathBuf::from("test_aot.so");
+            #[cfg(target_os = "macos")]
+            let out_path = std::path::PathBuf::from("test_aot.dylib");
             assert!(!out_path.exists());
             let result = compiler.compile_from_file(in_path, &out_path);
             assert!(result.is_ok());
@@ -180,7 +183,10 @@ mod tests {
             let compiler = result.unwrap();
             let in_path = std::path::PathBuf::from(env!("WASMEDGE_DIR"))
                 .join("bindings/rust/wasmedge-sys/tests/data/test.wasm");
+            #[cfg(target_os = "linux")]
             let out_path = std::path::PathBuf::from("test_aot_from_file.so");
+            #[cfg(target_os = "macos")]
+            let out_path = std::path::PathBuf::from("test_aot_from_file.dylib");
             assert!(!out_path.exists());
             let result = compiler.compile_from_file(in_path, &out_path);
             assert!(result.is_ok());
@@ -246,8 +252,10 @@ mod tests {
             let result = Compiler::create(Some(config));
             assert!(result.is_ok());
             let compiler = result.unwrap();
-
+            #[cfg(target_os = "linux")]
             let out_path = std::path::PathBuf::from("test_aot_from_bytes.so");
+            #[cfg(target_os = "macos")]
+            let out_path = std::path::PathBuf::from("test_aot_from_bytes.dylib");
             assert!(!out_path.exists());
             let result = compiler.compile_from_bytes(wasm_bytes, &out_path);
             assert!(result.is_ok());
@@ -279,7 +287,10 @@ mod tests {
             // compile a file for universal WASM output format
             let in_path = std::path::PathBuf::from(env!("WASMEDGE_DIR"))
                 .join("bindings/rust/wasmedge-sys/examples/data/fibonacci.wasm");
-            let out_path = std::path::PathBuf::from("fibonacci_send_thread_aot.wasm");
+            #[cfg(target_os = "linux")]
+            let out_path = std::path::PathBuf::from("test_aot_fib_send.so");
+            #[cfg(target_os = "macos")]
+            let out_path = std::path::PathBuf::from("test_aot_fib_send.dylib");
             assert!(!out_path.exists());
             let result = compiler.compile_from_file(in_path, &out_path);
             assert!(result.is_ok());
@@ -331,7 +342,10 @@ mod tests {
             // compile a file for universal WASM output format
             let in_path = std::path::PathBuf::from(env!("WASMEDGE_DIR"))
                 .join("bindings/rust/wasmedge-sys/examples/data/fibonacci.wasm");
-            let out_path = std::path::PathBuf::from("fibonacci_sync_main_aot.wasm");
+            #[cfg(target_os = "linux")]
+            let out_path = std::path::PathBuf::from("test_aot_fib_sync.so");
+            #[cfg(target_os = "macos")]
+            let out_path = std::path::PathBuf::from("test_aot_fib_sync.dylib");
             assert!(!out_path.exists());
             let result = compiler_main.compile_from_file(in_path, &out_path);
             assert!(result.is_ok());

--- a/bindings/rust/wasmedge-sys/src/compiler.rs
+++ b/bindings/rust/wasmedge-sys/src/compiler.rs
@@ -25,10 +25,7 @@ impl Compiler {
     #[cfg(feature = "aot")]
     pub fn create(config: Option<Config>) -> WasmEdgeResult<Self> {
         let ctx = match config {
-            Some(config) => {
-                let ctx = unsafe { ffi::WasmEdge_CompilerCreate(config.inner.0) };
-                ctx
-            }
+            Some(config) => unsafe { ffi::WasmEdge_CompilerCreate(config.inner.0) },
             None => unsafe { ffi::WasmEdge_CompilerCreate(std::ptr::null_mut()) },
         };
 

--- a/bindings/rust/wasmedge-sys/src/compiler.rs
+++ b/bindings/rust/wasmedge-sys/src/compiler.rs
@@ -25,12 +25,8 @@ impl Compiler {
     #[cfg(feature = "aot")]
     pub fn create(config: Option<Config>) -> WasmEdgeResult<Self> {
         let ctx = match config {
-            Some(mut config) => {
+            Some(config) => {
                 let ctx = unsafe { ffi::WasmEdge_CompilerCreate(config.inner.0) };
-
-                let inner_config = &mut *std::sync::Arc::get_mut(&mut config.inner).unwrap();
-                inner_config.0 = std::ptr::null_mut();
-
                 ctx
             }
             None => unsafe { ffi::WasmEdge_CompilerCreate(std::ptr::null_mut()) },

--- a/bindings/rust/wasmedge-sys/src/compiler.rs
+++ b/bindings/rust/wasmedge-sys/src/compiler.rs
@@ -154,9 +154,9 @@ mod tests {
             let out_path = std::path::PathBuf::from("test_aot.so");
             #[cfg(target_os = "macos")]
             let out_path = std::path::PathBuf::from("test_aot.dylib");
-            assert!(!out_path.exists());
             #[cfg(target_os = "windows")]
             let out_path = std::path::PathBuf::from("test_aot.dll");
+            assert!(!out_path.exists());
             let result = compiler.compile_from_file(in_path, &out_path);
             assert!(result.is_ok());
             assert!(out_path.exists());


### PR DESCRIPTION
In this PR, a critical bug in the `create` method of `wasmedge_sys::Compiler` is fixed. The version of `wasmedge-sys` bumps to `0.11.1`.  