### PR TITLE
[Rust] Support wat files

### DIFF
--- a/bindings/rust/wasmedge-sdk/examples/async_hello_world.rs
+++ b/bindings/rust/wasmedge-sdk/examples/async_hello_world.rs
@@ -3,7 +3,7 @@ use wasmedge_sdk::{
 };
 
 #[async_host_function]
-fn say_hello(caller: Caller, _args: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
+async fn say_hello(caller: Caller, _args: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     println!("Hello, world!");
 

--- a/bindings/rust/wasmedge-sdk/src/module.rs
+++ b/bindings/rust/wasmedge-sdk/src/module.rs
@@ -27,7 +27,7 @@ impl Module {
     pub fn from_file(config: Option<&Config>, file: impl AsRef<Path>) -> WasmEdgeResult<Self> {
         match file.as_ref().extension() {
             Some(extension) => match extension.to_str() {
-                Some("wasm") => {
+                Some("wasm") | Some("so") => {
                     let inner_config = config.map(|c| c.inner.clone());
                     let inner_loader = sys::Loader::create(inner_config)?;
                     // load module

--- a/bindings/rust/wasmedge-sdk/src/module.rs
+++ b/bindings/rust/wasmedge-sdk/src/module.rs
@@ -17,9 +17,9 @@ impl Module {
     ///
     /// # Arguments
     ///
-    /// - `config` specifies a global configuration.
+    /// * `config` - The global configuration.
     ///
-    /// - `file` specifies the path to the target WASM file.
+    /// * `file` - The `wasm` or `wat` file.
     ///
     /// # Error
     ///
@@ -59,9 +59,9 @@ impl Module {
     ///
     /// # Arguments
     ///
-    /// - `config` specifies a global configuration.
+    /// * `config` - The global configuration.
     ///
-    /// - `bytes` specifies the in-memory bytes to be parsed.
+    /// * `bytes` - The in-memory bytes to be parsed.
     ///
     /// # Error
     ///
@@ -120,7 +120,7 @@ impl Module {
     ///
     /// # Argument
     ///
-    /// - `name` specifies the name of the target exported WasmEdge instance.
+    /// * `name` - The name of the target exported WasmEdge instance.
     pub fn get_export(&self, name: impl AsRef<str>) -> Option<ExternalInstanceType> {
         let exports = self
             .exports()

--- a/bindings/rust/wasmedge-sdk/src/module.rs
+++ b/bindings/rust/wasmedge-sdk/src/module.rs
@@ -43,7 +43,7 @@ impl Module {
                 Some("wat") => {
                     let bytes = wat::parse_file(file.as_ref())
                         .map_err(|_| WasmEdgeError::Operation("Failed to parse wat file".into()))?;
-                    Self::from_bytes(config, &bytes)
+                    Self::from_bytes(config, bytes)
                 }
                 _ => Err(Box::new(WasmEdgeError::Operation(
                     "Invalid file extension".into(),

--- a/bindings/rust/wasmedge-sdk/src/module.rs
+++ b/bindings/rust/wasmedge-sdk/src/module.rs
@@ -31,9 +31,9 @@ impl Module {
                 #[cfg(target_os = "macos")]
                 Some("dylib") => Module::from_wasm_or_aot_file(config, &file),
                 #[cfg(target_os = "linux")]
-                Some("so") => Module::from_aot_file(config, &file),
+                Some("so") => Module::from_wasm_or_aot_file(config, &file),
                 #[cfg(target_os = "windows")]
-                Some("dll") => Module::from_aot_file(config, &file),
+                Some("dll") => Module::from_wasm_or_aot_file(config, &file),
                 Some("wat") => {
                     let bytes = wat::parse_file(file.as_ref())
                         .map_err(|_| WasmEdgeError::Operation("Failed to parse wat file".into()))?;

--- a/bindings/rust/wasmedge-sdk/src/module.rs
+++ b/bindings/rust/wasmedge-sdk/src/module.rs
@@ -3,6 +3,7 @@
 use crate::{config::Config, ExternalInstanceType, WasmEdgeResult};
 use std::{borrow::Cow, marker::PhantomData, path::Path};
 use wasmedge_sys as sys;
+use wasmedge_types::error::WasmEdgeError;
 
 /// Defines compiled in-memory representation of an input WASM binary.
 ///
@@ -24,17 +25,34 @@ impl Module {
     ///
     /// If fail to load and valiate a module from a file, returns an error.
     pub fn from_file(config: Option<&Config>, file: impl AsRef<Path>) -> WasmEdgeResult<Self> {
-        let inner_config = config.map(|c| c.inner.clone());
-        let inner_loader = sys::Loader::create(inner_config)?;
-        // load module
-        let inner = inner_loader.from_file(file.as_ref())?;
+        match file.as_ref().extension() {
+            Some(extension) => match extension.to_str() {
+                Some("wasm") => {
+                    let inner_config = config.map(|c| c.inner.clone());
+                    let inner_loader = sys::Loader::create(inner_config)?;
+                    // load module
+                    let inner = inner_loader.from_file(file.as_ref())?;
 
-        let inner_config = config.map(|c| c.inner.clone());
-        let inner_validator = sys::Validator::create(inner_config)?;
-        // validate module
-        inner_validator.validate(&inner)?;
+                    let inner_config = config.map(|c| c.inner.clone());
+                    let inner_validator = sys::Validator::create(inner_config)?;
+                    // validate module
+                    inner_validator.validate(&inner)?;
 
-        Ok(Self { inner })
+                    Ok(Self { inner })
+                }
+                Some("wat") => {
+                    let bytes = wat::parse_file(file.as_ref())
+                        .map_err(|_| WasmEdgeError::Operation("Failed to parse wat file".into()))?;
+                    Self::from_bytes(config, &bytes)
+                }
+                _ => Err(Box::new(WasmEdgeError::Operation(
+                    "Invalid file extension".into(),
+                ))),
+            },
+            None => Err(Box::new(WasmEdgeError::Operation(
+                "Invalid file extension".into(),
+            ))),
+        }
     }
 
     /// Loads a WebAssembly binary module from in-memory bytes.
@@ -169,7 +187,7 @@ mod tests {
 
     #[test]
     #[allow(clippy::assertions_on_result_states)]
-    fn test_module_from_file() {
+    fn test_module_from_wasm() {
         // load wasm module from a specified wasm file
         let file = std::path::PathBuf::from(env!("WASMEDGE_DIR"))
             .join("bindings/rust/wasmedge-sys/tests/data/fibonacci.wasm");
@@ -186,6 +204,17 @@ mod tests {
                 CoreLoadError::IllegalPath
             )))
         );
+    }
+
+    #[test]
+    #[allow(clippy::assertions_on_result_states)]
+    fn test_module_from_wat() {
+        // load wasm module from a specified wasm file
+        let file = std::path::PathBuf::from(env!("WASMEDGE_DIR"))
+            .join("bindings/rust/wasmedge-sys/tests/data/fibonacci.wat");
+
+        let result = Module::from_file(None, file);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/bindings/rust/wasmedge-sdk/src/vm.rs
+++ b/bindings/rust/wasmedge-sdk/src/vm.rs
@@ -133,7 +133,25 @@ impl Vm {
     ) -> WasmEdgeResult<Self> {
         match file.as_ref().extension() {
             Some(extension) => match extension.to_str() {
-                Some("wasm") | Some("so") => {
+                Some("wasm") => {
+                    self.inner
+                        .register_wasm_from_file(mod_name, file.as_ref())?;
+                    Ok(self)
+                }
+                #[cfg(target_os = "macos")]
+                Some("dylib") => {
+                    self.inner
+                        .register_wasm_from_file(mod_name, file.as_ref())?;
+                    Ok(self)
+                }
+                #[cfg(target_os = "linux")]
+                Some("so") => {
+                    self.inner
+                        .register_wasm_from_file(mod_name, file.as_ref())?;
+                    Ok(self)
+                }
+                #[cfg(target_os = "windows")]
+                Some("dll") => {
                     self.inner
                         .register_wasm_from_file(mod_name, file.as_ref())?;
                     Ok(self)
@@ -356,7 +374,22 @@ impl Vm {
     ) -> WasmEdgeResult<Vec<WasmValue>> {
         match file.as_ref().extension() {
             Some(extension) => match extension.to_str() {
-                Some("wasm") | Some("so") => {
+                Some("wasm") => {
+                    self.inner
+                        .run_wasm_from_file(file.as_ref(), func_name.as_ref(), args)
+                }
+                #[cfg(target_os = "macos")]
+                Some("dylib") => {
+                    self.inner
+                        .run_wasm_from_file(file.as_ref(), func_name.as_ref(), args)
+                }
+                #[cfg(target_os = "linux")]
+                Some("so") => {
+                    self.inner
+                        .run_wasm_from_file(file.as_ref(), func_name.as_ref(), args)
+                }
+                #[cfg(target_os = "windows")]
+                Some("dll") => {
                     self.inner
                         .run_wasm_from_file(file.as_ref(), func_name.as_ref(), args)
                 }
@@ -401,7 +434,25 @@ impl Vm {
     {
         match file.as_ref().extension() {
             Some(extension) => match extension.to_str() {
-                Some("wasm") | Some("so") => {
+                Some("wasm") => {
+                    self.inner
+                        .run_wasm_from_file_async(file.as_ref(), func_name.as_ref(), args)
+                        .await
+                }
+                #[cfg(target_os = "macos")]
+                Some("dylib") => {
+                    self.inner
+                        .run_wasm_from_file_async(file.as_ref(), func_name.as_ref(), args)
+                        .await
+                }
+                #[cfg(target_os = "linux")]
+                Some("so") => {
+                    self.inner
+                        .run_wasm_from_file_async(file.as_ref(), func_name.as_ref(), args)
+                        .await
+                }
+                #[cfg(target_os = "windows")]
+                Some("dll") => {
                     self.inner
                         .run_wasm_from_file_async(file.as_ref(), func_name.as_ref(), args)
                         .await

--- a/bindings/rust/wasmedge-sdk/src/vm.rs
+++ b/bindings/rust/wasmedge-sdk/src/vm.rs
@@ -133,7 +133,7 @@ impl Vm {
     ) -> WasmEdgeResult<Self> {
         match file.as_ref().extension() {
             Some(extension) => match extension.to_str() {
-                Some("wasm") => {
+                Some("wasm") | Some("so") => {
                     self.inner
                         .register_wasm_from_file(mod_name, file.as_ref())?;
                     Ok(self)
@@ -356,7 +356,7 @@ impl Vm {
     ) -> WasmEdgeResult<Vec<WasmValue>> {
         match file.as_ref().extension() {
             Some(extension) => match extension.to_str() {
-                Some("wasm") => {
+                Some("wasm") | Some("so") => {
                     self.inner
                         .run_wasm_from_file(file.as_ref(), func_name.as_ref(), args)
                 }
@@ -401,7 +401,7 @@ impl Vm {
     {
         match file.as_ref().extension() {
             Some(extension) => match extension.to_str() {
-                Some("wasm") => {
+                Some("wasm") | Some("so") => {
                     self.inner
                         .run_wasm_from_file_async(file.as_ref(), func_name.as_ref(), args)
                         .await

--- a/bindings/rust/wasmedge-sdk/src/vm.rs
+++ b/bindings/rust/wasmedge-sdk/src/vm.rs
@@ -121,7 +121,7 @@ impl Vm {
     ///
     /// * `mod_name` - The name for the WASM module to be registered.
     ///
-    /// * `file` - The target WASM file.
+    /// * `file` - The `wasm` or `wat` file.
     ///
     /// # Error
     ///
@@ -339,7 +339,7 @@ impl Vm {
     ///
     /// # Arguments
     ///
-    /// * `file` - The WASM file.
+    /// * `file` - The `wasm` or `wat` file.
     ///
     /// * `func_name` - The name of the target exported function to run.
     ///
@@ -379,7 +379,7 @@ impl Vm {
     ///
     /// # Arguments
     ///
-    /// * `file` - The WASM file.
+    /// * `file` - The `wasm` or `wat` file.
     ///
     /// * `func_name` - The name of the target exported function to run.
     ///
@@ -1106,21 +1106,41 @@ mod tests {
     #[test]
     #[allow(clippy::assertions_on_result_states)]
     fn test_vm_register_module_from_file() {
-        // create a Vm context
-        let result = Vm::new(None);
-        assert!(result.is_ok());
-        let vm = result.unwrap();
+        {
+            // create a Vm context
+            let result = Vm::new(None);
+            assert!(result.is_ok());
+            let vm = result.unwrap();
 
-        // register a wasm module from a specified wasm file
-        let file = std::path::PathBuf::from(env!("WASMEDGE_DIR"))
-            .join("bindings/rust/wasmedge-sys/tests/data/fibonacci.wasm");
-        let result = vm.register_module_from_file("extern", file);
-        assert!(result.is_ok());
-        let vm = result.unwrap();
+            // register a wasm module from a specified wasm file
+            let file = std::path::PathBuf::from(env!("WASMEDGE_DIR"))
+                .join("bindings/rust/wasmedge-sys/tests/data/fibonacci.wasm");
+            let result = vm.register_module_from_file("extern", file);
+            assert!(result.is_ok());
+            let vm = result.unwrap();
 
-        assert_eq!(vm.named_instance_count().unwrap(), 1);
-        assert!(vm.instance_names().is_ok());
-        assert_eq!(vm.instance_names().unwrap(), ["extern"]);
+            assert_eq!(vm.named_instance_count().unwrap(), 1);
+            assert!(vm.instance_names().is_ok());
+            assert_eq!(vm.instance_names().unwrap(), ["extern"]);
+        }
+
+        {
+            // create a Vm context
+            let result = Vm::new(None);
+            assert!(result.is_ok());
+            let vm = result.unwrap();
+
+            // register a wasm module from a specified wasm file
+            let file = std::path::PathBuf::from(env!("WASMEDGE_DIR"))
+                .join("bindings/rust/wasmedge-sys/tests/data/fibonacci.wat");
+            let result = vm.register_module_from_file("extern", file);
+            assert!(result.is_ok());
+            let vm = result.unwrap();
+
+            assert_eq!(vm.named_instance_count().unwrap(), 1);
+            assert!(vm.instance_names().is_ok());
+            assert_eq!(vm.instance_names().unwrap(), ["extern"]);
+        }
     }
 
     #[test]

--- a/bindings/rust/wasmedge-sdk/src/vm.rs
+++ b/bindings/rust/wasmedge-sdk/src/vm.rs
@@ -388,7 +388,7 @@ impl Vm {
     /// # Error
     ///
     /// If fail to run, then an error is returned.
-    pub async fn run_wasm_from_file_async<P, N, A>(
+    pub async fn run_func_from_file_async<P, N, A>(
         &self,
         file: P,
         func_name: N,

--- a/bindings/rust/wasmedge-sys/examples/async_run_registered_func.rs
+++ b/bindings/rust/wasmedge-sys/examples/async_run_registered_func.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // create a Vm context with the given Config and Store
     let result = Vm::create(Some(config), Some(&mut store));
     assert!(result.is_ok());
-    let mut vm = result.unwrap();
+    let vm = result.unwrap();
 
     // register a wasm module from a buffer
     let path = std::path::PathBuf::from(env!("WASMEDGE_DIR"))

--- a/bindings/rust/wasmedge-sys/examples/fibonacci.rs
+++ b/bindings/rust/wasmedge-sys/examples/fibonacci.rs
@@ -40,7 +40,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // create a Vm instance
-    let mut vm = Vm::create(None, None)?;
+    let vm = Vm::create(None, None)?;
 
     // register the wasm bytes
     let module_name = "extern-module";

--- a/bindings/rust/wasmedge-sys/examples/store_get_named_module.rs
+++ b/bindings/rust/wasmedge-sys/examples/store_get_named_module.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut store = Store::create()?;
 
     // create a Vm context with the given Config and Store
-    let mut vm = Vm::create(Some(config), Some(&mut store))?;
+    let vm = Vm::create(Some(config), Some(&mut store))?;
 
     // register a wasm module from a in-memory wasm bytes.
     vm.register_wasm_from_bytes("extern", &wasm_bytes)?;

--- a/bindings/rust/wasmedge-sys/src/vm.rs
+++ b/bindings/rust/wasmedge-sys/src/vm.rs
@@ -234,7 +234,7 @@ impl Vm {
     ///
     /// If fail to register the WASM module, then an error is returned.
     pub fn register_wasm_from_bytes(
-        &mut self,
+        &self,
         mod_name: impl AsRef<str>,
         bytes: &[u8],
     ) -> WasmEdgeResult<()> {
@@ -271,7 +271,7 @@ impl Vm {
     ///
     /// If fail to register the WASM module, then an error is returned.
     pub fn register_wasm_from_module(
-        &mut self,
+        &self,
         mod_name: impl AsRef<str>,
         mut module: Module,
     ) -> WasmEdgeResult<()> {
@@ -1615,7 +1615,7 @@ mod tests {
         // create a Vm context with the given Config and Store
         let result = Vm::create(Some(config), Some(&mut store));
         assert!(result.is_ok());
-        let mut vm = result.unwrap();
+        let vm = result.unwrap();
 
         // create a loader
         let result = Config::create();
@@ -1782,7 +1782,7 @@ mod tests {
         // create a Vm context with the given Config and Store
         let result = Vm::create(Some(config), Some(&mut store));
         assert!(result.is_ok());
-        let mut vm = result.unwrap();
+        let vm = result.unwrap();
 
         // register a wasm module from a buffer
         let path = std::path::PathBuf::from(env!("WASMEDGE_DIR"))


### PR DESCRIPTION
In this PR, some new APIs are introduced into `Vm` and `Module` of `wasmedge-sdk` to support `wat` files. In addition, improve the implementation of some APIs in `Vm` to support `AOT` files.