### PR TITLE
[Rust] Add standalone feature

### DIFF
--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Nightly Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly
           components: rustfmt, clippy
@@ -95,7 +95,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly
           components: rustfmt, clippy
@@ -166,7 +166,7 @@ jobs:
           sdk-version: 19041
 
       - name: Install Nightly Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly
           components: rustfmt, clippy

--- a/.github/workflows/rust-standalone.yml
+++ b/.github/workflows/rust-standalone.yml
@@ -1,0 +1,51 @@
+name: rust-standalone-test
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - master
+      - "rust/*"
+    paths:
+      - ".github/workflows/rust-standalone.yml"
+      - "bindings/rust/**"
+      - "include/api/wasmedge/**"
+      - "lib/api/**"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/rust-standalone.yml"
+      - "bindings/rust/**"
+      - "include/api/wasmedge/**"
+      - "lib/api/**"
+
+jobs:
+  build_ubuntu:
+    name: Ubuntu
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
+    container:
+      image: wasmedge/wasmedge:ubuntu-build-clang
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Nightly Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt, clippy
+
+      - name: Install libwasmedge
+        working-directory: bindings/rust/
+        run: |
+          export WASMEDGE_DIR="$(pwd)/../../"
+          cargo +nightly test -p wasmedge-sdk --all --examples --features standalone

--- a/.github/workflows/rust-standalone.yml
+++ b/.github/workflows/rust-standalone.yml
@@ -49,3 +49,35 @@ jobs:
         run: |
           export WASMEDGE_DIR="$(pwd)/../../"
           cargo +nightly test -p wasmedge-sdk --all --examples --features standalone
+
+  build_macos:
+    name: MacOS
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-11, macos-12]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly
+          components: rustfmt, clippy
+
+      - name: Install build tools
+        run: brew install llvm@14 ninja boost cmake
+
+      - name: Install libwasmedge
+        working-directory: bindings/rust/
+        run: |
+          export LLVM_DIR="/usr/local/opt/llvm@14/lib/cmake"
+          export CC=clang
+          export CXX=clang++
+          export DYLD_LIBRARY_PATH="/Users/runner/.wasmedge/lib"
+          export WASMEDGE_DIR="$(pwd)/../../"
+          cargo +nightly test -p wasmedge-sdk --all --examples --features standalone

--- a/.github/workflows/rust-standalone.yml
+++ b/.github/workflows/rust-standalone.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Nightly Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain
         with:
           toolchain: nightly
           components: rustfmt, clippy

--- a/.github/workflows/rust-standalone.yml
+++ b/.github/workflows/rust-standalone.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Nightly Rust
-        uses: dtolnay/rust-toolchain
+        uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly
           components: rustfmt, clippy

--- a/.github/workflows/rust-wasmedge-macro-release.yml
+++ b/.github/workflows/rust-wasmedge-macro-release.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Set up build environment
         run: |
           sudo apt-get update
-          sudo apt-get install -y software-properties-common libboost-all-dev llvm-12-dev liblld-12-dev ninja-build
-          sudo apt-get install -y gcc g++ clang-12
+          sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
+          sudo apt-get install -y llvm-14-dev liblld-14-dev clang-14
+          sudo apt-get install -y gcc g++
           sudo apt-get install -y libssl-dev pkg-config gh
 
       - name: Install Rust toolchain

--- a/.github/workflows/rust-wasmedge-macro-release.yml
+++ b/.github/workflows/rust-wasmedge-macro-release.yml
@@ -28,7 +28,7 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config gh
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly
           profile: minimal

--- a/.github/workflows/rust-wasmedge-sdk-release.yml
+++ b/.github/workflows/rust-wasmedge-sdk-release.yml
@@ -28,7 +28,7 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config gh
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly
           profile: minimal

--- a/.github/workflows/rust-wasmedge-sys-release.yml
+++ b/.github/workflows/rust-wasmedge-sys-release.yml
@@ -28,7 +28,7 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config gh
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly
           profile: minimal

--- a/.github/workflows/rust-wasmedge-types-release.yml
+++ b/.github/workflows/rust-wasmedge-types-release.yml
@@ -28,7 +28,7 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config gh
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly
           profile: minimal

--- a/.github/workflows/rust-wasmedge-types-release.yml
+++ b/.github/workflows/rust-wasmedge-types-release.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Set up build environment
         run: |
           sudo apt-get update
-          sudo apt-get install -y software-properties-common cmake libboost-all-dev llvm-12-dev liblld-12-dev ninja-build
-          sudo apt-get install -y gcc g++ clang-12
+          sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
+          sudo apt-get install -y llvm-14-dev liblld-14-dev clang-14
+          sudo apt-get install -y gcc g++
           sudo apt-get install -y libssl-dev pkg-config gh
 
       - name: Install Rust toolchain

--- a/bindings/rust/wasmedge-sdk/Cargo.toml
+++ b/bindings/rust/wasmedge-sdk/Cargo.toml
@@ -21,6 +21,7 @@ wat = "1.0"
 [features]
 aot = ["wasmedge-sys/aot"]
 default = ["aot"]
+standalone = ["wasmedge-sys/standalone"]
 wasi_crypto = ["wasmedge-sys/wasi_crypto"]
 wasi_nn = ["wasmedge-sys/wasi_nn"]
 

--- a/bindings/rust/wasmedge-sdk/Cargo.toml
+++ b/bindings/rust/wasmedge-sdk/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.7.0"
 anyhow = "1.0"
 thiserror = "1.0.30"
 wasmedge-macro = {path = "../wasmedge-macro", version = "0.2"}
-wasmedge-sys = {path = "../wasmedge-sys", version = "0.11", default-features = false}
+wasmedge-sys = {path = "../wasmedge-sys", version = "0.12", default-features = false}
 wasmedge-types = {path = "../wasmedge-types", version = "0.3"}
 wat = "1.0"
 

--- a/bindings/rust/wasmedge-sdk/src/executor.rs
+++ b/bindings/rust/wasmedge-sdk/src/executor.rs
@@ -39,11 +39,6 @@ impl Executor {
         })
     }
 }
-impl From<sys::Executor> for Executor {
-    fn from(v: sys::Executor) -> Self {
-        Executor { inner: v }
-    }
-}
 impl Engine for Executor {
     fn run_func(
         &self,

--- a/bindings/rust/wasmedge-sys/Cargo.toml
+++ b/bindings/rust/wasmedge-sys/Cargo.toml
@@ -34,5 +34,6 @@ tokio = {version = "1", features = ["full"]}
 [features]
 aot = []
 default = ["aot"]
+standalone = []
 wasi_crypto = []
 wasi_nn = []

--- a/bindings/rust/wasmedge-sys/Cargo.toml
+++ b/bindings/rust/wasmedge-sys/Cargo.toml
@@ -10,7 +10,7 @@ links = "wasmedge"
 name = "wasmedge-sys"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/WasmEdge/blob/master/bindings/rust/wasmedge-sys"
-version = "0.11.1"
+version = "0.12.0"
 
 [dependencies]
 lazy_static = "1.4.0"

--- a/bindings/rust/wasmedge-sys/build.rs
+++ b/bindings/rust/wasmedge-sys/build.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
-#[cfg(all(feature = "standalone", target_os = "lunix"))]
+#[cfg(all(feature = "standalone", target_os = "linux"))]
 use std::{env, process::Command};
 
 const WASMEDGE_H: &str = "wasmedge.h";
-#[cfg(all(feature = "standalone", target_os = "lunix"))]
+#[cfg(all(feature = "standalone", target_os = "linux"))]
 const WASMEDGE_RELEASE_VERSION: &str = "0.11.2";
 
 macro_rules! env_path {
@@ -20,7 +20,7 @@ struct Paths {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    #[cfg(all(feature = "standalone", target_os = "lunix"))]
+    #[cfg(all(feature = "standalone", target_os = "linux"))]
     install_libwasmedge();
 
     let Paths {
@@ -185,7 +185,7 @@ fn find_wasmedge() -> Option<Paths> {
     None
 }
 
-#[cfg(all(feature = "standalone", target_os = "lunix"))]
+#[cfg(all(feature = "standalone", target_os = "linux"))]
 fn install_libwasmedge() {
     let out_dir = env::var("OUT_DIR").expect("[wasmedge-sys] Failed to get OUT_DIR");
     println!("cargo:warning=[wasmedge-sys] OUT_DIR: {}", &out_dir);

--- a/bindings/rust/wasmedge-sys/build.rs
+++ b/bindings/rust/wasmedge-sys/build.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
-#[cfg(all(feature = "standalone", target_os = "linux"))]
+#[cfg(all(feature = "standalone", target_family = "unix"))]
 use std::{env, process::Command};
 
 const WASMEDGE_H: &str = "wasmedge.h";
-#[cfg(all(feature = "standalone", target_os = "linux"))]
+#[cfg(all(feature = "standalone", target_family = "unix"))]
 const WASMEDGE_RELEASE_VERSION: &str = "0.11.2";
 
 macro_rules! env_path {
@@ -20,7 +20,7 @@ struct Paths {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    #[cfg(all(feature = "standalone", target_os = "linux"))]
+    #[cfg(all(feature = "standalone", target_family = "unix"))]
     install_libwasmedge();
 
     let Paths {
@@ -185,7 +185,7 @@ fn find_wasmedge() -> Option<Paths> {
     None
 }
 
-#[cfg(all(feature = "standalone", target_os = "linux"))]
+#[cfg(all(feature = "standalone", target_family = "unix"))]
 fn install_libwasmedge() {
     let out_dir = env::var("OUT_DIR").expect("[wasmedge-sys] Failed to get OUT_DIR");
     println!("cargo:warning=[wasmedge-sys] OUT_DIR: {}", &out_dir);

--- a/bindings/rust/wasmedge-sys/build.rs
+++ b/bindings/rust/wasmedge-sys/build.rs
@@ -1,6 +1,10 @@
 use std::path::PathBuf;
+#[cfg(all(feature = "standalone", target_os = "lunix"))]
+use std::{env, process::Command};
 
 const WASMEDGE_H: &str = "wasmedge.h";
+#[cfg(all(feature = "standalone", target_os = "lunix"))]
+const WASMEDGE_RELEASE_VERSION: &str = "0.11.2";
 
 macro_rules! env_path {
     ($env_var:literal) => {
@@ -15,7 +19,10 @@ struct Paths {
     inc_dir: PathBuf,
 }
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(all(feature = "standalone", target_os = "lunix"))]
+    install_libwasmedge();
+
     let Paths {
         header,
         lib_dir,
@@ -43,10 +50,32 @@ fn main() {
     println!("cargo:rustc-env=LD_LIBRARY_PATH={}", lib_dir.display());
     println!("cargo:rustc-link-search={}", lib_dir.display());
     println!("cargo:rustc-link-lib=dylib=wasmedge");
+
+    Ok(())
 }
 
 /// Check header and Returns the location of wasmedge.h and libwasmedge_c.(dylib|so)
 fn find_wasmedge() -> Option<Paths> {
+    // search in /usr/local/
+    let inc_dir = PathBuf::from("/usr/local/include");
+    let lib_dir = if PathBuf::from("/usr/local/lib64").exists() {
+        PathBuf::from("/usr/local/lib64")
+    } else {
+        PathBuf::from("/usr/local/lib")
+    };
+    let header = inc_dir.join("wasmedge").join(WASMEDGE_H);
+    if inc_dir.join("wasmedge").exists() && lib_dir.join("wasmedge").exists() && header.exists() {
+        println!(
+            "cargo:warning=[wasmedge-sys] libwasmedge found in {}",
+            lib_dir.to_str().unwrap()
+        );
+        return Some(Paths {
+            header,
+            inc_dir,
+            lib_dir,
+        });
+    }
+
     // search in the env variables: WASMEDGE_INCLUDE_DIR, WASMEDGE_LIB_DIR
     let inc_dir = env_path!("WASMEDGE_INCLUDE_DIR");
     let lib_dir = env_path!("WASMEDGE_LIB_DIR");
@@ -56,12 +85,8 @@ fn find_wasmedge() -> Option<Paths> {
             let header = header.join(WASMEDGE_H);
             if inc_dir.exists() && lib_dir.exists() && header.exists() {
                 println!(
-                    "cargo:warning=[wasmedge-sys] Use WASMEDGE_INCLUDE_DIR: {:?}",
-                    inc_dir
-                );
-                println!(
-                    "cargo:warning=[wasmedge-sys] Use WASMEDGE_LIB_DIR: {:?}",
-                    lib_dir
+                    "cargo:warning=[wasmedge-sys] libwasmedge found in {}",
+                    lib_dir.to_str().unwrap()
                 );
                 return Some(Paths {
                     header,
@@ -91,8 +116,8 @@ fn find_wasmedge() -> Option<Paths> {
 
         if build_dir.exists() && inc_dir.exists() && lib_dir.exists() && header.exists() {
             println!(
-                "cargo:warning=[wasmedge-sys] Use WASMEDGE_BUILD_DIR: {:?}",
-                build_dir
+                "cargo:warning=[wasmedge-sys] libwasmedge found in {}",
+                lib_dir.to_str().unwrap()
             );
             return Some(Paths {
                 header,
@@ -120,8 +145,8 @@ fn find_wasmedge() -> Option<Paths> {
 
         if default_dir.exists() && inc_dir.exists() && lib_dir.exists() && header.exists() {
             println!(
-                "cargo:warning=[wasmedge-sys] Use default dir: {:?}",
-                default_dir
+                "cargo:warning=[wasmedge-sys] libwasmedge found in {}",
+                lib_dir.to_str().unwrap(),
             );
             return Some(Paths {
                 header,
@@ -143,7 +168,10 @@ fn find_wasmedge() -> Option<Paths> {
         };
 
         if xdg_dir.exists() && inc_dir.exists() && lib_dir.exists() && header.exists() {
-            println!("cargo:warning=[wasmedge-sys] Use xdg path: {xdg_dir:?}");
+            println!(
+                "cargo:warning=[wasmedge-sys] libwasmedge found in {}",
+                lib_dir.to_str().unwrap()
+            );
             return Some(Paths {
                 header,
                 lib_dir,
@@ -152,20 +180,33 @@ fn find_wasmedge() -> Option<Paths> {
         }
     }
 
-    // search in /usr/local/
-    let inc_dir = PathBuf::from("/usr/local/include");
-    let lib_dir = PathBuf::from("/usr/local/lib");
-    let header = inc_dir.join("wasmedge").join(WASMEDGE_H);
-    if inc_dir.join("wasmedge").exists() && lib_dir.join("wasmedge").exists() && header.exists() {
-        println!("cargo:warning=[wasmedge-sys] Use path: /usr/local/");
-        return Some(Paths {
-            header,
-            inc_dir,
-            lib_dir,
-        });
-    }
-
     println!("cargo:warning=[wasmedge-sys] Failed to locate lib_dir, include_dir, or header.",);
 
     None
+}
+
+#[cfg(all(feature = "standalone", target_os = "lunix"))]
+fn install_libwasmedge() {
+    let out_dir = env::var("OUT_DIR").expect("[wasmedge-sys] Failed to get OUT_DIR");
+    println!("cargo:warning=[wasmedge-sys] OUT_DIR: {}", &out_dir);
+
+    let output = Command::new("wget")
+        .current_dir(&out_dir)
+        .arg("https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh")
+        .output()
+        .expect("[wasmedge-sys] Failed to download libwasmedge installation script");
+    println!(
+        "cargo:warning=[wasmedge-sys] Download libwasmedge installation script: {:?}",
+        output
+    );
+
+    let output = Command::new("bash")
+        .current_dir(&out_dir)
+        .args(["install.sh", "-v", WASMEDGE_RELEASE_VERSION])
+        .output()
+        .expect("[wasmedge-sys] Failed to run libwasmedge installation script");
+    println!(
+        "cargo:warning=[wasmedge-sys] Run libwasmedge installation script: {:?}",
+        output
+    );
 }


### PR DESCRIPTION
In this PR, the `standalone` feature is introduced into WasmEdge Rust SDK.

In addition, the changes in PR #2076 are cancelled. The explanations are listed [here](https://github.com/WasmEdge/WasmEdge/issues/2075#issuecomment-1319695523) and [here](https://github.com/WasmEdge/WasmEdge/issues/2075#issuecomment-1319931003).