### PR TITLE
[Validator] Fix the error code when element segment mismatch.

### DIFF
--- a/lib/validator/validator.cpp
+++ b/lib/validator/validator.cpp
@@ -189,8 +189,11 @@ Expect<void> Validator::validate(const AST::ElementSegment &ElemSeg) {
     }
     if (TableVec[ElemSeg.getIdx()] != ElemSeg.getRefType()) {
       // Reference type not matched.
-      spdlog::error(ErrCode::Value::InvalidTableIdx);
-      return Unexpect(ErrCode::Value::InvalidTableIdx);
+      spdlog::error(ErrCode::Value::TypeCheckFailed);
+      spdlog::error(ErrInfo::InfoMismatch(
+          static_cast<ValType>(TableVec[ElemSeg.getIdx()]),
+          static_cast<ValType>(ElemSeg.getRefType())));
+      return Unexpect(ErrCode::Value::TypeCheckFailed);
     }
     // Check table initialization is a const expression.
     if (auto Res =

--- a/test/spec/hostfunc.h
+++ b/test/spec/hostfunc.h
@@ -32,6 +32,11 @@ public:
   Expect<void> body(const Runtime::CallingFrame &, uint32_t) { return {}; }
 };
 
+class SpecTestPrintI64 : public Runtime::HostFunction<SpecTestPrintI64> {
+public:
+  Expect<void> body(const Runtime::CallingFrame &, uint64_t) { return {}; }
+};
+
 class SpecTestPrintF32 : public Runtime::HostFunction<SpecTestPrintF32> {
 public:
   Expect<void> body(const Runtime::CallingFrame &, float) { return {}; }
@@ -61,6 +66,7 @@ public:
   SpecTestModule() : ModuleInstance("spectest") {
     addHostFunc("print", std::make_unique<SpecTestPrint>());
     addHostFunc("print_i32", std::make_unique<SpecTestPrintI32>());
+    addHostFunc("print_i64", std::make_unique<SpecTestPrintI64>());
     addHostFunc("print_f32", std::make_unique<SpecTestPrintF32>());
     addHostFunc("print_f64", std::make_unique<SpecTestPrintF64>());
     addHostFunc("print_i32_f32", std::make_unique<SpecTestPrintI32F32>());


### PR DESCRIPTION
This PR passed the newest spec tests on the branch `wasm-dev` in [WasmEdge unittest repo](https://github.com/second-state/WasmEdge-unittest/tree/wasm-dev), except the `threads` proposal.
Therefore, the `wasm-dev-0.11.0` tag should be used currently until the `threads` proposal implementation being fixed.