### PR TITLE
[CI] Update the workflows for Rust SDK release

### DIFF
--- a/.github/workflows/rust-wasmedge-sdk-release.yml
+++ b/.github/workflows/rust-wasmedge-sdk-release.yml
@@ -12,7 +12,9 @@ on:
 jobs:
   crate_release:
     name: Create Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
+    container:
+      image: wasmedge/wasmedge:ubuntu-build-clang
 
     steps:
       - uses: actions/checkout@v3
@@ -21,26 +23,15 @@ jobs:
 
       - name: Set up build environment
         run: |
-          sudo apt-get update
-          sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
-          sudo apt-get install -y llvm-14-dev liblld-14-dev clang-14
-          sudo apt-get install -y gcc g++
-          sudo apt-get install -y libssl-dev pkg-config gh
+          apt update
+          apt install -y software-properties-common libboost-all-dev ninja-build
+          apt install -y llvm-12-dev liblld-12-dev
 
       - name: Install Rust v1.65
         uses: dtolnay/rust-toolchain@1.65
         with:
           toolchain: 1.65
           components: rustfmt, clippy
-
-      - name: Set git credentials
-        run: |
-          git config --global user.name github-actions
-          git config --global user.email github-actions@github.com
-
-      - name: Prepare release
-        run: |
-          cargo install cargo-smart-release
 
       - name: Build WasmEdge with Release mode
         run: |
@@ -56,7 +47,7 @@ jobs:
           export WASMEDGE_DIR="$(pwd)/../../"
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
-          cargo smart-release --update-crates-index --dry-run-cargo-publish --no-dependencies --no-changelog --no-tag wasmedge-sdk
+          cargo publish --dry-run -p wasmedge-sdk
 
       - name: Publish
         if: github.ref == 'refs/heads/master'
@@ -69,7 +60,7 @@ jobs:
           export WASMEDGE_DIR="$(pwd)/../../"
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
-          cargo smart-release --update-crates-index --execute --no-dependencies --no-changelog --no-tag wasmedge-sdk
+          cargo publish -p wasmedge-sdk
 
       - name: Build API document
         working-directory: bindings/rust/wasmedge-sdk

--- a/.github/workflows/rust-wasmedge-sdk-release.yml
+++ b/.github/workflows/rust-wasmedge-sdk-release.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
     branches:
       - master
+      - "rust/refactor-ci-workflows"
 
 jobs:
   crate_release:

--- a/.github/workflows/rust-wasmedge-sdk-release.yml
+++ b/.github/workflows/rust-wasmedge-sdk-release.yml
@@ -8,7 +8,6 @@ on:
   workflow_dispatch:
     branches:
       - master
-      - "rust/refactor-ci-workflows"
 
 jobs:
   crate_release:

--- a/.github/workflows/rust-wasmedge-sys-release.yml
+++ b/.github/workflows/rust-wasmedge-sys-release.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   workflow_dispatch:
     branches:
-      - master
+      - "rust/refactor-ci-workflows"
 
 jobs:
   crate_release:
@@ -23,7 +23,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
-          sudo apt-get install -y llvm-14-dev liblld-14-dev clang-14
+          sudo apt-get install -y llvm-15-dev liblld-15-dev clang-15
           sudo apt-get install -y gcc g++
           sudo apt-get install -y libssl-dev pkg-config gh
 

--- a/.github/workflows/rust-wasmedge-sys-release.yml
+++ b/.github/workflows/rust-wasmedge-sys-release.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
-          sudo apt-get install -y llvm-15-dev liblld-15-dev clang-15
+          sudo apt-get install -y llvm-14-dev liblld-14-dev clang-14
           sudo apt-get install -y gcc g++
           sudo apt-get install -y libssl-dev pkg-config gh
 

--- a/.github/workflows/rust-wasmedge-sys-release.yml
+++ b/.github/workflows/rust-wasmedge-sys-release.yml
@@ -7,6 +7,7 @@ concurrency:
 on:
   workflow_dispatch:
     branches:
+      - master
       - "rust/refactor-ci-workflows"
 
 jobs:

--- a/.github/workflows/rust-wasmedge-sys-release.yml
+++ b/.github/workflows/rust-wasmedge-sys-release.yml
@@ -12,7 +12,9 @@ on:
 jobs:
   crate_release:
     name: Create Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
+    container:
+      image: wasmedge/wasmedge:ubuntu-build-clang
 
     steps:
       - uses: actions/checkout@v3
@@ -21,26 +23,15 @@ jobs:
 
       - name: Set up build environment
         run: |
-          sudo apt-get update
-          sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
-          sudo apt-get install -y llvm-14-dev liblld-14-dev clang-14
-          sudo apt-get install -y gcc g++
-          sudo apt-get install -y libssl-dev pkg-config gh
+          apt update
+          apt install -y software-properties-common libboost-all-dev ninja-build
+          apt install -y llvm-12-dev liblld-12-dev
 
       - name: Install Rust v1.65
         uses: dtolnay/rust-toolchain@1.65
         with:
           toolchain: 1.65
           components: rustfmt, clippy
-
-      - name: Set git credentials
-        run: |
-          git config --global user.name github-actions
-          git config --global user.email github-actions@github.com
-
-      - name: Prepare release
-        run: |
-          cargo install cargo-smart-release
 
       - name: Build WasmEdge with Release mode
         run: |
@@ -56,7 +47,7 @@ jobs:
           export WASMEDGE_DIR="$(pwd)/../../"
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
-          cargo smart-release --update-crates-index --dry-run-cargo-publish --no-dependencies --no-changelog --no-tag wasmedge-sys
+          cargo publish --dry-run -p wasmedge-sys
 
       - name: Publish
         if: github.ref == 'refs/heads/master'
@@ -69,7 +60,7 @@ jobs:
           export WASMEDGE_DIR="$(pwd)/../../"
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
-          cargo smart-release --update-crates-index --execute --no-dependencies --no-changelog --no-tag wasmedge-sys
+          cargo publish -p wasmedge-sys
 
       - name: Build API document
         working-directory: bindings/rust/wasmedge-sys

--- a/.github/workflows/rust-wasmedge-sys-release.yml
+++ b/.github/workflows/rust-wasmedge-sys-release.yml
@@ -8,7 +8,6 @@ on:
   workflow_dispatch:
     branches:
       - master
-      - "rust/refactor-ci-workflows"
 
 jobs:
   crate_release:


### PR DESCRIPTION
In this PR, the `cargo-smart-release` tool is replaced with the standard `cargo publish`. The changes are made in`rust-wasmedge-sys-release` and `rust-wasmedge-sdk-release`.