### PR TITLE
[Rust] rollback the changes on the error definition

### DIFF
--- a/bindings/rust/wasmedge-sys/src/utils.rs
+++ b/bindings/rust/wasmedge-sys/src/utils.rs
@@ -306,7 +306,7 @@ fn gen_runtime_error(code: u32) -> WasmEdgeResult<()> {
             CoreExecutionError::UnalignedAtomicAccess,
         )))),
         0x90 => Err(Box::new(WasmEdgeError::Core(CoreError::Execution(
-            CoreExecutionError::ExpectSharedMemory,
+            CoreExecutionError::WaitOnUnsharedMemory,
         )))),
 
         _ => panic!("unknown error code: {code}"),

--- a/bindings/rust/wasmedge-types/src/error.rs
+++ b/bindings/rust/wasmedge-types/src/error.rs
@@ -457,8 +457,8 @@ pub enum CoreExecutionError {
     RefTypeMismatch,
     #[error("unaligned atomic")]
     UnalignedAtomicAccess,
-    #[error("expected shared memory")]
-    ExpectSharedMemory,
+    #[error("wait on unshared memory")]
+    WaitOnUnsharedMemory,
 }
 
 #[derive(Error, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
The changes made to the error definition are rolled back for releasing `wasmedge-sys`.