### PR TITLE
[CI] Refactor rust-standalone workflow

### DIFF
--- a/.github/workflows/rust-standalone.yml
+++ b/.github/workflows/rust-standalone.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - master
       - "rust/*"
-      - "ci/refactor-rust-standalone"
     paths:
       - ".github/workflows/rust-standalone.yml"
       - "bindings/rust/**"

--- a/.github/workflows/rust-standalone.yml
+++ b/.github/workflows/rust-standalone.yml
@@ -12,16 +12,12 @@ on:
     paths:
       - ".github/workflows/rust-standalone.yml"
       - "bindings/rust/**"
-      - "include/api/wasmedge/**"
-      - "lib/api/**"
   pull_request:
     branches:
       - master
     paths:
       - ".github/workflows/rust-standalone.yml"
       - "bindings/rust/**"
-      - "include/api/wasmedge/**"
-      - "lib/api/**"
 
 jobs:
   build_ubuntu_2204:

--- a/.github/workflows/rust-standalone.yml
+++ b/.github/workflows/rust-standalone.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - "rust/*"
+      - "ci/refactor-rust-standalone"
     paths:
       - ".github/workflows/rust-standalone.yml"
       - "bindings/rust/**"

--- a/.github/workflows/rust-standalone.yml
+++ b/.github/workflows/rust-standalone.yml
@@ -24,19 +24,22 @@ on:
       - "lib/api/**"
 
 jobs:
-  build_ubuntu:
-    name: Ubuntu
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
-    container:
-      image: wasmedge/wasmedge:ubuntu-build-clang
+  build_ubuntu_2204:
+    name: Ubuntu-22.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Set up build environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
+          sudo apt-get install -y llvm-14-dev liblld-14-dev clang-14
+          sudo apt-get install -y gcc g++
+          sudo apt-get install -y libssl-dev pkg-config gh
 
       - name: Install Rust v1.65
         uses: dtolnay/rust-toolchain@1.65
@@ -44,9 +47,46 @@ jobs:
           toolchain: 1.65
           components: rustfmt, clippy
 
-      - name: Install libwasmedge
+      - name: Run in the standalone mode
         working-directory: bindings/rust/
         run: |
+          export LLVM_DIR="/usr/local/opt/llvm@14/lib/cmake"
+          export CC=clang
+          export CXX=clang++
+          export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
+          export WASMEDGE_DIR="$(pwd)/../../"
+          cargo test -p wasmedge-sdk --all --examples --features standalone
+
+  build_ubuntu_2004:
+    name: Ubuntu-20.04
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up build environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
+          sudo apt-get install -y llvm-12-dev liblld-12-dev clang-12
+          sudo apt-get install -y gcc g++
+          sudo apt-get install -y libssl-dev pkg-config gh
+
+      - name: Install Rust v1.65
+        uses: dtolnay/rust-toolchain@1.65
+        with:
+          toolchain: 1.65
+          components: rustfmt, clippy
+
+      - name: Run in the standalone mode
+        working-directory: bindings/rust/
+        run: |
+          export LLVM_DIR="/usr/local/opt/llvm@14/lib/cmake"
+          export CC=clang
+          export CXX=clang++
+          export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
           export WASMEDGE_DIR="$(pwd)/../../"
           cargo test -p wasmedge-sdk --all --examples --features standalone
 

--- a/.github/workflows/rust-standalone.yml
+++ b/.github/workflows/rust-standalone.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Run in the standalone mode
         working-directory: bindings/rust/
         run: |
-          export LLVM_DIR="/usr/local/opt/llvm@14/lib/cmake"
+          export LLVM_DIR="/usr/local/opt/llvm@12/lib/cmake"
           export CC=clang
           export CXX=clang++
           export LD_LIBRARY_PATH=$HOME/.wasmedge/lib


### PR DESCRIPTION
In this PR, the original `build_ubuntu` job in `rust-standalone` workflow is split into two separate jobs: one for `ubuntu-20.04` with `llvm-12` installed, one for `ubuntu-22.04` with `llvm-14` installed.