### PR TITLE
[Java][Refactor] Add constants, refactor Java API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ node_modules/
 **/cmake-build-debug
 **/cmake-build-debug-remote-host
 **/cmake-build-release
+
+# generated jni files
+bindings/java/wasmedge-java/wasmedge-jni/jni/*.h

--- a/bindings/java/wasmedge-java/build.gradle
+++ b/bindings/java/wasmedge-java/build.gradle
@@ -42,7 +42,7 @@ task compileJNI {
 }
 
 clean.doFirst {
-    delete fileTree('src/main/include') {
+    delete fileTree('wasmedge-jni/jni') {
         include '*.h'
     }
 }

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/ExecutorContext.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/ExecutorContext.java
@@ -15,10 +15,10 @@ public class ExecutorContext {
     public native ModuleInstanceContext instantiate(StoreContext storeContext, ASTModuleContext astModuleContext);
 
     public native void invoke(FunctionInstanceContext functionInstanceContext,
-                              List<WasmEdgeValue> params, List<WasmEdgeValue> returns);
+                              List<Value> params, List<Value> returns);
 
 
-    private int[] getValueTypeArray(List<WasmEdgeValue> values) {
+    private int[] getValueTypeArray(List<Value> values) {
 
         int[] types = new int[values.size()];
 
@@ -28,8 +28,8 @@ public class ExecutorContext {
         return types;
     }
 
-    private WasmEdgeValue[] valueListToArray(List<WasmEdgeValue> values) {
-        WasmEdgeValue[] valuesArray = new WasmEdgeValue[values.size()];
+    private Value[] valueListToArray(List<Value> values) {
+        Value[] valuesArray = new Value[values.size()];
         values.toArray(valuesArray);
         return valuesArray;
     }

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/ExternRef.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/ExternRef.java
@@ -4,18 +4,18 @@ import org.wasmedge.enums.ValueType;
 
 import java.util.UUID;
 
-public class WasmEdgeExternRef<T> implements WasmEdgeValue {
+public class ExternRef<T> implements Value {
     private long pointer;
     private String value;
 
-    public WasmEdgeExternRef(T val) {
+    public ExternRef(T val) {
         final String key = UUID.randomUUID().toString();
         this.value = key;
         WasmEdgeVM.addExternRef(key, val);
         nativeInit(key);
     }
 
-    private WasmEdgeExternRef() {
+    private ExternRef() {
 
     }
 

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/F32Value.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/F32Value.java
@@ -2,14 +2,14 @@ package org.wasmedge;
 
 import org.wasmedge.enums.ValueType;
 
-public final class WasmEdgeF32Value implements WasmEdgeValue {
+public final class F32Value implements Value {
     private float value;
 
-    public WasmEdgeF32Value() {
+    public F32Value() {
 
     }
 
-    public WasmEdgeF32Value(float value) {
+    public F32Value(float value) {
         this.value = value;
     }
 

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/F64Value.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/F64Value.java
@@ -2,14 +2,14 @@ package org.wasmedge;
 
 import org.wasmedge.enums.ValueType;
 
-public final class WasmEdgeF64Value implements WasmEdgeValue {
+public final class F64Value implements Value {
     private double value;
 
-    public WasmEdgeF64Value(double value) {
+    public F64Value(double value) {
         this.value = value;
     }
 
-    public WasmEdgeF64Value() {
+    public F64Value() {
 
     }
 

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/FuncRef.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/FuncRef.java
@@ -2,14 +2,14 @@ package org.wasmedge;
 
 import org.wasmedge.enums.ValueType;
 
-public class WasmEdgeFuncRef implements WasmEdgeValue {
+public class FuncRef implements Value {
     private long value;
 
-    public WasmEdgeFuncRef() {
+    public FuncRef() {
 
     }
 
-    public WasmEdgeFuncRef(long index) {
+    public FuncRef(long index) {
         this.value = index;
     }
 

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/FunctionTypeContext.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/FunctionTypeContext.java
@@ -63,7 +63,7 @@ public class FunctionTypeContext {
 
     public native void delete();
 
-    private int[] getValueTypeArray(List<WasmEdgeValue> values) {
+    private int[] getValueTypeArray(List<Value> values) {
 
         int[] types = new int[values.size()];
 
@@ -73,8 +73,8 @@ public class FunctionTypeContext {
         return types;
     }
 
-    private WasmEdgeValue[] valueListToArray(List<WasmEdgeValue> values) {
-        WasmEdgeValue[] valuesArray = new WasmEdgeValue[values.size()];
+    private Value[] valueListToArray(List<Value> values) {
+        Value[] valuesArray = new Value[values.size()];
         values.toArray(valuesArray);
         return valuesArray;
     }

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/GlobalInstanceContext.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/GlobalInstanceContext.java
@@ -2,7 +2,7 @@ package org.wasmedge;
 
 public class GlobalInstanceContext {
     private GlobalTypeContext globalTypeContext;
-    private WasmEdgeValue value;
+    private Value value;
     private long pointer;
 
     private GlobalInstanceContext(long pointer) {
@@ -10,25 +10,25 @@ public class GlobalInstanceContext {
     }
 
     public GlobalInstanceContext(GlobalTypeContext typeCxt,
-                                 WasmEdgeValue value) {
+                                 Value value) {
         this.globalTypeContext = typeCxt;
         this.value = value;
         nativeInit(typeCxt, value);
     }
 
-    private native void nativeInit(GlobalTypeContext typeCxt, WasmEdgeValue value);
+    private native void nativeInit(GlobalTypeContext typeCxt, Value value);
 
     public GlobalTypeContext getGlobalType() {
         return globalTypeContext;
     }
 
-    private native void nativeSetValue(WasmEdgeValue value);
+    private native void nativeSetValue(Value value);
 
-    public WasmEdgeValue getValue() {
+    public Value getValue() {
         return this.value;
     }
 
-    public void setValue(WasmEdgeValue value) {
+    public void setValue(Value value) {
         this.value = value;
         nativeSetValue(value);
     }

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/GlobalTypeContext.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/GlobalTypeContext.java
@@ -1,13 +1,13 @@
 package org.wasmedge;
 
 import org.wasmedge.enums.ValueType;
-import org.wasmedge.enums.WasmEdgeMutability;
+import org.wasmedge.enums.Mutability;
 
 public class GlobalTypeContext {
     private long pointer;
 
-    public GlobalTypeContext(ValueType valueType, WasmEdgeMutability wasmEdgeMutability) {
-        nativeInit(valueType.getValue(), wasmEdgeMutability.getValue());
+    public GlobalTypeContext(ValueType valueType, Mutability mutability) {
+        nativeInit(valueType.getValue(), mutability.getValue());
     }
 
     private GlobalTypeContext(long pointer) {
@@ -24,8 +24,8 @@ public class GlobalTypeContext {
 
     private native int nativeGetValueType();
 
-    public WasmEdgeMutability getMutability() {
-        return WasmEdgeMutability.parseMutability(nativeGetMutability());
+    public Mutability getMutability() {
+        return Mutability.parseMutability(nativeGetMutability());
     }
 
     private native int nativeGetMutability();

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/HostFunction.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/HostFunction.java
@@ -3,5 +3,5 @@ package org.wasmedge;
 import java.util.List;
 
 public interface HostFunction {
-    Result apply(MemoryInstanceContext mem, List<WasmEdgeValue> params, List<WasmEdgeValue> returns);
+    Result apply(MemoryInstanceContext mem, List<Value> params, List<Value> returns);
 }

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/I32Value.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/I32Value.java
@@ -2,14 +2,14 @@ package org.wasmedge;
 
 import org.wasmedge.enums.ValueType;
 
-public final class WasmEdgeI32Value implements WasmEdgeValue {
+public final class I32Value implements Value {
     private int value;
 
-    public WasmEdgeI32Value() {
+    public I32Value() {
 
     }
 
-    public WasmEdgeI32Value(int value) {
+    public I32Value(int value) {
         this.value = value;
     }
 

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/I64Value.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/I64Value.java
@@ -2,14 +2,14 @@ package org.wasmedge;
 
 import org.wasmedge.enums.ValueType;
 
-public final class WasmEdgeI64Value implements WasmEdgeValue {
+public final class I64Value implements Value {
     private long value;
 
-    public WasmEdgeI64Value(long value) {
+    public I64Value(long value) {
         this.value = value;
     }
 
-    public WasmEdgeI64Value() {
+    public I64Value() {
 
     }
 

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/Limit.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/Limit.java
@@ -1,11 +1,11 @@
 package org.wasmedge;
 
-public class WasmEdgeLimit {
+public class Limit {
     private final boolean hasMax;
     private final long min;
     private final long max;
 
-    public WasmEdgeLimit(boolean hasMax, long min, long max) {
+    public Limit(boolean hasMax, long min, long max) {
         this.hasMax = hasMax;
         this.min = min;
         this.max = max;
@@ -25,8 +25,8 @@ public class WasmEdgeLimit {
 
     @Override
     public boolean equals(Object other) {
-        if (other instanceof WasmEdgeLimit) {
-            WasmEdgeLimit that = (WasmEdgeLimit) other;
+        if (other instanceof Limit) {
+            Limit that = (Limit) other;
             return this.hasMax == that.hasMax
                     && this.min == that.min
                     && (!this.hasMax || (this.max == that.max));

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/MemoryTypeContext.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/MemoryTypeContext.java
@@ -2,18 +2,18 @@ package org.wasmedge;
 
 public class MemoryTypeContext {
     private long pointer;
-    private WasmEdgeLimit limit;
+    private Limit limit;
 
     private MemoryTypeContext(long pointer) {
         this.pointer = pointer;
     }
 
-    public MemoryTypeContext(WasmEdgeLimit limit) {
+    public MemoryTypeContext(Limit limit) {
         this.limit = limit;
         nativeInit(limit.isHasMax(), limit.getMin(), limit.getMax());
     }
 
-    public native WasmEdgeLimit getLimit();
+    public native Limit getLimit();
 
     private native void nativeInit(boolean hasMax, long min, long max);
 

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/TableInstanceContext.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/TableInstanceContext.java
@@ -25,9 +25,9 @@ public class TableInstanceContext {
         return this.tableTypeContext;
     }
 
-    public native void setData(WasmEdgeValue value, int index);
+    public native void setData(Value value, int index);
 
-    public native WasmEdgeValue getData(ValueType valueType, int offSet);
+    public native Value getData(ValueType valueType, int offSet);
 
     public native int getSize();
 

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/TableTypeContext.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/TableTypeContext.java
@@ -6,7 +6,7 @@ public class TableTypeContext {
 
     private long pointer;
 
-    public TableTypeContext(RefType refType, WasmEdgeLimit limit) {
+    public TableTypeContext(RefType refType, Limit limit) {
         nativeInit(refType.getVal(), limit);
     }
 
@@ -14,9 +14,9 @@ public class TableTypeContext {
         this.pointer = pointer;
     }
 
-    private native void nativeInit(int refType, WasmEdgeLimit limit);
+    private native void nativeInit(int refType, Limit limit);
 
-    public native WasmEdgeLimit getLimit();
+    public native Limit getLimit();
 
     public RefType getRefType() {
         return RefType.getType(nativeGetRefType());

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/Value.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/Value.java
@@ -2,6 +2,6 @@ package org.wasmedge;
 
 import org.wasmedge.enums.ValueType;
 
-public interface WasmEdgeValue {
+public interface Value {
     ValueType getType();
 }

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/WasmEdgeAsync.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/WasmEdgeAsync.java
@@ -20,12 +20,12 @@ public class WasmEdgeAsync {
 
     // turn returns to an array
     private native void wasmEdge_AsyncGet(
-             WasmEdgeValue[] returns, int[] returnTypes);
+            Value[] returns, int[] returnTypes);
 
     public void wasmEdge_AsyncGet(
-            List<WasmEdgeValue> returns) {
+            List<Value> returns) {
 
-            WasmEdgeValue[] valuesArray = new WasmEdgeValue[returns.size()];
+            Value[] valuesArray = new Value[returns.size()];
             returns.toArray(valuesArray);
             int[] types = new int[returns.size()];
 

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/WasmEdgeVM.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/WasmEdgeVM.java
@@ -44,10 +44,10 @@ public class WasmEdgeVM {
 
     private native void runWasmFromFile(String file,
                                         String funcName,
-                                        WasmEdgeValue[] params,
+                                        Value[] params,
                                         int paramSize,
                                         int[] paramTypes,
-                                        WasmEdgeValue[] returns,
+                                        Value[] returns,
                                         int returnSize,
                                         int[] returnTypes
     );
@@ -62,45 +62,45 @@ public class WasmEdgeVM {
      */
     public void runWasmFromFile(String file,
                                 String funcName,
-                                List<WasmEdgeValue> params,
-                                List<WasmEdgeValue> returns) {
-        WasmEdgeValue[] paramsArray = valueListToArray(params);
+                                List<Value> params,
+                                List<Value> returns) {
+        Value[] paramsArray = valueListToArray(params);
         int[] paramTypes = getValueTypeArray(params);
 
-        WasmEdgeValue[] returnsArray = valueListToArray(returns);
+        Value[] returnsArray = valueListToArray(returns);
         int[] returnTypes = getValueTypeArray(returns);
 
         runWasmFromFile(file, funcName, paramsArray, params.size(), paramTypes,
                 returnsArray, returns.size(), returnTypes);
     }
 
-    public void runWasmFromBuffer(byte[] buffer, String funcName, List<WasmEdgeValue> params, List<WasmEdgeValue> returns) {
-        WasmEdgeValue[] paramsArray = valueListToArray(params);
+    public void runWasmFromBuffer(byte[] buffer, String funcName, List<Value> params, List<Value> returns) {
+        Value[] paramsArray = valueListToArray(params);
         int[] paramTypes = getValueTypeArray(params);
 
-        WasmEdgeValue[] returnsArray = valueListToArray(returns);
+        Value[] returnsArray = valueListToArray(returns);
         int[] returnTypes = getValueTypeArray(returns);
 
         runWasmFromBuffer(buffer, funcName, paramsArray, paramTypes, returnsArray, returnTypes);
     }
 
-    private native void runWasmFromBuffer(byte[] buffer, String funcName, WasmEdgeValue[] params, int[] paramTypes, WasmEdgeValue[] returns, int[] returnTypes);
+    private native void runWasmFromBuffer(byte[] buffer, String funcName, Value[] params, int[] paramTypes, Value[] returns, int[] returnTypes);
 
 
-    public void runWasmFromASTModule(ASTModuleContext astModuleContext, String funcName, List<WasmEdgeValue> params, List<WasmEdgeValue> returns) {
-        WasmEdgeValue[] paramsArray = valueListToArray(params);
+    public void runWasmFromASTModule(ASTModuleContext astModuleContext, String funcName, List<Value> params, List<Value> returns) {
+        Value[] paramsArray = valueListToArray(params);
         int[] paramTypes = getValueTypeArray(params);
 
-        WasmEdgeValue[] returnsArray = valueListToArray(returns);
+        Value[] returnsArray = valueListToArray(returns);
         int[] returnTypes = getValueTypeArray(returns);
 
         runWasmFromASTModule(astModuleContext, funcName, paramsArray, paramTypes, returnsArray, returnTypes);
     }
 
-    private native void runWasmFromASTModule(ASTModuleContext astModuleContext, String funcName, WasmEdgeValue[] params, int[] paramTypes, WasmEdgeValue[] returns, int[] returnTypes);
+    private native void runWasmFromASTModule(ASTModuleContext astModuleContext, String funcName, Value[] params, int[] paramTypes, Value[] returns, int[] returnTypes);
 
 
-    private int[] getValueTypeArray(List<WasmEdgeValue> values) {
+    private int[] getValueTypeArray(List<Value> values) {
 
         int[] types = new int[values.size()];
 
@@ -110,8 +110,8 @@ public class WasmEdgeVM {
         return types;
     }
 
-    private WasmEdgeValue[] valueListToArray(List<WasmEdgeValue> values) {
-        WasmEdgeValue[] valuesArray = new WasmEdgeValue[values.size()];
+    private Value[] valueListToArray(List<Value> values) {
+        Value[] valuesArray = new Value[values.size()];
         values.toArray(valuesArray);
         return valuesArray;
     }
@@ -126,20 +126,20 @@ public class WasmEdgeVM {
 
     public native void instantiate();
 
-    public void execute(String funcName, List<WasmEdgeValue> params, List<WasmEdgeValue> returns) {
-        WasmEdgeValue[] paramsArray = valueListToArray(params);
+    public void execute(String funcName, List<Value> params, List<Value> returns) {
+        Value[] paramsArray = valueListToArray(params);
         int[] paramTypes = getValueTypeArray(params);
 
-        WasmEdgeValue[] returnsArray = valueListToArray(returns);
+        Value[] returnsArray = valueListToArray(returns);
         int[] returnTypes = getValueTypeArray(returns);
 
         execute(funcName, paramsArray, params.size(), paramTypes, returnsArray, returns.size(), returnTypes);
     }
 
-    public native void execute(String funcName, WasmEdgeValue[] params,
+    public native void execute(String funcName, Value[] params,
                                int paramSize,
                                int[] paramTypes,
-                               WasmEdgeValue[] returns,
+                               Value[] returns,
                                int returnSize,
                                int[] returnTypes);
 
@@ -164,18 +164,18 @@ public class WasmEdgeVM {
 
     public native void registerModuleFromASTModule(String moduleName, ASTModuleContext astModuleContext);
 
-    public void executeRegistered(String modName, String funcName, List<WasmEdgeValue> params,
-                                  List<WasmEdgeValue> returns) {
-        WasmEdgeValue[] paramsArray = valueListToArray(params);
+    public void executeRegistered(String modName, String funcName, List<Value> params,
+                                  List<Value> returns) {
+        Value[] paramsArray = valueListToArray(params);
         int[] paramTypes = getValueTypeArray(params);
 
-        WasmEdgeValue[] returnsArray = valueListToArray(returns);
+        Value[] returnsArray = valueListToArray(returns);
         int[] returnTypes = getValueTypeArray(returns);
         executeRegistered(modName, funcName, paramsArray, paramTypes, returnsArray, returnTypes);
     }
 
-    private native void executeRegistered(String modName, String funcName, WasmEdgeValue[] params,
-                                          int[] paramTypes, WasmEdgeValue[] returns, int[] returnTypes);
+    private native void executeRegistered(String modName, String funcName, Value[] params,
+                                          int[] paramTypes, Value[] returns, int[] returnTypes);
 
     private native void getFunctionList(List<FunctionTypeContext> functionList);
 
@@ -208,12 +208,12 @@ public class WasmEdgeVM {
     // Async API
     private native WasmEdgeAsync asyncRunWasmFromFile(
             String path, String funcName,
-            WasmEdgeValue[] params, int[] paramTypes);
+            Value[] params, int[] paramTypes);
 
     public WasmEdgeAsync asyncRunWasmFromFile(
             String path, String funcName,
-            List<WasmEdgeValue> params){
-                WasmEdgeValue[] paramsArray = valueListToArray(params);
+            List<Value> params){
+                Value[] paramsArray = valueListToArray(params);
                 int[] paramTypes = getValueTypeArray(params);
 
                 return asyncRunWasmFromFile(path, funcName, paramsArray, paramTypes);
@@ -221,13 +221,13 @@ public class WasmEdgeVM {
 
     private native WasmEdgeAsync asyncRunWasmFromBuffer(
             byte[] buffer,
-            String funcName, WasmEdgeValue[] params,
+            String funcName, Value[] params,
             int[] paramTypes);
 
     public WasmEdgeAsync asyncRunWasmFromBuffer(
             byte[] buffer,
-            String funcName, List<WasmEdgeValue> params){
-                WasmEdgeValue[] paramsArray = valueListToArray(params);
+            String funcName, List<Value> params){
+                Value[] paramsArray = valueListToArray(params);
                 int[] paramTypes = getValueTypeArray(params);
 
                 return asyncRunWasmFromBuffer(buffer, funcName, paramsArray, paramTypes);
@@ -235,13 +235,13 @@ public class WasmEdgeVM {
             
     private native WasmEdgeAsync asyncRunWasmFromASTModule(
             ASTModuleContext astCxt,
-            String funcName, WasmEdgeValue[] params,
+            String funcName, Value[] params,
             int[] paramTypes);
 
     public WasmEdgeAsync asyncRunWasmFromASTModule(
             ASTModuleContext astCxt,
-            String funcName, List<WasmEdgeValue> params){
-                WasmEdgeValue[] paramsArray = valueListToArray(params);
+            String funcName, List<Value> params){
+                Value[] paramsArray = valueListToArray(params);
                 int[] paramTypes = getValueTypeArray(params);
 
                 return asyncRunWasmFromASTModule(astCxt, funcName, paramsArray, paramTypes);
@@ -249,25 +249,25 @@ public class WasmEdgeVM {
 
     private native WasmEdgeAsync
     asyncExecute(String funcName,
-                            WasmEdgeValue[] params, int[] paramTypes);
+                 Value[] params, int[] paramTypes);
 
     public WasmEdgeAsync
-    asyncExecute(String funcName, List<WasmEdgeValue> params){
-         WasmEdgeValue[] paramsArray = valueListToArray(params);
+    asyncExecute(String funcName, List<Value> params){
+         Value[] paramsArray = valueListToArray(params);
         int[] paramTypes = getValueTypeArray(params);
         return asyncExecute(funcName, paramsArray, paramTypes);
                             }
 
     private native WasmEdgeAsync asyncExecuteRegistered(
             String moduleName,
-            String funcName, WasmEdgeValue[] params,
+            String funcName, Value[] params,
             int[] paramTypes);
 
     public WasmEdgeAsync asyncExecuteRegistered(
             String moduleName,
-            String funcName, List<WasmEdgeValue> params
+            String funcName, List<Value> params
             ){
-                WasmEdgeValue[] paramsArray = valueListToArray(params);
+                Value[] paramsArray = valueListToArray(params);
         int[] paramTypes = getValueTypeArray(params);
 
         return asyncExecuteRegistered(moduleName, funcName, paramsArray, paramTypes);

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/WrapFunction.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/WrapFunction.java
@@ -3,5 +3,5 @@ package org.wasmedge;
 import java.util.List;
 
 public interface WrapFunction {
-    void apply(List<WasmEdgeValue> params, List<WasmEdgeValue> returns);
+    void apply(List<Value> params, List<Value> returns);
 }

--- a/bindings/java/wasmedge-java/src/main/java/org/wasmedge/enums/Mutability.java
+++ b/bindings/java/wasmedge-java/src/main/java/org/wasmedge/enums/Mutability.java
@@ -2,17 +2,17 @@ package org.wasmedge.enums;
 
 import java.util.Arrays;
 
-public enum WasmEdgeMutability {
+public enum Mutability {
     CONST(0x00),
     VAR(0x01);
 
     private final int value;
 
-    WasmEdgeMutability(int value) {
+    Mutability(int value) {
         this.value = value;
     }
 
-    public static WasmEdgeMutability parseMutability(int value) {
+    public static Mutability parseMutability(int value) {
         return Arrays.stream(values()).filter(v -> v.value == value)
                 .findAny().orElse(null);
     }

--- a/bindings/java/wasmedge-java/src/test/java/org/wasmedge/BaseTest.java
+++ b/bindings/java/wasmedge-java/src/test/java/org/wasmedge/BaseTest.java
@@ -21,39 +21,39 @@ public class BaseTest {
 
     public static HostFunction extAdd = new HostFunction() {
         @Override
-        public Result apply(MemoryInstanceContext mem, List<WasmEdgeValue> params, List<WasmEdgeValue> returns) {
-            WasmEdgeI32Value value = (WasmEdgeI32Value) params.get(1);
-            returns.add(new WasmEdgeI32Value(value.getValue() + 1));
+        public Result apply(MemoryInstanceContext mem, List<Value> params, List<Value> returns) {
+            I32Value value = (I32Value) params.get(1);
+            returns.add(new I32Value(value.getValue() + 1));
             return new Result();
         }
     };
     public static HostFunction extSub = new HostFunction() {
         @Override
-        public Result apply(MemoryInstanceContext mem, List<WasmEdgeValue> params, List<WasmEdgeValue> returns) {
+        public Result apply(MemoryInstanceContext mem, List<Value> params, List<Value> returns) {
             return new Result();
         }
     };
     public static HostFunction extMul = new HostFunction() {
         @Override
-        public Result apply(MemoryInstanceContext mem, List<WasmEdgeValue> params, List<WasmEdgeValue> returns) {
+        public Result apply(MemoryInstanceContext mem, List<Value> params, List<Value> returns) {
             return new Result();
         }
     };
     public static HostFunction extDiv = new HostFunction() {
         @Override
-        public Result apply(MemoryInstanceContext mem, List<WasmEdgeValue> params, List<WasmEdgeValue> returns) {
+        public Result apply(MemoryInstanceContext mem, List<Value> params, List<Value> returns) {
             return new Result();
         }
     };
     public static HostFunction extTerm = new HostFunction() {
         @Override
-        public Result apply(MemoryInstanceContext mem, List<WasmEdgeValue> params, List<WasmEdgeValue> returns) {
+        public Result apply(MemoryInstanceContext mem, List<Value> params, List<Value> returns) {
             return new Result();
         }
     };
     public static HostFunction extFail = new HostFunction() {
         @Override
-        public Result apply(MemoryInstanceContext mem, List<WasmEdgeValue> params, List<WasmEdgeValue> returns) {
+        public Result apply(MemoryInstanceContext mem, List<Value> params, List<Value> returns) {
             return new Result();
         }
     };

--- a/bindings/java/wasmedge-java/src/test/java/org/wasmedge/ExecutorContextTest.java
+++ b/bindings/java/wasmedge-java/src/test/java/org/wasmedge/ExecutorContextTest.java
@@ -94,9 +94,9 @@ public class ExecutorContextTest extends BaseTest {
 
     @Test
     public void testInvokeFunction() {
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
-        List<WasmEdgeValue> returns = new ArrayList<>();
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
+        List<Value> returns = new ArrayList<>();
 
         ConfigureContext configureContext = new ConfigureContext();
         StatisticsContext statisticsContext = new StatisticsContext();
@@ -110,16 +110,16 @@ public class ExecutorContextTest extends BaseTest {
         ModuleInstanceContext moduleInstanceContext = executorContext.instantiate(storeContext, moduleContext);
         FunctionInstanceContext functionInstanceContext = moduleInstanceContext.findFunction(FUNC_NAME);
         executorContext.invoke(functionInstanceContext, params, returns);
-        Assert.assertEquals(3, ((WasmEdgeI32Value) returns.get(0)).getValue());
+        Assert.assertEquals(3, ((I32Value) returns.get(0)).getValue());
     }
 
     @Test(expected = Exception.class)
     public void testInvokeFunctionParamMismatch() {
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
-        params.add(new WasmEdgeI32Value(3));
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
+        params.add(new I32Value(3));
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
 
         ConfigureContext configureContext = new ConfigureContext();
         StatisticsContext statisticsContext = new StatisticsContext();
@@ -137,17 +137,17 @@ public class ExecutorContextTest extends BaseTest {
     @Ignore
     public void testInvokeFunctionNullParam() {
         String funcName = "func-mul-2";
-        List<WasmEdgeValue> returns = new ArrayList<>();
+        List<Value> returns = new ArrayList<>();
         ExecutorContext executorContext = new ExecutorContext(new ConfigureContext(), new StatisticsContext());
     }
 
     @Test(expected = Exception.class)
     @Ignore
     public void testInvokeFunctionFunctionNotFound() {
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
 
         ConfigureContext configureContext = new ConfigureContext();
         StatisticsContext statisticsContext = new StatisticsContext();
@@ -189,13 +189,13 @@ public class ExecutorContextTest extends BaseTest {
         Assert.assertNotNull(tab);
 
         // call add
-        List<WasmEdgeValue> param = new ArrayList<>();
-        param.add(new WasmEdgeI32Value(777));
+        List<Value> param = new ArrayList<>();
+        param.add(new I32Value(777));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
+        List<Value> returns = new ArrayList<>();
         FunctionInstanceContext hostFunc = moduleInstanceContext.findFunction("func-host-add");
         exeCxt.invoke(hostFunc, param, returns);
 
-        Assert.assertEquals(778, ((WasmEdgeI32Value) returns.get(0)).getValue());
+        Assert.assertEquals(778, ((I32Value) returns.get(0)).getValue());
     }
 }

--- a/bindings/java/wasmedge-java/src/test/java/org/wasmedge/ExportTypeContextTest.java
+++ b/bindings/java/wasmedge-java/src/test/java/org/wasmedge/ExportTypeContextTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.wasmedge.enums.ExternalType;
 import org.wasmedge.enums.RefType;
 import org.wasmedge.enums.ValueType;
-import org.wasmedge.enums.WasmEdgeMutability;
+import org.wasmedge.enums.Mutability;
 
 import java.util.List;
 
@@ -68,7 +68,7 @@ public class ExportTypeContextTest extends BaseTest {
 
         List<ExportTypeContext> expTypes = mod.listExports();
         Assert.assertEquals(expTypes.get(12).getTableType().getRefType(), RefType.EXTERREF);
-        Assert.assertEquals(expTypes.get(12).getTableType().getLimit(), new WasmEdgeLimit(false, 10, 10));
+        Assert.assertEquals(expTypes.get(12).getTableType().getLimit(), new Limit(false, 10, 10));
         loaderContext.delete();
         mod.delete();
     }
@@ -80,7 +80,7 @@ public class ExportTypeContextTest extends BaseTest {
         ASTModuleContext mod = loaderContext.parseFromFile(getResourcePath(IMPORT_WASM_PATH));
 
         List<ExportTypeContext> expTypes = mod.listExports();
-        Assert.assertEquals(expTypes.get(13).getMemoryType().getLimit(), new WasmEdgeLimit(true, 1, 3));
+        Assert.assertEquals(expTypes.get(13).getMemoryType().getLimit(), new Limit(true, 1, 3));
         loaderContext.delete();
         mod.delete();
     }
@@ -94,7 +94,7 @@ public class ExportTypeContextTest extends BaseTest {
 
         List<ExportTypeContext> expTypes = mod.listExports();
         Assert.assertEquals(expTypes.get(15).getGlobalType().getValueType(), ValueType.f32);
-        Assert.assertEquals(expTypes.get(15).getGlobalType().getMutability(), WasmEdgeMutability.CONST);
+        Assert.assertEquals(expTypes.get(15).getGlobalType().getMutability(), Mutability.CONST);
         loaderContext.delete();
         mod.delete();
     }

--- a/bindings/java/wasmedge-java/src/test/java/org/wasmedge/GlobalInstanceContextTest.java
+++ b/bindings/java/wasmedge-java/src/test/java/org/wasmedge/GlobalInstanceContextTest.java
@@ -3,7 +3,7 @@ package org.wasmedge;
 import org.junit.Assert;
 import org.junit.Test;
 import org.wasmedge.enums.ValueType;
-import org.wasmedge.enums.WasmEdgeMutability;
+import org.wasmedge.enums.Mutability;
 
 public class GlobalInstanceContextTest extends BaseTest {
     private GlobalTypeContext typeCxt;
@@ -11,8 +11,8 @@ public class GlobalInstanceContextTest extends BaseTest {
 
     @Test
     public void testCreation() {
-        typeCxt = new GlobalTypeContext(ValueType.i64, WasmEdgeMutability.VAR);
-        instCxt = new GlobalInstanceContext(typeCxt, new WasmEdgeI64Value(66666666666L));
+        typeCxt = new GlobalTypeContext(ValueType.i64, Mutability.VAR);
+        instCxt = new GlobalInstanceContext(typeCxt, new I64Value(66666666666L));
 
         typeCxt.delete();
         instCxt.delete();
@@ -20,8 +20,8 @@ public class GlobalInstanceContextTest extends BaseTest {
 
     @Test
     public void testGetValType() {
-        typeCxt = new GlobalTypeContext(ValueType.i64, WasmEdgeMutability.VAR);
-        instCxt = new GlobalInstanceContext(typeCxt, new WasmEdgeI64Value(66666666666L));
+        typeCxt = new GlobalTypeContext(ValueType.i64, Mutability.VAR);
+        instCxt = new GlobalInstanceContext(typeCxt, new I64Value(66666666666L));
 
         GlobalTypeContext globalTypeContext = instCxt.getGlobalType();
         Assert.assertEquals(globalTypeContext.getValueType(), typeCxt.getValueType());
@@ -34,18 +34,18 @@ public class GlobalInstanceContextTest extends BaseTest {
 
     @Test
     public void testGetValue() {
-        typeCxt = new GlobalTypeContext(ValueType.i64, WasmEdgeMutability.VAR);
-        instCxt = new GlobalInstanceContext(typeCxt, new WasmEdgeI64Value(66666666666L));
+        typeCxt = new GlobalTypeContext(ValueType.i64, Mutability.VAR);
+        instCxt = new GlobalInstanceContext(typeCxt, new I64Value(66666666666L));
 
-        WasmEdgeValue value = instCxt.getValue();
-        Assert.assertTrue(value instanceof WasmEdgeI64Value);
-        Assert.assertEquals(((WasmEdgeI64Value) value).getValue(), 66666666666L);
+        Value value = instCxt.getValue();
+        Assert.assertTrue(value instanceof I64Value);
+        Assert.assertEquals(((I64Value) value).getValue(), 66666666666L);
 
-        instCxt.setValue(new WasmEdgeI64Value(111L));
+        instCxt.setValue(new I64Value(111L));
 
         value = instCxt.getValue();
-        Assert.assertTrue(value instanceof WasmEdgeI64Value);
-        Assert.assertEquals(((WasmEdgeI64Value) value).getValue(), 111L);
+        Assert.assertTrue(value instanceof I64Value);
+        Assert.assertEquals(((I64Value) value).getValue(), 111L);
 
         typeCxt.delete();
         instCxt.delete();

--- a/bindings/java/wasmedge-java/src/test/java/org/wasmedge/GlobalTypeContextTest.java
+++ b/bindings/java/wasmedge-java/src/test/java/org/wasmedge/GlobalTypeContextTest.java
@@ -3,13 +3,13 @@ package org.wasmedge;
 import org.junit.Assert;
 import org.junit.Test;
 import org.wasmedge.enums.ValueType;
-import org.wasmedge.enums.WasmEdgeMutability;
+import org.wasmedge.enums.Mutability;
 
 public class GlobalTypeContextTest extends BaseTest {
     @Test
     public void testCreation() {
         ValueType valueType = ValueType.f32;
-        WasmEdgeMutability mutability = WasmEdgeMutability.VAR;
+        Mutability mutability = Mutability.VAR;
         GlobalTypeContext globalTypeContext = new GlobalTypeContext(valueType, mutability);
 
         Assert.assertEquals(globalTypeContext.getValueType(), valueType);

--- a/bindings/java/wasmedge-java/src/test/java/org/wasmedge/ImportTypeContextTest.java
+++ b/bindings/java/wasmedge-java/src/test/java/org/wasmedge/ImportTypeContextTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.wasmedge.enums.ExternalType;
 import org.wasmedge.enums.RefType;
 import org.wasmedge.enums.ValueType;
-import org.wasmedge.enums.WasmEdgeMutability;
+import org.wasmedge.enums.Mutability;
 
 import java.util.List;
 
@@ -73,7 +73,7 @@ public class ImportTypeContextTest extends BaseTest {
 
         List<ImportTypeContext> impTypes = mod.listImports();
         Assert.assertEquals(impTypes.get(11).getTableType().getRefType(), RefType.EXTERREF);
-        Assert.assertEquals(impTypes.get(11).getTableType().getLimit(), new WasmEdgeLimit(true, 10, 30));
+        Assert.assertEquals(impTypes.get(11).getTableType().getLimit(), new Limit(true, 10, 30));
         loaderContext.delete();
         mod.delete();
     }
@@ -85,7 +85,7 @@ public class ImportTypeContextTest extends BaseTest {
         ASTModuleContext mod = loaderContext.parseFromFile(getResourcePath(IMPORT_WASM_PATH));
 
         List<ImportTypeContext> impTypes = mod.listImports();
-        Assert.assertEquals(impTypes.get(13).getMemoryType().getLimit(), new WasmEdgeLimit(false, 2, 2));
+        Assert.assertEquals(impTypes.get(13).getMemoryType().getLimit(), new Limit(false, 2, 2));
         loaderContext.delete();
         mod.delete();
     }
@@ -99,7 +99,7 @@ public class ImportTypeContextTest extends BaseTest {
 
         List<ImportTypeContext> impTypes = mod.listImports();
         Assert.assertEquals(impTypes.get(7).getGlobalType().getValueType(), ValueType.i64);
-        Assert.assertEquals(impTypes.get(7).getGlobalType().getMutability(), WasmEdgeMutability.CONST);
+        Assert.assertEquals(impTypes.get(7).getGlobalType().getMutability(), Mutability.CONST);
         loaderContext.delete();
         mod.delete();
     }

--- a/bindings/java/wasmedge-java/src/test/java/org/wasmedge/MemoryInstanceTest.java
+++ b/bindings/java/wasmedge-java/src/test/java/org/wasmedge/MemoryInstanceTest.java
@@ -7,7 +7,7 @@ public class MemoryInstanceTest extends BaseTest {
     @Test
     public void test() {
         MemoryTypeContext memType =
-                new MemoryTypeContext(new WasmEdgeLimit(false, 1, 1));
+                new MemoryTypeContext(new Limit(false, 1, 1));
         MemoryInstanceContext memCxt = new MemoryInstanceContext(memType);
         memCxt.delete();
         memType.delete();
@@ -16,7 +16,7 @@ public class MemoryInstanceTest extends BaseTest {
     @Test
     public void testSetDataAndGetData() {
         MemoryTypeContext memType =
-                new MemoryTypeContext(new WasmEdgeLimit(false, 1, 1));
+                new MemoryTypeContext(new Limit(false, 1, 1));
         MemoryInstanceContext memCxt = new MemoryInstanceContext(memType);
         byte[] data = {1, 2, 3, 4, 5};
 
@@ -29,7 +29,7 @@ public class MemoryInstanceTest extends BaseTest {
     @Test
     public void testGetSizeAndGrow() {
         MemoryTypeContext memType =
-                new MemoryTypeContext(new WasmEdgeLimit(false, 1, 1));
+                new MemoryTypeContext(new Limit(false, 1, 1));
         MemoryInstanceContext memCxt = new MemoryInstanceContext(memType);
         Assert.assertEquals(memCxt.getPageSize(), 1);
 

--- a/bindings/java/wasmedge-java/src/test/java/org/wasmedge/MemoryTypeContextTest.java
+++ b/bindings/java/wasmedge-java/src/test/java/org/wasmedge/MemoryTypeContextTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 public class MemoryTypeContextTest extends BaseTest {
     @Test
     public void testCreation() {
-        WasmEdgeLimit limit = new WasmEdgeLimit(true, 1, 1000);
+        Limit limit = new Limit(true, 1, 1000);
         MemoryTypeContext memoryTypeContext = new MemoryTypeContext(limit);
 
         Assert.assertEquals(memoryTypeContext.getLimit().isHasMax(), limit.isHasMax());

--- a/bindings/java/wasmedge-java/src/test/java/org/wasmedge/ModuleInstanceContextTest.java
+++ b/bindings/java/wasmedge-java/src/test/java/org/wasmedge/ModuleInstanceContextTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.wasmedge.enums.HostRegistration;
 import org.wasmedge.enums.RefType;
 import org.wasmedge.enums.ValueType;
-import org.wasmedge.enums.WasmEdgeMutability;
+import org.wasmedge.enums.Mutability;
 
 import java.util.List;
 import java.util.UUID;
@@ -48,7 +48,7 @@ public class ModuleInstanceContextTest extends BaseTest {
     public void testAddHostFunction() {
         HostFunction addHostFunc = new HostFunction() {
             @Override
-            public Result apply(MemoryInstanceContext mem, List<WasmEdgeValue> params, List<WasmEdgeValue> returns) {
+            public Result apply(MemoryInstanceContext mem, List<Value> params, List<Value> returns) {
                 return new Result();
             }
         };
@@ -62,7 +62,7 @@ public class ModuleInstanceContextTest extends BaseTest {
 
     @Test
     public void testAddHostTable() {
-        WasmEdgeLimit limit = new WasmEdgeLimit(true, 10, 20);
+        Limit limit = new Limit(true, 10, 20);
         TableTypeContext tableType = new TableTypeContext(RefType.FUNCREF, limit);
         TableInstanceContext tabIns = new TableInstanceContext(tableType);
         ModuleInstanceContext impCxt = new ModuleInstanceContext("extern");
@@ -71,7 +71,7 @@ public class ModuleInstanceContextTest extends BaseTest {
 
     @Test
     public void testAddHostMemory() {
-        WasmEdgeLimit limit = new WasmEdgeLimit(true, 1, 2);
+        Limit limit = new Limit(true, 1, 2);
         MemoryTypeContext memType = new MemoryTypeContext(limit);
         MemoryInstanceContext memIns = new MemoryInstanceContext(memType);
         ModuleInstanceContext impCxt = new ModuleInstanceContext("extern");
@@ -80,8 +80,8 @@ public class ModuleInstanceContextTest extends BaseTest {
 
     @Test
     public void testAddHostGlobal() {
-        GlobalTypeContext glbType = new GlobalTypeContext(ValueType.i32, WasmEdgeMutability.CONST);
-        GlobalInstanceContext glbIns = new GlobalInstanceContext(glbType, new WasmEdgeI32Value(666));
+        GlobalTypeContext glbType = new GlobalTypeContext(ValueType.i32, Mutability.CONST);
+        GlobalInstanceContext glbIns = new GlobalInstanceContext(glbType, new I32Value(666));
         ModuleInstanceContext impCxt = new ModuleInstanceContext("extern");
         impCxt.addGlobal("global_i32", glbIns);
     }

--- a/bindings/java/wasmedge-java/src/test/java/org/wasmedge/StatisticsContextTest.java
+++ b/bindings/java/wasmedge-java/src/test/java/org/wasmedge/StatisticsContextTest.java
@@ -37,14 +37,14 @@ public class StatisticsContextTest extends BaseTest {
         statisticsContext.setCostTable(costTable);
         statisticsContext.setCostLimit(500000);
 
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
 
         vm.runWasmFromFile(getResourcePath(FIB_WASM_PATH), FUNC_NAME, params, returns);
-        Assert.assertEquals(3, ((WasmEdgeI32Value) returns.get(0)).getValue());
+        Assert.assertEquals(3, ((I32Value) returns.get(0)).getValue());
 
         long cost = statisticsContext.getTotalCost();
         double ips = statisticsContext.getInstrPerSecond();

--- a/bindings/java/wasmedge-java/src/test/java/org/wasmedge/TableInstanceTest.java
+++ b/bindings/java/wasmedge-java/src/test/java/org/wasmedge/TableInstanceTest.java
@@ -9,7 +9,7 @@ public class TableInstanceTest extends BaseTest {
     @Test
     public void test() {
         TableTypeContext tab = new TableTypeContext(RefType.EXTERREF,
-                new WasmEdgeLimit(false, 10, 10));
+                new Limit(false, 10, 10));
         TableInstanceContext tabInstance = new TableInstanceContext(tab);
 
         tab.delete();
@@ -19,7 +19,7 @@ public class TableInstanceTest extends BaseTest {
     @Test
     public void testGetTableType() {
         TableTypeContext tab = new TableTypeContext(RefType.EXTERREF,
-                new WasmEdgeLimit(false, 10, 10));
+                new Limit(false, 10, 10));
         TableInstanceContext tabInstance = new TableInstanceContext(tab);
         Assert.assertEquals(tabInstance.getTableType().getRefType(), RefType.EXTERREF);
 
@@ -30,30 +30,30 @@ public class TableInstanceTest extends BaseTest {
     @Test
     public void testSetAndGetFuncRefData() {
         TableTypeContext tabCxt = new TableTypeContext(RefType.FUNCREF,
-                new WasmEdgeLimit(false, 10, 10));
+                new Limit(false, 10, 10));
         TableInstanceContext tabIns = new TableInstanceContext(tabCxt);
         int idx = 1;
-        WasmEdgeValue val = new WasmEdgeFuncRef(1);
+        Value val = new FuncRef(1);
 
         tabIns.setData(val, 5);
 
-        WasmEdgeFuncRef returnRef = (WasmEdgeFuncRef) tabIns.getData(ValueType.ExternRef, 5);
+        FuncRef returnRef = (FuncRef) tabIns.getData(ValueType.ExternRef, 5);
         Assert.assertEquals(idx, returnRef.getIndex());
     }
 
     @Test(expected = Exception.class)
     public void testSetDataInvalid() {
         TableTypeContext tabCxt = new TableTypeContext(RefType.FUNCREF,
-                new WasmEdgeLimit(true, 10, 10));
+                new Limit(true, 10, 10));
         TableInstanceContext tabIns = new TableInstanceContext(tabCxt);
-        WasmEdgeValue val = new WasmEdgeFuncRef(1);
+        Value val = new FuncRef(1);
         tabIns.setData(val, 12);
     }
 
     @Test
     public void testGetSizeAndGrow() {
         TableTypeContext tabCxt = new TableTypeContext(RefType.EXTERREF,
-                new WasmEdgeLimit(false, 10, 10));
+                new Limit(false, 10, 10));
         TableInstanceContext tabIns = new TableInstanceContext(tabCxt);
         Assert.assertEquals(tabIns.getSize(), 10);
         tabIns.grow(8);

--- a/bindings/java/wasmedge-java/src/test/java/org/wasmedge/TableTypeContextTest.java
+++ b/bindings/java/wasmedge-java/src/test/java/org/wasmedge/TableTypeContextTest.java
@@ -9,7 +9,7 @@ public class TableTypeContextTest extends BaseTest {
     @Test
     public void testCreateExtRef() {
         RefType refType = RefType.EXTERREF;
-        WasmEdgeLimit limit = new WasmEdgeLimit(true, 1, 1000);
+        Limit limit = new Limit(true, 1, 1000);
         TableTypeContext tableTypeContext = new TableTypeContext(refType, limit);
 
         Assert.assertEquals(tableTypeContext.getRefType(), refType);
@@ -21,7 +21,7 @@ public class TableTypeContextTest extends BaseTest {
     @Test
     public void testCreateFunRef() {
         RefType refType = RefType.FUNCREF;
-        WasmEdgeLimit limit = new WasmEdgeLimit(true, 1, 1000);
+        Limit limit = new Limit(true, 1, 1000);
         TableTypeContext tableTypeContext = new TableTypeContext(refType, limit);
 
         Assert.assertEquals(tableTypeContext.getRefType(), refType);

--- a/bindings/java/wasmedge-java/src/test/java/org/wasmedge/WasmEdgeAsyncTest.java
+++ b/bindings/java/wasmedge-java/src/test/java/org/wasmedge/WasmEdgeAsyncTest.java
@@ -14,15 +14,15 @@ public class WasmEdgeAsyncTest extends BaseTest{
         ConfigureContext configureContext = new ConfigureContext();
         configureContext.addHostRegistration(HostRegistration.WasmEdge_HostRegistration_Wasi);
         WasmEdgeVM vm = new WasmEdgeVM(configureContext, null);
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
 
         WasmEdgeAsync async = vm.asyncRunWasmFromFile(getResourcePath(FIB_WASM_PATH), FUNC_NAME, params);
         async.wasmEdge_AsyncGet(returns);
-        Assert.assertEquals(3, ((WasmEdgeI32Value) returns.get(0)).getValue());
+        Assert.assertEquals(3, ((I32Value) returns.get(0)).getValue());
         async.wasmEdge_AsyncDelete();
         vm.destroy();
     }
@@ -32,11 +32,11 @@ public class WasmEdgeAsyncTest extends BaseTest{
         ConfigureContext configureContext = new ConfigureContext();
         configureContext.addHostRegistration(HostRegistration.WasmEdge_HostRegistration_Wasi);
         WasmEdgeVM vm = new WasmEdgeVM(configureContext, null);
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
 
         WasmEdgeAsync async = vm.asyncRunWasmFromFile(getResourcePath(FIB_WASM_PATH), FUNC_NAME, params);
         int len = async.wasmEdge_AsyncGetReturnsLength();
@@ -49,16 +49,16 @@ public class WasmEdgeAsyncTest extends BaseTest{
         ConfigureContext configureContext = new ConfigureContext();
         configureContext.addHostRegistration(HostRegistration.WasmEdge_HostRegistration_Wasi);
         WasmEdgeVM vm = new WasmEdgeVM(configureContext, null);
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
 
         WasmEdgeAsync async = vm.asyncRunWasmFromFile(getResourcePath(FIB_WASM_PATH), FUNC_NAME, params);
         async.wasmEdge_AsyncWait();
         async.wasmEdge_AsyncGet(returns);
-        Assert.assertEquals(3, ((WasmEdgeI32Value) returns.get(0)).getValue());
+        Assert.assertEquals(3, ((I32Value) returns.get(0)).getValue());
         vm.destroy();
     }
 
@@ -67,11 +67,11 @@ public class WasmEdgeAsyncTest extends BaseTest{
         ConfigureContext configureContext = new ConfigureContext();
         configureContext.addHostRegistration(HostRegistration.WasmEdge_HostRegistration_Wasi);
         WasmEdgeVM vm = new WasmEdgeVM(configureContext, null);
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
 
         WasmEdgeAsync async = vm.asyncRunWasmFromFile(getResourcePath(FIB_WASM_PATH), FUNC_NAME, params);
         boolean isEnd = async.wasmEdge_AsyncWaitFor(100);
@@ -85,11 +85,11 @@ public class WasmEdgeAsyncTest extends BaseTest{
         ConfigureContext configureContext = new ConfigureContext();
         configureContext.addHostRegistration(HostRegistration.WasmEdge_HostRegistration_Wasi);
         WasmEdgeVM vm = new WasmEdgeVM(configureContext, null);
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(35));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(35));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
 
         WasmEdgeAsync async = vm.asyncRunWasmFromFile(getResourcePath(FIB_WASM_PATH), FUNC_NAME, params);
         boolean isEnd = async.wasmEdge_AsyncWaitFor(100);
@@ -105,18 +105,18 @@ public class WasmEdgeAsyncTest extends BaseTest{
         ConfigureContext configureContext = new ConfigureContext();
         configureContext.addHostRegistration(HostRegistration.WasmEdge_HostRegistration_Wasi);
         WasmEdgeVM vm = new WasmEdgeVM(configureContext, null);
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(35));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(35));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
 
         WasmEdgeAsync async = vm.asyncRunWasmFromFile(getResourcePath(FIB_WASM_PATH), FUNC_NAME, params);
         boolean isEnd = async.wasmEdge_AsyncWaitFor(100);
         if (!isEnd){
             async.wasmEdge_AsyncCancel();
         }
-        Assert.assertEquals(0, ((WasmEdgeI32Value) returns.get(0)).getValue());
+        Assert.assertEquals(0, ((I32Value) returns.get(0)).getValue());
         vm.destroy();
     }
     

--- a/bindings/java/wasmedge-java/src/test/java/org/wasmedge/WasmEdgeVMTest.java
+++ b/bindings/java/wasmedge-java/src/test/java/org/wasmedge/WasmEdgeVMTest.java
@@ -16,14 +16,14 @@ public class WasmEdgeVMTest extends BaseTest {
         ConfigureContext configureContext = new ConfigureContext();
         configureContext.addHostRegistration(HostRegistration.WasmEdge_HostRegistration_Wasi);
         WasmEdgeVM vm = new WasmEdgeVM(configureContext, null);
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
 
         vm.runWasmFromFile(getResourcePath(FIB_WASM_PATH), FUNC_NAME, params, returns);
-        Assert.assertEquals(3, ((WasmEdgeI32Value) returns.get(0)).getValue());
+        Assert.assertEquals(3, ((I32Value) returns.get(0)).getValue());
         vm.destroy();
     }
 
@@ -35,14 +35,14 @@ public class WasmEdgeVMTest extends BaseTest {
         vm.loadWasmFromFile(getResourcePath(FIB_WASM_PATH));
         vm.validate();
         vm.instantiate();
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
         vm.execute("fib", params, returns);
 
-        Assert.assertEquals(3, ((WasmEdgeI32Value) returns.get(0)).getValue());
+        Assert.assertEquals(3, ((I32Value) returns.get(0)).getValue());
         vm.destroy();
     }
 
@@ -58,11 +58,11 @@ public class WasmEdgeVMTest extends BaseTest {
         vm.loadWasmFromFile(getResourcePath(FIB_WASM_PATH));
         vm.validate();
         vm.instantiate();
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
         vm.execute(UUID.randomUUID().toString(), params, returns);
     }
 
@@ -135,14 +135,14 @@ public class WasmEdgeVMTest extends BaseTest {
         String modName = "module";
         vm.registerModuleFromBuffer(modName, loadFile(getResourcePath(FIB_WASM_PATH)));
 
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
 
         vm.executeRegistered(modName, FUNC_NAME, params, returns);
-        Assert.assertEquals(3, ((WasmEdgeI32Value) returns.get(0)).getValue());
+        Assert.assertEquals(3, ((I32Value) returns.get(0)).getValue());
         vm.destroy();
     }
 
@@ -163,14 +163,14 @@ public class WasmEdgeVMTest extends BaseTest {
         byte[] data = loadFile(getResourcePath(FIB_WASM_PATH));
         WasmEdgeVM vm = new WasmEdgeVM(null, null);
 
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
         vm.runWasmFromBuffer(data, FUNC_NAME, params, returns);
 
-        WasmEdgeI32Value value = (WasmEdgeI32Value) returns.get(0);
+        I32Value value = (I32Value) returns.get(0);
         Assert.assertEquals(3, value.getValue());
     }
 
@@ -181,14 +181,14 @@ public class WasmEdgeVMTest extends BaseTest {
 
         WasmEdgeVM vm = new WasmEdgeVM(null, null);
 
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
 
         vm.runWasmFromASTModule(mod, FUNC_NAME, params, returns);
-        WasmEdgeI32Value value = (WasmEdgeI32Value) returns.get(0);
+        I32Value value = (I32Value) returns.get(0);
         Assert.assertEquals(3, value.getValue());
     }
     
@@ -197,15 +197,15 @@ public class WasmEdgeVMTest extends BaseTest {
         ConfigureContext configureContext = new ConfigureContext();
         configureContext.addHostRegistration(HostRegistration.WasmEdge_HostRegistration_Wasi);
         WasmEdgeVM vm = new WasmEdgeVM(configureContext, null);
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
 
         WasmEdgeAsync async = vm.asyncRunWasmFromFile(getResourcePath(FIB_WASM_PATH), FUNC_NAME, params);
         async.wasmEdge_AsyncGet(returns);
-        Assert.assertEquals(3, ((WasmEdgeI32Value) returns.get(0)).getValue());
+        Assert.assertEquals(3, ((I32Value) returns.get(0)).getValue());
         vm.destroy();
     }
 
@@ -217,14 +217,14 @@ public class WasmEdgeVMTest extends BaseTest {
         vm.loadWasmFromFile(getResourcePath(FIB_WASM_PATH));
         vm.validate();
         vm.instantiate();
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
         WasmEdgeAsync async = vm.asyncExecute("fib", params);
         async.wasmEdge_AsyncGet(returns);
-        Assert.assertEquals(3, ((WasmEdgeI32Value) returns.get(0)).getValue());
+        Assert.assertEquals(3, ((I32Value) returns.get(0)).getValue());
         vm.destroy();
     }
 
@@ -234,15 +234,15 @@ public class WasmEdgeVMTest extends BaseTest {
         String modName = "module";
         vm.registerModuleFromBuffer(modName, loadFile(getResourcePath(FIB_WASM_PATH)));
 
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
 
         WasmEdgeAsync async = vm.asyncExecuteRegistered(modName, FUNC_NAME, params);
         async.wasmEdge_AsyncGet(returns);
-        Assert.assertEquals(3, ((WasmEdgeI32Value) returns.get(0)).getValue());
+        Assert.assertEquals(3, ((I32Value) returns.get(0)).getValue());
         vm.destroy();
     }
 
@@ -251,14 +251,14 @@ public class WasmEdgeVMTest extends BaseTest {
         byte[] data = loadFile(getResourcePath(FIB_WASM_PATH));
         WasmEdgeVM vm = new WasmEdgeVM(null, null);
 
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
         WasmEdgeAsync async = vm.asyncRunWasmFromBuffer(data, FUNC_NAME, params);
         async.wasmEdge_AsyncGet(returns);
-        WasmEdgeI32Value value = (WasmEdgeI32Value) returns.get(0);
+        I32Value value = (I32Value) returns.get(0);
         Assert.assertEquals(3, value.getValue());
     }
 
@@ -269,15 +269,15 @@ public class WasmEdgeVMTest extends BaseTest {
 
         WasmEdgeVM vm = new WasmEdgeVM(null, null);
 
-        List<WasmEdgeValue> params = new ArrayList<>();
-        params.add(new WasmEdgeI32Value(3));
+        List<Value> params = new ArrayList<>();
+        params.add(new I32Value(3));
 
-        List<WasmEdgeValue> returns = new ArrayList<>();
-        returns.add(new WasmEdgeI32Value());
+        List<Value> returns = new ArrayList<>();
+        returns.add(new I32Value());
 
         WasmEdgeAsync async = vm.asyncRunWasmFromASTModule(mod, FUNC_NAME, params);
         async.wasmEdge_AsyncGet(returns);
-        WasmEdgeI32Value value = (WasmEdgeI32Value) returns.get(0);
+        I32Value value = (I32Value) returns.get(0);
         Assert.assertEquals(3, value.getValue());
     }
 }

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/AstModuleContext.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/AstModuleContext.c
@@ -9,13 +9,7 @@
 #include "wasmedge/wasmedge.h"
 #include <stdlib.h>
 
-WasmEdge_ASTModuleContext *getASTModuleContext(JNIEnv *env,
-                                               jobject thisObject) {
-  if (thisObject == NULL) {
-    return NULL;
-  }
-  return (WasmEdge_ASTModuleContext *)getPointer(env, thisObject);
-}
+GETTER(ASTModuleContext)
 
 JNIEXPORT jobject JNICALL Java_org_wasmedge_ASTModuleContext_listImports(
     JNIEnv *env, jobject thisObject) {
@@ -65,8 +59,8 @@ JNIEXPORT jobject JNICALL Java_org_wasmedge_ASTModuleContext_listExports(
 jobject createAstModuleContext(JNIEnv *env,
                                const WasmEdge_ASTModuleContext *mod) {
 
-  jclass cls = findJavaClass(env, "org/wasmedge/ASTModuleContext");
-  jmethodID constructor = findJavaMethod(env, cls, "<init>", "()V");
+  jclass cls = findJavaClass(env, ORG_WASMEDGE_ASTMODULECONTEXT);
+  jmethodID constructor = findJavaMethod(env, cls, DEFAULT_CONSTRUCTOR, VOID_VOID);
   jobject obj = (*env)->NewObject(env, cls, constructor);
   setPointer(env, obj, (long)mod);
   return obj;

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/CompilerContext.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/CompilerContext.c
@@ -6,13 +6,7 @@
 #include "common.h"
 #include "wasmedge/wasmedge.h"
 
-WasmEdge_CompilerContext *getCompilerContext(JNIEnv *env,
-                                             jobject jCompilerContext) {
-  if (jCompilerContext == NULL) {
-    return NULL;
-  }
-  return (WasmEdge_CompilerContext *)getPointer(env, jCompilerContext);
-}
+GETTER(CompilerContext)
 
 JNIEXPORT void JNICALL Java_org_wasmedge_CompilerContext_nativeInit(
     JNIEnv *env, jobject thisObject, jobject jConfigContext) {

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/ConfigureContext.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/ConfigureContext.c
@@ -6,18 +6,13 @@
 #include "wasmedge/wasmedge.h"
 #include <stdint.h>
 
+GETTER(ConfigureContext)
+
+
 JNIEXPORT void JNICALL
 Java_org_wasmedge_ConfigureContext_nativeInit(JNIEnv *env, jobject thisObj) {
   WasmEdge_ConfigureContext *ConfigureContext = WasmEdge_ConfigureCreate();
   setPointer(env, thisObj, (jlong)ConfigureContext);
-}
-
-WasmEdge_ConfigureContext *getConfigureContext(JNIEnv *env,
-                                               jobject jConfigureContext) {
-  if (jConfigureContext == NULL) {
-    return NULL;
-  }
-  return (WasmEdge_ConfigureContext *)getPointer(env, jConfigureContext);
 }
 
 JNIEXPORT void JNICALL

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/ExecutorContext.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/ExecutorContext.c
@@ -13,13 +13,7 @@
 #include "wasmedge/wasmedge.h"
 #include <stdlib.h>
 
-WasmEdge_ExecutorContext *getExecutorContext(JNIEnv *env, jobject jExeCtx) {
-  if (jExeCtx == NULL) {
-    return NULL;
-  }
-
-  return (WasmEdge_ExecutorContext *)getPointer(env, jExeCtx);
-}
+GETTER(ExecutorContext)
 
 JNIEXPORT void JNICALL Java_org_wasmedge_ExecutorContext_nativeInit(
     JNIEnv *env, jobject thisObject, jobject jConfigContext, jobject jStatCxt) {

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/ExportTypeContext.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/ExportTypeContext.c
@@ -11,13 +11,7 @@
 #include "jni.h"
 #include "wasmedge/wasmedge.h"
 
-WasmEdge_ExportTypeContext *getExportTypeContext(JNIEnv *env,
-                                                 jobject jExpType) {
-  if (jExpType == NULL) {
-    return NULL;
-  }
-  return (WasmEdge_ExportTypeContext *)getPointer(env, jExpType);
-}
+GETTER(ExportTypeContext)
 
 /*
  * Class:     org_wasmedge_ExportTypeContext
@@ -117,9 +111,9 @@ jobject createExportTypeContext(JNIEnv *env,
                                 const WasmEdge_ExportTypeContext *cxt,
                                 jobject jAstMod) {
 
-  jclass cls = findJavaClass(env, "org/wasmedge/ExportTypeContext");
+  jclass cls = findJavaClass(env, ORG_WASMEDGE_EXPORTTYPECONTEXT);
   jmethodID constructor =
-      findJavaMethod(env, cls, "<init>", "(JLorg/wasmedge/ASTModuleContext;)V");
+      findJavaMethod(env, cls, DEFAULT_CONSTRUCTOR, ASTMODULECONTEXT_VOID);
   jobject obj = (*env)->NewObject(env, cls, constructor, (long)cxt, jAstMod);
   return obj;
 }

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/ExternRef.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/ExternRef.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2019-2022 Second State INC
 
-#include "../jni/org_wasmedge_WasmEdgeExternRef.h"
 #include "common.h"
 #include <stdlib.h>
 #include <string.h>

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/FunctionTypeInstance.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/FunctionTypeInstance.c
@@ -10,6 +10,8 @@
 #include "wasmedge/wasmedge.h"
 #include <stdlib.h>
 
+GETTER(FunctionInstanceContext)
+
 WasmEdge_Result HostFuncWrap(void *This, void *Data,
                              const WasmEdge_CallingFrameContext *Mem,
                              const WasmEdge_Value *In, const unsigned int InLen,
@@ -21,10 +23,9 @@ WasmEdge_Result HostFuncWrap(void *This, void *Data,
 
   jstring jFuncKey = (*env)->NewStringUTF(env, funcKey);
 
-  jclass clazz = (*env)->FindClass(env, "org/wasmedge/WasmEdgeVM");
+  jclass clazz = (*env)->FindClass(env, ORG_WASMEDGE_WASMEDGEVM);
   jmethodID funcGetter = (*env)->GetStaticMethodID(
-      env, clazz, "getHostFunc",
-      "(Ljava/lang/String;)Lorg/wasmedge/HostFunction;");
+      env, clazz, GET_HOST_FUNC, STRING_HOSTFUNCTION);
 
   jobject jFunc =
       (*env)->CallStaticObjectMethod(env, clazz, funcGetter, jFuncKey);
@@ -32,9 +33,8 @@ WasmEdge_Result HostFuncWrap(void *This, void *Data,
   jclass jFuncClass = (*env)->GetObjectClass(env, jFunc);
 
   jmethodID funcMethod =
-      (*env)->GetMethodID(env, jFuncClass, "apply",
-                          "(Lorg/wasmedge/MemoryInstanceContext;Ljava/util/"
-                          "List;Ljava/util/List;)Lorg/wasmedge/Result;");
+      (*env)->GetMethodID(env, jFuncClass, APPLY,
+                          MEMORYINSTANCECONTEXTLIST_RESULT);
 
   // TODO replace with CallingFrameContext
   jobject jMem =
@@ -55,18 +55,6 @@ WasmEdge_Result HostFuncWrap(void *This, void *Data,
   }
 
   return WasmEdge_Result_Success;
-}
-
-WasmEdge_FunctionInstanceContext *
-getFunctionInstanceContext(JNIEnv *env, jobject jFuncInstance) {
-
-  if (jFuncInstance == NULL) {
-    return NULL;
-  }
-  WasmEdge_FunctionInstanceContext *funcInstance =
-      (struct WasmEdge_FunctionInstanceContext *)getPointer(env, jFuncInstance);
-
-  return funcInstance;
 }
 
 JNIEXPORT jobject JNICALL
@@ -108,8 +96,8 @@ jobject createJFunctionInstanceContext(
     return NULL;
   }
 
-  jclass clazz = (*env)->FindClass(env, "org/wasmedge/FunctionInstanceContext");
-  jmethodID constructorId = (*env)->GetMethodID(env, clazz, "<init>", "(J)V");
+  jclass clazz = (*env)->FindClass(env, ORG_WASMEDGE_FUNCTIONINSTANCECONTEXT);
+  jmethodID constructorId = (*env)->GetMethodID(env, clazz, DEFAULT_CONSTRUCTOR, LONG_VOID);
   return (*env)->NewObject(env, clazz, constructorId, (long)funcInstance);
 }
 

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/GlobalInstanceContext.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/GlobalInstanceContext.c
@@ -9,18 +9,7 @@
 #include "ValueType.h"
 #include "common.h"
 
-WasmEdge_GlobalInstanceContext *
-getGlobalInstanceContext(JNIEnv *env, jobject jGlobalInstanceContext) {
-
-  if (jGlobalInstanceContext == NULL) {
-    return NULL;
-  }
-  WasmEdge_GlobalInstanceContext *globalInstanceContext =
-      (struct WasmEdge_GlobalInstanceContext *)getPointer(
-          env, jGlobalInstanceContext);
-
-  return globalInstanceContext;
-}
+GETTER(GlobalInstanceContext)
 
 JNIEXPORT void JNICALL Java_org_wasmedge_GlobalInstanceContext_nativeInit(
     JNIEnv *env, jobject thisObject, jobject jGlobalTypeCxt, jobject jVal) {
@@ -58,7 +47,7 @@ jobject createJGlobalInstanceContext(
     return NULL;
   }
 
-  jclass clazz = (*env)->FindClass(env, "org/wasmedge/GlobalInstanceContext");
-  jmethodID constructorId = (*env)->GetMethodID(env, clazz, "<init>", "(J)V");
+  jclass clazz = (*env)->FindClass(env, ORG_WASMEDGE_GLOBALINSTANCECONTEXT);
+  jmethodID constructorId = (*env)->GetMethodID(env, clazz, DEFAULT_CONSTRUCTOR, LONG_VOID);
   return (*env)->NewObject(env, clazz, constructorId, (long)globInstance);
 }

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/GlobalTypeContext.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/GlobalTypeContext.c
@@ -7,17 +7,7 @@
 #include "common.h"
 #include "wasmedge/wasmedge.h"
 
-WasmEdge_GlobalTypeContext *getGlobalTypeContext(JNIEnv *env,
-                                                 jobject jGlobalTypeContext) {
-
-  if (jGlobalTypeContext == NULL) {
-    return NULL;
-  }
-  WasmEdge_GlobalTypeContext *globalTypeContext =
-      (struct WasmEdge_GlobalTypeContext *)getPointer(env, jGlobalTypeContext);
-
-  return globalTypeContext;
-}
+GETTER(GlobalTypeContext)
 
 JNIEXPORT void JNICALL Java_org_wasmedge_GlobalTypeContext_nativeInit(
     JNIEnv *env, jobject thisObject, jint valueType, jint mutability) {
@@ -31,8 +21,8 @@ jobject
 createJGlobalTypeContext(JNIEnv *env,
                          const WasmEdge_GlobalTypeContext *globalTypeContext) {
 
-  jclass clazz = (*env)->FindClass(env, "org/wasmedge/GlobalTypeContext");
-  jmethodID constructorId = (*env)->GetMethodID(env, clazz, "<init>", "(J)V");
+  jclass clazz = (*env)->FindClass(env, ORG_WASMEDGE_GLOBALTYPECONTEXT);
+  jmethodID constructorId = (*env)->GetMethodID(env, clazz, DEFAULT_CONSTRUCTOR, LONG_VOID);
   return (*env)->NewObject(env, clazz, constructorId, (long)globalTypeContext);
 }
 JNIEXPORT void JNICALL

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/ImportTypeContext.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/ImportTypeContext.c
@@ -11,14 +11,7 @@
 #include "jni.h"
 #include "wasmedge/wasmedge.h"
 
-WasmEdge_ImportTypeContext *getImportTypeContext(JNIEnv *env,
-                                                 jobject jExpType) {
-  if (jExpType == NULL) {
-    return NULL;
-  }
-
-  return (WasmEdge_ImportTypeContext *)getPointer(env, jExpType);
-}
+GETTER(ImportTypeContext)
 
 JNIEXPORT jstring JNICALL Java_org_wasmedge_ImportTypeContext_getModuleName(
     JNIEnv *env, jobject thisObject) {
@@ -127,9 +120,9 @@ jobject createImportTypeContext(JNIEnv *env,
                                 const WasmEdge_ImportTypeContext *cxt,
                                 jobject jAstMod) {
 
-  jclass cls = findJavaClass(env, "org/wasmedge/ImportTypeContext");
+  jclass cls = findJavaClass(env, ORG_WASMEDGE_IMPORTTYPECONTEXT);
   jmethodID constructor =
-      findJavaMethod(env, cls, "<init>", "(JLorg/wasmedge/ASTModuleContext;)V");
+      findJavaMethod(env, cls, DEFAULT_CONSTRUCTOR, ASTMODULECONTEXT_VOID);
   jobject obj = (*env)->NewObject(env, cls, constructor, (long)cxt, jAstMod);
   return obj;
 }

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/LoaderContext.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/LoaderContext.c
@@ -7,13 +7,11 @@
 #include "common.h"
 #include "wasmedge/wasmedge.h"
 
-WasmEdge_LoaderContext *getLoader(JNIEnv *env, jobject jLoader) {
-  return (WasmEdge_LoaderContext *)getPointer(env, jLoader);
-}
+GETTER(LoaderContext)
 
 JNIEXPORT jobject JNICALL Java_org_wasmedge_LoaderContext_parseFromFile(
     JNIEnv *env, jobject thisObject, jstring jInputPath) {
-  WasmEdge_LoaderContext *loader = getLoader(env, thisObject);
+  WasmEdge_LoaderContext *loader = getLoaderContext(env, thisObject);
 
   const char *inputPath = (*env)->GetStringUTFChars(env, jInputPath, NULL);
 
@@ -33,7 +31,7 @@ JNIEXPORT jobject JNICALL Java_org_wasmedge_LoaderContext_parseFromFile(
 
 JNIEXPORT jobject JNICALL Java_org_wasmedge_LoaderContext_parseFromBuffer(
     JNIEnv *env, jobject thisObject, jbyteArray jBuf, jint jSize) {
-  WasmEdge_LoaderContext *loader = getLoader(env, thisObject);
+  WasmEdge_LoaderContext *loader = getLoaderContext(env, thisObject);
 
   WasmEdge_ASTModuleContext *mod = NULL;
 
@@ -58,6 +56,6 @@ JNIEXPORT void JNICALL Java_org_wasmedge_LoaderContext_nativeInit(
 JNIEXPORT void JNICALL
 Java_org_wasmedge_LoaderContext_delete(JNIEnv *env, jobject thisObject) {
 
-  WasmEdge_LoaderContext *loader = getLoader(env, thisObject);
+  WasmEdge_LoaderContext *loader = getLoaderContext(env, thisObject);
   WasmEdge_LoaderDelete(loader);
 }

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/MemoryInstanceContext.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/MemoryInstanceContext.c
@@ -7,18 +7,7 @@
 #include "wasmedge/wasmedge.h"
 #include <stdlib.h>
 
-WasmEdge_MemoryInstanceContext *
-getMemoryInstanceContext(JNIEnv *env, jobject jMemoryInstanceContext) {
-
-  if (jMemoryInstanceContext == NULL) {
-    return NULL;
-  }
-  WasmEdge_MemoryInstanceContext *memoryInstanceContext =
-      (struct WasmEdge_MemoryInstanceContext *)getPointer(
-          env, jMemoryInstanceContext);
-
-  return memoryInstanceContext;
-}
+GETTER(MemoryInstanceContext)
 
 JNIEXPORT void JNICALL Java_org_wasmedge_MemoryInstanceContext_nativeInit(
     JNIEnv *env, jobject thisObject, jobject jMemoryTypeContext) {
@@ -106,7 +95,7 @@ jobject createJMemoryInstanceContext(
     return NULL;
   }
 
-  jclass clazz = (*env)->FindClass(env, "org/wasmedge/MemoryInstanceContext");
-  jmethodID constructorId = (*env)->GetMethodID(env, clazz, "<init>", "(J)V");
+  jclass clazz = (*env)->FindClass(env, ORG_WASMEDGE_MEMORYINSTANCECONTEXT);
+  jmethodID constructorId = (*env)->GetMethodID(env, clazz, DEFAULT_CONSTRUCTOR, LONG_VOID);
   return (*env)->NewObject(env, clazz, constructorId, (long)memInstance);
 }

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/MemoryTypeContext.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/MemoryTypeContext.c
@@ -5,17 +5,7 @@
 #include "common.h"
 #include "wasmedge/wasmedge.h"
 
-WasmEdge_MemoryTypeContext *getMemoryTypeContext(JNIEnv *env,
-                                                 jobject jMemoryTypeContext) {
-
-  if (jMemoryTypeContext == NULL) {
-    return NULL;
-  }
-  WasmEdge_MemoryTypeContext *memoryTypeContext =
-      (struct WasmEdge_MemoryTypeContext *)getPointer(env, jMemoryTypeContext);
-
-  return memoryTypeContext;
-}
+GETTER(MemoryTypeContext)
 
 JNIEXPORT void JNICALL Java_org_wasmedge_MemoryTypeContext_nativeInit(
     JNIEnv *env, jobject thisObject, jboolean jHasMax, jlong jMin, jlong jMax) {
@@ -38,9 +28,9 @@ jobject
 createJMemoryTypeContext(JNIEnv *env,
                          const WasmEdge_MemoryTypeContext *memTypeContext) {
 
-  jclass clazz = (*env)->FindClass(env, "org/wasmedge/MemoryTypeContext");
+  jclass clazz = (*env)->FindClass(env, ORG_WASMEDGE_MEMORYTYPECONTEXT);
 
-  jmethodID constructorId = (*env)->GetMethodID(env, clazz, "<init>", "(J)V");
+  jmethodID constructorId = (*env)->GetMethodID(env, clazz, DEFAULT_CONSTRUCTOR, LONG_VOID);
 
   return (*env)->NewObject(env, clazz, constructorId, (long)memTypeContext);
 }
@@ -52,9 +42,9 @@ Java_org_wasmedge_MemoryTypeContext_getLimit(JNIEnv *env, jobject thisObject) {
       getMemoryTypeContext(env, thisObject);
   WasmEdge_Limit limit = WasmEdge_MemoryTypeGetLimit(memoryTypeContext);
 
-  jclass limitClass = findJavaClass(env, "org/wasmedge/WasmEdgeLimit");
+  jclass limitClass = findJavaClass(env, ORG_WASMEDGE_LIMIT);
 
-  jmethodID constructor = findJavaMethod(env, limitClass, "<init>", "(ZJJ)V");
+  jmethodID constructor = findJavaMethod(env, limitClass, DEFAULT_CONSTRUCTOR, BOOLLONGLONG_VOID);
 
   return (*env)->NewObject(env, limitClass, constructor, (jboolean)limit.HasMax,
                            (jlong)limit.Min, (jlong)limit.Max);

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/ModuleInstanceContext.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/ModuleInstanceContext.c
@@ -10,21 +10,11 @@
 #include "wasmedge/wasmedge.h"
 #include <stdlib.h>
 
+GETTER(ModuleInstanceContext)
+
 jobject
 createJModuleInstanceContext(JNIEnv *env,
                              const WasmEdge_ModuleInstanceContext *impObj);
-
-WasmEdge_ModuleInstanceContext *getModuleInstanceContext(JNIEnv *env,
-                                                         jobject jImpObjCxt) {
-
-  if (jImpObjCxt == NULL) {
-    return NULL;
-  }
-  WasmEdge_ModuleInstanceContext *importObjectContext =
-      (struct WasmEdge_ModuleInstanceContext *)getPointer(env, jImpObjCxt);
-
-  return importObjectContext;
-}
 
 JNIEXPORT void JNICALL Java_org_wasmedge_ModuleInstanceContext_nativeInit(
     JNIEnv *env, jobject thisObject, jstring moduleName) {
@@ -290,9 +280,9 @@ jobject
 createJModuleInstanceContext(JNIEnv *env,
                              const WasmEdge_ModuleInstanceContext *impObj) {
 
-  jclass clazz = (*env)->FindClass(env, "org/wasmedge/ModuleInstanceContext");
+  jclass clazz = (*env)->FindClass(env, ORG_WASMEDGE_MODULEINSTANCECONTEXT);
 
-  jmethodID constructorId = (*env)->GetMethodID(env, clazz, "<init>", "(J)V");
+  jmethodID constructorId = (*env)->GetMethodID(env, clazz, DEFAULT_CONSTRUCTOR, LONG_VOID);
 
   return (*env)->NewObject(env, clazz, constructorId, (long)impObj);
 }

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/StatisticsContext.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/StatisticsContext.c
@@ -7,24 +7,18 @@
 #include "wasmedge/wasmedge.h"
 #include <stdlib.h>
 
-WasmEdge_StatisticsContext *getStatisticsContext(JNIEnv *env,
-                                                 jobject jStatCxt) {
-  if (jStatCxt == NULL) {
-    return NULL;
-  }
-  return (WasmEdge_StatisticsContext *)getPointer(env, jStatCxt);
-}
+GETTER(StatisticsContext)
 
 jobject
 CreateJavaStatisticsContext(JNIEnv *env,
                             WasmEdge_StatisticsContext *statisticsContext) {
-  jclass statClass = findJavaClass(env, "org/wasmedge/StatisticsContext");
+  jclass statClass = findJavaClass(env, ORG_WASMEDGE_STATISTICSCONTEXT);
 
-  jmethodID constructor = (*env)->GetMethodID(env, statClass, "<init>", "(J)V");
+  jmethodID constructor = (*env)->GetMethodID(env, statClass, DEFAULT_CONSTRUCTOR, LONG_VOID);
 
   jobject jStatContext =
       (*env)->NewObject(env, statClass, constructor, (long)statisticsContext);
-  checkAndHandleException(env, "error creating stat context");
+  checkAndHandleException(env, ERR_CREATE_STATICS_CONTEXT_FAILED);
 
   return jStatContext;
 }

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/StoreContext.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/StoreContext.c
@@ -10,29 +10,20 @@
 #include "wasmedge/wasmedge.h"
 #include <stdlib.h>
 
+GETTER(StoreContext)
+
 JNIEXPORT void JNICALL
 Java_org_wasmedge_StoreContext_nativeInit(JNIEnv *env, jobject thisObj) {
   WasmEdge_StoreContext *StoreContext = WasmEdge_StoreCreate();
   setPointer(env, thisObj, (jlong)StoreContext);
 }
 
-WasmEdge_StoreContext *getStoreContext(JNIEnv *env, jobject jStoreContext) {
-
-  if (jStoreContext == NULL) {
-    return NULL;
-  }
-  WasmEdge_StoreContext *StoreContext =
-      (WasmEdge_StoreContext *)getPointer(env, jStoreContext);
-
-  return StoreContext;
-}
-
 jobject CreateJavaStoreContext(JNIEnv *env,
                                WasmEdge_StoreContext *storeContext) {
-  jclass storeClass = findJavaClass(env, "org/wasmedge/StoreContext");
+  jclass storeClass = findJavaClass(env, ORG_WASMEDGE_STORECONTEXT);
 
   jmethodID constructor =
-      (*env)->GetMethodID(env, storeClass, "<init>", "(J)V");
+      (*env)->GetMethodID(env, storeClass, DEFAULT_CONSTRUCTOR, LONG_VOID);
 
   jobject jStoreContext =
       (*env)->NewObject(env, storeClass, constructor, (long)storeContext);

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/TableInstanceContext.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/TableInstanceContext.c
@@ -7,18 +7,7 @@
 #include "common.h"
 #include "wasmedge/wasmedge.h"
 
-WasmEdge_TableInstanceContext *
-getTableInstanceContext(JNIEnv *env, jobject jTableInstanceContext) {
-
-  if (jTableInstanceContext == NULL) {
-    return NULL;
-  }
-  WasmEdge_TableInstanceContext *tableInstanceContext =
-      (struct WasmEdge_TableInstanceContext *)getPointer(env,
-                                                         jTableInstanceContext);
-
-  return tableInstanceContext;
-}
+GETTER(TableInstanceContext)
 
 JNIEXPORT void JNICALL Java_org_wasmedge_TableInstanceContext_nativeInit(
     JNIEnv *env, jobject thisObject, jobject jTableTypeContext) {
@@ -53,7 +42,7 @@ JNIEXPORT jobject JNICALL Java_org_wasmedge_TableInstanceContext_getData(
       getTableInstanceContext(env, thisObject);
 
   jclass typeClass = (*env)->GetObjectClass(env, jValType);
-  jmethodID typeGetter = (*env)->GetMethodID(env, typeClass, "getValue", "()I");
+  jmethodID typeGetter = (*env)->GetMethodID(env, typeClass, GET_VALUE, VOID_INT);
 
   jint valType = (*env)->CallIntMethod(env, jValType, typeGetter);
 
@@ -109,7 +98,7 @@ createJTableInstanceContext(JNIEnv *env,
     return NULL;
   }
 
-  jclass clazz = (*env)->FindClass(env, "org/wasmedge/TableInstanceContext");
-  jmethodID constructorId = (*env)->GetMethodID(env, clazz, "<init>", "(J)V");
+  jclass clazz = (*env)->FindClass(env, ORG_WASMEDGE_TABLEINSTANCECONTEXT);
+  jmethodID constructorId = (*env)->GetMethodID(env, clazz, DEFAULT_CONSTRUCTOR, LONG_VOID);
   return (*env)->NewObject(env, clazz, constructorId, (long)tabInstance);
 }

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/TableTypeContext.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/TableTypeContext.c
@@ -5,30 +5,20 @@
 #include "common.h"
 #include "wasmedge/wasmedge.h"
 
-WasmEdge_TableTypeContext *getTableTypeContext(JNIEnv *env,
-                                               jobject jTableTypeContext) {
-
-  if (jTableTypeContext == NULL) {
-    return NULL;
-  }
-  WasmEdge_TableTypeContext *tableTypeContext =
-      (WasmEdge_TableTypeContext *)getPointer(env, jTableTypeContext);
-
-  return tableTypeContext;
-}
+GETTER(TableTypeContext)
 
 JNIEXPORT void JNICALL Java_org_wasmedge_TableTypeContext_nativeInit(
     JNIEnv *env, jobject thisObject, jint refType, jobject jLimit) {
 
   jclass cls = (*env)->GetObjectClass(env, jLimit);
 
-  jmethodID hasMaxMid = (*env)->GetMethodID(env, cls, "isHasMax", "()Z");
+  jmethodID hasMaxMid = (*env)->GetMethodID(env, cls, LIMIT_IS_HAS_MAX, VOID_BOOL);
   jboolean hasMax = (*env)->CallBooleanMethod(env, jLimit, hasMaxMid);
 
-  jmethodID maxMid = (*env)->GetMethodID(env, cls, "getMax", "()J");
+  jmethodID maxMid = (*env)->GetMethodID(env, cls, LIMIT_GET_MAX, VOID_LONG);
   jlong max = (*env)->CallLongMethod(env, jLimit, maxMid);
 
-  jmethodID minMid = (*env)->GetMethodID(env, cls, "getMin", "()J");
+  jmethodID minMid = (*env)->GetMethodID(env, cls, LIMIT_GET_MIN, VOID_LONG);
   jlong min = (*env)->CallLongMethod(env, jLimit, minMid);
 
   WasmEdge_Limit tableLimit = {.HasMax = hasMax, .Min = min, .Max = max};
@@ -44,9 +34,9 @@ Java_org_wasmedge_TableTypeContext_getLimit(JNIEnv *env, jobject thisObject) {
 
   WasmEdge_Limit limit = WasmEdge_TableTypeGetLimit(tableTypeContext);
 
-  jclass limitClass = findJavaClass(env, "org/wasmedge/WasmEdgeLimit");
+  jclass limitClass = findJavaClass(env, ORG_WASMEDGE_LIMIT);
 
-  jmethodID constructor = findJavaMethod(env, limitClass, "<init>", "(ZJJ)V");
+  jmethodID constructor = findJavaMethod(env, limitClass, DEFAULT_CONSTRUCTOR, BOOLLONGLONG_VOID);
 
   return (*env)->NewObject(env, limitClass, constructor, (jboolean)limit.HasMax,
                            (jlong)limit.Min, (jlong)limit.Max);
@@ -71,9 +61,9 @@ jobject
 createJTableTypeContext(JNIEnv *env,
                         const WasmEdge_TableTypeContext *tableTypeContext) {
 
-  jclass clazz = (*env)->FindClass(env, "org/wasmedge/TableTypeContext");
+  jclass clazz = (*env)->FindClass(env, ORG_WASMEDGE_TABLETYPECONTEXT);
 
-  jmethodID constructorId = (*env)->GetMethodID(env, clazz, "<init>", "(J)V");
+  jmethodID constructorId = (*env)->GetMethodID(env, clazz, DEFAULT_CONSTRUCTOR, LONG_VOID);
 
   jobject table =
       (*env)->NewObject(env, clazz, constructorId, (long)tableTypeContext);

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/ValidatorContext.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/ValidatorContext.c
@@ -8,13 +8,7 @@
 #include "jni.h"
 #include "wasmedge/wasmedge.h"
 
-WasmEdge_ValidatorContext *getValidatorContext(JNIEnv *env,
-                                               jobject thisObject) {
-  if (thisObject == NULL) {
-    return NULL;
-  }
-  return (WasmEdge_ValidatorContext *)getPointer(env, thisObject);
-}
+GETTER(ValidatorContext)
 
 JNIEXPORT void JNICALL Java_org_wasmedge_ValidatorContext_validate(
     JNIEnv *env, jobject thisObject, jobject jAstModCxt) {

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/ValueType.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/ValueType.c
@@ -6,16 +6,16 @@
 #include "wasmedge/wasmedge.h"
 
 WasmEdge_Value JavaValueToWasmEdgeValue(JNIEnv *env, jobject jVal) {
-  jclass valueClass = (*env)->FindClass(env, "org/wasmedge/WasmEdgeValue");
+  jclass valueClass = (*env)->FindClass(env, ORG_WASMEDGE_VALUE);
 
-  jmethodID getType = (*env)->GetMethodID(env, valueClass, "getType",
-                                          "()Lorg/wasmedge/enums/ValueType;");
+  jmethodID getType = (*env)->GetMethodID(env, valueClass, GET_TYPE,
+                                          VOID_VALUETYPE);
 
   jobject valType = (*env)->CallObjectMethod(env, jVal, getType);
 
   jclass typeClass = (*env)->GetObjectClass(env, valType);
 
-  jmethodID getVal = (*env)->GetMethodID(env, typeClass, "getValue", "()I");
+  jmethodID getVal = (*env)->GetMethodID(env, typeClass, GET_VALUE, VOID_INT);
 
   jint jType = (*env)->CallIntMethod(env, valType, getVal);
 
@@ -48,30 +48,30 @@ jobject WasmEdgeValueToJavaValue(JNIEnv *env, WasmEdge_Value value) {
   const char *valClassName = NULL;
   switch (value.Type) {
   case WasmEdge_ValType_I32:
-    valClassName = "org/wasmedge/WasmEdgeI32Value";
+    valClassName = ORG_WASMEDGE_I32VALUE;
     break;
   case WasmEdge_ValType_I64:
-    valClassName = "org/wasmedge/WasmEdgeI64Value";
+    valClassName = ORG_WASMEDGE_I64VALUE;
     break;
   case WasmEdge_ValType_F32:
-    valClassName = "org/wasmedge/WasmEdgeF32Value";
+    valClassName = ORG_WASMEDGE_F32VALUE;
     break;
   case WasmEdge_ValType_V128:
-    valClassName = "org/wasmedge/WasmEdgeV128Value";
+    valClassName = ORG_WASMEDGE_V128VALUE;
     break;
   case WasmEdge_ValType_F64:
-    valClassName = "org/wasmedge/WasmEdgeF64Value";
+    valClassName = ORG_WASMEDGE_F64VALUE;
     break;
   case WasmEdge_ValType_ExternRef:
-    valClassName = "org/wasmedge/WasmEdgeExternRef";
+    valClassName = ORG_WASMEDGE_EXTERNREF;
     break;
   case WasmEdge_ValType_FuncRef:
-    valClassName = "org/wasmedge/WasmEdgeFuncRef";
+    valClassName = ORG_WASMEDGE_FUNCREF;
     break;
   }
   jclass valClass = (*env)->FindClass(env, valClassName);
 
-  jmethodID constructor = (*env)->GetMethodID(env, valClass, "<init>", "()V");
+  jmethodID constructor = (*env)->GetMethodID(env, valClass, DEFAULT_CONSTRUCTOR, VOID_VOID);
 
   jobject jVal = (*env)->NewObject(env, valClass, constructor);
 

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/WasmEdgeAsync.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/WasmEdgeAsync.c
@@ -95,7 +95,7 @@ JNIEXPORT void JNICALL Java_org_wasmedge_WasmEdgeAsync_wasmEdge_1AsyncDelete(
 
 jobject createJAsyncObject(JNIEnv *env, WasmEdge_Async *asyncObj) {
 
-  jclass clazz = (*env)->FindClass(env, "org/wasmedge/WasmEdgeAsync");
-  jmethodID constructorId = (*env)->GetMethodID(env, clazz, "<init>", "(J)V");
+  jclass clazz = (*env)->FindClass(env, ORG_WASMEDGE_WASMEDGEASYNC);
+  jmethodID constructorId = (*env)->GetMethodID(env, clazz, DEFAULT_CONSTRUCTOR, LONG_VOID);
   return (*env)->NewObject(env, clazz, constructorId, (long)asyncObj);
 }

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/WasmEdgeVM.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/WasmEdgeVM.c
@@ -16,20 +16,20 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+
 void setJavaIntValue(JNIEnv *env, WasmEdge_Value val, jobject jobj) {
   int int_val = WasmEdge_ValueGetI32(val);
   jclass val_clazz = (*env)->GetObjectClass(env, jobj);
   jmethodID val_setter =
-      (*env)->GetMethodID(env, val_clazz, "setValue", "(I)V");
+      (*env)->GetMethodID(env, val_clazz, SET_VALUE_METHOD, INT_VOID);
   (*env)->CallIntMethod(env, jobj, val_setter, int_val);
-  checkAndHandleException(env, "Error set int value");
 }
 
 void setJavaLongValue(JNIEnv *env, WasmEdge_Value val, jobject jobj) {
   int long_val = WasmEdge_ValueGetI64(val);
   jclass val_clazz = (*env)->GetObjectClass(env, jobj);
   jmethodID val_setter =
-      (*env)->GetMethodID(env, val_clazz, "setValue", "(J)V");
+      (*env)->GetMethodID(env, val_clazz, SET_VALUE_METHOD, LONG_VOID);
   (*env)->CallLongMethod(env, jobj, val_setter, long_val);
 }
 
@@ -37,7 +37,7 @@ void setJavaFloatValue(JNIEnv *env, WasmEdge_Value val, jobject jobj) {
   float float_val = WasmEdge_ValueGetF32(val);
   jclass val_clazz = (*env)->GetObjectClass(env, jobj);
   jmethodID val_setter =
-      (*env)->GetMethodID(env, val_clazz, "setValue", "(F)V");
+      (*env)->GetMethodID(env, val_clazz, SET_VALUE_METHOD, FLOAT_VOID);
   (*env)->CallFloatMethod(env, jobj, val_setter, float_val);
 }
 
@@ -45,7 +45,7 @@ void setJavaDoubleValue(JNIEnv *env, WasmEdge_Value val, jobject jobj) {
   float double_val = WasmEdge_ValueGetF64(val);
   jclass val_clazz = (*env)->GetObjectClass(env, jobj);
   jmethodID val_setter =
-      (*env)->GetMethodID(env, val_clazz, "setValue", "(D)V");
+      (*env)->GetMethodID(env, val_clazz, SET_VALUE_METHOD, DOUBLE_VOID);
   (*env)->CallFloatMethod(env, jobj, val_setter, double_val);
 }
 
@@ -54,20 +54,10 @@ void setJavaStringValue(JNIEnv *env, WasmEdge_Value val, jobject jobj) {
   jclass val_clazz = (*env)->GetObjectClass(env, jobj);
 
   jmethodID val_setter =
-      (*env)->GetMethodID(env, val_clazz, "setValue", "(Ljava/lang/String;)V");
+      (*env)->GetMethodID(env, val_clazz, SET_VALUE_METHOD, STRING_VOID);
 
   jstring jkey = (*env)->NewStringUTF(env, key);
   (*env)->CallObjectMethod(env, jobj, val_setter, jkey);
-}
-
-jobject createDoubleJavaLongValueObject(JNIEnv *env, WasmEdge_Value val) {
-  float double_val = WasmEdge_ValueGetF64(val);
-  jclass val_clazz = (*env)->FindClass(env, "org/wasmedge/WasmEdgeF64Value");
-  jmethodID val_constructor =
-      (*env)->GetMethodID(env, val_clazz, "<init>", "(D)V");
-  jobject j_val =
-      (*env)->NewObject(env, val_clazz, val_constructor, double_val);
-  return j_val;
 }
 
 WasmEdge_VMContext *getVmContext(JNIEnv *env, jobject vmContextObj) {
@@ -135,10 +125,10 @@ JNIEXPORT void JNICALL Java_org_wasmedge_WasmEdgeVM_runWasmFromFile(
   } else {
     char exceptionBuffer[1024];
     sprintf(exceptionBuffer,
-            "Error running wasm from file %s, error message: %s.", c_file_path,
+            ERR_RUN_FROM_FILE_TEMPLATE, c_file_path,
             WasmEdge_ResultGetMessage(Res));
 
-    (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/Exception"),
+    (*env)->ThrowNew(env, (*env)->FindClass(env, JAVA_LANG_EXCEPTION),
                      exceptionBuffer);
   }
 

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/common.c
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/common.c
@@ -13,21 +13,21 @@ void exitWithError(enum ErrorCode error, char *message) { exit(-1); }
 
 void throwNoClassDefError(JNIEnv *env, char *message) {
   jclass exClass;
-  char *className = "java/lang/NoClassDefFoundError";
+  char *className = JAVA_LANG_NOCLASSDEFFOUNDERROR;
 
   exClass = (*env)->FindClass(env, className);
 
   if (exClass == NULL) {
-    exitWithError(JVM_ERROR, "Exception class not found.");
+    exitWithError(JVM_ERROR, ERR_CLASS_NOT_FOUND);
   }
   (*env)->ThrowNew(env, exClass, message);
 
-  exitWithError(JVM_ERROR, "Exception thrown for no class def");
+  exitWithError(JVM_ERROR, ERR_EXCEPTION_THROWN_CLASS_NOT_FOUND);
 }
 
 void throwNoSuchMethodError(JNIEnv *env, char *methodName, char *sig) {
   jclass exClass;
-  char *className = "java/lang/NoSuchMethodError";
+  char *className = JAVA_LANG_NOSUCHMETHODERROR;
 
   char message[1000];
 
@@ -39,13 +39,13 @@ void throwNoSuchMethodError(JNIEnv *env, char *methodName, char *sig) {
   }
 
   (*env)->ThrowNew(env, exClass, methodName);
-  exitWithError(JVM_ERROR, "Exception thrown for no such method");
+  exitWithError(JVM_ERROR, ERR_NO_SUCH_METHOD);
 }
 
 jclass findJavaClass(JNIEnv *env, char *className) {
   jclass class = (*env)->FindClass(env, className);
 
-  bool hasException = checkAndHandleException(env, "find class error");
+  bool hasException = checkAndHandleException(env, ERR_FIND_CLASS);
   if (hasException) {
     return NULL;
   }
@@ -67,19 +67,19 @@ void getClassName(JNIEnv *env, jobject obj, char *buff) {
 
   // First get the class object
   jmethodID mid =
-      (*env)->GetMethodID(env, cls, "getClass", "()Ljava/lang/Class;");
+      (*env)->GetMethodID(env, cls, GET_CLASS, VOID_CLASS);
   jobject clsObj = (*env)->CallObjectMethod(env, obj, mid);
-  checkAndHandleException(env, "get class name error");
+  checkAndHandleException(env, ERR_GET_CLASS_NAME);
 
   // Now get the class object's class descriptor
   cls = (*env)->GetObjectClass(env, clsObj);
 
   // Find the getName() method on the class object
-  mid = (*env)->GetMethodID(env, cls, "getName", "()Ljava/lang/String;");
+  mid = (*env)->GetMethodID(env, cls, GET_NAME, VOID_STRING);
 
   // Call the getName() to get a jstring object back
   jstring strObj = (jstring)(*env)->CallObjectMethod(env, clsObj, mid);
-  checkAndHandleException(env, "get name error");
+  checkAndHandleException(env, ERR_GET_NAME_FALIED);
 
   // Now get the c string from the java jstring object
   const char *str = (*env)->GetStringUTFChars(env, strObj, NULL);
@@ -95,12 +95,12 @@ long getPointer(JNIEnv *env, jobject obj) {
   jclass cls = (*env)->GetObjectClass(env, obj);
 
   if (cls == NULL) {
-    exitWithError(JVM_ERROR, "class not found!");
+    exitWithError(JVM_ERROR, ERR_CLASS_NOT_FOUND);
   }
 
-  jfieldID fidPointer = (*env)->GetFieldID(env, cls, "pointer", "J");
+  jfieldID fidPointer = (*env)->GetFieldID(env, cls, POINTER, POINTER_TYPE);
   if (fidPointer == NULL) {
-    exitWithError(JVM_ERROR, "pointer filed not found!");
+    exitWithError(JVM_ERROR, ERR_POINTER_FIELD_NOT_FOUND);
   }
   jlong value = (*env)->GetLongField(env, obj, fidPointer);
   return value;
@@ -108,48 +108,48 @@ long getPointer(JNIEnv *env, jobject obj) {
 
 void setPointer(JNIEnv *env, jobject obj, long val) {
   jclass cls = (*env)->GetObjectClass(env, obj);
-  jfieldID fidPointer = (*env)->GetFieldID(env, cls, "pointer", "J");
+  jfieldID fidPointer = (*env)->GetFieldID(env, cls, POINTER, POINTER_TYPE);
   (*env)->SetLongField(env, obj, fidPointer, val);
 }
 
 void handleWasmEdgeResult(JNIEnv *env, WasmEdge_Result *result) {
   if (!WasmEdge_ResultOK(*result)) {
     char exceptionBuffer[1024];
-    sprintf(exceptionBuffer, "Error occurred with message: %s.",
+    sprintf(exceptionBuffer, ERR_TEMPLATE,
             WasmEdge_ResultGetMessage(*result));
 
-    (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/Exception"),
+    (*env)->ThrowNew(env, (*env)->FindClass(env, JAVA_LANG_EXCEPTION),
                      exceptionBuffer);
   }
 }
 
 int getIntVal(JNIEnv *env, jobject val) {
   jclass clazz = (*env)->GetObjectClass(env, val);
-  jmethodID methodId = findJavaMethod(env, clazz, "getValue", "()I");
+  jmethodID methodId = findJavaMethod(env, clazz, GET_VALUE, VOID_INT);
 
   jint value = (*env)->CallIntMethod(env, val, methodId);
-  checkAndHandleException(env, "Error get int value");
+  checkAndHandleException(env, ERR_GET_INT_VALUE);
   return value;
 }
 
 long getLongVal(JNIEnv *env, jobject val) {
   jclass clazz = (*env)->GetObjectClass(env, val);
 
-  jmethodID methodId = (*env)->GetMethodID(env, clazz, "getValue", "()J");
+  jmethodID methodId = (*env)->GetMethodID(env, clazz, GET_VALUE, VOID_LONG);
   jlong value = (*env)->CallLongMethod(env, val, methodId);
   return value;
 }
 
 long getFloatVal(JNIEnv *env, jobject val) {
   jclass clazz = (*env)->GetObjectClass(env, val);
-  jmethodID methodId = findJavaMethod(env, clazz, "getValue", "()F");
+  jmethodID methodId = findJavaMethod(env, clazz, GET_VALUE, VOID_FLOAT);
   jfloat value = (*env)->CallFloatMethod(env, val, methodId);
   return value;
 }
 
 double getDoubleVal(JNIEnv *env, jobject val) {
   jclass clazz = (*env)->GetObjectClass(env, val);
-  jmethodID methodId = findJavaMethod(env, clazz, "getValue", "()D");
+  jmethodID methodId = findJavaMethod(env, clazz, GET_VALUE, VOID_DOUBLE);
   jdouble value = (*env)->CallDoubleMethod(env, val, methodId);
   return value;
 }
@@ -158,7 +158,7 @@ char *getStringVal(JNIEnv *env, jobject val) {
   jclass clazz = (*env)->GetObjectClass(env, val);
 
   jmethodID methodId =
-      findJavaMethod(env, clazz, "getValue", "()Ljava/lang/String;");
+      findJavaMethod(env, clazz, GET_VALUE, VOID_STRING);
 
   jstring value = (jstring)(*env)->CallObjectMethod(env, val, methodId);
 
@@ -194,12 +194,12 @@ bool checkAndHandleException(JNIEnv *env, const char *msg) {
     jclass eclass = (*env)->GetObjectClass(env, e);
 
     jmethodID mid =
-        (*env)->GetMethodID(env, eclass, "toString", "()Ljava/lang/String;");
+        (*env)->GetMethodID(env, eclass, TO_STRING, VOID_STRING);
     jstring jErrorMsg = (*env)->CallObjectMethod(env, e, mid);
     const char *cMsg = (*env)->GetStringUTFChars(env, jErrorMsg, NULL);
 
     (*env)->ReleaseStringUTFChars(env, jErrorMsg, cMsg);
-    jclass newExcCls = (*env)->FindClass(env, "java/lang/RuntimeException");
+    jclass newExcCls = (*env)->FindClass(env, JAVA_LANG_RUNTIMEEXCEPTION);
     if (newExcCls == 0) { /* Unable to find the new exception class, give up. */
       return true;
     }
@@ -244,13 +244,13 @@ jstring WasmEdgeStringToJString(JNIEnv *env, WasmEdge_String wStr) {
 }
 
 jobject CreateJavaArrayList(JNIEnv *env, jint len) {
-  jclass listClass = findJavaClass(env, "java/util/ArrayList");
+  jclass listClass = findJavaClass(env, JAVA_UTIL_ARRAYLIST);
 
   if (listClass == NULL) {
     return NULL;
   }
 
-  jmethodID listConstructor = findJavaMethod(env, listClass, "<init>", "(I)V");
+  jmethodID listConstructor = findJavaMethod(env, listClass, DEFAULT_CONSTRUCTOR, INT_VOID);
 
   if (listConstructor == NULL) {
     return NULL;
@@ -262,21 +262,21 @@ jobject CreateJavaArrayList(JNIEnv *env, jint len) {
     return NULL;
   }
 
-  if (checkAndHandleException(env, "Error when creating java list\n")) {
+  if (checkAndHandleException(env, ERR_CREATE_JAVA_LIST)) {
     return NULL;
   }
   return jList;
 }
 
 bool AddElementToJavaList(JNIEnv *env, jobject jList, jobject ele) {
-  jclass listClass = findJavaClass(env, "java/util/ArrayList");
+  jclass listClass = findJavaClass(env, JAVA_UTIL_ARRAYLIST);
 
   if (listClass == NULL) {
     return false;
   }
 
   jmethodID addMethod =
-      findJavaMethod(env, listClass, "add", "(Ljava/lang/Object;)Z");
+      findJavaMethod(env, listClass, ADD_ELEMENT, OBJECT_BOOL);
 
   return (*env)->CallBooleanMethod(env, jList, addMethod, ele);
 }
@@ -284,7 +284,7 @@ bool AddElementToJavaList(JNIEnv *env, jobject jList, jobject ele) {
 jobject GetListElement(JNIEnv *env, jobject jList, jint idx) {
   jclass listClass = (*env)->GetObjectClass(env, jList);
   jmethodID getMethod =
-      findJavaMethod(env, listClass, "get", "(I)Ljava/lang/Object;");
+      findJavaMethod(env, listClass, GET, INT_OBJECT);
 
   return (*env)->CallObjectMethod(env, jList, getMethod, idx);
 }
@@ -292,7 +292,7 @@ jobject GetListElement(JNIEnv *env, jobject jList, jint idx) {
 jint GetListSize(JNIEnv *env, jobject jList) {
 
   jclass listClass = (*env)->GetObjectClass(env, jList);
-  jmethodID sizeMethod = (*env)->GetMethodID(env, listClass, "size", "()I");
+  jmethodID sizeMethod = (*env)->GetMethodID(env, listClass, LIST_SIZE, VOID_INT);
   jint size = (*env)->CallIntMethod(env, jList, sizeMethod);
 
   return size;
@@ -343,3 +343,4 @@ jobject WasmEdgeStringArrayToJavaList(JNIEnv *env, WasmEdge_String *wStrList,
   }
   return strList;
 }
+

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/common.h
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/common.h
@@ -6,8 +6,10 @@
 
 #include "jni.h"
 #include "wasmedge/wasmedge.h"
+#include "constants.h"
 
 #define MAX_BUF_LEN 1024
+
 
 enum ErrorCode { JVM_ERROR, WVM_ERROR };
 
@@ -74,5 +76,13 @@ void ReleaseCString(JNIEnv *env, jarray jStrArray, const char **ptr);
 jobject GetListElement(JNIEnv *env, jobject jList, jint idx);
 
 jint GetListSize(JNIEnv *env, jobject jList);
+
+#define GETTER(NAME) WasmEdge_ ## NAME *get ## NAME(JNIEnv *env,\
+                                             jobject j ## NAME) {\
+    if (j ## NAME == NULL) {\
+        return NULL;\
+    }\
+    return (WasmEdge_ ##NAME  *)getPointer(env, j ##NAME );\
+}\
 
 #endif // WASMEDGE_JAVA_COMMON_H

--- a/bindings/java/wasmedge-java/wasmedge-jni/lib/constants.h
+++ b/bindings/java/wasmedge-java/wasmedge-jni/lib/constants.h
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2022 Second State INC
+
+#ifndef WASMEDGE_JAVA_CONSTANTS_H
+#define WASMEDGE_JAVA_CONSTANTS_H
+
+#define ORG_WASMEDGE_FUNCTIONTYPECONTEXT "org/wasmedge/FunctionTypeContext"
+#define ORG_WASMEDGE_STATISTICSCONTEXT "org/wasmedge/StatisticsContext"
+#define ORG_WASMEDGE_MEMORYINSTANCECONTEXT "org/wasmedge/MemoryInstanceContext"
+#define ORG_WASMEDGE_GLOBALTYPECONTEXT "org/wasmedge/GlobalTypeContext"
+#define ORG_WASMEDGE_EXPORTTYPECONTEXT "org/wasmedge/ExportTypeContext"
+#define ORG_WASMEDGE_MEMORYTYPECONTEXT "org/wasmedge/MemoryTypeContext"
+#define ORG_WASMEDGE_GLOBALINSTANCECONTEXT "org/wasmedge/GlobalInstanceContext"
+#define ORG_WASMEDGE_MODULEINSTANCECONTEXT "org/wasmedge/ModuleInstanceContext"
+#define ORG_WASMEDGE_WASMEDGEVM "org/wasmedge/WasmEdgeVM"
+#define ORG_WASMEDGE_FUNCTIONINSTANCECONTEXT "org/wasmedge/FunctionInstanceContext"
+#define ORG_WASMEDGE_TABLEINSTANCECONTEXT "org/wasmedge/TableInstanceContext"
+#define ORG_WASMEDGE_WASMEDGEASYNC "org/wasmedge/WasmEdgeAsync"
+#define ORG_WASMEDGE_ASTMODULECONTEXT "org/wasmedge/ASTModuleContext"
+#define ORG_WASMEDGE_STORECONTEXT "org/wasmedge/StoreContext"
+#define ORG_WASMEDGE_TABLETYPECONTEXT "org/wasmedge/TableTypeContext"
+#define ORG_WASMEDGE_IMPORTTYPECONTEXT "org/wasmedge/ImportTypeContext"
+#define ORG_WASMEDGE_LIMIT "org/wasmedge/Limit"
+#define LIMIT_IS_HAS_MAX "isHasMax"
+#define LIMIT_GET_MAX "getMax"
+#define LIMIT_GET_MIN "getMin"
+#define SET_NAME "setName"
+#define GET "get"
+
+#define DEFAULT_CONSTRUCTOR "<init>"
+#define SET_VALUE_METHOD "setValue"
+#define GET_NAME "getName"
+#define TO_STRING "toString"
+
+/** Internal Values **/
+#define POINTER "pointer"
+#define POINTER_TYPE "J"
+
+/** Java Exceptions **/
+#define JAVA_LANG_NOCLASSDEFFOUNDERROR "java/lang/NoClassDefFoundError"
+#define JAVA_LANG_NOSUCHMETHODERROR "java/lang/NoSuchMethodError"
+#define JAVA_LANG_EXCEPTION "java/lang/Exception"
+#define JAVA_LANG_RUNTIMEEXCEPTION "java/lang/RuntimeException"
+#define GET_CLASS "getClass"
+
+/** ArrayList **/
+#define JAVA_UTIL_ARRAYLIST "java/util/ArrayList"
+#define LIST_SIZE "size"
+#define ADD_ELEMENT "add"
+
+/** Value Types **/
+#define ORG_WASMEDGE_VALUE "org/wasmedge/Value"
+#define ORG_WASMEDGE_ENUMS_VALUETYPE "org/wasmedge/enums/ValueType"
+#define GET_VALUE "getValue"
+#define GET_TYPE "getType"
+#define PARSE_TYPE "parseType"
+#define VOID_VALUETYPE "()Lorg/wasmedge/enums/ValueType;"
+#define INT_VALUETYPE "(I)Lorg/wasmedge/enums/ValueType;"
+
+#define ORG_WASMEDGE_I32VALUE "org/wasmedge/I32Value"
+#define ORG_WASMEDGE_I64VALUE "org/wasmedge/I64Value"
+#define ORG_WASMEDGE_F32VALUE "org/wasmedge/F32Value"
+#define ORG_WASMEDGE_V128VALUE "org/wasmedge/V128Value"
+#define ORG_WASMEDGE_F64VALUE "org/wasmedge/F64Value"
+#define ORG_WASMEDGE_EXTERNREF "org/wasmedge/ExternRef"
+#define ORG_WASMEDGE_FUNCREF "org/wasmedge/FuncRef"
+
+/** method signatures **/
+#define VOID_VOID "()V"
+#define VOID_CLASS "()Ljava/lang/Class;"
+#define VOID_STRING "()Ljava/lang/String;"
+#define VOID_LONG "()J"
+#define VOID_INT "()I"
+#define VOID_FLOAT "()F"
+#define VOID_DOUBLE "()D"
+
+#define INT_VOID "(I)V"
+#define LONG_VOID "(J)V"
+#define FLOAT_VOID "(F)V"
+#define DOUBLE_VOID "(D)V"
+#define STRING_VOID "(Ljava/lang/String;)V"
+#define VOID_BOOL "()Z"
+#define BOOLLONGLONG_VOID "(ZJJ)V"
+#define ASTMODULECONTEXT_VOID "(JLorg/wasmedge/ASTModuleContext;)V"
+#define STRING_HOSTFUNCTION "(Ljava/lang/String;)Lorg/wasmedge/HostFunction;"
+#define MEMORYINSTANCECONTEXTLIST_RESULT "(Lorg/wasmedge/MemoryInstanceContext;Ljava/util/List;Ljava/util/List;)Lorg/wasmedge/Result;"
+#define OBJECT_BOOL "(Ljava/lang/Object;)Z"
+#define LISTLIST_VOID "(Ljava/util/List;Ljava/util/List;)V"
+#define INT_OBJECT "(I)Ljava/lang/Object;"
+
+/** host function **/
+#define GET_HOST_FUNC "getHostFunc"
+#define APPLY "apply"
+
+/** messages **/
+#define ERR_CLASS_NOT_FOUND "Exception class not found"
+#define ERR_EXCEPTION_THROWN_CLASS_NOT_FOUND "Exception thrown for no class def"
+#define ERR_NO_SUCH_METHOD "Exception thrown for no such method"
+#define ERR_FIND_CLASS "find class error"
+#define ERR_GET_CLASS_NAME "get class name error"
+#define ERR_POINTER_FIELD_NOT_FOUND "pointer filed not found"
+#define ERR_TEMPLATE "Error occurred with message: %s."
+#define ERR_GET_INT_VALUE "Error get int value"
+#define ERR_CREATE_JAVA_LIST "Error when creating java list"
+#define ERR_GET_NAME_FALIED "get name error"
+#define ERR_RUN_FROM_FILE_TEMPLATE "Error running wasm from file %s, error message: %s."
+#define ERR_CREATE_VALUE_TYPE_LIST_FAILED "Error when creating value type list"
+#define ERR_ADD_VALUE_TYPE "Error when adding value type"
+#define ERROR_CREATE_FUNCTION_TYPE_FAILED "Error when creating function type context"
+#define ERR_SET_FUNCTION_TYPE_FAILED "Error when setting function type context name"
+#define ERR_CREATE_STATICS_CONTEXT_FAILED "error creating stat context"
+
+#endif


### PR DESCRIPTION
- Add constants
    - Replace JNI method names and signatures with macros
    - Replace error messages with macros
- Refactor Java API
    - `WasmEdgeExternRef` -> `ExternRef`
    - `WasmEdgeI32Value` -> `I32Value`
    - `WasmEdgeF32Value` -> `F32Value`
    - `WasmEdgeI64Value` -> `I64Value`
    - `WasmEdgeF64Value` -> `F64Value`
    - `WasmEdgeValue` -> `Value`
    - `WasmEdgeMutability` -> `Mutability`
- .gitignore
   - exclude generated JNI headers
- build.gradler
   - clean jni headers in clean task, change to correct path.