### PR TITLE
[CI] Refactor rust workflows

### DIFF
--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust v1.65
-        uses: dtolnay/rust-toolchain@1.65
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.65
           components: rustfmt, clippy
@@ -96,7 +96,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust v1.65
-        uses: dtolnay/rust-toolchain@1.65
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.65
           components: rustfmt, clippy
@@ -168,7 +168,7 @@ jobs:
           sdk-version: 19041
 
       - name: Install Rust v1.65
-        uses: dtolnay/rust-toolchain@1.65
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.65
           components: rustfmt, clippy

--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - "rust/*"
+      - "ci/refactor-rust-workflows"
     paths:
       - ".github/workflows/bindings-rust.yml"
       - "bindings/rust/**"

--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - master
       - "rust/*"
-      - "ci/refactor-rust-workflows"
     paths:
       - ".github/workflows/bindings-rust.yml"
       - "bindings/rust/**"

--- a/.github/workflows/rust-standalone.yml
+++ b/.github/workflows/rust-standalone.yml
@@ -38,7 +38,7 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config gh
 
       - name: Install Rust v1.65
-        uses: dtolnay/rust-toolchain@1.65
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.65
           components: rustfmt, clippy
@@ -71,7 +71,7 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config gh
 
       - name: Install Rust v1.65
-        uses: dtolnay/rust-toolchain@1.65
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.65
           components: rustfmt, clippy
@@ -100,7 +100,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust v1.65
-        uses: dtolnay/rust-toolchain@1.65
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.65
           components: rustfmt, clippy

--- a/.github/workflows/rust-wasmedge-macro-release.yml
+++ b/.github/workflows/rust-wasmedge-macro-release.yml
@@ -28,7 +28,7 @@ jobs:
           sudo apt-get install -y libssl-dev
 
       - name: Install Rust v1.65
-        uses: dtolnay/rust-toolchain@1.65
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.65
           components: rustfmt, clippy

--- a/.github/workflows/rust-wasmedge-sdk-release.yml
+++ b/.github/workflows/rust-wasmedge-sdk-release.yml
@@ -28,7 +28,7 @@ jobs:
           apt install -y llvm-12-dev liblld-12-dev
 
       - name: Install Rust v1.65
-        uses: dtolnay/rust-toolchain@1.65
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.65
           components: rustfmt, clippy

--- a/.github/workflows/rust-wasmedge-sys-release.yml
+++ b/.github/workflows/rust-wasmedge-sys-release.yml
@@ -28,7 +28,7 @@ jobs:
           apt install -y llvm-12-dev liblld-12-dev
 
       - name: Install Rust v1.65
-        uses: dtolnay/rust-toolchain@1.65
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.65
           components: rustfmt, clippy

--- a/.github/workflows/rust-wasmedge-types-release.yml
+++ b/.github/workflows/rust-wasmedge-types-release.yml
@@ -28,7 +28,7 @@ jobs:
           sudo apt-get install -y libssl-dev
 
       - name: Install Rust v1.65
-        uses: dtolnay/rust-toolchain@1.65
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.65
           components: rustfmt, clippy


### PR DESCRIPTION
In this PR, refactor the Rust SDK related workflows to use `dtolnay/rust-toolchain@stable`.