### PR TITLE
refactor: reduce the use of VType in validator

### DIFF
--- a/include/validator/formchecker.h
+++ b/include/validator/formchecker.h
@@ -47,7 +47,6 @@ public:
 
   void reset(bool CleanGlobal = false);
   Expect<void> validate(AST::InstrView Instrs, Span<const ValType> RetVals);
-  Expect<void> validate(AST::InstrView Instrs, Span<const VType> RetVals);
 
   /// Adder of contexts
   void addType(const AST::FunctionType &Func);
@@ -59,7 +58,6 @@ public:
   void addData(const AST::DataSegment &Data);
   void addRef(const uint32_t FuncIdx);
   void addLocal(const ValType &V);
-  void addLocal(const VType &V);
 
   std::vector<VType> result() { return ValStack; }
   auto &getTypes() { return Types; }
@@ -82,13 +80,13 @@ public:
     CtrlFrame(const struct CtrlFrame &F)
         : StartTypes(F.StartTypes), EndTypes(F.EndTypes), Jump(F.Jump),
           Height(F.Height), IsUnreachable(F.IsUnreachable), Code(F.Code) {}
-    CtrlFrame(Span<const VType> In, Span<const VType> Out,
+    CtrlFrame(Span<const ValType> In, Span<const ValType> Out,
               const AST::Instruction *J, size_t H,
               OpCode Op = OpCode::Unreachable)
         : StartTypes(In.begin(), In.end()), EndTypes(Out.begin(), Out.end()),
           Jump(J), Height(H), IsUnreachable(false), Code(Op) {}
-    std::vector<VType> StartTypes;
-    std::vector<VType> EndTypes;
+    std::vector<ValType> StartTypes;
+    std::vector<ValType> EndTypes;
     const AST::Instruction *Jump;
     size_t Height;
     bool IsUnreachable;
@@ -108,30 +106,32 @@ private:
   /// Stack operations
   void pushType(VType);
   void pushTypes(Span<const VType> Input);
+  void pushTypes(Span<const ValType> Input);
   Expect<VType> popType();
-  Expect<VType> popType(VType E);
-  Expect<void> popTypes(Span<const VType> Input);
-  void pushCtrl(Span<const VType> In, Span<const VType> Out,
+  Expect<VType> popType(ValType E);
+  Expect<void> popTypes(Span<const ValType> Input);
+  void pushCtrl(Span<const ValType> In, Span<const ValType> Out,
                 const AST::Instruction *Jump,
                 OpCode Code = OpCode::Unreachable);
   Expect<CtrlFrame> popCtrl();
-  Span<const VType> getLabelTypes(const CtrlFrame &F);
+  Span<const ValType> getLabelTypes(const CtrlFrame &F);
   Expect<void> unreachable();
-  Expect<void> StackTrans(Span<const VType> Take, Span<const VType> Put);
+  Expect<void> StackTrans(Span<const ValType> Take, Span<const ValType> Put);
+  Expect<void> StackPopAny();
 
   /// Contexts.
-  std::vector<std::pair<std::vector<VType>, std::vector<VType>>> Types;
+  std::vector<std::pair<std::vector<ValType>, std::vector<ValType>>> Types;
   std::vector<uint32_t> Funcs;
   std::vector<RefType> Tables;
   uint32_t Mems = 0;
-  std::vector<std::pair<VType, ValMut>> Globals;
+  std::vector<std::pair<ValType, ValMut>> Globals;
   std::vector<RefType> Elems;
   std::vector<uint32_t> Datas;
   std::unordered_set<uint32_t> Refs;
   uint32_t NumImportFuncs = 0;
   uint32_t NumImportGlobals = 0;
-  std::vector<VType> Locals;
-  std::vector<VType> Returns;
+  std::vector<ValType> Locals;
+  std::vector<ValType> Returns;
 
   /// Running stack.
   std::vector<CtrlFrame> CtrlStack;

--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -49,21 +49,13 @@ void FormChecker::reset(bool CleanGlobal) {
 Expect<void> FormChecker::validate(AST::InstrView Instrs,
                                    Span<const ValType> RetVals) {
   for (const ValType &Val : RetVals) {
-    Returns.push_back(VType(Val));
-  }
-  return checkExpr(Instrs);
-}
-
-Expect<void> FormChecker::validate(AST::InstrView Instrs,
-                                   Span<const VType> RetVals) {
-  for (const VType &Val : RetVals) {
     Returns.push_back(Val);
   }
   return checkExpr(Instrs);
 }
 
 void FormChecker::addType(const AST::FunctionType &Func) {
-  std::vector<VType> Param, Ret;
+  std::vector<ValType> Param, Ret;
   Param.reserve(Func.getParamTypes().size());
   Ret.reserve(Func.getReturnTypes().size());
   for (auto Val : Func.getParamTypes()) {
@@ -110,8 +102,6 @@ void FormChecker::addRef(const uint32_t FuncIdx) { Refs.emplace(FuncIdx); }
 
 void FormChecker::addLocal(const ValType &V) { Locals.push_back(V); }
 
-void FormChecker::addLocal(const VType &V) { Locals.push_back(V); }
-
 ValType FormChecker::VTypeToAST(const VType &V) {
   if (!V) {
     return ValTypeCode::I32;
@@ -139,10 +129,10 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   // configuration checking in loader phase.
 
   // Helper lambda for checking and resolve the block type.
-  auto checkBlockType = [this](std::vector<VType> &Buffer,
+  auto checkBlockType = [this](std::vector<ValType> &Buffer,
                                const BlockType &BType)
-      -> Expect<std::pair<Span<const VType>, Span<const VType>>> {
-    using ReturnType = std::pair<Span<const VType>, Span<const VType>>;
+      -> Expect<std::pair<Span<const ValType>, Span<const ValType>>> {
+    using ReturnType = std::pair<Span<const ValType>, Span<const ValType>>;
     if (BType.isEmpty()) {
       // Empty case. t2* = none
       return ReturnType{{}, {}};
@@ -177,8 +167,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
 
   // Helper lambda for checking memory index and perform transformation.
   auto checkMemAndTrans = [this,
-                           &Instr](Span<const VType> Take,
-                                   Span<const VType> Put) -> Expect<void> {
+                           &Instr](Span<const ValType> Take,
+                                   Span<const ValType> Put) -> Expect<void> {
     if (Instr.getTargetIndex() >= Mems) {
       return logOutOfRange(ErrCode::Value::InvalidMemoryIdx,
                            ErrInfo::IndexCategory::Memory,
@@ -189,8 +179,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
 
   // Helper lambda for checking lane index and perform transformation.
   auto checkLaneAndTrans = [this,
-                            &Instr](uint32_t N, Span<const VType> Take,
-                                    Span<const VType> Put) -> Expect<void> {
+                            &Instr](uint32_t N, Span<const ValType> Take,
+                                    Span<const ValType> Put) -> Expect<void> {
     if (Instr.getMemoryLane() >= N) {
       return logOutOfRange(ErrCode::Value::InvalidLaneIdx,
                            ErrInfo::IndexCategory::Lane, Instr.getMemoryLane(),
@@ -201,8 +191,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
 
   // Helper lambda for checking memory alignment and perform transformation.
   auto checkAlignAndTrans = [this, checkLaneAndTrans,
-                             &Instr](uint32_t N, Span<const VType> Take,
-                                     Span<const VType> Put,
+                             &Instr](uint32_t N, Span<const ValType> Take,
+                                     Span<const ValType> Put,
                                      bool CheckLane = false) -> Expect<void> {
     if (Instr.getTargetIndex() >= Mems) {
       return logOutOfRange(ErrCode::Value::InvalidMemoryIdx,
@@ -224,18 +214,18 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   };
 
   // Helper lambda for checking vtypes matching.
-  auto checkTypesMatching = [this](Span<const VType> Exp,
-                                   Span<const VType> Got) -> Expect<void> {
+  auto checkTypesMatching = [](Span<const ValType> Exp,
+                               Span<const ValType> Got) -> Expect<void> {
     if (Exp.size() != Got.size() ||
         !std::equal(Exp.begin(), Exp.end(), Got.begin())) {
       std::vector<ValType> ExpV, GotV;
       ExpV.reserve(Exp.size());
       for (auto &I : Exp) {
-        ExpV.push_back(VTypeToAST(I));
+        ExpV.push_back(I);
       }
       GotV.reserve(Got.size());
       for (auto &I : Got) {
-        GotV.push_back(VTypeToAST(I));
+        GotV.push_back(I);
       }
       spdlog::error(ErrCode::Value::TypeCheckFailed);
       spdlog::error(ErrInfo::InfoMismatch(ExpV, GotV));
@@ -260,8 +250,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::Block:
   case OpCode::Loop: {
     // Get blocktype [t1*] -> [t2*]
-    std::vector<VType> Buffer(1);
-    Span<const VType> T1, T2;
+    std::vector<ValType> Buffer(1);
+    Span<const ValType> T1, T2;
     if (auto Res = checkBlockType(Buffer, Instr.getBlockType())) {
       std::tie(T1, T2) = std::move(*Res);
     } else {
@@ -505,8 +495,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
 
   // Reference Instructions.
   case OpCode::Ref__null:
-    return StackTrans(
-        {}, {VType(ValType(RefTypeCode::RefNull, Instr.getHeapType()))});
+    return StackTrans({}, {ValType(RefTypeCode::RefNull, Instr.getHeapType())});
   case OpCode::Ref__is_null:
     if (auto Res = popType()) {
       if (!isRefType(*Res)) {
@@ -518,18 +507,18 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
     } else {
       return Unexpect(Res);
     }
-    return StackTrans({}, {VType(ValTypeCode::I32)});
+    return StackTrans({}, {ValType(ValTypeCode::I32)});
   case OpCode::Ref__func:
     if (Refs.find(Instr.getTargetIndex()) == Refs.cend()) {
       // Undeclared function reference.
       spdlog::error(ErrCode::Value::InvalidRefIdx);
       return Unexpect(ErrCode::Value::InvalidRefIdx);
     }
-    return StackTrans({}, {VType(ValTypeCode::FuncRef)});
+    return StackTrans({}, {ValType(ValTypeCode::FuncRef)});
 
   // Parametric Instructions.
   case OpCode::Drop:
-    return StackTrans({unreachableVType()}, {});
+    return StackPopAny();
   case OpCode::Select: {
     // Pop I32.
     if (auto Res = popType(ValTypeCode::I32); !Res) {
@@ -578,8 +567,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
       spdlog::error(ErrCode::Value::InvalidResultArity);
       return Unexpect(ErrCode::Value::InvalidResultArity);
     }
-    VType ExpT = Instr.getValTypeList()[0];
-    if (auto Res = popTypes({ExpT, ExpT, VType(ValTypeCode::I32)}); !Res) {
+    ValType ExpT = Instr.getValTypeList()[0];
+    if (auto Res = popTypes({ExpT, ExpT, ValType(ValTypeCode::I32)}); !Res) {
       return Unexpect(Res);
     }
     pushType(ExpT);
@@ -595,7 +584,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
           ErrCode::Value::InvalidLocalIdx, ErrInfo::IndexCategory::Local,
           Instr.getTargetIndex(), static_cast<uint32_t>(Locals.size()));
     }
-    VType TExpect = Locals[Instr.getTargetIndex()];
+    ValType TExpect = Locals[Instr.getTargetIndex()];
     const_cast<AST::Instruction &>(Instr).getStackOffset() =
         static_cast<uint32_t>(ValStack.size() +
                               (Locals.size() - Instr.getTargetIndex()));
@@ -622,7 +611,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
           ErrCode::Value::InvalidGlobalIdx, ErrInfo::IndexCategory::Global,
           Instr.getTargetIndex(), static_cast<uint32_t>(Globals.size()));
     }
-    VType ExpT = Globals[Instr.getTargetIndex()].first;
+    ValType ExpT = Globals[Instr.getTargetIndex()].first;
     if (Instr.getOpCode() == OpCode::Global__set) {
       return StackTrans({ExpT}, {});
     } else {
@@ -644,19 +633,19 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
           ErrCode::Value::InvalidTableIdx, ErrInfo::IndexCategory::Table,
           Instr.getTargetIndex(), static_cast<uint32_t>(Tables.size()));
     }
-    VType ExpT = VType(Tables[Instr.getTargetIndex()]);
+    ValType ExpT = Tables[Instr.getTargetIndex()];
     if (Instr.getOpCode() == OpCode::Table__get) {
-      return StackTrans({VType(ValTypeCode::I32)}, {ExpT});
+      return StackTrans({ValType(ValTypeCode::I32)}, {ExpT});
     } else if (Instr.getOpCode() == OpCode::Table__set) {
-      return StackTrans({VType(ValTypeCode::I32), ExpT}, {});
+      return StackTrans({ValType(ValTypeCode::I32), ExpT}, {});
     } else if (Instr.getOpCode() == OpCode::Table__grow) {
-      return StackTrans({ExpT, VType(ValTypeCode::I32)},
-                        {VType(ValTypeCode::I32)});
+      return StackTrans({ExpT, ValType(ValTypeCode::I32)},
+                        {ValType(ValTypeCode::I32)});
     } else if (Instr.getOpCode() == OpCode::Table__size) {
-      return StackTrans({}, {VType(ValTypeCode::I32)});
+      return StackTrans({}, {ValType(ValTypeCode::I32)});
     } else if (Instr.getOpCode() == OpCode::Table__fill) {
       return StackTrans(
-          {VType(ValTypeCode::I32), ExpT, VType(ValTypeCode::I32)}, {});
+          {ValType(ValTypeCode::I32), ExpT, ValType(ValTypeCode::I32)}, {});
     } else if (Instr.getOpCode() == OpCode::Table__init) {
       // Check source element index for initialization.
       if (Instr.getSourceIndex() >= Elems.size()) {
@@ -671,8 +660,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
                                             Elems[Instr.getSourceIndex()]));
         return Unexpect(ErrCode::Value::TypeCheckFailed);
       }
-      return StackTrans({VType(ValTypeCode::I32), VType(ValTypeCode::I32),
-                         VType(ValTypeCode::I32)},
+      return StackTrans({ValType(ValTypeCode::I32), ValType(ValTypeCode::I32),
+                         ValType(ValTypeCode::I32)},
                         {});
     } else {
       // Check source table index for copying.
@@ -688,8 +677,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
                                             Tables[Instr.getSourceIndex()]));
         return Unexpect(ErrCode::Value::TypeCheckFailed);
       }
-      return StackTrans({VType(ValTypeCode::I32), VType(ValTypeCode::I32),
-                         VType(ValTypeCode::I32)},
+      return StackTrans({ValType(ValTypeCode::I32), ValType(ValTypeCode::I32),
+                         ValType(ValTypeCode::I32)},
                         {});
     }
   }
@@ -704,69 +693,69 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
 
   // Memory Instructions.
   case OpCode::I32__load:
-    return checkAlignAndTrans(32, {VType(ValTypeCode::I32)},
-                              {VType(ValTypeCode::I32)});
+    return checkAlignAndTrans(32, {ValType(ValTypeCode::I32)},
+                              {ValType(ValTypeCode::I32)});
   case OpCode::I64__load:
-    return checkAlignAndTrans(64, {VType(ValTypeCode::I32)},
-                              {VType(ValTypeCode::I64)});
+    return checkAlignAndTrans(64, {ValType(ValTypeCode::I32)},
+                              {ValType(ValTypeCode::I64)});
   case OpCode::F32__load:
-    return checkAlignAndTrans(32, {VType(ValTypeCode::I32)},
-                              {VType(ValTypeCode::F32)});
+    return checkAlignAndTrans(32, {ValType(ValTypeCode::I32)},
+                              {ValType(ValTypeCode::F32)});
   case OpCode::F64__load:
-    return checkAlignAndTrans(64, {VType(ValTypeCode::I32)},
-                              {VType(ValTypeCode::F64)});
+    return checkAlignAndTrans(64, {ValType(ValTypeCode::I32)},
+                              {ValType(ValTypeCode::F64)});
   case OpCode::I32__load8_s:
   case OpCode::I32__load8_u:
-    return checkAlignAndTrans(8, {VType(ValTypeCode::I32)},
-                              {VType(ValTypeCode::I32)});
+    return checkAlignAndTrans(8, {ValType(ValTypeCode::I32)},
+                              {ValType(ValTypeCode::I32)});
   case OpCode::I32__load16_s:
   case OpCode::I32__load16_u:
-    return checkAlignAndTrans(16, {VType(ValTypeCode::I32)},
-                              {VType(ValTypeCode::I32)});
+    return checkAlignAndTrans(16, {ValType(ValTypeCode::I32)},
+                              {ValType(ValTypeCode::I32)});
   case OpCode::I64__load8_s:
   case OpCode::I64__load8_u:
-    return checkAlignAndTrans(8, {VType(ValTypeCode::I32)},
-                              {VType(ValTypeCode::I64)});
+    return checkAlignAndTrans(8, {ValType(ValTypeCode::I32)},
+                              {ValType(ValTypeCode::I64)});
   case OpCode::I64__load16_s:
   case OpCode::I64__load16_u:
-    return checkAlignAndTrans(16, {VType(ValTypeCode::I32)},
-                              {VType(ValTypeCode::I64)});
+    return checkAlignAndTrans(16, {ValType(ValTypeCode::I32)},
+                              {ValType(ValTypeCode::I64)});
   case OpCode::I64__load32_s:
   case OpCode::I64__load32_u:
-    return checkAlignAndTrans(32, {VType(ValTypeCode::I32)},
-                              {VType(ValTypeCode::I64)});
+    return checkAlignAndTrans(32, {ValType(ValTypeCode::I32)},
+                              {ValType(ValTypeCode::I64)});
   case OpCode::I32__store:
     return checkAlignAndTrans(
-        32, {VType(ValTypeCode::I32), VType(ValTypeCode::I32)}, {});
+        32, {ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)}, {});
   case OpCode::I64__store:
     return checkAlignAndTrans(
-        64, {VType(ValTypeCode::I32), VType(ValTypeCode::I64)}, {});
+        64, {ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)}, {});
   case OpCode::F32__store:
     return checkAlignAndTrans(
-        32, {VType(ValTypeCode::I32), VType(ValTypeCode::F32)}, {});
+        32, {ValType(ValTypeCode::I32), ValType(ValTypeCode::F32)}, {});
   case OpCode::F64__store:
     return checkAlignAndTrans(
-        64, {VType(ValTypeCode::I32), VType(ValTypeCode::F64)}, {});
+        64, {ValType(ValTypeCode::I32), ValType(ValTypeCode::F64)}, {});
   case OpCode::I32__store8:
     return checkAlignAndTrans(
-        8, {VType(ValTypeCode::I32), VType(ValTypeCode::I32)}, {});
+        8, {ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)}, {});
   case OpCode::I32__store16:
     return checkAlignAndTrans(
-        16, {VType(ValTypeCode::I32), VType(ValTypeCode::I32)}, {});
+        16, {ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)}, {});
   case OpCode::I64__store8:
     return checkAlignAndTrans(
-        8, {VType(ValTypeCode::I32), VType(ValTypeCode::I64)}, {});
+        8, {ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)}, {});
   case OpCode::I64__store16:
     return checkAlignAndTrans(
-        16, {VType(ValTypeCode::I32), VType(ValTypeCode::I64)}, {});
+        16, {ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)}, {});
   case OpCode::I64__store32:
     return checkAlignAndTrans(
-        32, {VType(ValTypeCode::I32), VType(ValTypeCode::I64)}, {});
+        32, {ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)}, {});
   case OpCode::Memory__size:
-    return checkMemAndTrans({}, {VType(ValTypeCode::I32)});
+    return checkMemAndTrans({}, {ValType(ValTypeCode::I32)});
   case OpCode::Memory__grow:
-    return checkMemAndTrans({VType(ValTypeCode::I32)},
-                            {VType(ValTypeCode::I32)});
+    return checkMemAndTrans({ValType(ValTypeCode::I32)},
+                            {ValType(ValTypeCode::I32)});
   case OpCode::Memory__init:
     // Check the target memory index. Memory index should be checked first.
     if (Instr.getTargetIndex() >= Mems) {
@@ -780,8 +769,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
                            ErrInfo::IndexCategory::Data, Instr.getSourceIndex(),
                            static_cast<uint32_t>(Datas.size()));
     }
-    return StackTrans({VType(ValTypeCode::I32), VType(ValTypeCode::I32),
-                       VType(ValTypeCode::I32)},
+    return StackTrans({ValType(ValTypeCode::I32), ValType(ValTypeCode::I32),
+                       ValType(ValTypeCode::I32)},
                       {});
   case OpCode::Memory__copy:
     /// Check the source memory index.
@@ -792,8 +781,9 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
     }
     [[fallthrough]];
   case OpCode::Memory__fill:
-    return checkMemAndTrans({VType(ValTypeCode::I32), VType(ValTypeCode::I32),
-                             VType(ValTypeCode::I32)},
+    return checkMemAndTrans({ValType(ValTypeCode::I32),
+                             ValType(ValTypeCode::I32),
+                             ValType(ValTypeCode::I32)},
                             {});
   case OpCode::Data__drop:
     // Check the target data index.
@@ -806,27 +796,27 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
 
   // Const Instructions.
   case OpCode::I32__const:
-    return StackTrans({}, {VType(ValTypeCode::I32)});
+    return StackTrans({}, {ValType(ValTypeCode::I32)});
   case OpCode::I64__const:
-    return StackTrans({}, {VType(ValTypeCode::I64)});
+    return StackTrans({}, {ValType(ValTypeCode::I64)});
   case OpCode::F32__const:
-    return StackTrans({}, {VType(ValTypeCode::F32)});
+    return StackTrans({}, {ValType(ValTypeCode::F32)});
   case OpCode::F64__const:
-    return StackTrans({}, {VType(ValTypeCode::F64)});
+    return StackTrans({}, {ValType(ValTypeCode::F64)});
 
   // Unary Numeric Instructions.
   case OpCode::I32__eqz:
-    return StackTrans({VType(ValTypeCode::I32)}, {VType(ValTypeCode::I32)});
+    return StackTrans({ValType(ValTypeCode::I32)}, {ValType(ValTypeCode::I32)});
   case OpCode::I64__eqz:
-    return StackTrans({VType(ValTypeCode::I64)}, {VType(ValTypeCode::I32)});
+    return StackTrans({ValType(ValTypeCode::I64)}, {ValType(ValTypeCode::I32)});
   case OpCode::I32__clz:
   case OpCode::I32__ctz:
   case OpCode::I32__popcnt:
-    return StackTrans({VType(ValTypeCode::I32)}, {VType(ValTypeCode::I32)});
+    return StackTrans({ValType(ValTypeCode::I32)}, {ValType(ValTypeCode::I32)});
   case OpCode::I64__clz:
   case OpCode::I64__ctz:
   case OpCode::I64__popcnt:
-    return StackTrans({VType(ValTypeCode::I64)}, {VType(ValTypeCode::I64)});
+    return StackTrans({ValType(ValTypeCode::I64)}, {ValType(ValTypeCode::I64)});
   case OpCode::F32__abs:
   case OpCode::F32__neg:
   case OpCode::F32__ceil:
@@ -834,7 +824,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::F32__trunc:
   case OpCode::F32__nearest:
   case OpCode::F32__sqrt:
-    return StackTrans({VType(ValTypeCode::F32)}, {VType(ValTypeCode::F32)});
+    return StackTrans({ValType(ValTypeCode::F32)}, {ValType(ValTypeCode::F32)});
   case OpCode::F64__abs:
   case OpCode::F64__neg:
   case OpCode::F64__ceil:
@@ -842,67 +832,67 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::F64__trunc:
   case OpCode::F64__nearest:
   case OpCode::F64__sqrt:
-    return StackTrans({VType(ValTypeCode::F64)}, {VType(ValTypeCode::F64)});
+    return StackTrans({ValType(ValTypeCode::F64)}, {ValType(ValTypeCode::F64)});
   case OpCode::I32__wrap_i64:
-    return StackTrans({VType(ValTypeCode::I64)}, {VType(ValTypeCode::I32)});
+    return StackTrans({ValType(ValTypeCode::I64)}, {ValType(ValTypeCode::I32)});
   case OpCode::I32__trunc_f32_s:
   case OpCode::I32__trunc_f32_u:
-    return StackTrans({VType(ValTypeCode::F32)}, {VType(ValTypeCode::I32)});
+    return StackTrans({ValType(ValTypeCode::F32)}, {ValType(ValTypeCode::I32)});
   case OpCode::I32__trunc_f64_s:
   case OpCode::I32__trunc_f64_u:
-    return StackTrans({VType(ValTypeCode::F64)}, {VType(ValTypeCode::I32)});
+    return StackTrans({ValType(ValTypeCode::F64)}, {ValType(ValTypeCode::I32)});
   case OpCode::I64__extend_i32_s:
   case OpCode::I64__extend_i32_u:
-    return StackTrans({VType(ValTypeCode::I32)}, {VType(ValTypeCode::I64)});
+    return StackTrans({ValType(ValTypeCode::I32)}, {ValType(ValTypeCode::I64)});
   case OpCode::I64__trunc_f32_s:
   case OpCode::I64__trunc_f32_u:
-    return StackTrans({VType(ValTypeCode::F32)}, {VType(ValTypeCode::I64)});
+    return StackTrans({ValType(ValTypeCode::F32)}, {ValType(ValTypeCode::I64)});
   case OpCode::I64__trunc_f64_s:
   case OpCode::I64__trunc_f64_u:
-    return StackTrans({VType(ValTypeCode::F64)}, {VType(ValTypeCode::I64)});
+    return StackTrans({ValType(ValTypeCode::F64)}, {ValType(ValTypeCode::I64)});
   case OpCode::F32__convert_i32_s:
   case OpCode::F32__convert_i32_u:
-    return StackTrans({VType(ValTypeCode::I32)}, {VType(ValTypeCode::F32)});
+    return StackTrans({ValType(ValTypeCode::I32)}, {ValType(ValTypeCode::F32)});
   case OpCode::F32__convert_i64_s:
   case OpCode::F32__convert_i64_u:
-    return StackTrans({VType(ValTypeCode::I64)}, {VType(ValTypeCode::F32)});
+    return StackTrans({ValType(ValTypeCode::I64)}, {ValType(ValTypeCode::F32)});
   case OpCode::F32__demote_f64:
-    return StackTrans({VType(ValTypeCode::F64)}, {VType(ValTypeCode::F32)});
+    return StackTrans({ValType(ValTypeCode::F64)}, {ValType(ValTypeCode::F32)});
   case OpCode::F64__convert_i32_s:
   case OpCode::F64__convert_i32_u:
-    return StackTrans({VType(ValTypeCode::I32)}, {VType(ValTypeCode::F64)});
+    return StackTrans({ValType(ValTypeCode::I32)}, {ValType(ValTypeCode::F64)});
   case OpCode::F64__convert_i64_s:
   case OpCode::F64__convert_i64_u:
-    return StackTrans({VType(ValTypeCode::I64)}, {VType(ValTypeCode::F64)});
+    return StackTrans({ValType(ValTypeCode::I64)}, {ValType(ValTypeCode::F64)});
   case OpCode::F64__promote_f32:
-    return StackTrans({VType(ValTypeCode::F32)}, {VType(ValTypeCode::F64)});
+    return StackTrans({ValType(ValTypeCode::F32)}, {ValType(ValTypeCode::F64)});
   case OpCode::I32__reinterpret_f32:
-    return StackTrans({VType(ValTypeCode::F32)}, {VType(ValTypeCode::I32)});
+    return StackTrans({ValType(ValTypeCode::F32)}, {ValType(ValTypeCode::I32)});
   case OpCode::I64__reinterpret_f64:
-    return StackTrans({VType(ValTypeCode::F64)}, {VType(ValTypeCode::I64)});
+    return StackTrans({ValType(ValTypeCode::F64)}, {ValType(ValTypeCode::I64)});
   case OpCode::F32__reinterpret_i32:
-    return StackTrans({VType(ValTypeCode::I32)}, {VType(ValTypeCode::F32)});
+    return StackTrans({ValType(ValTypeCode::I32)}, {ValType(ValTypeCode::F32)});
   case OpCode::F64__reinterpret_i64:
-    return StackTrans({VType(ValTypeCode::I64)}, {VType(ValTypeCode::F64)});
+    return StackTrans({ValType(ValTypeCode::I64)}, {ValType(ValTypeCode::F64)});
   case OpCode::I32__extend8_s:
   case OpCode::I32__extend16_s:
-    return StackTrans({VType(ValTypeCode::I32)}, {VType(ValTypeCode::I32)});
+    return StackTrans({ValType(ValTypeCode::I32)}, {ValType(ValTypeCode::I32)});
   case OpCode::I64__extend8_s:
   case OpCode::I64__extend16_s:
   case OpCode::I64__extend32_s:
-    return StackTrans({VType(ValTypeCode::I64)}, {VType(ValTypeCode::I64)});
+    return StackTrans({ValType(ValTypeCode::I64)}, {ValType(ValTypeCode::I64)});
   case OpCode::I32__trunc_sat_f32_s:
   case OpCode::I32__trunc_sat_f32_u:
-    return StackTrans({VType(ValTypeCode::F32)}, {VType(ValTypeCode::I32)});
+    return StackTrans({ValType(ValTypeCode::F32)}, {ValType(ValTypeCode::I32)});
   case OpCode::I32__trunc_sat_f64_s:
   case OpCode::I32__trunc_sat_f64_u:
-    return StackTrans({VType(ValTypeCode::F64)}, {VType(ValTypeCode::I32)});
+    return StackTrans({ValType(ValTypeCode::F64)}, {ValType(ValTypeCode::I32)});
   case OpCode::I64__trunc_sat_f32_s:
   case OpCode::I64__trunc_sat_f32_u:
-    return StackTrans({VType(ValTypeCode::F32)}, {VType(ValTypeCode::I64)});
+    return StackTrans({ValType(ValTypeCode::F32)}, {ValType(ValTypeCode::I64)});
   case OpCode::I64__trunc_sat_f64_s:
   case OpCode::I64__trunc_sat_f64_u:
-    return StackTrans({VType(ValTypeCode::F64)}, {VType(ValTypeCode::I64)});
+    return StackTrans({ValType(ValTypeCode::F64)}, {ValType(ValTypeCode::I64)});
 
   // Binary Numeric Instructions.
   case OpCode::I32__eq:
@@ -915,8 +905,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::I32__le_u:
   case OpCode::I32__ge_s:
   case OpCode::I32__ge_u:
-    return StackTrans({VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-                      {VType(ValTypeCode::I32)});
+    return StackTrans({ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+                      {ValType(ValTypeCode::I32)});
   case OpCode::I64__eq:
   case OpCode::I64__ne:
   case OpCode::I64__lt_s:
@@ -927,24 +917,24 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::I64__le_u:
   case OpCode::I64__ge_s:
   case OpCode::I64__ge_u:
-    return StackTrans({VType(ValTypeCode::I64), VType(ValTypeCode::I64)},
-                      {VType(ValTypeCode::I32)});
+    return StackTrans({ValType(ValTypeCode::I64), ValType(ValTypeCode::I64)},
+                      {ValType(ValTypeCode::I32)});
   case OpCode::F32__eq:
   case OpCode::F32__ne:
   case OpCode::F32__lt:
   case OpCode::F32__gt:
   case OpCode::F32__le:
   case OpCode::F32__ge:
-    return StackTrans({VType(ValTypeCode::F32), VType(ValTypeCode::F32)},
-                      {VType(ValTypeCode::I32)});
+    return StackTrans({ValType(ValTypeCode::F32), ValType(ValTypeCode::F32)},
+                      {ValType(ValTypeCode::I32)});
   case OpCode::F64__eq:
   case OpCode::F64__ne:
   case OpCode::F64__lt:
   case OpCode::F64__gt:
   case OpCode::F64__le:
   case OpCode::F64__ge:
-    return StackTrans({VType(ValTypeCode::F64), VType(ValTypeCode::F64)},
-                      {VType(ValTypeCode::I32)});
+    return StackTrans({ValType(ValTypeCode::F64), ValType(ValTypeCode::F64)},
+                      {ValType(ValTypeCode::I32)});
   case OpCode::I32__add:
   case OpCode::I32__sub:
   case OpCode::I32__mul:
@@ -960,8 +950,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::I32__shr_u:
   case OpCode::I32__rotl:
   case OpCode::I32__rotr:
-    return StackTrans({VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-                      {VType(ValTypeCode::I32)});
+    return StackTrans({ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+                      {ValType(ValTypeCode::I32)});
   case OpCode::I64__add:
   case OpCode::I64__sub:
   case OpCode::I64__mul:
@@ -977,8 +967,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::I64__shr_u:
   case OpCode::I64__rotl:
   case OpCode::I64__rotr:
-    return StackTrans({VType(ValTypeCode::I64), VType(ValTypeCode::I64)},
-                      {VType(ValTypeCode::I64)});
+    return StackTrans({ValType(ValTypeCode::I64), ValType(ValTypeCode::I64)},
+                      {ValType(ValTypeCode::I64)});
   case OpCode::F32__add:
   case OpCode::F32__sub:
   case OpCode::F32__mul:
@@ -986,8 +976,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::F32__min:
   case OpCode::F32__max:
   case OpCode::F32__copysign:
-    return StackTrans({VType(ValTypeCode::F32), VType(ValTypeCode::F32)},
-                      {VType(ValTypeCode::F32)});
+    return StackTrans({ValType(ValTypeCode::F32), ValType(ValTypeCode::F32)},
+                      {ValType(ValTypeCode::F32)});
   case OpCode::F64__add:
   case OpCode::F64__sub:
   case OpCode::F64__mul:
@@ -995,13 +985,13 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::F64__min:
   case OpCode::F64__max:
   case OpCode::F64__copysign:
-    return StackTrans({VType(ValTypeCode::F64), VType(ValTypeCode::F64)},
-                      {VType(ValTypeCode::F64)});
+    return StackTrans({ValType(ValTypeCode::F64), ValType(ValTypeCode::F64)},
+                      {ValType(ValTypeCode::F64)});
 
   // SIMD Memory Instruction.
   case OpCode::V128__load:
-    return checkAlignAndTrans(128, {VType(ValTypeCode::I32)},
-                              {VType(ValTypeCode::V128)});
+    return checkAlignAndTrans(128, {ValType(ValTypeCode::I32)},
+                              {ValType(ValTypeCode::V128)});
   case OpCode::V128__load8x8_s:
   case OpCode::V128__load8x8_u:
   case OpCode::V128__load16x4_s:
@@ -1010,53 +1000,53 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::V128__load32x2_u:
   case OpCode::V128__load64_splat:
   case OpCode::V128__load64_zero:
-    return checkAlignAndTrans(64, {VType(ValTypeCode::I32)},
-                              {VType(ValTypeCode::V128)});
+    return checkAlignAndTrans(64, {ValType(ValTypeCode::I32)},
+                              {ValType(ValTypeCode::V128)});
   case OpCode::V128__load8_splat:
-    return checkAlignAndTrans(8, {VType(ValTypeCode::I32)},
-                              {VType(ValTypeCode::V128)});
+    return checkAlignAndTrans(8, {ValType(ValTypeCode::I32)},
+                              {ValType(ValTypeCode::V128)});
   case OpCode::V128__load16_splat:
-    return checkAlignAndTrans(16, {VType(ValTypeCode::I32)},
-                              {VType(ValTypeCode::V128)});
+    return checkAlignAndTrans(16, {ValType(ValTypeCode::I32)},
+                              {ValType(ValTypeCode::V128)});
   case OpCode::V128__load32_splat:
   case OpCode::V128__load32_zero:
-    return checkAlignAndTrans(32, {VType(ValTypeCode::I32)},
-                              {VType(ValTypeCode::V128)});
+    return checkAlignAndTrans(32, {ValType(ValTypeCode::I32)},
+                              {ValType(ValTypeCode::V128)});
   case OpCode::V128__store:
     return checkAlignAndTrans(
-        128, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)}, {});
+        128, {ValType(ValTypeCode::I32), ValType(ValTypeCode::V128)}, {});
   case OpCode::V128__load8_lane:
     return checkAlignAndTrans(
-        8, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)},
-        {VType(ValTypeCode::V128)}, true);
+        8, {ValType(ValTypeCode::I32), ValType(ValTypeCode::V128)},
+        {ValType(ValTypeCode::V128)}, true);
   case OpCode::V128__load16_lane:
     return checkAlignAndTrans(
-        16, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)},
-        {VType(ValTypeCode::V128)}, true);
+        16, {ValType(ValTypeCode::I32), ValType(ValTypeCode::V128)},
+        {ValType(ValTypeCode::V128)}, true);
   case OpCode::V128__load32_lane:
     return checkAlignAndTrans(
-        32, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)},
-        {VType(ValTypeCode::V128)}, true);
+        32, {ValType(ValTypeCode::I32), ValType(ValTypeCode::V128)},
+        {ValType(ValTypeCode::V128)}, true);
   case OpCode::V128__load64_lane:
     return checkAlignAndTrans(
-        64, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)},
-        {VType(ValTypeCode::V128)}, true);
+        64, {ValType(ValTypeCode::I32), ValType(ValTypeCode::V128)},
+        {ValType(ValTypeCode::V128)}, true);
   case OpCode::V128__store8_lane:
     return checkAlignAndTrans(
-        8, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)}, {}, true);
+        8, {ValType(ValTypeCode::I32), ValType(ValTypeCode::V128)}, {}, true);
   case OpCode::V128__store16_lane:
     return checkAlignAndTrans(
-        16, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)}, {}, true);
+        16, {ValType(ValTypeCode::I32), ValType(ValTypeCode::V128)}, {}, true);
   case OpCode::V128__store32_lane:
     return checkAlignAndTrans(
-        32, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)}, {}, true);
+        32, {ValType(ValTypeCode::I32), ValType(ValTypeCode::V128)}, {}, true);
   case OpCode::V128__store64_lane:
     return checkAlignAndTrans(
-        64, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)}, {}, true);
+        64, {ValType(ValTypeCode::I32), ValType(ValTypeCode::V128)}, {}, true);
 
   // SIMD Const Instruction.
   case OpCode::V128__const:
-    return StackTrans({}, {VType(ValTypeCode::V128)});
+    return StackTrans({}, {ValType(ValTypeCode::V128)});
 
   // SIMD Shuffle Instruction.
   case OpCode::I8x16__shuffle: {
@@ -1068,67 +1058,71 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
       spdlog::error(ErrCode::Value::InvalidLaneIdx);
       return Unexpect(ErrCode::Value::InvalidLaneIdx);
     }
-    return StackTrans({VType(ValTypeCode::V128), VType(ValTypeCode::V128)},
-                      {VType(ValTypeCode::V128)});
+    return StackTrans({ValType(ValTypeCode::V128), ValType(ValTypeCode::V128)},
+                      {ValType(ValTypeCode::V128)});
   }
 
   // SIMD Lane Instructions.
   case OpCode::I8x16__extract_lane_s:
   case OpCode::I8x16__extract_lane_u:
-    return checkLaneAndTrans(16, {VType(ValTypeCode::V128)},
-                             {VType(ValTypeCode::I32)});
+    return checkLaneAndTrans(16, {ValType(ValTypeCode::V128)},
+                             {ValType(ValTypeCode::I32)});
   case OpCode::I8x16__replace_lane:
     return checkLaneAndTrans(
-        16, {VType(ValTypeCode::V128), VType(ValTypeCode::I32)},
-        {VType(ValTypeCode::V128)});
+        16, {ValType(ValTypeCode::V128), ValType(ValTypeCode::I32)},
+        {ValType(ValTypeCode::V128)});
   case OpCode::I16x8__extract_lane_s:
   case OpCode::I16x8__extract_lane_u:
-    return checkLaneAndTrans(8, {VType(ValTypeCode::V128)},
-                             {VType(ValTypeCode::I32)});
+    return checkLaneAndTrans(8, {ValType(ValTypeCode::V128)},
+                             {ValType(ValTypeCode::I32)});
   case OpCode::I16x8__replace_lane:
     return checkLaneAndTrans(
-        8, {VType(ValTypeCode::V128), VType(ValTypeCode::I32)},
-        {VType(ValTypeCode::V128)});
+        8, {ValType(ValTypeCode::V128), ValType(ValTypeCode::I32)},
+        {ValType(ValTypeCode::V128)});
   case OpCode::I32x4__extract_lane:
-    return checkLaneAndTrans(4, {VType(ValTypeCode::V128)},
-                             {VType(ValTypeCode::I32)});
+    return checkLaneAndTrans(4, {ValType(ValTypeCode::V128)},
+                             {ValType(ValTypeCode::I32)});
   case OpCode::I32x4__replace_lane:
     return checkLaneAndTrans(
-        4, {VType(ValTypeCode::V128), VType(ValTypeCode::I32)},
-        {VType(ValTypeCode::V128)});
+        4, {ValType(ValTypeCode::V128), ValType(ValTypeCode::I32)},
+        {ValType(ValTypeCode::V128)});
   case OpCode::I64x2__extract_lane:
-    return checkLaneAndTrans(2, {VType(ValTypeCode::V128)},
-                             {VType(ValTypeCode::I64)});
+    return checkLaneAndTrans(2, {ValType(ValTypeCode::V128)},
+                             {ValType(ValTypeCode::I64)});
   case OpCode::I64x2__replace_lane:
     return checkLaneAndTrans(
-        2, {VType(ValTypeCode::V128), VType(ValTypeCode::I64)},
-        {VType(ValTypeCode::V128)});
+        2, {ValType(ValTypeCode::V128), ValType(ValTypeCode::I64)},
+        {ValType(ValTypeCode::V128)});
   case OpCode::F32x4__extract_lane:
-    return checkLaneAndTrans(4, {VType(ValTypeCode::V128)},
-                             {VType(ValTypeCode::F32)});
+    return checkLaneAndTrans(4, {ValType(ValTypeCode::V128)},
+                             {ValType(ValTypeCode::F32)});
   case OpCode::F32x4__replace_lane:
     return checkLaneAndTrans(
-        4, {VType(ValTypeCode::V128), VType(ValTypeCode::F32)},
-        {VType(ValTypeCode::V128)});
+        4, {ValType(ValTypeCode::V128), ValType(ValTypeCode::F32)},
+        {ValType(ValTypeCode::V128)});
   case OpCode::F64x2__extract_lane:
-    return checkLaneAndTrans(2, {VType(ValTypeCode::V128)},
-                             {VType(ValTypeCode::F64)});
+    return checkLaneAndTrans(2, {ValType(ValTypeCode::V128)},
+                             {ValType(ValTypeCode::F64)});
   case OpCode::F64x2__replace_lane:
     return checkLaneAndTrans(
-        2, {VType(ValTypeCode::V128), VType(ValTypeCode::F64)},
-        {VType(ValTypeCode::V128)});
+        2, {ValType(ValTypeCode::V128), ValType(ValTypeCode::F64)},
+        {ValType(ValTypeCode::V128)});
 
   // SIMD Numeric Instructions.
   case OpCode::I8x16__splat:
   case OpCode::I16x8__splat:
   case OpCode::I32x4__splat:
-    return StackTrans({VType(ValTypeCode::I32)}, {VType(ValTypeCode::V128)});
+    return StackTrans({ValType(ValTypeCode::I32)},
+                      {ValType(ValTypeCode::V128)});
   case OpCode::I64x2__splat:
-    return StackTrans({VType(ValTypeCode::I64)}, {VType(ValTypeCode::V128)});
+    return StackTrans({ValType(ValTypeCode::I64)},
+                      {ValType(ValTypeCode::V128)});
   case OpCode::F32x4__splat:
-    return StackTrans({VType(ValTypeCode::F32)}, {VType(ValTypeCode::V128)});
+    return StackTrans({ValType(ValTypeCode::F32)},
+                      {ValType(ValTypeCode::V128)});
   case OpCode::F64x2__splat:
-    return StackTrans({VType(ValTypeCode::F64)}, {VType(ValTypeCode::V128)});
+    return StackTrans({ValType(ValTypeCode::F64)},
+                      {ValType(ValTypeCode::V128)});
   case OpCode::V128__not:
   case OpCode::I8x16__abs:
   case OpCode::I8x16__neg:
@@ -1179,7 +1173,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::F64x2__floor:
   case OpCode::F64x2__trunc:
   case OpCode::F64x2__nearest:
-    return StackTrans({VType(ValTypeCode::V128)}, {VType(ValTypeCode::V128)});
+    return StackTrans({ValType(ValTypeCode::V128)},
+                      {ValType(ValTypeCode::V128)});
   case OpCode::I8x16__swizzle:
   case OpCode::I8x16__eq:
   case OpCode::I8x16__ne:
@@ -1300,12 +1295,12 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::F64x2__pmin:
   case OpCode::F64x2__pmax:
   case OpCode::I32x4__dot_i16x8_s:
-    return StackTrans({VType(ValTypeCode::V128), VType(ValTypeCode::V128)},
-                      {VType(ValTypeCode::V128)});
+    return StackTrans({ValType(ValTypeCode::V128), ValType(ValTypeCode::V128)},
+                      {ValType(ValTypeCode::V128)});
   case OpCode::V128__bitselect:
-    return StackTrans({VType(ValTypeCode::V128), VType(ValTypeCode::V128),
-                       VType(ValTypeCode::V128)},
-                      {VType(ValTypeCode::V128)});
+    return StackTrans({ValType(ValTypeCode::V128), ValType(ValTypeCode::V128),
+                       ValType(ValTypeCode::V128)},
+                      {ValType(ValTypeCode::V128)});
   case OpCode::V128__any_true:
   case OpCode::I8x16__all_true:
   case OpCode::I8x16__bitmask:
@@ -1315,7 +1310,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::I32x4__bitmask:
   case OpCode::I64x2__all_true:
   case OpCode::I64x2__bitmask:
-    return StackTrans({VType(ValTypeCode::V128)}, {VType(ValTypeCode::I32)});
+    return StackTrans({ValType(ValTypeCode::V128)},
+                      {ValType(ValTypeCode::I32)});
   case OpCode::I8x16__shl:
   case OpCode::I8x16__shr_s:
   case OpCode::I8x16__shr_u:
@@ -1328,281 +1324,288 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::I64x2__shl:
   case OpCode::I64x2__shr_s:
   case OpCode::I64x2__shr_u:
-    return StackTrans({VType(ValTypeCode::V128), VType(ValTypeCode::I32)},
-                      {VType(ValTypeCode::V128)});
+    return StackTrans({ValType(ValTypeCode::V128), ValType(ValTypeCode::I32)},
+                      {ValType(ValTypeCode::V128)});
 
   case OpCode::Atomic__fence:
     return {};
 
   case OpCode::Memory__atomic__notify:
     return checkAlignAndTrans(
-        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        32, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::Memory__atomic__wait32:
     return checkAlignAndTrans(32,
-                              std::array{VType(ValTypeCode::I32),
-                                         VType(ValTypeCode::I32),
-                                         VType(ValTypeCode::I64)},
-                              std::array{VType(ValTypeCode::I32)});
+                              std::array{ValType(ValTypeCode::I32),
+                                         ValType(ValTypeCode::I32),
+                                         ValType(ValTypeCode::I64)},
+                              std::array{ValType(ValTypeCode::I32)});
   case OpCode::Memory__atomic__wait64:
     return checkAlignAndTrans(64,
-                              std::array{VType(ValTypeCode::I32),
-                                         VType(ValTypeCode::I64),
-                                         VType(ValTypeCode::I64)},
-                              std::array{VType(ValTypeCode::I32)});
+                              std::array{ValType(ValTypeCode::I32),
+                                         ValType(ValTypeCode::I64),
+                                         ValType(ValTypeCode::I64)},
+                              std::array{ValType(ValTypeCode::I32)});
 
   case OpCode::I32__atomic__load:
-    return checkAlignAndTrans(32, std::array{VType(ValTypeCode::I32)},
-                              std::array{VType(ValTypeCode::I32)});
+    return checkAlignAndTrans(32, std::array{ValType(ValTypeCode::I32)},
+                              std::array{ValType(ValTypeCode::I32)});
   case OpCode::I64__atomic__load:
-    return checkAlignAndTrans(64, std::array{VType(ValTypeCode::I32)},
-                              std::array{VType(ValTypeCode::I64)});
+    return checkAlignAndTrans(64, std::array{ValType(ValTypeCode::I32)},
+                              std::array{ValType(ValTypeCode::I64)});
   case OpCode::I32__atomic__load8_u:
-    return checkAlignAndTrans(8, std::array{VType(ValTypeCode::I32)},
-                              std::array{VType(ValTypeCode::I32)});
+    return checkAlignAndTrans(8, std::array{ValType(ValTypeCode::I32)},
+                              std::array{ValType(ValTypeCode::I32)});
   case OpCode::I32__atomic__load16_u:
-    return checkAlignAndTrans(16, std::array{VType(ValTypeCode::I32)},
-                              std::array{VType(ValTypeCode::I32)});
+    return checkAlignAndTrans(16, std::array{ValType(ValTypeCode::I32)},
+                              std::array{ValType(ValTypeCode::I32)});
   case OpCode::I64__atomic__load8_u:
-    return checkAlignAndTrans(8, std::array{VType(ValTypeCode::I32)},
-                              std::array{VType(ValTypeCode::I64)});
+    return checkAlignAndTrans(8, std::array{ValType(ValTypeCode::I32)},
+                              std::array{ValType(ValTypeCode::I64)});
   case OpCode::I64__atomic__load16_u:
-    return checkAlignAndTrans(16, std::array{VType(ValTypeCode::I32)},
-                              std::array{VType(ValTypeCode::I64)});
+    return checkAlignAndTrans(16, std::array{ValType(ValTypeCode::I32)},
+                              std::array{ValType(ValTypeCode::I64)});
   case OpCode::I64__atomic__load32_u:
-    return checkAlignAndTrans(32, std::array{VType(ValTypeCode::I32)},
-                              std::array{VType(ValTypeCode::I64)});
+    return checkAlignAndTrans(32, std::array{ValType(ValTypeCode::I32)},
+                              std::array{ValType(ValTypeCode::I64)});
   case OpCode::I32__atomic__store:
     return checkAlignAndTrans(
-        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)}, {});
+        32, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        {});
   case OpCode::I64__atomic__store:
     return checkAlignAndTrans(
-        64, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)}, {});
+        64, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        {});
   case OpCode::I32__atomic__store8:
     return checkAlignAndTrans(
-        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)}, {});
+        8, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        {});
   case OpCode::I32__atomic__store16:
     return checkAlignAndTrans(
-        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)}, {});
+        16, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        {});
   case OpCode::I64__atomic__store8:
     return checkAlignAndTrans(
-        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)}, {});
+        8, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        {});
   case OpCode::I64__atomic__store16:
     return checkAlignAndTrans(
-        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)}, {});
+        16, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        {});
   case OpCode::I64__atomic__store32:
     return checkAlignAndTrans(
-        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)}, {});
+        32, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        {});
   case OpCode::I32__atomic__rmw__add:
     return checkAlignAndTrans(
-        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        32, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw__add:
     return checkAlignAndTrans(
-        64, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        64, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw8__add_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        8, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I32__atomic__rmw16__add_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        16, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw8__add_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        8, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw16__add_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        16, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw32__add_u:
     return checkAlignAndTrans(
-        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        32, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw__sub:
     return checkAlignAndTrans(
-        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        32, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw__sub:
     return checkAlignAndTrans(
-        64, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        64, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw8__sub_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        8, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I32__atomic__rmw16__sub_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        16, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw8__sub_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        8, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw16__sub_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        16, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw32__sub_u:
     return checkAlignAndTrans(
-        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        32, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw__and:
     return checkAlignAndTrans(
-        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        32, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw__and:
     return checkAlignAndTrans(
-        64, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        64, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw8__and_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        8, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I32__atomic__rmw16__and_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        16, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw8__and_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        8, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw16__and_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        16, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw32__and_u:
     return checkAlignAndTrans(
-        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        32, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw__or:
     return checkAlignAndTrans(
-        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        32, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw__or:
     return checkAlignAndTrans(
-        64, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        64, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw8__or_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        8, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I32__atomic__rmw16__or_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        16, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw8__or_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        8, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw16__or_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        16, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw32__or_u:
     return checkAlignAndTrans(
-        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        32, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw__xor:
     return checkAlignAndTrans(
-        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        32, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw__xor:
     return checkAlignAndTrans(
-        64, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        64, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw8__xor_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        8, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I32__atomic__rmw16__xor_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        16, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw8__xor_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        8, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw16__xor_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        16, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw32__xor_u:
     return checkAlignAndTrans(
-        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        32, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw__xchg:
     return checkAlignAndTrans(
-        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        32, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw__xchg:
     return checkAlignAndTrans(
-        64, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        64, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw8__xchg_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        8, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I32__atomic__rmw16__xchg_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
-        std::array{VType(ValTypeCode::I32)});
+        16, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I32)},
+        std::array{ValType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw8__xchg_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        8, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw16__xchg_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        16, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw32__xchg_u:
     return checkAlignAndTrans(
-        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
-        std::array{VType(ValTypeCode::I64)});
+        32, std::array{ValType(ValTypeCode::I32), ValType(ValTypeCode::I64)},
+        std::array{ValType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw__cmpxchg:
     return checkAlignAndTrans(32,
-                              std::array{VType(ValTypeCode::I32),
-                                         VType(ValTypeCode::I32),
-                                         VType(ValTypeCode::I32)},
-                              std::array{VType(ValTypeCode::I32)});
+                              std::array{ValType(ValTypeCode::I32),
+                                         ValType(ValTypeCode::I32),
+                                         ValType(ValTypeCode::I32)},
+                              std::array{ValType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw__cmpxchg:
     return checkAlignAndTrans(64,
-                              std::array{VType(ValTypeCode::I32),
-                                         VType(ValTypeCode::I64),
-                                         VType(ValTypeCode::I64)},
-                              std::array{VType(ValTypeCode::I64)});
+                              std::array{ValType(ValTypeCode::I32),
+                                         ValType(ValTypeCode::I64),
+                                         ValType(ValTypeCode::I64)},
+                              std::array{ValType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw8__cmpxchg_u:
     return checkAlignAndTrans(8,
-                              std::array{VType(ValTypeCode::I32),
-                                         VType(ValTypeCode::I32),
-                                         VType(ValTypeCode::I32)},
-                              std::array{VType(ValTypeCode::I32)});
+                              std::array{ValType(ValTypeCode::I32),
+                                         ValType(ValTypeCode::I32),
+                                         ValType(ValTypeCode::I32)},
+                              std::array{ValType(ValTypeCode::I32)});
   case OpCode::I32__atomic__rmw16__cmpxchg_u:
     return checkAlignAndTrans(16,
-                              std::array{VType(ValTypeCode::I32),
-                                         VType(ValTypeCode::I32),
-                                         VType(ValTypeCode::I32)},
-                              std::array{VType(ValTypeCode::I32)});
+                              std::array{ValType(ValTypeCode::I32),
+                                         ValType(ValTypeCode::I32),
+                                         ValType(ValTypeCode::I32)},
+                              std::array{ValType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw8__cmpxchg_u:
     return checkAlignAndTrans(8,
-                              std::array{VType(ValTypeCode::I32),
-                                         VType(ValTypeCode::I64),
-                                         VType(ValTypeCode::I64)},
-                              std::array{VType(ValTypeCode::I64)});
+                              std::array{ValType(ValTypeCode::I32),
+                                         ValType(ValTypeCode::I64),
+                                         ValType(ValTypeCode::I64)},
+                              std::array{ValType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw16__cmpxchg_u:
     return checkAlignAndTrans(16,
-                              std::array{VType(ValTypeCode::I32),
-                                         VType(ValTypeCode::I64),
-                                         VType(ValTypeCode::I64)},
-                              std::array{VType(ValTypeCode::I64)});
+                              std::array{ValType(ValTypeCode::I32),
+                                         ValType(ValTypeCode::I64),
+                                         ValType(ValTypeCode::I64)},
+                              std::array{ValType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw32__cmpxchg_u:
     return checkAlignAndTrans(32,
-                              std::array{VType(ValTypeCode::I32),
-                                         VType(ValTypeCode::I64),
-                                         VType(ValTypeCode::I64)},
-                              std::array{VType(ValTypeCode::I64)});
+                              std::array{ValType(ValTypeCode::I32),
+                                         ValType(ValTypeCode::I64),
+                                         ValType(ValTypeCode::I64)},
+                              std::array{ValType(ValTypeCode::I64)});
 
   default:
     assumingUnreachable();
@@ -1612,6 +1615,12 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
 void FormChecker::pushType(VType V) { ValStack.emplace_back(V); }
 
 void FormChecker::pushTypes(Span<const VType> Input) {
+  for (auto Val : Input) {
+    pushType(Val);
+  }
+}
+
+void FormChecker::pushTypes(Span<const ValType> Input) {
   for (auto Val : Input) {
     pushType(Val);
   }
@@ -1632,7 +1641,7 @@ Expect<VType> FormChecker::popType() {
   return Res;
 }
 
-Expect<VType> FormChecker::popType(VType E) {
+Expect<VType> FormChecker::popType(ValType E) {
   auto Res = popType();
   if (!Res) {
     return Unexpect(Res);
@@ -1640,9 +1649,7 @@ Expect<VType> FormChecker::popType(VType E) {
   if (*Res == unreachableVType()) {
     return E;
   }
-  if (E == unreachableVType()) {
-    return *Res;
-  }
+  // TODO: may consider subtyping
   if (*Res != E) {
     // Expect value on value stack is not matched
     spdlog::error(ErrCode::Value::TypeCheckFailed);
@@ -1652,7 +1659,7 @@ Expect<VType> FormChecker::popType(VType E) {
   return *Res;
 }
 
-Expect<void> FormChecker::popTypes(Span<const VType> Input) {
+Expect<void> FormChecker::popTypes(Span<const ValType> Input) {
   for (auto Val = Input.rbegin(); Val != Input.rend(); ++Val) {
     if (auto Res = popType(*Val); !Res) {
       return Unexpect(Res);
@@ -1661,7 +1668,7 @@ Expect<void> FormChecker::popTypes(Span<const VType> Input) {
   return {};
 }
 
-void FormChecker::pushCtrl(Span<const VType> In, Span<const VType> Out,
+void FormChecker::pushCtrl(Span<const ValType> In, Span<const ValType> Out,
                            const AST::Instruction *Jump, OpCode Code) {
   CtrlStack.emplace_back(In, Out, Jump, ValStack.size(), Code);
   pushTypes(In);
@@ -1688,7 +1695,8 @@ Expect<FormChecker::CtrlFrame> FormChecker::popCtrl() {
   return Head;
 }
 
-Span<const VType> FormChecker::getLabelTypes(const FormChecker::CtrlFrame &F) {
+Span<const ValType>
+FormChecker::getLabelTypes(const FormChecker::CtrlFrame &F) {
   if (F.Code == OpCode::Loop) {
     return F.StartTypes;
   }
@@ -1705,12 +1713,19 @@ Expect<void> FormChecker::unreachable() {
   return {};
 }
 
-Expect<void> FormChecker::StackTrans(Span<const VType> Take,
-                                     Span<const VType> Put) {
+Expect<void> FormChecker::StackTrans(Span<const ValType> Take,
+                                     Span<const ValType> Put) {
   if (auto Res = popTypes(Take); !Res) {
     return Unexpect(Res);
   }
   pushTypes(Put);
+  return {};
+}
+
+Expect<void> FormChecker::StackPopAny() {
+  if (auto Res = popType(); !Res) {
+    return Unexpect(Res);
+  }
   return {};
 }
 


### PR DESCRIPTION
In https://github.com/WasmEdge/WasmEdge/pull/2097, we turn `VType` in validator into `Optional<ValType>`, and use `None` as the original `VType::Unknown`, which was used as unreachable type. After further examine the code the validator, most usage of `VType` make no difference to using `ValType`. In this PR, we further reduce the usage of `VType`. Currently, the `VType` is only stored in the `ValStack` of `FormChecker`. All other usages have been turned into `ValType`.

This PR is after https://github.com/WasmEdge/WasmEdge/pull/2099.