### PR TITLE
[Rust] Refactor call method

### DIFF
--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -30,6 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
+        rust: [1.64, 1.65]
     container:
       image: wasmedge/wasmedge:ubuntu-build-clang
 
@@ -38,10 +39,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Rust v1.65
+      - name: Install Rust-stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.65
+          toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
       - name: Build WasmEdge with Release mode

--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -89,6 +89,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-11, macos-12]
+        rust: [1.64, 1.65]
 
     steps:
       - name: Checkout sources
@@ -96,10 +97,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Rust v1.65
+      - name: Install Rust-stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.65
+          toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
       - name: Install build tools
@@ -111,7 +112,7 @@ jobs:
           export CC=clang
           export CXX=clang++
           rm -rf build
-          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWASMEDGE_BUILD_TESTS=$BUILD_TESTS -DWASMEDGE_LINK_LLVM_STATIC=ON -DWASMEDGE_BUILD_PACKAGE="TGZ" .
+          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_TESTS=ON .
           cmake --build build
 
       - name: Test WasmEdge
@@ -149,6 +150,9 @@ jobs:
   build_windows:
     name: Windows
     runs-on: windows-2022
+    strategy:
+      matrix:
+        rust: [1.64, 1.65]
     env:
       WASMEDGE_DIR: ${{ github.workspace }}
       WASMEDGE_BUILD_DIR: ${{ github.workspace }}\build
@@ -168,10 +172,10 @@ jobs:
         with:
           sdk-version: 19041
 
-      - name: Install Rust v1.65
+      - name: Install Rust-stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.65
+          toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
       - name: Rustfmt

--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        rust: [1.64, 1.65]
+        rust: [1.64, 1.65, 1.66]
     container:
       image: wasmedge/wasmedge:ubuntu-build-clang
 
@@ -89,7 +89,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-11, macos-12]
-        rust: [1.64, 1.65]
+        rust: [1.64, 1.65, 1.66]
 
     steps:
       - name: Checkout sources
@@ -152,7 +152,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        rust: [1.64, 1.65]
+        rust: [1.64, 1.65, 1.66]
     env:
       WASMEDGE_DIR: ${{ github.workspace }}
       WASMEDGE_BUILD_DIR: ${{ github.workspace }}\build

--- a/.github/workflows/rust-standalone.yml
+++ b/.github/workflows/rust-standalone.yml
@@ -5,19 +5,10 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
+  workflow_dispatch:
     branches:
       - master
       - "rust/*"
-    paths:
-      - ".github/workflows/rust-standalone.yml"
-      - "bindings/rust/**"
-  pull_request:
-    branches:
-      - master
-    paths:
-      - ".github/workflows/rust-standalone.yml"
-      - "bindings/rust/**"
 
 jobs:
   build_ubuntu_2204:

--- a/bindings/rust/wasmedge-sdk/Cargo.toml
+++ b/bindings/rust/wasmedge-sdk/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "wasmedge-sdk"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/WasmEdge/blob/master/bindings/rust/wasmedge-sdk"
-version = "0.7.1"
+version = "0.8.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/bindings/rust/wasmedge-sdk/examples/create_host_func_in_host_func.rs
+++ b/bindings/rust/wasmedge-sdk/examples/create_host_func_in_host_func.rs
@@ -44,10 +44,10 @@ fn func(_caller: Caller, _input: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostF
         let func = result.unwrap();
 
         // create an executor
-        let mut executor = Executor::new(None, None).unwrap();
+        let executor = Executor::new(None, None).unwrap();
 
         // call the host function
-        let result = func.call(&mut executor, params!(2, 3));
+        let result = func.call(&executor, params!(2, 3));
         assert!(result.is_ok());
         let returns = result.unwrap();
         assert_eq!(returns[0].to_i32(), 5);

--- a/bindings/rust/wasmedge-sdk/examples/executor_register_active_module.rs
+++ b/bindings/rust/wasmedge-sdk/examples/executor_register_active_module.rs
@@ -61,7 +61,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("Not found the wasm function named 'fib'.");
 
     // call the wasm function
-    let returns = fib.call(&mut executor, params!(5))?;
+    let returns = fib.call(&executor, params!(5))?;
     assert_eq!(returns.len(), 1);
     assert_eq!(returns[0].to_i32(), 8);
 

--- a/bindings/rust/wasmedge-sdk/examples/executor_register_named_module.rs
+++ b/bindings/rust/wasmedge-sdk/examples/executor_register_named_module.rs
@@ -62,7 +62,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("Not found the wasm function named 'fib'.");
 
     // call the host function
-    let returns = fib.call(&mut executor, params!(5))?;
+    let returns = fib.call(&executor, params!(5))?;
     assert_eq!(returns.len(), 1);
     assert_eq!(returns[0].to_i32(), 8);
 

--- a/bindings/rust/wasmedge-sdk/examples/hello_world.rs
+++ b/bindings/rust/wasmedge-sdk/examples/hello_world.rs
@@ -79,7 +79,7 @@ fn main() -> anyhow::Result<()> {
         .ok_or_else(|| anyhow::Error::msg("Not found exported function named 'run'."))?;
 
     // run host function
-    run.call(&mut executor, params!())?;
+    run.call(&executor, params!())?;
 
     Ok(())
 }

--- a/bindings/rust/wasmedge-sdk/examples/memory.rs
+++ b/bindings/rust/wasmedge-sdk/examples/memory.rs
@@ -65,20 +65,20 @@ fn main() -> anyhow::Result<()> {
     // call the exported function named "set_at"
     let mem_addr = 0x2220;
     let val = 0xFEFEFFE;
-    set_at.call(&mut executor, params!(mem_addr, val))?;
+    set_at.call(&executor, params!(mem_addr, val))?;
 
     // call the exported function named "get_at"
-    let returns = get_at.call(&mut executor, params!(mem_addr))?;
+    let returns = get_at.call(&executor, params!(mem_addr))?;
     assert_eq!(returns[0].to_i32(), val);
 
     // call the exported function named "set_at"
     let page_size = 0x1_0000;
     let mem_addr = (page_size * 2) - std::mem::size_of_val(&val) as i32;
     let val = 0xFEA09;
-    set_at.call(&mut executor, params!(mem_addr, val))?;
+    set_at.call(&executor, params!(mem_addr, val))?;
 
     // call the exported function named "get_at"
-    let returns = get_at.call(&mut executor, params!(mem_addr))?;
+    let returns = get_at.call(&executor, params!(mem_addr))?;
     assert_eq!(returns[0].to_i32(), val);
 
     Ok(())

--- a/bindings/rust/wasmedge-sdk/examples/multi_value.rs
+++ b/bindings/rust/wasmedge-sdk/examples/multi_value.rs
@@ -27,7 +27,7 @@ fn main() -> anyhow::Result<()> {
         .func("swap")
         .expect("Not found a host function named 'swap'.");
 
-    let returns = swap.call(&mut executor, params!(2, 3))?;
+    let returns = swap.call(&executor, params!(2, 3))?;
     assert_eq!(returns.len(), 2);
 
     println!(

--- a/bindings/rust/wasmedge-sdk/examples/table.rs
+++ b/bindings/rust/wasmedge-sdk/examples/table.rs
@@ -67,7 +67,7 @@ fn main() -> anyhow::Result<()> {
 
     // call the exported function named "call_callback"
     // the first argument is the table index, while the other two arguments are passed to the function found in the table.
-    let returns = call_via_table.call(&mut executor, params!(1, 2, 7))?;
+    let returns = call_via_table.call(&executor, params!(1, 2, 7))?;
     assert_eq!(returns[0].to_i32(), 18);
 
     // get module instance
@@ -122,7 +122,7 @@ fn main() -> anyhow::Result<()> {
 
     // We then repeat the call from before but this time it will find the host function
     // that we put at table index 1.
-    let returns = call_via_table.call(&mut executor, params!(1, 2, 7))?;
+    let returns = call_via_table.call(&executor, params!(1, 2, 7))?;
     assert_eq!(returns[0].to_i32(), 9);
 
     // * growing a table
@@ -139,7 +139,7 @@ fn main() -> anyhow::Result<()> {
     // Now demonstrate that the function we grew the table with is actually in the table.
     for idx in 3..6 {
         if let Val::FuncRef(Some(func_ref)) = guest_table.get(idx)? {
-            let returns = func_ref.call(&mut executor, params!(1, 9))?;
+            let returns = func_ref.call(&executor, params!(1, 9))?;
             assert_eq!(returns[0].to_i32(), 10);
         } else {
             panic!("expected to find funcref in table!");
@@ -147,26 +147,26 @@ fn main() -> anyhow::Result<()> {
     }
 
     // Call function at index 0 to show that it's still the same.
-    let returns = call_via_table.call(&mut executor, params!(0, 2, 7))?;
+    let returns = call_via_table.call(&executor, params!(0, 2, 7))?;
     assert_eq!(returns[0].to_i32(), 18);
 
     // Now overwrite index 0 with our host_callback.
     let func = Func::wrap::<(i32, i32), i32>(Box::new(host_callback))?;
     guest_table.set(0, Val::FuncRef(Some(func.as_ref())))?;
     // And verify that it does what we expect.
-    let returns = call_via_table.call(&mut executor, params!(0, 2, 7))?;
+    let returns = call_via_table.call(&executor, params!(0, 2, 7))?;
     assert_eq!(returns[0].to_i32(), 9);
 
     // Now demonstrate that the host and guest see the same table and that both
     // get the same result.
     for idx in 3..6 {
         if let Val::FuncRef(Some(func_ref)) = guest_table.get(idx)? {
-            let returns = func_ref.call(&mut executor, params!(1, 9))?;
+            let returns = func_ref.call(&executor, params!(1, 9))?;
             assert_eq!(returns[0].to_i32(), 10);
         } else {
             panic!("expected to find funcref in table!");
         }
-        let returns = call_via_table.call(&mut executor, params!(idx as i32, 1, 9))?;
+        let returns = call_via_table.call(&executor, params!(idx as i32, 1, 9))?;
         assert_eq!(returns[0].to_i32(), 10);
     }
 

--- a/bindings/rust/wasmedge-sdk/examples/table_and_funcref.rs
+++ b/bindings/rust/wasmedge-sdk/examples/table_and_funcref.rs
@@ -92,7 +92,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(return_tys, [ValType::I32]);
 
         // call the function by func_ref
-        let returns = func_ref.call(&mut executor, params!(1, 2))?;
+        let returns = func_ref.call(&executor, params!(1, 2))?;
         assert_eq!(returns.len(), 1);
         assert_eq!(returns[0].to_i32(), 3);
     }

--- a/bindings/rust/wasmedge-sdk/src/externals/function.rs
+++ b/bindings/rust/wasmedge-sdk/src/externals/function.rs
@@ -316,7 +316,7 @@ impl FuncRef {
     ///
     pub fn call<E: Engine>(
         &self,
-        engine: &mut E,
+        engine: &E,
         args: impl IntoIterator<Item = WasmValue>,
     ) -> WasmEdgeResult<Vec<WasmValue>> {
         engine.run_func_ref(self, args)

--- a/bindings/rust/wasmedge-sdk/src/externals/function.rs
+++ b/bindings/rust/wasmedge-sdk/src/externals/function.rs
@@ -213,7 +213,7 @@ impl Func {
     ///
     pub fn call<E: Engine>(
         &self,
-        engine: &mut E,
+        engine: &E,
         args: impl IntoIterator<Item = WasmValue>,
     ) -> WasmEdgeResult<Vec<WasmValue>> {
         engine.run_func(self, args)


### PR DESCRIPTION
In this PR, the following changes are introduced:

- Refactored the signature of `call` methods of `Func` and `FuncRef` structs, respectively
- Updated the `rust-standalone` workflow
- Updated the `bindings-rust` workflow to support Rust `1.64`, `1.65`, and `1.66`