### PR TITLE
Fix fdReaddir on large numbers of entries

### DIFF
--- a/include/host/wasi/inode.h
+++ b/include/host/wasi/inode.h
@@ -107,8 +107,9 @@ struct DirHolder {
     Dir = NewDir;
   }
 
+  const static uint64_t DIRCOOKIE_START = 0;
   DIR *Dir = nullptr;
-  uint64_t Cookie = 0;
+  uint64_t Cookie = DIRCOOKIE_START;
   std::vector<uint8_t, boost::alignment::aligned_allocator<
                            uint8_t, alignof(__wasi_dirent_t)>>
       Buffer;

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -501,8 +501,9 @@ WasiExpect<void> INode::fdReaddir(Span<uint8_t> Buffer,
                 Buffer.begin());
       Buffer = Buffer.subspan(NewDataSize);
       Size += NewDataSize;
-      Dir.Buffer.erase(Dir.Buffer.begin(), Dir.Buffer.begin() + NewDataSize);
-      if (unlikely(Buffer.empty())) {
+      if (!Buffer.empty()) {
+        Dir.Buffer.erase(Dir.Buffer.begin(), Dir.Buffer.begin() + NewDataSize);
+      } else {
         break;
       }
     }

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -488,8 +488,7 @@ WasiExpect<void> INode::fdReaddir(Span<uint8_t> Buffer,
     }
   }
 
-  if (unlikely(Cookie != Dir.Cookie)) {
-    Dir.Buffer.clear();
+  if (unlikely(Cookie != DirHolder::DIRCOOKIE_START)) {
     seekdir(Dir.Dir, Cookie);
   }
 

--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -473,8 +473,9 @@ WasiExpect<void> INode::fdReaddir(Span<uint8_t> Buffer,
                 Buffer.begin());
       Buffer = Buffer.subspan(NewDataSize);
       Size += NewDataSize;
-      Dir.Buffer.erase(Dir.Buffer.begin(), Dir.Buffer.begin() + NewDataSize);
-      if (unlikely(Buffer.empty())) {
+      if (!Buffer.empty()) {
+        Dir.Buffer.erase(Dir.Buffer.begin(), Dir.Buffer.begin() + NewDataSize);
+      } else {
         break;
       }
     }

--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -460,8 +460,7 @@ WasiExpect<void> INode::fdReaddir(Span<uint8_t> Buffer,
     }
   }
 
-  if (unlikely(Cookie != Dir.Cookie)) {
-    Dir.Buffer.clear();
+  if (unlikely(Cookie != DirHolder::DIRCOOKIE_START)) {
     seekdir(Dir.Dir, Cookie);
   }
 


### PR DESCRIPTION
This is based on #1823.

According to the [definition of fdReaddir](https://docs.rs/wasi/0.9.0+wasi-snapshot-preview1/wasi/fn.fd_readdir.html), the return value is equal to the size of the read buffer whenever the buffer size is not enough, so it may need additional `fdReaddir` to get the rest of the files, potentially truncating the last directory entry. 

If `fdReaddir` is returned due to not enough size of buffer, then we may not erase the last value on `Dir.buffer` so that it can be copy to the buffer by the next `fdReaddir` call. Also when `Buffer.size` is less than the `Dir.buffer.size()`, the original implementation may copy an incomplete data to the `Buffer` then erase the whole `Dir.buffer` which may leads to crashing.

@LFsWang @hydai Please review the change, thanks. 

I'm working on adding the unit test to this situation.