### PR TITLE
[Utils] Installer and CI: Fix installer appending incorrect filename

### DIFF
--- a/utils/install.py
+++ b/utils/install.py
@@ -151,6 +151,10 @@ def extract_archive(
                     fname = fname.replace("lib64", "lib", 1)
                 if "Plugin" in fname:
                     if is_default_path(args):
+                        fname = fname.replace(
+                            join(ipath, CONST_lib_dir, "wasmedge/"), ""
+                        )
+
                         fname = join(ipath, "plugin", fname)
                     else:
                         fname = join(ipath, CONST_lib_dir, "wasmedge", fname)

--- a/utils/installer_changes.sh
+++ b/utils/installer_changes.sh
@@ -11,7 +11,7 @@ test_diff_env() {
     echo "Testing path: $_path_ args: $_common_args_"
     bash ./utils/install.sh.old -p "$_path_" $_common_args_
     cp "$_path_"/env "$HOME"/env.old
-    INSTALL_PY_URL="https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.py" bash ./utils/install.sh -p "$_path_" $_common_args_
+    INSTALL_PY_URL="https://raw.githubusercontent.com/SAtacker/WasmEdge/fix_python_installer/utils/install.py" bash ./utils/install.sh -p "$_path_" $_common_args_
     cp "$_path_"/env "$HOME"/env
     diff -u \
         <(sed '1,/Please/d' "$HOME"/env.old | sed -e 's/\/\//\//g' |


### PR DESCRIPTION
- Fix CI not failing due to installer link specified of master branch
- Ref - https://github.com/WasmEdge/WasmEdge/issues/2217

Signed-off-by: Shreyas Atre <shreyasatre16@gmail.com>