### PR TITLE
[CI] Update bindings-rust workflow

### DIFF
--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -199,3 +199,53 @@ jobs:
           cd bindings\rust
           cargo test --workspace --features aot,async --locked
           cargo test --examples --features aot,async --locked
+
+  build_fedora:
+    name: Fedora 35
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [1.65, 1.66, 1.67]
+    container:
+      image: fedora:latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust-stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: rustfmt, clippy
+
+      - name: Build WasmEdge with Release mode
+        run: |
+          dnf update -y
+          dnf install -y cmake ninja-build boost llvm llvm-devel lld-devel clang git file rpm-build dpkg-dev
+          git config --global --add safe.directory $(pwd)
+          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_PACKAGE="TGZ;DEB;RPM" .
+          cmake --build build
+
+      - name: Rustfmt
+        working-directory: bindings/rust/
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        working-directory: bindings/rust/
+        run: |
+          export WASMEDGE_DIR="$(pwd)/../../"
+          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
+          export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
+          cargo clippy -V
+          cargo clippy --lib --examples --features aot,async,wasi_crypto,wasi_nn -- -D warnings
+
+      - name: Test Rust Bindings
+        working-directory: bindings/rust/
+        run: |
+          export WASMEDGE_DIR="$(pwd)/../../"
+          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
+          export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
+          export LD_LIBRARY_PATH="$(pwd)/../../build/lib/api"
+          cargo test --workspace --locked --features aot,async
+          cargo test --examples --locked --features aot,async

--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        rust: [1.64, 1.65, 1.66]
+        rust: [1.65, 1.66, 1.67]
     container:
       image: wasmedge/wasmedge:ubuntu-build-clang
 
@@ -81,7 +81,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-11, macos-12]
-        rust: [1.64, 1.65, 1.66]
+        rust: [1.65, 1.66, 1.67]
 
     steps:
       - name: Checkout sources
@@ -135,7 +135,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        rust: [1.64, 1.65, 1.66]
+        rust: [1.65, 1.66, 1.67]
     env:
       WASMEDGE_DIR: ${{ github.workspace }}
       WASMEDGE_BUILD_DIR: ${{ github.workspace }}\build

--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - master
       - "rust/*"
-      - "ci/update-bindings-rust"
     paths:
       - ".github/workflows/bindings-rust.yml"
       - "bindings/rust/**"

--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - "rust/*"
+      - "ci/update-bindings-rust"
     paths:
       - ".github/workflows/bindings-rust.yml"
       - "bindings/rust/**"

--- a/bindings/rust/wasmedge-sys/examples/async_host_func_indirect.rs
+++ b/bindings/rust/wasmedge-sys/examples/async_host_func_indirect.rs
@@ -54,7 +54,7 @@ async fn real_add(
     tokio::time::sleep(std::time::Duration::from_secs(4)).await;
 
     let c = a + b;
-    println!("Rust: calcuating in real_add c: {:?}", c);
+    println!("Rust: calcuating in real_add c: {c:?}");
 
     println!("Rust: Leaving Rust function real_add");
     Ok(vec![WasmValue::from_i32(c)])

--- a/bindings/rust/wasmedge-sys/src/instance/function.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/function.rs
@@ -54,7 +54,7 @@ extern "C" fn wraper_fn(
 
             match real_fn_locked(frame, input) {
                 Ok(returns) => {
-                    assert!(returns.len() == return_len);
+                    assert!(returns.len() == return_len, "[wasmedge-sys] check the number of returns of host function. Expected: {}, actual: {}", return_len, returns.len());
                     for (idx, wasm_value) in returns.into_iter().enumerate() {
                         raw_returns[idx] = wasm_value.as_raw();
                     }

--- a/bindings/rust/wasmedge-types/src/lib.rs
+++ b/bindings/rust/wasmedge-types/src/lib.rs
@@ -335,10 +335,7 @@ impl From<u32> for ExternalInstanceType {
             1 => ExternalInstanceType::Table(TableType::default()),
             2 => ExternalInstanceType::Memory(MemoryType::default()),
             3 => ExternalInstanceType::Global(GlobalType::default()),
-            _ => panic!(
-                "[wasmedge-types] Invalid WasmEdge_ExternalType: {:#X}",
-                value
-            ),
+            _ => panic!("[wasmedge-types] Invalid WasmEdge_ExternalType: {value:#X}",),
         }
     }
 }
@@ -349,10 +346,7 @@ impl From<i32> for ExternalInstanceType {
             1 => ExternalInstanceType::Table(TableType::default()),
             2 => ExternalInstanceType::Memory(MemoryType::default()),
             3 => ExternalInstanceType::Global(GlobalType::default()),
-            _ => panic!(
-                "[wasmedge-types] Invalid WasmEdge_ExternalType: {:#X}",
-                value
-            ),
+            _ => panic!("[wasmedge-types] Invalid WasmEdge_ExternalType: {value:#X}",),
         }
     }
 }


### PR DESCRIPTION
In this PR, `bindings-rust` workflow has been updated with `Fedora-35` platform and `Rust-1.67`.