### PR TITLE
docs(platforms): correct typo: respberry -> raspberry

### DIFF
--- a/docs/book/en/src/features/platforms.md
+++ b/docs/book/en/src/features/platforms.md
@@ -13,4 +13,4 @@ WasmEdge now supports:
 * [seL4](../contribute/build_from_src/sel4.md)
 * [OpenWrt](../contribute/build_from_src/openwrt.md)
 * [OpenHarmony](../contribute/build_from_src/openharmony.md)
-* [Respberry Pi](../contribute/build_from_src/raspberrypi.md)
+* [Raspberry Pi](../contribute/build_from_src/raspberrypi.md)


### PR DESCRIPTION
Corrects a typo on the [supported platforms page](https://wasmedge.org/book/en/features/platforms.html) .
That's all