### PR TITLE
[Rust] Implement Clone trait for external instances

### DIFF
--- a/bindings/rust/wasmedge-sdk/src/externals/function.rs
+++ b/bindings/rust/wasmedge-sdk/src/externals/function.rs
@@ -58,7 +58,7 @@ use wasmedge_sys as sys;
 /// ```
 /// [[Click for more examples]](https://github.com/WasmEdge/WasmEdge/tree/master/bindings/rust/wasmedge-sdk/examples)
 ///
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Func {
     pub(crate) inner: sys::Function,
     pub(crate) name: Option<String>,

--- a/bindings/rust/wasmedge-sdk/src/externals/global.rs
+++ b/bindings/rust/wasmedge-sdk/src/externals/global.rs
@@ -4,7 +4,7 @@ use crate::{types::Val, GlobalType, WasmEdgeResult};
 use wasmedge_sys as sys;
 
 /// Defines a WebAssembly global variable, which stores a single value of the given [GlobalType](https://wasmedge.github.io/WasmEdge/wasmedge_types/struct.GlobalType.html) and a flag indicating whether it is mutable or not.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Global {
     pub(crate) inner: sys::Global,
     pub(crate) name: Option<String>,

--- a/bindings/rust/wasmedge-sdk/src/externals/memory.rs
+++ b/bindings/rust/wasmedge-sdk/src/externals/memory.rs
@@ -142,7 +142,7 @@ impl Memory {
     ///
     /// If fail to get the data pointer, then an error is returned.
     ///
-    pub fn data_pointer(&self, offset: u32, len: u32) -> WasmEdgeResult<&u8> {
+    pub fn data_pointer(&self, offset: u32, len: u32) -> WasmEdgeResult<*const u8> {
         self.inner.data_pointer(offset, len)
     }
 
@@ -158,7 +158,7 @@ impl Memory {
     ///
     /// If fail to get the data pointer, then an error is returned.
     ///
-    pub fn data_pointer_mut(&mut self, offset: u32, len: u32) -> WasmEdgeResult<&mut u8> {
+    pub fn data_pointer_mut(&mut self, offset: u32, len: u32) -> WasmEdgeResult<*mut u8> {
         self.inner.data_pointer_mut(offset, len)
     }
 }

--- a/bindings/rust/wasmedge-sdk/src/externals/memory.rs
+++ b/bindings/rust/wasmedge-sdk/src/externals/memory.rs
@@ -3,7 +3,7 @@ use wasmedge_sys as sys;
 use wasmedge_types::MemoryType;
 
 /// Defines a linear memory.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Memory {
     pub(crate) inner: sys::Memory,
     pub(crate) name: Option<String>,
@@ -312,5 +312,33 @@ mod tests {
         assert!(result.is_ok());
         let data = result.unwrap();
         assert_eq!(data, s);
+    }
+
+    #[test]
+    fn test_memory_clone() {
+        #[derive(Debug, Clone)]
+        struct RecordsMemory {
+            memory: Memory,
+        }
+
+        // create a memory instance
+        let result = MemoryType::new(10, Some(20), false);
+        assert!(result.is_ok());
+        let memory_type = result.unwrap();
+        let result = Memory::new(memory_type);
+        assert!(result.is_ok());
+        let memory = result.unwrap();
+
+        // create a RecordsMemory instance
+        let rec_mem = RecordsMemory { memory };
+
+        // clone the RecordsMemory instance
+        let rec_mem_cloned = rec_mem.clone();
+
+        // drop the original RecordsMemory instance
+        drop(rec_mem);
+
+        // check the cloned RecordsMemory instance
+        assert_eq!(rec_mem_cloned.memory.size(), 10);
     }
 }

--- a/bindings/rust/wasmedge-sdk/src/externals/table.rs
+++ b/bindings/rust/wasmedge-sdk/src/externals/table.rs
@@ -3,7 +3,7 @@ use wasmedge_sys as sys;
 use wasmedge_types::TableType;
 
 /// Defines a table storing the references to host functions or external objects.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Table {
     pub(crate) inner: sys::Table,
     pub(crate) name: Option<String>,

--- a/bindings/rust/wasmedge-sys/src/frame.rs
+++ b/bindings/rust/wasmedge-sys/src/frame.rs
@@ -77,7 +77,7 @@ impl CallingFrame {
 
         match ctx.is_null() {
             false => Some(Memory {
-                inner: InnerMemory(ctx),
+                inner: std::sync::Arc::new(InnerMemory(ctx)),
                 registered: true,
             }),
             true => None,

--- a/bindings/rust/wasmedge-sys/src/instance/memory.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/memory.rs
@@ -170,17 +170,11 @@ impl Memory {
     ///
     /// If fail to get the data pointer, then an error is returned.
     ///
-    pub fn data_pointer(&self, offset: u32, len: u32) -> WasmEdgeResult<&u8> {
+    pub fn data_pointer(&self, offset: u32, len: u32) -> WasmEdgeResult<*const u8> {
         let ptr = unsafe { ffi::WasmEdge_MemoryInstanceGetPointerConst(self.inner.0, offset, len) };
         match ptr.is_null() {
             true => Err(Box::new(WasmEdgeError::Mem(MemError::ConstPtr))),
-            false => {
-                let result = unsafe { ptr.as_ref() };
-                match result {
-                    Some(ptr) => Ok(ptr),
-                    None => Err(Box::new(WasmEdgeError::Mem(MemError::Ptr2Ref))),
-                }
-            }
+            false => Ok(ptr),
         }
     }
 
@@ -196,17 +190,11 @@ impl Memory {
     ///
     /// If fail to get the data pointer, then an error is returned.
     ///
-    pub fn data_pointer_mut(&mut self, offset: u32, len: u32) -> WasmEdgeResult<&mut u8> {
+    pub fn data_pointer_mut(&mut self, offset: u32, len: u32) -> WasmEdgeResult<*mut u8> {
         let ptr = unsafe { ffi::WasmEdge_MemoryInstanceGetPointer(self.inner.0, offset, len) };
         match ptr.is_null() {
             true => Err(Box::new(WasmEdgeError::Mem(MemError::MutPtr))),
-            false => {
-                let result = unsafe { ptr.as_mut() };
-                match result {
-                    Some(ptr) => Ok(ptr),
-                    None => Err(Box::new(WasmEdgeError::Mem(MemError::Ptr2Ref))),
-                }
-            }
+            false => Ok(ptr),
         }
     }
 

--- a/bindings/rust/wasmedge-sys/src/instance/memory.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/memory.rs
@@ -246,7 +246,7 @@ impl Clone for Memory {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
-            registered: self.registered,
+            registered: false,
         }
     }
 }

--- a/bindings/rust/wasmedge-sys/src/instance/module.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/module.rs
@@ -144,7 +144,7 @@ impl Instance {
                 InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
-                inner: InnerGlobal(ctx),
+                inner: Arc::new(InnerGlobal(ctx)),
                 registered: true,
             }),
         }
@@ -497,7 +497,7 @@ impl AsImport for ImportModule {
                 global.inner.0,
             );
         }
-        global.inner.0 = std::ptr::null_mut();
+        global.registered = true;
     }
 }
 
@@ -756,7 +756,7 @@ impl AsInstance for WasiModule {
                 InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
-                inner: InnerGlobal(ctx),
+                inner: Arc::new(InnerGlobal(ctx)),
                 registered: true,
             }),
         }
@@ -920,7 +920,7 @@ impl AsImport for WasiModule {
                 global.inner.0,
             );
         }
-        global.inner.0 = std::ptr::null_mut();
+        global.registered = true;
     }
 }
 
@@ -1264,7 +1264,7 @@ impl AsImport for WasmEdgeProcessModule {
                 global.inner.0,
             );
         }
-        global.inner.0 = std::ptr::null_mut();
+        global.registered = true;
     }
 }
 
@@ -1528,7 +1528,7 @@ impl AsImport for WasiNnModule {
                 global.inner.0,
             );
         }
-        global.inner.0 = std::ptr::null_mut();
+        global.registered = true;
     }
 }
 
@@ -1792,7 +1792,7 @@ impl AsImport for WasiCryptoCommonModule {
                 global.inner.0,
             );
         }
-        global.inner.0 = std::ptr::null_mut();
+        global.registered = true;
     }
 }
 
@@ -2056,7 +2056,7 @@ impl AsImport for WasiCryptoAsymmetricCommonModule {
                 global.inner.0,
             );
         }
-        global.inner.0 = std::ptr::null_mut();
+        global.registered = true;
     }
 }
 
@@ -2320,7 +2320,7 @@ impl AsImport for WasiCryptoSymmetricModule {
                 global.inner.0,
             );
         }
-        global.inner.0 = std::ptr::null_mut();
+        global.registered = true;
     }
 }
 
@@ -2584,7 +2584,7 @@ impl AsImport for WasiCryptoKxModule {
                 global.inner.0,
             );
         }
-        global.inner.0 = std::ptr::null_mut();
+        global.registered = true;
     }
 }
 
@@ -2848,7 +2848,7 @@ impl AsImport for WasiCryptoSignaturesModule {
                 global.inner.0,
             );
         }
-        global.inner.0 = std::ptr::null_mut();
+        global.registered = true;
     }
 }
 

--- a/bindings/rust/wasmedge-sys/src/instance/module.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/module.rs
@@ -94,7 +94,7 @@ impl Instance {
                 InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
-                inner: InnerTable(ctx),
+                inner: Arc::new(InnerTable(ctx)),
                 registered: true,
             }),
         }
@@ -477,7 +477,7 @@ impl AsImport for ImportModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddTable(self.inner.0, table_name.as_raw(), table.inner.0);
         }
-        table.inner.0 = std::ptr::null_mut();
+        table.registered = true;
     }
 
     fn add_memory(&mut self, name: impl AsRef<str>, mut memory: Memory) {
@@ -724,7 +724,7 @@ impl AsInstance for WasiModule {
                 InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
-                inner: InnerTable(ctx),
+                inner: Arc::new(InnerTable(ctx)),
                 registered: true,
             }),
         }
@@ -900,7 +900,7 @@ impl AsImport for WasiModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddTable(self.inner.0, table_name.as_raw(), table.inner.0);
         }
-        table.inner.0 = std::ptr::null_mut();
+        table.registered = true;
     }
 
     fn add_memory(&mut self, name: impl AsRef<str>, mut memory: Memory) {
@@ -1067,7 +1067,7 @@ impl AsInstance for WasmEdgeProcessModule {
                 InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
-                inner: InnerTable(ctx),
+                inner: Arc::new(InnerTable(ctx)),
                 registered: true,
             }),
         }
@@ -1244,7 +1244,7 @@ impl AsImport for WasmEdgeProcessModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddTable(self.inner.0, table_name.as_raw(), table.inner.0);
         }
-        table.inner.0 = std::ptr::null_mut();
+        table.registered = true;
     }
 
     fn add_memory(&mut self, name: impl AsRef<str>, mut memory: Memory) {
@@ -1331,7 +1331,7 @@ impl AsInstance for WasiNnModule {
                 InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
-                inner: InnerTable(ctx),
+                inner: Arc::new(InnerTable(ctx)),
                 registered: true,
             }),
         }
@@ -1508,7 +1508,7 @@ impl AsImport for WasiNnModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddTable(self.inner.0, table_name.as_raw(), table.inner.0);
         }
-        table.inner.0 = std::ptr::null_mut();
+        table.registered = true;
     }
 
     fn add_memory(&mut self, name: impl AsRef<str>, mut memory: Memory) {
@@ -1595,7 +1595,7 @@ impl AsInstance for WasiCryptoCommonModule {
                 InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
-                inner: InnerTable(ctx),
+                inner: Arc::new(InnerTable(ctx)),
                 registered: true,
             }),
         }
@@ -1772,7 +1772,7 @@ impl AsImport for WasiCryptoCommonModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddTable(self.inner.0, table_name.as_raw(), table.inner.0);
         }
-        table.inner.0 = std::ptr::null_mut();
+        table.registered = true;
     }
 
     fn add_memory(&mut self, name: impl AsRef<str>, mut memory: Memory) {
@@ -1859,7 +1859,7 @@ impl AsInstance for WasiCryptoAsymmetricCommonModule {
                 InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
-                inner: InnerTable(ctx),
+                inner: Arc::new(InnerTable(ctx)),
                 registered: true,
             }),
         }
@@ -2036,7 +2036,7 @@ impl AsImport for WasiCryptoAsymmetricCommonModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddTable(self.inner.0, table_name.as_raw(), table.inner.0);
         }
-        table.inner.0 = std::ptr::null_mut();
+        table.registered = true;
     }
 
     fn add_memory(&mut self, name: impl AsRef<str>, mut memory: Memory) {
@@ -2123,7 +2123,7 @@ impl AsInstance for WasiCryptoSymmetricModule {
                 InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
-                inner: InnerTable(ctx),
+                inner: Arc::new(InnerTable(ctx)),
                 registered: true,
             }),
         }
@@ -2300,7 +2300,7 @@ impl AsImport for WasiCryptoSymmetricModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddTable(self.inner.0, table_name.as_raw(), table.inner.0);
         }
-        table.inner.0 = std::ptr::null_mut();
+        table.registered = true;
     }
 
     fn add_memory(&mut self, name: impl AsRef<str>, mut memory: Memory) {
@@ -2387,7 +2387,7 @@ impl AsInstance for WasiCryptoKxModule {
                 InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
-                inner: InnerTable(ctx),
+                inner: Arc::new(InnerTable(ctx)),
                 registered: true,
             }),
         }
@@ -2564,7 +2564,7 @@ impl AsImport for WasiCryptoKxModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddTable(self.inner.0, table_name.as_raw(), table.inner.0);
         }
-        table.inner.0 = std::ptr::null_mut();
+        table.registered = true;
     }
 
     fn add_memory(&mut self, name: impl AsRef<str>, mut memory: Memory) {
@@ -2651,7 +2651,7 @@ impl AsInstance for WasiCryptoSignaturesModule {
                 InstanceError::NotFoundTable(name.as_ref().to_string()),
             ))),
             false => Ok(Table {
-                inner: InnerTable(ctx),
+                inner: Arc::new(InnerTable(ctx)),
                 registered: true,
             }),
         }
@@ -2828,7 +2828,7 @@ impl AsImport for WasiCryptoSignaturesModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddTable(self.inner.0, table_name.as_raw(), table.inner.0);
         }
-        table.inner.0 = std::ptr::null_mut();
+        table.registered = true;
     }
 
     fn add_memory(&mut self, name: impl AsRef<str>, mut memory: Memory) {

--- a/bindings/rust/wasmedge-sys/src/instance/module.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/module.rs
@@ -1083,7 +1083,7 @@ impl AsInstance for WasmEdgeProcessModule {
                 InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
-                inner: InnerMemory(ctx),
+                inner: Arc::new(InnerMemory(ctx)),
                 registered: true,
             }),
         }
@@ -1611,7 +1611,7 @@ impl AsInstance for WasiCryptoCommonModule {
                 InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
-                inner: InnerMemory(ctx),
+                inner: Arc::new(InnerMemory(ctx)),
                 registered: true,
             }),
         }
@@ -1875,7 +1875,7 @@ impl AsInstance for WasiCryptoAsymmetricCommonModule {
                 InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
-                inner: InnerMemory(ctx),
+                inner: Arc::new(InnerMemory(ctx)),
                 registered: true,
             }),
         }
@@ -2139,7 +2139,7 @@ impl AsInstance for WasiCryptoSymmetricModule {
                 InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
-                inner: InnerMemory(ctx),
+                inner: Arc::new(InnerMemory(ctx)),
                 registered: true,
             }),
         }
@@ -2403,7 +2403,7 @@ impl AsInstance for WasiCryptoKxModule {
                 InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
-                inner: InnerMemory(ctx),
+                inner: Arc::new(InnerMemory(ctx)),
                 registered: true,
             }),
         }
@@ -2667,7 +2667,7 @@ impl AsInstance for WasiCryptoSignaturesModule {
                 InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
-                inner: InnerMemory(ctx),
+                inner: Arc::new(InnerMemory(ctx)),
                 registered: true,
             }),
         }

--- a/bindings/rust/wasmedge-sys/src/instance/module.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/module.rs
@@ -119,7 +119,7 @@ impl Instance {
                 InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
-                inner: InnerMemory(ctx),
+                inner: Arc::new(InnerMemory(ctx)),
                 registered: true,
             }),
         }
@@ -485,7 +485,7 @@ impl AsImport for ImportModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddMemory(self.inner.0, mem_name.as_raw(), memory.inner.0);
         }
-        memory.inner.0 = std::ptr::null_mut();
+        memory.registered = true;
     }
 
     fn add_global(&mut self, name: impl AsRef<str>, mut global: Global) {
@@ -740,7 +740,7 @@ impl AsInstance for WasiModule {
                 InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
-                inner: InnerMemory(ctx),
+                inner: Arc::new(InnerMemory(ctx)),
                 registered: true,
             }),
         }
@@ -908,7 +908,7 @@ impl AsImport for WasiModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddMemory(self.inner.0, mem_name.as_raw(), memory.inner.0);
         }
-        memory.inner.0 = std::ptr::null_mut();
+        memory.registered = true;
     }
 
     fn add_global(&mut self, name: impl AsRef<str>, mut global: Global) {
@@ -1252,7 +1252,7 @@ impl AsImport for WasmEdgeProcessModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddMemory(self.inner.0, mem_name.as_raw(), memory.inner.0);
         }
-        memory.inner.0 = std::ptr::null_mut();
+        memory.registered = true;
     }
 
     fn add_global(&mut self, name: impl AsRef<str>, mut global: Global) {
@@ -1516,7 +1516,7 @@ impl AsImport for WasiNnModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddMemory(self.inner.0, mem_name.as_raw(), memory.inner.0);
         }
-        memory.inner.0 = std::ptr::null_mut();
+        memory.registered = true;
     }
 
     fn add_global(&mut self, name: impl AsRef<str>, mut global: Global) {
@@ -1780,7 +1780,7 @@ impl AsImport for WasiCryptoCommonModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddMemory(self.inner.0, mem_name.as_raw(), memory.inner.0);
         }
-        memory.inner.0 = std::ptr::null_mut();
+        memory.registered = true;
     }
 
     fn add_global(&mut self, name: impl AsRef<str>, mut global: Global) {
@@ -2044,7 +2044,7 @@ impl AsImport for WasiCryptoAsymmetricCommonModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddMemory(self.inner.0, mem_name.as_raw(), memory.inner.0);
         }
-        memory.inner.0 = std::ptr::null_mut();
+        memory.registered = true;
     }
 
     fn add_global(&mut self, name: impl AsRef<str>, mut global: Global) {
@@ -2308,7 +2308,7 @@ impl AsImport for WasiCryptoSymmetricModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddMemory(self.inner.0, mem_name.as_raw(), memory.inner.0);
         }
-        memory.inner.0 = std::ptr::null_mut();
+        memory.registered = true;
     }
 
     fn add_global(&mut self, name: impl AsRef<str>, mut global: Global) {
@@ -2572,7 +2572,7 @@ impl AsImport for WasiCryptoKxModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddMemory(self.inner.0, mem_name.as_raw(), memory.inner.0);
         }
-        memory.inner.0 = std::ptr::null_mut();
+        memory.registered = true;
     }
 
     fn add_global(&mut self, name: impl AsRef<str>, mut global: Global) {
@@ -2836,7 +2836,7 @@ impl AsImport for WasiCryptoSignaturesModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddMemory(self.inner.0, mem_name.as_raw(), memory.inner.0);
         }
-        memory.inner.0 = std::ptr::null_mut();
+        memory.registered = true;
     }
 
     fn add_global(&mut self, name: impl AsRef<str>, mut global: Global) {

--- a/bindings/rust/wasmedge-sys/src/instance/module.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/module.rs
@@ -1099,7 +1099,7 @@ impl AsInstance for WasmEdgeProcessModule {
                 InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
-                inner: InnerGlobal(ctx),
+                inner: Arc::new(InnerGlobal(ctx)),
                 registered: true,
             }),
         }
@@ -1363,7 +1363,7 @@ impl AsInstance for WasiNnModule {
                 InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
-                inner: InnerGlobal(ctx),
+                inner: Arc::new(InnerGlobal(ctx)),
                 registered: true,
             }),
         }
@@ -1627,7 +1627,7 @@ impl AsInstance for WasiCryptoCommonModule {
                 InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
-                inner: InnerGlobal(ctx),
+                inner: Arc::new(InnerGlobal(ctx)),
                 registered: true,
             }),
         }
@@ -1891,7 +1891,7 @@ impl AsInstance for WasiCryptoAsymmetricCommonModule {
                 InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
-                inner: InnerGlobal(ctx),
+                inner: Arc::new(InnerGlobal(ctx)),
                 registered: true,
             }),
         }
@@ -2155,7 +2155,7 @@ impl AsInstance for WasiCryptoSymmetricModule {
                 InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
-                inner: InnerGlobal(ctx),
+                inner: Arc::new(InnerGlobal(ctx)),
                 registered: true,
             }),
         }
@@ -2419,7 +2419,7 @@ impl AsInstance for WasiCryptoKxModule {
                 InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
-                inner: InnerGlobal(ctx),
+                inner: Arc::new(InnerGlobal(ctx)),
                 registered: true,
             }),
         }
@@ -2683,7 +2683,7 @@ impl AsInstance for WasiCryptoSignaturesModule {
                 InstanceError::NotFoundGlobal(name.as_ref().to_string()),
             ))),
             false => Ok(Global {
-                inner: InnerGlobal(ctx),
+                inner: Arc::new(InnerGlobal(ctx)),
                 registered: true,
             }),
         }

--- a/bindings/rust/wasmedge-sys/src/instance/module.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/module.rs
@@ -69,7 +69,7 @@ impl Instance {
                 InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
-                inner: InnerFunc(func_ctx),
+                inner: Arc::new(InnerFunc(func_ctx)),
                 registered: true,
             }),
         }
@@ -469,7 +469,7 @@ impl AsImport for ImportModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddFunction(self.inner.0, func_name.as_raw(), func.inner.0);
         }
-        func.inner.0 = std::ptr::null_mut();
+        func.registered = true;
     }
 
     fn add_table(&mut self, name: impl AsRef<str>, mut table: Table) {
@@ -708,7 +708,7 @@ impl AsInstance for WasiModule {
                 InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
-                inner: InnerFunc(func_ctx),
+                inner: Arc::new(InnerFunc(func_ctx)),
                 registered: true,
             }),
         }
@@ -892,7 +892,7 @@ impl AsImport for WasiModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddFunction(self.inner.0, func_name.as_raw(), func.inner.0);
         }
-        func.inner.0 = std::ptr::null_mut();
+        func.registered = true;
     }
 
     fn add_table(&mut self, name: impl AsRef<str>, mut table: Table) {
@@ -1051,7 +1051,7 @@ impl AsInstance for WasmEdgeProcessModule {
                 InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
-                inner: InnerFunc(func_ctx),
+                inner: Arc::new(InnerFunc(func_ctx)),
                 registered: true,
             }),
         }
@@ -1236,7 +1236,7 @@ impl AsImport for WasmEdgeProcessModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddFunction(self.inner.0, func_name.as_raw(), func.inner.0);
         }
-        func.inner.0 = std::ptr::null_mut();
+        func.registered = true;
     }
 
     fn add_table(&mut self, name: impl AsRef<str>, mut table: Table) {
@@ -1315,7 +1315,7 @@ impl AsInstance for WasiNnModule {
                 InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
-                inner: InnerFunc(func_ctx),
+                inner: Arc::new(InnerFunc(func_ctx)),
                 registered: true,
             }),
         }
@@ -1500,7 +1500,7 @@ impl AsImport for WasiNnModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddFunction(self.inner.0, func_name.as_raw(), func.inner.0);
         }
-        func.inner.0 = std::ptr::null_mut();
+        func.registered = true;
     }
 
     fn add_table(&mut self, name: impl AsRef<str>, mut table: Table) {
@@ -1579,7 +1579,7 @@ impl AsInstance for WasiCryptoCommonModule {
                 InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
-                inner: InnerFunc(func_ctx),
+                inner: Arc::new(InnerFunc(func_ctx)),
                 registered: true,
             }),
         }
@@ -1764,7 +1764,7 @@ impl AsImport for WasiCryptoCommonModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddFunction(self.inner.0, func_name.as_raw(), func.inner.0);
         }
-        func.inner.0 = std::ptr::null_mut();
+        func.registered = true;
     }
 
     fn add_table(&mut self, name: impl AsRef<str>, mut table: Table) {
@@ -1843,7 +1843,7 @@ impl AsInstance for WasiCryptoAsymmetricCommonModule {
                 InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
-                inner: InnerFunc(func_ctx),
+                inner: Arc::new(InnerFunc(func_ctx)),
                 registered: true,
             }),
         }
@@ -2028,7 +2028,7 @@ impl AsImport for WasiCryptoAsymmetricCommonModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddFunction(self.inner.0, func_name.as_raw(), func.inner.0);
         }
-        func.inner.0 = std::ptr::null_mut();
+        func.registered = true;
     }
 
     fn add_table(&mut self, name: impl AsRef<str>, mut table: Table) {
@@ -2107,7 +2107,7 @@ impl AsInstance for WasiCryptoSymmetricModule {
                 InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
-                inner: InnerFunc(func_ctx),
+                inner: Arc::new(InnerFunc(func_ctx)),
                 registered: true,
             }),
         }
@@ -2292,7 +2292,7 @@ impl AsImport for WasiCryptoSymmetricModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddFunction(self.inner.0, func_name.as_raw(), func.inner.0);
         }
-        func.inner.0 = std::ptr::null_mut();
+        func.registered = true;
     }
 
     fn add_table(&mut self, name: impl AsRef<str>, mut table: Table) {
@@ -2371,7 +2371,7 @@ impl AsInstance for WasiCryptoKxModule {
                 InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
-                inner: InnerFunc(func_ctx),
+                inner: Arc::new(InnerFunc(func_ctx)),
                 registered: true,
             }),
         }
@@ -2556,7 +2556,7 @@ impl AsImport for WasiCryptoKxModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddFunction(self.inner.0, func_name.as_raw(), func.inner.0);
         }
-        func.inner.0 = std::ptr::null_mut();
+        func.registered = true;
     }
 
     fn add_table(&mut self, name: impl AsRef<str>, mut table: Table) {
@@ -2635,7 +2635,7 @@ impl AsInstance for WasiCryptoSignaturesModule {
                 InstanceError::NotFoundFunc(name.as_ref().to_string()),
             ))),
             false => Ok(Function {
-                inner: InnerFunc(func_ctx),
+                inner: Arc::new(InnerFunc(func_ctx)),
                 registered: true,
             }),
         }
@@ -2820,7 +2820,7 @@ impl AsImport for WasiCryptoSignaturesModule {
         unsafe {
             ffi::WasmEdge_ModuleInstanceAddFunction(self.inner.0, func_name.as_raw(), func.inner.0);
         }
-        func.inner.0 = std::ptr::null_mut();
+        func.registered = true;
     }
 
     fn add_table(&mut self, name: impl AsRef<str>, mut table: Table) {

--- a/bindings/rust/wasmedge-sys/src/instance/module.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/module.rs
@@ -1347,7 +1347,7 @@ impl AsInstance for WasiNnModule {
                 InstanceError::NotFoundMem(name.as_ref().to_string()),
             ))),
             false => Ok(Memory {
-                inner: InnerMemory(ctx),
+                inner: Arc::new(InnerMemory(ctx)),
                 registered: true,
             }),
         }

--- a/bindings/rust/wasmedge-sys/src/instance/table.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/table.rs
@@ -461,7 +461,7 @@ mod tests {
         // create a Table instance
         let result = Table::create(&ty);
         assert!(result.is_ok());
-        let mut table = result.unwrap();
+        let table = result.unwrap();
 
         // check capacity
         assert_eq!(table.capacity(), 10);


### PR DESCRIPTION
In this PR, the `Clone` trait is implemented for `Func`, `Memory`, `Global` and `Table` external instances.