### PR TITLE
fix typo: sockGetLoaclAddr => sockGetLocalAddr

### DIFF
--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -1048,13 +1048,13 @@ public:
     }
   }
 
-  WasiExpect<void> sockGetLoaclAddr(__wasi_fd_t Fd, uint8_t *Address,
+  WasiExpect<void> sockGetLocalAddr(__wasi_fd_t Fd, uint8_t *Address,
                                     uint32_t *PortPtr) const noexcept {
     auto Node = getNodeOrNull(Fd);
     if (unlikely(!Node)) {
       return WasiUnexpect(__WASI_ERRNO_BADF);
     } else {
-      return Node->sockGetLoaclAddr(Address, PortPtr);
+      return Node->sockGetLocalAddr(Address, PortPtr);
     }
   }
 

--- a/include/host/wasi/inode.h
+++ b/include/host/wasi/inode.h
@@ -625,7 +625,7 @@ public:
                               __wasi_sock_opt_so_t SockOptName, void *FlagPtr,
                               uint32_t FlagSizePtr) const noexcept;
 
-  WasiExpect<void> sockGetLoaclAddr(uint8_t *Address,
+  WasiExpect<void> sockGetLocalAddr(uint8_t *Address,
                                     uint32_t *PortPtr) const noexcept;
 
   WasiExpect<void> sockGetPeerAddr(uint8_t *Address,

--- a/include/host/wasi/vinode.h
+++ b/include/host/wasi/vinode.h
@@ -675,9 +675,9 @@ public:
     return Node.sockSetOpt(SockOptLevel, SockOptName, FlagPtr, FlagSizePtr);
   }
 
-  WasiExpect<void> sockGetLoaclAddr(uint8_t *Address,
+  WasiExpect<void> sockGetLocalAddr(uint8_t *Address,
                                     uint32_t *PortPtr) const noexcept {
-    return Node.sockGetLoaclAddr(Address, PortPtr);
+    return Node.sockGetLocalAddr(Address, PortPtr);
   }
 
   WasiExpect<void> sockGetPeerAddr(uint8_t *Address,

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -1302,7 +1302,7 @@ WasiExpect<void> INode::sockSetOpt(__wasi_sock_opt_level_t SockOptLevel,
   return {};
 }
 
-WasiExpect<void> INode::sockGetLoaclAddr(uint8_t *AddressBufPtr,
+WasiExpect<void> INode::sockGetLocalAddr(uint8_t *AddressBufPtr,
                                          uint32_t *PortPtr) const noexcept {
   auto AddrFamilyPtr = getAddressFamily(AddressBufPtr);
   auto AddressPtr = getAddress(AddressBufPtr);

--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -1185,7 +1185,7 @@ WasiExpect<void> INode::sockSetOpt(__wasi_sock_opt_level_t SockOptLevel,
   return {};
 }
 
-WasiExpect<void> INode::sockGetLoaclAddr(uint8_t *AddressBufPtr,
+WasiExpect<void> INode::sockGetLocalAddr(uint8_t *AddressBufPtr,
                                          uint32_t *PortPtr) const noexcept {
   auto AddrFamilyPtr = getAddressFamily(AddressBufPtr);
   auto AddressPtr = getAddress(AddressBufPtr);

--- a/lib/host/wasi/inode-win.cpp
+++ b/lib/host/wasi/inode-win.cpp
@@ -2216,7 +2216,7 @@ WasiExpect<void> INode::sockSetOpt(__wasi_sock_opt_level_t SockOptLevel,
   return {};
 }
 
-WasiExpect<void> INode::sockGetLoaclAddr(uint8_t *AddressBufPtr,
+WasiExpect<void> INode::sockGetLocalAddr(uint8_t *AddressBufPtr,
                                          uint32_t *PortPtr) const noexcept {
   EnsureWSAStartup();
 

--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -2461,7 +2461,7 @@ Expect<uint32_t> WasiSockGetLocalAddr::body(const Runtime::CallingFrame &Frame,
 
   const __wasi_fd_t WasiFd = Fd;
 
-  if (auto Res = Env.sockGetLoaclAddr(WasiFd, AddressBuf, RoPort);
+  if (auto Res = Env.sockGetLocalAddr(WasiFd, AddressBuf, RoPort);
       unlikely(!Res)) {
     return Res.error();
   }


### PR DESCRIPTION
https://github.com/WasmEdge/WasmEdge/pull/1599 seems to have introduced a typo in the name of this function.

Signed-off-by: Achille Roussel <achille.roussel@gmail.com>