### PR TITLE
[Socket] fix SockGetPeerAddr buffer size

### DIFF
--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -2481,7 +2481,7 @@ Expect<uint32_t> WasiSockGetPeerAddr::body(const Runtime::CallingFrame &Frame,
     return __WASI_ERRNO_FAULT;
   }
 
-  if (InnerAddress->buf_len != 16) {
+  if (InnerAddress->buf_len != 128) {
     return __WASI_ERRNO_INVAL;
   }
 


### PR DESCRIPTION
Fix #2280
