### PR TITLE
[Rust] Implement VmBuilder

### DIFF
--- a/bindings/rust/wasmedge-sdk/README.md
+++ b/bindings/rust/wasmedge-sdk/README.md
@@ -27,8 +27,8 @@ The example below is using `wasmedge-sdk` to run a WebAssembly module written wi
 
 ```rust
 use wasmedge_sdk::{
-    error::HostFuncError, host_function, params, wat2wasm, Caller, ImportObjectBuilder, Module, Vm,
-    WasmValue,
+    error::HostFuncError, host_function, params, wat2wasm, Caller, ImportObjectBuilder, Module,
+    VmBuilder, WasmValue,
 };
 
 // We define a function to act as our "env" "say_hello" function imported in the
@@ -69,7 +69,8 @@ fn main() -> anyhow::Result<()> {
     let module = Module::from_bytes(None, wasm_bytes)?;
 
     // create an executor
-    Vm::new(None, None)?
+    VmBuilder::new()
+        .build()?
         .register_import_module(import)?
         .register_module(Some("extern"), module)?
         .run_func(Some("extern"), "run", params!())?;

--- a/bindings/rust/wasmedge-sdk/examples/async_hello_world.rs
+++ b/bindings/rust/wasmedge-sdk/examples/async_hello_world.rs
@@ -6,7 +6,8 @@
 //!
 #[cfg(feature = "async")]
 use wasmedge_sdk::{
-    async_host_function, error::HostFuncError, params, Caller, ImportObjectBuilder, Vm, WasmValue,
+    async_host_function, error::HostFuncError, params, Caller, ImportObjectBuilder, VmBuilder,
+    WasmValue,
 };
 
 #[cfg(feature = "async")]
@@ -45,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_func_async::<(), ()>("say_hello", say_hello)?
             .build("extern")?;
 
-        let vm = Vm::new(None, None)?.register_import_module(import)?;
+        let vm = VmBuilder::new().build()?.register_import_module(import)?;
 
         tokio::spawn(async move {
             let _ = vm

--- a/bindings/rust/wasmedge-sdk/examples/async_run_func.rs
+++ b/bindings/rust/wasmedge-sdk/examples/async_run_func.rs
@@ -8,7 +8,7 @@
 #[cfg(feature = "async")]
 use wasmedge_sdk::{
     config::{CommonConfigOptions, ConfigBuilder},
-    params, Vm, WasmVal,
+    params, VmBuilder, WasmVal,
 };
 
 #[tokio::main]
@@ -22,7 +22,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         assert!(config.bulk_memory_operations_enabled());
 
         // create Vm instance
-        let vm = Vm::new(Some(config), None)?.register_module_from_file("extern", wasm_file)?;
+        let vm = VmBuilder::new()
+            .with_config(config)
+            .build()?
+            .register_module_from_file("extern", wasm_file)?;
 
         // async run function
         let fut1 = vm.run_func_async(Some("extern"), "fib", params!(20));

--- a/bindings/rust/wasmedge-sdk/examples/create_host_func_in_host_func.rs
+++ b/bindings/rust/wasmedge-sdk/examples/create_host_func_in_host_func.rs
@@ -1,6 +1,6 @@
 use wasmedge_sdk::{
     error::HostFuncError, host_function, params, Caller, Executor, Func, ImportObjectBuilder,
-    ValType, Vm, WasmVal, WasmValue,
+    ValType, VmBuilder, WasmVal, WasmValue,
 };
 
 #[host_function]
@@ -65,7 +65,8 @@ fn main() -> anyhow::Result<()> {
         .with_func::<(), ()>("outer-func", func)?
         .build("extern")?;
 
-    let _ = Vm::new(None, None)?
+    let _ = VmBuilder::new()
+        .build()?
         .register_import_module(import)?
         .run_func(Some("extern"), "outer-func", params!())?;
 

--- a/bindings/rust/wasmedge-sdk/examples/hello_world.rs
+++ b/bindings/rust/wasmedge-sdk/examples/hello_world.rs
@@ -1,6 +1,6 @@
 use wasmedge_sdk::{
-    error::HostFuncError, host_function, params, wat2wasm, Caller, ImportObjectBuilder, Module, Vm,
-    WasmValue,
+    error::HostFuncError, host_function, params, wat2wasm, Caller, ImportObjectBuilder, Module,
+    VmBuilder, WasmValue,
 };
 
 // We define a function to act as our "env" "say_hello" function imported in the
@@ -41,7 +41,8 @@ fn main() -> anyhow::Result<()> {
     let module = Module::from_bytes(None, wasm_bytes)?;
 
     // create an executor
-    Vm::new(None, None)?
+    VmBuilder::new()
+        .build()?
         .register_import_module(import)?
         .register_module(Some("extern"), module)?
         .run_func(Some("extern"), "run", params!())?;

--- a/bindings/rust/wasmedge-sdk/examples/host_func_with_custom_error.rs
+++ b/bindings/rust/wasmedge-sdk/examples/host_func_with_custom_error.rs
@@ -19,7 +19,7 @@ use wasmedge_sdk::{
     error::{HostFuncError, WasmEdgeError},
     host_function, params,
     types::ExternRef,
-    Caller, ImportObjectBuilder, ValType, Vm, WasmVal, WasmValue,
+    Caller, ImportObjectBuilder, ValType, VmBuilder, WasmVal, WasmValue,
 };
 
 // Define custom error type
@@ -101,7 +101,10 @@ fn main() -> anyhow::Result<()> {
 
     // create a vm instance
     let config = ConfigBuilder::default().build()?;
-    let mut vm = Vm::new(Some(config), None)?.register_import_module(import)?;
+    let mut vm = VmBuilder::new()
+        .with_config(config)
+        .build()?
+        .register_import_module(import)?;
 
     // run the export wasm function named "call_add" from func.wasm
     let wasm_file = std::env::current_dir()?.join("examples/data/funcs.wasm");

--- a/bindings/rust/wasmedge-sdk/examples/hostfunc_call_chain.rs
+++ b/bindings/rust/wasmedge-sdk/examples/hostfunc_call_chain.rs
@@ -17,13 +17,13 @@
 //! ```
 
 use wasmedge_sdk::{
-    error::HostFuncError, params, wat2wasm, Caller, CallingFrame, ImportObjectBuilder, Module, Vm,
-    WasmValue,
+    error::HostFuncError, params, wat2wasm, Caller, CallingFrame, ImportObjectBuilder, Module,
+    VmBuilder, WasmValue,
 };
 
 #[cfg_attr(test, test)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let vm = Vm::new(None, None)?;
+    let vm = VmBuilder::new().build()?;
 
     let host_layer1 =
         |_frame: CallingFrame, _args: Vec<WasmValue>| -> Result<Vec<WasmValue>, HostFuncError> {

--- a/bindings/rust/wasmedge-sdk/examples/run_func_in_aot_mode.rs
+++ b/bindings/rust/wasmedge-sdk/examples/run_func_in_aot_mode.rs
@@ -10,7 +10,7 @@ use wasmedge_sdk::{
     config::{
         CommonConfigOptions, CompilerConfigOptions, ConfigBuilder, HostRegistrationConfigOptions,
     },
-    params, Compiler, CompilerOutputFormat, Vm, WasmVal,
+    params, Compiler, CompilerOutputFormat, VmBuilder, WasmVal,
 };
 
 #[cfg_attr(test, test)]
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         #[cfg(target_os = "windows")]
         assert!(aot_file_path.ends_with("example_aot_fibonacci.dll"));
 
-        let mut vm = Vm::new(Some(config), None)?;
+        let mut vm = VmBuilder::new().with_config(config).build()?;
 
         let res = vm.run_func_from_file(&aot_file_path, "fib", params!(5))?;
         println!("fib(5): {}", res[0].to_i32());

--- a/bindings/rust/wasmedge-sdk/examples/vm.rs
+++ b/bindings/rust/wasmedge-sdk/examples/vm.rs
@@ -3,13 +3,13 @@
 // If the version of rust used is less than v1.63, please uncomment the follow attribute.
 // #![feature(explicit_generic_args_with_impl_trait)]
 
-use wasmedge_sdk::{params, Vm, WasmVal};
+use wasmedge_sdk::{params, VmBuilder, WasmVal};
 use wasmedge_types::wat2wasm;
 
 #[cfg_attr(test, test)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // create a Vm context
-    let vm = Vm::new(None, None)?;
+    let vm = VmBuilder::new().build()?;
 
     // register a wasm module from the given in-memory wasm bytes
     let wasm_bytes = wat2wasm(

--- a/bindings/rust/wasmedge-sdk/examples/wasi_print_env.rs
+++ b/bindings/rust/wasmedge-sdk/examples/wasi_print_env.rs
@@ -12,7 +12,7 @@
 
 use wasmedge_sdk::{
     config::{CommonConfigOptions, ConfigBuilder, HostRegistrationConfigOptions},
-    params, Vm,
+    params, VmBuilder,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()?;
 
     // create a vm
-    let mut vm = Vm::new(Some(config), None)?;
+    let mut vm = VmBuilder::new().with_config(config).build()?;
 
     // set the envs and args for the wasi module
     let args = vec!["arg1", "arg2"];

--- a/bindings/rust/wasmedge-sdk/src/compiler.rs
+++ b/bindings/rust/wasmedge-sdk/src/compiler.rs
@@ -96,7 +96,7 @@ mod tests {
     use super::*;
     use crate::{
         config::{CompilerConfigOptions, ConfigBuilder},
-        params, wat2wasm, CompilerOutputFormat, Vm, WasmVal,
+        params, wat2wasm, CompilerOutputFormat, VmBuilder, WasmVal,
     };
     use std::io::Read;
 
@@ -131,7 +131,10 @@ mod tests {
             let wasm_magic: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];
             assert_ne!(buffer, wasm_magic);
 
-            let res = Vm::new(None, None)?.run_func_from_file(&aot_file_path, "fib", params!(5))?;
+            let res =
+                VmBuilder::new()
+                    .build()?
+                    .run_func_from_file(&aot_file_path, "fib", params!(5))?;
             assert_eq!(res[0].to_i32(), 8);
 
             // cleanup
@@ -201,7 +204,10 @@ mod tests {
             let wasm_magic: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];
             assert_ne!(buffer, wasm_magic);
 
-            let res = Vm::new(None, None)?.run_func_from_file(&aot_file_path, "fib", params!(5))?;
+            let res =
+                VmBuilder::new()
+                    .build()?
+                    .run_func_from_file(&aot_file_path, "fib", params!(5))?;
             assert_eq!(res[0].to_i32(), 8);
 
             // cleanup

--- a/bindings/rust/wasmedge-sdk/src/config.rs
+++ b/bindings/rust/wasmedge-sdk/src/config.rs
@@ -736,25 +736,9 @@ impl StatisticsConfigOptions {
 /// [HostRegistrationConfigOptions] is used to set the host registration configuration options, which are
 ///
 ///   - `Wasi` turns on the `WASI` support.
-///
-///   - `WasmEdgeProcess` turns on the `wasmedge_process` support.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct HostRegistrationConfigOptions {
     wasi: bool,
-    #[cfg(target_os = "linux")]
-    wasmedge_process: bool,
-    #[cfg(all(target_os = "linux", feature = "wasi_nn", target_arch = "x86_64"))]
-    wasi_nn: bool,
-    #[cfg(all(target_os = "linux", feature = "wasi_crypto"))]
-    wasi_crypto_common: bool,
-    #[cfg(all(target_os = "linux", feature = "wasi_crypto"))]
-    wasi_crypto_asymmetric_common: bool,
-    #[cfg(all(target_os = "linux", feature = "wasi_crypto"))]
-    wasi_crypto_symmetric: bool,
-    #[cfg(all(target_os = "linux", feature = "wasi_crypto"))]
-    wasi_crypto_kx: bool,
-    #[cfg(all(target_os = "linux", feature = "wasi_crypto"))]
-    wasi_crypto_signatures: bool,
 }
 impl HostRegistrationConfigOptions {
     /// Creates a new instance of [HostRegistrationConfigOptions].
@@ -768,84 +752,7 @@ impl HostRegistrationConfigOptions {
     ///
     /// - `enable` specifies if the option turns on or not.
     pub fn wasi(self, enable: bool) -> Self {
-        Self {
-            wasi: enable,
-            #[cfg(target_os = "linux")]
-            wasmedge_process: self.wasmedge_process,
-            #[cfg(all(target_os = "linux", feature = "wasi_nn", target_arch = "x86_64"))]
-            wasi_nn: self.wasi_nn,
-            #[cfg(all(target_os = "linux", feature = "wasi_crypto"))]
-            wasi_crypto_common: self.wasi_crypto_common,
-            #[cfg(all(target_os = "linux", feature = "wasi_crypto"))]
-            wasi_crypto_asymmetric_common: self.wasi_crypto_asymmetric_common,
-            #[cfg(all(target_os = "linux", feature = "wasi_crypto"))]
-            wasi_crypto_symmetric: self.wasi_crypto_symmetric,
-            #[cfg(all(target_os = "linux", feature = "wasi_crypto"))]
-            wasi_crypto_kx: self.wasi_crypto_kx,
-            #[cfg(all(target_os = "linux", feature = "wasi_crypto"))]
-            wasi_crypto_signatures: self.wasi_crypto_signatures,
-        }
-    }
-
-    /// Enables or disables host registration WasmEdge process.
-    ///
-    /// # Argument
-    ///
-    /// - `enable` specifies if the option turns on or not.
-    #[cfg(target_os = "linux")]
-    pub fn wasmedge_process(self, enable: bool) -> Self {
-        Self {
-            wasmedge_process: enable,
-            ..self
-        }
-    }
-
-    #[cfg(all(target_os = "linux", feature = "wasi_nn", target_arch = "x86_64"))]
-    pub fn wasi_nn(self, enable: bool) -> Self {
-        Self {
-            wasi_nn: enable,
-            ..self
-        }
-    }
-
-    #[cfg(all(target_os = "linux", feature = "wasi_crypto"))]
-    pub fn wasi_crypto_common(self, enable: bool) -> Self {
-        Self {
-            wasi_crypto_common: enable,
-            ..self
-        }
-    }
-
-    #[cfg(all(target_os = "linux", feature = "wasi_crypto"))]
-    pub fn wasi_crypto_asymmetric_common(self, enable: bool) -> Self {
-        Self {
-            wasi_crypto_asymmetric_common: enable,
-            ..self
-        }
-    }
-
-    #[cfg(all(target_os = "linux", feature = "wasi_crypto"))]
-    pub fn wasi_crypto_symmetric(self, enable: bool) -> Self {
-        Self {
-            wasi_crypto_symmetric: enable,
-            ..self
-        }
-    }
-
-    #[cfg(all(target_os = "linux", feature = "wasi_crypto"))]
-    pub fn wasi_crypto_kx(self, enable: bool) -> Self {
-        Self {
-            wasi_crypto_kx: enable,
-            ..self
-        }
-    }
-
-    #[cfg(all(target_os = "linux", feature = "wasi_crypto"))]
-    pub fn wasi_crypto_signatures(self, enable: bool) -> Self {
-        Self {
-            wasi_crypto_signatures: enable,
-            ..self
-        }
+        Self { wasi: enable }
     }
 }
 

--- a/bindings/rust/wasmedge-sdk/src/import.rs
+++ b/bindings/rust/wasmedge-sdk/src/import.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use wasmedge_sys::{self as sys, AsImport};
 
-/// Creates a normal, wasi, or wasmedge process [import object](crate::ImportObject).
+/// Creates a normal or wasi [import object](crate::ImportObject).
 ///
 /// # Example
 ///

--- a/bindings/rust/wasmedge-sdk/src/lib.rs
+++ b/bindings/rust/wasmedge-sdk/src/lib.rs
@@ -35,8 +35,8 @@
 //!
 //!  ```rust
 //!  use wasmedge_sdk::{
-//!      error::HostFuncError, host_function, params, wat2wasm, Caller, ImportObjectBuilder, Module, Vm,
-//!      WasmValue,
+//!      error::HostFuncError, host_function, params, wat2wasm, Caller, ImportObjectBuilder, Module,
+//!      VmBuilder, WasmValue,
 //!  };
 //!  
 //!  // We define a function to act as our "env" "say_hello" function imported in the
@@ -77,13 +77,15 @@
 //!      let module = Module::from_bytes(None, wasm_bytes)?;
 //!  
 //!      // create an executor
-//!      Vm::new(None, None)?
+//!      VmBuilder::new()
+//!          .build()?
 //!          .register_import_module(import)?
 //!          .register_module(Some("extern"), module)?
 //!          .run_func(Some("extern"), "run", params!())?;
 //!  
 //!      Ok(())
 //!  }
+//!  
 //!  ```
 //!
 
@@ -137,7 +139,7 @@ pub use store::Store;
 #[doc(inline)]
 pub use utils::Driver;
 #[doc(inline)]
-pub use vm::Vm;
+pub use vm::{Vm, VmBuilder};
 
 /// Parses in-memory bytes as either the [WebAssembly Text format](http://webassembly.github.io/spec/core/text/index.html), or a binary WebAssembly module
 pub use wasmedge_types::{

--- a/bindings/rust/wasmedge-sys/Cargo.toml
+++ b/bindings/rust/wasmedge-sys/Cargo.toml
@@ -21,7 +21,7 @@ rand = "0.8.4"
 thiserror = "1.0.30"
 wasmedge-macro = {path = "../wasmedge-macro", version = "0.3"}
 wasmedge-types = {path = "../wasmedge-types", version = "0.4"}
-wasmtime-fiber = {version = "2", optional = true}
+wasmtime-fiber = {version = "6", optional = true}
 wat = "1.0"
 
 [build-dependencies]


### PR DESCRIPTION
In this PR `VmBuilder` is introduced in `wasmedge-sdk` and used to create `Vm` instances with different settings. In addition, PR #2306 failed DCO, therefore, the `wasmtime-fiber` dependency in `Cargo.toml` of `wasmedge-sys` bumps to `6.0.0` in this PR.