### PR TITLE
[Docs] update LLVM_DIR for macOS

### DIFF
--- a/docs/book/en/src/contribute/build_from_src/macos.md
+++ b/docs/book/en/src/contribute/build_from_src/macos.md
@@ -29,9 +29,7 @@ If you want to build from source, you may need to install these dependencies by 
 ```bash
 # Tools and libraries
 brew install boost cmake ninja llvm
-export LLVM_DIR="/usr/local/opt/llvm/lib/cmake"
-# For Apple Silicon:
-# export LLVM_DIR="/opt/homebrew/opt/llvm/lib/cmake"
+export LLVM_DIR="$(brew --prefix)/opt/llvm/lib/cmake"
 export CC=clang
 export CXX=clang++
 ```

--- a/docs/book/en/src/contribute/build_from_src/macos.md
+++ b/docs/book/en/src/contribute/build_from_src/macos.md
@@ -30,6 +30,8 @@ If you want to build from source, you may need to install these dependencies by 
 # Tools and libraries
 brew install boost cmake ninja llvm
 export LLVM_DIR="/usr/local/opt/llvm/lib/cmake"
+# For Apple Silicon:
+# export LLVM_DIR="/opt/homebrew/opt/llvm/lib/cmake"
 export CC=clang
 export CXX=clang++
 ```


### PR DESCRIPTION
According to https://docs.brew.sh/Installation, `/usr/local` for macOS Intel, `/opt/homebrew` for Apple Silicon, so use `brew --prefix` to unify them.