### PR TITLE
Function reference proposal: Refactor the `ValType`.

### DIFF
--- a/include/api/wasmedge/wasmedge.h
+++ b/include/api/wasmedge/wasmedge.h
@@ -303,6 +303,79 @@ WASMEDGE_CAPI_EXPORT extern bool
 WasmEdge_ValTypeIsEqual(const WasmEdge_ValType ValType1,
                         const WasmEdge_ValType ValType2);
 
+/// Specify the WASM value type is an I32 or not.
+///
+/// \param ValType the WasmEdge_ValType object to check.
+///
+/// \returns true if the value type is an I32, false if not.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_ValTypeIsI32(const WasmEdge_ValType ValType);
+
+/// Specify the WASM value type is an I64 or not.
+///
+/// \param ValType the WasmEdge_ValType object to check.
+///
+/// \returns true if the value type is an I64, false if not.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_ValTypeIsI64(const WasmEdge_ValType ValType);
+
+/// Specify the WASM value type is a F32 or not.
+///
+/// \param ValType the WasmEdge_ValType object to check.
+///
+/// \returns true if the value type is a F32, false if not.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_ValTypeIsF32(const WasmEdge_ValType ValType);
+
+/// Specify the WASM value type is a F64 or not.
+///
+/// \param ValType the WasmEdge_ValType object to check.
+///
+/// \returns true if the value type is a F64, false if not.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_ValTypeIsF64(const WasmEdge_ValType ValType);
+
+/// Specify the WASM value type is a V128 or not.
+///
+/// \param ValType the WasmEdge_ValType object to check.
+///
+/// \returns true if the value type is a V128, false if not.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_ValTypeIsV128(const WasmEdge_ValType ValType);
+
+/// Specify the WASM value type is a FuncRef or not.
+///
+/// \param ValType the WasmEdge_ValType object to check.
+///
+/// \returns true if the value type is a FuncRef, false if not.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_ValTypeIsFuncRef(const WasmEdge_ValType ValType);
+
+/// Specify the WASM value type is an ExternRef or not.
+///
+/// \param ValType the WasmEdge_ValType object to check.
+///
+/// \returns true if the value type is an ExternRef, false if not.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_ValTypeIsExternRef(const WasmEdge_ValType ValType);
+
+/// Specify the WASM value type is a Ref (includes nullable and non-nullable) or
+/// not.
+///
+/// \param ValType the WasmEdge_ValType object to check.
+///
+/// \returns true if the value type is a Ref, false if not.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_ValTypeIsRef(const WasmEdge_ValType ValType);
+
+/// Specify the WASM value type is a nullable Ref or not.
+///
+/// \param ValType the WasmEdge_ValType object to check.
+///
+/// \returns true if the value type is a nullable Ref, false if not.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_ValTypeIsRefNull(const WasmEdge_ValType ValType);
+
 // <<<<<<<< WasmEdge valtype functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 // >>>>>>>> WasmEdge value functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

--- a/include/api/wasmedge/wasmedge.h
+++ b/include/api/wasmedge/wasmedge.h
@@ -41,6 +41,14 @@
 #include "wasmedge/int128.h"
 #include "wasmedge/version.h"
 
+/// WasmEdge WASM value type struct.
+typedef struct WasmEdge_ValType {
+  // This struct contains the raw data which describes the value type in WASM.
+  // Developers should use the corresponding `WasmEdge_ValueTypeGen` functions
+  // to generate this struct.
+  uint64_t Data;
+} WasmEdge_ValType;
+
 /// WasmEdge WASM value struct.
 typedef struct WasmEdge_Value {
   uint128_t Value;
@@ -48,7 +56,7 @@ typedef struct WasmEdge_Value {
   // functions. Developers should use the corresponding `WasmEdge_ValueGen`
   // functions to generate this struct, and the `WasmEdge_ValueGet` functions to
   // retrieve the value from this struct.
-  WasmEdge_FullValType Type;
+  WasmEdge_ValType Type;
 } WasmEdge_Value;
 
 /// WasmEdge string struct.
@@ -247,6 +255,56 @@ WASMEDGE_CAPI_EXPORT extern void WasmEdge_LogOff(void);
 
 // <<<<<<<< WasmEdge logging functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
+// >>>>>>>> WasmEdge valtype functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+/// Generate the I32 WASM value type.
+///
+/// \returns WasmEdge_ValType struct with the I32 value type.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_ValType WasmEdge_ValTypeGenI32();
+
+/// Generate the I64 WASM value type.
+///
+/// \returns WasmEdge_ValType struct with the I64 value type.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_ValType WasmEdge_ValTypeGenI64();
+
+/// Generate the F32 WASM value type.
+///
+/// \returns WasmEdge_ValType struct with the F32 value type.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_ValType WasmEdge_ValTypeGenF32();
+
+/// Generate the F64 WASM value type.
+///
+/// \returns WasmEdge_ValType struct with the F64 value type.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_ValType WasmEdge_ValTypeGenF64();
+
+/// Generate the V128 WASM value type.
+///
+/// \returns WasmEdge_ValType struct with the V128 value type.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_ValType WasmEdge_ValTypeGenV128();
+
+/// Generate the FuncRef WASM value type.
+///
+/// \returns WasmEdge_ValType struct with the FuncRef value type.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_ValType WasmEdge_ValTypeGenFuncRef();
+
+/// Generate the ExternRef WASM value type.
+///
+/// \returns WasmEdge_ValType struct with the ExternRef value type.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_ValType WasmEdge_ValTypeGenExternRef();
+
+/// Compare the two WasmEdge_ValType objects.
+///
+/// \param ValType1 the first WasmEdge_ValType object to compare.
+/// \param ValType2 the second WasmEdge_ValType object to compare.
+///
+/// \returns true if the content of two WasmEdge_ValType objects are the same,
+/// false if not.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_ValTypeIsEqual(const WasmEdge_ValType ValType1,
+                        const WasmEdge_ValType ValType2);
+
+// <<<<<<<< WasmEdge valtype functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
 // >>>>>>>> WasmEdge value functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 /// Generate the I32 WASM value.
@@ -299,7 +357,7 @@ WasmEdge_ValueGenV128(const int128_t Val);
 ///
 /// \returns WasmEdge_Value struct with the NULL reference.
 WASMEDGE_CAPI_EXPORT extern WasmEdge_Value
-WasmEdge_ValueGenNullRef(const enum WasmEdge_RefType T);
+WasmEdge_ValueGenNullRef(const enum WasmEdge_RefTypeCode T);
 
 /// Generate the function reference WASM value.
 ///
@@ -1010,9 +1068,9 @@ WasmEdge_ASTModuleDelete(WasmEdge_ASTModuleContext *Cxt);
 ///
 /// \returns pointer to context, NULL if failed.
 WASMEDGE_CAPI_EXPORT extern WasmEdge_FunctionTypeContext *
-WasmEdge_FunctionTypeCreate(const enum WasmEdge_ValType *ParamList,
+WasmEdge_FunctionTypeCreate(const WasmEdge_ValType *ParamList,
                             const uint32_t ParamLen,
-                            const enum WasmEdge_ValType *ReturnList,
+                            const WasmEdge_ValType *ReturnList,
                             const uint32_t ReturnLen);
 
 /// Get the parameter types list length from the WasmEdge_FunctionTypeContext.
@@ -1036,8 +1094,7 @@ WASMEDGE_CAPI_EXPORT extern uint32_t WasmEdge_FunctionTypeGetParametersLength(
 /// \returns the actual parameter types list length.
 WASMEDGE_CAPI_EXPORT extern uint32_t
 WasmEdge_FunctionTypeGetParameters(const WasmEdge_FunctionTypeContext *Cxt,
-                                   enum WasmEdge_ValType *List,
-                                   const uint32_t Len);
+                                   WasmEdge_ValType *List, const uint32_t Len);
 
 /// Get the return types list length from the WasmEdge_FunctionTypeContext.
 ///
@@ -1060,8 +1117,7 @@ WasmEdge_FunctionTypeGetReturnsLength(const WasmEdge_FunctionTypeContext *Cxt);
 /// \returns the actual return types list length.
 WASMEDGE_CAPI_EXPORT extern uint32_t
 WasmEdge_FunctionTypeGetReturns(const WasmEdge_FunctionTypeContext *Cxt,
-                                enum WasmEdge_ValType *List,
-                                const uint32_t Len);
+                                WasmEdge_ValType *List, const uint32_t Len);
 
 /// Deletion of the WasmEdge_FunctionTypeContext.
 ///
@@ -1081,20 +1137,22 @@ WasmEdge_FunctionTypeDelete(WasmEdge_FunctionTypeContext *Cxt);
 /// The caller owns the object and should call `WasmEdge_TableTypeDelete` to
 /// destroy it.
 ///
-/// \param RefType the reference type of the table type.
+/// \param RefType the value type of the table type. This value type should be a
+/// reference type, or this function will fail.
 /// \param Limit the limit struct of the table type.
 ///
 /// \returns pointer to context, NULL if failed.
 WASMEDGE_CAPI_EXPORT extern WasmEdge_TableTypeContext *
-WasmEdge_TableTypeCreate(const enum WasmEdge_RefType RefType,
+WasmEdge_TableTypeCreate(const WasmEdge_ValType RefType,
                          const WasmEdge_Limit Limit);
 
 /// Get the reference type from a table type.
 ///
 /// \param Cxt the WasmEdge_TableTypeContext.
 ///
-/// \returns the reference type of the table type.
-WASMEDGE_CAPI_EXPORT extern enum WasmEdge_RefType
+/// \returns the value type of the table type. This value type will must be a
+/// reference type.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_ValType
 WasmEdge_TableTypeGetRefType(const WasmEdge_TableTypeContext *Cxt);
 
 /// Get the limit from a table type.
@@ -1160,7 +1218,7 @@ WasmEdge_MemoryTypeDelete(WasmEdge_MemoryTypeContext *Cxt);
 ///
 /// \returns pointer to context, NULL if failed.
 WASMEDGE_CAPI_EXPORT extern WasmEdge_GlobalTypeContext *
-WasmEdge_GlobalTypeCreate(const enum WasmEdge_ValType ValType,
+WasmEdge_GlobalTypeCreate(const WasmEdge_ValType ValType,
                           const enum WasmEdge_Mutability Mut);
 
 /// Get the value type from a global type.
@@ -1168,7 +1226,7 @@ WasmEdge_GlobalTypeCreate(const enum WasmEdge_ValType ValType,
 /// \param Cxt the WasmEdge_GlobalTypeContext.
 ///
 /// \returns the value type of the global type.
-WASMEDGE_CAPI_EXPORT extern enum WasmEdge_ValType
+WASMEDGE_CAPI_EXPORT extern WasmEdge_ValType
 WasmEdge_GlobalTypeGetValType(const WasmEdge_GlobalTypeContext *Cxt);
 
 /// Get the mutability from a global type.
@@ -2121,9 +2179,9 @@ typedef WasmEdge_Result (*WasmEdge_HostFunc_t)(
 ///   return WasmEdge_Result_Success;
 /// }
 ///
-/// enum WasmEdge_ValType Params[2] = {WasmEdge_ValType_I32,
-///                                    WasmEdge_ValType_I32};
-/// enum WasmEdge_ValType Returns[1] = {WasmEdge_ValType_I32};
+/// WasmEdge_ValType Params[2] = {WasmEdge_ValTypeGenI32(),
+///                               WasmEdge_ValTypeGenI32()};
+/// WasmEdge_ValType Returns[1] = {WasmEdge_ValTypeGenI32()};
 /// WasmEdge_FunctionTypeContext *FuncType =
 ///     WasmEdge_FunctionTypeCreate(Params, 2, Returns, 1);
 /// WasmEdge_FunctionInstanceContext *HostFunc =
@@ -2193,9 +2251,9 @@ typedef WasmEdge_Result (*WasmEdge_WrapFunc_t)(
 ///   return WasmEdge_Result_Success;
 /// }
 ///
-/// enum WasmEdge_ValType Params[2] = {WasmEdge_ValType_I32,
-///                                    WasmEdge_ValType_I32};
-/// enum WasmEdge_ValType Returns[1] = {WasmEdge_ValType_I32};
+/// WasmEdge_ValType Params[2] = {WasmEdge_ValTypeGenI32(),
+///                               WasmEdge_ValTypeGenI32()};
+/// WasmEdge_ValType Returns[1] = {WasmEdge_ValTypeGenI32()};
 /// WasmEdge_FunctionTypeContext *FuncType =
 ///     WasmEdge_FunctionTypeCreate(Params, 2, Returns, 1);
 /// WasmEdge_FunctionInstanceContext *HostFunc =

--- a/include/ast/instruction.h
+++ b/include/ast/instruction.h
@@ -57,7 +57,7 @@ public:
       std::copy_n(Instr.Data.BrTable.LabelList, Data.BrTable.LabelListSize,
                   Data.BrTable.LabelList);
     } else if (Flags.IsAllocValTypeList) {
-      Data.SelectT.ValTypeList = new FullValType[Data.SelectT.ValTypeListSize];
+      Data.SelectT.ValTypeList = new ValType[Data.SelectT.ValTypeListSize];
       std::copy_n(Instr.Data.SelectT.ValTypeList, Data.SelectT.ValTypeListSize,
                   Data.SelectT.ValTypeList);
     }
@@ -90,8 +90,8 @@ public:
   uint32_t getOffset() const noexcept { return Offset; }
 
   /// Getter and setter of block type.
-  BlockType getBlockType() const noexcept { return Data.Blocks.ResType; }
-  void setBlockType(FullValType VType) noexcept {
+  const BlockType &getBlockType() const noexcept { return Data.Blocks.ResType; }
+  void setBlockType(const ValType &VType) noexcept {
     Data.Blocks.ResType.setData(VType);
   }
   void setBlockType(uint32_t Idx) noexcept { Data.Blocks.ResType.setData(Idx); }
@@ -106,8 +106,8 @@ public:
   void setJumpElse(const uint32_t Cnt) noexcept { Data.Blocks.JumpElse = Cnt; }
 
   /// Getter and setter of reference type.
-  FullRefType getRefType() const noexcept { return Data.ReferenceType; }
-  void setRefType(FullRefType RType) noexcept { Data.ReferenceType = RType; }
+  const RefType &getRefType() const noexcept { return Data.ReferenceType; }
+  void setRefType(const RefType &RType) noexcept { Data.ReferenceType = RType; }
 
   /// Getter and setter of label list.
   void setLabelListSize(uint32_t Size) {
@@ -142,17 +142,17 @@ public:
     reset();
     if (Size > 0) {
       Data.SelectT.ValTypeListSize = Size;
-      Data.SelectT.ValTypeList = new FullValType[Size];
+      Data.SelectT.ValTypeList = new ValType[Size];
       Flags.IsAllocValTypeList = true;
     }
   }
-  Span<const FullValType> getValTypeList() const noexcept {
-    return Span<const FullValType>(Data.SelectT.ValTypeList,
-                                   Data.SelectT.ValTypeListSize);
+  Span<const ValType> getValTypeList() const noexcept {
+    return Span<const ValType>(Data.SelectT.ValTypeList,
+                               Data.SelectT.ValTypeListSize);
   }
-  Span<FullValType> getValTypeList() noexcept {
-    return Span<FullValType>(Data.SelectT.ValTypeList,
-                             Data.SelectT.ValTypeListSize);
+  Span<ValType> getValTypeList() noexcept {
+    return Span<ValType>(Data.SelectT.ValTypeList,
+                         Data.SelectT.ValTypeListSize);
   }
 
   /// Getter and setter of target index.
@@ -243,11 +243,11 @@ private:
       JumpDescriptor *LabelList;
     } BrTable;
     // Type 5: RefType.
-    FullRefType ReferenceType;
+    RefType ReferenceType;
     // Type 6: ValTypeList.
     struct {
       uint32_t ValTypeListSize;
-      FullValType *ValTypeList;
+      ValType *ValTypeList;
     } SelectT;
     // Type 7: TargetIdx, MemAlign, MemOffset, and MemLane.
     struct {

--- a/include/ast/segment.h
+++ b/include/ast/segment.h
@@ -59,8 +59,8 @@ public:
   void setMode(ElemMode EMode) noexcept { Mode = EMode; }
 
   /// Getter of reference type.
-  FullRefType getRefType() const noexcept { return Type; }
-  void setRefType(FullRefType RType) noexcept { Type = RType; }
+  const RefType &getRefType() const noexcept { return Type; }
+  void setRefType(const RefType &RType) noexcept { Type = RType; }
 
   /// Getter of table index.
   uint32_t getIdx() const noexcept { return TableIdx; }
@@ -74,7 +74,7 @@ private:
   /// \name Data of ElementSegment node.
   /// @{
   ElemMode Mode = ElemMode::Active;
-  FullRefType Type = RefType::FuncRef;
+  RefType Type = RefTypeCode::FuncRef;
   uint32_t TableIdx = 0;
   std::vector<Expression> InitExprs;
   /// @}
@@ -88,10 +88,10 @@ public:
   void setSegSize(uint32_t Size) noexcept { SegSize = Size; }
 
   /// Getter of locals vector.
-  Span<const std::pair<uint32_t, FullValType>> getLocals() const noexcept {
+  Span<const std::pair<uint32_t, ValType>> getLocals() const noexcept {
     return Locals;
   }
-  std::vector<std::pair<uint32_t, FullValType>> &getLocals() noexcept {
+  std::vector<std::pair<uint32_t, ValType>> &getLocals() noexcept {
     return Locals;
   }
 
@@ -103,7 +103,7 @@ private:
   /// \name Data of CodeSegment node.
   /// @{
   uint32_t SegSize = 0;
-  std::vector<std::pair<uint32_t, FullValType>> Locals;
+  std::vector<std::pair<uint32_t, ValType>> Locals;
   Symbol<void> FuncSymbol;
   /// @}
 };

--- a/include/ast/type.h
+++ b/include/ast/type.h
@@ -81,10 +81,9 @@ public:
 
   /// Constructors.
   FunctionType() = default;
-  FunctionType(Span<const FullValType> P, Span<const FullValType> R)
+  FunctionType(Span<const ValType> P, Span<const ValType> R)
       : ParamTypes(P.begin(), P.end()), ReturnTypes(R.begin(), R.end()) {}
-  FunctionType(Span<const FullValType> P, Span<const FullValType> R,
-               Symbol<Wrapper> S)
+  FunctionType(Span<const ValType> P, Span<const ValType> R, Symbol<Wrapper> S)
       : ParamTypes(P.begin(), P.end()), ReturnTypes(R.begin(), R.end()),
         WrapSymbol(std::move(S)) {}
 
@@ -101,16 +100,16 @@ public:
   }
 
   /// Getter of param types.
-  const std::vector<FullValType> &getParamTypes() const noexcept {
+  const std::vector<ValType> &getParamTypes() const noexcept {
     return ParamTypes;
   }
-  std::vector<FullValType> &getParamTypes() noexcept { return ParamTypes; }
+  std::vector<ValType> &getParamTypes() noexcept { return ParamTypes; }
 
   /// Getter of return types.
-  const std::vector<FullValType> &getReturnTypes() const noexcept {
+  const std::vector<ValType> &getReturnTypes() const noexcept {
     return ReturnTypes;
   }
-  std::vector<FullValType> &getReturnTypes() noexcept { return ReturnTypes; }
+  std::vector<ValType> &getReturnTypes() noexcept { return ReturnTypes; }
 
   /// Getter and setter of symbol.
   const auto &getSymbol() const noexcept { return WrapSymbol; }
@@ -119,8 +118,8 @@ public:
 private:
   /// \name Data of FunctionType.
   /// @{
-  std::vector<FullValType> ParamTypes;
-  std::vector<FullValType> ReturnTypes;
+  std::vector<ValType> ParamTypes;
+  std::vector<ValType> ReturnTypes;
   Symbol<Wrapper> WrapSymbol;
   /// @}
 };
@@ -150,16 +149,17 @@ private:
 class TableType {
 public:
   /// Constructors.
-  TableType() noexcept : Type(RefType::FuncRef), Lim() {}
-  TableType(FullRefType RType, uint32_t MinVal) noexcept
+  TableType() noexcept : Type(RefTypeCode::FuncRef), Lim() {}
+  TableType(const RefType &RType, uint32_t MinVal) noexcept
       : Type(RType), Lim(MinVal) {}
-  TableType(FullRefType RType, uint32_t MinVal, uint32_t MaxVal) noexcept
+  TableType(const RefType &RType, uint32_t MinVal, uint32_t MaxVal) noexcept
       : Type(RType), Lim(MinVal, MaxVal) {}
-  TableType(FullRefType RType, const Limit &L) noexcept : Type(RType), Lim(L) {}
+  TableType(const RefType &RType, const Limit &L) noexcept
+      : Type(RType), Lim(L) {}
 
   /// Getter of reference type.
-  FullRefType getRefType() const noexcept { return Type; }
-  void setRefType(FullRefType RType) noexcept { Type = RType; }
+  const RefType &getRefType() const noexcept { return Type; }
+  void setRefType(const RefType &RType) noexcept { Type = RType; }
 
   /// Getter of limit.
   const Limit &getLimit() const noexcept { return Lim; }
@@ -168,7 +168,7 @@ public:
 private:
   /// \name Data of TableType.
   /// @{
-  FullRefType Type;
+  RefType Type;
   Limit Lim;
   /// @}
 };
@@ -177,8 +177,8 @@ private:
 class GlobalType {
 public:
   /// Constructors.
-  GlobalType() noexcept : Type(ValType::I32), Mut(ValMut::Const) {}
-  GlobalType(FullValType VType, ValMut VMut) noexcept
+  GlobalType() noexcept : Type(ValTypeCode::I32), Mut(ValMut::Const) {}
+  GlobalType(const ValType &VType, ValMut VMut) noexcept
       : Type(VType), Mut(VMut) {}
 
   /// `==` and `!=` operator overloadings.
@@ -193,8 +193,8 @@ public:
   }
 
   /// Getter and setter of value type.
-  FullValType getValType() const noexcept { return Type; }
-  void setValType(FullValType VType) noexcept { Type = VType; }
+  const ValType &getValType() const noexcept { return Type; }
+  void setValType(const ValType &VType) noexcept { Type = VType; }
 
   /// Getter and setter of value mutation.
   ValMut getValMut() const noexcept { return Mut; }
@@ -203,7 +203,7 @@ public:
 private:
   /// \name Data of GlobalType.
   /// @{
-  FullValType Type;
+  ValType Type;
   ValMut Mut;
   /// @}
 };

--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -41,10 +41,8 @@ A(Seg_Global, "global segment")
 A(Seg_Element, "element segment")
 A(Seg_Code, "code segment")
 A(Seg_Data, "data segment")
-A(Type_Function, "function type")
-A(Type_ValType, "value type")
-A(Type_RefType, "reference type")
 A(Type_Limit, "limit")
+A(Type_Function, "function type")
 A(Type_Memory, "memory type")
 A(Type_Table, "table type")
 A(Type_Global, "global type")
@@ -902,9 +900,7 @@ I(Lane, "lane")
 
 // enum_types.h
 
-// The raw ValType definition is deprecated. If you want to support more
-// ValType, add to the new definition of NumType or RefType.
-#ifdef UseValType
+#ifdef UseValTypeCode
 #define V Line
 
 V(I32, 0x7F, "i32")
@@ -912,13 +908,15 @@ V(I64, 0x7E, "i64")
 V(F32, 0x7D, "f32")
 V(F64, 0x7C, "f64")
 V(V128, 0x7B, "v128")
-V(FuncRef, 0x70, "funcref")
-V(ExternRef, 0x6F, "externref")
+V(FuncRef, 0x70, "func")
+V(ExternRef, 0x6F, "extern")
+V(Ref, 0x6B, "ref")
+V(RefNull, 0x6C, "nullable ref")
 
 #undef V
-#endif // UseValType
+#endif // UseValTypeCode
 
-#ifdef UseNumType
+#ifdef UseNumTypeCode
 #define N Line
 
 N(I32, 0x7F)
@@ -928,39 +926,18 @@ N(F64, 0x7C)
 N(V128, 0x7B)
 
 #undef N
-#endif // UseNumType
-
-#ifdef UseHeapTypeCode
-#define H Line
-
-H(Extern, 0x6F)
-H(Func, 0x70)
-// This stands for type defined in wasm module. The value `0xFF` is an arbitary
-// value.
-H(Defined, 0xFF)
-
-#undef V
-#endif // UseHeapTypeCode
+#endif // UseNumTypeCode
 
 #ifdef UseRefTypeCode
 #define R Line
 
 R(Ref, 0x6B)
 R(RefNull, 0x6C)
+R(ExternRef, 0x6F)
+R(FuncRef, 0x70)
 
 #undef R
 #endif // UseRefTypeCode
-
-// The raw RefType definition is deprecated. If you want to support more
-// RefType, add to HeapType and RefTypeCode.
-#ifdef UseRefType
-#define R Line
-
-R(FuncRef, 0x70)
-R(ExternRef, 0x6F)
-
-#undef R
-#endif // UseRefType
 
 #ifdef UseValMut
 #define M Line

--- a/include/common/enum_types.h
+++ b/include/common/enum_types.h
@@ -16,68 +16,24 @@
 #define WASMEDGE_C_API_ENUM_TYPES_H
 
 /// WASM Value type C enumeration.
-enum WasmEdge_ValType {
-#define UseValType
-#define Line(NAME, VALUE, STRING) WasmEdge_ValType_##NAME = VALUE,
-#include "enum.inc"
-#undef Line
-#undef UseValType
-};
-
 enum WasmEdge_ValTypeCode {
-#define UseNumType
-#define Line(NAME, VALUE) WasmEdge_ValTypeCode_##NAME = VALUE,
+#define UseValTypeCode
+#define Line(NAME, VALUE, STRING) WasmEdge_ValTypeCode_##NAME = VALUE,
 #include "enum.inc"
 #undef Line
-#undef UseNumType
-
-#define UseRefType
-#define Line(NAME, VALUE) WasmEdge_ValTypeCode_##NAME = VALUE,
-#include "enum.inc"
-#undef Line
-#undef UseRefType
+#undef UseValTypeCode
 };
-
-enum WasmEdge_HeapTypeCode {
-#define UseHeapTypeCode
-#define Line(NAME, VALUE) WasmEdge_HeapTypeCode_##NAME = VALUE,
-#include "enum.inc"
-#undef Line
-#undef UseHeapTypeCode
-};
-
-typedef struct WasmEdge_HeapType {
-  enum WasmEdge_HeapTypeCode HeapTypeCode;
-  uint32_t DefinedTypeIdx;
-} WasmEdge_HeapType;
-
-union WasmEdge_ValTypeExt {
-  WasmEdge_HeapType HeapType;
-};
-
-typedef struct WasmEdge_FullValType {
-  enum WasmEdge_ValTypeCode TypeCode;
-  union WasmEdge_ValTypeExt Ext;
-} WasmEdge_FullValType;
 
 /// WASM Number type C enumeration.
-enum WasmEdge_NumType {
-#define UseNumType
-#define Line(NAME, VALUE) WasmEdge_NumType_##NAME = VALUE,
+enum WasmEdge_NumTypeCode {
+#define UseNumTypeCode
+#define Line(NAME, VALUE) WasmEdge_NumTypeCode_##NAME = VALUE,
 #include "enum.inc"
 #undef Line
-#undef UseNumType
+#undef UseNumTypeCode
 };
 
 /// WASM Reference type C enumeration.
-enum WasmEdge_RefType {
-#define UseRefType
-#define Line(NAME, VALUE) WasmEdge_RefType_##NAME = VALUE,
-#include "enum.inc"
-#undef Line
-#undef UseRefType
-};
-
 enum WasmEdge_RefTypeCode {
 #define UseRefTypeCode
 #define Line(NAME, VALUE) WasmEdge_RefTypeCode_##NAME = VALUE,

--- a/include/common/enum_types.hpp
+++ b/include/common/enum_types.hpp
@@ -15,7 +15,6 @@
 #pragma once
 
 #include "dense_enum_map.h"
-#include "enum_types.h"
 #include "errcode.h"
 #include "spare_enum_map.h"
 
@@ -25,268 +24,42 @@
 namespace WasmEdge {
 
 /// WASM Value type C++ enumeration class.
-enum class ValType : uint8_t {
-#define UseValType
+enum class ValTypeCode : uint8_t {
+#define UseValTypeCode
 #define Line(NAME, VALUE, STRING) NAME = VALUE,
 #include "enum.inc"
 #undef Line
-#undef UseValType
+#undef UseValTypeCode
 };
 
 static inline constexpr const auto ValTypeStr = []() constexpr {
   using namespace std::literals::string_view_literals;
-  std::pair<ValType, std::string_view> Array[] = {
-#define UseValType
-#define Line(NAME, VALUE, STRING) {ValType::NAME, STRING},
+  std::pair<ValTypeCode, std::string_view> Array[] = {
+#define UseValTypeCode
+#define Line(NAME, VALUE, STRING) {ValTypeCode::NAME, STRING},
 #include "enum.inc"
 #undef Line
-#undef UseValType
+#undef UseValTypeCode
   };
   return SpareEnumMap(Array);
 }();
 
 /// WASM Number type C++ enumeration class.
-enum class NumType : uint8_t {
-#define UseNumType
+enum class NumTypeCode : uint8_t {
+#define UseNumTypeCode
 #define Line(NAME, VALUE) NAME = VALUE,
 #include "enum.inc"
 #undef Line
-#undef UseNumType
+#undef UseNumTypeCode
 };
 
 /// WASM Reference type C++ enumeration class.
-enum class RefType : uint8_t {
-#define UseRefType
-#define Line(NAME, VALUE) NAME = VALUE,
-#include "enum.inc"
-#undef Line
-#undef UseRefType
-};
-
-enum class HeapTypeCode : uint8_t {
-#define UseHeapTypeCode
-#define Line(NAME, VALUE) NAME = VALUE,
-#include "enum.inc"
-#undef Line
-#undef UseHeapTypeCode
-};
-
-enum class ValTypeCode : uint8_t {
-#define UseNumType
-#define Line(NAME, VALUE) NAME = VALUE,
-#include "enum.inc"
-#undef Line
-#undef UseNumType
-
+enum class RefTypeCode : uint8_t {
 #define UseRefTypeCode
 #define Line(NAME, VALUE) NAME = VALUE,
 #include "enum.inc"
 #undef Line
 #undef UseRefTypeCode
-};
-
-static inline constexpr const auto ValTypeCodeStr = []() constexpr {
-  using namespace std::literals::string_view_literals;
-  std::pair<ValTypeCode, std::string_view> Array[] = {
-#define UseNumType
-#define Line(NAME, VALUE) {ValTypeCode::NAME, #NAME},
-#include "enum.inc"
-#undef Line
-#undef UseNumType
-
-#define UseRefTypeCode
-#define Line(NAME, VALUE) {ValTypeCode::NAME, #NAME},
-#include "enum.inc"
-#undef Line
-#undef UseRefTypeCode
-  };
-  return SpareEnumMap(Array);
-}();
-
-enum RefTypeCode : uint8_t {
-#define UseRefTypeCode
-#define Line(NAME, VALUE) NAME = VALUE,
-#include "enum.inc"
-#undef Line
-#undef UseRefTypeCode
-};
-
-class HeapType {
-public:
-  HeapType() = default;
-  HeapType(HeapTypeCode HTypeCode) : HTypeCode(HTypeCode), DefinedTypeIdx(0) {
-    assuming(HTypeCode != HeapTypeCode::Defined);
-  }
-  HeapType(uint32_t TypeIdx)
-      : HTypeCode(HeapTypeCode::Defined), DefinedTypeIdx(TypeIdx) {}
-
-  HeapType(WasmEdge_HeapType HType)
-      : HTypeCode(static_cast<HeapTypeCode>(HType.HeapTypeCode)),
-        DefinedTypeIdx(HType.DefinedTypeIdx) {
-    switch (HType.HeapTypeCode) {
-    case (uint8_t)HeapTypeCode::Func:
-    case (uint8_t)HeapTypeCode::Extern:
-    case (uint8_t)HeapTypeCode::Defined:
-      break;
-    default:
-      assumingUnreachable();
-    }
-  }
-
-  WasmEdge_HeapType asCStruct() const {
-    return WasmEdge_HeapType{
-        .HeapTypeCode = static_cast<WasmEdge_HeapTypeCode>(HTypeCode),
-        .DefinedTypeIdx = DefinedTypeIdx,
-    };
-  }
-
-  HeapTypeCode getHTypeCode() const { return HTypeCode; }
-
-  uint32_t getDefinedTypeIdx() const { return DefinedTypeIdx; }
-
-private:
-  HeapTypeCode HTypeCode;
-  uint32_t DefinedTypeIdx;
-};
-
-class FullRefType {
-public:
-  FullRefType() = default;
-  FullRefType(const RefType RType)
-      : TypeCode(RefTypeCode::RefNull),
-        HType(static_cast<HeapTypeCode>(RType)) {}
-  FullRefType(const HeapTypeCode HTypeCode)
-      : TypeCode(RefTypeCode::RefNull), HType(HTypeCode) {
-    assuming(HTypeCode != HeapTypeCode::Defined);
-  }
-  FullRefType(const RefTypeCode TypeCode, const HeapTypeCode HTypeCode)
-      : TypeCode(TypeCode), HType(HTypeCode) {
-    assuming(HTypeCode != HeapTypeCode::Defined);
-  }
-  FullRefType(const RefTypeCode TypeCode, const uint32_t TypeIdx)
-      : TypeCode(TypeCode), HType(TypeIdx) {}
-  FullRefType(const RefTypeCode TypeCode, const HeapType HType)
-      : TypeCode(TypeCode), HType(HType) {}
-  RefTypeCode getTypeCode() const { return TypeCode; }
-  HeapType getHeapType() const { return HType; }
-
-  friend bool operator==(const FullRefType &LHS,
-                         const FullRefType &RHS) noexcept {
-    if (LHS.TypeCode != RHS.TypeCode) {
-      return false;
-    }
-    if (LHS.HType.getHTypeCode() != RHS.HType.getHTypeCode()) {
-      return false;
-    }
-    if (LHS.HType.getHTypeCode() == HeapTypeCode::Defined) {
-      return LHS.HType.getDefinedTypeIdx() == RHS.HType.getDefinedTypeIdx();
-    } else {
-      return true;
-    }
-  }
-  friend bool operator!=(const FullRefType &LHS,
-                         const FullRefType &RHS) noexcept {
-    return !(LHS.TypeCode == RHS.TypeCode);
-  }
-
-private:
-  RefTypeCode TypeCode;
-  HeapType HType;
-};
-
-class FullValType {
-public:
-  FullValType() = default;
-  FullValType(const ValType VType) {
-    switch (VType) {
-    case ValType::I32:
-    case ValType::I64:
-    case ValType::F32:
-    case ValType::F64:
-    case ValType::V128: {
-      *this = FullValType(static_cast<NumType>(VType));
-      break;
-    }
-    case ValType::ExternRef:
-    case ValType::FuncRef: {
-      *this = FullValType(static_cast<RefType>(VType));
-      break;
-    }
-    }
-  }
-  FullValType(const NumType NType)
-      : TypeCode(static_cast<ValTypeCode>(NType)), Ext({}) {}
-  FullValType(const WasmEdge_FullValType VType)
-      : TypeCode(static_cast<ValTypeCode>(VType.TypeCode)), Ext({}) {
-    if (isRefType()) {
-      Ext.HType = VType.Ext.HeapType;
-    }
-  }
-  FullValType(const FullRefType RType)
-      : TypeCode(static_cast<ValTypeCode>(RType.getTypeCode())),
-        Ext({.HType = RType.getHeapType()}) {}
-  ValTypeCode getTypeCode() const { return TypeCode; }
-  bool isNumType() const {
-    switch (TypeCode) {
-    case ValTypeCode::I32:
-    case ValTypeCode::I64:
-    case ValTypeCode::F32:
-    case ValTypeCode::F64:
-    case ValTypeCode::V128:
-      return true;
-    default:
-      return false;
-    }
-  }
-  bool isRefType() const {
-    switch (TypeCode) {
-    case ValTypeCode::Ref:
-    case ValTypeCode::RefNull:
-      return true;
-    default:
-      return false;
-    }
-  }
-  WasmEdge_FullValType asCStruct() const {
-    if (isNumType()) {
-      return WasmEdge_FullValType{
-          .TypeCode = static_cast<WasmEdge_ValTypeCode>(TypeCode),
-          .Ext = {},
-      };
-    } else {
-      return WasmEdge_FullValType{
-          .TypeCode = static_cast<WasmEdge_ValTypeCode>(TypeCode),
-          .Ext = {.HeapType = Ext.HType.asCStruct()}};
-    }
-  }
-
-  FullRefType asRefType() const {
-    assuming(isRefType());
-    return FullRefType(static_cast<RefTypeCode>(TypeCode), Ext.HType);
-  }
-
-  friend bool operator==(const FullValType &LHS,
-                         const FullValType &RHS) noexcept {
-    if (LHS.TypeCode != RHS.TypeCode) {
-      return false;
-    }
-
-    if (LHS.isNumType()) {
-      return true;
-    }
-
-    return LHS.asRefType() == RHS.asRefType();
-  }
-  friend bool operator!=(const FullValType &LHS,
-                         const FullValType &RHS) noexcept {
-    return !(LHS.TypeCode == RHS.TypeCode);
-  }
-
-private:
-  ValTypeCode TypeCode;
-  union ValTypeExt {
-    HeapType HType;
-  } Ext;
 };
 
 /// WASM Mutability C++ enumeration class.

--- a/include/common/errinfo.h
+++ b/include/common/errinfo.h
@@ -156,13 +156,13 @@ struct InfoMismatch {
         GotAlignment(GotAlign) {}
 
   /// Case 2: unexpected value type
-  InfoMismatch(const FullValType ExpVT, const FullValType GotVT) noexcept
+  InfoMismatch(const ValType &ExpVT, const ValType &GotVT) noexcept
       : Category(MismatchCategory::ValueType), ExpValType(ExpVT),
         GotValType(GotVT) {}
 
   /// Case 3: unexpected value type list
-  InfoMismatch(const std::vector<FullValType> &ExpV,
-               const std::vector<FullValType> &GotV) noexcept
+  InfoMismatch(const std::vector<ValType> &ExpV,
+               const std::vector<ValType> &GotV) noexcept
       : Category(MismatchCategory::ValueTypes), ExpParams(ExpV),
         GotParams(GotV) {}
 
@@ -177,18 +177,18 @@ struct InfoMismatch {
         GotExtType(GotExt) {}
 
   /// Case 6: unexpected function types
-  InfoMismatch(const std::vector<FullValType> &ExpP,
-               const std::vector<FullValType> &ExpR,
-               const std::vector<FullValType> &GotP,
-               const std::vector<FullValType> &GotR) noexcept
+  InfoMismatch(const std::vector<ValType> &ExpP,
+               const std::vector<ValType> &ExpR,
+               const std::vector<ValType> &GotP,
+               const std::vector<ValType> &GotR) noexcept
       : Category(MismatchCategory::FunctionType), ExpParams(ExpP),
         GotParams(GotP), ExpReturns(ExpR), GotReturns(GotR) {}
 
   /// Case 7: unexpected table types
-  InfoMismatch(const FullRefType ExpRType, /// Reference type
+  InfoMismatch(const RefType &ExpRType, /// Reference type
                const bool ExpHasMax, const uint32_t ExpMin,
-               const uint32_t ExpMax,      /// Expect Limit
-               const FullRefType GotRType, /// Got reference type
+               const uint32_t ExpMax,   /// Expect Limit
+               const RefType &GotRType, /// Got reference type
                const bool GotHasMax, const uint32_t GotMin,
                const uint32_t GotMax /// Got limit
                ) noexcept
@@ -208,8 +208,8 @@ struct InfoMismatch {
         ExpLimMax(ExpMax), GotLimMax(GotMax) {}
 
   /// Case 9: unexpected global types
-  InfoMismatch(const FullValType ExpVType, const ValMut ExpVMut,
-               const FullValType GotVType, const ValMut GotVMut) noexcept
+  InfoMismatch(const ValType &ExpVType, const ValMut ExpVMut,
+               const ValType &GotVType, const ValMut GotVMut) noexcept
       : Category(MismatchCategory::Global), ExpValType(ExpVType),
         GotValType(GotVType), ExpValMut(ExpVMut), GotValMut(GotVMut) {}
 
@@ -233,18 +233,18 @@ struct InfoMismatch {
 
   /// Case 6: unexpected function type
   /// Case 3: unexpected value type list
-  std::vector<FullValType> ExpParams, GotParams;
-  std::vector<FullValType> ExpReturns, GotReturns;
+  std::vector<ValType> ExpParams, GotParams;
+  std::vector<ValType> ExpReturns, GotReturns;
 
   /// Case 7 & 8: unexpected table or memory limit
-  FullRefType ExpRefType, GotRefType;
+  RefType ExpRefType, GotRefType;
   bool ExpLimHasMax, GotLimHasMax;
   uint32_t ExpLimMin, GotLimMin;
   uint32_t ExpLimMax, GotLimMax;
 
   /// Case 2: unexpected value type
   /// Case 9: unexpected global type: value type
-  FullValType ExpValType, GotValType;
+  ValType ExpValType, GotValType;
   /// Case 4: unexpected mutation settings
   /// Case 9: unexpected global type: value mutation
   ValMut ExpValMut, GotValMut;
@@ -257,7 +257,7 @@ struct InfoInstruction {
   InfoInstruction() = delete;
   InfoInstruction(const OpCode Op, const uint64_t Off,
                   const std::vector<ValVariant> &ArgsVec = {},
-                  const std::vector<FullValType> &ArgsTypesVec = {},
+                  const std::vector<ValType> &ArgsTypesVec = {},
                   const bool Signed = false) noexcept
       : Code(Op), Offset(Off), Args(ArgsVec), ArgsTypes(ArgsTypesVec),
         IsSigned(Signed) {}
@@ -268,7 +268,7 @@ struct InfoInstruction {
   OpCode Code;
   uint64_t Offset;
   std::vector<ValVariant> Args;
-  std::vector<FullValType> ArgsTypes;
+  std::vector<ValType> ArgsTypes;
   bool IsSigned;
 };
 

--- a/include/common/types.h
+++ b/include/common/types.h
@@ -50,6 +50,251 @@ using uint8x16_t [[gnu::vector_size(16)]] = uint8_t;
 using doublex2_t [[gnu::vector_size(16)]] = double;
 using floatx4_t [[gnu::vector_size(16)]] = float;
 
+// The bit pattern of the value types:
+// -----------------------------------------------------------------------
+//  byte | 0-th | 1-st |     2-nd    |     3-rd     |     4-th ~ 7-th
+// ------|-------------|-------------|--------------|---------------------
+//       |             | ValTypeCode | HeapTypeCode |     Type index
+//       |             | 0x7F, 0x7E, | 0x6F or 0x70 |     (uint32_t)
+//  code |  Reserved   | 0x7D, 0x7C, |              |
+//       |  (Padding)  | 0x7B, 0x6B, |        For the HeapType use
+//       |             | or 0x6C     |    (Function references proposal)
+// -----------------------------------------------------------------------
+// Due to compress the whole value types into uint64_t length, WasmEdge
+// implements the HeapType into the RefType and ValType classes.
+// As the definitions in the function references proposal, the `FuncRef` and
+// `ExternRef` are reinterpreted as the `ref.null` types, respectively.
+// Therefore, WasmEdge hendles them into `ref null func` and `ref null extern`
+// in the ValType classes.
+
+/// HeapTypeCode enumeration class.
+enum class HeapTypeCode : uint8_t {
+  // This enum class is for the internal use only.
+  NotHeapType = 0x00,
+  Extern = 0x6F,
+  Func = 0x70,
+  TypeIndex = 0xFF,
+};
+
+/// TypeBase definition. The basic data structure of value types.
+class ValTypeBase {
+public:
+  // Note: The padding bytes are reserved and should not be written.
+  ValTypeBase() noexcept = default;
+  ValTypeBase(ValTypeCode C, HeapTypeCode HT, uint32_t I) noexcept {
+    Inner.Data.Code = C;
+    Inner.Data.HTCode = HT;
+    Inner.Data.Idx = I;
+  }
+  ValTypeBase(uint64_t R) noexcept { Inner.Raw = R; }
+
+  friend bool operator==(const ValTypeBase &LHS,
+                         const ValTypeBase &RHS) noexcept {
+    return (LHS.Inner.Data.Code == RHS.Inner.Data.Code) &&
+           (LHS.Inner.Data.HTCode == RHS.Inner.Data.HTCode) &&
+           (LHS.Inner.Data.Idx == RHS.Inner.Data.Idx);
+  }
+  friend bool operator!=(const ValTypeBase &LHS,
+                         const ValTypeBase &RHS) noexcept {
+    return !(LHS == RHS);
+  }
+
+  ValTypeCode getCode() const noexcept { return Inner.Data.Code; }
+  HeapTypeCode getHeapTypeCode() const noexcept { return Inner.Data.HTCode; }
+  uint32_t getTypeIndex() const noexcept { return Inner.Data.Idx; }
+  uint64_t getRawData() const noexcept { return Inner.Raw; }
+
+  bool isNumType() const noexcept {
+    switch (Inner.Data.Code) {
+    case ValTypeCode::I32:
+    case ValTypeCode::I64:
+    case ValTypeCode::F32:
+    case ValTypeCode::F64:
+    case ValTypeCode::V128:
+      return true;
+    default:
+      return false;
+    }
+  }
+
+  bool isRefType() const noexcept {
+    switch (Inner.Data.Code) {
+    case ValTypeCode::Ref:
+    case ValTypeCode::RefNull:
+      return true;
+    default:
+      return false;
+    }
+  }
+
+  bool isFuncRefType() const noexcept {
+    return (Inner.Data.HTCode == HeapTypeCode::Func);
+  }
+
+  bool isExternRefType() const noexcept {
+    return (Inner.Data.HTCode == HeapTypeCode::Extern);
+  }
+
+  bool isNullableRefType() const noexcept {
+    return (Inner.Data.Code == ValTypeCode::RefNull);
+  }
+
+protected:
+  union {
+    uint64_t Raw;
+    struct {
+      uint8_t Paddings[2];
+      ValTypeCode Code;
+      HeapTypeCode HTCode;
+      uint32_t Idx;
+    } Data;
+  } Inner;
+};
+
+/// RefType definition. The RefType is the subset of the ValType.
+class RefType : public ValTypeBase {
+public:
+  RefType() noexcept = default;
+  // Constructor for the old type of externref and funcref.
+  RefType(RefTypeCode C) noexcept
+      : ValTypeBase(ValTypeCode::RefNull, static_cast<HeapTypeCode>(C), 0) {
+    assuming(Inner.Data.Code == ValTypeCode::RefNull);
+    assuming((Inner.Data.HTCode == HeapTypeCode::Func) ||
+             (Inner.Data.HTCode == HeapTypeCode::Extern));
+  }
+  // Constructor for the heap types (func and extern).
+  RefType(RefTypeCode C, HeapTypeCode HT) noexcept
+      : ValTypeBase(static_cast<ValTypeCode>(C), HT, 0) {
+    assuming((Inner.Data.Code == ValTypeCode::Ref) ||
+             (Inner.Data.Code == ValTypeCode::RefNull));
+    assuming((Inner.Data.HTCode == HeapTypeCode::Func) ||
+             (Inner.Data.HTCode == HeapTypeCode::Extern));
+  }
+  // Constructor for the heap types (type index).
+  RefType(RefTypeCode C, uint32_t I) noexcept
+      : ValTypeBase(static_cast<ValTypeCode>(C), HeapTypeCode::TypeIndex, I) {
+    assuming((Inner.Data.Code == ValTypeCode::Ref) ||
+             (Inner.Data.Code == ValTypeCode::RefNull));
+  }
+  // Constructor for setting the raw data.
+  RefType(uint64_t R) noexcept : ValTypeBase(R) {}
+};
+
+/// ValType definition.
+class ValType : public ValTypeBase {
+public:
+  ValType() noexcept = default;
+  // Constructor for the value type codes without heap type immediates.
+  ValType(ValTypeCode C) noexcept
+      : ValTypeBase(C, HeapTypeCode::NotHeapType, 0) {
+    switch (C) {
+    case ValTypeCode::I32:
+    case ValTypeCode::I64:
+    case ValTypeCode::F32:
+    case ValTypeCode::F64:
+    case ValTypeCode::V128:
+      break;
+    case ValTypeCode::ExternRef:
+    case ValTypeCode::FuncRef:
+      Inner.Data.HTCode = static_cast<HeapTypeCode>(Inner.Data.Code);
+      Inner.Data.Code = ValTypeCode::RefNull;
+      break;
+    case ValTypeCode::Ref:
+    case ValTypeCode::RefNull:
+    default:
+      assumingUnreachable();
+    }
+  }
+  // Constructor for the number type codes.
+  ValType(NumTypeCode C) noexcept
+      : ValTypeBase(static_cast<ValTypeCode>(C), HeapTypeCode::NotHeapType, 0) {
+  }
+  // Constructor for the reference type codes without heap type immediates.
+  ValType(RefTypeCode C) noexcept
+      : ValTypeBase(ValTypeCode::RefNull, static_cast<HeapTypeCode>(C), 0) {
+    assuming(Inner.Data.Code == ValTypeCode::RefNull);
+    assuming((Inner.Data.HTCode == HeapTypeCode::Func) ||
+             (Inner.Data.HTCode == HeapTypeCode::Extern));
+  }
+  // Constructor for the heap types (func and extern).
+  ValType(RefTypeCode C, HeapTypeCode HT) noexcept
+      : ValTypeBase(static_cast<ValTypeCode>(C), HT, 0) {
+    assuming((Inner.Data.Code == ValTypeCode::Ref) ||
+             (Inner.Data.Code == ValTypeCode::RefNull));
+    assuming((Inner.Data.HTCode == HeapTypeCode::Func) ||
+             (Inner.Data.HTCode == HeapTypeCode::Extern));
+  }
+  // Constructor for the heap types (type index).
+  ValType(RefTypeCode C, uint32_t I) noexcept
+      : ValTypeBase(static_cast<ValTypeCode>(C), HeapTypeCode::TypeIndex, I) {
+    assuming((Inner.Data.Code == ValTypeCode::Ref) ||
+             (Inner.Data.Code == ValTypeCode::RefNull));
+  }
+  // Constructor for the RefTypes.
+  ValType(const RefType &RType) noexcept
+      : ValTypeBase(RType.getCode(), RType.getHeapTypeCode(),
+                    RType.getTypeIndex()) {}
+  // Constructor for setting the raw data.
+  ValType(uint64_t R) noexcept : ValTypeBase(R) {}
+
+  RefType toRefType() const noexcept {
+    assuming(isRefType());
+    return RefType(Inner.Raw);
+  }
+};
+
+/// BlockType definition.
+class BlockType {
+public:
+  // Note: The BlockType should be compressed into 8 bytes to reduce the
+  // insturction class size.
+  enum class TypeEnum : uint8_t {
+    Empty,
+    ValType,
+    TypeIdx,
+  };
+
+  BlockType() noexcept = default;
+  BlockType(const ValType &VType) noexcept { setData(VType); }
+  BlockType(uint32_t Idx) noexcept { setData(Idx); }
+
+  void setEmpty() noexcept { Inner.Data.TypeFlag = TypeEnum::Empty; }
+  void setData(const ValType &VType) noexcept {
+    Inner.Type = VType;
+    Inner.Data.TypeFlag = TypeEnum::ValType;
+  }
+  void setData(uint32_t Idx) noexcept {
+    Inner.Data.Idx = Idx;
+    Inner.Data.TypeFlag = TypeEnum::TypeIdx;
+  }
+  bool isEmpty() const noexcept {
+    return Inner.Data.TypeFlag == TypeEnum::Empty;
+  }
+  bool isValType() const noexcept {
+    return Inner.Data.TypeFlag == TypeEnum::ValType;
+  }
+  ValType getValType() const noexcept { return Inner.Type; }
+  uint32_t getTypeIndex() const noexcept { return Inner.Data.Idx; }
+
+private:
+  // The ValType has reserved the padding 2 bytes.
+  // Therefore, use the first byte to store the flag.
+  union {
+    // The ValType has 8 bytes length.
+    ValType Type;
+    // The Data struct has 8 bytes length.
+    struct {
+      TypeEnum TypeFlag;
+      uint8_t Paddings[3];
+      uint32_t Idx;
+    } Data;
+  } Inner;
+};
+
+// <<<<<<<< Type definitions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>> Value definitions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
 /// UnknownRef definition.
 struct UnknownRef {
   uint64_t Value = 0;
@@ -79,7 +324,7 @@ struct ExternRef {
   template <typename T> ExternRef(T *P) : Ptr(reinterpret_cast<void *>(P)) {}
 };
 
-/// NumType and RefType variant definitions.
+/// Value variant definitions.
 using RefVariant = Variant<UnknownRef, FuncRef, ExternRef>;
 using ValVariant =
     Variant<uint32_t, int32_t, uint64_t, int64_t, float, double, uint128_t,
@@ -87,35 +332,7 @@ using ValVariant =
             int16x8_t, uint8x16_t, int8x16_t, floatx4_t, doublex2_t, UnknownRef,
             FuncRef, ExternRef>;
 
-/// BlockType definition.
-struct BlockType {
-  enum class TypeEnum : uint8_t {
-    Empty,
-    ValType,
-    TypeIdx,
-  };
-  TypeEnum TypeFlag;
-  union {
-    FullValType Type;
-    uint32_t Idx;
-  } Data;
-  BlockType() = default;
-  BlockType(FullValType VType) { setData(VType); }
-  BlockType(uint32_t Idx) { setData(Idx); }
-  void setEmpty() { TypeFlag = TypeEnum::Empty; }
-  void setData(FullValType VType) {
-    TypeFlag = TypeEnum::ValType;
-    Data.Type = VType;
-  }
-  void setData(uint32_t Idx) {
-    TypeFlag = TypeEnum::TypeIdx;
-    Data.Idx = Idx;
-  }
-  bool isEmpty() const { return TypeFlag == TypeEnum::Empty; }
-  bool isValType() const { return TypeFlag == TypeEnum::ValType; }
-};
-
-// <<<<<<<< Type definitions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+// <<<<<<<< Value definitions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 // >>>>>>>> Const expressions to checking value types >>>>>>>>>>>>>>>>>>>>>>>>>>
 
@@ -217,45 +434,45 @@ toUnsigned(T Val) {
 
 // >>>>>>>> Template to get value type from type >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-template <typename T> inline FullValType ValTypeFromType() noexcept;
+template <typename T> inline ValType ValTypeFromType() noexcept;
 
-template <> inline FullValType ValTypeFromType<uint32_t>() noexcept {
-  return FullValType(ValType::I32);
+template <> inline ValType ValTypeFromType<uint32_t>() noexcept {
+  return ValType(ValTypeCode::I32);
 }
-template <> inline FullValType ValTypeFromType<int32_t>() noexcept {
-  return FullValType(ValType::I32);
+template <> inline ValType ValTypeFromType<int32_t>() noexcept {
+  return ValType(ValTypeCode::I32);
 }
-template <> inline FullValType ValTypeFromType<uint64_t>() noexcept {
-  return FullValType(ValType::I64);
+template <> inline ValType ValTypeFromType<uint64_t>() noexcept {
+  return ValType(ValTypeCode::I64);
 }
-template <> inline FullValType ValTypeFromType<int64_t>() noexcept {
-  return FullValType(ValType::I64);
+template <> inline ValType ValTypeFromType<int64_t>() noexcept {
+  return ValType(ValTypeCode::I64);
 }
-template <> inline FullValType ValTypeFromType<uint128_t>() noexcept {
-  return FullValType(ValType::V128);
+template <> inline ValType ValTypeFromType<uint128_t>() noexcept {
+  return ValType(ValTypeCode::V128);
 }
-template <> inline FullValType ValTypeFromType<int128_t>() noexcept {
-  return FullValType(ValType::V128);
+template <> inline ValType ValTypeFromType<int128_t>() noexcept {
+  return ValType(ValTypeCode::V128);
 }
-template <> inline FullValType ValTypeFromType<float>() noexcept {
-  return FullValType(ValType::F32);
+template <> inline ValType ValTypeFromType<float>() noexcept {
+  return ValType(ValTypeCode::F32);
 }
-template <> inline FullValType ValTypeFromType<double>() noexcept {
-  return FullValType(ValType::F64);
+template <> inline ValType ValTypeFromType<double>() noexcept {
+  return ValType(ValTypeCode::F64);
 }
-template <> inline FullValType ValTypeFromType<FuncRef>() noexcept {
-  return FullValType(ValType::FuncRef);
+template <> inline ValType ValTypeFromType<FuncRef>() noexcept {
+  return ValType(ValTypeCode::FuncRef);
 }
-template <> inline FullValType ValTypeFromType<ExternRef>() noexcept {
-  return FullValType(ValType::ExternRef);
+template <> inline ValType ValTypeFromType<ExternRef>() noexcept {
+  return ValType(ValTypeCode::ExternRef);
 }
 
 // <<<<<<<< Template to get value type from type <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 // >>>>>>>> Const expression to generate value from value type >>>>>>>>>>>>>>>>>
 
-inline ValVariant ValueFromType(FullValType Type) noexcept {
-  switch (Type.getTypeCode()) {
+inline ValVariant ValueFromType(ValType Type) noexcept {
+  switch (Type.getCode()) {
   case ValTypeCode::I32:
     return uint32_t(0U);
   case ValTypeCode::I64:
@@ -266,6 +483,8 @@ inline ValVariant ValueFromType(FullValType Type) noexcept {
     return double(0.0);
   case ValTypeCode::V128:
     return uint128_t(0U);
+  case ValTypeCode::FuncRef:
+  case ValTypeCode::ExternRef:
   case ValTypeCode::Ref:
   case ValTypeCode::RefNull:
     return UnknownRef();

--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -127,9 +127,9 @@ public:
                               const Runtime::Instance::ModuleInstance &ModInst);
 
   /// Invoke a WASM function by function instance.
-  Expect<std::vector<std::pair<ValVariant, FullValType>>>
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
   invoke(const Runtime::Instance::FunctionInstance &FuncInst,
-         Span<const ValVariant> Params, Span<const FullValType> ParamTypes);
+         Span<const ValVariant> Params, Span<const ValType> ParamTypes);
 
   /// Register new thread
   void newThread() noexcept {

--- a/include/loader/loader.h
+++ b/include/loader/loader.h
@@ -194,10 +194,10 @@ private:
   Expect<void> loadSegment(AST::DataSegment &DataSeg);
   Expect<void> loadDesc(AST::ImportDesc &ImpDesc);
   Expect<void> loadDesc(AST::ExportDesc &ExpDesc);
+  Expect<RefType> loadHeapType(RefTypeCode Code, ASTNodeAttr From);
+  Expect<ValType> loadValType(ASTNodeAttr From);
+  Expect<RefType> loadRefType(ASTNodeAttr From);
   Expect<void> loadLimit(AST::Limit &Lim);
-  Expect<FullValType> loadFullValType();
-  Expect<FullValType> loadFullValType(uint8_t TypeCode);
-  Expect<FullRefType> loadFullRefType();
   Expect<void> loadType(AST::FunctionType &FuncType);
   Expect<void> loadType(AST::MemoryType &MemType);
   Expect<void> loadType(AST::TableType &TabType);

--- a/include/runtime/instance/elem.h
+++ b/include/runtime/instance/elem.h
@@ -25,7 +25,7 @@ namespace Instance {
 class ElementInstance {
 public:
   ElementInstance() = delete;
-  ElementInstance(const uint32_t Offset, const FullRefType EType,
+  ElementInstance(const uint32_t Offset, const RefType &EType,
                   Span<const RefVariant> Init) noexcept
       : Off(Offset), Type(EType), Refs(Init.begin(), Init.end()) {}
 
@@ -33,7 +33,7 @@ public:
   uint32_t getOffset() const noexcept { return Off; }
 
   /// Get reference type of element instance.
-  FullRefType getRefType() const noexcept { return Type; }
+  const RefType &getRefType() const noexcept { return Type; }
 
   /// Get reference lists in element instance.
   Span<const RefVariant> getRefs() const noexcept { return Refs; }
@@ -45,7 +45,7 @@ private:
   /// \name Data of element instance.
   /// @{
   const uint32_t Off;
-  const FullRefType Type;
+  const RefType Type;
   std::vector<RefVariant> Refs;
   /// @}
 };

--- a/include/runtime/instance/function.h
+++ b/include/runtime/instance/function.h
@@ -39,7 +39,7 @@ public:
         Data(std::move(Inst.Data)) {}
   /// Constructor for native function.
   FunctionInstance(const ModuleInstance *Mod, const AST::FunctionType &Type,
-                   Span<const std::pair<uint32_t, FullValType>> Locs,
+                   Span<const std::pair<uint32_t, ValType>> Locs,
                    AST::InstrView Expr) noexcept
       : ModInst(Mod), FuncType(Type),
         Data(std::in_place_type_t<WasmFunction>(), Locs, Expr) {}
@@ -77,7 +77,7 @@ public:
   const AST::FunctionType &getFuncType() const noexcept { return FuncType; }
 
   /// Getter of function local variables.
-  Span<const std::pair<uint32_t, FullValType>> getLocals() const noexcept {
+  Span<const std::pair<uint32_t, ValType>> getLocals() const noexcept {
     return std::get_if<WasmFunction>(&Data)->Locals;
   }
 
@@ -107,10 +107,10 @@ public:
 
 private:
   struct WasmFunction {
-    const std::vector<std::pair<uint32_t, FullValType>> Locals;
+    const std::vector<std::pair<uint32_t, ValType>> Locals;
     const uint32_t LocalNum;
     AST::InstrVec Instrs;
-    WasmFunction(Span<const std::pair<uint32_t, FullValType>> Locs,
+    WasmFunction(Span<const std::pair<uint32_t, ValType>> Locs,
                  AST::InstrView Expr) noexcept
         : Locals(Locs.begin(), Locs.end()),
           LocalNum(

--- a/include/validator/formchecker.h
+++ b/include/validator/formchecker.h
@@ -28,7 +28,7 @@
 namespace WasmEdge {
 namespace Validator {
 
-typedef std::optional<FullValType> VType;
+typedef std::optional<ValType> VType;
 
 static inline constexpr VType unreachableVType() { return VType(); }
 
@@ -46,7 +46,7 @@ public:
   ~FormChecker() = default;
 
   void reset(bool CleanGlobal = false);
-  Expect<void> validate(AST::InstrView Instrs, Span<const FullValType> RetVals);
+  Expect<void> validate(AST::InstrView Instrs, Span<const ValType> RetVals);
   Expect<void> validate(AST::InstrView Instrs, Span<const VType> RetVals);
 
   /// Adder of contexts
@@ -58,7 +58,7 @@ public:
   void addElem(const AST::ElementSegment &Elem);
   void addData(const AST::DataSegment &Data);
   void addRef(const uint32_t FuncIdx);
-  void addLocal(const FullValType &V);
+  void addLocal(const ValType &V);
   void addLocal(const VType &V);
 
   std::vector<VType> result() { return ValStack; }
@@ -71,7 +71,7 @@ public:
   uint32_t getNumImportGlobals() const { return NumImportGlobals; }
 
   /// Helper function
-  FullValType VTypeToAST(const VType &V);
+  ValType VTypeToAST(const VType &V);
 
   struct CtrlFrame {
     CtrlFrame() = default;
@@ -122,10 +122,10 @@ private:
   /// Contexts.
   std::vector<std::pair<std::vector<VType>, std::vector<VType>>> Types;
   std::vector<uint32_t> Funcs;
-  std::vector<FullRefType> Tables;
+  std::vector<RefType> Tables;
   uint32_t Mems = 0;
   std::vector<std::pair<VType, ValMut>> Globals;
-  std::vector<FullRefType> Elems;
+  std::vector<RefType> Elems;
   std::vector<uint32_t> Datas;
   std::unordered_set<uint32_t> Refs;
   uint32_t NumImportFuncs = 0;

--- a/include/validator/validator.h
+++ b/include/validator/validator.h
@@ -65,7 +65,7 @@ private:
 
   /// Validate const expression
   Expect<void> validateConstExpr(AST::InstrView Instrs,
-                                 Span<const FullValType> Returns);
+                                 Span<const ValType> Returns);
 
   static inline const uint32_t LIMIT_MEMORYTYPE = 1U << 16;
   /// Proposal configure

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -69,40 +69,40 @@ public:
   }
 
   /// Rapidly load, validate, instantiate, and run wasm function.
-  Expect<std::vector<std::pair<ValVariant, FullValType>>>
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
   runWasmFile(const std::filesystem::path &Path, std::string_view Func,
               Span<const ValVariant> Params = {},
-              Span<const FullValType> ParamTypes = {}) {
+              Span<const ValType> ParamTypes = {}) {
     std::unique_lock Lock(Mutex);
     return unsafeRunWasmFile(Path, Func, Params, ParamTypes);
   }
-  Expect<std::vector<std::pair<ValVariant, FullValType>>>
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
   runWasmFile(Span<const Byte> Code, std::string_view Func,
               Span<const ValVariant> Params = {},
-              Span<const FullValType> ParamTypes = {}) {
+              Span<const ValType> ParamTypes = {}) {
     std::unique_lock Lock(Mutex);
     return unsafeRunWasmFile(Code, Func, Params, ParamTypes);
   }
-  Expect<std::vector<std::pair<ValVariant, FullValType>>>
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
   runWasmFile(const AST::Module &Module, std::string_view Func,
               Span<const ValVariant> Params = {},
-              Span<const FullValType> ParamTypes = {}) {
+              Span<const ValType> ParamTypes = {}) {
     std::unique_lock Lock(Mutex);
     return unsafeRunWasmFile(Module, Func, Params, ParamTypes);
   }
 
-  Async<Expect<std::vector<std::pair<ValVariant, FullValType>>>>
+  Async<Expect<std::vector<std::pair<ValVariant, ValType>>>>
   asyncRunWasmFile(const std::filesystem::path &Path, std::string_view Func,
                    Span<const ValVariant> Params = {},
-                   Span<const FullValType> ParamTypes = {});
-  Async<Expect<std::vector<std::pair<ValVariant, FullValType>>>>
+                   Span<const ValType> ParamTypes = {});
+  Async<Expect<std::vector<std::pair<ValVariant, ValType>>>>
   asyncRunWasmFile(Span<const Byte> Code, std::string_view Func,
                    Span<const ValVariant> Params = {},
-                   Span<const FullValType> ParamTypes = {});
-  Async<Expect<std::vector<std::pair<ValVariant, FullValType>>>>
+                   Span<const ValType> ParamTypes = {});
+  Async<Expect<std::vector<std::pair<ValVariant, ValType>>>>
   asyncRunWasmFile(const AST::Module &Module, std::string_view Func,
                    Span<const ValVariant> Params = {},
-                   Span<const FullValType> ParamTypes = {});
+                   Span<const ValType> ParamTypes = {});
 
   /// Load given wasm file, wasm bytecode, or wasm module.
   Expect<void> loadWasm(const std::filesystem::path &Path) {
@@ -134,32 +134,32 @@ public:
 
   /// ======= Functions can be called after instantiated stage. =======
   /// Execute wasm with given input.
-  Expect<std::vector<std::pair<ValVariant, FullValType>>>
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
   execute(std::string_view Func, Span<const ValVariant> Params = {},
-          Span<const FullValType> ParamTypes = {}) {
+          Span<const ValType> ParamTypes = {}) {
     std::shared_lock Lock(Mutex);
     return unsafeExecute(Func, Params, ParamTypes);
   }
 
   /// Execute function of registered module with given input.
-  Expect<std::vector<std::pair<ValVariant, FullValType>>>
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
   execute(std::string_view ModName, std::string_view Func,
           Span<const ValVariant> Params = {},
-          Span<const FullValType> ParamTypes = {}) {
+          Span<const ValType> ParamTypes = {}) {
     std::shared_lock Lock(Mutex);
     return unsafeExecute(ModName, Func, Params, ParamTypes);
   }
 
   /// Asynchronous execute wasm with given input.
-  Async<Expect<std::vector<std::pair<ValVariant, FullValType>>>>
+  Async<Expect<std::vector<std::pair<ValVariant, ValType>>>>
   asyncExecute(std::string_view Func, Span<const ValVariant> Params = {},
-               Span<const FullValType> ParamTypes = {});
+               Span<const ValType> ParamTypes = {});
 
   /// Asynchronous execute function of registered module with given input.
-  Async<Expect<std::vector<std::pair<ValVariant, FullValType>>>>
+  Async<Expect<std::vector<std::pair<ValVariant, ValType>>>>
   asyncExecute(std::string_view ModName, std::string_view Func,
                Span<const ValVariant> Params = {},
-               Span<const FullValType> ParamTypes = {});
+               Span<const ValType> ParamTypes = {});
 
   /// Register new thread
   void newThread() noexcept { ExecutorEngine.newThread(); }
@@ -221,18 +221,18 @@ private:
   Expect<void>
   unsafeRegisterModule(const Runtime::Instance::ModuleInstance &ModInst);
 
-  Expect<std::vector<std::pair<ValVariant, FullValType>>>
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
   unsafeRunWasmFile(const std::filesystem::path &Path, std::string_view Func,
                     Span<const ValVariant> Params = {},
-                    Span<const FullValType> ParamTypes = {});
-  Expect<std::vector<std::pair<ValVariant, FullValType>>>
+                    Span<const ValType> ParamTypes = {});
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
   unsafeRunWasmFile(Span<const Byte> Code, std::string_view Func,
                     Span<const ValVariant> Params = {},
-                    Span<const FullValType> ParamTypes = {});
-  Expect<std::vector<std::pair<ValVariant, FullValType>>>
+                    Span<const ValType> ParamTypes = {});
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
   unsafeRunWasmFile(const AST::Module &Module, std::string_view Func,
                     Span<const ValVariant> Params = {},
-                    Span<const FullValType> ParamTypes = {});
+                    Span<const ValType> ParamTypes = {});
 
   Expect<void> unsafeLoadWasm(const std::filesystem::path &Path);
   Expect<void> unsafeLoadWasm(Span<const Byte> Code);
@@ -242,14 +242,14 @@ private:
 
   Expect<void> unsafeInstantiate();
 
-  Expect<std::vector<std::pair<ValVariant, FullValType>>>
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
   unsafeExecute(std::string_view Func, Span<const ValVariant> Params = {},
-                Span<const FullValType> ParamTypes = {});
+                Span<const ValType> ParamTypes = {});
 
-  Expect<std::vector<std::pair<ValVariant, FullValType>>>
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
   unsafeExecute(std::string_view Mod, std::string_view Func,
                 Span<const ValVariant> Params = {},
-                Span<const FullValType> ParamTypes = {});
+                Span<const ValType> ParamTypes = {});
 
   void unsafeCleanup();
 
@@ -270,10 +270,10 @@ private:
   void unsafeRegisterPlugInHosts();
 
   /// Helper function for execution.
-  Expect<std::vector<std::pair<ValVariant, FullValType>>>
+  Expect<std::vector<std::pair<ValVariant, ValType>>>
   unsafeExecute(const Runtime::Instance::ModuleInstance *ModInst,
                 std::string_view Func, Span<const ValVariant> Params = {},
-                Span<const FullValType> ParamTypes = {});
+                Span<const ValType> ParamTypes = {});
 
   /// \name VM environment.
   /// @{

--- a/lib/aot/compiler.cpp
+++ b/lib/aot/compiler.cpp
@@ -111,20 +111,20 @@ static inline auto elementCount(llvm::VectorType *VectorTy) noexcept {
 #endif
 }
 
-static bool isVoidReturn(WasmEdge::Span<const WasmEdge::FullValType> ValTypes);
+static bool isVoidReturn(WasmEdge::Span<const WasmEdge::ValType> ValTypes);
 static llvm::Type *toLLVMType(llvm::LLVMContext &LLContext,
-                              const WasmEdge::FullValType &ValType);
+                              const WasmEdge::ValType &ValType);
 static std::vector<llvm::Type *>
 toLLVMArgsType(llvm::PointerType *ExecCtxPtrTy,
-               WasmEdge::Span<const WasmEdge::FullValType> ValTypes);
+               WasmEdge::Span<const WasmEdge::ValType> ValTypes);
 static llvm::Type *
 toLLVMRetsType(llvm::LLVMContext &LLContext,
-               WasmEdge::Span<const WasmEdge::FullValType> ValTypes);
+               WasmEdge::Span<const WasmEdge::ValType> ValTypes);
 static llvm::FunctionType *
 toLLVMType(llvm::PointerType *ExecCtxPtrTy,
            const WasmEdge::AST::FunctionType &FuncType);
 static llvm::Constant *toLLVMConstantZero(llvm::LLVMContext &LLContext,
-                                          const WasmEdge::FullValType &ValType);
+                                          const WasmEdge::ValType &ValType);
 static std::vector<llvm::Value *> unpackStruct(llvm::IRBuilder<> &Builder,
                                                llvm::Value *Struct);
 static llvm::Value *createLikely(llvm::IRBuilder<> &Builder,
@@ -431,18 +431,18 @@ struct WasmEdge::AOT::Compiler::CompileContext {
     return llvm::FunctionCallee(Ty,
                                 Builder.CreateLoad(Ty->getPointerTo(), Ptr));
   }
-  std::pair<std::vector<FullValType>, std::vector<FullValType>>
+  std::pair<std::vector<ValType>, std::vector<ValType>>
   resolveBlockType(const BlockType &BType) const {
-    using VecT = std::vector<FullValType>;
+    using VecT = std::vector<ValType>;
     using RetT = std::pair<VecT, VecT>;
     if (BType.isEmpty()) {
       return RetT{};
     }
     if (BType.isValType()) {
-      return RetT{{}, {BType.Data.Type}};
+      return RetT{{}, {BType.getValType()}};
     } else {
       // Type index case. t2* = type[index].returns
-      const uint32_t TypeIdx = BType.Data.Idx;
+      const uint32_t TypeIdx = BType.getTypeIndex();
       const auto &FType = *FunctionTypes[TypeIdx];
       return RetT{
           VecT(FType.getParamTypes().begin(), FType.getParamTypes().end()),
@@ -455,13 +455,13 @@ namespace {
 
 using namespace WasmEdge;
 
-static bool isVoidReturn(Span<const WasmEdge::FullValType> ValTypes) {
+static bool isVoidReturn(Span<const WasmEdge::ValType> ValTypes) {
   return ValTypes.empty();
 }
 
 static llvm::Type *toLLVMType(llvm::LLVMContext &LLContext,
-                              const FullValType &ValType) {
-  switch (ValType.getTypeCode()) {
+                              const ValType &ValType) {
+  switch (ValType.getCode()) {
   case ValTypeCode::I32:
     return llvm::Type::getInt32Ty(LLContext);
   case ValTypeCode::I64:
@@ -480,8 +480,7 @@ static llvm::Type *toLLVMType(llvm::LLVMContext &LLContext,
 }
 
 static std::vector<llvm::Type *>
-toLLVMTypeVector(llvm::LLVMContext &LLContext,
-                 Span<const FullValType> ValTypes) {
+toLLVMTypeVector(llvm::LLVMContext &LLContext, Span<const ValType> ValTypes) {
   std::vector<llvm::Type *> Result;
   Result.reserve(ValTypes.size());
   for (const auto &Type : ValTypes) {
@@ -490,16 +489,15 @@ toLLVMTypeVector(llvm::LLVMContext &LLContext,
   return Result;
 }
 
-static std::vector<llvm::Type *>
-toLLVMArgsType(llvm::PointerType *ExecCtxPtrTy,
-               Span<const FullValType> ValTypes) {
+static std::vector<llvm::Type *> toLLVMArgsType(llvm::PointerType *ExecCtxPtrTy,
+                                                Span<const ValType> ValTypes) {
   auto Result = toLLVMTypeVector(ExecCtxPtrTy->getContext(), ValTypes);
   Result.insert(Result.begin(), ExecCtxPtrTy);
   return Result;
 }
 
 static llvm::Type *toLLVMRetsType(llvm::LLVMContext &LLContext,
-                                  Span<const FullValType> ValTypes) {
+                                  Span<const ValType> ValTypes) {
   if (isVoidReturn(ValTypes)) {
     return llvm::Type::getVoidTy(LLContext);
   }
@@ -523,8 +521,8 @@ static llvm::FunctionType *toLLVMType(llvm::PointerType *ExecCtxPtrTy,
 }
 
 static llvm::Constant *toLLVMConstantZero(llvm::LLVMContext &LLContext,
-                                          const FullValType &ValType) {
-  switch (ValType.getTypeCode()) {
+                                          const ValType &ValType) {
+  switch (ValType.getCode()) {
   case ValTypeCode::I32:
     return llvm::ConstantInt::get(llvm::Type::getInt32Ty(LLContext), 0);
   case ValTypeCode::I64:
@@ -548,7 +546,7 @@ class FunctionCompiler {
 
 public:
   FunctionCompiler(AOT::Compiler::CompileContext &Context, llvm::Function *F,
-                   Span<const FullValType> Locals, bool Interruptible,
+                   Span<const ValType> Locals, bool Interruptible,
                    bool InstructionCounting, bool GasMeasuring, bool OptNone)
       : Context(Context), LLContext(Context.LLContext),
         Interruptible(Interruptible), OptNone(OptNone), F(F),
@@ -599,9 +597,8 @@ public:
     return BB;
   }
 
-  void
-  compile(const AST::CodeSegment &Code,
-          std::pair<std::vector<FullValType>, std::vector<FullValType>> Type) {
+  void compile(const AST::CodeSegment &Code,
+               std::pair<std::vector<ValType>, std::vector<ValType>> Type) {
     auto *RetBB = llvm::BasicBlock::Create(LLContext, "ret", F);
     Type.first.clear();
     enterBlock(RetBB, nullptr, nullptr, {}, std::move(Type));
@@ -4494,7 +4491,7 @@ private:
   void enterBlock(
       llvm::BasicBlock *JumpBlock, llvm::BasicBlock *NextBlock,
       llvm::BasicBlock *ElseBlock, std::vector<llvm::Value *> Args,
-      std::pair<std::vector<FullValType>, std::vector<FullValType>> Type,
+      std::pair<std::vector<ValType>, std::vector<ValType>> Type,
       std::vector<std::tuple<std::vector<llvm::Value *>, llvm::BasicBlock *>>
           ReturnPHI = {}) {
     assuming(Type.first.size() == Args.size());
@@ -4569,7 +4566,7 @@ private:
   }
 
   void buildPHI(
-      Span<const FullValType> RetType,
+      Span<const ValType> RetType,
       Span<const std::tuple<std::vector<llvm::Value *>, llvm::BasicBlock *>>
           Incomings) {
     if (isVoidReturn(RetType)) {
@@ -4660,13 +4657,13 @@ private:
     llvm::BasicBlock *NextBlock;
     llvm::BasicBlock *ElseBlock;
     std::vector<llvm::Value *> Args;
-    std::pair<std::vector<FullValType>, std::vector<FullValType>> Type;
+    std::pair<std::vector<ValType>, std::vector<ValType>> Type;
     std::vector<std::tuple<std::vector<llvm::Value *>, llvm::BasicBlock *>>
         ReturnPHI;
     Control(
         size_t S, bool U, llvm::BasicBlock *J, llvm::BasicBlock *N,
         llvm::BasicBlock *E, std::vector<llvm::Value *> A,
-        std::pair<std::vector<FullValType>, std::vector<FullValType>> T,
+        std::pair<std::vector<ValType>, std::vector<ValType>> T,
         std::vector<std::tuple<std::vector<llvm::Value *>, llvm::BasicBlock *>>
             R)
         : StackSize(S), Unreachable(U), JumpBlock(J), NextBlock(N),
@@ -5527,7 +5524,7 @@ void Compiler::compile(const AST::FunctionSection &FuncSec,
       continue;
     }
 
-    std::vector<FullValType> Locals;
+    std::vector<ValType> Locals;
     for (const auto &Local : Code->getLocals()) {
       for (unsigned I = 0; I < Local.first; ++I) {
         Locals.push_back(Local.second);

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -104,7 +104,7 @@ struct WasmEdge_Async {
   WasmEdge_Async(Args &&...Vals) noexcept
       : Async(std::forward<Args>(Vals)...) {}
   WasmEdge::VM::Async<WasmEdge::Expect<
-      std::vector<std::pair<WasmEdge::ValVariant, WasmEdge::FullValType>>>>
+      std::vector<std::pair<WasmEdge::ValVariant, WasmEdge::ValType>>>>
       Async;
 };
 
@@ -167,29 +167,29 @@ inline constexpr C to_WasmEdge_128_t(T Val) noexcept {
 
 // Helper functions for returning a WasmEdge_Value by various values.
 template <typename T> inline WasmEdge_Value genWasmEdge_Value(T Val) noexcept {
-  return WasmEdge_Value{.Value = to_uint128_t(ValVariant(Val).unwrap()),
-                        .Type = WasmEdge::ValTypeFromType<T>().asCStruct()};
+  return WasmEdge_Value{
+      .Value = to_uint128_t(ValVariant(Val).unwrap()),
+      .Type = {.Data = WasmEdge::ValTypeFromType<T>().getRawData()}};
 }
-inline WasmEdge_Value genWasmEdge_Value(ValVariant Val,
-                                        FullValType T) noexcept {
+inline WasmEdge_Value genWasmEdge_Value(ValVariant Val, ValType T) noexcept {
   return WasmEdge_Value{.Value = to_uint128_t(Val.unwrap()),
-                        .Type = T.asCStruct()};
+                        .Type = {.Data = T.getRawData()}};
 }
 
 // Helper function for converting a WasmEdge_Value array to a ValVariant
 // vector.
-inline std::pair<std::vector<ValVariant>, std::vector<FullValType>>
+inline std::pair<std::vector<ValVariant>, std::vector<ValType>>
 genParamPair(const WasmEdge_Value *Val, const uint32_t Len) noexcept {
   std::vector<ValVariant> VVec;
-  std::vector<FullValType> TVec;
+  std::vector<ValType> TVec;
   if (Val == nullptr) {
     return {VVec, TVec};
   }
   VVec.resize(Len);
   TVec.resize(Len);
   for (uint32_t I = 0; I < Len; I++) {
-    TVec[I] = Val[I].Type;
-    switch (TVec[I].getTypeCode()) {
+    TVec[I] = ValType(Val[I].Type.Data);
+    switch (TVec[I].getCode()) {
     case ValTypeCode::I32:
       VVec[I] = ValVariant::wrap<uint32_t>(
           to_WasmEdge_128_t<WasmEdge::uint128_t>(Val[I].Value));
@@ -212,21 +212,16 @@ genParamPair(const WasmEdge_Value *Val, const uint32_t Len) noexcept {
       break;
     case ValTypeCode::Ref:
     case ValTypeCode::RefNull: {
-      switch (TVec[I].asRefType().getHeapType().getHTypeCode()) {
-      case HeapTypeCode::Func: {
+      if (TVec[I].isFuncRefType()) {
         VVec[I] = ValVariant::wrap<FuncRef>(
             to_WasmEdge_128_t<WasmEdge::uint128_t>(Val[I].Value));
         break;
-      }
-      case HeapTypeCode::Extern: {
+      } else if (TVec[I].isExternRefType()) {
         VVec[I] = ValVariant::wrap<ExternRef>(
             to_WasmEdge_128_t<WasmEdge::uint128_t>(Val[I].Value));
         break;
       }
-      default:
-        assumingUnreachable();
-      }
-      break;
+      // TODO: Handle the type index case.
     }
       [[fallthrough]];
     default:
@@ -252,7 +247,7 @@ inline std::string_view genStrView(const WasmEdge_String S) noexcept {
 // Helper functions for converting a ValVariant vector to a WasmEdge_Value
 // array.
 inline constexpr void
-fillWasmEdge_ValueArr(Span<const std::pair<ValVariant, FullValType>> Vec,
+fillWasmEdge_ValueArr(Span<const std::pair<ValVariant, ValType>> Vec,
                       WasmEdge_Value *Val, const uint32_t Len) noexcept {
   if (Val == nullptr) {
     return;
@@ -399,7 +394,7 @@ public:
         Returns(FuncType.getReturnTypes().size());
     for (uint32_t I = 0; I < Args.size(); I++) {
       Params[I].Value = to_uint128_t(Args[I].get<WasmEdge::uint128_t>());
-      Params[I].Type = FuncType.getParamTypes()[I].asCStruct();
+      Params[I].Type.Data = FuncType.getParamTypes()[I].getRawData();
     }
     WasmEdge_Value *PPtr = Params.size() ? (&Params[0]) : nullptr;
     WasmEdge_Value *RPtr = Returns.size() ? (&Returns[0]) : nullptr;
@@ -474,6 +469,44 @@ WASMEDGE_CAPI_EXPORT void WasmEdge_LogOff(void) { WasmEdge::Log::setLogOff(); }
 
 // <<<<<<<< WasmEdge logging functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
+// >>>>>>>> WasmEdge valtype functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+WASMEDGE_CAPI_EXPORT WasmEdge_ValType WasmEdge_ValTypeGenI32() {
+  return WasmEdge_ValType{.Data = ValType(ValTypeCode::I32).getRawData()};
+}
+
+WASMEDGE_CAPI_EXPORT WasmEdge_ValType WasmEdge_ValTypeGenI64() {
+  return WasmEdge_ValType{.Data = ValType(ValTypeCode::I64).getRawData()};
+}
+
+WASMEDGE_CAPI_EXPORT WasmEdge_ValType WasmEdge_ValTypeGenF32() {
+  return WasmEdge_ValType{.Data = ValType(ValTypeCode::F32).getRawData()};
+}
+
+WASMEDGE_CAPI_EXPORT WasmEdge_ValType WasmEdge_ValTypeGenF64() {
+  return WasmEdge_ValType{.Data = ValType(ValTypeCode::F64).getRawData()};
+}
+
+WASMEDGE_CAPI_EXPORT WasmEdge_ValType WasmEdge_ValTypeGenV128() {
+  return WasmEdge_ValType{.Data = ValType(ValTypeCode::V128).getRawData()};
+}
+
+WASMEDGE_CAPI_EXPORT WasmEdge_ValType WasmEdge_ValTypeGenFuncRef() {
+  return WasmEdge_ValType{.Data = ValType(ValTypeCode::FuncRef).getRawData()};
+}
+
+WASMEDGE_CAPI_EXPORT WasmEdge_ValType WasmEdge_ValTypeGenExternRef() {
+  return WasmEdge_ValType{.Data = ValType(ValTypeCode::ExternRef).getRawData()};
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_ValTypeIsEqual(const WasmEdge_ValType ValType1,
+                        const WasmEdge_ValType ValType2) {
+  return ValType(ValType1.Data) == ValType(ValType2.Data);
+}
+
+// <<<<<<<< WasmEdge valtype functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
 // >>>>>>>> WasmEdge value functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 WASMEDGE_CAPI_EXPORT WasmEdge_Value WasmEdge_ValueGenI32(const int32_t Val) {
@@ -498,18 +531,18 @@ WasmEdge_ValueGenV128(const ::int128_t Val) {
 }
 
 WASMEDGE_CAPI_EXPORT WasmEdge_Value
-WasmEdge_ValueGenNullRef(const WasmEdge_RefType T) {
-  return genWasmEdge_Value(WasmEdge::UnknownRef(), static_cast<ValType>(T));
+WasmEdge_ValueGenNullRef(const enum WasmEdge_RefTypeCode T) {
+  return genWasmEdge_Value(WasmEdge::UnknownRef(), static_cast<ValTypeCode>(T));
 }
 
 WASMEDGE_CAPI_EXPORT WasmEdge_Value
 WasmEdge_ValueGenFuncRef(const WasmEdge_FunctionInstanceContext *Cxt) {
   return genWasmEdge_Value(WasmEdge::FuncRef(fromFuncCxt(Cxt)),
-                           ValType::FuncRef);
+                           ValTypeCode::FuncRef);
 }
 
 WASMEDGE_CAPI_EXPORT WasmEdge_Value WasmEdge_ValueGenExternRef(void *Ref) {
-  return genWasmEdge_Value(WasmEdge::ExternRef(Ref), ValType::ExternRef);
+  return genWasmEdge_Value(WasmEdge::ExternRef(Ref), ValTypeCode::ExternRef);
 }
 
 WASMEDGE_CAPI_EXPORT int32_t WasmEdge_ValueGetI32(const WasmEdge_Value Val) {
@@ -1023,20 +1056,20 @@ WasmEdge_ASTModuleDelete(WasmEdge_ASTModuleContext *Cxt) {
 // >>>>>>>> WasmEdge function type functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 WASMEDGE_CAPI_EXPORT WasmEdge_FunctionTypeContext *WasmEdge_FunctionTypeCreate(
-    const enum WasmEdge_ValType *ParamList, const uint32_t ParamLen,
-    const enum WasmEdge_ValType *ReturnList, const uint32_t ReturnLen) {
+    const WasmEdge_ValType *ParamList, const uint32_t ParamLen,
+    const WasmEdge_ValType *ReturnList, const uint32_t ReturnLen) {
   auto *Cxt = new WasmEdge::AST::FunctionType;
   if (ParamLen > 0) {
     Cxt->getParamTypes().resize(ParamLen);
   }
   for (uint32_t I = 0; I < ParamLen; I++) {
-    Cxt->getParamTypes()[I] = static_cast<WasmEdge::ValType>(ParamList[I]);
+    Cxt->getParamTypes()[I] = WasmEdge::ValType(ParamList[I].Data);
   }
   if (ReturnLen > 0) {
     Cxt->getReturnTypes().resize(ReturnLen);
   }
   for (uint32_t I = 0; I < ReturnLen; I++) {
-    Cxt->getReturnTypes()[I] = static_cast<WasmEdge::ValType>(ReturnList[I]);
+    Cxt->getReturnTypes()[I] = WasmEdge::ValType(ReturnList[I].Data);
   }
   return toFuncTypeCxt(Cxt);
 }
@@ -1055,8 +1088,8 @@ WasmEdge_FunctionTypeGetParameters(const WasmEdge_FunctionTypeContext *Cxt,
   if (Cxt) {
     for (uint32_t I = 0;
          I < fromFuncTypeCxt(Cxt)->getParamTypes().size() && I < Len; I++) {
-      List[I] = static_cast<WasmEdge_ValType>(
-          fromFuncTypeCxt(Cxt)->getParamTypes()[I].getTypeCode());
+      List[I] = WasmEdge_ValType{
+          .Data = fromFuncTypeCxt(Cxt)->getParamTypes()[I].getRawData()};
     }
     return static_cast<uint32_t>(fromFuncTypeCxt(Cxt)->getParamTypes().size());
   }
@@ -1077,8 +1110,8 @@ WasmEdge_FunctionTypeGetReturns(const WasmEdge_FunctionTypeContext *Cxt,
   if (Cxt) {
     for (uint32_t I = 0;
          I < fromFuncTypeCxt(Cxt)->getReturnTypes().size() && I < Len; I++) {
-      List[I] = static_cast<WasmEdge_ValType>(
-          fromFuncTypeCxt(Cxt)->getReturnTypes()[I].getTypeCode());
+      List[I] = WasmEdge_ValType{
+          .Data = fromFuncTypeCxt(Cxt)->getReturnTypes()[I].getRawData()};
     }
     return static_cast<uint32_t>(fromFuncTypeCxt(Cxt)->getReturnTypes().size());
   }
@@ -1095,24 +1128,28 @@ WasmEdge_FunctionTypeDelete(WasmEdge_FunctionTypeContext *Cxt) {
 // >>>>>>>> WasmEdge table type functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 WASMEDGE_CAPI_EXPORT WasmEdge_TableTypeContext *
-WasmEdge_TableTypeCreate(const enum WasmEdge_RefType RefType,
+WasmEdge_TableTypeCreate(const WasmEdge_ValType RefType,
                          const WasmEdge_Limit Limit) {
-  WasmEdge::RefType Type = static_cast<WasmEdge::RefType>(RefType);
+  WasmEdge::ValType RT(RefType.Data);
+  if (!RT.isRefType()) {
+    return nullptr;
+  }
   if (Limit.HasMax) {
     return toTabTypeCxt(
-        new WasmEdge::AST::TableType(Type, Limit.Min, Limit.Max));
+        new WasmEdge::AST::TableType(RT.toRefType(), Limit.Min, Limit.Max));
   } else {
-    return toTabTypeCxt(new WasmEdge::AST::TableType(Type, Limit.Min));
+    return toTabTypeCxt(
+        new WasmEdge::AST::TableType(RT.toRefType(), Limit.Min));
   }
 }
 
-WASMEDGE_CAPI_EXPORT enum WasmEdge_RefType
+WASMEDGE_CAPI_EXPORT WasmEdge_ValType
 WasmEdge_TableTypeGetRefType(const WasmEdge_TableTypeContext *Cxt) {
   if (Cxt) {
-    return static_cast<WasmEdge_RefType>(
-        fromTabTypeCxt(Cxt)->getRefType().getTypeCode());
+    return WasmEdge_ValType{.Data =
+                                fromTabTypeCxt(Cxt)->getRefType().getRawData()};
   }
-  return WasmEdge_RefType_FuncRef;
+  return WasmEdge_ValTypeGenFuncRef();
 }
 
 WASMEDGE_CAPI_EXPORT WasmEdge_Limit
@@ -1170,20 +1207,19 @@ WasmEdge_MemoryTypeDelete(WasmEdge_MemoryTypeContext *Cxt) {
 // >>>>>>>> WasmEdge global type functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 WASMEDGE_CAPI_EXPORT WasmEdge_GlobalTypeContext *
-WasmEdge_GlobalTypeCreate(const enum WasmEdge_ValType ValType,
+WasmEdge_GlobalTypeCreate(const WasmEdge_ValType ValType,
                           const enum WasmEdge_Mutability Mut) {
-  return toGlobTypeCxt(
-      new WasmEdge::AST::GlobalType(static_cast<WasmEdge::ValType>(ValType),
-                                    static_cast<WasmEdge::ValMut>(Mut)));
+  return toGlobTypeCxt(new WasmEdge::AST::GlobalType(
+      WasmEdge::ValType(ValType.Data), static_cast<WasmEdge::ValMut>(Mut)));
 }
 
-WASMEDGE_CAPI_EXPORT enum WasmEdge_ValType
+WASMEDGE_CAPI_EXPORT WasmEdge_ValType
 WasmEdge_GlobalTypeGetValType(const WasmEdge_GlobalTypeContext *Cxt) {
   if (Cxt) {
-    return static_cast<WasmEdge_ValType>(
-        fromGlobTypeCxt(Cxt)->getValType().getTypeCode());
+    return WasmEdge_ValType{
+        .Data = fromGlobTypeCxt(Cxt)->getValType().getRawData()};
   }
-  return WasmEdge_ValType_I32;
+  return WasmEdge_ValTypeGenI32();
 }
 
 WASMEDGE_CAPI_EXPORT enum WasmEdge_Mutability
@@ -1637,8 +1673,9 @@ WasmEdge_ExecutorInvoke(WasmEdge_ExecutorContext *Cxt,
                         WasmEdge_Value *Returns, const uint32_t ReturnLen) {
   auto ParamPair = genParamPair(Params, ParamLen);
   return wrap(
-      [&]() -> WasmEdge::Expect<std::vector<
-                std::pair<WasmEdge::ValVariant, WasmEdge::FullValType>>> {
+      [&]()
+          -> WasmEdge::Expect<
+              std::vector<std::pair<WasmEdge::ValVariant, WasmEdge::ValType>>> {
         return fromExecutorCxt(Cxt)->invoke(*fromFuncCxt(FuncCxt),
                                             ParamPair.first, ParamPair.second);
       },
@@ -2050,11 +2087,12 @@ WasmEdge_TableInstanceSetData(WasmEdge_TableInstanceContext *Cxt,
                               WasmEdge_Value Data, const uint32_t Offset) {
   return wrap(
       [&]() -> WasmEdge::Expect<void> {
-        WasmEdge::FullValType expType =
+        WasmEdge::ValType expType =
             fromTabCxt(Cxt)->getTableType().getRefType();
-        if (expType != Data.Type) {
+        WasmEdge::ValType gotType(Data.Type.Data);
+        if (expType != gotType) {
           spdlog::error(WasmEdge::ErrCode::Value::RefTypeMismatch);
-          spdlog::error(WasmEdge::ErrInfo::InfoMismatch(expType, Data.Type));
+          spdlog::error(WasmEdge::ErrInfo::InfoMismatch(expType, gotType));
           return Unexpect(WasmEdge::ErrCode::Value::RefTypeMismatch);
         }
         return fromTabCxt(Cxt)->setRefAddr(
@@ -2187,7 +2225,8 @@ WasmEdge_MemoryInstanceDelete(WasmEdge_MemoryInstanceContext *Cxt) {
 WASMEDGE_CAPI_EXPORT WasmEdge_GlobalInstanceContext *
 WasmEdge_GlobalInstanceCreate(const WasmEdge_GlobalTypeContext *GlobType,
                               const WasmEdge_Value Value) {
-  if (GlobType && Value.Type == fromGlobTypeCxt(GlobType)->getValType()) {
+  if (GlobType &&
+      ValType(Value.Type.Data) == fromGlobTypeCxt(GlobType)->getValType()) {
     return toGlobCxt(new WasmEdge::Runtime::Instance::GlobalInstance(
         *fromGlobTypeCxt(GlobType),
         to_WasmEdge_128_t<WasmEdge::uint128_t>(Value.Value)));
@@ -2211,7 +2250,8 @@ WasmEdge_GlobalInstanceGetValue(const WasmEdge_GlobalInstanceContext *Cxt) {
                              fromGlobCxt(Cxt)->getGlobalType().getValType());
   }
   return genWasmEdge_Value(
-      WasmEdge::ValVariant(static_cast<WasmEdge::uint128_t>(0)), ValType::I32);
+      WasmEdge::ValVariant(static_cast<WasmEdge::uint128_t>(0)),
+      ValTypeCode::I32);
 }
 
 WASMEDGE_CAPI_EXPORT void
@@ -2219,7 +2259,8 @@ WasmEdge_GlobalInstanceSetValue(WasmEdge_GlobalInstanceContext *Cxt,
                                 const WasmEdge_Value Value) {
   if (Cxt &&
       fromGlobCxt(Cxt)->getGlobalType().getValMut() == WasmEdge::ValMut::Var &&
-      Value.Type == fromGlobCxt(Cxt)->getGlobalType().getValType()) {
+      ValType(Value.Type.Data) ==
+          fromGlobCxt(Cxt)->getGlobalType().getValType()) {
     fromGlobCxt(Cxt)->getValue() =
         to_WasmEdge_128_t<WasmEdge::uint128_t>(Value.Value);
   }

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -505,6 +505,56 @@ WasmEdge_ValTypeIsEqual(const WasmEdge_ValType ValType1,
   return ValType(ValType1.Data) == ValType(ValType2.Data);
 }
 
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_ValTypeIsI32(const WasmEdge_ValType ValType) {
+  return WasmEdge::ValType(ValType.Data).getCode() ==
+         WasmEdge::ValTypeCode::I32;
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_ValTypeIsI64(const WasmEdge_ValType ValType) {
+  return WasmEdge::ValType(ValType.Data).getCode() ==
+         WasmEdge::ValTypeCode::I64;
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_ValTypeIsF32(const WasmEdge_ValType ValType) {
+  return WasmEdge::ValType(ValType.Data).getCode() ==
+         WasmEdge::ValTypeCode::F32;
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_ValTypeIsF64(const WasmEdge_ValType ValType) {
+  return WasmEdge::ValType(ValType.Data).getCode() ==
+         WasmEdge::ValTypeCode::F64;
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_ValTypeIsV128(const WasmEdge_ValType ValType) {
+  return WasmEdge::ValType(ValType.Data).getCode() ==
+         WasmEdge::ValTypeCode::V128;
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_ValTypeIsFuncRef(const WasmEdge_ValType ValType) {
+  return WasmEdge::ValType(ValType.Data).isFuncRefType();
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_ValTypeIsExternRef(const WasmEdge_ValType ValType) {
+  return WasmEdge::ValType(ValType.Data).isExternRefType();
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_ValTypeIsRef(const WasmEdge_ValType ValType) {
+  return WasmEdge::ValType(ValType.Data).isRefType();
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_ValTypeIsRefNull(const WasmEdge_ValType ValType) {
+  return WasmEdge::ValType(ValType.Data).isNullableRefType();
+}
+
 // <<<<<<<< WasmEdge valtype functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 // >>>>>>>> WasmEdge value functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -228,6 +228,7 @@ genParamPair(const WasmEdge_Value *Val, const uint32_t Len) noexcept {
       }
       break;
     }
+      [[fallthrough]];
     default:
       // TODO: Return error
       assumingUnreachable();

--- a/lib/driver/runtimeTool.cpp
+++ b/lib/driver/runtimeTool.cpp
@@ -338,35 +338,35 @@ int Tool(int Argc, const char *Argv[]) noexcept {
     }
 
     std::vector<ValVariant> FuncArgs;
-    std::vector<FullValType> FuncArgTypes;
+    std::vector<ValType> FuncArgTypes;
     for (size_t I = 0;
          I < FuncType.getParamTypes().size() && I + 1 < Args.value().size();
          ++I) {
-      switch (FuncType.getParamTypes()[I].getTypeCode()) {
+      switch (FuncType.getParamTypes()[I].getCode()) {
       case ValTypeCode::I32: {
         const uint32_t Value =
             static_cast<uint32_t>(std::stol(Args.value()[I + 1]));
         FuncArgs.emplace_back(Value);
-        FuncArgTypes.emplace_back(NumType::I32);
+        FuncArgTypes.emplace_back(NumTypeCode::I32);
         break;
       }
       case ValTypeCode::I64: {
         const uint64_t Value =
             static_cast<uint64_t>(std::stoll(Args.value()[I + 1]));
         FuncArgs.emplace_back(Value);
-        FuncArgTypes.emplace_back(NumType::I64);
+        FuncArgTypes.emplace_back(NumTypeCode::I64);
         break;
       }
       case ValTypeCode::F32: {
         const float Value = std::stof(Args.value()[I + 1]);
         FuncArgs.emplace_back(Value);
-        FuncArgTypes.emplace_back(NumType::F32);
+        FuncArgTypes.emplace_back(NumTypeCode::F32);
         break;
       }
       case ValTypeCode::F64: {
         const double Value = std::stod(Args.value()[I + 1]);
         FuncArgs.emplace_back(Value);
-        FuncArgTypes.emplace_back(NumType::F64);
+        FuncArgTypes.emplace_back(NumTypeCode::F64);
         break;
       }
       /// TODO: FuncRef and ExternRef
@@ -380,7 +380,7 @@ int Tool(int Argc, const char *Argv[]) noexcept {
         const uint64_t Value =
             static_cast<uint64_t>(std::stoll(Args.value()[I]));
         FuncArgs.emplace_back(Value);
-        FuncArgTypes.emplace_back(ValType::I64);
+        FuncArgTypes.emplace_back(ValTypeCode::I64);
       }
     }
 
@@ -393,7 +393,7 @@ int Tool(int Argc, const char *Argv[]) noexcept {
     if (auto Result = AsyncResult.get()) {
       /// Print results.
       for (size_t I = 0; I < Result->size(); ++I) {
-        switch ((*Result)[I].second.getTypeCode()) {
+        switch ((*Result)[I].second.getCode()) {
         case ValTypeCode::I32:
           std::cout << (*Result)[I].first.get<uint32_t>() << '\n';
           break;

--- a/lib/executor/executor.cpp
+++ b/lib/executor/executor.cpp
@@ -56,16 +56,16 @@ Executor::registerModule(Runtime::StoreManager &StoreMgr,
 }
 
 // Invoke function. See "include/executor/executor.h".
-Expect<std::vector<std::pair<ValVariant, FullValType>>>
+Expect<std::vector<std::pair<ValVariant, ValType>>>
 Executor::invoke(const Runtime::Instance::FunctionInstance &FuncInst,
                  Span<const ValVariant> Params,
-                 Span<const FullValType> ParamTypes) {
+                 Span<const ValType> ParamTypes) {
   // Check parameter and function type.
   const auto &FuncType = FuncInst.getFuncType();
   const auto &PTypes = FuncType.getParamTypes();
   const auto &RTypes = FuncType.getReturnTypes();
-  std::vector<FullValType> GotParamTypes(ParamTypes.begin(), ParamTypes.end());
-  GotParamTypes.resize(Params.size(), ValType::I32);
+  std::vector<ValType> GotParamTypes(ParamTypes.begin(), ParamTypes.end());
+  GotParamTypes.resize(Params.size(), ValTypeCode::I32);
   if (PTypes != GotParamTypes) {
     spdlog::error(ErrCode::Value::FuncSigMismatch);
     spdlog::error(ErrInfo::InfoMismatch(PTypes, RTypes, GotParamTypes, RTypes));
@@ -80,7 +80,7 @@ Executor::invoke(const Runtime::Instance::FunctionInstance &FuncInst,
   }
 
   // Get return values.
-  std::vector<std::pair<ValVariant, FullValType>> Returns(RTypes.size());
+  std::vector<std::pair<ValVariant, ValType>> Returns(RTypes.size());
   for (uint32_t I = 0; I < RTypes.size(); ++I) {
     Returns[RTypes.size() - I - 1] =
         std::make_pair(StackMgr.pop(), RTypes[RTypes.size() - I - 1]);

--- a/lib/loader/ast/segment.cpp
+++ b/lib/loader/ast/segment.cpp
@@ -124,7 +124,7 @@ Expect<void> Loader::loadSegment(AST::ElementSegment &ElemSeg) {
   }
 
   // Read element kind and init function indices.
-  ElemSeg.setRefType(RefType::FuncRef);
+  ElemSeg.setRefType(RefTypeCode::FuncRef);
   switch (Check) {
   case 0x01:
   case 0x02:
@@ -172,7 +172,7 @@ Expect<void> Loader::loadSegment(AST::ElementSegment &ElemSeg) {
   case 0x05:
   case 0x06:
   case 0x07:
-    if (auto Res = loadFullRefType()) {
+    if (auto Res = loadRefType(ASTNodeAttr::Seg_Element)) {
       ElemSeg.setRefType(*Res);
     } else {
       return logLoadError(Res.error(), FMgr.getLastOffset(),
@@ -240,7 +240,7 @@ Expect<void> Loader::loadSegment(AST::CodeSegment &CodeSeg) {
   uint32_t TotalLocalCnt = 0;
   for (uint32_t I = 0; I < VecCnt; ++I) {
     uint32_t LocalCnt = 0;
-    FullValType LocalType;
+    ValType LocalType;
     if (auto Res = FMgr.readU32(); unlikely(!Res)) {
       return logLoadError(Res.error(), FMgr.getLastOffset(),
                           ASTNodeAttr::Seg_Code);
@@ -254,7 +254,7 @@ Expect<void> Loader::loadSegment(AST::CodeSegment &CodeSeg) {
     }
     TotalLocalCnt += LocalCnt;
     // Read the number type.
-    if (auto Res = loadFullValType()) {
+    if (auto Res = loadValType(ASTNodeAttr::Seg_Code)) {
       LocalType = *Res;
     } else {
       return logLoadError(Res.error(), FMgr.getLastOffset(),

--- a/lib/loader/ast/type.cpp
+++ b/lib/loader/ast/type.cpp
@@ -8,10 +8,115 @@
 namespace WasmEdge {
 namespace Loader {
 
+// Load binary decode HeapType. See "include/loader/loader.h".
+Expect<RefType> Loader::loadHeapType(RefTypeCode Code, ASTNodeAttr From) {
+  if (auto Res = FMgr.readS33()) {
+    if (*Res < 0) {
+      // Type index case.
+      RefTypeCode HTCode = static_cast<RefTypeCode>(
+          static_cast<uint8_t>((*Res) & INT64_C(0x7F)));
+      switch (HTCode) {
+      case RefTypeCode::FuncRef:
+        return RefType(Code, HeapTypeCode::Func);
+      case RefTypeCode::ExternRef:
+        return RefType(Code, HeapTypeCode::Extern);
+      default:
+        return logLoadError(Res.error(), FMgr.getLastOffset(), From);
+      }
+    } else {
+      return RefType(Code, static_cast<uint32_t>(*Res));
+    }
+  } else {
+    return logLoadError(Res.error(), FMgr.getLastOffset(), From);
+  }
+}
+
+// Load binary decode ValType. See "include/loader/loader.h".
+Expect<ValType> Loader::loadValType(ASTNodeAttr From) {
+  if (auto Res = FMgr.readByte()) {
+    ValTypeCode Code = static_cast<ValTypeCode>(*Res);
+    switch (Code) {
+    case ValTypeCode::V128:
+      if (!Conf.hasProposal(Proposal::SIMD)) {
+        return logNeedProposal(ErrCode::Value::MalformedValType, Proposal::SIMD,
+                               FMgr.getLastOffset(), From);
+      }
+      [[fallthrough]];
+    case ValTypeCode::I32:
+    case ValTypeCode::I64:
+    case ValTypeCode::F32:
+    case ValTypeCode::F64:
+      return ValType(Code);
+    case ValTypeCode::FuncRef:
+      if (!Conf.hasProposal(Proposal::ReferenceTypes) &&
+          !Conf.hasProposal(Proposal::BulkMemoryOperations)) {
+        return logNeedProposal(ErrCode::Value::MalformedElemType,
+                               Proposal::ReferenceTypes, FMgr.getLastOffset(),
+                               From);
+      }
+      return ValType(Code);
+    case ValTypeCode::ExternRef:
+      if (!Conf.hasProposal(Proposal::ReferenceTypes)) {
+        return logNeedProposal(ErrCode::Value::MalformedElemType,
+                               Proposal::ReferenceTypes, FMgr.getLastOffset(),
+                               From);
+      }
+      return ValType(Code);
+    case ValTypeCode::Ref:
+    case ValTypeCode::RefNull:
+      if (!Conf.hasProposal(Proposal::FunctionReferences)) {
+        return logNeedProposal(ErrCode::Value::MalformedValType,
+                               Proposal::FunctionReferences,
+                               FMgr.getLastOffset(), From);
+      }
+      return loadHeapType(static_cast<RefTypeCode>(Code), From);
+    default:
+      return logLoadError(ErrCode::Value::MalformedValType,
+                          FMgr.getLastOffset(), From);
+    }
+  } else {
+    return logLoadError(Res.error(), FMgr.getLastOffset(), From);
+  }
+}
+
+// Load binary decode RefType. See "include/loader/loader.h".
+Expect<RefType> Loader::loadRefType(ASTNodeAttr From) {
+  if (auto Res = FMgr.readByte()) {
+    // The error code is different when the reference-types proposal turned off.
+    ErrCode::Value FailCode = Conf.hasProposal(Proposal::ReferenceTypes)
+                                  ? ErrCode::Value::MalformedRefType
+                                  : ErrCode::Value::MalformedElemType;
+    RefTypeCode Code = static_cast<RefTypeCode>(*Res);
+    switch (Code) {
+    case RefTypeCode::ExternRef:
+      if (!Conf.hasProposal(Proposal::ReferenceTypes)) {
+        return logNeedProposal(FailCode, Proposal::ReferenceTypes,
+                               FMgr.getLastOffset(), From);
+      }
+      [[fallthrough]];
+    case RefTypeCode::FuncRef:
+      // The FuncRef (0x70) is always allowed in the RefType even if the
+      // reference-types proposal not enabled.
+      return RefType(Code);
+    case RefTypeCode::Ref:
+    case RefTypeCode::RefNull:
+      if (!Conf.hasProposal(Proposal::FunctionReferences)) {
+        return logNeedProposal(FailCode, Proposal::FunctionReferences,
+                               FMgr.getLastOffset(), From);
+      }
+      return loadHeapType(Code, From);
+    default:
+      return logLoadError(FailCode, FMgr.getLastOffset(), From);
+    }
+  } else {
+    return logLoadError(Res.error(), FMgr.getLastOffset(), From);
+  }
+}
+
+// Load binary to construct Limit node. See "include/loader/loader.h".
 Expect<void> Loader::loadLimit(AST::Limit &Lim) {
   // Read limit.
   if (auto Res = FMgr.readByte()) {
-
     switch (static_cast<AST::Limit::LimitType>(*Res)) {
     case AST::Limit::LimitType::HasMin:
       Lim.setType(AST::Limit::LimitType::HasMin);
@@ -64,81 +169,6 @@ Expect<void> Loader::loadLimit(AST::Limit &Lim) {
   return {};
 }
 
-Expect<FullValType> Loader::loadFullValType(uint8_t TypeCode) {
-  switch (TypeCode) {
-  case (uint8_t)NumType::I32:
-    return NumType::I32;
-  case (uint8_t)NumType::I64:
-    return NumType::I64;
-  case (uint8_t)NumType::F32:
-    return NumType::F32;
-  case (uint8_t)NumType::F64:
-    return NumType::F64;
-  case (uint8_t)NumType::V128:
-    if (!Conf.hasProposal(Proposal::SIMD)) {
-      return logNeedProposal(ErrCode::Value::MalformedValType, Proposal::SIMD,
-                             FMgr.getLastOffset(), ASTNodeAttr::Type_ValType);
-    }
-    return NumType::V128;
-  case (uint8_t)HeapTypeCode::Extern:
-    if (!Conf.hasProposal(Proposal::ReferenceTypes)) {
-      return logNeedProposal(ErrCode::Value::MalformedElemType,
-                             Proposal::ReferenceTypes, FMgr.getLastOffset(),
-                             ASTNodeAttr::Type_ValType);
-    }
-    return FullRefType(HeapTypeCode::Extern);
-  case (uint8_t)HeapTypeCode::Func:
-    if (!Conf.hasProposal(Proposal::ReferenceTypes) &&
-        !Conf.hasProposal(Proposal::BulkMemoryOperations)) {
-      return logNeedProposal(ErrCode::Value::MalformedElemType,
-                             Proposal::ReferenceTypes, FMgr.getLastOffset(),
-                             ASTNodeAttr::Type_ValType);
-    }
-    return FullRefType(HeapTypeCode::Func);
-  default:
-    return logLoadError(ErrCode::Value::MalformedValType, FMgr.getLastOffset(),
-                        ASTNodeAttr::Type_ValType);
-  }
-}
-
-Expect<FullValType> Loader::loadFullValType() {
-  if (auto Res = FMgr.readByte()) {
-    return loadFullValType(*Res);
-  } else {
-    return logLoadError(Res.error(), FMgr.getLastOffset(),
-                        ASTNodeAttr::Type_ValType);
-  }
-}
-
-Expect<FullRefType> Loader::loadFullRefType() {
-  Byte TypeCode;
-  if (auto Res = FMgr.readByte()) {
-    TypeCode = *Res;
-  } else {
-    return logLoadError(Res.error(), FMgr.getLastOffset(),
-                        ASTNodeAttr::Type_RefType);
-  }
-  switch (TypeCode) {
-  case (uint8_t)HeapTypeCode::Extern:
-    if (!Conf.hasProposal(Proposal::ReferenceTypes)) {
-      return logNeedProposal(ErrCode::Value::MalformedElemType,
-                             Proposal::ReferenceTypes, FMgr.getLastOffset(),
-                             ASTNodeAttr::Type_RefType);
-    }
-    return HeapTypeCode::Extern;
-  case (uint8_t)HeapTypeCode::Func:
-    return HeapTypeCode::Func;
-  default:
-    if (Conf.hasProposal(Proposal::ReferenceTypes)) {
-      return logLoadError(ErrCode::Value::MalformedRefType,
-                          FMgr.getLastOffset(), ASTNodeAttr::Type_RefType);
-    } else {
-      return logLoadError(ErrCode::Value::MalformedElemType,
-                          FMgr.getLastOffset(), ASTNodeAttr::Type_RefType);
-    }
-  }
-}
-
 // Load binary to construct FunctionType node. See "include/loader/loader.h".
 Expect<void> Loader::loadType(AST::FunctionType &FuncType) {
   uint32_t VecCnt = 0;
@@ -168,11 +198,11 @@ Expect<void> Loader::loadType(AST::FunctionType &FuncType) {
                         ASTNodeAttr::Type_Function);
   }
   for (uint32_t I = 0; I < VecCnt; ++I) {
-    if (auto Res = loadFullValType()) {
+    if (auto Res = loadValType(ASTNodeAttr::Type_Function)) {
       FuncType.getParamTypes().push_back(*Res);
     } else {
-      return logLoadError(Res.error(), FMgr.getLastOffset(),
-                          ASTNodeAttr::Type_Function);
+      // The AST node information is handled.
+      return Unexpect(Res);
     }
   }
 
@@ -195,11 +225,11 @@ Expect<void> Loader::loadType(AST::FunctionType &FuncType) {
                            ASTNodeAttr::Type_Function);
   }
   for (uint32_t I = 0; I < VecCnt; ++I) {
-    if (auto Res = loadFullValType()) {
+    if (auto Res = loadValType(ASTNodeAttr::Type_Function)) {
       FuncType.getReturnTypes().push_back(*Res);
     } else {
-      return logLoadError(Res.error(), FMgr.getLastOffset(),
-                          ASTNodeAttr::Type_Function);
+      // The AST node information is handled.
+      return Unexpect(Res);
     }
   }
   return {};
@@ -218,11 +248,11 @@ Expect<void> Loader::loadType(AST::MemoryType &MemType) {
 // Load binary to construct TableType node. See "include/loader/loader.h".
 Expect<void> Loader::loadType(AST::TableType &TabType) {
   // Read reference type.
-  if (auto Res = loadFullRefType()) {
+  if (auto Res = loadRefType(ASTNodeAttr::Type_Table)) {
     TabType.setRefType(*Res);
   } else {
-    return logLoadError(Res.error(), FMgr.getLastOffset(),
-                        ASTNodeAttr::Type_Table);
+    // The AST node information is handled.
+    return Unexpect(Res);
   }
 
   // Read limit.
@@ -236,11 +266,11 @@ Expect<void> Loader::loadType(AST::TableType &TabType) {
 // Load binary to construct GlobalType node. See "include/loader/loader.h".
 Expect<void> Loader::loadType(AST::GlobalType &GlobType) {
   // Read value type.
-  if (auto Res = loadFullValType()) {
+  if (auto Res = loadValType(ASTNodeAttr::Type_Global)) {
     GlobType.setValType(*Res);
   } else {
-    return logLoadError(Res.error(), FMgr.getLastOffset(),
-                        ASTNodeAttr::Type_Global);
+    // The AST node information is handled.
+    return Unexpect(Res);
   }
 
   // Read mutability.

--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -47,8 +47,8 @@ void FormChecker::reset(bool CleanGlobal) {
 }
 
 Expect<void> FormChecker::validate(AST::InstrView Instrs,
-                                   Span<const FullValType> RetVals) {
-  for (const FullValType &Val : RetVals) {
+                                   Span<const ValType> RetVals) {
+  for (const ValType &Val : RetVals) {
     Returns.push_back(VType(Val));
   }
   return checkExpr(Instrs);
@@ -108,13 +108,13 @@ void FormChecker::addElem(const AST::ElementSegment &Elem) {
 
 void FormChecker::addRef(const uint32_t FuncIdx) { Refs.emplace(FuncIdx); }
 
-void FormChecker::addLocal(const FullValType &V) { Locals.push_back(V); }
+void FormChecker::addLocal(const ValType &V) { Locals.push_back(V); }
 
 void FormChecker::addLocal(const VType &V) { Locals.push_back(V); }
 
-FullValType FormChecker::VTypeToAST(const VType &V) {
+ValType FormChecker::VTypeToAST(const VType &V) {
   if (!V) {
-    return ValType::I32;
+    return ValTypeCode::I32;
   }
   return *V;
 }
@@ -144,17 +144,15 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
       -> Expect<std::pair<Span<const VType>, Span<const VType>>> {
     using ReturnType = std::pair<Span<const VType>, Span<const VType>>;
     if (BType.isEmpty()) {
-      return ReturnType{{}, Buffer};
-    }
-    if (BType.isValType()) {
-      // ValType case. t2* = valtype | none
-      Buffer.clear();
-      Buffer.reserve(1);
-      Buffer.push_back(BType.Data.Type);
+      // Empty case. t2* = none
+      return ReturnType{{}, {}};
+    } else if (BType.isValType()) {
+      // ValType case. t2* = valtype
+      Buffer[0] = BType.getValType();
       return ReturnType{{}, Buffer};
     } else {
       // Type index case. t2* = type[index].returns
-      const uint32_t TypeIdx = BType.Data.Idx;
+      const uint32_t TypeIdx = BType.getTypeIndex();
       if (TypeIdx >= Types.size()) {
         return logOutOfRange(ErrCode::Value::InvalidFuncTypeIdx,
                              ErrInfo::IndexCategory::FunctionType, TypeIdx,
@@ -230,7 +228,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
                                    Span<const VType> Got) -> Expect<void> {
     if (Exp.size() != Got.size() ||
         !std::equal(Exp.begin(), Exp.end(), Got.begin())) {
-      std::vector<FullValType> ExpV, GotV;
+      std::vector<ValType> ExpV, GotV;
       ExpV.reserve(Exp.size());
       for (auto &I : Exp) {
         ExpV.push_back(VTypeToAST(I));
@@ -255,14 +253,14 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
 
   case OpCode::If:
     // Pop I32
-    if (auto Res = popType(ValType::I32); !Res) {
+    if (auto Res = popType(ValTypeCode::I32); !Res) {
       return Unexpect(Res);
     }
     [[fallthrough]];
   case OpCode::Block:
   case OpCode::Loop: {
     // Get blocktype [t1*] -> [t2*]
-    std::vector<VType> Buffer;
+    std::vector<VType> Buffer(1);
     Span<const VType> T1, T2;
     if (auto Res = checkBlockType(Buffer, Instr.getBlockType())) {
       std::tie(T1, T2) = std::move(*Res);
@@ -327,7 +325,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
       return Unexpect(D);
     } else {
       // D is the last D element of control stack.
-      if (auto Res = popType(ValType::I32); !Res) {
+      if (auto Res = popType(ValTypeCode::I32); !Res) {
         return Unexpect(Res);
       }
       const auto NTypes = getLabelTypes(CtrlStack[*D]);
@@ -345,7 +343,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
       return {};
     }
   case OpCode::Br_table: {
-    if (auto Res = popType(ValType::I32); !Res) {
+    if (auto Res = popType(ValTypeCode::I32); !Res) {
       return Unexpect(Res);
     }
     auto LabelTable = const_cast<AST::Instruction &>(Instr).getLabelList();
@@ -433,7 +431,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
                            ErrInfo::IndexCategory::Table, T,
                            static_cast<uint32_t>(Tables.size()));
     }
-    if (Tables[T] != RefType::FuncRef) {
+    if (!Tables[T].isFuncRefType()) {
       spdlog::error(ErrCode::Value::InvalidTableIdx);
       return Unexpect(ErrCode::Value::InvalidTableIdx);
     }
@@ -443,7 +441,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
                            ErrInfo::IndexCategory::FunctionType, N,
                            static_cast<uint32_t>(Types.size()));
     }
-    if (auto Res = popType(ValType::I32); !Res) {
+    if (auto Res = popType(ValTypeCode::I32); !Res) {
       return Unexpect(Res);
     }
     return StackTrans(Types[N].first, Types[N].second);
@@ -479,7 +477,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
                                    static_cast<uint32_t>(Tables.size())));
       return Unexpect(ErrCode::Value::InvalidTableIdx);
     }
-    if (Tables[T] != RefType::FuncRef) {
+    if (!Tables[T].isFuncRefType()) {
       spdlog::error(ErrCode::Value::InvalidTableIdx);
       return Unexpect(ErrCode::Value::InvalidTableIdx);
     }
@@ -496,7 +494,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
       // TODO: Print the error info of types.
       return Unexpect(ErrCode::Value::TypeCheckFailed);
     }
-    if (auto Res = popType(ValType::I32); !Res) {
+    if (auto Res = popType(ValTypeCode::I32); !Res) {
       return Unexpect(Res);
     }
     if (auto Res = popTypes(Types[N].first); !Res) {
@@ -513,27 +511,27 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
       if (!isRefType(*Res)) {
         spdlog::error(ErrCode::Value::TypeCheckFailed);
         spdlog::error(
-            ErrInfo::InfoMismatch(ValType::FuncRef, VTypeToAST(*Res)));
+            ErrInfo::InfoMismatch(ValTypeCode::FuncRef, VTypeToAST(*Res)));
         return Unexpect(ErrCode::Value::TypeCheckFailed);
       }
     } else {
       return Unexpect(Res);
     }
-    return StackTrans({}, {VType(ValType::I32)});
+    return StackTrans({}, {VType(ValTypeCode::I32)});
   case OpCode::Ref__func:
     if (Refs.find(Instr.getTargetIndex()) == Refs.cend()) {
       // Undeclared function reference.
       spdlog::error(ErrCode::Value::InvalidRefIdx);
       return Unexpect(ErrCode::Value::InvalidRefIdx);
     }
-    return StackTrans({}, {VType(ValType::FuncRef)});
+    return StackTrans({}, {VType(ValTypeCode::FuncRef)});
 
   // Parametric Instructions.
   case OpCode::Drop:
     return StackTrans({unreachableVType()}, {});
   case OpCode::Select: {
     // Pop I32.
-    if (auto Res = popType(ValType::I32); !Res) {
+    if (auto Res = popType(ValTypeCode::I32); !Res) {
       return Unexpect(Res);
     }
     // Pop T1 and T2.
@@ -551,7 +549,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
     // T1 and T2 should be number type.
     if (!isNumType(T1)) {
       spdlog::error(ErrCode::Value::TypeCheckFailed);
-      spdlog::error(ErrInfo::InfoMismatch(ValType::I32, VTypeToAST(T1)));
+      spdlog::error(ErrInfo::InfoMismatch(ValTypeCode::I32, VTypeToAST(T1)));
       return Unexpect(ErrCode::Value::TypeCheckFailed);
     }
     if (!isNumType(T2)) {
@@ -580,7 +578,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
       return Unexpect(ErrCode::Value::InvalidResultArity);
     }
     VType ExpT = Instr.getValTypeList()[0];
-    if (auto Res = popTypes({ExpT, ExpT, VType(ValType::I32)}); !Res) {
+    if (auto Res = popTypes({ExpT, ExpT, VType(ValTypeCode::I32)}); !Res) {
       return Unexpect(Res);
     }
     pushType(ExpT);
@@ -647,15 +645,17 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
     }
     VType ExpT = VType(Tables[Instr.getTargetIndex()]);
     if (Instr.getOpCode() == OpCode::Table__get) {
-      return StackTrans({VType(ValType::I32)}, {ExpT});
+      return StackTrans({VType(ValTypeCode::I32)}, {ExpT});
     } else if (Instr.getOpCode() == OpCode::Table__set) {
-      return StackTrans({VType(ValType::I32), ExpT}, {});
+      return StackTrans({VType(ValTypeCode::I32), ExpT}, {});
     } else if (Instr.getOpCode() == OpCode::Table__grow) {
-      return StackTrans({ExpT, VType(ValType::I32)}, {VType(ValType::I32)});
+      return StackTrans({ExpT, VType(ValTypeCode::I32)},
+                        {VType(ValTypeCode::I32)});
     } else if (Instr.getOpCode() == OpCode::Table__size) {
-      return StackTrans({}, {VType(ValType::I32)});
+      return StackTrans({}, {VType(ValTypeCode::I32)});
     } else if (Instr.getOpCode() == OpCode::Table__fill) {
-      return StackTrans({VType(ValType::I32), ExpT, VType(ValType::I32)}, {});
+      return StackTrans(
+          {VType(ValTypeCode::I32), ExpT, VType(ValTypeCode::I32)}, {});
     } else if (Instr.getOpCode() == OpCode::Table__init) {
       // Check source element index for initialization.
       if (Instr.getSourceIndex() >= Elems.size()) {
@@ -670,8 +670,9 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
                                             Elems[Instr.getSourceIndex()]));
         return Unexpect(ErrCode::Value::TypeCheckFailed);
       }
-      return StackTrans(
-          {VType(ValType::I32), VType(ValType::I32), VType(ValType::I32)}, {});
+      return StackTrans({VType(ValTypeCode::I32), VType(ValTypeCode::I32),
+                         VType(ValTypeCode::I32)},
+                        {});
     } else {
       // Check source table index for copying.
       if (Instr.getSourceIndex() >= Tables.size()) {
@@ -686,8 +687,9 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
                                             Tables[Instr.getSourceIndex()]));
         return Unexpect(ErrCode::Value::TypeCheckFailed);
       }
-      return StackTrans(
-          {VType(ValType::I32), VType(ValType::I32), VType(ValType::I32)}, {});
+      return StackTrans({VType(ValTypeCode::I32), VType(ValTypeCode::I32),
+                         VType(ValTypeCode::I32)},
+                        {});
     }
   }
   case OpCode::Elem__drop:
@@ -701,59 +703,69 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
 
   // Memory Instructions.
   case OpCode::I32__load:
-    return checkAlignAndTrans(32, {VType(ValType::I32)}, {VType(ValType::I32)});
+    return checkAlignAndTrans(32, {VType(ValTypeCode::I32)},
+                              {VType(ValTypeCode::I32)});
   case OpCode::I64__load:
-    return checkAlignAndTrans(64, {VType(ValType::I32)}, {VType(ValType::I64)});
+    return checkAlignAndTrans(64, {VType(ValTypeCode::I32)},
+                              {VType(ValTypeCode::I64)});
   case OpCode::F32__load:
-    return checkAlignAndTrans(32, {VType(ValType::I32)}, {VType(ValType::F32)});
+    return checkAlignAndTrans(32, {VType(ValTypeCode::I32)},
+                              {VType(ValTypeCode::F32)});
   case OpCode::F64__load:
-    return checkAlignAndTrans(64, {VType(ValType::I32)}, {VType(ValType::F64)});
+    return checkAlignAndTrans(64, {VType(ValTypeCode::I32)},
+                              {VType(ValTypeCode::F64)});
   case OpCode::I32__load8_s:
   case OpCode::I32__load8_u:
-    return checkAlignAndTrans(8, {VType(ValType::I32)}, {VType(ValType::I32)});
+    return checkAlignAndTrans(8, {VType(ValTypeCode::I32)},
+                              {VType(ValTypeCode::I32)});
   case OpCode::I32__load16_s:
   case OpCode::I32__load16_u:
-    return checkAlignAndTrans(16, {VType(ValType::I32)}, {VType(ValType::I32)});
+    return checkAlignAndTrans(16, {VType(ValTypeCode::I32)},
+                              {VType(ValTypeCode::I32)});
   case OpCode::I64__load8_s:
   case OpCode::I64__load8_u:
-    return checkAlignAndTrans(8, {VType(ValType::I32)}, {VType(ValType::I64)});
+    return checkAlignAndTrans(8, {VType(ValTypeCode::I32)},
+                              {VType(ValTypeCode::I64)});
   case OpCode::I64__load16_s:
   case OpCode::I64__load16_u:
-    return checkAlignAndTrans(16, {VType(ValType::I32)}, {VType(ValType::I64)});
+    return checkAlignAndTrans(16, {VType(ValTypeCode::I32)},
+                              {VType(ValTypeCode::I64)});
   case OpCode::I64__load32_s:
   case OpCode::I64__load32_u:
-    return checkAlignAndTrans(32, {VType(ValType::I32)}, {VType(ValType::I64)});
+    return checkAlignAndTrans(32, {VType(ValTypeCode::I32)},
+                              {VType(ValTypeCode::I64)});
   case OpCode::I32__store:
-    return checkAlignAndTrans(32, {VType(ValType::I32), VType(ValType::I32)},
-                              {});
+    return checkAlignAndTrans(
+        32, {VType(ValTypeCode::I32), VType(ValTypeCode::I32)}, {});
   case OpCode::I64__store:
-    return checkAlignAndTrans(64, {VType(ValType::I32), VType(ValType::I64)},
-                              {});
+    return checkAlignAndTrans(
+        64, {VType(ValTypeCode::I32), VType(ValTypeCode::I64)}, {});
   case OpCode::F32__store:
-    return checkAlignAndTrans(32, {VType(ValType::I32), VType(ValType::F32)},
-                              {});
+    return checkAlignAndTrans(
+        32, {VType(ValTypeCode::I32), VType(ValTypeCode::F32)}, {});
   case OpCode::F64__store:
-    return checkAlignAndTrans(64, {VType(ValType::I32), VType(ValType::F64)},
-                              {});
+    return checkAlignAndTrans(
+        64, {VType(ValTypeCode::I32), VType(ValTypeCode::F64)}, {});
   case OpCode::I32__store8:
-    return checkAlignAndTrans(8, {VType(ValType::I32), VType(ValType::I32)},
-                              {});
+    return checkAlignAndTrans(
+        8, {VType(ValTypeCode::I32), VType(ValTypeCode::I32)}, {});
   case OpCode::I32__store16:
-    return checkAlignAndTrans(16, {VType(ValType::I32), VType(ValType::I32)},
-                              {});
+    return checkAlignAndTrans(
+        16, {VType(ValTypeCode::I32), VType(ValTypeCode::I32)}, {});
   case OpCode::I64__store8:
-    return checkAlignAndTrans(8, {VType(ValType::I32), VType(ValType::I64)},
-                              {});
+    return checkAlignAndTrans(
+        8, {VType(ValTypeCode::I32), VType(ValTypeCode::I64)}, {});
   case OpCode::I64__store16:
-    return checkAlignAndTrans(16, {VType(ValType::I32), VType(ValType::I64)},
-                              {});
+    return checkAlignAndTrans(
+        16, {VType(ValTypeCode::I32), VType(ValTypeCode::I64)}, {});
   case OpCode::I64__store32:
-    return checkAlignAndTrans(32, {VType(ValType::I32), VType(ValType::I64)},
-                              {});
+    return checkAlignAndTrans(
+        32, {VType(ValTypeCode::I32), VType(ValTypeCode::I64)}, {});
   case OpCode::Memory__size:
-    return checkMemAndTrans({}, {VType(ValType::I32)});
+    return checkMemAndTrans({}, {VType(ValTypeCode::I32)});
   case OpCode::Memory__grow:
-    return checkMemAndTrans({VType(ValType::I32)}, {VType(ValType::I32)});
+    return checkMemAndTrans({VType(ValTypeCode::I32)},
+                            {VType(ValTypeCode::I32)});
   case OpCode::Memory__init:
     // Check the target memory index. Memory index should be checked first.
     if (Instr.getTargetIndex() >= Mems) {
@@ -767,8 +779,9 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
                            ErrInfo::IndexCategory::Data, Instr.getSourceIndex(),
                            static_cast<uint32_t>(Datas.size()));
     }
-    return StackTrans(
-        {VType(ValType::I32), VType(ValType::I32), VType(ValType::I32)}, {});
+    return StackTrans({VType(ValTypeCode::I32), VType(ValTypeCode::I32),
+                       VType(ValTypeCode::I32)},
+                      {});
   case OpCode::Memory__copy:
     /// Check the source memory index.
     if (Instr.getSourceIndex() >= Mems) {
@@ -778,8 +791,9 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
     }
     [[fallthrough]];
   case OpCode::Memory__fill:
-    return checkMemAndTrans(
-        {VType(ValType::I32), VType(ValType::I32), VType(ValType::I32)}, {});
+    return checkMemAndTrans({VType(ValTypeCode::I32), VType(ValTypeCode::I32),
+                             VType(ValTypeCode::I32)},
+                            {});
   case OpCode::Data__drop:
     // Check the target data index.
     if (Instr.getTargetIndex() >= Datas.size()) {
@@ -791,27 +805,27 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
 
   // Const Instructions.
   case OpCode::I32__const:
-    return StackTrans({}, {VType(ValType::I32)});
+    return StackTrans({}, {VType(ValTypeCode::I32)});
   case OpCode::I64__const:
-    return StackTrans({}, {VType(ValType::I64)});
+    return StackTrans({}, {VType(ValTypeCode::I64)});
   case OpCode::F32__const:
-    return StackTrans({}, {VType(ValType::F32)});
+    return StackTrans({}, {VType(ValTypeCode::F32)});
   case OpCode::F64__const:
-    return StackTrans({}, {VType(ValType::F64)});
+    return StackTrans({}, {VType(ValTypeCode::F64)});
 
   // Unary Numeric Instructions.
   case OpCode::I32__eqz:
-    return StackTrans({VType(ValType::I32)}, {VType(ValType::I32)});
+    return StackTrans({VType(ValTypeCode::I32)}, {VType(ValTypeCode::I32)});
   case OpCode::I64__eqz:
-    return StackTrans({VType(ValType::I64)}, {VType(ValType::I32)});
+    return StackTrans({VType(ValTypeCode::I64)}, {VType(ValTypeCode::I32)});
   case OpCode::I32__clz:
   case OpCode::I32__ctz:
   case OpCode::I32__popcnt:
-    return StackTrans({VType(ValType::I32)}, {VType(ValType::I32)});
+    return StackTrans({VType(ValTypeCode::I32)}, {VType(ValTypeCode::I32)});
   case OpCode::I64__clz:
   case OpCode::I64__ctz:
   case OpCode::I64__popcnt:
-    return StackTrans({VType(ValType::I64)}, {VType(ValType::I64)});
+    return StackTrans({VType(ValTypeCode::I64)}, {VType(ValTypeCode::I64)});
   case OpCode::F32__abs:
   case OpCode::F32__neg:
   case OpCode::F32__ceil:
@@ -819,7 +833,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::F32__trunc:
   case OpCode::F32__nearest:
   case OpCode::F32__sqrt:
-    return StackTrans({VType(ValType::F32)}, {VType(ValType::F32)});
+    return StackTrans({VType(ValTypeCode::F32)}, {VType(ValTypeCode::F32)});
   case OpCode::F64__abs:
   case OpCode::F64__neg:
   case OpCode::F64__ceil:
@@ -827,67 +841,67 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::F64__trunc:
   case OpCode::F64__nearest:
   case OpCode::F64__sqrt:
-    return StackTrans({VType(ValType::F64)}, {VType(ValType::F64)});
+    return StackTrans({VType(ValTypeCode::F64)}, {VType(ValTypeCode::F64)});
   case OpCode::I32__wrap_i64:
-    return StackTrans({VType(ValType::I64)}, {VType(ValType::I32)});
+    return StackTrans({VType(ValTypeCode::I64)}, {VType(ValTypeCode::I32)});
   case OpCode::I32__trunc_f32_s:
   case OpCode::I32__trunc_f32_u:
-    return StackTrans({VType(ValType::F32)}, {VType(ValType::I32)});
+    return StackTrans({VType(ValTypeCode::F32)}, {VType(ValTypeCode::I32)});
   case OpCode::I32__trunc_f64_s:
   case OpCode::I32__trunc_f64_u:
-    return StackTrans({VType(ValType::F64)}, {VType(ValType::I32)});
+    return StackTrans({VType(ValTypeCode::F64)}, {VType(ValTypeCode::I32)});
   case OpCode::I64__extend_i32_s:
   case OpCode::I64__extend_i32_u:
-    return StackTrans({VType(ValType::I32)}, {VType(ValType::I64)});
+    return StackTrans({VType(ValTypeCode::I32)}, {VType(ValTypeCode::I64)});
   case OpCode::I64__trunc_f32_s:
   case OpCode::I64__trunc_f32_u:
-    return StackTrans({VType(ValType::F32)}, {VType(ValType::I64)});
+    return StackTrans({VType(ValTypeCode::F32)}, {VType(ValTypeCode::I64)});
   case OpCode::I64__trunc_f64_s:
   case OpCode::I64__trunc_f64_u:
-    return StackTrans({VType(ValType::F64)}, {VType(ValType::I64)});
+    return StackTrans({VType(ValTypeCode::F64)}, {VType(ValTypeCode::I64)});
   case OpCode::F32__convert_i32_s:
   case OpCode::F32__convert_i32_u:
-    return StackTrans({VType(ValType::I32)}, {VType(ValType::F32)});
+    return StackTrans({VType(ValTypeCode::I32)}, {VType(ValTypeCode::F32)});
   case OpCode::F32__convert_i64_s:
   case OpCode::F32__convert_i64_u:
-    return StackTrans({VType(ValType::I64)}, {VType(ValType::F32)});
+    return StackTrans({VType(ValTypeCode::I64)}, {VType(ValTypeCode::F32)});
   case OpCode::F32__demote_f64:
-    return StackTrans({VType(ValType::F64)}, {VType(ValType::F32)});
+    return StackTrans({VType(ValTypeCode::F64)}, {VType(ValTypeCode::F32)});
   case OpCode::F64__convert_i32_s:
   case OpCode::F64__convert_i32_u:
-    return StackTrans({VType(ValType::I32)}, {VType(ValType::F64)});
+    return StackTrans({VType(ValTypeCode::I32)}, {VType(ValTypeCode::F64)});
   case OpCode::F64__convert_i64_s:
   case OpCode::F64__convert_i64_u:
-    return StackTrans({VType(ValType::I64)}, {VType(ValType::F64)});
+    return StackTrans({VType(ValTypeCode::I64)}, {VType(ValTypeCode::F64)});
   case OpCode::F64__promote_f32:
-    return StackTrans({VType(ValType::F32)}, {VType(ValType::F64)});
+    return StackTrans({VType(ValTypeCode::F32)}, {VType(ValTypeCode::F64)});
   case OpCode::I32__reinterpret_f32:
-    return StackTrans({VType(ValType::F32)}, {VType(ValType::I32)});
+    return StackTrans({VType(ValTypeCode::F32)}, {VType(ValTypeCode::I32)});
   case OpCode::I64__reinterpret_f64:
-    return StackTrans({VType(ValType::F64)}, {VType(ValType::I64)});
+    return StackTrans({VType(ValTypeCode::F64)}, {VType(ValTypeCode::I64)});
   case OpCode::F32__reinterpret_i32:
-    return StackTrans({VType(ValType::I32)}, {VType(ValType::F32)});
+    return StackTrans({VType(ValTypeCode::I32)}, {VType(ValTypeCode::F32)});
   case OpCode::F64__reinterpret_i64:
-    return StackTrans({VType(ValType::I64)}, {VType(ValType::F64)});
+    return StackTrans({VType(ValTypeCode::I64)}, {VType(ValTypeCode::F64)});
   case OpCode::I32__extend8_s:
   case OpCode::I32__extend16_s:
-    return StackTrans({VType(ValType::I32)}, {VType(ValType::I32)});
+    return StackTrans({VType(ValTypeCode::I32)}, {VType(ValTypeCode::I32)});
   case OpCode::I64__extend8_s:
   case OpCode::I64__extend16_s:
   case OpCode::I64__extend32_s:
-    return StackTrans({VType(ValType::I64)}, {VType(ValType::I64)});
+    return StackTrans({VType(ValTypeCode::I64)}, {VType(ValTypeCode::I64)});
   case OpCode::I32__trunc_sat_f32_s:
   case OpCode::I32__trunc_sat_f32_u:
-    return StackTrans({VType(ValType::F32)}, {VType(ValType::I32)});
+    return StackTrans({VType(ValTypeCode::F32)}, {VType(ValTypeCode::I32)});
   case OpCode::I32__trunc_sat_f64_s:
   case OpCode::I32__trunc_sat_f64_u:
-    return StackTrans({VType(ValType::F64)}, {VType(ValType::I32)});
+    return StackTrans({VType(ValTypeCode::F64)}, {VType(ValTypeCode::I32)});
   case OpCode::I64__trunc_sat_f32_s:
   case OpCode::I64__trunc_sat_f32_u:
-    return StackTrans({VType(ValType::F32)}, {VType(ValType::I64)});
+    return StackTrans({VType(ValTypeCode::F32)}, {VType(ValTypeCode::I64)});
   case OpCode::I64__trunc_sat_f64_s:
   case OpCode::I64__trunc_sat_f64_u:
-    return StackTrans({VType(ValType::F64)}, {VType(ValType::I64)});
+    return StackTrans({VType(ValTypeCode::F64)}, {VType(ValTypeCode::I64)});
 
   // Binary Numeric Instructions.
   case OpCode::I32__eq:
@@ -900,8 +914,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::I32__le_u:
   case OpCode::I32__ge_s:
   case OpCode::I32__ge_u:
-    return StackTrans({VType(ValType::I32), VType(ValType::I32)},
-                      {VType(ValType::I32)});
+    return StackTrans({VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+                      {VType(ValTypeCode::I32)});
   case OpCode::I64__eq:
   case OpCode::I64__ne:
   case OpCode::I64__lt_s:
@@ -912,24 +926,24 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::I64__le_u:
   case OpCode::I64__ge_s:
   case OpCode::I64__ge_u:
-    return StackTrans({VType(ValType::I64), VType(ValType::I64)},
-                      {VType(ValType::I32)});
+    return StackTrans({VType(ValTypeCode::I64), VType(ValTypeCode::I64)},
+                      {VType(ValTypeCode::I32)});
   case OpCode::F32__eq:
   case OpCode::F32__ne:
   case OpCode::F32__lt:
   case OpCode::F32__gt:
   case OpCode::F32__le:
   case OpCode::F32__ge:
-    return StackTrans({VType(ValType::F32), VType(ValType::F32)},
-                      {VType(ValType::I32)});
+    return StackTrans({VType(ValTypeCode::F32), VType(ValTypeCode::F32)},
+                      {VType(ValTypeCode::I32)});
   case OpCode::F64__eq:
   case OpCode::F64__ne:
   case OpCode::F64__lt:
   case OpCode::F64__gt:
   case OpCode::F64__le:
   case OpCode::F64__ge:
-    return StackTrans({VType(ValType::F64), VType(ValType::F64)},
-                      {VType(ValType::I32)});
+    return StackTrans({VType(ValTypeCode::F64), VType(ValTypeCode::F64)},
+                      {VType(ValTypeCode::I32)});
   case OpCode::I32__add:
   case OpCode::I32__sub:
   case OpCode::I32__mul:
@@ -945,8 +959,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::I32__shr_u:
   case OpCode::I32__rotl:
   case OpCode::I32__rotr:
-    return StackTrans({VType(ValType::I32), VType(ValType::I32)},
-                      {VType(ValType::I32)});
+    return StackTrans({VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+                      {VType(ValTypeCode::I32)});
   case OpCode::I64__add:
   case OpCode::I64__sub:
   case OpCode::I64__mul:
@@ -962,8 +976,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::I64__shr_u:
   case OpCode::I64__rotl:
   case OpCode::I64__rotr:
-    return StackTrans({VType(ValType::I64), VType(ValType::I64)},
-                      {VType(ValType::I64)});
+    return StackTrans({VType(ValTypeCode::I64), VType(ValTypeCode::I64)},
+                      {VType(ValTypeCode::I64)});
   case OpCode::F32__add:
   case OpCode::F32__sub:
   case OpCode::F32__mul:
@@ -971,8 +985,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::F32__min:
   case OpCode::F32__max:
   case OpCode::F32__copysign:
-    return StackTrans({VType(ValType::F32), VType(ValType::F32)},
-                      {VType(ValType::F32)});
+    return StackTrans({VType(ValTypeCode::F32), VType(ValTypeCode::F32)},
+                      {VType(ValTypeCode::F32)});
   case OpCode::F64__add:
   case OpCode::F64__sub:
   case OpCode::F64__mul:
@@ -980,13 +994,13 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::F64__min:
   case OpCode::F64__max:
   case OpCode::F64__copysign:
-    return StackTrans({VType(ValType::F64), VType(ValType::F64)},
-                      {VType(ValType::F64)});
+    return StackTrans({VType(ValTypeCode::F64), VType(ValTypeCode::F64)},
+                      {VType(ValTypeCode::F64)});
 
   // SIMD Memory Instruction.
   case OpCode::V128__load:
-    return checkAlignAndTrans(128, {VType(ValType::I32)},
-                              {VType(ValType::V128)});
+    return checkAlignAndTrans(128, {VType(ValTypeCode::I32)},
+                              {VType(ValTypeCode::V128)});
   case OpCode::V128__load8x8_s:
   case OpCode::V128__load8x8_u:
   case OpCode::V128__load16x4_s:
@@ -995,48 +1009,53 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::V128__load32x2_u:
   case OpCode::V128__load64_splat:
   case OpCode::V128__load64_zero:
-    return checkAlignAndTrans(64, {VType(ValType::I32)},
-                              {VType(ValType::V128)});
+    return checkAlignAndTrans(64, {VType(ValTypeCode::I32)},
+                              {VType(ValTypeCode::V128)});
   case OpCode::V128__load8_splat:
-    return checkAlignAndTrans(8, {VType(ValType::I32)}, {VType(ValType::V128)});
+    return checkAlignAndTrans(8, {VType(ValTypeCode::I32)},
+                              {VType(ValTypeCode::V128)});
   case OpCode::V128__load16_splat:
-    return checkAlignAndTrans(16, {VType(ValType::I32)},
-                              {VType(ValType::V128)});
+    return checkAlignAndTrans(16, {VType(ValTypeCode::I32)},
+                              {VType(ValTypeCode::V128)});
   case OpCode::V128__load32_splat:
   case OpCode::V128__load32_zero:
-    return checkAlignAndTrans(32, {VType(ValType::I32)},
-                              {VType(ValType::V128)});
+    return checkAlignAndTrans(32, {VType(ValTypeCode::I32)},
+                              {VType(ValTypeCode::V128)});
   case OpCode::V128__store:
-    return checkAlignAndTrans(128, {VType(ValType::I32), VType(ValType::V128)},
-                              {});
+    return checkAlignAndTrans(
+        128, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)}, {});
   case OpCode::V128__load8_lane:
-    return checkAlignAndTrans(8, {VType(ValType::I32), VType(ValType::V128)},
-                              {VType(ValType::V128)}, true);
+    return checkAlignAndTrans(
+        8, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)},
+        {VType(ValTypeCode::V128)}, true);
   case OpCode::V128__load16_lane:
-    return checkAlignAndTrans(16, {VType(ValType::I32), VType(ValType::V128)},
-                              {VType(ValType::V128)}, true);
+    return checkAlignAndTrans(
+        16, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)},
+        {VType(ValTypeCode::V128)}, true);
   case OpCode::V128__load32_lane:
-    return checkAlignAndTrans(32, {VType(ValType::I32), VType(ValType::V128)},
-                              {VType(ValType::V128)}, true);
+    return checkAlignAndTrans(
+        32, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)},
+        {VType(ValTypeCode::V128)}, true);
   case OpCode::V128__load64_lane:
-    return checkAlignAndTrans(64, {VType(ValType::I32), VType(ValType::V128)},
-                              {VType(ValType::V128)}, true);
+    return checkAlignAndTrans(
+        64, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)},
+        {VType(ValTypeCode::V128)}, true);
   case OpCode::V128__store8_lane:
-    return checkAlignAndTrans(8, {VType(ValType::I32), VType(ValType::V128)},
-                              {}, true);
+    return checkAlignAndTrans(
+        8, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)}, {}, true);
   case OpCode::V128__store16_lane:
-    return checkAlignAndTrans(16, {VType(ValType::I32), VType(ValType::V128)},
-                              {}, true);
+    return checkAlignAndTrans(
+        16, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)}, {}, true);
   case OpCode::V128__store32_lane:
-    return checkAlignAndTrans(32, {VType(ValType::I32), VType(ValType::V128)},
-                              {}, true);
+    return checkAlignAndTrans(
+        32, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)}, {}, true);
   case OpCode::V128__store64_lane:
-    return checkAlignAndTrans(64, {VType(ValType::I32), VType(ValType::V128)},
-                              {}, true);
+    return checkAlignAndTrans(
+        64, {VType(ValTypeCode::I32), VType(ValTypeCode::V128)}, {}, true);
 
   // SIMD Const Instruction.
   case OpCode::V128__const:
-    return StackTrans({}, {VType(ValType::V128)});
+    return StackTrans({}, {VType(ValTypeCode::V128)});
 
   // SIMD Shuffle Instruction.
   case OpCode::I8x16__shuffle: {
@@ -1048,55 +1067,67 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
       spdlog::error(ErrCode::Value::InvalidLaneIdx);
       return Unexpect(ErrCode::Value::InvalidLaneIdx);
     }
-    return StackTrans({VType(ValType::V128), VType(ValType::V128)},
-                      {VType(ValType::V128)});
+    return StackTrans({VType(ValTypeCode::V128), VType(ValTypeCode::V128)},
+                      {VType(ValTypeCode::V128)});
   }
 
   // SIMD Lane Instructions.
   case OpCode::I8x16__extract_lane_s:
   case OpCode::I8x16__extract_lane_u:
-    return checkLaneAndTrans(16, {VType(ValType::V128)}, {VType(ValType::I32)});
+    return checkLaneAndTrans(16, {VType(ValTypeCode::V128)},
+                             {VType(ValTypeCode::I32)});
   case OpCode::I8x16__replace_lane:
-    return checkLaneAndTrans(16, {VType(ValType::V128), VType(ValType::I32)},
-                             {VType(ValType::V128)});
+    return checkLaneAndTrans(
+        16, {VType(ValTypeCode::V128), VType(ValTypeCode::I32)},
+        {VType(ValTypeCode::V128)});
   case OpCode::I16x8__extract_lane_s:
   case OpCode::I16x8__extract_lane_u:
-    return checkLaneAndTrans(8, {VType(ValType::V128)}, {VType(ValType::I32)});
+    return checkLaneAndTrans(8, {VType(ValTypeCode::V128)},
+                             {VType(ValTypeCode::I32)});
   case OpCode::I16x8__replace_lane:
-    return checkLaneAndTrans(8, {VType(ValType::V128), VType(ValType::I32)},
-                             {VType(ValType::V128)});
+    return checkLaneAndTrans(
+        8, {VType(ValTypeCode::V128), VType(ValTypeCode::I32)},
+        {VType(ValTypeCode::V128)});
   case OpCode::I32x4__extract_lane:
-    return checkLaneAndTrans(4, {VType(ValType::V128)}, {VType(ValType::I32)});
+    return checkLaneAndTrans(4, {VType(ValTypeCode::V128)},
+                             {VType(ValTypeCode::I32)});
   case OpCode::I32x4__replace_lane:
-    return checkLaneAndTrans(4, {VType(ValType::V128), VType(ValType::I32)},
-                             {VType(ValType::V128)});
+    return checkLaneAndTrans(
+        4, {VType(ValTypeCode::V128), VType(ValTypeCode::I32)},
+        {VType(ValTypeCode::V128)});
   case OpCode::I64x2__extract_lane:
-    return checkLaneAndTrans(2, {VType(ValType::V128)}, {VType(ValType::I64)});
+    return checkLaneAndTrans(2, {VType(ValTypeCode::V128)},
+                             {VType(ValTypeCode::I64)});
   case OpCode::I64x2__replace_lane:
-    return checkLaneAndTrans(2, {VType(ValType::V128), VType(ValType::I64)},
-                             {VType(ValType::V128)});
+    return checkLaneAndTrans(
+        2, {VType(ValTypeCode::V128), VType(ValTypeCode::I64)},
+        {VType(ValTypeCode::V128)});
   case OpCode::F32x4__extract_lane:
-    return checkLaneAndTrans(4, {VType(ValType::V128)}, {VType(ValType::F32)});
+    return checkLaneAndTrans(4, {VType(ValTypeCode::V128)},
+                             {VType(ValTypeCode::F32)});
   case OpCode::F32x4__replace_lane:
-    return checkLaneAndTrans(4, {VType(ValType::V128), VType(ValType::F32)},
-                             {VType(ValType::V128)});
+    return checkLaneAndTrans(
+        4, {VType(ValTypeCode::V128), VType(ValTypeCode::F32)},
+        {VType(ValTypeCode::V128)});
   case OpCode::F64x2__extract_lane:
-    return checkLaneAndTrans(2, {VType(ValType::V128)}, {VType(ValType::F64)});
+    return checkLaneAndTrans(2, {VType(ValTypeCode::V128)},
+                             {VType(ValTypeCode::F64)});
   case OpCode::F64x2__replace_lane:
-    return checkLaneAndTrans(2, {VType(ValType::V128), VType(ValType::F64)},
-                             {VType(ValType::V128)});
+    return checkLaneAndTrans(
+        2, {VType(ValTypeCode::V128), VType(ValTypeCode::F64)},
+        {VType(ValTypeCode::V128)});
 
   // SIMD Numeric Instructions.
   case OpCode::I8x16__splat:
   case OpCode::I16x8__splat:
   case OpCode::I32x4__splat:
-    return StackTrans({VType(ValType::I32)}, {VType(ValType::V128)});
+    return StackTrans({VType(ValTypeCode::I32)}, {VType(ValTypeCode::V128)});
   case OpCode::I64x2__splat:
-    return StackTrans({VType(ValType::I64)}, {VType(ValType::V128)});
+    return StackTrans({VType(ValTypeCode::I64)}, {VType(ValTypeCode::V128)});
   case OpCode::F32x4__splat:
-    return StackTrans({VType(ValType::F32)}, {VType(ValType::V128)});
+    return StackTrans({VType(ValTypeCode::F32)}, {VType(ValTypeCode::V128)});
   case OpCode::F64x2__splat:
-    return StackTrans({VType(ValType::F64)}, {VType(ValType::V128)});
+    return StackTrans({VType(ValTypeCode::F64)}, {VType(ValTypeCode::V128)});
   case OpCode::V128__not:
   case OpCode::I8x16__abs:
   case OpCode::I8x16__neg:
@@ -1147,7 +1178,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::F64x2__floor:
   case OpCode::F64x2__trunc:
   case OpCode::F64x2__nearest:
-    return StackTrans({VType(ValType::V128)}, {VType(ValType::V128)});
+    return StackTrans({VType(ValTypeCode::V128)}, {VType(ValTypeCode::V128)});
   case OpCode::I8x16__swizzle:
   case OpCode::I8x16__eq:
   case OpCode::I8x16__ne:
@@ -1268,12 +1299,12 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::F64x2__pmin:
   case OpCode::F64x2__pmax:
   case OpCode::I32x4__dot_i16x8_s:
-    return StackTrans({VType(ValType::V128), VType(ValType::V128)},
-                      {VType(ValType::V128)});
+    return StackTrans({VType(ValTypeCode::V128), VType(ValTypeCode::V128)},
+                      {VType(ValTypeCode::V128)});
   case OpCode::V128__bitselect:
-    return StackTrans(
-        {VType(ValType::V128), VType(ValType::V128), VType(ValType::V128)},
-        {VType(ValType::V128)});
+    return StackTrans({VType(ValTypeCode::V128), VType(ValTypeCode::V128),
+                       VType(ValTypeCode::V128)},
+                      {VType(ValTypeCode::V128)});
   case OpCode::V128__any_true:
   case OpCode::I8x16__all_true:
   case OpCode::I8x16__bitmask:
@@ -1283,7 +1314,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::I32x4__bitmask:
   case OpCode::I64x2__all_true:
   case OpCode::I64x2__bitmask:
-    return StackTrans({VType(ValType::V128)}, {VType(ValType::I32)});
+    return StackTrans({VType(ValTypeCode::V128)}, {VType(ValTypeCode::I32)});
   case OpCode::I8x16__shl:
   case OpCode::I8x16__shr_s:
   case OpCode::I8x16__shr_u:
@@ -1296,281 +1327,281 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::I64x2__shl:
   case OpCode::I64x2__shr_s:
   case OpCode::I64x2__shr_u:
-    return StackTrans({VType(ValType::V128), VType(ValType::I32)},
-                      {VType(ValType::V128)});
+    return StackTrans({VType(ValTypeCode::V128), VType(ValTypeCode::I32)},
+                      {VType(ValTypeCode::V128)});
 
   case OpCode::Atomic__fence:
     return {};
 
   case OpCode::Memory__atomic__notify:
     return checkAlignAndTrans(
-        32, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::Memory__atomic__wait32:
     return checkAlignAndTrans(32,
-                              std::array{VType(ValType::I32),
-                                         VType(ValType::I32),
-                                         VType(ValType::I64)},
-                              std::array{VType(ValType::I32)});
+                              std::array{VType(ValTypeCode::I32),
+                                         VType(ValTypeCode::I32),
+                                         VType(ValTypeCode::I64)},
+                              std::array{VType(ValTypeCode::I32)});
   case OpCode::Memory__atomic__wait64:
     return checkAlignAndTrans(64,
-                              std::array{VType(ValType::I32),
-                                         VType(ValType::I64),
-                                         VType(ValType::I64)},
-                              std::array{VType(ValType::I32)});
+                              std::array{VType(ValTypeCode::I32),
+                                         VType(ValTypeCode::I64),
+                                         VType(ValTypeCode::I64)},
+                              std::array{VType(ValTypeCode::I32)});
 
   case OpCode::I32__atomic__load:
-    return checkAlignAndTrans(32, std::array{VType(ValType::I32)},
-                              std::array{VType(ValType::I32)});
+    return checkAlignAndTrans(32, std::array{VType(ValTypeCode::I32)},
+                              std::array{VType(ValTypeCode::I32)});
   case OpCode::I64__atomic__load:
-    return checkAlignAndTrans(64, std::array{VType(ValType::I32)},
-                              std::array{VType(ValType::I64)});
+    return checkAlignAndTrans(64, std::array{VType(ValTypeCode::I32)},
+                              std::array{VType(ValTypeCode::I64)});
   case OpCode::I32__atomic__load8_u:
-    return checkAlignAndTrans(8, std::array{VType(ValType::I32)},
-                              std::array{VType(ValType::I32)});
+    return checkAlignAndTrans(8, std::array{VType(ValTypeCode::I32)},
+                              std::array{VType(ValTypeCode::I32)});
   case OpCode::I32__atomic__load16_u:
-    return checkAlignAndTrans(16, std::array{VType(ValType::I32)},
-                              std::array{VType(ValType::I32)});
+    return checkAlignAndTrans(16, std::array{VType(ValTypeCode::I32)},
+                              std::array{VType(ValTypeCode::I32)});
   case OpCode::I64__atomic__load8_u:
-    return checkAlignAndTrans(8, std::array{VType(ValType::I32)},
-                              std::array{VType(ValType::I64)});
+    return checkAlignAndTrans(8, std::array{VType(ValTypeCode::I32)},
+                              std::array{VType(ValTypeCode::I64)});
   case OpCode::I64__atomic__load16_u:
-    return checkAlignAndTrans(16, std::array{VType(ValType::I32)},
-                              std::array{VType(ValType::I64)});
+    return checkAlignAndTrans(16, std::array{VType(ValTypeCode::I32)},
+                              std::array{VType(ValTypeCode::I64)});
   case OpCode::I64__atomic__load32_u:
-    return checkAlignAndTrans(32, std::array{VType(ValType::I32)},
-                              std::array{VType(ValType::I64)});
+    return checkAlignAndTrans(32, std::array{VType(ValTypeCode::I32)},
+                              std::array{VType(ValTypeCode::I64)});
   case OpCode::I32__atomic__store:
     return checkAlignAndTrans(
-        32, std::array{VType(ValType::I32), VType(ValType::I32)}, {});
+        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)}, {});
   case OpCode::I64__atomic__store:
     return checkAlignAndTrans(
-        64, std::array{VType(ValType::I32), VType(ValType::I64)}, {});
+        64, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)}, {});
   case OpCode::I32__atomic__store8:
     return checkAlignAndTrans(
-        8, std::array{VType(ValType::I32), VType(ValType::I32)}, {});
+        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)}, {});
   case OpCode::I32__atomic__store16:
     return checkAlignAndTrans(
-        16, std::array{VType(ValType::I32), VType(ValType::I32)}, {});
+        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)}, {});
   case OpCode::I64__atomic__store8:
     return checkAlignAndTrans(
-        8, std::array{VType(ValType::I32), VType(ValType::I64)}, {});
+        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)}, {});
   case OpCode::I64__atomic__store16:
     return checkAlignAndTrans(
-        16, std::array{VType(ValType::I32), VType(ValType::I64)}, {});
+        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)}, {});
   case OpCode::I64__atomic__store32:
     return checkAlignAndTrans(
-        32, std::array{VType(ValType::I32), VType(ValType::I64)}, {});
+        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)}, {});
   case OpCode::I32__atomic__rmw__add:
     return checkAlignAndTrans(
-        32, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw__add:
     return checkAlignAndTrans(
-        64, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        64, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw8__add_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I32__atomic__rmw16__add_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw8__add_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw16__add_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw32__add_u:
     return checkAlignAndTrans(
-        32, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw__sub:
     return checkAlignAndTrans(
-        32, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw__sub:
     return checkAlignAndTrans(
-        64, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        64, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw8__sub_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I32__atomic__rmw16__sub_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw8__sub_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw16__sub_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw32__sub_u:
     return checkAlignAndTrans(
-        32, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw__and:
     return checkAlignAndTrans(
-        32, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw__and:
     return checkAlignAndTrans(
-        64, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        64, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw8__and_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I32__atomic__rmw16__and_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw8__and_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw16__and_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw32__and_u:
     return checkAlignAndTrans(
-        32, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw__or:
     return checkAlignAndTrans(
-        32, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw__or:
     return checkAlignAndTrans(
-        64, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        64, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw8__or_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I32__atomic__rmw16__or_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw8__or_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw16__or_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw32__or_u:
     return checkAlignAndTrans(
-        32, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw__xor:
     return checkAlignAndTrans(
-        32, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw__xor:
     return checkAlignAndTrans(
-        64, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        64, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw8__xor_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I32__atomic__rmw16__xor_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw8__xor_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw16__xor_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw32__xor_u:
     return checkAlignAndTrans(
-        32, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw__xchg:
     return checkAlignAndTrans(
-        32, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw__xchg:
     return checkAlignAndTrans(
-        64, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        64, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw8__xchg_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I32__atomic__rmw16__xchg_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValType::I32), VType(ValType::I32)},
-        std::array{VType(ValType::I32)});
+        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I32)},
+        std::array{VType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw8__xchg_u:
     return checkAlignAndTrans(
-        8, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        8, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw16__xchg_u:
     return checkAlignAndTrans(
-        16, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        16, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw32__xchg_u:
     return checkAlignAndTrans(
-        32, std::array{VType(ValType::I32), VType(ValType::I64)},
-        std::array{VType(ValType::I64)});
+        32, std::array{VType(ValTypeCode::I32), VType(ValTypeCode::I64)},
+        std::array{VType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw__cmpxchg:
     return checkAlignAndTrans(32,
-                              std::array{VType(ValType::I32),
-                                         VType(ValType::I32),
-                                         VType(ValType::I32)},
-                              std::array{VType(ValType::I32)});
+                              std::array{VType(ValTypeCode::I32),
+                                         VType(ValTypeCode::I32),
+                                         VType(ValTypeCode::I32)},
+                              std::array{VType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw__cmpxchg:
     return checkAlignAndTrans(64,
-                              std::array{VType(ValType::I32),
-                                         VType(ValType::I64),
-                                         VType(ValType::I64)},
-                              std::array{VType(ValType::I64)});
+                              std::array{VType(ValTypeCode::I32),
+                                         VType(ValTypeCode::I64),
+                                         VType(ValTypeCode::I64)},
+                              std::array{VType(ValTypeCode::I64)});
   case OpCode::I32__atomic__rmw8__cmpxchg_u:
     return checkAlignAndTrans(8,
-                              std::array{VType(ValType::I32),
-                                         VType(ValType::I32),
-                                         VType(ValType::I32)},
-                              std::array{VType(ValType::I32)});
+                              std::array{VType(ValTypeCode::I32),
+                                         VType(ValTypeCode::I32),
+                                         VType(ValTypeCode::I32)},
+                              std::array{VType(ValTypeCode::I32)});
   case OpCode::I32__atomic__rmw16__cmpxchg_u:
     return checkAlignAndTrans(16,
-                              std::array{VType(ValType::I32),
-                                         VType(ValType::I32),
-                                         VType(ValType::I32)},
-                              std::array{VType(ValType::I32)});
+                              std::array{VType(ValTypeCode::I32),
+                                         VType(ValTypeCode::I32),
+                                         VType(ValTypeCode::I32)},
+                              std::array{VType(ValTypeCode::I32)});
   case OpCode::I64__atomic__rmw8__cmpxchg_u:
     return checkAlignAndTrans(8,
-                              std::array{VType(ValType::I32),
-                                         VType(ValType::I64),
-                                         VType(ValType::I64)},
-                              std::array{VType(ValType::I64)});
+                              std::array{VType(ValTypeCode::I32),
+                                         VType(ValTypeCode::I64),
+                                         VType(ValTypeCode::I64)},
+                              std::array{VType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw16__cmpxchg_u:
     return checkAlignAndTrans(16,
-                              std::array{VType(ValType::I32),
-                                         VType(ValType::I64),
-                                         VType(ValType::I64)},
-                              std::array{VType(ValType::I64)});
+                              std::array{VType(ValTypeCode::I32),
+                                         VType(ValTypeCode::I64),
+                                         VType(ValTypeCode::I64)},
+                              std::array{VType(ValTypeCode::I64)});
   case OpCode::I64__atomic__rmw32__cmpxchg_u:
     return checkAlignAndTrans(32,
-                              std::array{VType(ValType::I32),
-                                         VType(ValType::I64),
-                                         VType(ValType::I64)},
-                              std::array{VType(ValType::I64)});
+                              std::array{VType(ValTypeCode::I32),
+                                         VType(ValTypeCode::I64),
+                                         VType(ValTypeCode::I64)},
+                              std::array{VType(ValTypeCode::I64)});
 
   default:
     assumingUnreachable();

--- a/lib/validator/validator.cpp
+++ b/lib/validator/validator.cpp
@@ -169,7 +169,7 @@ Expect<void> Validator::validate(const AST::ElementSegment &ElemSeg) {
   // Check initialization expressions are const expressions.
   for (auto &Expr : ElemSeg.getInitExprs()) {
     if (auto Res = validateConstExpr(Expr.getInstrs(),
-                                     {FullValType(ElemSeg.getRefType())});
+                                     {ValType(ElemSeg.getRefType())});
         !Res) {
       spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Expression));
       return Unexpect(Res);
@@ -196,7 +196,7 @@ Expect<void> Validator::validate(const AST::ElementSegment &ElemSeg) {
     }
     // Check table initialization is a const expression.
     if (auto Res = validateConstExpr(ElemSeg.getExpr().getInstrs(),
-                                     {FullValType(ValType::I32)});
+                                     {ValType(ValTypeCode::I32)});
         !Res) {
       spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Expression));
       return Unexpect(Res);
@@ -243,7 +243,7 @@ Expect<void> Validator::validate(const AST::DataSegment &DataSeg) {
     }
     // Check memory initialization is a const expression.
     if (auto Res = validateConstExpr(DataSeg.getExpr().getInstrs(),
-                                     {FullValType(ValType::I32)});
+                                     {ValType(ValTypeCode::I32)});
         !Res) {
       spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Expression));
       return Unexpect(Res);
@@ -482,7 +482,7 @@ Expect<void> Validator::validate(const AST::StartSection &StartSec) {
     auto &Type = Checker.getTypes()[TId];
     if (Type.first.size() != 0 || Type.second.size() != 0) {
       // Start function signature should be {}->{}
-      std::vector<FullValType> Params, Returns;
+      std::vector<ValType> Params, Returns;
       for (auto &V : Type.first) {
         Params.push_back(Checker.VTypeToAST(V));
       }
@@ -518,7 +518,7 @@ Expect<void> Validator::validate(const AST::ExportSection &ExportSec) {
 
 // Validate constant expression. See "include/validator/validator.h".
 Expect<void> Validator::validateConstExpr(AST::InstrView Instrs,
-                                          Span<const FullValType> Returns) {
+                                          Span<const ValType> Returns) {
   for (auto &Instr : Instrs) {
     // Only these instructions are accepted.
     switch (Instr.getOpCode()) {

--- a/lib/vm/vm.cpp
+++ b/lib/vm/vm.cpp
@@ -183,10 +183,10 @@ VM::unsafeRegisterModule(const Runtime::Instance::ModuleInstance &ModInst) {
   return ExecutorEngine.registerModule(StoreRef, ModInst);
 }
 
-Expect<std::vector<std::pair<ValVariant, FullValType>>>
+Expect<std::vector<std::pair<ValVariant, ValType>>>
 VM::unsafeRunWasmFile(const std::filesystem::path &Path, std::string_view Func,
                       Span<const ValVariant> Params,
-                      Span<const FullValType> ParamTypes) {
+                      Span<const ValType> ParamTypes) {
   if (Stage == VMStage::Instantiated) {
     // When running another module, instantiated module in store will be reset.
     // Therefore the instantiation should restart.
@@ -200,10 +200,10 @@ VM::unsafeRunWasmFile(const std::filesystem::path &Path, std::string_view Func,
   }
 }
 
-Expect<std::vector<std::pair<ValVariant, FullValType>>>
+Expect<std::vector<std::pair<ValVariant, ValType>>>
 VM::unsafeRunWasmFile(Span<const Byte> Code, std::string_view Func,
                       Span<const ValVariant> Params,
-                      Span<const FullValType> ParamTypes) {
+                      Span<const ValType> ParamTypes) {
   if (Stage == VMStage::Instantiated) {
     // When running another module, instantiated module in store will be reset.
     // Therefore the instantiation should restart.
@@ -217,10 +217,10 @@ VM::unsafeRunWasmFile(Span<const Byte> Code, std::string_view Func,
   }
 }
 
-Expect<std::vector<std::pair<ValVariant, FullValType>>>
+Expect<std::vector<std::pair<ValVariant, ValType>>>
 VM::unsafeRunWasmFile(const AST::Module &Module, std::string_view Func,
                       Span<const ValVariant> Params,
-                      Span<const FullValType> ParamTypes) {
+                      Span<const ValType> ParamTypes) {
   if (Stage == VMStage::Instantiated) {
     // When running another module, instantiated module in store will be reset.
     // Therefore the instantiation should restart.
@@ -245,13 +245,13 @@ VM::unsafeRunWasmFile(const AST::Module &Module, std::string_view Func,
   }
 }
 
-Async<Expect<std::vector<std::pair<ValVariant, FullValType>>>>
+Async<Expect<std::vector<std::pair<ValVariant, ValType>>>>
 VM::asyncRunWasmFile(const std::filesystem::path &Path, std::string_view Func,
                      Span<const ValVariant> Params,
-                     Span<const FullValType> ParamTypes) {
-  Expect<std::vector<std::pair<ValVariant, FullValType>>> (VM::*FPtr)(
+                     Span<const ValType> ParamTypes) {
+  Expect<std::vector<std::pair<ValVariant, ValType>>> (VM::*FPtr)(
       const std::filesystem::path &, std::string_view, Span<const ValVariant>,
-      Span<const FullValType>) = &VM::runWasmFile;
+      Span<const ValType>) = &VM::runWasmFile;
   return {FPtr,
           *this,
           std::filesystem::path(Path),
@@ -260,13 +260,13 @@ VM::asyncRunWasmFile(const std::filesystem::path &Path, std::string_view Func,
           std::vector(ParamTypes.begin(), ParamTypes.end())};
 }
 
-Async<Expect<std::vector<std::pair<ValVariant, FullValType>>>>
+Async<Expect<std::vector<std::pair<ValVariant, ValType>>>>
 VM::asyncRunWasmFile(Span<const Byte> Code, std::string_view Func,
                      Span<const ValVariant> Params,
-                     Span<const FullValType> ParamTypes) {
-  Expect<std::vector<std::pair<ValVariant, FullValType>>> (VM::*FPtr)(
+                     Span<const ValType> ParamTypes) {
+  Expect<std::vector<std::pair<ValVariant, ValType>>> (VM::*FPtr)(
       Span<const Byte>, std::string_view, Span<const ValVariant>,
-      Span<const FullValType>) = &VM::runWasmFile;
+      Span<const ValType>) = &VM::runWasmFile;
   return {FPtr,
           *this,
           Code,
@@ -275,13 +275,13 @@ VM::asyncRunWasmFile(Span<const Byte> Code, std::string_view Func,
           std::vector(ParamTypes.begin(), ParamTypes.end())};
 }
 
-Async<Expect<std::vector<std::pair<ValVariant, FullValType>>>>
+Async<Expect<std::vector<std::pair<ValVariant, ValType>>>>
 VM::asyncRunWasmFile(const AST::Module &Module, std::string_view Func,
                      Span<const ValVariant> Params,
-                     Span<const FullValType> ParamTypes) {
-  Expect<std::vector<std::pair<ValVariant, FullValType>>> (VM::*FPtr)(
+                     Span<const ValType> ParamTypes) {
+  Expect<std::vector<std::pair<ValVariant, ValType>>> (VM::*FPtr)(
       const AST::Module &, std::string_view, Span<const ValVariant>,
-      Span<const FullValType>) = &VM::runWasmFile;
+      Span<const ValType>) = &VM::runWasmFile;
   return {FPtr,
           *this,
           Module,
@@ -347,9 +347,9 @@ Expect<void> VM::unsafeInstantiate() {
   }
 }
 
-Expect<std::vector<std::pair<ValVariant, FullValType>>>
+Expect<std::vector<std::pair<ValVariant, ValType>>>
 VM::unsafeExecute(std::string_view Func, Span<const ValVariant> Params,
-                  Span<const FullValType> ParamTypes) {
+                  Span<const ValType> ParamTypes) {
   if (ActiveModInst) {
     // Execute function and return values with the module instance.
     return unsafeExecute(ActiveModInst.get(), Func, Params, ParamTypes);
@@ -360,10 +360,10 @@ VM::unsafeExecute(std::string_view Func, Span<const ValVariant> Params,
   }
 }
 
-Expect<std::vector<std::pair<ValVariant, FullValType>>>
+Expect<std::vector<std::pair<ValVariant, ValType>>>
 VM::unsafeExecute(std::string_view ModName, std::string_view Func,
                   Span<const ValVariant> Params,
-                  Span<const FullValType> ParamTypes) {
+                  Span<const ValType> ParamTypes) {
   // Find module instance by name.
   const auto *FindModInst = StoreRef.findModule(ModName);
   if (FindModInst != nullptr) {
@@ -376,10 +376,10 @@ VM::unsafeExecute(std::string_view ModName, std::string_view Func,
   }
 }
 
-Expect<std::vector<std::pair<ValVariant, FullValType>>>
+Expect<std::vector<std::pair<ValVariant, ValType>>>
 VM::unsafeExecute(const Runtime::Instance::ModuleInstance *ModInst,
                   std::string_view Func, Span<const ValVariant> Params,
-                  Span<const FullValType> ParamTypes) {
+                  Span<const ValType> ParamTypes) {
   // Find exported function by name.
   Runtime::Instance::FunctionInstance *FuncInst =
       ModInst->findFuncExports(Func);
@@ -401,24 +401,24 @@ VM::unsafeExecute(const Runtime::Instance::ModuleInstance *ModInst,
   }
 }
 
-Async<Expect<std::vector<std::pair<ValVariant, FullValType>>>>
+Async<Expect<std::vector<std::pair<ValVariant, ValType>>>>
 VM::asyncExecute(std::string_view Func, Span<const ValVariant> Params,
-                 Span<const FullValType> ParamTypes) {
-  Expect<std::vector<std::pair<ValVariant, FullValType>>> (VM::*FPtr)(
-      std::string_view, Span<const ValVariant>, Span<const FullValType>) =
+                 Span<const ValType> ParamTypes) {
+  Expect<std::vector<std::pair<ValVariant, ValType>>> (VM::*FPtr)(
+      std::string_view, Span<const ValVariant>, Span<const ValType>) =
       &VM::execute;
   return {FPtr, *this, std::string(Func),
           std::vector(Params.begin(), Params.end()),
           std::vector(ParamTypes.begin(), ParamTypes.end())};
 }
 
-Async<Expect<std::vector<std::pair<ValVariant, FullValType>>>>
+Async<Expect<std::vector<std::pair<ValVariant, ValType>>>>
 VM::asyncExecute(std::string_view ModName, std::string_view Func,
                  Span<const ValVariant> Params,
-                 Span<const FullValType> ParamTypes) {
-  Expect<std::vector<std::pair<ValVariant, FullValType>>> (VM::*FPtr)(
+                 Span<const ValType> ParamTypes) {
+  Expect<std::vector<std::pair<ValVariant, ValType>>> (VM::*FPtr)(
       std::string_view, std::string_view, Span<const ValVariant>,
-      Span<const FullValType>) = &VM::execute;
+      Span<const ValType>) = &VM::execute;
   return {FPtr,
           *this,
           std::string(ModName),

--- a/test/aot/AOTcoreTest.cpp
+++ b/test/aot/AOTcoreTest.cpp
@@ -114,8 +114,8 @@ TEST_P(NativeCoreTest, TestSuites) {
   // Helper function to call functions.
   T.onInvoke = [&VM](const std::string &ModName, const std::string &Field,
                      const std::vector<ValVariant> &Params,
-                     const std::vector<FullValType> &ParamTypes)
-      -> Expect<std::vector<std::pair<ValVariant, FullValType>>> {
+                     const std::vector<ValType> &ParamTypes)
+      -> Expect<std::vector<std::pair<ValVariant, ValType>>> {
     if (!ModName.empty()) {
       // Invoke function of named module. Named modules are registered in Store
       // Manager.
@@ -128,7 +128,7 @@ TEST_P(NativeCoreTest, TestSuites) {
   };
   // Helper function to get values.
   T.onGet = [&VM](const std::string &ModName, const std::string &Field)
-      -> Expect<std::pair<ValVariant, FullValType>> {
+      -> Expect<std::pair<ValVariant, ValType>> {
     // Get module instance.
     const WasmEdge::Runtime::Instance::ModuleInstance *ModInst = nullptr;
     if (ModName.empty()) {
@@ -220,8 +220,8 @@ TEST_P(CustomWasmCoreTest, TestSuites) {
   // Helper function to call functions.
   T.onInvoke = [&VM](const std::string &ModName, const std::string &Field,
                      const std::vector<ValVariant> &Params,
-                     const std::vector<FullValType> &ParamTypes)
-      -> Expect<std::vector<std::pair<ValVariant, FullValType>>> {
+                     const std::vector<ValType> &ParamTypes)
+      -> Expect<std::vector<std::pair<ValVariant, ValType>>> {
     if (!ModName.empty()) {
       // Invoke function of named module. Named modules are registered in Store
       // Manager.
@@ -234,7 +234,7 @@ TEST_P(CustomWasmCoreTest, TestSuites) {
   };
   // Helper function to get values.
   T.onGet = [&VM](const std::string &ModName, const std::string &Field)
-      -> Expect<std::pair<ValVariant, FullValType>> {
+      -> Expect<std::pair<ValVariant, ValType>> {
     // Get module instance.
     const WasmEdge::Runtime::Instance::ModuleInstance *ModInst = nullptr;
     if (ModName.empty()) {

--- a/test/api/APIAOTCoreTest.cpp
+++ b/test/api/APIAOTCoreTest.cpp
@@ -142,8 +142,8 @@ TEST_P(CoreCompileTest, TestSuites) {
   // Helper function to call functions.
   T.onInvoke = [&VM](const std::string &ModName, const std::string &Field,
                      const std::vector<ValVariant> &Params,
-                     const std::vector<FullValType> &ParamTypes)
-      -> Expect<std::vector<std::pair<ValVariant, FullValType>>> {
+                     const std::vector<ValType> &ParamTypes)
+      -> Expect<std::vector<std::pair<ValVariant, ValType>>> {
     WasmEdge_Result Res;
     std::vector<WasmEdge_Value> CParams = convFromValVec(Params, ParamTypes);
     std::vector<WasmEdge_Value> CReturns;
@@ -186,7 +186,7 @@ TEST_P(CoreCompileTest, TestSuites) {
   };
   // Helper function to get values.
   T.onGet = [&VM](const std::string &ModName, const std::string &Field)
-      -> Expect<std::pair<ValVariant, FullValType>> {
+      -> Expect<std::pair<ValVariant, ValType>> {
     // Get module instance.
     const WasmEdge_ModuleInstanceContext *ModCxt = nullptr;
     WasmEdge_StoreContext *StoreCxt = WasmEdge_VMGetStoreContext(VM);
@@ -211,11 +211,11 @@ TEST_P(CoreCompileTest, TestSuites) {
     }
     WasmEdge_Value Val = WasmEdge_GlobalInstanceGetValue(GlobCxt);
 #if defined(__x86_64__) || defined(__aarch64__)
-    return std::make_pair(ValVariant(Val.Value), Val.Type);
+    return std::make_pair(ValVariant(Val.Value), ValType(Val.Type.Data));
 #else
     return std::make_pair(
         ValVariant(WasmEdge::uint128_t(Val.Value.High, Val.Value.Low)),
-        Val.Type);
+        ValType(Val.Type.Data));
 #endif
   };
 

--- a/test/api/APIStepsCoreTest.cpp
+++ b/test/api/APIStepsCoreTest.cpp
@@ -134,8 +134,8 @@ TEST_P(CoreTest, TestSuites) {
   // Helper function to call functions.
   T.onInvoke = [&](const std::string &ModName, const std::string &Field,
                    const std::vector<ValVariant> &Params,
-                   const std::vector<FullValType> &ParamTypes)
-      -> Expect<std::vector<std::pair<ValVariant, FullValType>>> {
+                   const std::vector<ValType> &ParamTypes)
+      -> Expect<std::vector<std::pair<ValVariant, ValType>>> {
     WasmEdge_Result Res;
     std::vector<WasmEdge_Value> CParams = convFromValVec(Params, ParamTypes);
     std::vector<WasmEdge_Value> CReturns;
@@ -182,8 +182,9 @@ TEST_P(CoreTest, TestSuites) {
     return convToValVec(CReturns);
   };
   // Helper function to get values.
-  T.onGet = [&](const std::string &ModName, const std::string &Field)
-      -> Expect<std::pair<ValVariant, FullValType>> {
+  T.onGet =
+      [&](const std::string &ModName,
+          const std::string &Field) -> Expect<std::pair<ValVariant, ValType>> {
     // Get module instance.
     const WasmEdge_ModuleInstanceContext *ModCxt = nullptr;
     if (ModName.empty()) {
@@ -204,11 +205,11 @@ TEST_P(CoreTest, TestSuites) {
     }
     WasmEdge_Value Val = WasmEdge_GlobalInstanceGetValue(GlobCxt);
 #if defined(__x86_64__) || defined(__aarch64__)
-    return std::make_pair(ValVariant(Val.Value), Val.Type);
+    return std::make_pair(ValVariant(Val.Value), ValType(Val.Type.Data));
 #else
     return std::make_pair(
         ValVariant(WasmEdge::uint128_t(Val.Value.High, Val.Value.Low)),
-        Val.Type);
+        ValType(Val.Type.Data));
 #endif
   };
 

--- a/test/api/APIUnitTest.cpp
+++ b/test/api/APIUnitTest.cpp
@@ -119,9 +119,9 @@ WasmEdge_ModuleInstanceContext *createExternModule
       WasmEdge_StringWrap(Name.data(), static_cast<uint32_t>(Name.length()));
   WasmEdge_ModuleInstanceContext *HostMod =
       WasmEdge_ModuleInstanceCreate(HostName);
-  enum WasmEdge_ValType Param[2] = {WasmEdge_ValType_ExternRef,
-                                    WasmEdge_ValType_I32},
-                        Result[1] = {WasmEdge_ValType_I32};
+  WasmEdge_ValType Param[2] = {WasmEdge_ValTypeGenExternRef(),
+                               WasmEdge_ValTypeGenI32()},
+                   Result[1] = {WasmEdge_ValTypeGenI32()};
   WasmEdge_FunctionTypeContext *HostFType =
       WasmEdge_FunctionTypeCreate(Param, 2, Result, 1);
   WasmEdge_FunctionInstanceContext *HostFunc = nullptr;
@@ -304,6 +304,40 @@ TEST(APICoreTest, Log) {
   EXPECT_TRUE(true);
 }
 
+TEST(APICoreTest, ValType) {
+  WasmEdge_ValType VT;
+
+  VT = WasmEdge_ValTypeGenI32();
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(VT));
+  EXPECT_FALSE(WasmEdge_ValTypeIsRef(VT));
+
+  VT = WasmEdge_ValTypeGenI64();
+  EXPECT_TRUE(WasmEdge_ValTypeIsI64(VT));
+  EXPECT_FALSE(WasmEdge_ValTypeIsRef(VT));
+
+  VT = WasmEdge_ValTypeGenF32();
+  EXPECT_TRUE(WasmEdge_ValTypeIsF32(VT));
+  EXPECT_FALSE(WasmEdge_ValTypeIsRef(VT));
+
+  VT = WasmEdge_ValTypeGenF64();
+  EXPECT_TRUE(WasmEdge_ValTypeIsF64(VT));
+  EXPECT_FALSE(WasmEdge_ValTypeIsRef(VT));
+
+  VT = WasmEdge_ValTypeGenV128();
+  EXPECT_TRUE(WasmEdge_ValTypeIsV128(VT));
+  EXPECT_FALSE(WasmEdge_ValTypeIsRef(VT));
+
+  VT = WasmEdge_ValTypeGenFuncRef();
+  EXPECT_TRUE(WasmEdge_ValTypeIsFuncRef(VT));
+  EXPECT_TRUE(WasmEdge_ValTypeIsRef(VT));
+  EXPECT_TRUE(WasmEdge_ValTypeIsRefNull(VT));
+
+  VT = WasmEdge_ValTypeGenExternRef();
+  EXPECT_TRUE(WasmEdge_ValTypeIsExternRef(VT));
+  EXPECT_TRUE(WasmEdge_ValTypeIsRef(VT));
+  EXPECT_TRUE(WasmEdge_ValTypeIsRefNull(VT));
+}
+
 TEST(APICoreTest, Value) {
   std::vector<uint32_t> Vec = {1U, 2U, 3U};
   WasmEdge_Value Val = WasmEdge_ValueGenI32(INT32_MAX);
@@ -323,7 +357,7 @@ TEST(APICoreTest, Value) {
   Val = WasmEdge_ValueGenV128(V);
   EXPECT_TRUE(0 == std::memcmp(&V, &Val, sizeof(V)));
 #endif
-  Val = WasmEdge_ValueGenNullRef(WasmEdge_RefType_FuncRef);
+  Val = WasmEdge_ValueGenNullRef(WasmEdge_RefTypeCode_FuncRef);
   EXPECT_TRUE(WasmEdge_ValueIsNullRef(Val));
   Val = WasmEdge_ValueGenFuncRef(nullptr);
   EXPECT_EQ(WasmEdge_ValueGetFuncRef(Val), nullptr);
@@ -482,12 +516,13 @@ TEST(APICoreTest, Configure) {
 
 TEST(APICoreTest, FunctionType) {
   std::vector<WasmEdge_ValType> Param = {
-      WasmEdge_ValType_I32,  WasmEdge_ValType_I64, WasmEdge_ValType_ExternRef,
-      WasmEdge_ValType_V128, WasmEdge_ValType_F64, WasmEdge_ValType_F32};
-  std::vector<WasmEdge_ValType> Result = {WasmEdge_ValType_FuncRef,
-                                          WasmEdge_ValType_ExternRef,
-                                          WasmEdge_ValType_V128};
-  enum WasmEdge_ValType Buf1[6], Buf2[2];
+      WasmEdge_ValTypeGenI32(),       WasmEdge_ValTypeGenI64(),
+      WasmEdge_ValTypeGenExternRef(), WasmEdge_ValTypeGenV128(),
+      WasmEdge_ValTypeGenF64(),       WasmEdge_ValTypeGenF32()};
+  std::vector<WasmEdge_ValType> Result = {WasmEdge_ValTypeGenFuncRef(),
+                                          WasmEdge_ValTypeGenExternRef(),
+                                          WasmEdge_ValTypeGenV128()};
+  WasmEdge_ValType Buf1[6], Buf2[2];
   WasmEdge_FunctionTypeContext *FType =
       WasmEdge_FunctionTypeCreate(&Param[0], 6, &Result[0], 3);
   EXPECT_EQ(WasmEdge_FunctionTypeGetParametersLength(FType), 6U);
@@ -495,16 +530,22 @@ TEST(APICoreTest, FunctionType) {
   EXPECT_EQ(WasmEdge_FunctionTypeGetReturnsLength(FType), 3U);
   EXPECT_EQ(WasmEdge_FunctionTypeGetReturnsLength(nullptr), 0U);
   EXPECT_EQ(WasmEdge_FunctionTypeGetParameters(FType, Buf1, 6), 6U);
-  EXPECT_EQ(Param, std::vector<WasmEdge_ValType>(Buf1, Buf1 + 6));
+  for (uint32_t I = 0; I < 6; I++) {
+    EXPECT_TRUE(WasmEdge_ValTypeIsEqual(Param[I], Buf1[I]));
+  }
   EXPECT_EQ(WasmEdge_FunctionTypeGetParameters(FType, Buf2, 2), 6U);
-  EXPECT_EQ(std::vector<WasmEdge_ValType>(Param.cbegin(), Param.cbegin() + 2),
-            std::vector<WasmEdge_ValType>(Buf2, Buf2 + 2));
+  for (uint32_t I = 0; I < 2; I++) {
+    EXPECT_TRUE(WasmEdge_ValTypeIsEqual(Param[I], Buf2[I]));
+  }
   EXPECT_EQ(WasmEdge_FunctionTypeGetParameters(nullptr, Buf1, 6), 0U);
   EXPECT_EQ(WasmEdge_FunctionTypeGetReturns(FType, Buf1, 6), 3U);
-  EXPECT_EQ(Result, std::vector<WasmEdge_ValType>(Buf1, Buf1 + 3));
+  for (uint32_t I = 0; I < 3; I++) {
+    EXPECT_TRUE(WasmEdge_ValTypeIsEqual(Result[I], Buf1[I]));
+  }
   EXPECT_EQ(WasmEdge_FunctionTypeGetReturns(FType, Buf2, 2), 3U);
-  EXPECT_EQ(std::vector<WasmEdge_ValType>(Result.cbegin(), Result.cbegin() + 2),
-            std::vector<WasmEdge_ValType>(Buf2, Buf2 + 2));
+  for (uint32_t I = 0; I < 2; I++) {
+    EXPECT_TRUE(WasmEdge_ValTypeIsEqual(Result[I], Buf2[I]));
+  }
   EXPECT_EQ(WasmEdge_FunctionTypeGetReturns(nullptr, Buf1, 6), 0U);
   WasmEdge_FunctionTypeDelete(FType);
   WasmEdge_FunctionTypeDelete(nullptr);
@@ -520,16 +561,16 @@ TEST(APICoreTest, TableType) {
   WasmEdge_Limit Lim2 = {
       .HasMax = false, .Shared = false, .Min = 30, .Max = 30};
   WasmEdge_TableTypeContext *TType =
-      WasmEdge_TableTypeCreate(WasmEdge_RefType_ExternRef, Lim1);
-  EXPECT_EQ(WasmEdge_TableTypeGetRefType(TType), WasmEdge_RefType_ExternRef);
-  EXPECT_EQ(WasmEdge_TableTypeGetRefType(nullptr), WasmEdge_RefType_FuncRef);
+      WasmEdge_TableTypeCreate(WasmEdge_ValTypeGenExternRef(), Lim1);
+  EXPECT_TRUE(WasmEdge_ValTypeIsExternRef(WasmEdge_TableTypeGetRefType(TType)));
+  EXPECT_TRUE(WasmEdge_ValTypeIsFuncRef(WasmEdge_TableTypeGetRefType(nullptr)));
   EXPECT_TRUE(WasmEdge_LimitIsEqual(WasmEdge_TableTypeGetLimit(TType), Lim1));
   EXPECT_FALSE(
       WasmEdge_LimitIsEqual(WasmEdge_TableTypeGetLimit(nullptr), Lim1));
   WasmEdge_TableTypeDelete(TType);
   WasmEdge_TableTypeDelete(nullptr);
-  TType = WasmEdge_TableTypeCreate(WasmEdge_RefType_FuncRef, Lim2);
-  EXPECT_EQ(WasmEdge_TableTypeGetRefType(TType), WasmEdge_RefType_FuncRef);
+  TType = WasmEdge_TableTypeCreate(WasmEdge_ValTypeGenFuncRef(), Lim2);
+  EXPECT_TRUE(WasmEdge_ValTypeIsFuncRef(WasmEdge_TableTypeGetRefType(TType)));
   EXPECT_TRUE(WasmEdge_LimitIsEqual(WasmEdge_TableTypeGetLimit(TType), Lim2));
   WasmEdge_TableTypeDelete(TType);
   WasmEdge_TableTypeDelete(nullptr);
@@ -553,10 +594,10 @@ TEST(APICoreTest, MemoryType) {
 }
 
 TEST(APICoreTest, GlobalType) {
-  WasmEdge_GlobalTypeContext *GType =
-      WasmEdge_GlobalTypeCreate(WasmEdge_ValType_V128, WasmEdge_Mutability_Var);
-  EXPECT_EQ(WasmEdge_GlobalTypeGetValType(GType), WasmEdge_ValType_V128);
-  EXPECT_EQ(WasmEdge_GlobalTypeGetValType(nullptr), WasmEdge_ValType_I32);
+  WasmEdge_GlobalTypeContext *GType = WasmEdge_GlobalTypeCreate(
+      WasmEdge_ValTypeGenV128(), WasmEdge_Mutability_Var);
+  EXPECT_TRUE(WasmEdge_ValTypeIsV128(WasmEdge_GlobalTypeGetValType(GType)));
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(WasmEdge_GlobalTypeGetValType(nullptr)));
   EXPECT_EQ(WasmEdge_GlobalTypeGetMutability(GType), WasmEdge_Mutability_Var);
   EXPECT_EQ(WasmEdge_GlobalTypeGetMutability(nullptr),
             WasmEdge_Mutability_Const);
@@ -707,9 +748,8 @@ TEST(APICoreTest, ImportType) {
   EXPECT_EQ(WasmEdge_ImportTypeGetTableType(nullptr, ImpTypes[11]), nullptr);
   EXPECT_EQ(WasmEdge_ImportTypeGetTableType(Mod, ImpTypes[0]), nullptr);
   EXPECT_NE(WasmEdge_ImportTypeGetTableType(Mod, ImpTypes[11]), nullptr);
-  EXPECT_EQ(WasmEdge_TableTypeGetRefType(
-                WasmEdge_ImportTypeGetTableType(Mod, ImpTypes[11])),
-            WasmEdge_RefType_ExternRef);
+  EXPECT_TRUE(WasmEdge_ValTypeIsExternRef(WasmEdge_TableTypeGetRefType(
+      WasmEdge_ImportTypeGetTableType(Mod, ImpTypes[11]))));
   Lim = {.HasMax = true, .Shared = false, .Min = 10, .Max = 30};
   EXPECT_TRUE(WasmEdge_LimitIsEqual(
       WasmEdge_TableTypeGetLimit(
@@ -734,9 +774,8 @@ TEST(APICoreTest, ImportType) {
   EXPECT_EQ(WasmEdge_ImportTypeGetGlobalType(nullptr, ImpTypes[7]), nullptr);
   EXPECT_EQ(WasmEdge_ImportTypeGetGlobalType(Mod, ImpTypes[0]), nullptr);
   EXPECT_NE(WasmEdge_ImportTypeGetGlobalType(Mod, ImpTypes[7]), nullptr);
-  EXPECT_EQ(WasmEdge_GlobalTypeGetValType(
-                WasmEdge_ImportTypeGetGlobalType(Mod, ImpTypes[7])),
-            WasmEdge_ValType_I64);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI64(WasmEdge_GlobalTypeGetValType(
+      WasmEdge_ImportTypeGetGlobalType(Mod, ImpTypes[7]))));
   EXPECT_EQ(WasmEdge_GlobalTypeGetMutability(
                 WasmEdge_ImportTypeGetGlobalType(Mod, ImpTypes[7])),
             WasmEdge_Mutability_Const);
@@ -863,9 +902,8 @@ TEST(APICoreTest, ExportType) {
   EXPECT_EQ(WasmEdge_ExportTypeGetTableType(nullptr, ExpTypes[12]), nullptr);
   EXPECT_EQ(WasmEdge_ExportTypeGetTableType(Mod, ExpTypes[0]), nullptr);
   EXPECT_NE(WasmEdge_ExportTypeGetTableType(Mod, ExpTypes[12]), nullptr);
-  EXPECT_EQ(WasmEdge_TableTypeGetRefType(
-                WasmEdge_ExportTypeGetTableType(Mod, ExpTypes[12])),
-            WasmEdge_RefType_ExternRef);
+  EXPECT_TRUE(WasmEdge_ValTypeIsExternRef(WasmEdge_TableTypeGetRefType(
+      WasmEdge_ExportTypeGetTableType(Mod, ExpTypes[12]))));
   Lim = {.HasMax = false, .Shared = false, .Min = 10, .Max = 10};
   EXPECT_TRUE(WasmEdge_LimitIsEqual(
       WasmEdge_TableTypeGetLimit(
@@ -890,9 +928,8 @@ TEST(APICoreTest, ExportType) {
   EXPECT_EQ(WasmEdge_ExportTypeGetGlobalType(nullptr, ExpTypes[15]), nullptr);
   EXPECT_EQ(WasmEdge_ExportTypeGetGlobalType(Mod, ExpTypes[0]), nullptr);
   EXPECT_NE(WasmEdge_ExportTypeGetGlobalType(Mod, ExpTypes[15]), nullptr);
-  EXPECT_EQ(WasmEdge_GlobalTypeGetValType(
-                WasmEdge_ExportTypeGetGlobalType(Mod, ExpTypes[15])),
-            WasmEdge_ValType_F32);
+  EXPECT_TRUE(WasmEdge_ValTypeIsF32(WasmEdge_GlobalTypeGetValType(
+      WasmEdge_ExportTypeGetGlobalType(Mod, ExpTypes[15]))));
   EXPECT_EQ(WasmEdge_GlobalTypeGetMutability(
                 WasmEdge_ExportTypeGetGlobalType(Mod, ExpTypes[15])),
             WasmEdge_Mutability_Const);
@@ -1286,9 +1323,9 @@ TEST(APICoreTest, ExecutorWithStatistics) {
   EXPECT_TRUE(
       WasmEdge_ResultOK(WasmEdge_ExecutorInvoke(ExecCxt, FuncCxt, P, 2, R, 2)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(912, WasmEdge_ValueGetI32(R[1]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[1].Type));
   EXPECT_TRUE(
       isErrMatch(WasmEdge_ErrCode_WrongVMWorkflow,
                  WasmEdge_ExecutorInvoke(nullptr, FuncCxt, P, 2, R, 2)));
@@ -1318,7 +1355,7 @@ TEST(APICoreTest, ExecutorWithStatistics) {
   EXPECT_TRUE(
       WasmEdge_ResultOK(WasmEdge_ExecutorInvoke(ExecCxt, FuncCxt, P, 2, R, 1)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   // Discard result
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_ExecutorInvoke(ExecCxt, FuncCxt, P, 2, nullptr, 0)));
@@ -1352,7 +1389,7 @@ TEST(APICoreTest, ExecutorWithStatistics) {
   EXPECT_TRUE(
       WasmEdge_ResultOK(WasmEdge_ExecutorInvoke(ExecCxt, FuncCxt, P, 1, R, 1)));
   EXPECT_EQ(1000, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   // Call sub: (123) - (456)
   FuncName = WasmEdge_StringCreateByCString("func-host-sub");
   FuncCxt = WasmEdge_ModuleInstanceFindFunction(ModCxt, FuncName);
@@ -1363,7 +1400,7 @@ TEST(APICoreTest, ExecutorWithStatistics) {
   EXPECT_TRUE(
       WasmEdge_ResultOK(WasmEdge_ExecutorInvoke(ExecCxt, FuncCxt, P, 1, R, 1)));
   EXPECT_EQ(-333, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   // Call mul: (-30) * (-66)
   FuncName = WasmEdge_StringCreateByCString("func-host-mul");
   FuncCxt = WasmEdge_ModuleInstanceFindFunction(ModCxt, FuncName);
@@ -1374,7 +1411,7 @@ TEST(APICoreTest, ExecutorWithStatistics) {
   EXPECT_TRUE(
       WasmEdge_ResultOK(WasmEdge_ExecutorInvoke(ExecCxt, FuncCxt, P, 1, R, 1)));
   EXPECT_EQ(1980, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   // Call div: (-9999) / (1234)
   FuncName = WasmEdge_StringCreateByCString("func-host-div");
   FuncCxt = WasmEdge_ModuleInstanceFindFunction(ModCxt, FuncName);
@@ -1385,7 +1422,7 @@ TEST(APICoreTest, ExecutorWithStatistics) {
   EXPECT_TRUE(
       WasmEdge_ResultOK(WasmEdge_ExecutorInvoke(ExecCxt, FuncCxt, P, 1, R, 1)));
   EXPECT_EQ(-8, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
 
   // Invoke functions of registered module
   FuncName = WasmEdge_StringCreateByCString("func-add");
@@ -1398,7 +1435,7 @@ TEST(APICoreTest, ExecutorWithStatistics) {
   EXPECT_TRUE(
       WasmEdge_ResultOK(WasmEdge_ExecutorInvoke(ExecCxt, FuncCxt, P, 2, R, 1)));
   EXPECT_EQ(6500, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
 
   // Invoke host function to terminate or fail execution
   FuncName = WasmEdge_StringCreateByCString("func-term");
@@ -1426,7 +1463,7 @@ TEST(APICoreTest, ExecutorWithStatistics) {
   EXPECT_TRUE(
       WasmEdge_ResultOK(WasmEdge_ExecutorInvoke(ExecCxt, FuncCxt, P, 2, R, 1)));
   EXPECT_EQ(-266, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   FuncName = WasmEdge_StringCreateByCString("func-term");
   FuncCxt = WasmEdge_ModuleInstanceFindFunction(HostModWrap, FuncName);
   EXPECT_NE(FuncCxt, nullptr);
@@ -1649,10 +1686,10 @@ TEST(APICoreTest, Instance) {
 
   // Function instance
   WasmEdge_FunctionInstanceContext *FuncCxt;
-  enum WasmEdge_ValType Param[2], Result[1];
-  Param[0] = WasmEdge_ValType_ExternRef;
-  Param[1] = WasmEdge_ValType_I32;
-  Result[0] = WasmEdge_ValType_I32;
+  WasmEdge_ValType Param[2], Result[1];
+  Param[0] = WasmEdge_ValTypeGenExternRef();
+  Param[1] = WasmEdge_ValTypeGenI32();
+  Result[0] = WasmEdge_ValTypeGenI32();
   WasmEdge_FunctionTypeContext *FuncType =
       WasmEdge_FunctionTypeCreate(Param, 2, Result, 1);
 
@@ -1704,7 +1741,7 @@ TEST(APICoreTest, Instance) {
   TabCxt = WasmEdge_TableInstanceCreate(nullptr);
   EXPECT_EQ(TabCxt, nullptr);
   TabType = WasmEdge_TableTypeCreate(
-      WasmEdge_RefType_ExternRef,
+      WasmEdge_ValTypeGenExternRef(),
       WasmEdge_Limit{.HasMax = false, .Shared = false, .Min = 10, .Max = 10});
   TabCxt = WasmEdge_TableInstanceCreate(TabType);
   WasmEdge_TableTypeDelete(TabType);
@@ -1712,16 +1749,15 @@ TEST(APICoreTest, Instance) {
   WasmEdge_TableInstanceDelete(TabCxt);
   EXPECT_TRUE(true);
   TabType = WasmEdge_TableTypeCreate(
-      WasmEdge_RefType_ExternRef,
+      WasmEdge_ValTypeGenExternRef(),
       WasmEdge_Limit{.HasMax = true, .Shared = false, .Min = 10, .Max = 20});
   TabCxt = WasmEdge_TableInstanceCreate(TabType);
   WasmEdge_TableTypeDelete(TabType);
   EXPECT_NE(TabCxt, nullptr);
 
   // Table instance get table type
-  EXPECT_EQ(
-      WasmEdge_TableTypeGetRefType(WasmEdge_TableInstanceGetTableType(TabCxt)),
-      WasmEdge_RefType_ExternRef);
+  EXPECT_TRUE(WasmEdge_ValTypeIsExternRef(WasmEdge_TableTypeGetRefType(
+      WasmEdge_TableInstanceGetTableType(TabCxt))));
   EXPECT_EQ(WasmEdge_TableInstanceGetTableType(nullptr), nullptr);
 
   // Table instance set data
@@ -1890,15 +1926,15 @@ TEST(APICoreTest, Instance) {
   // Global instance creation
   GlobVCxt = WasmEdge_GlobalInstanceCreate(nullptr, WasmEdge_ValueGenI32(0));
   EXPECT_EQ(GlobVCxt, nullptr);
-  GlobVType =
-      WasmEdge_GlobalTypeCreate(WasmEdge_ValType_F32, WasmEdge_Mutability_Var);
+  GlobVType = WasmEdge_GlobalTypeCreate(WasmEdge_ValTypeGenF32(),
+                                        WasmEdge_Mutability_Var);
   GlobVCxt = WasmEdge_GlobalInstanceCreate(GlobVType, WasmEdge_ValueGenI32(0));
   WasmEdge_GlobalTypeDelete(GlobVType);
   EXPECT_EQ(GlobVCxt, nullptr);
-  GlobCType = WasmEdge_GlobalTypeCreate(WasmEdge_ValType_I64,
+  GlobCType = WasmEdge_GlobalTypeCreate(WasmEdge_ValTypeGenI64(),
                                         WasmEdge_Mutability_Const);
-  GlobVType =
-      WasmEdge_GlobalTypeCreate(WasmEdge_ValType_I64, WasmEdge_Mutability_Var);
+  GlobVType = WasmEdge_GlobalTypeCreate(WasmEdge_ValTypeGenI64(),
+                                        WasmEdge_Mutability_Var);
   GlobCCxt = WasmEdge_GlobalInstanceCreate(GlobCType,
                                            WasmEdge_ValueGenI64(55555555555LL));
   GlobVCxt = WasmEdge_GlobalInstanceCreate(GlobVType,
@@ -1909,12 +1945,10 @@ TEST(APICoreTest, Instance) {
   EXPECT_NE(GlobVCxt, nullptr);
 
   // Global instance get global type
-  EXPECT_EQ(WasmEdge_GlobalTypeGetValType(
-                WasmEdge_GlobalInstanceGetGlobalType(GlobCCxt)),
-            WasmEdge_ValType_I64);
-  EXPECT_EQ(WasmEdge_GlobalTypeGetValType(
-                WasmEdge_GlobalInstanceGetGlobalType(GlobVCxt)),
-            WasmEdge_ValType_I64);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI64(WasmEdge_GlobalTypeGetValType(
+      WasmEdge_GlobalInstanceGetGlobalType(GlobCCxt))));
+  EXPECT_TRUE(WasmEdge_ValTypeIsI64(WasmEdge_GlobalTypeGetValType(
+      WasmEdge_GlobalInstanceGetGlobalType(GlobVCxt))));
   EXPECT_EQ(WasmEdge_GlobalTypeGetMutability(
                 WasmEdge_GlobalInstanceGetGlobalType(GlobCCxt)),
             WasmEdge_Mutability_Const);
@@ -1969,7 +2003,7 @@ TEST(APICoreTest, ModuleInstance) {
   WasmEdge_TableInstanceContext *HostTable = nullptr;
   WasmEdge_MemoryInstanceContext *HostMemory = nullptr;
   WasmEdge_GlobalInstanceContext *HostGlobal = nullptr;
-  enum WasmEdge_ValType Param[2], Result[1];
+  WasmEdge_ValType Param[2], Result[1];
 
   // Create module instance with name ""
   HostMod = WasmEdge_ModuleInstanceCreate({.Length = 0, .Buf = nullptr});
@@ -1985,9 +2019,9 @@ TEST(APICoreTest, ModuleInstance) {
   WasmEdge_StringDelete(HostName);
 
   // Add host function "func-add": {externref, i32} -> {i32}
-  Param[0] = WasmEdge_ValType_ExternRef;
-  Param[1] = WasmEdge_ValType_I32;
-  Result[0] = WasmEdge_ValType_I32;
+  Param[0] = WasmEdge_ValTypeGenExternRef();
+  Param[1] = WasmEdge_ValTypeGenI32();
+  Result[0] = WasmEdge_ValTypeGenI32();
   HostFType = WasmEdge_FunctionTypeCreate(Param, 2, Result, 1);
   HostFunc = WasmEdge_FunctionInstanceCreate(HostFType, ExternAdd, nullptr, 0);
   EXPECT_NE(HostFunc, nullptr);
@@ -2004,7 +2038,7 @@ TEST(APICoreTest, ModuleInstance) {
   // Add host table "table"
   WasmEdge_Limit TabLimit = {
       .HasMax = true, .Shared = false, .Min = 10, .Max = 20};
-  HostTType = WasmEdge_TableTypeCreate(WasmEdge_RefType_FuncRef, TabLimit);
+  HostTType = WasmEdge_TableTypeCreate(WasmEdge_ValTypeGenFuncRef(), TabLimit);
   HostTable = WasmEdge_TableInstanceCreate(HostTType);
   EXPECT_NE(HostTable, nullptr);
   HostName = WasmEdge_StringCreateByCString("table");
@@ -2034,7 +2068,7 @@ TEST(APICoreTest, ModuleInstance) {
   WasmEdge_StringDelete(HostName);
 
   // Add host global "global_i32": const 666
-  HostGType = WasmEdge_GlobalTypeCreate(WasmEdge_ValType_I32,
+  HostGType = WasmEdge_GlobalTypeCreate(WasmEdge_ValTypeGenI32(),
                                         WasmEdge_Mutability_Const);
   HostGlobal =
       WasmEdge_GlobalInstanceCreate(HostGType, WasmEdge_ValueGenI32(666));
@@ -2168,9 +2202,9 @@ TEST(APICoreTest, Async) {
   EXPECT_EQ(WasmEdge_AsyncGetReturnsLength(Async), 2);
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_AsyncGet(Async, R, 2)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(912, WasmEdge_ValueGetI32(R[1]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[1].Type));
   WasmEdge_AsyncDelete(Async);
   // VM nullptr case
   Async = WasmEdge_VMAsyncRunWasmFromFile(nullptr, TPath, FuncName, P, 2);
@@ -2221,9 +2255,9 @@ TEST(APICoreTest, Async) {
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_AsyncGet(Async, R, 1)));
   WasmEdge_AsyncDelete(Async);
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(0, WasmEdge_ValueGetI32(R[1]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[1].Type));
   // Discard result
   Async = WasmEdge_VMAsyncRunWasmFromFile(VM, TPath, FuncName, P, 2);
   EXPECT_NE(Async, nullptr);
@@ -2246,9 +2280,9 @@ TEST(APICoreTest, Async) {
   EXPECT_EQ(WasmEdge_AsyncGetReturnsLength(Async), 2);
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_AsyncGet(Async, R, 2)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(912, WasmEdge_ValueGetI32(R[1]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[1].Type));
   WasmEdge_AsyncDelete(Async);
   // VM nullptr case
   Async = WasmEdge_VMAsyncRunWasmFromBuffer(
@@ -2306,9 +2340,9 @@ TEST(APICoreTest, Async) {
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_AsyncGet(Async, R, 1)));
   WasmEdge_AsyncDelete(Async);
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(0, WasmEdge_ValueGetI32(R[1]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[1].Type));
   // Discard result
   Async = WasmEdge_VMAsyncRunWasmFromBuffer(
       VM, Buf.data(), static_cast<uint32_t>(Buf.size()), FuncName, P, 2);
@@ -2332,9 +2366,9 @@ TEST(APICoreTest, Async) {
   EXPECT_EQ(WasmEdge_AsyncGetReturnsLength(Async), 2);
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_AsyncGet(Async, R, 2)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(912, WasmEdge_ValueGetI32(R[1]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[1].Type));
   WasmEdge_AsyncDelete(Async);
   // VM nullptr case
   Async = WasmEdge_VMAsyncRunWasmFromASTModule(nullptr, Mod, FuncName, P, 2);
@@ -2382,9 +2416,9 @@ TEST(APICoreTest, Async) {
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_AsyncGet(Async, R, 1)));
   WasmEdge_AsyncDelete(Async);
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(0, WasmEdge_ValueGetI32(R[1]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[1].Type));
   // Discard result
   Async = WasmEdge_VMAsyncRunWasmFromASTModule(VM, Mod, FuncName, P, 2);
   EXPECT_NE(Async, nullptr);
@@ -2430,9 +2464,9 @@ TEST(APICoreTest, Async) {
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_AsyncGet(Async, R, 2)));
   WasmEdge_AsyncDelete(Async);
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(912, WasmEdge_ValueGetI32(R[1]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[1].Type));
   // VM nullptr case
   Async = WasmEdge_VMAsyncExecute(nullptr, FuncName, P, 2);
   EXPECT_EQ(Async, nullptr);
@@ -2476,9 +2510,9 @@ TEST(APICoreTest, Async) {
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_AsyncGet(Async, R, 1)));
   WasmEdge_AsyncDelete(Async);
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(0, WasmEdge_ValueGetI32(R[1]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[1].Type));
   // Discard result
   Async = WasmEdge_VMAsyncExecute(VM, FuncName, P, 2);
   EXPECT_NE(Async, nullptr);
@@ -2505,9 +2539,9 @@ TEST(APICoreTest, Async) {
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_AsyncGet(Async, R, 2)));
   WasmEdge_AsyncDelete(Async);
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(912, WasmEdge_ValueGetI32(R[1]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[1].Type));
   // VM nullptr case
   Async = WasmEdge_VMAsyncExecuteRegistered(nullptr, ModName, FuncName, P, 2);
   EXPECT_EQ(Async, nullptr);
@@ -2557,9 +2591,9 @@ TEST(APICoreTest, Async) {
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_AsyncGet(Async, R, 1)));
   WasmEdge_AsyncDelete(Async);
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(0, WasmEdge_ValueGetI32(R[1]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[1].Type));
   // Discard result
   Async = WasmEdge_VMAsyncExecuteRegistered(VM, ModName, FuncName, P, 2);
   EXPECT_NE(Async, nullptr);
@@ -2678,9 +2712,9 @@ TEST(APICoreTest, VM) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMRunWasmFromFile(VM, TPath, FuncName, P, 2, R, 2)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(912, WasmEdge_ValueGetI32(R[1]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[1].Type));
   EXPECT_TRUE(isErrMatch(
       WasmEdge_ErrCode_WrongVMWorkflow,
       WasmEdge_VMRunWasmFromFile(nullptr, TPath, FuncName, P, 2, R, 2)));
@@ -2714,7 +2748,7 @@ TEST(APICoreTest, VM) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMRunWasmFromFile(VM, TPath, FuncName, P, 2, R, 1)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   // Discard result
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMRunWasmFromFile(VM, TPath, FuncName, P, 2, nullptr, 0)));
@@ -2729,9 +2763,9 @@ TEST(APICoreTest, VM) {
       VM, Buf.data(), static_cast<uint32_t>(Buf.size()), FuncName, P, 2, R,
       2)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(912, WasmEdge_ValueGetI32(R[1]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[1].Type));
   EXPECT_TRUE(
       isErrMatch(WasmEdge_ErrCode_WrongVMWorkflow,
                  WasmEdge_VMRunWasmFromBuffer(nullptr, Buf.data(),
@@ -2773,7 +2807,7 @@ TEST(APICoreTest, VM) {
       VM, Buf.data(), static_cast<uint32_t>(Buf.size()), FuncName, P, 2, R,
       1)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   // Discard result
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_VMRunWasmFromBuffer(
       VM, Buf.data(), static_cast<uint32_t>(Buf.size()), FuncName, P, 2,
@@ -2789,9 +2823,9 @@ TEST(APICoreTest, VM) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMRunWasmFromASTModule(VM, Mod, FuncName, P, 2, R, 2)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(912, WasmEdge_ValueGetI32(R[1]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[1].Type));
   EXPECT_TRUE(isErrMatch(
       WasmEdge_ErrCode_WrongVMWorkflow,
       WasmEdge_VMRunWasmFromASTModule(nullptr, Mod, FuncName, P, 2, R, 2)));
@@ -2825,7 +2859,7 @@ TEST(APICoreTest, VM) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMRunWasmFromASTModule(VM, Mod, FuncName, P, 2, R, 1)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   // Discard result
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMRunWasmFromASTModule(VM, Mod, FuncName, P, 2, nullptr, 0)));
@@ -2922,9 +2956,9 @@ TEST(APICoreTest, VM) {
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_VMInstantiate(VM)));
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_VMExecute(VM, FuncName, P, 2, R, 2)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(912, WasmEdge_ValueGetI32(R[1]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[1].Type));
   EXPECT_TRUE(isErrMatch(WasmEdge_ErrCode_WrongVMWorkflow,
                          WasmEdge_VMExecute(nullptr, FuncName, P, 2, R, 2)));
   // Function type mismatch
@@ -2948,7 +2982,7 @@ TEST(APICoreTest, VM) {
   R[0] = WasmEdge_ValueGenI32(0);
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_VMExecute(VM, FuncName, P, 2, R, 1)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   // Discard result
   EXPECT_TRUE(
       WasmEdge_ResultOK(WasmEdge_VMExecute(VM, FuncName, P, 2, nullptr, 0)));
@@ -2967,9 +3001,9 @@ TEST(APICoreTest, VM) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMExecuteRegistered(VM, ModName, FuncName, P, 2, R, 2)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(912, WasmEdge_ValueGetI32(R[1]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[1].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[1].Type));
   EXPECT_TRUE(isErrMatch(
       WasmEdge_ErrCode_WrongVMWorkflow,
       WasmEdge_VMExecuteRegistered(nullptr, ModName, FuncName, P, 2, R, 2)));
@@ -3004,7 +3038,7 @@ TEST(APICoreTest, VM) {
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMExecuteRegistered(VM, ModName, FuncName, P, 2, R, 1)));
   EXPECT_EQ(246, WasmEdge_ValueGetI32(R[0]));
-  EXPECT_EQ(WasmEdge_ValType_I32, R[0].Type.TypeCode);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   // Discard result
   EXPECT_TRUE(WasmEdge_ResultOK(
       WasmEdge_VMExecuteRegistered(VM, ModName, FuncName, P, 2, nullptr, 0)));

--- a/test/api/APIVMCoreTest.cpp
+++ b/test/api/APIVMCoreTest.cpp
@@ -105,8 +105,8 @@ TEST_P(CoreTest, TestSuites) {
   // Helper function to call functions.
   T.onInvoke = [&VM](const std::string &ModName, const std::string &Field,
                      const std::vector<ValVariant> &Params,
-                     const std::vector<FullValType> &ParamTypes)
-      -> Expect<std::vector<std::pair<ValVariant, FullValType>>> {
+                     const std::vector<ValType> &ParamTypes)
+      -> Expect<std::vector<std::pair<ValVariant, ValType>>> {
     WasmEdge_Result Res;
     std::vector<WasmEdge_Value> CParams = convFromValVec(Params, ParamTypes);
     std::vector<WasmEdge_Value> CReturns;
@@ -149,7 +149,7 @@ TEST_P(CoreTest, TestSuites) {
   };
   // Helper function to get values.
   T.onGet = [&VM](const std::string &ModName, const std::string &Field)
-      -> Expect<std::pair<ValVariant, FullValType>> {
+      -> Expect<std::pair<ValVariant, ValType>> {
     // Get module instance.
     const WasmEdge_ModuleInstanceContext *ModCxt = nullptr;
     WasmEdge_StoreContext *StoreCxt = WasmEdge_VMGetStoreContext(VM);
@@ -171,11 +171,11 @@ TEST_P(CoreTest, TestSuites) {
     }
     WasmEdge_Value Val = WasmEdge_GlobalInstanceGetValue(GlobCxt);
 #if defined(__x86_64__) || defined(__aarch64__)
-    return std::make_pair(ValVariant(Val.Value), Val.Type);
+    return std::make_pair(ValVariant(Val.Value), ValType(Val.Type.Data));
 #else
     return std::make_pair(
         ValVariant(WasmEdge::uint128_t(Val.Value.High, Val.Value.Low)),
-        Val.Type);
+        ValType(Val.Type.Data));
 #endif
   };
 

--- a/test/api/helper.cpp
+++ b/test/api/helper.cpp
@@ -41,35 +41,35 @@ ErrCode convResult(WasmEdge_Result Res) {
   return static_cast<ErrCode::Value>(WasmEdge_ResultGetCode(Res));
 }
 
-std::vector<std::pair<ValVariant, FullValType>>
+std::vector<std::pair<ValVariant, ValType>>
 convToValVec(const std::vector<WasmEdge_Value> &CVals) {
-  std::vector<std::pair<ValVariant, FullValType>> Vals(CVals.size());
+  std::vector<std::pair<ValVariant, ValType>> Vals(CVals.size());
   std::transform(CVals.cbegin(), CVals.cend(), Vals.begin(),
                  [](const WasmEdge_Value &Val) {
 #if defined(__x86_64__) || defined(__aarch64__)
-                   return std::make_pair(ValVariant(Val.Value), Val.Type);
+                   return std::make_pair(ValVariant(Val.Value),
+                                         ValType(Val.Type.Data));
 #else
                    return std::make_pair(ValVariant(WasmEdge::uint128_t(
                                              Val.Value.High, Val.Value.Low)),
-                                         Val.Type);
+                                         ValType(Val.Type.Data));
 #endif
                  });
   return Vals;
 }
 
-std::vector<WasmEdge_Value>
-convFromValVec(const std::vector<ValVariant> &Vals,
-               const std::vector<FullValType> &Types) {
+std::vector<WasmEdge_Value> convFromValVec(const std::vector<ValVariant> &Vals,
+                                           const std::vector<ValType> &Types) {
   std::vector<WasmEdge_Value> CVals(Vals.size());
   for (uint32_t I = 0; I < Vals.size(); I++) {
 #if defined(__x86_64__) || defined(__aarch64__)
     CVals[I] = WasmEdge_Value{.Value = Vals[I].get<WasmEdge::uint128_t>(),
-                              .Type = Types[I].asCStruct()};
+                              .Type = {.Data = Types[I].getRawData()}};
 #else
     WasmEdge::uint128_t Val = Vals[I].get<WasmEdge::uint128_t>();
     CVals[I] = WasmEdge_Value{
         .Value = {.Low = Val.low(), .High = static_cast<uint64_t>(Val.high())},
-        .Type = Types[I].asCStruct()};
+        .Type = {.Data = Types[I].getRawData()}};
 #endif
   }
   return CVals;

--- a/test/api/helper.h
+++ b/test/api/helper.h
@@ -27,10 +27,10 @@ WasmEdge_ConfigureContext *createConf(const Configure &Conf);
 
 ErrCode convResult(WasmEdge_Result Res);
 
-std::vector<std::pair<ValVariant, FullValType>>
+std::vector<std::pair<ValVariant, ValType>>
 convToValVec(const std::vector<WasmEdge_Value> &CVals);
 
 std::vector<WasmEdge_Value> convFromValVec(const std::vector<ValVariant> &Vals,
-                                           const std::vector<FullValType> &Types);
+                                           const std::vector<ValType> &Types);
 
 } // namespace WasmEdge

--- a/test/api/hostfunc_c.c
+++ b/test/api/hostfunc_c.c
@@ -93,7 +93,7 @@ WasmEdge_ModuleInstanceContext *createSpecTestModule(void) {
   WasmEdge_Limit TabLimit;
   WasmEdge_Limit MemLimit;
   WasmEdge_Limit SharedMemLimit;
-  enum WasmEdge_ValType Param[2];
+  WasmEdge_ValType Param[2];
 
   HostName = WasmEdge_StringCreateByCString("spectest");
   HostMod = WasmEdge_ModuleInstanceCreate(HostName);
@@ -108,7 +108,7 @@ WasmEdge_ModuleInstanceContext *createSpecTestModule(void) {
   WasmEdge_StringDelete(HostName);
 
   // Add host function "print_i32": {i32} -> {}
-  Param[0] = WasmEdge_ValType_I32;
+  Param[0] = WasmEdge_ValTypeGenI32();
   HostFType = WasmEdge_FunctionTypeCreate(Param, 1, NULL, 0);
   HostFunc =
       WasmEdge_FunctionInstanceCreate(HostFType, SpecTestPrintI32, NULL, 0);
@@ -118,7 +118,7 @@ WasmEdge_ModuleInstanceContext *createSpecTestModule(void) {
   WasmEdge_StringDelete(HostName);
 
   // Add host function "print_i64": {i64} -> {}
-  Param[0] = WasmEdge_ValType_I64;
+  Param[0] = WasmEdge_ValTypeGenI64();
   HostFType = WasmEdge_FunctionTypeCreate(Param, 1, NULL, 0);
   HostFunc =
       WasmEdge_FunctionInstanceCreate(HostFType, SpecTestPrintI64, NULL, 0);
@@ -128,7 +128,7 @@ WasmEdge_ModuleInstanceContext *createSpecTestModule(void) {
   WasmEdge_StringDelete(HostName);
 
   // Add host function "print_f32": {f32} -> {}
-  Param[0] = WasmEdge_ValType_F32;
+  Param[0] = WasmEdge_ValTypeGenF32();
   HostFType = WasmEdge_FunctionTypeCreate(Param, 1, NULL, 0);
   HostFunc =
       WasmEdge_FunctionInstanceCreate(HostFType, SpecTestPrintF32, NULL, 0);
@@ -138,7 +138,7 @@ WasmEdge_ModuleInstanceContext *createSpecTestModule(void) {
   WasmEdge_StringDelete(HostName);
 
   // Add host function "print_f64": {f64} -> {}
-  Param[0] = WasmEdge_ValType_F64;
+  Param[0] = WasmEdge_ValTypeGenF64();
   HostFType = WasmEdge_FunctionTypeCreate(Param, 1, NULL, 0);
   HostFunc =
       WasmEdge_FunctionInstanceCreate(HostFType, SpecTestPrintF64, NULL, 0);
@@ -148,8 +148,8 @@ WasmEdge_ModuleInstanceContext *createSpecTestModule(void) {
   WasmEdge_StringDelete(HostName);
 
   // Add host function "print_i32_f32": {i32, f32} -> {}
-  Param[0] = WasmEdge_ValType_I32;
-  Param[1] = WasmEdge_ValType_F32;
+  Param[0] = WasmEdge_ValTypeGenI32();
+  Param[1] = WasmEdge_ValTypeGenF32();
   HostFType = WasmEdge_FunctionTypeCreate(Param, 2, NULL, 0);
   HostFunc =
       WasmEdge_FunctionInstanceCreate(HostFType, SpecTestPrintI32F32, NULL, 0);
@@ -159,8 +159,8 @@ WasmEdge_ModuleInstanceContext *createSpecTestModule(void) {
   WasmEdge_StringDelete(HostName);
 
   // Add host function "print_f64_f64": {f64, f64} -> {}
-  Param[0] = WasmEdge_ValType_F64;
-  Param[1] = WasmEdge_ValType_F64;
+  Param[0] = WasmEdge_ValTypeGenF64();
+  Param[1] = WasmEdge_ValTypeGenF64();
   HostFType = WasmEdge_FunctionTypeCreate(Param, 2, NULL, 0);
   HostFunc =
       WasmEdge_FunctionInstanceCreate(HostFType, SpecTestPrintF64F64, NULL, 0);
@@ -174,7 +174,7 @@ WasmEdge_ModuleInstanceContext *createSpecTestModule(void) {
   TabLimit.Shared = false;
   TabLimit.Min = 10;
   TabLimit.Max = 20;
-  HostTType = WasmEdge_TableTypeCreate(WasmEdge_RefType_FuncRef, TabLimit);
+  HostTType = WasmEdge_TableTypeCreate(WasmEdge_ValTypeGenFuncRef(), TabLimit);
   HostTable = WasmEdge_TableInstanceCreate(HostTType);
   WasmEdge_TableTypeDelete(HostTType);
   HostName = WasmEdge_StringCreateByCString("table");
@@ -206,7 +206,7 @@ WasmEdge_ModuleInstanceContext *createSpecTestModule(void) {
   WasmEdge_StringDelete(HostName);
 
   // Add host global "global_i32": const 666
-  HostGType = WasmEdge_GlobalTypeCreate(WasmEdge_ValType_I32,
+  HostGType = WasmEdge_GlobalTypeCreate(WasmEdge_ValTypeGenI32(),
                                         WasmEdge_Mutability_Const);
   HostGlobal =
       WasmEdge_GlobalInstanceCreate(HostGType, WasmEdge_ValueGenI32(666));
@@ -216,7 +216,7 @@ WasmEdge_ModuleInstanceContext *createSpecTestModule(void) {
   WasmEdge_StringDelete(HostName);
 
   // Add host global "global_i64": const 666
-  HostGType = WasmEdge_GlobalTypeCreate(WasmEdge_ValType_I64,
+  HostGType = WasmEdge_GlobalTypeCreate(WasmEdge_ValTypeGenI64(),
                                         WasmEdge_Mutability_Const);
   HostGlobal =
       WasmEdge_GlobalInstanceCreate(HostGType, WasmEdge_ValueGenI64(666));
@@ -226,7 +226,7 @@ WasmEdge_ModuleInstanceContext *createSpecTestModule(void) {
   WasmEdge_StringDelete(HostName);
 
   // Add host global "global_f32": const 666.0
-  HostGType = WasmEdge_GlobalTypeCreate(WasmEdge_ValType_F32,
+  HostGType = WasmEdge_GlobalTypeCreate(WasmEdge_ValTypeGenF32(),
                                         WasmEdge_Mutability_Const);
   HostGlobal =
       WasmEdge_GlobalInstanceCreate(HostGType, WasmEdge_ValueGenF32(666.0));
@@ -236,7 +236,7 @@ WasmEdge_ModuleInstanceContext *createSpecTestModule(void) {
   WasmEdge_StringDelete(HostName);
 
   // Add host global "global_f64": const 666.0
-  HostGType = WasmEdge_GlobalTypeCreate(WasmEdge_ValType_F64,
+  HostGType = WasmEdge_GlobalTypeCreate(WasmEdge_ValTypeGenF64(),
                                         WasmEdge_Mutability_Const);
   HostGlobal =
       WasmEdge_GlobalInstanceCreate(HostGType, WasmEdge_ValueGenF64(666.0));

--- a/test/errinfo/errinfoTest.cpp
+++ b/test/errinfo/errinfoTest.cpp
@@ -82,13 +82,13 @@ TEST(ErrInfoTest, Info__Executing) {
 TEST(ErrInfoTest, Info__Mismatch) {
   WasmEdge::ErrInfo::InfoMismatch Info1(static_cast<uint8_t>(16), 8888);
   std::cout << Info1 << std::endl;
-  WasmEdge::ErrInfo::InfoMismatch Info2(WasmEdge::ValType::ExternRef,
-                                        WasmEdge::ValType::FuncRef);
+  WasmEdge::ErrInfo::InfoMismatch Info2(WasmEdge::ValTypeCode::ExternRef,
+                                        WasmEdge::ValTypeCode::FuncRef);
   std::cout << Info2 << std::endl;
   WasmEdge::ErrInfo::InfoMismatch Info3(
-      {WasmEdge::ValType::I32, WasmEdge::ValType::FuncRef},
-      {WasmEdge::ValType::F64, WasmEdge::ValType::ExternRef,
-       WasmEdge::ValType::V128});
+      {WasmEdge::ValTypeCode::I32, WasmEdge::ValTypeCode::FuncRef},
+      {WasmEdge::ValTypeCode::F64, WasmEdge::ValTypeCode::ExternRef,
+       WasmEdge::ValTypeCode::V128});
   std::cout << Info3 << std::endl;
   WasmEdge::ErrInfo::InfoMismatch Info4(WasmEdge::ValMut::Const,
                                         WasmEdge::ValMut::Var);
@@ -97,27 +97,27 @@ TEST(ErrInfoTest, Info__Mismatch) {
                                         WasmEdge::ExternalType::Global);
   std::cout << Info5 << std::endl;
   WasmEdge::ErrInfo::InfoMismatch Info6(
-      {WasmEdge::ValType::I32, WasmEdge::ValType::FuncRef},
-      {WasmEdge::ValType::I64, WasmEdge::ValType::F64},
-      {WasmEdge::ValType::F64, WasmEdge::ValType::ExternRef,
-       WasmEdge::ValType::V128},
-      {WasmEdge::ValType::V128});
+      {WasmEdge::ValTypeCode::I32, WasmEdge::ValTypeCode::FuncRef},
+      {WasmEdge::ValTypeCode::I64, WasmEdge::ValTypeCode::F64},
+      {WasmEdge::ValTypeCode::F64, WasmEdge::ValTypeCode::ExternRef,
+       WasmEdge::ValTypeCode::V128},
+      {WasmEdge::ValTypeCode::V128});
   std::cout << Info6 << std::endl;
-  WasmEdge::ErrInfo::InfoMismatch Info7(WasmEdge::RefType::ExternRef, true, 10,
-                                        20, WasmEdge::RefType::FuncRef, true,
-                                        20, 50);
+  WasmEdge::ErrInfo::InfoMismatch Info7(WasmEdge::RefTypeCode::ExternRef, true,
+                                        10, 20, WasmEdge::RefTypeCode::FuncRef,
+                                        true, 20, 50);
   std::cout << Info7 << std::endl;
-  WasmEdge::ErrInfo::InfoMismatch Info8(WasmEdge::RefType::ExternRef, false, 10,
-                                        10, WasmEdge::RefType::FuncRef, false,
-                                        20, 20);
+  WasmEdge::ErrInfo::InfoMismatch Info8(WasmEdge::RefTypeCode::ExternRef, false,
+                                        10, 10, WasmEdge::RefTypeCode::FuncRef,
+                                        false, 20, 20);
   std::cout << Info8 << std::endl;
   WasmEdge::ErrInfo::InfoMismatch Info9(true, 10, 20, true, 20, 50);
   std::cout << Info9 << std::endl;
   WasmEdge::ErrInfo::InfoMismatch Info10(false, 10, 10, false, 20, 20);
   std::cout << Info10 << std::endl;
   WasmEdge::ErrInfo::InfoMismatch Info11(
-      WasmEdge::ValType::I32, WasmEdge::ValMut::Var, WasmEdge::ValType::I64,
-      WasmEdge::ValMut::Const);
+      WasmEdge::ValTypeCode::I32, WasmEdge::ValMut::Var,
+      WasmEdge::ValTypeCode::I64, WasmEdge::ValMut::Const);
   std::cout << Info11 << std::endl;
   WasmEdge::ErrInfo::InfoMismatch Info12(12345678U, 98765432U);
   std::cout << Info12 << std::endl;
@@ -131,40 +131,45 @@ TEST(ErrInfoTest, Info__Instruction) {
       WasmEdge::FuncRef(
           reinterpret_cast<WasmEdge::Runtime::Instance::FunctionInstance *>(
               100))};
-  WasmEdge::ErrInfo::InfoInstruction Info1(
-      WasmEdge::OpCode::Block, 255, Args,
-      {WasmEdge::ValType::I32, WasmEdge::ValType::I32, WasmEdge::ValType::I32});
+  WasmEdge::ErrInfo::InfoInstruction Info1(WasmEdge::OpCode::Block, 255, Args,
+                                           {WasmEdge::ValTypeCode::I32,
+                                            WasmEdge::ValTypeCode::I32,
+                                            WasmEdge::ValTypeCode::I32});
   std::cout << Info1 << std::endl;
-  WasmEdge::ErrInfo::InfoInstruction Info2(
-      WasmEdge::OpCode::Block, 255, Args,
-      {WasmEdge::ValType::I32, WasmEdge::ValType::I32, WasmEdge::ValType::I32});
+  WasmEdge::ErrInfo::InfoInstruction Info2(WasmEdge::OpCode::Block, 255, Args,
+                                           {WasmEdge::ValTypeCode::I32,
+                                            WasmEdge::ValTypeCode::I32,
+                                            WasmEdge::ValTypeCode::I32});
   std::cout << Info2 << std::endl;
-  WasmEdge::ErrInfo::InfoInstruction Info3(
-      WasmEdge::OpCode::Block, 255, Args,
-      {WasmEdge::ValType::I64, WasmEdge::ValType::I64, WasmEdge::ValType::I64});
+  WasmEdge::ErrInfo::InfoInstruction Info3(WasmEdge::OpCode::Block, 255, Args,
+                                           {WasmEdge::ValTypeCode::I64,
+                                            WasmEdge::ValTypeCode::I64,
+                                            WasmEdge::ValTypeCode::I64});
   std::cout << Info3 << std::endl;
-  WasmEdge::ErrInfo::InfoInstruction Info4(
-      WasmEdge::OpCode::Block, 255, Args,
-      {WasmEdge::ValType::F32, WasmEdge::ValType::F32, WasmEdge::ValType::F32});
+  WasmEdge::ErrInfo::InfoInstruction Info4(WasmEdge::OpCode::Block, 255, Args,
+                                           {WasmEdge::ValTypeCode::F32,
+                                            WasmEdge::ValTypeCode::F32,
+                                            WasmEdge::ValTypeCode::F32});
   std::cout << Info4 << std::endl;
-  WasmEdge::ErrInfo::InfoInstruction Info5(
-      WasmEdge::OpCode::Block, 255, Args,
-      {WasmEdge::ValType::F64, WasmEdge::ValType::F64, WasmEdge::ValType::F64});
+  WasmEdge::ErrInfo::InfoInstruction Info5(WasmEdge::OpCode::Block, 255, Args,
+                                           {WasmEdge::ValTypeCode::F64,
+                                            WasmEdge::ValTypeCode::F64,
+                                            WasmEdge::ValTypeCode::F64});
   std::cout << Info5 << std::endl;
   WasmEdge::ErrInfo::InfoInstruction Info6(WasmEdge::OpCode::Block, 255, Args,
-                                           {WasmEdge::ValType::V128,
-                                            WasmEdge::ValType::V128,
-                                            WasmEdge::ValType::V128});
+                                           {WasmEdge::ValTypeCode::V128,
+                                            WasmEdge::ValTypeCode::V128,
+                                            WasmEdge::ValTypeCode::V128});
   std::cout << Info6 << std::endl;
   WasmEdge::ErrInfo::InfoInstruction Info7(WasmEdge::OpCode::Block, 255, Args,
-                                           {WasmEdge::ValType::FuncRef,
-                                            WasmEdge::ValType::FuncRef,
-                                            WasmEdge::ValType::FuncRef});
+                                           {WasmEdge::ValTypeCode::FuncRef,
+                                            WasmEdge::ValTypeCode::FuncRef,
+                                            WasmEdge::ValTypeCode::FuncRef});
   std::cout << Info7 << std::endl;
   WasmEdge::ErrInfo::InfoInstruction Info8(WasmEdge::OpCode::Block, 255, Args,
-                                           {WasmEdge::ValType::ExternRef,
-                                            WasmEdge::ValType::ExternRef,
-                                            WasmEdge::ValType::ExternRef});
+                                           {WasmEdge::ValTypeCode::ExternRef,
+                                            WasmEdge::ValTypeCode::ExternRef,
+                                            WasmEdge::ValTypeCode::ExternRef});
   std::cout << Info8 << std::endl;
   EXPECT_TRUE(true);
 }

--- a/test/executor/ExecutorTest.cpp
+++ b/test/executor/ExecutorTest.cpp
@@ -71,8 +71,8 @@ TEST_P(CoreTest, TestSuites) {
   // Helper function to call functions.
   T.onInvoke = [&VM](const std::string &ModName, const std::string &Field,
                      const std::vector<ValVariant> &Params,
-                     const std::vector<FullValType> &ParamTypes)
-      -> Expect<std::vector<std::pair<ValVariant, FullValType>>> {
+                     const std::vector<ValType> &ParamTypes)
+      -> Expect<std::vector<std::pair<ValVariant, ValType>>> {
     if (!ModName.empty()) {
       // Invoke function of named module. Named modules are registered in Store
       // Manager.
@@ -85,7 +85,7 @@ TEST_P(CoreTest, TestSuites) {
   };
   // Helper function to get values.
   T.onGet = [&VM](const std::string &ModName, const std::string &Field)
-      -> Expect<std::pair<ValVariant, FullValType>> {
+      -> Expect<std::pair<ValVariant, ValType>> {
     // Get module instance.
     const WasmEdge::Runtime::Instance::ModuleInstance *ModInst = nullptr;
     if (ModName.empty()) {

--- a/test/externref/ExternrefTest.cpp
+++ b/test/externref/ExternrefTest.cpp
@@ -178,7 +178,7 @@ WasmEdge_ModuleInstanceContext *createExternModule() {
   WasmEdge_String HostName;
   WasmEdge_FunctionTypeContext *HostFType = nullptr;
   WasmEdge_FunctionInstanceContext *HostFunc = nullptr;
-  enum WasmEdge_ValType P[3], R[1];
+  WasmEdge_ValType P[3], R[1];
 
   HostName = WasmEdge_StringCreateByCString("extern_module");
   WasmEdge_ModuleInstanceContext *HostMod =
@@ -186,9 +186,9 @@ WasmEdge_ModuleInstanceContext *createExternModule() {
   WasmEdge_StringDelete(HostName);
 
   // Add host function "functor_square": {externref, i32} -> {i32}
-  P[0] = WasmEdge_ValType_ExternRef;
-  P[1] = WasmEdge_ValType_I32;
-  R[0] = WasmEdge_ValType_I32;
+  P[0] = WasmEdge_ValTypeGenExternRef();
+  P[1] = WasmEdge_ValTypeGenI32();
+  R[0] = WasmEdge_ValTypeGenI32();
   HostFType = WasmEdge_FunctionTypeCreate(P, 2, R, 1);
   HostFunc = WasmEdge_FunctionInstanceCreate(HostFType, ExternFunctorSquare,
                                              nullptr, 0);
@@ -198,7 +198,7 @@ WasmEdge_ModuleInstanceContext *createExternModule() {
   WasmEdge_StringDelete(HostName);
 
   // Add host function "class_add": {externref, i32, i32} -> {i32}
-  P[2] = WasmEdge_ValType_I32;
+  P[2] = WasmEdge_ValTypeGenI32();
   HostFType = WasmEdge_FunctionTypeCreate(P, 3, R, 1);
   HostFunc =
       WasmEdge_FunctionInstanceCreate(HostFType, ExternClassAdd, nullptr, 0);
@@ -217,7 +217,7 @@ WasmEdge_ModuleInstanceContext *createExternModule() {
   WasmEdge_StringDelete(HostName);
 
   // Add host function "stl_ostream_str": {externref, externref} -> {}
-  P[1] = WasmEdge_ValType_ExternRef;
+  P[1] = WasmEdge_ValTypeGenExternRef();
   HostFType = WasmEdge_FunctionTypeCreate(P, 2, nullptr, 0);
   HostFunc = WasmEdge_FunctionInstanceCreate(HostFType, ExternSTLOStreamStr,
                                              nullptr, 0);
@@ -227,7 +227,7 @@ WasmEdge_ModuleInstanceContext *createExternModule() {
   WasmEdge_StringDelete(HostName);
 
   // Add host function "stl_ostream_u32": {externref, i32} -> {}
-  P[1] = WasmEdge_ValType_I32;
+  P[1] = WasmEdge_ValTypeGenI32();
   HostFType = WasmEdge_FunctionTypeCreate(P, 2, nullptr, 0);
   HostFunc = WasmEdge_FunctionInstanceCreate(HostFType, ExternSTLOStreamU32,
                                              nullptr, 0);
@@ -237,8 +237,8 @@ WasmEdge_ModuleInstanceContext *createExternModule() {
   WasmEdge_StringDelete(HostName);
 
   // Add host function "stl_map_insert": {externref, externref, externref}->{}
-  P[1] = WasmEdge_ValType_ExternRef;
-  P[2] = WasmEdge_ValType_ExternRef;
+  P[1] = WasmEdge_ValTypeGenExternRef();
+  P[2] = WasmEdge_ValTypeGenExternRef();
   HostFType = WasmEdge_FunctionTypeCreate(P, 3, nullptr, 0);
   HostFunc = WasmEdge_FunctionInstanceCreate(HostFType, ExternSTLMapInsert,
                                              nullptr, 0);
@@ -257,7 +257,7 @@ WasmEdge_ModuleInstanceContext *createExternModule() {
   WasmEdge_StringDelete(HostName);
 
   // Add host function "stl_set_insert": {externref, i32}->{}
-  P[1] = WasmEdge_ValType_I32;
+  P[1] = WasmEdge_ValTypeGenI32();
   HostFType = WasmEdge_FunctionTypeCreate(P, 2, nullptr, 0);
   HostFunc = WasmEdge_FunctionInstanceCreate(HostFType, ExternSTLSetInsert,
                                              nullptr, 0);
@@ -285,7 +285,7 @@ WasmEdge_ModuleInstanceContext *createExternModule() {
   WasmEdge_StringDelete(HostName);
 
   // Add host function "stl_vector_sum": {externref, externref} -> {i32}
-  P[1] = WasmEdge_ValType_ExternRef;
+  P[1] = WasmEdge_ValTypeGenExternRef();
   HostFType = WasmEdge_FunctionTypeCreate(P, 2, R, 1);
   HostFunc = WasmEdge_FunctionInstanceCreate(HostFType, ExternSTLVectorSum,
                                              nullptr, 0);
@@ -323,7 +323,7 @@ TEST(ExternRefTest, Ref__Functions) {
   EXPECT_TRUE(
       WasmEdge_ResultOK(WasmEdge_VMExecute(VMCxt, FuncName, P, 3, R, 1)));
   WasmEdge_StringDelete(FuncName);
-  EXPECT_EQ(R[0].Type.TypeCode, WasmEdge_ValType_I32);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(WasmEdge_ValueGetI32(R[0]), 6912);
 
   // Test 2: call mul -- 789 * 4321
@@ -334,7 +334,7 @@ TEST(ExternRefTest, Ref__Functions) {
   EXPECT_TRUE(
       WasmEdge_ResultOK(WasmEdge_VMExecute(VMCxt, FuncName, P, 3, R, 1)));
   WasmEdge_StringDelete(FuncName);
-  EXPECT_EQ(R[0].Type.TypeCode, WasmEdge_ValType_I32);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(WasmEdge_ValueGetI32(R[0]), 3409269);
 
   // Test 3: call square -- 8256^2
@@ -344,7 +344,7 @@ TEST(ExternRefTest, Ref__Functions) {
   EXPECT_TRUE(
       WasmEdge_ResultOK(WasmEdge_VMExecute(VMCxt, FuncName, P, 2, R, 1)));
   WasmEdge_StringDelete(FuncName);
-  EXPECT_EQ(R[0].Type.TypeCode, WasmEdge_ValType_I32);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(WasmEdge_ValueGetI32(R[0]), 68161536);
 
   // Test 4: call sum and square -- (210 + 654)^2
@@ -356,7 +356,7 @@ TEST(ExternRefTest, Ref__Functions) {
   EXPECT_TRUE(
       WasmEdge_ResultOK(WasmEdge_VMExecute(VMCxt, FuncName, P, 4, R, 1)));
   WasmEdge_StringDelete(FuncName);
-  EXPECT_EQ(R[0].Type.TypeCode, WasmEdge_ValType_I32);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(WasmEdge_ValueGetI32(R[0]), 746496);
 
   WasmEdge_VMDelete(VMCxt);
@@ -465,7 +465,7 @@ TEST(ExternRefTest, Ref__STL) {
   EXPECT_TRUE(
       WasmEdge_ResultOK(WasmEdge_VMExecute(VMCxt, FuncName, P, 2, R, 1)));
   WasmEdge_StringDelete(FuncName);
-  EXPECT_EQ(R[0].Type.TypeCode, WasmEdge_ValType_I32);
+  EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
   EXPECT_EQ(WasmEdge_ValueGetI32(R[0]), 40 + 50 + 60 + 70 + 80);
 
   WasmEdge_VMDelete(VMCxt);

--- a/test/mixcall/mixcallTest.cpp
+++ b/test/mixcall/mixcallTest.cpp
@@ -68,7 +68,7 @@ TEST(MixCallTest, Call__InterpCallAOT) {
   WasmEdge::Expect<void> Res;
   HostModule HostMod;
   std::vector<WasmEdge::ValVariant> FuncArgs;
-  std::vector<WasmEdge::FullValType> FuncArgTypes;
+  std::vector<WasmEdge::ValType> FuncArgTypes;
 
   // Compile the `module2` into AOT mode.
   EXPECT_TRUE(compileModule(Conf, "mixcallTestData/module2.wasm",
@@ -90,28 +90,28 @@ TEST(MixCallTest, Call__InterpCallAOT) {
 
   // Run `printAdd`
   FuncArgs = {uint32_t(1234), uint32_t(5678)};
-  FuncArgTypes = {WasmEdge::ValType::I32, WasmEdge::ValType::I32};
+  FuncArgTypes = {WasmEdge::ValTypeCode::I32, WasmEdge::ValTypeCode::I32};
   auto Ret = VM.execute("printAdd", FuncArgs, FuncArgTypes);
   EXPECT_TRUE(Ret);
   EXPECT_EQ((*Ret).size(), 0);
 
   // Run `printDiv`
   FuncArgs = {double(9876.0), double(4321.0)};
-  FuncArgTypes = {WasmEdge::ValType::F64, WasmEdge::ValType::F64};
+  FuncArgTypes = {WasmEdge::ValTypeCode::F64, WasmEdge::ValTypeCode::F64};
   Ret = VM.execute("printDiv", FuncArgs, FuncArgTypes);
   EXPECT_TRUE(Ret);
   EXPECT_EQ((*Ret).size(), 0);
 
   // Run `printI32`
   FuncArgs = {uint32_t(87654321)};
-  FuncArgTypes = {WasmEdge::ValType::I32};
+  FuncArgTypes = {WasmEdge::ValTypeCode::I32};
   Ret = VM.execute("printI32", FuncArgs, FuncArgTypes);
   EXPECT_TRUE(Ret);
   EXPECT_EQ((*Ret).size(), 0);
 
   // Run `printF64`
   FuncArgs = {double(5566.1122)};
-  FuncArgTypes = {WasmEdge::ValType::F64};
+  FuncArgTypes = {WasmEdge::ValTypeCode::F64};
   Ret = VM.execute("printF64", FuncArgs, FuncArgTypes);
   EXPECT_TRUE(Ret);
   EXPECT_EQ((*Ret).size(), 0);
@@ -123,7 +123,7 @@ TEST(MixCallTest, Call__AOTCallInterp) {
   WasmEdge::Expect<void> Res;
   HostModule HostMod;
   std::vector<WasmEdge::ValVariant> FuncArgs;
-  std::vector<WasmEdge::FullValType> FuncArgTypes;
+  std::vector<WasmEdge::ValType> FuncArgTypes;
 
   // Compile the `module1` into AOT mode.
   EXPECT_TRUE(compileModule(Conf, "mixcallTestData/module1.wasm",
@@ -145,28 +145,28 @@ TEST(MixCallTest, Call__AOTCallInterp) {
 
   // Run `printAdd`
   FuncArgs = {uint32_t(1234), uint32_t(5678)};
-  FuncArgTypes = {WasmEdge::ValType::I32, WasmEdge::ValType::I32};
+  FuncArgTypes = {WasmEdge::ValTypeCode::I32, WasmEdge::ValTypeCode::I32};
   auto Ret = VM.execute("printAdd", FuncArgs, FuncArgTypes);
   EXPECT_TRUE(Ret);
   EXPECT_EQ((*Ret).size(), 0);
 
   // Run `printDiv`
   FuncArgs = {double(9876.0), double(4321.0)};
-  FuncArgTypes = {WasmEdge::ValType::F64, WasmEdge::ValType::F64};
+  FuncArgTypes = {WasmEdge::ValTypeCode::F64, WasmEdge::ValTypeCode::F64};
   Ret = VM.execute("printDiv", FuncArgs, FuncArgTypes);
   EXPECT_TRUE(Ret);
   EXPECT_EQ((*Ret).size(), 0);
 
   // Run `printI32`
   FuncArgs = {uint32_t(87654321)};
-  FuncArgTypes = {WasmEdge::ValType::I32};
+  FuncArgTypes = {WasmEdge::ValTypeCode::I32};
   Ret = VM.execute("printI32", FuncArgs, FuncArgTypes);
   EXPECT_TRUE(Ret);
   EXPECT_EQ((*Ret).size(), 0);
 
   // Run `printF64`
   FuncArgs = {double(5566.1122)};
-  FuncArgTypes = {WasmEdge::ValType::F64};
+  FuncArgTypes = {WasmEdge::ValTypeCode::F64};
   Ret = VM.execute("printF64", FuncArgs, FuncArgTypes);
   EXPECT_TRUE(Ret);
   EXPECT_EQ((*Ret).size(), 0);

--- a/test/spec/hostfunc.h
+++ b/test/spec/hostfunc.h
@@ -73,7 +73,7 @@ public:
     addHostFunc("print_f64_f64", std::make_unique<SpecTestPrintF64F64>());
 
     addHostTable("table", std::make_unique<Runtime::Instance::TableInstance>(
-                              AST::TableType(RefType::FuncRef, 10, 20)));
+                              AST::TableType(RefTypeCode::FuncRef, 10, 20)));
 
     addHostMemory("memory", std::make_unique<Runtime::Instance::MemoryInstance>(
                                 AST::MemoryType(1, 2)));
@@ -85,19 +85,19 @@ public:
     addHostGlobal(
         "global_i32",
         std::make_unique<Runtime::Instance::GlobalInstance>(
-            AST::GlobalType(ValType::I32, ValMut::Const), uint32_t(666)));
+            AST::GlobalType(ValTypeCode::I32, ValMut::Const), uint32_t(666)));
     addHostGlobal(
         "global_i64",
         std::make_unique<Runtime::Instance::GlobalInstance>(
-            AST::GlobalType(ValType::I64, ValMut::Const), uint64_t(666)));
+            AST::GlobalType(ValTypeCode::I64, ValMut::Const), uint64_t(666)));
     addHostGlobal(
         "global_f32",
         std::make_unique<Runtime::Instance::GlobalInstance>(
-            AST::GlobalType(ValType::F32, ValMut::Const), float(666)));
+            AST::GlobalType(ValTypeCode::F32, ValMut::Const), float(666)));
     addHostGlobal(
         "global_f64",
         std::make_unique<Runtime::Instance::GlobalInstance>(
-            AST::GlobalType(ValType::F64, ValMut::Const), double(666)));
+            AST::GlobalType(ValTypeCode::F64, ValMut::Const), double(666)));
   }
   ~SpecTestModule() noexcept override = default;
 };

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -101,10 +101,10 @@ SpecTest::CommandID resolveCommand(std::string_view Name) {
 }
 
 // Helper function to parse parameters from json to vector of value.
-std::pair<std::vector<WasmEdge::ValVariant>, std::vector<WasmEdge::FullValType>>
+std::pair<std::vector<WasmEdge::ValVariant>, std::vector<WasmEdge::ValType>>
 parseValueList(const rapidjson::Value &Args) {
   std::vector<WasmEdge::ValVariant> Result;
-  std::vector<WasmEdge::FullValType> ResultTypes;
+  std::vector<WasmEdge::ValType> ResultTypes;
   Result.reserve(Args.Size());
   ResultTypes.reserve(Args.Size());
   for (const auto &Element : Args.GetArray()) {
@@ -120,7 +120,7 @@ parseValueList(const rapidjson::Value &Args) {
           Result.emplace_back(WasmEdge::ExternRef(
               reinterpret_cast<void *>(std::stoul(Value) + 0x100000000ULL)));
         }
-        ResultTypes.emplace_back(WasmEdge::ValType::ExternRef);
+        ResultTypes.emplace_back(WasmEdge::ValTypeCode::ExternRef);
       } else if (Type == "funcref"sv) {
         if (Value == "null"sv) {
           Result.emplace_back(WasmEdge::UnknownRef());
@@ -130,19 +130,19 @@ parseValueList(const rapidjson::Value &Args) {
               reinterpret_cast<WasmEdge::Runtime::Instance::FunctionInstance *>(
                   std::stoul(Value) + 0x100000000ULL)));
         }
-        ResultTypes.emplace_back(WasmEdge::ValType::FuncRef);
+        ResultTypes.emplace_back(WasmEdge::ValTypeCode::FuncRef);
       } else if (Type == "i32"sv) {
         Result.emplace_back(static_cast<uint32_t>(std::stoul(Value)));
-        ResultTypes.emplace_back(WasmEdge::ValType::I32);
+        ResultTypes.emplace_back(WasmEdge::ValTypeCode::I32);
       } else if (Type == "f32"sv) {
         Result.emplace_back(static_cast<uint32_t>(std::stoul(Value)));
-        ResultTypes.emplace_back(WasmEdge::ValType::F32);
+        ResultTypes.emplace_back(WasmEdge::ValTypeCode::F32);
       } else if (Type == "i64"sv) {
         Result.emplace_back(static_cast<uint64_t>(std::stoull(Value)));
-        ResultTypes.emplace_back(WasmEdge::ValType::I64);
+        ResultTypes.emplace_back(WasmEdge::ValTypeCode::I64);
       } else if (Type == "f64"sv) {
         Result.emplace_back(static_cast<uint64_t>(std::stoull(Value)));
-        ResultTypes.emplace_back(WasmEdge::ValType::F64);
+        ResultTypes.emplace_back(WasmEdge::ValTypeCode::F64);
       } else {
         assumingUnreachable();
       }
@@ -178,7 +178,7 @@ parseValueList(const rapidjson::Value &Args) {
         I64x2 = reinterpret_cast<WasmEdge::uint64x2_t>(I8x16);
       }
       Result.emplace_back(I64x2);
-      ResultTypes.emplace_back(WasmEdge::ValType::V128);
+      ResultTypes.emplace_back(WasmEdge::ValTypeCode::V128);
     } else {
       assumingUnreachable();
     }
@@ -261,7 +261,7 @@ SpecTest::resolve(std::string_view Params) const {
 }
 
 bool SpecTest::compare(const std::pair<std::string, std::string> &Expected,
-                       const std::pair<ValVariant, FullValType> &Got) const {
+                       const std::pair<ValVariant, ValType> &Got) const {
   const auto &TypeStr = Expected.first;
   const auto &ValStr = Expected.second;
   bool IsV128 = (std::string_view(TypeStr).substr(0, 4) == "v128"sv);
@@ -269,22 +269,18 @@ bool SpecTest::compare(const std::pair<std::string, std::string> &Expected,
     // Handle NaN case
     // TODO: nan:canonical and nan:arithmetic
     if (TypeStr == "f32"sv) {
-      if (Got.second.getTypeCode() != ValTypeCode::F32) {
+      if (Got.second.getCode() != ValTypeCode::F32) {
         return false;
       }
       return std::isnan(Got.first.get<float>());
     } else if (TypeStr == "f64"sv) {
-      if (Got.second.getTypeCode() != ValTypeCode::F64) {
+      if (Got.second.getCode() != ValTypeCode::F64) {
         return false;
       }
       return std::isnan(Got.first.get<double>());
     }
   } else if (TypeStr == "funcref"sv) {
-    if (Got.second.getTypeCode() != ValTypeCode::RefNull) {
-      return false;
-    }
-    if (Got.second.asRefType().getHeapType().getHTypeCode() !=
-        HeapTypeCode::Func) {
+    if (!Got.second.isFuncRefType()) {
       return false;
     }
     if (ValStr == "null"sv) {
@@ -298,11 +294,7 @@ bool SpecTest::compare(const std::pair<std::string, std::string> &Expected,
              static_cast<uint32_t>(std::stoul(ValStr));
     }
   } else if (TypeStr == "externref"sv) {
-    if (Got.second.getTypeCode() != ValTypeCode::RefNull) {
-      return false;
-    }
-    if (Got.second.asRefType().getHeapType().getHTypeCode() !=
-        HeapTypeCode::Extern) {
+    if (!Got.second.isExternRefType()) {
       return false;
     }
     if (ValStr == "null"sv) {
@@ -316,23 +308,23 @@ bool SpecTest::compare(const std::pair<std::string, std::string> &Expected,
              static_cast<uint32_t>(std::stoul(ValStr));
     }
   } else if (TypeStr == "i32"sv) {
-    if (Got.second != NumType::I32) {
+    if (Got.second.getCode() != ValTypeCode::I32) {
       return false;
     }
     return Got.first.get<uint32_t>() == uint32_t(std::stoul(ValStr));
   } else if (TypeStr == "f32"sv) {
-    if (Got.second != NumType::F32) {
+    if (Got.second.getCode() != ValTypeCode::F32) {
       return false;
     }
     // Compare the 32-bit pattern
     return Got.first.get<uint32_t>() == uint32_t(std::stoul(ValStr));
   } else if (TypeStr == "i64"sv) {
-    if (Got.second != NumType::I64) {
+    if (Got.second.getCode() != ValTypeCode::I64) {
       return false;
     }
     return Got.first.get<uint64_t>() == uint64_t(std::stoull(ValStr));
   } else if (TypeStr == "f64"sv) {
-    if (Got.second != NumType::F64) {
+    if (Got.second.getCode() != ValTypeCode::F64) {
       return false;
     }
     // Compare the 64-bit pattern
@@ -340,7 +332,7 @@ bool SpecTest::compare(const std::pair<std::string, std::string> &Expected,
   } else if (IsV128) {
     std::vector<std::string_view> Parts;
     std::string_view Ev = ValStr;
-    if (Got.second != NumType::V128) {
+    if (Got.second.getCode() != ValTypeCode::V128) {
       return false;
     }
     for (std::string::size_type Begin = 0, End = Ev.find(' ');
@@ -449,7 +441,7 @@ bool SpecTest::compare(const std::pair<std::string, std::string> &Expected,
 
 bool SpecTest::compares(
     const std::vector<std::pair<std::string, std::string>> &Expected,
-    const std::vector<std::pair<ValVariant, FullValType>> &Got) const {
+    const std::vector<std::pair<ValVariant, ValType>> &Got) const {
   if (Expected.size() != Got.size()) {
     return false;
   }

--- a/test/spec/spectest.h
+++ b/test/spec/spectest.h
@@ -53,10 +53,10 @@ public:
   std::tuple<std::string_view, WasmEdge::Configure, std::string>
   resolve(std::string_view Params) const;
   bool compare(const std::pair<std::string, std::string> &Expected,
-               const std::pair<ValVariant, FullValType> &Got) const;
+               const std::pair<ValVariant, ValType> &Got) const;
   bool
   compares(const std::vector<std::pair<std::string, std::string>> &Expected,
-           const std::vector<std::pair<ValVariant, FullValType>> &Got) const;
+           const std::vector<std::pair<ValVariant, ValType>> &Got) const;
   bool stringContains(std::string_view Expected, std::string_view Got) const;
 
   void run(std::string_view Proposal, std::string_view UnitName);
@@ -74,13 +74,13 @@ public:
   using InstantiateCallback = Expect<void>(const std::string &Filename);
   std::function<InstantiateCallback> onInstantiate;
 
-  using InvokeCallback = Expect<std::vector<std::pair<ValVariant, FullValType>>>(
+  using InvokeCallback = Expect<std::vector<std::pair<ValVariant, ValType>>>(
       const std::string &ModName, const std::string &Field,
       const std::vector<ValVariant> &Params,
-      const std::vector<FullValType> &ParamTypes);
+      const std::vector<ValType> &ParamTypes);
   std::function<InvokeCallback> onInvoke;
 
-  using GetCallback = Expect<std::pair<ValVariant, FullValType>>(
+  using GetCallback = Expect<std::pair<ValVariant, ValType>>(
       const std::string &ModName, const std::string &Field);
   std::function<GetCallback> onGet;
 

--- a/test/thread/ThreadTest.cpp
+++ b/test/thread/ThreadTest.cpp
@@ -172,7 +172,7 @@ TEST(AsyncExecute, ThreadTest) {
   ASSERT_TRUE(VM.instantiate());
   {
     std::array<WasmEdge::VM::Async<WasmEdge::Expect<std::vector<
-                   std::pair<WasmEdge::ValVariant, WasmEdge::FullValType>>>>,
+                   std::pair<WasmEdge::ValVariant, WasmEdge::ValType>>>>,
                4>
         AsyncResults;
     for (uint64_t Index = 0; Index < Answers.size(); ++Index) {
@@ -180,14 +180,14 @@ TEST(AsyncExecute, ThreadTest) {
           "mt19937",
           std::initializer_list<WasmEdge::ValVariant>{
               UINT32_C(2504) * Index, UINT64_C(5489), UINT64_C(100000) + Index},
-          {WasmEdge::FullValType(WasmEdge::ValType::I32),
-           WasmEdge::FullValType(WasmEdge::ValType::I64),
-           WasmEdge::FullValType(WasmEdge::ValType::I64)});
+          {WasmEdge::ValType(WasmEdge::ValTypeCode::I32),
+           WasmEdge::ValType(WasmEdge::ValTypeCode::I64),
+           WasmEdge::ValType(WasmEdge::ValTypeCode::I64)});
     }
     for (uint64_t Index = 0; Index < Answers.size(); ++Index) {
       auto Result = AsyncResults[Index].get();
       ASSERT_TRUE(Result);
-      ASSERT_EQ((*Result)[0].second, WasmEdge::ValType::I64);
+      ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::ValTypeCode::I64);
       EXPECT_EQ((*Result)[0].first.get<uint64_t>(), Answers[Index]);
     }
   }
@@ -204,7 +204,7 @@ TEST(AsyncExecute, GasThreadTest) {
   ASSERT_TRUE(VM.instantiate());
   {
     std::array<WasmEdge::VM::Async<WasmEdge::Expect<std::vector<
-                   std::pair<WasmEdge::ValVariant, WasmEdge::FullValType>>>>,
+                   std::pair<WasmEdge::ValVariant, WasmEdge::ValType>>>>,
                4>
         AsyncResults;
     for (uint64_t Index = 0; Index < Answers.size(); ++Index) {
@@ -212,14 +212,14 @@ TEST(AsyncExecute, GasThreadTest) {
           "mt19937",
           std::initializer_list<WasmEdge::ValVariant>{
               UINT32_C(2504) * Index, UINT64_C(5489), UINT64_C(100000) + Index},
-          {WasmEdge::FullValType(WasmEdge::ValType::I32),
-           WasmEdge::FullValType(WasmEdge::ValType::I64),
-           WasmEdge::FullValType(WasmEdge::ValType::I64)});
+          {WasmEdge::ValType(WasmEdge::ValTypeCode::I32),
+           WasmEdge::ValType(WasmEdge::ValTypeCode::I64),
+           WasmEdge::ValType(WasmEdge::ValTypeCode::I64)});
     }
     for (uint64_t Index = 0; Index < Answers.size(); ++Index) {
       auto Result = AsyncResults[Index].get();
       ASSERT_TRUE(Result);
-      ASSERT_EQ((*Result)[0].second, WasmEdge::ValType::I64);
+      ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::ValTypeCode::I64);
       EXPECT_EQ((*Result)[0].first.get<uint64_t>(), Answers[Index]);
     }
   }
@@ -250,7 +250,7 @@ TEST(AOTAsyncExecute, ThreadTest) {
   ASSERT_TRUE(VM.instantiate());
   {
     std::array<WasmEdge::VM::Async<WasmEdge::Expect<std::vector<
-                   std::pair<WasmEdge::ValVariant, WasmEdge::FullValType>>>>,
+                   std::pair<WasmEdge::ValVariant, WasmEdge::ValType>>>>,
                4>
         AsyncResults;
     for (uint64_t Index = 0; Index < Answers.size(); ++Index) {
@@ -258,14 +258,14 @@ TEST(AOTAsyncExecute, ThreadTest) {
           "mt19937",
           std::initializer_list<WasmEdge::ValVariant>{
               UINT32_C(2504) * Index, UINT64_C(5489), UINT64_C(100000) + Index},
-          {WasmEdge::FullValType(WasmEdge::ValType::I32),
-           WasmEdge::FullValType(WasmEdge::ValType::I64),
-           WasmEdge::FullValType(WasmEdge::ValType::I64)});
+          {WasmEdge::ValType(WasmEdge::ValTypeCode::I32),
+           WasmEdge::ValType(WasmEdge::ValTypeCode::I64),
+           WasmEdge::ValType(WasmEdge::ValTypeCode::I64)});
     }
     for (uint64_t Index = 0; Index < Answers.size(); ++Index) {
       auto Result = AsyncResults[Index].get();
       ASSERT_TRUE(Result);
-      ASSERT_EQ((*Result)[0].second, WasmEdge::ValType::I64);
+      ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::ValTypeCode::I64);
       EXPECT_EQ((*Result)[0].first.get<uint64_t>(), Answers[Index]);
     }
   }
@@ -298,7 +298,7 @@ TEST(AOTAsyncExecute, GasThreadTest) {
   ASSERT_TRUE(VM.instantiate());
   {
     std::array<WasmEdge::VM::Async<WasmEdge::Expect<std::vector<
-                   std::pair<WasmEdge::ValVariant, WasmEdge::FullValType>>>>,
+                   std::pair<WasmEdge::ValVariant, WasmEdge::ValType>>>>,
                4>
         AsyncResults;
     for (uint64_t Index = 0; Index < Answers.size(); ++Index) {
@@ -306,14 +306,14 @@ TEST(AOTAsyncExecute, GasThreadTest) {
           "mt19937",
           std::initializer_list<WasmEdge::ValVariant>{
               UINT32_C(2504) * Index, UINT64_C(5489), UINT64_C(100000) + Index},
-          {WasmEdge::FullValType(WasmEdge::ValType::I32),
-           WasmEdge::FullValType(WasmEdge::ValType::I64),
-           WasmEdge::FullValType(WasmEdge::ValType::I64)});
+          {WasmEdge::ValType(WasmEdge::ValTypeCode::I32),
+           WasmEdge::ValType(WasmEdge::ValTypeCode::I64),
+           WasmEdge::ValType(WasmEdge::ValTypeCode::I64)});
     }
     for (uint64_t Index = 0; Index < Answers.size(); ++Index) {
       auto Result = AsyncResults[Index].get();
       ASSERT_TRUE(Result);
-      ASSERT_EQ((*Result)[0].second, WasmEdge::ValType::I64);
+      ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::ValTypeCode::I64);
       EXPECT_EQ((*Result)[0].first.get<uint64_t>(), Answers[Index]);
     }
   }


### PR DESCRIPTION
Concepts:

1. The types, include the `ValType`, `RefType`, and `BlockType` should be in less or equal to 8 bytes, or the instruction class size will raised.
   - Therefore, reserved the `uint64_t` length of data to these types.
   - `RefType` will be the subset of the `ValType`.
   - Implement the `HeapType` in the `RefType`.
   - For the C API, copy the raw data to the struct.
2. Naming patterns:
   - `WasmEdge::ValType` and `WasmEdge::RefType` are the classes of describing the value types.
   - `WasmEdge::ValTypeCode`, `WasmEdge::RefTypeCode`, and `WasmEdge::NumTypeCode` are the C++ enum classes for the codes.
   - `WasmEdge_ValType` is the struct of storing the value type data.
   - `WasmEdge_ValTypeCode`, `WasmEdge_RefTypeCode`, and `WasmEdge_NumTypeCode` are the C enum for the codes.

TODO:

- [ ] Fix the JAVA binding
- [ ] Fix the Rust binding