### PR TITLE
[CI] Add `cript` to ignore_words to pass the CI

### DIFF
--- a/.github/workflows/ignore_words
+++ b/.github/workflows/ignore_words
@@ -14,3 +14,4 @@ seh
 ser
 te
 unexpect
+scipr

--- a/.github/workflows/ignore_words
+++ b/.github/workflows/ignore_words
@@ -14,4 +14,4 @@ seh
 ser
 te
 unexpect
-scipr
+cript


### PR DESCRIPTION
This pull request fixes the linting issue appeared in `docs/book/en/src/write_wasm/js/ssr.md:293`, where codespell regards the truncated HTML `cript>` as a spelling error.