### PR TITLE
[WASI-NN] tensorflow lite backend - fix set_input and get_output bugs when checking

### DIFF
--- a/plugins/wasi_nn/wasinnenv.h
+++ b/plugins/wasi_nn/wasinnenv.h
@@ -26,8 +26,10 @@ namespace WASINN {
 enum class ErrNo : uint32_t {
   Success = 0,         // No error occurred.
   InvalidArgument = 1, // Caller module passed an invalid argument.
-  MissingMemory = 2,   // Caller module is missing a memory export.
-  Busy = 3             // Device or resource busy.
+  InvalidEncoding = 2, // Invalid encoding.
+  MissingMemory = 3,   // Caller module is missing a memory export.
+  Busy = 4,            // Device or resource busy.
+  RuntimeError = 5,    // Runtime Error.
 };
 
 enum class TensorType : uint8_t { F16 = 0, F32 = 1, U8 = 2, I32 = 3 };


### PR DESCRIPTION
1. Update errno for wasi-nn plugin.    [wasi-nn spec main branch](https://github.com/WebAssembly/wasi-nn/blob/main/wasi-nn.wit.md)
2. ```TfLiteTensorCopyToBuffer``` requires that ```output_data_size == TfLiteTensorByteSize(tensor)```. when getting output and ```OutBuffMaxSize < TfLiteTensorByteSize(tensor)```, TfLite will return ```kTfLiteError``` and wasi-nn plugin will return ```Success```. In this situation, the wasi-nn plugin may return the ```InvalidArgument``` to tell the user ```get_output``` fail.
3. In ```SetInput```, variable ```DimensionBuf``` is used before checking it if is ```NULL```, and variable ```TFDimension``` has never been used, so I delete it.  And I add the dimension check and tensor bytes check to ensure ```input_data_size == TfLiteTensorByteSize(tensor)```.

BTW, in tflite API:
> The caller retains ownership of the `model_data` buffer and should ensure that the lifetime of the `model_data` buffer must be at least as long as the lifetime of the `TfLiteModel` and of any `TfLiteInterpreter` objects created from that `TfLiteModel`, and furthermore the contents of the `model_data` buffer must not be modified during that time."

WASI-NN tensorflow lite plugin should ensure that the ```model_data``` cannot be released or modified during ```TfLiteModel``` and ```TfLiteInterpreter``` lifetime to avoid segment fault.

TODO: solve the problem above.
