### PR TITLE
[Docs] Update documents for unified tool

### DIFF
--- a/docs/book/en/book.toml
+++ b/docs/book/en/book.toml
@@ -160,6 +160,7 @@ copy-js = true
 "/extend/build_on_mac.html" = "/book/en/contribute/build_from_src/macos.html"
 "/extend/build_on_windows.html" = "/book/en/contribute/build_from_src/windows.html"
 "/extend/build_for_android.html" = "/book/en/contribute/build_from_src/android.html"
+"/cli/wasmedgec.html" = "/book/en/cli/wasmedge_compile.html"
 
 [preprocessor.variables.variables]
 wasmedge_version = "0.12.1"

--- a/docs/book/en/src/SUMMARY.md
+++ b/docs/book/en/src/SUMMARY.md
@@ -133,6 +133,7 @@
 - [Use WasmEdge CLI](cli.md)
   - [`wasmedge` WASM Runner](cli/wasmedge.md)
   - [`wasmedgec` AOT Compiler](cli/wasmedge_compile.md)
+  - [`wasmedge run` WASM Runner](cli/wasmedge_tool.md)
 
 - [Develop WasmEdge Plug-in](plugin.md)
   - [Develop Plug-in in C API](develop_plugin/c.md)

--- a/docs/book/en/src/SUMMARY.md
+++ b/docs/book/en/src/SUMMARY.md
@@ -132,7 +132,7 @@
 
 - [Use WasmEdge CLI](cli.md)
   - [`wasmedge` WASM Runner](cli/wasmedge.md)
-  - [`wasmedgec` AOT Compiler](cli/wasmedgec.md)
+  - [`wasmedgec` AOT Compiler](cli/wasmedge_compile.md)
 
 - [Develop WasmEdge Plug-in](plugin.md)
   - [Develop Plug-in in C API](develop_plugin/c.md)

--- a/docs/book/en/src/contribute/build_from_src.md
+++ b/docs/book/en/src/contribute/build_from_src.md
@@ -24,6 +24,7 @@ You can find that there are several wasmedge related tools:
 2. `wasmedgec` is the ahead-of-time `WASM` compiler.
    - `wasmedgec` compiles a general `WASM` file into a compiled `WASM` file.
    - To disable building the ahead-of-time compiler only, you can set the CMake option `WASMEDGE_BUILD_AOT_RUNTIME` to `OFF`.
+   - NOTE: The usage of `wasmedgec` is equal to `wasmedge compile`. We decide to deprecate `wasmedgec` in the future.
 3. `libwasmedge.so` is the WasmEdge C API shared library. (`libwasmedge.dylib` on MacOS and `wasmedge.dll` on Windows)
    - `libwasmedge.so`, `libwasmedge.dylib`, or `wasmedge.dll` provides the C API for the ahead-of-time compiler and the WASM runtime.
    - The APIs related to the ahead-of-time compiler will always fail if the CMake option `WASMEDGE_BUILD_AOT_RUNTIME` is set as `OFF`.

--- a/docs/book/en/src/contribute/build_from_src/riscv64.md
+++ b/docs/book/en/src/contribute/build_from_src/riscv64.md
@@ -62,12 +62,12 @@ ubuntu@riscv-lab:/labs/riscv-lab/WasmEdge/examples/wasm$ wasmedge --reactor add.
 4
 ```
 
-### Execute the wasmedgec tool
+### Execute wasmedge compile
 
-To improve the performance, the `wasmedgec` can compile WebAssembly into native machine code. After compiling with the `wasmedgec` AOT compiler, the wasmedge tool can execute the WASM in AOT mode which is much faster.
+To improve the performance, the `wasmedge compile` can compile WebAssembly into native machine code. After compiling with the `wasmedge compile` AOT compiler, the wasmedge tool can execute the WASM in AOT mode which is much faster.
 
 ```bash
-ubuntu@riscv-lab:/labs/riscv-lab/WasmEdge/examples/wasm$ wasmedgec fibonacci.wasm fibonacci_aot.wasm
+ubuntu@riscv-lab:/labs/riscv-lab/WasmEdge/examples/wasm$ wasmedge compile fibonacci.wasm fibonacci_aot.wasm
 [2023-02-01 22:39:15.807] [info] compile start
 [2023-02-01 22:39:15.857] [info] verify start
 [2023-02-01 22:39:15.866] [info] optimize start

--- a/docs/book/en/src/quick_start/install.md
+++ b/docs/book/en/src/quick_start/install.md
@@ -84,6 +84,7 @@ For the full options of the WasmEdge installer, please refer to the [document he
   * The `wasmedgec` tool is the ahead-of-time (AOT) compiler to compile a `.wasm` file into a native `.so` file (or `.dylib` on MacOS, `.dll` on Windows, or `.wasm` as the universal WASM format on all platforms). The `wasmedge` can then execute the output file.
     * Compile a WASM file into a AOT-compiled WASM: `wasmedgec app.wasm app.so`
     * Execute the WASM in AOT mode: `wasmedge --dir .:. app.so`
+    * NOTE: The usage of `wasmedgec` is equal to `wasmedge compile`. We decide to deprecate `wasmedgec` in the future.
   * The `wasmedge-tensorflow`, `wasmedge-tensorflow-lite` tools are runtimes that support the WasmEdge tensorflow extension.
 * The `$HOME/.wasmedge/lib` directory contains WasmEdge shared libraries, as well as dependency libraries. They are useful for WasmEdge SDKs to launch WasmEdge programs and functions from host applications.
 * The `$HOME/.wasmedge/include` directory contains the WasmEdge header files. They are useful for WasmEdge SDKs.

--- a/docs/book/en/src/quick_start/run_cli.md
+++ b/docs/book/en/src/quick_start/run_cli.md
@@ -9,7 +9,7 @@ The `wasmedge` binary is a command line interface (CLI) program that runs WebAss
 * If the WebAssembly program contains a `main()` function, `wasmedge` would execute it as a standalone program in the command mode.
 * If the WebAssembly program contains one or more exported public functions, `wasmedge` could invoke individual functions in the reactor mode.
 
-By default, the `wasmedge` will execute WebAssembly programs in interpreter mode, and [execute the AOT-compiled `.so`, `.dylib`, `.dll`, or `.wasm` (universal output format) in AOT mode](run_in_aot_mode.md). If you want to accelerate the WASM execution, we recommend to [compile the WebAssembly with the AOT compiler](#wasmedgec-cli) first.
+By default, the `wasmedge` will execute WebAssembly programs in interpreter mode, and [execute the AOT-compiled `.so`, `.dylib`, `.dll`, or `.wasm` (universal output format) in AOT mode](run_in_aot_mode.md). If you want to accelerate the WASM execution, we recommend to [compile the WebAssembly with the AOT compiler](#wasmedge-compile-cli) first.
 
 Users can run the `wasmedge -h` for realizing the command line options quickly, or [refer to the detailed `wasmedge` CLI options here](../cli/wasmedge.md).
 
@@ -68,25 +68,25 @@ second
 state
 ```
 
-## `wasmedgec` CLI
+## `wasmedge compile` CLI
 
-The `wasmedgec` binary is a CLI program to compile WebAssembly into native machine code (i.e., the AOT compiler). For the pure WebAssembly, the `wasmedge` tool will execute the WASM in interpreter mode. After compiling with the AOT compiler, the `wasmedge` tool can execute the WASM in AOT mode which is much faster.
+The `wasmedge compile` is a CLI command to compile WebAssembly into native machine code (i.e., the AOT compiler). For the pure WebAssembly, the `wasmedge` tool will execute the WASM in interpreter mode. After compiling with the AOT compiler, the `wasmedge` tool can execute the WASM in AOT mode which is much faster.
 
-The options and flags for the `wasmedgec` are as follows.
+The options and flags for the `wasmedge compile` are as follows.
 
 1. Input Wasm file(`/path/to/input/wasm/file`).
 2. Output file name(`/path/to/output/file`).
    * By default, it will generate the [universal Wasm binary format](run_in_aot_mode.md#output-format-universal-wasm).
    * Users can still generate native binary only by specifying the `.so`, `.dylib`, or `.dll` extensions.
 
-Users can run the `wasmedgec -h` for realizing the command line options quickly, or [refer to the detailed `wasmedgec` CLI options here](../cli/wasmedgec.md).
+Users can run the `wasmedge compile -h` for realizing the command line options quickly, or [refer to the detailed `wasmedge compile` CLI options here](../cli/wasmedge_compile.md).
 
 ```bash
 # This is slow in interpreter mode.
 wasmedge app.wasm
 
 # AOT compilation.
-wasmedgec app.wasm app_aot.wasm
+wasmedge compile app.wasm app_aot.wasm
 
 # This is now MUCH faster in AOT mode.
 wasmedge app_aot.wasm

--- a/docs/book/en/src/quick_start/run_in_aot_mode.md
+++ b/docs/book/en/src/quick_start/run_in_aot_mode.md
@@ -1,17 +1,17 @@
 # Execution in AOT Mode
 
-The `wasmedge` command line tool will execute the original WASM files in interpreter mode. For the much better performance, we recommend users to compile the WASM with the `wasmedgec` AOT compiler to execute the WASM in AOT mode. There are 2 output formats of the AOT compiler:
+The `wasmedge` command line tool will execute the original WASM files in interpreter mode. For the much better performance, we recommend users to compile the WASM with the `wasmedge compile` AOT compiler to execute the WASM in AOT mode. There are 2 output formats of the AOT compiler:
 
 ## Output Format: Universal WASM
 
-By default, the `wasmedgec` AOT compiler tool could wrap the AOT-compiled native binary into a custom section in the origin WASM file. We call this the universal WASM binary format.
+By default, the `wasmedge compile` AOT compiler tool could wrap the AOT-compiled native binary into a custom section in the origin WASM file. We call this the universal WASM binary format.
 
 This AOT-compiled WASM file is compatible with any WebAssembly runtime. However, when this WASM file is executed by the WasmEdge runtime, WasmEdge will extract the native binary from the custom section and execute it in AOT mode.
 
-> Note: On MacOS platforms, the universal WASM format will `bus error` in execution. It's because the `wasmedgec` tool optimizes the WASM in `O2` level by default. We are trying to fix this issue. For working around, please use the shared library output format instead.
+> Note: On MacOS platforms, the universal WASM format will `bus error` in execution. It's because the `wasmedge compile` tool optimizes the WASM in `O2` level by default. We are trying to fix this issue. For working around, please use the shared library output format instead.
 
 ```bash
-wasmedgec app.wasm app_aot.wasm
+wasmedge compile app.wasm app_aot.wasm
 wasmedge app_aot.wasm
 ```
 
@@ -22,6 +22,6 @@ Users can assign the shared library extension for the output files (`.so` on Lin
 This AOT-compiled WASM file is only for WasmEdge use, and cannot be used by other WebAssembly runtimes.
 
 ```bash
-wasmedgec app.wasm app_aot.so
+wasmedge compile app.wasm app_aot.so
 wasmedge app_aot.so
 ```

--- a/docs/book/en/src/quick_start/use_docker.md
+++ b/docs/book/en/src/quick_start/use_docker.md
@@ -15,15 +15,16 @@ The `wasmedge/slim:{version}` Docker images provide a slim WasmEdge images built
   * `wasmedge-tensorflow`
   * `show-tflite-tensor`
 * The working directory of the release docker image is `/app`.
+* NOTE: The usage of `wasmedgec` is equal to `wasmedge compile`. We decide to deprecate `wasmedgec` in the future.
 
 ### Examples
 
-Use `wasmedgec` and `wasmedge` ([link](https://github.com/WasmEdge/WasmEdge/tree/master/examples/wasm)):
+Use `wasmedge compile` and `wasmedge` ([link](https://github.com/WasmEdge/WasmEdge/tree/master/examples/wasm)):
 
 ```bash
 $ docker pull wasmedge/slim:{{ wasmedge_version }}
 
-$ docker run -it --rm -v $PWD:/app wasmedge/slim:{{ wasmedge_version }} wasmedgec hello.wasm hello.aot.wasm
+$ docker run -it --rm -v $PWD:/app wasmedge/slim:{{ wasmedge_version }} wasmedge compile hello.wasm hello.aot.wasm
 [2022-07-07 08:15:49.154] [info] compile start
 [2022-07-07 08:15:49.163] [info] verify start
 [2022-07-07 08:15:49.169] [info] optimize start

--- a/docs/book/en/src/sdk/go/tensorflow.md
+++ b/docs/book/en/src/sdk/go/tensorflow.md
@@ -37,10 +37,10 @@ cp target/wasm32-wasi/release/rust_tflite_food_lib.wasm ../
 cd ../
 ```
 
-You can use our AOT compiler `wasmedgec` to instrument the WebAssembly file to make it run much faster. [Learn more](../../quick_start/run_in_aot_mode.md).
+You can use our AOT compiler `wasmedge compile` to instrument the WebAssembly file to make it run much faster. [Learn more](../../quick_start/run_in_aot_mode.md).
 
 ```bash
-wasmedgec rust_tflite_food_lib.wasm rust_tflite_food_lib.wasm
+wasmedge compile rust_tflite_food_lib.wasm rust_tflite_food_lib.wasm
 ```
 
 ## Go host app

--- a/docs/book/en/src/use_cases/frameworks/app/yomo.md
+++ b/docs/book/en/src/use_cases/frameworks/app/yomo.md
@@ -131,7 +131,7 @@ cp target/wasm32-wasi/release/rust_mobilenet_food_lib.wasm ../
 To release the best performance of WasmEdge, you should enable the AOT mode by compiling the `.wasm` file to the `.so`.
 
 ```bash
-wasmedgec rust_mobilenet_food_lib.wasm rust_mobilenet_food_lib.so
+wasmedge compile rust_mobilenet_food_lib.wasm rust_mobilenet_food_lib.so
 ```
 
 ## Integration with YoMo

--- a/docs/book/en/src/write_wasm/c/simd.md
+++ b/docs/book/en/src/write_wasm/c/simd.md
@@ -175,7 +175,7 @@ wasmedge mandelbrot-simd.wasm 15000
 
 ```bash
 # Compile wasm-simd with wasmedge aot compiler
-$ wasmedgec mandelbrot-simd.wasm mandelbrot-simd-out.wasm
+$ wasmedge compile mandelbrot-simd.wasm mandelbrot-simd-out.wasm
 # Run the native binary with wasmedge
 $ wasmedge mandelbrot-simd-out.wasm 15000
 ```

--- a/docs/book/en/src/write_wasm/go.md
+++ b/docs/book/en/src/write_wasm/go.md
@@ -100,10 +100,10 @@ $ wasmedge --reactor fib.wasm fibArray 10
 
 ## Improve performance
 
-To achieve native Go performance for those applications, you could use the `wasmedgec` command to AOT compile the `wasm` program, and then run it with the `wasmedge` command.
+To achieve native Go performance for those applications, you could use the `wasmedge compile` command to AOT compile the `wasm` program, and then run it with the `wasmedge` command.
 
 ```bash
-$ wasmedgec hello.wasm hello.wasm
+$ wasmedge compile hello.wasm hello.wasm
 
 $ wasmedge hello.wasm
 Hello TinyGo from WasmEdge!
@@ -112,7 +112,7 @@ Hello TinyGo from WasmEdge!
 For the `--reactor` mode,
 
 ```bash
-$ wasmedgec fib.wasm fib.wasm
+$ wasmedge compile fib.wasm fib.wasm
 
 $ wasmedge --reactor fib.wasm fibArray 10
 34

--- a/docs/book/en/src/write_wasm/js/quickstart.md
+++ b/docs/book/en/src/write_wasm/js/quickstart.md
@@ -54,10 +54,10 @@ cargo build --target wasm32-wasi --release
 
 The WebAssembly-based JavaScript interpreter program is located in the build `target` directory.
 
-WasmEdge provides a `wasmedgec` utility to compile and add a native machine code section to the `wasm` file. You can use `wasmedge` to run the natively instrumented `wasm` file to get much faster performance.
+WasmEdge provides a `wasmedge compile` utility to compile and add a native machine code section to the `wasm` file. You can use `wasmedge` to run the natively instrumented `wasm` file to get much faster performance.
 
 ```bash
-wasmedgec target/wasm32-wasi/release/wasmedge_quickjs.wasm wasmedge_quickjs.wasm
+wasmedge compile target/wasm32-wasi/release/wasmedge_quickjs.wasm wasmedge_quickjs.wasm
 wasmedge --dir .:. wasmedge_quickjs.wasm example_js/hello.js
 ```
 

--- a/docs/book/en/src/write_wasm/python.md
+++ b/docs/book/en/src/write_wasm/python.md
@@ -25,7 +25,7 @@ cargo build --release --target wasm32-wasi --features="freeze-stdlib"
 WasmEdge supports compiling WebAssembly bytecode programs into native machine code for better performance. It is highly recommended to compile the RustPython to native machine code before running.
 
 ```bash
-wasmedgec ./target/wasm32-wasi/release/rustpython.wasm ./target/wasm32-wasi/release/rustpython.wasm
+wasmedge compile ./target/wasm32-wasi/release/rustpython.wasm ./target/wasm32-wasi/release/rustpython.wasm
 ```
 
 ## Run

--- a/docs/book/en/src/write_wasm/rust.md
+++ b/docs/book/en/src/write_wasm/rust.md
@@ -87,10 +87,10 @@ Below are some SDK examples for complex call parameters and return values.
 
 ## Improve the Performance
 
-To achieve native Rust performance for those applications, you could use the `wasmedgec` command to AOT compile the `wasm` program, and then run it with the `wasmedge` command.
+To achieve native Rust performance for those applications, you could use the `wasmedge compile` command to AOT compile the `wasm` program, and then run it with the `wasmedge` command.
 
 ```bash
-$ wasmedgec hello.wasm hello_aot.wasm
+$ wasmedge compile hello.wasm hello_aot.wasm
 
 $ wasmedge hello_aot.wasm second state
 hello
@@ -101,7 +101,7 @@ state
 For the `--reactor` mode,
 
 ```bash
-$ wasmedgec add.wasm add_aot.wasm
+$ wasmedge compile add.wasm add_aot.wasm
 
 $ wasmedge --reactor add_aot.wasm add 2 2
 4

--- a/docs/book/en/src/write_wasm/rust/tensorflow.md
+++ b/docs/book/en/src/write_wasm/rust/tensorflow.md
@@ -47,7 +47,7 @@ It is very likely a <a href='https://www.google.com/search?q=military uniform'>m
 To make Tensorflow inference run *much* faster, you could AOT compile it down to machine native code, and then use WasmEdge sandbox to run the native code.
 
 ```bash
-$ wasmedgec target/wasm32-wasi/release/classify.wasm classify.wasm
+$ wasmedge compile target/wasm32-wasi/release/classify.wasm classify.wasm
 $ wasmedge-tensorflow-lite classify.wasm < grace_hopper.jpg
 It is very likely a <a href='https://www.google.com/search?q=military uniform'>military uniform</a> in the picture
 ```

--- a/docs/book/en/src/write_wasm/rust/wasinn.md
+++ b/docs/book/en/src/write_wasm/rust/wasinn.md
@@ -534,7 +534,7 @@ Executed graph inference
 For the AOT mode which is much more quickly, you can compile the WASM first:
 
 ```bash
-wasmedgec wasmedge-wasinn-example-mobilenet.wasm out.wasm
+wasmedge compile wasmedge-wasinn-example-mobilenet.wasm out.wasm
 wasmedge --dir .:. out.wasm mobilenet.xml mobilenet.bin input.jpg
 ```
 
@@ -584,7 +584,7 @@ Executed graph inference
 For the AOT mode which is much more quickly, you can compile the WASM first:
 
 ```bash
-wasmedgec wasmedge-wasinn-example-mobilenet.wasm out.wasm
+wasmedge compile wasmedge-wasinn-example-mobilenet.wasm out.wasm
 wasmedge --dir .:. out.wasm mobilenet.pt input.jpg
 ```
 
@@ -634,7 +634,7 @@ Executed graph inference
 For the AOT mode which is much more quickly, you can compile the WASM first:
 
 ```bash
-wasmedgec wasmedge-wasinn-example-tflite-bird-image.wasm out.wasm
+wasmedge compile wasmedge-wasinn-example-tflite-bird-image.wasm out.wasm
 wasmedge --dir .:. out.wasm lite-model_aiy_vision_classifier_birds_V1_3.tflite bird.jpg
 ```
 


### PR DESCRIPTION
1. Since we reserve `wasmedgec` tool at this time, I did not remove `wasmedgec` in the installation documents. Besides, I added notes to remind user that `wasmedgec` is equal to `wasmedge compile` and we decide to deprecate `wasmedgec` in the future.

2. Since `wasmedgec` is equal to `wasmedge compile`, I replace `wasmedgec` to `wasmedge compile` in user guides and examples.