### PR TITLE
[Rust] Derive Clone trait for Vm

### DIFF
--- a/bindings/rust/wasmedge-sdk/src/executor.rs
+++ b/bindings/rust/wasmedge-sdk/src/executor.rs
@@ -4,7 +4,7 @@ use crate::{config::Config, Func, FuncRef, Statistics, WasmEdgeResult, WasmValue
 use wasmedge_sys as sys;
 
 /// Defines an execution environment for both pure WASM and compiled WASM.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Executor {
     pub(crate) inner: sys::Executor,
 }

--- a/bindings/rust/wasmedge-sdk/src/import.rs
+++ b/bindings/rust/wasmedge-sdk/src/import.rs
@@ -289,7 +289,7 @@ impl ImportObjectBuilder {
 /// Defines an import object that contains the required import data used when instantiating a [module](crate::Module).
 ///
 /// An [ImportObject] instance is created with [ImportObjectBuilder](crate::ImportObjectBuilder).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ImportObject(pub(crate) sys::ImportObject);
 impl ImportObject {
     /// Returns the name of the import object.

--- a/bindings/rust/wasmedge-sdk/src/store.rs
+++ b/bindings/rust/wasmedge-sdk/src/store.rs
@@ -4,7 +4,7 @@ use crate::{Executor, ImportObject, Instance, Module, WasmEdgeResult};
 use wasmedge_sys as sys;
 
 /// Represents all global state that can be manipulated by WebAssembly programs. A [store](crate::Store) consists of the runtime representation of all instances of [functions](crate::Func), [tables](crate::Table), [memories](crate::Memory), and [globals](crate::Global).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Store {
     pub(crate) inner: sys::Store,
 }

--- a/bindings/rust/wasmedge-sdk/src/vm.rs
+++ b/bindings/rust/wasmedge-sdk/src/vm.rs
@@ -231,7 +231,7 @@ impl VmBuilder {
 ///     Ok(())
 /// }
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Vm {
     pub(crate) config: Option<Config>,
     stat: Option<Statistics>,
@@ -738,7 +738,7 @@ impl Vm {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum HostRegistrationInstance {
     Wasi(crate::wasi::WasiInstance),
 }

--- a/bindings/rust/wasmedge-sdk/src/wasi.rs
+++ b/bindings/rust/wasmedge-sdk/src/wasi.rs
@@ -7,7 +7,7 @@ use crate::{
 use wasmedge_sys::{self as sys, AsImport, AsInstance as sys_as_instance_trait};
 
 /// Represents a wasi module instance.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WasiInstance {
     pub(crate) inner: sys::WasiModule,
 }

--- a/bindings/rust/wasmedge-sys/src/frame.rs
+++ b/bindings/rust/wasmedge-sys/src/frame.rs
@@ -33,7 +33,7 @@ impl CallingFrame {
 
         match ctx.is_null() {
             false => Some(Executor {
-                inner: InnerExecutor(ctx),
+                inner: std::sync::Arc::new(InnerExecutor(ctx)),
                 registered: true,
             }),
             true => None,


### PR DESCRIPTION
In this PR, the `Clone` trait is derived for `Vm`, `Store`, and `Executor` in `wasmedge-sdk`.