### PR TITLE
[Rust] Optimize host function

### DIFF
--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -247,5 +247,5 @@ jobs:
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           export LD_LIBRARY_PATH="$(pwd)/../../build/lib/api"
-          cargo test --workspace --locked --features aot,async,ffi
-          cargo test --examples --locked --features aot,async,ffi
+          cargo test --workspace --locked --features aot,async,ffi -- --test-threads=1
+          cargo test --examples --locked --features aot,async,ffi -- --test-threads=1

--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -72,8 +72,8 @@ jobs:
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           export LD_LIBRARY_PATH="$(pwd)/../../build/lib/api"
-          cargo test --workspace --locked --features aot,async,ffi
-          cargo test --examples --locked --features aot,async,ffi
+          cargo test --workspace --locked --features aot,async,ffi -- --test-threads=1
+          cargo test --examples --locked --features aot,async,ffi -- --test-threads=1
 
   build_macos:
     name: MacOS
@@ -127,8 +127,8 @@ jobs:
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           export DYLD_LIBRARY_PATH="$(pwd)/../../build/lib/api"
-          cargo test --workspace --locked --features aot,async,ffi
-          cargo test --examples --locked --features aot,async,ffi
+          cargo test --workspace --locked --features aot,async,ffi -- --test-threads=1
+          cargo test --examples --locked --features aot,async,ffi -- --test-threads=1
 
   build_windows:
     name: Windows
@@ -197,8 +197,8 @@ jobs:
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
           $env:Path="$env:Path;C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin;D:\a\WasmEdge\WasmEdge\build\lib\api"
           cd bindings\rust
-          cargo test --workspace --features aot,async,ffi --locked
-          cargo test --examples --features aot,async,ffi --locked
+          cargo test --workspace --features aot,async,ffi --locked -- --test-threads=1
+          cargo test --examples --features aot,async,ffi --locked -- --test-threads=1
 
   build_fedora:
     name: Fedora 37

--- a/.github/workflows/rust-static-lib.yml
+++ b/.github/workflows/rust-static-lib.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        rust: [1.64, 1.65, 1.66]
+        rust: [1.66, 1.67, 1.68]
     container:
       image: wasmedge/wasmedge:latest
 
@@ -69,5 +69,5 @@ jobs:
         run: |
           export WASMEDGE_DIR="$(pwd)/../../"
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
-          cargo test --workspace --features static --locked
-          cargo test --examples --features static --locked
+          cargo test --workspace --features static --locked -- --test-threads=1
+          cargo test --examples --features static --locked -- --test-threads=1

--- a/bindings/rust/wasmedge-sys/src/instance/function.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/function.rs
@@ -1178,8 +1178,9 @@ mod tests {
         );
         println!("len of HOST_FUNCS: {}", HOST_FUNCS.read().len());
 
-        assert!(
-            HOST_FUNCS.read().len() - start_num >= funcs.len(),
+        assert_eq!(
+            HOST_FUNCS.read().len() - start_num,
+            funcs.len(),
             "expected: {}, actual: {}, start_num: {}",
             funcs.len(),
             HOST_FUNCS.read().len() - start_num,

--- a/bindings/rust/wasmedge-sys/src/instance/function.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/function.rs
@@ -1178,9 +1178,8 @@ mod tests {
         );
         println!("len of HOST_FUNCS: {}", HOST_FUNCS.read().len());
 
-        assert_eq!(
-            HOST_FUNCS.read().len() - start_num,
-            funcs.len(),
+        assert!(
+            HOST_FUNCS.read().len() - start_num >= funcs.len(),
             "expected: {}, actual: {}, start_num: {}",
             funcs.len(),
             HOST_FUNCS.read().len() - start_num,

--- a/bindings/rust/wasmedge-sys/src/instance/function.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/function.rs
@@ -1160,7 +1160,7 @@ mod tests {
         println!("start_num: {}", start_num);
 
         let mut funcs = vec![];
-        for _ in 1..=10 {
+        for _ in 1..=1_000_000 {
             // create a FuncType
             let result = FuncType::create(vec![ValType::I32; 2], vec![ValType::I32]);
             assert!(result.is_ok());

--- a/bindings/rust/wasmedge-sys/src/lib.rs
+++ b/bindings/rust/wasmedge-sys/src/lib.rs
@@ -43,7 +43,7 @@
 extern crate lazy_static;
 
 use parking_lot::{Mutex, RwLock};
-use std::{collections::HashMap, env, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 #[allow(warnings)]
 /// Foreign function interfaces generated from WasmEdge C-API.
@@ -119,13 +119,12 @@ pub type BoxedFn = Box<
 
 lazy_static! {
     static ref HOST_FUNCS: RwLock<HashMap<usize, Arc<Mutex<BoxedFn>>>> =
-        RwLock::new(HashMap::with_capacity(
-            env::var("MAX_HOST_FUNC_LENGTH")
-                .map(|s| s
-                    .parse::<usize>()
-                    .expect("MAX_HOST_FUNC_LENGTH should be a positive integer."))
-                .unwrap_or(500)
-        ));
+        RwLock::new(HashMap::new());
+}
+
+// Stores the mapping from the address of each host function pointer to the key of the `HOST_FUNCS`.
+lazy_static! {
+    static ref HOST_FUNC_FOOTPRINTS: Mutex<HashMap<usize, usize>> = Mutex::new(HashMap::new());
 }
 
 #[cfg(feature = "async")]


### PR DESCRIPTION
In this PR, the host function design is improved to support removing host functions from the lazy static `HOST_FUNCS`. 