### PR TITLE
[Utils] Install Script: Support Ubuntu packages for versions above 0.11.1

### DIFF
--- a/.github/workflows/test-python-install-script.yml
+++ b/.github/workflows/test-python-install-script.yml
@@ -35,7 +35,7 @@ jobs:
             python_package: python3 python2
             python2_ex: python2
             python3_ex: python3
-            extra_setup_command: echo "No extra command"
+            extra_setup_command: yum install -y diffutils
           - name: CentOS 7
             host_runner: ubuntu-latest
             package_manager: yum

--- a/.github/workflows/test-python-install-script.yml
+++ b/.github/workflows/test-python-install-script.yml
@@ -216,16 +216,14 @@ jobs:
     - name: Check if distro-specific downloads are selected(Ubuntu)
       if: ${{ matrix.name == 'Ubuntu 20.04' }}
       run: |
-        # Unknown plugin
         ${{ matrix.python2_ex }} utils/install.py -e tensorflow -D  2>&1 | grep -q "DEBUG   - Downloading dist package: ubuntu20.04_x86_64.tar.gz" && echo "Pass: Ubuntu Package selected for tensorflow" || (echo "Fail: Ubuntu Package not selected for tensorflow" && exit 1)
         ${{ matrix.python3_ex }} utils/install.py -e tensorflow -D  2>&1 | grep -q "DEBUG   - Downloading dist package: ubuntu20.04_x86_64.tar.gz" && echo "Pass: Ubuntu Package selected for tensorflow" || (echo "Fail: Ubuntu Package not selected for tensorflow" && exit 1)
         ${{ matrix.python2_ex }} utils/install.py -e image -D  2>&1 | grep -q "DEBUG   - Downloading dist package: ubuntu20.04_x86_64.tar.gz" && echo "Pass: Ubuntu Package selected for image" || (echo "Fail: Ubuntu Package not selected for image" && exit 1)
         ${{ matrix.python3_ex }} utils/install.py -e image -D  2>&1 | grep -q "DEBUG   - Downloading dist package: ubuntu20.04_x86_64.tar.gz" && echo "Pass: Ubuntu Package selected for image" || (echo "Fail: Ubuntu Package not selected for image" && exit 1)
 
-    - name: Check if distro-specific downloads are selected(Ubuntu)
+    - name: Check if distro-specific downloads are selected(Non-Ubuntu)
       if: ${{ matrix.name != 'Ubuntu 20.04' }}
       run: |
-        # Unknown plugin
         ${{ matrix.python2_ex }} utils/install.py -e tensorflow -D  2>&1 | grep -q "DEBUG   - Downloading dist package: ubuntu20.04_x86_64.tar.gz" && (echo "Fail: Ubuntu Package selected for tensorflow" && exit 1) || (echo "Pass: Ubuntu Package not selected for tensorflow")
         ${{ matrix.python3_ex }} utils/install.py -e tensorflow -D  2>&1 | grep -q "DEBUG   - Downloading dist package: ubuntu20.04_x86_64.tar.gz" && (echo "Fail: Ubuntu Package selected for tensorflow" && exit 1) || (echo "Pass: Ubuntu Package not selected for tensorflow")
         ${{ matrix.python2_ex }} utils/install.py -e image -D  2>&1 | grep -q "DEBUG   - Downloading dist package: ubuntu20.04_x86_64.tar.gz" && (echo "Fail: Ubuntu Package selected for image" && exit 1) || (echo "Pass: Ubuntu Package not selected for image")

--- a/.github/workflows/test-python-install-script.yml
+++ b/.github/workflows/test-python-install-script.yml
@@ -213,6 +213,24 @@ jobs:
         ${{ matrix.python3_ex }} utils/install.py --plugins unknown_plugin_name_on_purpose -D
         (ls ~/.wasmedge/plugin/ | grep libwasmedgePluginWasiCrypto.so && echo "Fail: Plugins found" && exit 1) || (echo "Pass: Plugins not found")
 
+    - name: Check if distro-specific downloads are selected(Ubuntu)
+      if: ${{ matrix.name == 'Ubuntu 20.04' }}
+      run: |
+        # Unknown plugin
+        ${{ matrix.python2_ex }} utils/install.py -e tensorflow -D  2>&1 | grep -q "DEBUG   - Downloading dist package: ubuntu20.04_x86_64.tar.gz" && echo "Pass: Ubuntu Package selected for tensorflow" || (echo "Fail: Ubuntu Package not selected for tensorflow" && exit 1)
+        ${{ matrix.python3_ex }} utils/install.py -e tensorflow -D  2>&1 | grep -q "DEBUG   - Downloading dist package: ubuntu20.04_x86_64.tar.gz" && echo "Pass: Ubuntu Package selected for tensorflow" || (echo "Fail: Ubuntu Package not selected for tensorflow" && exit 1)
+        ${{ matrix.python2_ex }} utils/install.py -e image -D  2>&1 | grep -q "DEBUG   - Downloading dist package: ubuntu20.04_x86_64.tar.gz" && echo "Pass: Ubuntu Package selected for image" || (echo "Fail: Ubuntu Package not selected for image" && exit 1)
+        ${{ matrix.python3_ex }} utils/install.py -e image -D  2>&1 | grep -q "DEBUG   - Downloading dist package: ubuntu20.04_x86_64.tar.gz" && echo "Pass: Ubuntu Package selected for image" || (echo "Fail: Ubuntu Package not selected for image" && exit 1)
+
+    - name: Check if distro-specific downloads are selected(Ubuntu)
+      if: ${{ matrix.name != 'Ubuntu 20.04' }}
+      run: |
+        # Unknown plugin
+        ${{ matrix.python2_ex }} utils/install.py -e tensorflow -D  2>&1 | grep -q "DEBUG   - Downloading dist package: ubuntu20.04_x86_64.tar.gz" && (echo "Fail: Ubuntu Package selected for tensorflow" && exit 1) || (echo "Pass: Ubuntu Package not selected for tensorflow")
+        ${{ matrix.python3_ex }} utils/install.py -e tensorflow -D  2>&1 | grep -q "DEBUG   - Downloading dist package: ubuntu20.04_x86_64.tar.gz" && (echo "Fail: Ubuntu Package selected for tensorflow" && exit 1) || (echo "Pass: Ubuntu Package not selected for tensorflow")
+        ${{ matrix.python2_ex }} utils/install.py -e image -D  2>&1 | grep -q "DEBUG   - Downloading dist package: ubuntu20.04_x86_64.tar.gz" && (echo "Fail: Ubuntu Package selected for image" && exit 1) || (echo "Pass: Ubuntu Package not selected for image")
+        ${{ matrix.python3_ex }} utils/install.py -e image -D  2>&1 | grep -q "DEBUG   - Downloading dist package: ubuntu20.04_x86_64.tar.gz" && (echo "Fail: Ubuntu Package selected for image" && exit 1) || (echo "Pass: Ubuntu Package not selected for image")
+
     - name: Externally Specified plugin install check (single)(Non Ubuntu)
       if: ${{ matrix.name != 'manylinux2014 aarch64' }}
       run: |

--- a/utils/install.py
+++ b/utils/install.py
@@ -717,7 +717,7 @@ def install_tensorflow_extension(args, compat):
             "WasmEdge-tensorflow-deps-TF-"
             + args.tf_deps_version
             + "-"
-            + local_release_package
+            + CONST_release_pkg
         )
 
         print("Downloading tensorflow extension")
@@ -757,7 +757,7 @@ def install_tensorflow_extension(args, compat):
             "WasmEdge-tensorflow-deps-TFLite-"
             + args.tf_deps_version
             + "-"
-            + local_release_package
+            + CONST_release_pkg
         )
 
         print("Downloading tensorflow-lite extension")
@@ -1062,6 +1062,7 @@ def set_consts(args, compat):
     # Installation of ubuntu version extensions when the ubuntu version of WasmEdge selected.
     if VersionString(args.tf_version).compare("0.11.1") >= 0:
         local_release_package_tf = compat.release_package_wasmedge
+        logging.debug("Tensorflow release pkg: {0}".format(local_release_package_tf))
 
     local_release_package_im = CONST_release_pkg
 
@@ -1069,6 +1070,7 @@ def set_consts(args, compat):
     # Installation of ubuntu version extensions when the ubuntu version of WasmEdge selected.
     if VersionString(args.image_version).compare("0.11.1") >= 0:
         local_release_package_im = compat.release_package_wasmedge
+        logging.debug("Image release pkg: {0}".format(local_release_package_im))
 
     CONST_urls = {
         WASMEDGE: "https://github.com/WasmEdge/WasmEdge/releases/download/{0}/WasmEdge-{0}-{1}".format(
@@ -1081,10 +1083,10 @@ def set_consts(args, compat):
             args.image_version, local_release_package_im
         ),
         TENSORFLOW_DEPS: "https://github.com/second-state/WasmEdge-tensorflow-deps/releases/download/{0}/WasmEdge-tensorflow-deps-TF-{0}-{1}".format(
-            args.tf_deps_version, local_release_package_tf
+            args.tf_deps_version, CONST_release_pkg
         ),
         TENSORFLOW_LITE_DEPS: "https://github.com/second-state/WasmEdge-tensorflow-deps/releases/download/{0}/WasmEdge-tensorflow-deps-TFLite-{0}-{1}".format(
-            args.tf_deps_version, local_release_package_tf
+            args.tf_deps_version, CONST_release_pkg
         ),
         TENSORFLOW: "https://github.com/second-state/WasmEdge-tensorflow/releases/download/{0}/WasmEdge-tensorflow-{0}-{1}".format(
             args.tf_version, local_release_package_tf

--- a/utils/install.py
+++ b/utils/install.py
@@ -594,6 +594,7 @@ def install_image_extension(args, compat):
     # Installation of ubuntu version extensions when the ubuntu version of WasmEdge selected.
     if VersionString(args.image_version).compare("0.11.1") >= 0:
         local_release_package = compat.release_package_wasmedge
+        logging.debug("Downloading dist package: {0}".format(local_release_package))
 
     image_pkg = "WasmEdge-image-" + args.image_version + "-" + local_release_package
 
@@ -708,6 +709,7 @@ def install_tensorflow_extension(args, compat):
     # Installation of ubuntu version extensions when the ubuntu version of WasmEdge selected.
     if VersionString(args.tf_version).compare("0.11.1") >= 0:
         local_release_package = compat.release_package_wasmedge
+        logging.debug("Downloading dist package: {0}".format(local_release_package))
 
     if download_tf:
         tf_pkg = "WasmEdge-tensorflow-" + args.tf_version + "-" + local_release_package
@@ -1054,6 +1056,20 @@ def set_consts(args, compat):
     CONST_ipkg = compat.install_package_name
     CONST_lib_ext = compat.lib_extension
 
+    local_release_package_tf = CONST_release_pkg
+
+    # From WasmEdge 0.11.1, we have the Ubuntu release.
+    # Installation of ubuntu version extensions when the ubuntu version of WasmEdge selected.
+    if VersionString(args.tf_version).compare("0.11.1") >= 0:
+        local_release_package_tf = compat.release_package_wasmedge
+
+    local_release_package_im = CONST_release_pkg
+
+    # From WasmEdge 0.11.1, we have the Ubuntu release.
+    # Installation of ubuntu version extensions when the ubuntu version of WasmEdge selected.
+    if VersionString(args.image_version).compare("0.11.1") >= 0:
+        local_release_package_im = compat.release_package_wasmedge
+
     CONST_urls = {
         WASMEDGE: "https://github.com/WasmEdge/WasmEdge/releases/download/{0}/WasmEdge-{0}-{1}".format(
             args.version, compat.release_package_wasmedge
@@ -1062,19 +1078,19 @@ def set_consts(args, compat):
             args.uninstall_script_tag
         ),
         IMAGE: "https://github.com/second-state/WasmEdge-image/releases/download/{0}/WasmEdge-image-{0}-{1}".format(
-            args.image_version, CONST_release_pkg
+            args.image_version, local_release_package_im
         ),
         TENSORFLOW_DEPS: "https://github.com/second-state/WasmEdge-tensorflow-deps/releases/download/{0}/WasmEdge-tensorflow-deps-TF-{0}-{1}".format(
-            args.tf_deps_version, CONST_release_pkg
+            args.tf_deps_version, local_release_package_tf
         ),
         TENSORFLOW_LITE_DEPS: "https://github.com/second-state/WasmEdge-tensorflow-deps/releases/download/{0}/WasmEdge-tensorflow-deps-TFLite-{0}-{1}".format(
-            args.tf_deps_version, CONST_release_pkg
+            args.tf_deps_version, local_release_package_tf
         ),
         TENSORFLOW: "https://github.com/second-state/WasmEdge-tensorflow/releases/download/{0}/WasmEdge-tensorflow-{0}-{1}".format(
-            args.tf_version, CONST_release_pkg
+            args.tf_version, local_release_package_tf
         ),
         TENSORFLOW_LITE: "https://github.com/second-state/WasmEdge-tensorflow/releases/download/{0}/WasmEdge-tensorflowlite-{0}-{1}".format(
-            args.tf_version, CONST_release_pkg
+            args.tf_version, local_release_package_tf
         ),
         TENSORFLOW_TOOLS: "https://github.com/second-state/WasmEdge-tensorflow-tools/releases/download/{0}/WasmEdge-tensorflow-tools-{0}-{1}".format(
             args.tf_tools_version, CONST_release_pkg

--- a/utils/install.py
+++ b/utils/install.py
@@ -442,13 +442,11 @@ fi
 
 
 def shell_configure(args, compat):
-
     global CONST_shell_profile, CONST_shell_config
 
     source_string = '\n. "{0}"\n'.format(join(args.path, "env"))
 
     if ("bash" in SHELL) or ("zsh" in SHELL):
-
         CONST_shell_config = join(HOME, "." + SHELL + "rc")
 
         if "zsh" in SHELL:
@@ -590,7 +588,14 @@ def install_image_extension(args, compat):
 
     print("Downloading image extension")
 
-    image_pkg = "WasmEdge-image-" + args.image_version + "-" + CONST_release_pkg
+    local_release_package = CONST_release_pkg
+
+    # From WasmEdge 0.11.1, we have the Ubuntu release.
+    # Installation of ubuntu version extensions when the ubuntu version of WasmEdge selected.
+    if VersionString(args.image_version).compare("0.11.1") >= 0:
+        local_release_package = compat.release_package_wasmedge
+
+    image_pkg = "WasmEdge-image-" + args.image_version + "-" + local_release_package
 
     download_url(CONST_urls[IMAGE], join(TEMP_PATH, image_pkg), show_progress)
 
@@ -697,13 +702,20 @@ def install_tensorflow_extension(args, compat):
     if compat.machine == "aarch64":
         download_tf = False
 
+    local_release_package = CONST_release_pkg
+
+    # From WasmEdge 0.11.1, we have the Ubuntu release.
+    # Installation of ubuntu version extensions when the ubuntu version of WasmEdge selected.
+    if VersionString(args.tf_version).compare("0.11.1") >= 0:
+        local_release_package = compat.release_package_wasmedge
+
     if download_tf:
-        tf_pkg = "WasmEdge-tensorflow-" + args.tf_version + "-" + CONST_release_pkg
+        tf_pkg = "WasmEdge-tensorflow-" + args.tf_version + "-" + local_release_package
         tf_deps_pkg = (
             "WasmEdge-tensorflow-deps-TF-"
             + args.tf_deps_version
             + "-"
-            + CONST_release_pkg
+            + local_release_package
         )
 
         print("Downloading tensorflow extension")
@@ -737,13 +749,13 @@ def install_tensorflow_extension(args, compat):
 
     if download_tf_lite:
         tf_lite_pkg = (
-            "WasmEdge-tensorflowlite-" + args.tf_version + "-" + CONST_release_pkg
+            "WasmEdge-tensorflowlite-" + args.tf_version + "-" + local_release_package
         )
         tf_deps_lite_pkg = (
             "WasmEdge-tensorflow-deps-TFLite-"
             + args.tf_deps_version
             + "-"
-            + CONST_release_pkg
+            + local_release_package
         )
 
         print("Downloading tensorflow-lite extension")


### PR DESCRIPTION
GitHub Issue Reference: https://github.com/WasmEdge/WasmEdge/issues/2397

From WasmEdge 0.11.1, we have the Ubuntu release.
For the WasmEdge-tensorflow and WasmEdge-image, they have updated the ubuntu releases.
This commit installs the same DIST of the extensions and WasmEdge, such as the plugins (the policy described in the comment of #2196).

For the WasmEdge-tensorflow-tools, we do not apply this because the tools are the stand-alone executables.

The extension with Ubuntu releases can be test: 0.11.1, 0.11.2, and 0.12.0-alpha.2