### PR TITLE
[Validator] Fix validated target index for Br and Br_if

### DIFF
--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -356,7 +356,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
     return {};
 
   case OpCode::Br:
-    if (auto D = checkCtrlStackDepth(Instr.getTargetIndex()); !D) {
+    if (auto D = checkCtrlStackDepth(Instr.getJump().TargetIndex); !D) {
       return Unexpect(D);
     } else {
       // D is the last D element of control stack.
@@ -374,7 +374,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
       return unreachable();
     }
   case OpCode::Br_if:
-    if (auto D = checkCtrlStackDepth(Instr.getTargetIndex()); !D) {
+    if (auto D = checkCtrlStackDepth(Instr.getJump().TargetIndex); !D) {
       return Unexpect(D);
     } else {
       // D is the last D element of control stack.


### PR DESCRIPTION
From my perspective, due to the ambiguous member name, the original code use the wrong variable to do validation.

Please double check whether this change is reasonable. Thanks!