### PR TITLE
[Plugin] Add hostname verification in HTTPS request plugin to fix SSL connection errors

### DIFF
--- a/plugins/wasmedge_httpsreq/httpsreqfunc.cpp
+++ b/plugins/wasmedge_httpsreq/httpsreqfunc.cpp
@@ -92,9 +92,9 @@ Expect<void> WasmEdgeHttpsReqSendData::body(const Runtime::CallingFrame &Frame,
 
   const int Status = SSL_connect(Ssl);
   if (Status != 1) {
-    SSL_get_error(Ssl, Status);
+    const int Code = SSL_get_error(Ssl, Status);
     ERR_print_errors_fp(stderr);
-    spdlog::error("[WasmEdge Httpsreq] SSL_get_error code {}", Status);
+    spdlog::error("[WasmEdge Httpsreq] SSL_get_error code {}", Code);
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 

--- a/plugins/wasmedge_httpsreq/httpsreqfunc.cpp
+++ b/plugins/wasmedge_httpsreq/httpsreqfunc.cpp
@@ -10,6 +10,7 @@
 #include <cstdio>
 #include <errno.h>
 #include <netdb.h>
+#include <openssl/tls1.h>
 #include <resolv.h>
 #include <string.h>
 #include <string>
@@ -89,6 +90,8 @@ Expect<void> WasmEdgeHttpsReqSendData::body(const Runtime::CallingFrame &Frame,
   }
 
   SSL_set_fd(Ssl, Sfd);
+
+  SSL_set_tlsext_host_name(Ssl, Host);
 
   const int Status = SSL_connect(Ssl);
   if (Status != 1) {


### PR DESCRIPTION
This PR addresses the issue described in openssl/openssl#7147 that led to SSL connection errors when the hostname verification check was lacked.

The issue was identified and fixed in the WasmEdge HTTPS request client plugin by adding support for TLS extension with a hostname for remote hostname verification. This improvement enhances the security of communication in the client connection and avoids any potential SSL connection errors.

There is a repository contains test case: https://github.com/jetjinser/https-test

I tested this functionality internally and verified that it resolves the issue reported in OpenSSL. Please review and consider merging this pull request.

Thank you.