### PR TITLE
[WASI Socket][Don't merge until the discussion is finalized] Provide multiple WASI socket API implementation

### DIFF
--- a/.CurrentChangelog.md
+++ b/.CurrentChangelog.md
@@ -1,4 +1,4 @@
-### 0.12.0-alpha.2 (2023-02-24)
+### 0.12.0 (2023-04-24)
 
 Breaking changes:
 
@@ -29,6 +29,9 @@ Features:
   * Added the `WasmEdge_PluginGetPluginName()` API for retrieving the plug-in name.
   * Added the `WasmEdge_PluginListModuleLength()` and `WasmEdge_PluginListModule()` APIs for listing the module names of a plug-in.
   * Added the `WasmEdge_PluginCreateModule()` API for creating the specific module instance in a plug-in by its name.
+* Introduced the multiple WASI socket API implementation.
+  * The `sock_accept()` is compatible with the WASI spec.
+  * The V2 socket implementation is using a larger socket address data structures. With this, we can start to supporting `AF_UINX`
 * Added the `VM` APIs.
   * Added the `WasmEdge_VMGetRegisteredModule()` API for retrieving a registered module by its name.
   * Added the `WasmEdge_VMListRegisteredModuleLength()` and `WasmEdge_VMListRegisteredModule()` APIs for listing the registered module names.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-### 0.12.0-alpha.2 (2023-02-24)
+### 0.12.0 (2023-04-24)
 
 Breaking changes:
 
@@ -29,6 +29,9 @@ Features:
   * Added the `WasmEdge_PluginGetPluginName()` API for retrieving the plug-in name.
   * Added the `WasmEdge_PluginListModuleLength()` and `WasmEdge_PluginListModule()` APIs for listing the module names of a plug-in.
   * Added the `WasmEdge_PluginCreateModule()` API for creating the specific module instance in a plug-in by its name.
+* Introduced the multiple WASI socket API implementation.
+  * The `sock_accept()` is compatible with the WASI spec.
+  * The V2 socket implementation is using a larger socket address data structures. With this, we can start to supporting `AF_UINX`
 * Added the `VM` APIs.
   * Added the `WasmEdge_VMGetRegisteredModule()` API for retrieving a registered module by its name.
   * Added the `WasmEdge_VMListRegisteredModuleLength()` and `WasmEdge_VMListRegisteredModule()` APIs for listing the registered module names.

--- a/include/host/wasi/inode.h
+++ b/include/host/wasi/inode.h
@@ -542,15 +542,22 @@ public:
   static WasiExpect<INode> sockOpen(__wasi_address_family_t SysDomain,
                                     __wasi_sock_type_t SockType) noexcept;
 
-  WasiExpect<void> sockBind(uint8_t *AddressBuf, uint8_t AddressLength,
-                            uint16_t Port) noexcept;
+  WasiExpect<void> sockBindV1(uint8_t *AddressBuf, uint8_t AddressLength,
+                              uint16_t Port) noexcept;
+
+  WasiExpect<void> sockBindV2(uint8_t *AddressBuf, uint8_t AddressLength,
+                              uint16_t Port) noexcept;
 
   WasiExpect<void> sockListen(int32_t Backlog) noexcept;
 
-  WasiExpect<INode> sockAccept(__wasi_fdflags_t FdFlags) noexcept;
+  WasiExpect<INode> sockAcceptV1() noexcept;
+  WasiExpect<INode> sockAcceptV2(__wasi_fdflags_t FdFlags) noexcept;
 
-  WasiExpect<void> sockConnect(uint8_t *Address, uint8_t AddressLength,
-                               uint16_t Port) noexcept;
+  WasiExpect<void> sockConnectV1(uint8_t *Address, uint8_t AddressLength,
+                                 uint16_t Port) noexcept;
+
+  WasiExpect<void> sockConnectV2(uint8_t *Address, uint8_t AddressLength,
+                                 uint16_t Port) noexcept;
 
   /// Receive a message from a socket.
   ///
@@ -576,11 +583,27 @@ public:
   /// @param[out] NRead Return the number of bytes stored in RiData.
   /// @param[out] RoFlags Return message flags.
   /// @return Nothing or WASI error.
-  WasiExpect<void> sockRecvFrom(Span<Span<uint8_t>> RiData,
-                                __wasi_riflags_t RiFlags, uint8_t *Address,
-                                uint8_t AddressLength, uint32_t *PortPtr,
-                                __wasi_size_t &NRead,
-                                __wasi_roflags_t &RoFlags) const noexcept;
+  WasiExpect<void> sockRecvFromV1(Span<Span<uint8_t>> RiData,
+                                  __wasi_riflags_t RiFlags, uint8_t *Address,
+                                  uint8_t AddressLength, __wasi_size_t &NRead,
+                                  __wasi_roflags_t &RoFlags) const noexcept;
+
+  /// Receive a message from a socket.
+  ///
+  /// Note: This is similar to `recv` in POSIX, though it also supports
+  /// reading the data into multiple buffers in the manner of `readv`.
+  ///
+  /// @param[in] RiData List of scatter/gather vectors to which to store data.
+  /// @param[in] RiFlags Message flags.
+  /// @param[out] PortPtr the Port information.
+  /// @param[out] NRead Return the number of bytes stored in RiData.
+  /// @param[out] RoFlags Return message flags.
+  /// @return Nothing or WASI error.
+  WasiExpect<void> sockRecvFromV2(Span<Span<uint8_t>> RiData,
+                                  __wasi_riflags_t RiFlags, uint8_t *Address,
+                                  uint8_t AddressLength, uint32_t *PortPtr,
+                                  __wasi_size_t &NRead,
+                                  __wasi_roflags_t &RoFlags) const noexcept;
 
   /// Send a message on a socket.
   ///
@@ -630,11 +653,17 @@ public:
                               __wasi_sock_opt_so_t SockOptName, void *FlagPtr,
                               uint32_t FlagSizePtr) const noexcept;
 
-  WasiExpect<void> sockGetLocalAddr(uint8_t *Address,
-                                    uint32_t *PortPtr) const noexcept;
+  WasiExpect<void> sockGetLocalAddrV1(uint8_t *Address, uint32_t *AddrTypePtr,
+                                      uint32_t *PortPtr) const noexcept;
 
-  WasiExpect<void> sockGetPeerAddr(uint8_t *Address,
-                                   uint32_t *PortPtr) const noexcept;
+  WasiExpect<void> sockGetPeerAddrV1(uint8_t *Address, uint32_t *AddrTypePtr,
+                                     uint32_t *PortPtr) const noexcept;
+
+  WasiExpect<void> sockGetLocalAddrV2(uint8_t *Address,
+                                      uint32_t *PortPtr) const noexcept;
+
+  WasiExpect<void> sockGetPeerAddrV2(uint8_t *Address,
+                                     uint32_t *PortPtr) const noexcept;
 
   /// File type.
   WasiExpect<__wasi_filetype_t> filetype() const noexcept;

--- a/include/host/wasi/vinode.h
+++ b/include/host/wasi/vinode.h
@@ -574,20 +574,31 @@ public:
   sockOpen(VFS &FS, __wasi_address_family_t SysDomain,
            __wasi_sock_type_t SockType);
 
-  WasiExpect<void> sockBind(uint8_t *Address, uint8_t AddressLength,
-                            uint16_t Port) noexcept {
-    return Node.sockBind(Address, AddressLength, Port);
+  WasiExpect<void> sockBindV1(uint8_t *Address, uint8_t AddressLength,
+                              uint16_t Port) noexcept {
+    return Node.sockBindV1(Address, AddressLength, Port);
+  }
+
+  WasiExpect<void> sockBindV2(uint8_t *Address, uint8_t AddressLength,
+                              uint16_t Port) noexcept {
+    return Node.sockBindV2(Address, AddressLength, Port);
   }
 
   WasiExpect<void> sockListen(int32_t Backlog) noexcept {
     return Node.sockListen(Backlog);
   }
 
-  WasiExpect<std::shared_ptr<VINode>> sockAccept(__wasi_fdflags_t FdFlags);
+  WasiExpect<std::shared_ptr<VINode>> sockAcceptV1();
+  WasiExpect<std::shared_ptr<VINode>> sockAcceptV2(__wasi_fdflags_t FdFlags);
 
-  WasiExpect<void> sockConnect(uint8_t *Address, uint8_t AddressLength,
-                               uint16_t Port) noexcept {
-    return Node.sockConnect(Address, AddressLength, Port);
+  WasiExpect<void> sockConnectV1(uint8_t *Address, uint8_t AddressLength,
+                                 uint16_t Port) noexcept {
+    return Node.sockConnectV1(Address, AddressLength, Port);
+  }
+
+  WasiExpect<void> sockConnectV2(uint8_t *Address, uint8_t AddressLength,
+                                 uint16_t Port) noexcept {
+    return Node.sockConnectV2(Address, AddressLength, Port);
   }
 
   /// Receive a message from a socket.
@@ -618,13 +629,34 @@ public:
   /// @param[out] NRead Return the number of bytes stored in RiData.
   /// @param[out] RoFlags Return message flags.
   /// @return Nothing or WASI error.
-  WasiExpect<void> sockRecvFrom(Span<Span<uint8_t>> RiData,
-                                __wasi_riflags_t RiFlags, uint8_t *Address,
-                                uint8_t AddressLength, uint32_t *PortPtr,
-                                __wasi_size_t &NRead,
-                                __wasi_roflags_t &RoFlags) const noexcept {
-    return Node.sockRecvFrom(RiData, RiFlags, Address, AddressLength, PortPtr,
-                             NRead, RoFlags);
+  WasiExpect<void> sockRecvFromV1(Span<Span<uint8_t>> RiData,
+                                  __wasi_riflags_t RiFlags, uint8_t *Address,
+                                  uint8_t AddressLength, __wasi_size_t &NRead,
+                                  __wasi_roflags_t &RoFlags) const noexcept {
+    return Node.sockRecvFromV1(RiData, RiFlags, Address, AddressLength, NRead,
+                               RoFlags);
+  }
+
+  /// Receive a message from a socket.
+  ///
+  /// Note: This is similar to `recvfrom` in POSIX, though it also supports
+  /// reading the data into multiple buffers in the manner of `readv`.
+  ///
+  /// @param[in] RiData List of scatter/gather vectors to which to store data.
+  /// @param[in] RiFlags Message flags.
+  /// @param[in] Address Address of the target.
+  /// @param[in] AddressLength The buffer size of Address.
+  /// @param[out] PortPtr The port from the given address.
+  /// @param[out] NRead Return the number of bytes stored in RiData.
+  /// @param[out] RoFlags Return message flags.
+  /// @return Nothing or WASI error.
+  WasiExpect<void> sockRecvFromV2(Span<Span<uint8_t>> RiData,
+                                  __wasi_riflags_t RiFlags, uint8_t *Address,
+                                  uint8_t AddressLength, uint32_t *PortPtr,
+                                  __wasi_size_t &NRead,
+                                  __wasi_roflags_t &RoFlags) const noexcept {
+    return Node.sockRecvFromV2(RiData, RiFlags, Address, AddressLength, PortPtr,
+                               NRead, RoFlags);
   }
 
   /// Send a message on a socket.
@@ -685,14 +717,24 @@ public:
     return Node.sockSetOpt(SockOptLevel, SockOptName, FlagPtr, FlagSizePtr);
   }
 
-  WasiExpect<void> sockGetLocalAddr(uint8_t *Address,
-                                    uint32_t *PortPtr) const noexcept {
-    return Node.sockGetLocalAddr(Address, PortPtr);
+  WasiExpect<void> sockGetLocalAddrV1(uint8_t *Address, uint32_t *AddrTypePtr,
+                                      uint32_t *PortPtr) const noexcept {
+    return Node.sockGetLocalAddrV1(Address, AddrTypePtr, PortPtr);
   }
 
-  WasiExpect<void> sockGetPeerAddr(uint8_t *Address,
-                                   uint32_t *PortPtr) const noexcept {
-    return Node.sockGetPeerAddr(Address, PortPtr);
+  WasiExpect<void> sockGetPeerAddrV1(uint8_t *Address, uint32_t *AddrTypePtr,
+                                     uint32_t *PortPtr) const noexcept {
+    return Node.sockGetPeerAddrV1(Address, AddrTypePtr, PortPtr);
+  }
+
+  WasiExpect<void> sockGetLocalAddrV2(uint8_t *Address,
+                                      uint32_t *PortPtr) const noexcept {
+    return Node.sockGetLocalAddrV2(Address, PortPtr);
+  }
+
+  WasiExpect<void> sockGetPeerAddrV2(uint8_t *Address,
+                                     uint32_t *PortPtr) const noexcept {
+    return Node.sockGetPeerAddrV2(Address, PortPtr);
   }
 
   __wasi_rights_t fsRightsBase() const noexcept { return FsRightsBase; }

--- a/include/host/wasi/wasifunc.h
+++ b/include/host/wasi/wasifunc.h
@@ -368,50 +368,50 @@ public:
                         uint32_t BufLen);
 };
 
-class WasiSockOpen : public Wasi<WasiSockOpen> {
+class WasiSockOpenV1 : public Wasi<WasiSockOpenV1> {
 public:
-  WasiSockOpen(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockOpenV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame,
                         uint32_t AddressFamily, uint32_t SockType,
                         uint32_t /* Out */ RoFdPtr);
 };
 
-class WasiSockBind : public Wasi<WasiSockBind> {
+class WasiSockBindV1 : public Wasi<WasiSockBindV1> {
 public:
-  WasiSockBind(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockBindV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
                         uint32_t AddressPtr, uint32_t Port);
 };
 
-class WasiSockListen : public Wasi<WasiSockListen> {
+class WasiSockListenV1 : public Wasi<WasiSockListenV1> {
 public:
-  WasiSockListen(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockListenV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
                         int32_t Backlog);
 };
 
-class WasiSockAccept : public Wasi<WasiSockAccept> {
+class WasiSockAcceptV1 : public Wasi<WasiSockAcceptV1> {
 public:
-  WasiSockAccept(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockAcceptV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
                         uint32_t FsFlags, uint32_t /* Out */ RoFdPtr);
 };
 
-class WasiSockConnect : public Wasi<WasiSockConnect> {
+class WasiSockConnectV1 : public Wasi<WasiSockConnectV1> {
 public:
-  WasiSockConnect(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockConnectV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
                         uint32_t AddressPtr, uint32_t Port);
 };
 
-class WasiSockRecv : public Wasi<WasiSockRecv> {
+class WasiSockRecvV1 : public Wasi<WasiSockRecvV1> {
 public:
-  WasiSockRecv(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockRecvV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
                         uint32_t RiDataPtr, uint32_t RiDataLen,
@@ -419,9 +419,9 @@ public:
                         uint32_t /* Out */ RoFlagsPtr);
 };
 
-class WasiSockRecvFrom : public Wasi<WasiSockRecvFrom> {
+class WasiSockRecvFromV1 : public Wasi<WasiSockRecvFromV1> {
 public:
-  WasiSockRecvFrom(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockRecvFromV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
                         uint32_t RiDataPtr, uint32_t RiDataLen,
@@ -431,18 +431,18 @@ public:
                         uint32_t /* Out */ RoFlagsPtr);
 };
 
-class WasiSockSend : public Wasi<WasiSockSend> {
+class WasiSockSendV1 : public Wasi<WasiSockSendV1> {
 public:
-  WasiSockSend(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockSendV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
                         uint32_t SiDataPtr, uint32_t SiDataLen,
                         uint32_t SiFlags, uint32_t /* Out */ SoDataLenPtr);
 };
 
-class WasiSockSendTo : public Wasi<WasiSockSendTo> {
+class WasiSockSendToV1 : public Wasi<WasiSockSendToV1> {
 public:
-  WasiSockSendTo(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockSendToV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
                         uint32_t SiDataPtr, uint32_t SiDataLen,
@@ -450,51 +450,51 @@ public:
                         uint32_t /* Out */ SoDataLenPtr);
 };
 
-class WasiSockShutdown : public Wasi<WasiSockShutdown> {
+class WasiSockShutdownV1 : public Wasi<WasiSockShutdownV1> {
 public:
-  WasiSockShutdown(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockShutdownV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
                         uint32_t SdFlags);
 };
 
-class WasiSockGetOpt : public Wasi<WasiSockGetOpt> {
+class WasiSockGetOptV1 : public Wasi<WasiSockGetOptV1> {
 public:
-  WasiSockGetOpt(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockGetOptV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
                         uint32_t SockOptLevel, uint32_t SockOptName,
                         uint32_t FlagPtr, uint32_t FlagSizePtr);
 };
 
-class WasiSockSetOpt : public Wasi<WasiSockSetOpt> {
+class WasiSockSetOptV1 : public Wasi<WasiSockSetOptV1> {
 public:
-  WasiSockSetOpt(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockSetOptV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
                         uint32_t SockOptLevel, uint32_t SockOptName,
                         uint32_t FlagPtr, uint32_t FlagSizePtr);
 };
 
-class WasiSockGetLocalAddr : public Wasi<WasiSockGetLocalAddr> {
+class WasiSockGetLocalAddrV1 : public Wasi<WasiSockGetLocalAddrV1> {
 public:
-  WasiSockGetLocalAddr(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockGetLocalAddrV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
                         uint32_t AddressPtr, uint32_t PortPtr);
 };
 
-class WasiSockGetPeerAddr : public Wasi<WasiSockGetPeerAddr> {
+class WasiSockGetPeerAddrV1 : public Wasi<WasiSockGetPeerAddrV1> {
 public:
-  WasiSockGetPeerAddr(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockGetPeerAddrV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
                         uint32_t AddressPtr, uint32_t PortPtr);
 };
 
-class WasiGetAddrinfo : public Wasi<WasiGetAddrinfo> {
+class WasiSockGetAddrinfoV1 : public Wasi<WasiSockGetAddrinfoV1> {
 public:
-  WasiGetAddrinfo(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockGetAddrinfoV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t NodePtr,
                         uint32_t NodeLen, uint32_t ServicePtr,

--- a/include/host/wasi/wasifunc.h
+++ b/include/host/wasi/wasifunc.h
@@ -398,7 +398,7 @@ public:
   WasiSockAcceptV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
-                        uint32_t FsFlags, uint32_t /* Out */ RoFdPtr);
+                        uint32_t /* Out */ RoFdPtr);
 };
 
 class WasiSockConnectV1 : public Wasi<WasiSockConnectV1> {
@@ -426,7 +426,6 @@ public:
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
                         uint32_t RiDataPtr, uint32_t RiDataLen,
                         uint32_t AddressPtr, uint32_t RiFlags,
-                        uint32_t /* Out */ PortPtr,
                         uint32_t /* Out */ RoDataLenPtr,
                         uint32_t /* Out */ RoFlagsPtr);
 };
@@ -450,26 +449,26 @@ public:
                         uint32_t /* Out */ SoDataLenPtr);
 };
 
-class WasiSockShutdownV1 : public Wasi<WasiSockShutdownV1> {
+class WasiSockShutdown : public Wasi<WasiSockShutdown> {
 public:
-  WasiSockShutdownV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockShutdown(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
                         uint32_t SdFlags);
 };
 
-class WasiSockGetOptV1 : public Wasi<WasiSockGetOptV1> {
+class WasiSockGetOpt : public Wasi<WasiSockGetOpt> {
 public:
-  WasiSockGetOptV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockGetOpt(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
                         uint32_t SockOptLevel, uint32_t SockOptName,
                         uint32_t FlagPtr, uint32_t FlagSizePtr);
 };
 
-class WasiSockSetOptV1 : public Wasi<WasiSockSetOptV1> {
+class WasiSockSetOpt : public Wasi<WasiSockSetOpt> {
 public:
-  WasiSockSetOptV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockSetOpt(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
                         uint32_t SockOptLevel, uint32_t SockOptName,
@@ -481,7 +480,8 @@ public:
   WasiSockGetLocalAddrV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
-                        uint32_t AddressPtr, uint32_t PortPtr);
+                        uint32_t AddressPtr, uint32_t AddressTypePtr,
+                        uint32_t PortPtr);
 };
 
 class WasiSockGetPeerAddrV1 : public Wasi<WasiSockGetPeerAddrV1> {
@@ -489,17 +489,116 @@ public:
   WasiSockGetPeerAddrV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
-                        uint32_t AddressPtr, uint32_t PortPtr);
+                        uint32_t AddressPtr, uint32_t AddressTypePtr,
+                        uint32_t PortPtr);
 };
 
-class WasiSockGetAddrinfoV1 : public Wasi<WasiSockGetAddrinfoV1> {
+class WasiSockGetAddrinfo : public Wasi<WasiSockGetAddrinfo> {
 public:
-  WasiSockGetAddrinfoV1(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiSockGetAddrinfo(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t NodePtr,
                         uint32_t NodeLen, uint32_t ServicePtr,
                         uint32_t ServiceLen, uint32_t HintsPtr, uint32_t ResPtr,
                         uint32_t MaxResLength, uint32_t ResLengthPtr);
+};
+
+class WasiSockOpenV2 : public Wasi<WasiSockOpenV2> {
+public:
+  WasiSockOpenV2(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame,
+                        uint32_t AddressFamily, uint32_t SockType,
+                        uint32_t /* Out */ RoFdPtr);
+};
+
+class WasiSockBindV2 : public Wasi<WasiSockBindV2> {
+public:
+  WasiSockBindV2(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
+                        uint32_t AddressPtr, uint32_t Port);
+};
+
+class WasiSockListenV2 : public Wasi<WasiSockListenV2> {
+public:
+  WasiSockListenV2(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
+                        int32_t Backlog);
+};
+
+class WasiSockAcceptV2 : public Wasi<WasiSockAcceptV2> {
+public:
+  WasiSockAcceptV2(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
+                        uint32_t FsFlags, uint32_t /* Out */ RoFdPtr);
+};
+
+class WasiSockConnectV2 : public Wasi<WasiSockConnectV2> {
+public:
+  WasiSockConnectV2(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
+                        uint32_t AddressPtr, uint32_t Port);
+};
+
+class WasiSockRecvV2 : public Wasi<WasiSockRecvV2> {
+public:
+  WasiSockRecvV2(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
+                        uint32_t RiDataPtr, uint32_t RiDataLen,
+                        uint32_t RiFlags, uint32_t /* Out */ RoDataLenPtr,
+                        uint32_t /* Out */ RoFlagsPtr);
+};
+
+class WasiSockRecvFromV2 : public Wasi<WasiSockRecvFromV2> {
+public:
+  WasiSockRecvFromV2(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
+                        uint32_t RiDataPtr, uint32_t RiDataLen,
+                        uint32_t AddressPtr, uint32_t RiFlags,
+                        uint32_t /* Out */ PortPtr,
+                        uint32_t /* Out */ RoDataLenPtr,
+                        uint32_t /* Out */ RoFlagsPtr);
+};
+
+class WasiSockSendV2 : public Wasi<WasiSockSendV2> {
+public:
+  WasiSockSendV2(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
+                        uint32_t SiDataPtr, uint32_t SiDataLen,
+                        uint32_t SiFlags, uint32_t /* Out */ SoDataLenPtr);
+};
+
+class WasiSockSendToV2 : public Wasi<WasiSockSendToV2> {
+public:
+  WasiSockSendToV2(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
+                        uint32_t SiDataPtr, uint32_t SiDataLen,
+                        uint32_t AddressPtr, int32_t Port, uint32_t SiFlags,
+                        uint32_t /* Out */ SoDataLenPtr);
+};
+
+class WasiSockGetLocalAddrV2 : public Wasi<WasiSockGetLocalAddrV2> {
+public:
+  WasiSockGetLocalAddrV2(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
+                        uint32_t AddressPtr, uint32_t PortPtr);
+};
+
+class WasiSockGetPeerAddrV2 : public Wasi<WasiSockGetPeerAddrV2> {
+public:
+  WasiSockGetPeerAddrV2(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, int32_t Fd,
+                        uint32_t AddressPtr, uint32_t PortPtr);
 };
 
 } // namespace Host

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -942,9 +942,37 @@ WasiExpect<INode> INode::sockOpen(__wasi_address_family_t AddressFamily,
   }
 }
 
-WasiExpect<void> INode::sockBind(uint8_t *AddressBuf,
-                                 [[maybe_unused]] uint8_t AddressLength,
-                                 uint16_t Port) noexcept {
+WasiExpect<void> INode::sockBindV1(uint8_t *Address, uint8_t AddressLength,
+                                   uint16_t Port) noexcept {
+  if (AddressLength == 4) {
+    struct sockaddr_in ServerAddr;
+    ServerAddr.sin_family = AF_INET;
+    ServerAddr.sin_port = htons(Port);
+    std::memcpy(&ServerAddr.sin_addr.s_addr, Address, AddressLength);
+    if (auto Res = ::bind(Fd, reinterpret_cast<struct sockaddr *>(&ServerAddr),
+                          sizeof(ServerAddr));
+        unlikely(Res < 0)) {
+      return WasiUnexpect(fromErrNo(errno));
+    }
+  } else if (AddressLength == 16) {
+    struct sockaddr_in6 ServerAddr;
+    std::memset(&ServerAddr, 0x00, sizeof(ServerAddr));
+
+    ServerAddr.sin6_family = AF_INET6;
+    ServerAddr.sin6_port = htons(Port);
+    std::memcpy(ServerAddr.sin6_addr.s6_addr, Address, AddressLength);
+    if (auto Res = ::bind(Fd, reinterpret_cast<struct sockaddr *>(&ServerAddr),
+                          sizeof(ServerAddr));
+        unlikely(Res < 0)) {
+      return WasiUnexpect(fromErrNo(errno));
+    }
+  }
+  return {};
+}
+
+WasiExpect<void> INode::sockBindV2(uint8_t *AddressBuf,
+                                   [[maybe_unused]] uint8_t AddressLength,
+                                   uint16_t Port) noexcept {
   int AddrFamily;
   uint8_t *Address;
 
@@ -1001,7 +1029,24 @@ WasiExpect<void> INode::sockListen(int32_t Backlog) noexcept {
   return {};
 }
 
-WasiExpect<INode> INode::sockAccept(__wasi_fdflags_t FdFlags) noexcept {
+WasiExpect<INode> INode::sockAcceptV1() noexcept {
+  struct sockaddr_in ServerSocketAddr;
+  ServerSocketAddr.sin_family = AF_INET;
+  ServerSocketAddr.sin_addr.s_addr = INADDR_ANY;
+  socklen_t AddressLen = sizeof(ServerSocketAddr);
+
+  if (auto NewFd =
+          ::accept(Fd, reinterpret_cast<struct sockaddr *>(&ServerSocketAddr),
+                   &AddressLen);
+      unlikely(NewFd < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  } else {
+    INode New(NewFd);
+    return New;
+  }
+}
+
+WasiExpect<INode> INode::sockAcceptV2(__wasi_fdflags_t FdFlags) noexcept {
   int NewFd;
   if (NewFd = ::accept(Fd, nullptr, nullptr); unlikely(NewFd < 0)) {
     return WasiUnexpect(fromErrNo(errno));
@@ -1022,9 +1067,40 @@ WasiExpect<INode> INode::sockAccept(__wasi_fdflags_t FdFlags) noexcept {
   }
 }
 
-WasiExpect<void> INode::sockConnect(uint8_t *AddressBuf,
-                                    [[maybe_unused]] uint8_t AddressLength,
-                                    uint16_t Port) noexcept {
+WasiExpect<void> INode::sockConnectV1(uint8_t *Address, uint8_t AddressLength,
+                                      uint16_t Port) noexcept {
+  if (AddressLength == 4) {
+    struct sockaddr_in ClientSocketAddr;
+    ClientSocketAddr.sin_family = AF_INET;
+    ClientSocketAddr.sin_port = htons(Port);
+    std::memcpy(&ClientSocketAddr.sin_addr.s_addr, Address, AddressLength);
+
+    if (auto Res = ::connect(
+            Fd, reinterpret_cast<struct sockaddr *>(&ClientSocketAddr),
+            sizeof(ClientSocketAddr));
+        unlikely(Res < 0)) {
+      return WasiUnexpect(fromErrNo(errno));
+    }
+  } else if (AddressLength == 16) {
+    struct sockaddr_in6 ClientSocketAddr;
+    std::memset(&ClientSocketAddr, 0x00, sizeof(ClientSocketAddr));
+
+    ClientSocketAddr.sin6_family = AF_INET6;
+    ClientSocketAddr.sin6_port = htons(Port);
+    std::memcpy(ClientSocketAddr.sin6_addr.s6_addr, Address, AddressLength);
+    if (auto Res = ::connect(
+            Fd, reinterpret_cast<struct sockaddr *>(&ClientSocketAddr),
+            sizeof(ClientSocketAddr));
+        unlikely(Res < 0)) {
+      return WasiUnexpect(fromErrNo(errno));
+    }
+  }
+  return {};
+}
+
+WasiExpect<void> INode::sockConnectV2(uint8_t *AddressBuf,
+                                      [[maybe_unused]] uint8_t AddressLength,
+                                      uint16_t Port) noexcept {
   int AddrFamily;
   uint8_t *Address;
 
@@ -1077,15 +1153,76 @@ WasiExpect<void> INode::sockConnect(uint8_t *AddressBuf,
 WasiExpect<void> INode::sockRecv(Span<Span<uint8_t>> RiData,
                                  __wasi_riflags_t RiFlags, __wasi_size_t &NRead,
                                  __wasi_roflags_t &RoFlags) const noexcept {
-  return sockRecvFrom(RiData, RiFlags, nullptr, 0, nullptr, NRead, RoFlags);
+  return sockRecvFromV1(RiData, RiFlags, nullptr, 0, NRead, RoFlags);
 }
 
-WasiExpect<void> INode::sockRecvFrom(Span<Span<uint8_t>> RiData,
-                                     __wasi_riflags_t RiFlags,
-                                     uint8_t *AddressBuf,
-                                     [[maybe_unused]] uint8_t AddressLength,
-                                     uint32_t *PortPtr, __wasi_size_t &NRead,
-                                     __wasi_roflags_t &RoFlags) const noexcept {
+WasiExpect<void>
+INode::sockRecvFromV1(Span<Span<uint8_t>> RiData, __wasi_riflags_t RiFlags,
+                      uint8_t *Address, uint8_t AddressLength,
+                      __wasi_size_t &NRead,
+                      __wasi_roflags_t &RoFlags) const noexcept {
+  int SysRiFlags = 0;
+  if (RiFlags & __WASI_RIFLAGS_RECV_PEEK) {
+    SysRiFlags |= MSG_PEEK;
+  }
+  if (RiFlags & __WASI_RIFLAGS_RECV_WAITALL) {
+    SysRiFlags |= MSG_WAITALL;
+  }
+
+  iovec SysIOVs[kIOVMax];
+  size_t SysIOVsSize = 0;
+  for (auto &IOV : RiData) {
+    SysIOVs[SysIOVsSize].iov_base = IOV.data();
+    SysIOVs[SysIOVsSize].iov_len = IOV.size();
+    ++SysIOVsSize;
+  }
+
+  sockaddr_storage SockAddrStorage;
+  int MaxAllowLength = 0;
+  if (AddressLength == 4) {
+    MaxAllowLength = sizeof(sockaddr_in);
+  } else if (AddressLength == 16) {
+    MaxAllowLength = sizeof(sockaddr_in6);
+  }
+
+  msghdr SysMsgHdr;
+  SysMsgHdr.msg_name = &SockAddrStorage;
+  SysMsgHdr.msg_namelen = MaxAllowLength;
+  SysMsgHdr.msg_iov = SysIOVs;
+  SysMsgHdr.msg_iovlen = SysIOVsSize;
+  SysMsgHdr.msg_control = nullptr;
+  SysMsgHdr.msg_controllen = 0;
+  SysMsgHdr.msg_flags = 0;
+
+  // Store recv bytes length and flags.
+  if (auto Res = ::recvmsg(Fd, &SysMsgHdr, SysRiFlags); unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  } else {
+    NRead = Res;
+  }
+
+  if (AddressLength == 4) {
+    std::memcpy(Address,
+                &reinterpret_cast<sockaddr_in *>(&SockAddrStorage)->sin_addr,
+                AddressLength);
+  } else if (AddressLength == 16) {
+    std::memcpy(Address,
+                &reinterpret_cast<sockaddr_in6 *>(&SockAddrStorage)->sin6_addr,
+                AddressLength);
+  }
+
+  RoFlags = static_cast<__wasi_roflags_t>(0);
+  if (SysMsgHdr.msg_flags & MSG_TRUNC) {
+    RoFlags |= __WASI_ROFLAGS_RECV_DATA_TRUNCATED;
+  }
+
+  return {};
+}
+
+WasiExpect<void> INode::sockRecvFromV2(
+    Span<Span<uint8_t>> RiData, __wasi_riflags_t RiFlags, uint8_t *AddressBuf,
+    [[maybe_unused]] uint8_t AddressLength, uint32_t *PortPtr,
+    __wasi_size_t &NRead, __wasi_roflags_t &RoFlags) const noexcept {
   uint8_t *Address = nullptr;
   __wasi_address_family_t *AddrFamily = nullptr;
   __wasi_address_family_t Dummy; // Write garbage on fallback mode.
@@ -1312,8 +1449,44 @@ WasiExpect<void> INode::sockSetOpt(__wasi_sock_opt_level_t SockOptLevel,
   return {};
 }
 
-WasiExpect<void> INode::sockGetLocalAddr(uint8_t *AddressBufPtr,
-                                         uint32_t *PortPtr) const noexcept {
+WasiExpect<void> INode::sockGetLocalAddrV1(uint8_t *AddressPtr,
+                                           uint32_t *AddrTypePtr,
+                                           uint32_t *PortPtr) const noexcept {
+  struct sockaddr_storage SocketAddr;
+  socklen_t Slen = sizeof(SocketAddr);
+  std::memset(&SocketAddr, 0, sizeof(SocketAddr));
+
+  if (auto Res =
+          ::getsockname(Fd, reinterpret_cast<sockaddr *>(&SocketAddr), &Slen);
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  auto AddrLen = 4;
+  if (Slen != 16) {
+    AddrLen = 16;
+  }
+
+  if (SocketAddr.ss_family == AF_INET) {
+    *AddrTypePtr = 4;
+    auto SocketAddrv4 = reinterpret_cast<struct sockaddr_in *>(&SocketAddr);
+    *PortPtr = ntohs(SocketAddrv4->sin_port);
+    std::memcpy(AddressPtr, &(SocketAddrv4->sin_addr.s_addr), AddrLen);
+  } else if (SocketAddr.ss_family == AF_INET6) {
+    *AddrTypePtr = 6;
+    auto SocketAddrv6 = reinterpret_cast<struct sockaddr_in6 *>(&SocketAddr);
+
+    *PortPtr = ntohs(SocketAddrv6->sin6_port);
+    std::memcpy(AddressPtr, SocketAddrv6->sin6_addr.s6_addr, AddrLen);
+  } else {
+    return WasiUnexpect(__WASI_ERRNO_NOSYS);
+  }
+
+  return {};
+}
+
+WasiExpect<void> INode::sockGetLocalAddrV2(uint8_t *AddressBufPtr,
+                                           uint32_t *PortPtr) const noexcept {
   auto AddrFamilyPtr = getAddressFamily(AddressBufPtr);
   auto AddressPtr = getAddress(AddressBufPtr);
 
@@ -1346,8 +1519,44 @@ WasiExpect<void> INode::sockGetLocalAddr(uint8_t *AddressBufPtr,
   return {};
 }
 
-WasiExpect<void> INode::sockGetPeerAddr(uint8_t *AddressBufPtr,
-                                        uint32_t *PortPtr) const noexcept {
+WasiExpect<void> INode::sockGetPeerAddrV1(uint8_t *AddressPtr,
+                                          uint32_t *AddrTypePtr,
+                                          uint32_t *PortPtr) const noexcept {
+  struct sockaddr_storage SocketAddr;
+  socklen_t Slen = sizeof(SocketAddr);
+  std::memset(&SocketAddr, 0, sizeof(SocketAddr));
+
+  if (auto Res =
+          ::getpeername(Fd, reinterpret_cast<sockaddr *>(&SocketAddr), &Slen);
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  auto AddrLen = 4;
+  if (Slen != 16) {
+    AddrLen = 16;
+  }
+
+  if (SocketAddr.ss_family == AF_INET) {
+    *AddrTypePtr = 4;
+    auto SocketAddrv4 = reinterpret_cast<struct sockaddr_in *>(&SocketAddr);
+
+    *PortPtr = ntohs(SocketAddrv4->sin_port);
+    std::memcpy(AddressPtr, &(SocketAddrv4->sin_addr.s_addr), AddrLen);
+  } else if (SocketAddr.ss_family == AF_INET6) {
+    *AddrTypePtr = 6;
+    auto SocketAddrv6 = reinterpret_cast<struct sockaddr_in6 *>(&SocketAddr);
+    *PortPtr = ntohs(SocketAddrv6->sin6_port);
+    std::memcpy(AddressPtr, SocketAddrv6->sin6_addr.s6_addr, AddrLen);
+  } else {
+    return WasiUnexpect(__WASI_ERRNO_NOSYS);
+  }
+
+  return {};
+}
+
+WasiExpect<void> INode::sockGetPeerAddrV2(uint8_t *AddressBufPtr,
+                                          uint32_t *PortPtr) const noexcept {
   auto AddrFamilyPtr = getAddressFamily(AddressBufPtr);
   auto AddressPtr = getAddress(AddressBufPtr);
 

--- a/lib/host/wasi/inode-win.cpp
+++ b/lib/host/wasi/inode-win.cpp
@@ -1846,9 +1846,42 @@ WasiExpect<INode> INode::sockOpen(__wasi_address_family_t AddressFamily,
   }
 }
 
-WasiExpect<void> INode::sockBind(uint8_t *AddressBuf,
-                                 [[maybe_unused]] uint8_t AddressLength,
-                                 uint16_t Port) noexcept {
+WasiExpect<void> INode::sockBindV1(uint8_t *Address, uint8_t AddressLength,
+                                   uint16_t Port) noexcept {
+  EnsureWSAStartup();
+
+  if (AddressLength == 4) {
+    struct sockaddr_in ServerAddr;
+    ServerAddr.sin_family = AF_INET;
+    ServerAddr.sin_port = htons(Port);
+    std::memcpy(&ServerAddr.sin_addr.s_addr, Address, AddressLength);
+
+    if (auto Res = ::bind(toSocket(Handle),
+                          reinterpret_cast<struct sockaddr *>(&ServerAddr),
+                          sizeof(ServerAddr));
+        unlikely(Res == SOCKET_ERROR)) {
+      return WasiUnexpect(fromWSALastError(WSAGetLastError()));
+    }
+
+  } else if (AddressLength == 16) {
+    struct sockaddr_in6 ServerAddr;
+    std::memset(&ServerAddr, 0, sizeof(ServerAddr));
+    ServerAddr.sin6_family = AF_INET6;
+    ServerAddr.sin6_port = htons(Port);
+    std::memcpy(ServerAddr.sin6_addr.s6_addr, Address, AddressLength);
+    if (auto Res = ::bind(toSocket(Handle),
+                          reinterpret_cast<struct sockaddr *>(&ServerAddr),
+                          sizeof(ServerAddr));
+        unlikely(Res == SOCKET_ERROR)) {
+      return WasiUnexpect(fromWSALastError(WSAGetLastError()));
+    }
+  }
+  return {};
+}
+
+WasiExpect<void> INode::sockBindV2(uint8_t *AddressBuf,
+                                   [[maybe_unused]] uint8_t AddressLength,
+                                   uint16_t Port) noexcept {
   EnsureWSAStartup();
 
   int AddrFamily;
@@ -1910,7 +1943,26 @@ WasiExpect<void> INode::sockListen(int32_t Backlog) noexcept {
   return {};
 }
 
-WasiExpect<INode> INode::sockAccept(__wasi_fdflags_t FdFlags) noexcept {
+WasiExpect<INode> INode::sockAcceptV1() noexcept {
+  EnsureWSAStartup();
+
+  struct sockaddr_in ServerSocketAddr;
+  ServerSocketAddr.sin_family = AF_INET;
+  ServerSocketAddr.sin_addr.s_addr = INADDR_ANY;
+  socklen_t AddressLen = sizeof(ServerSocketAddr);
+
+  if (auto NewSock = ::accept(
+          toSocket(Handle),
+          reinterpret_cast<struct sockaddr *>(&ServerSocketAddr), &AddressLen);
+      unlikely(NewSock == INVALID_SOCKET)) {
+    return WasiUnexpect(fromWSALastError(WSAGetLastError()));
+  } else {
+    INode New(reinterpret_cast<boost::winapi::HANDLE_>(NewSock));
+    return New;
+  }
+}
+
+WasiExpect<INode> INode::sockAcceptV2(__wasi_fdflags_t FdFlags) noexcept {
   EnsureWSAStartup();
   SOCKET NewSock;
   if (NewSock = ::accept(toSocket(Handle), nullptr, nullptr);
@@ -1935,9 +1987,43 @@ WasiExpect<INode> INode::sockAccept(__wasi_fdflags_t FdFlags) noexcept {
   }
 }
 
-WasiExpect<void> INode::sockConnect(uint8_t *AddressBuf,
-                                    [[maybe_unused]] uint8_t AddressLength,
-                                    uint16_t Port) noexcept {
+WasiExpect<void> INode::sockConnectV1(uint8_t *Address, uint8_t AddressLength,
+                                      uint16_t Port) noexcept {
+  EnsureWSAStartup();
+
+  if (AddressLength == 4) {
+    struct sockaddr_in ClientSocketAddr;
+    ClientSocketAddr.sin_family = AF_INET;
+    ClientSocketAddr.sin_port = htons(Port);
+    std::memcpy(&ClientSocketAddr.sin_addr.s_addr, Address, AddressLength);
+
+    if (auto Res =
+            ::connect(toSocket(Handle),
+                      reinterpret_cast<struct sockaddr *>(&ClientSocketAddr),
+                      sizeof(ClientSocketAddr));
+        unlikely(Res == SOCKET_ERROR)) {
+      return WasiUnexpect(fromWSALastError(WSAGetLastError()));
+    }
+  } else if (AddressLength == 16) {
+    struct sockaddr_in6 ClientSocketAddr;
+
+    ClientSocketAddr.sin6_family = AF_INET6;
+    ClientSocketAddr.sin6_port = htons(Port);
+    std::memcpy(ClientSocketAddr.sin6_addr.s6_addr, Address, AddressLength);
+    if (auto Res =
+            ::connect(toSocket(Handle),
+                      reinterpret_cast<struct sockaddr *>(&ClientSocketAddr),
+                      sizeof(ClientSocketAddr));
+        unlikely(Res == SOCKET_ERROR)) {
+      return WasiUnexpect(fromWSALastError(WSAGetLastError()));
+    }
+  }
+  return {};
+}
+
+WasiExpect<void> INode::sockConnectV2(uint8_t *AddressBuf,
+                                      [[maybe_unused]] uint8_t AddressLength,
+                                      uint16_t Port) noexcept {
   EnsureWSAStartup();
 
   int AddrFamily;
@@ -1993,15 +2079,78 @@ WasiExpect<void> INode::sockConnect(uint8_t *AddressBuf,
 WasiExpect<void> INode::sockRecv(Span<Span<uint8_t>> RiData,
                                  __wasi_riflags_t RiFlags, __wasi_size_t &NRead,
                                  __wasi_roflags_t &RoFlags) const noexcept {
-  return sockRecvFrom(RiData, RiFlags, nullptr, 0, nullptr, NRead, RoFlags);
+  return sockRecvFromV1(RiData, RiFlags, nullptr, 0, NRead, RoFlags);
 }
 
-WasiExpect<void> INode::sockRecvFrom(Span<Span<uint8_t>> RiData,
-                                     __wasi_riflags_t RiFlags,
-                                     uint8_t *AddressBuf,
-                                     [[maybe_unused]] uint8_t AddressLength,
-                                     uint32_t *PortPtr, __wasi_size_t &NRead,
-                                     __wasi_roflags_t &RoFlags) const noexcept {
+WasiExpect<void>
+INode::sockRecvFromV1(Span<Span<uint8_t>> RiData, __wasi_riflags_t RiFlags,
+                      uint8_t *Address, uint8_t AddressLength,
+                      __wasi_size_t &NRead,
+                      __wasi_roflags_t &RoFlags) const noexcept {
+  EnsureWSAStartup();
+  // recvmsg is not available on WINDOWS. fall back to call recvfrom
+
+  int SysRiFlags = 0;
+  if (RiFlags & __WASI_RIFLAGS_RECV_PEEK) {
+    SysRiFlags |= MSG_PEEK;
+  }
+  if (RiFlags & __WASI_RIFLAGS_RECV_WAITALL) {
+    SysRiFlags |= MSG_WAITALL;
+  }
+
+  std::size_t TmpBufSize = 0;
+  for (auto &IOV : RiData) {
+    TmpBufSize += IOV.size();
+  }
+
+  std::vector<uint8_t> TmpBuf(TmpBufSize, 0);
+
+  sockaddr_storage SockAddrStorage;
+
+  int MaxAllowLength = 0;
+  if (AddressLength == 4) {
+    MaxAllowLength = sizeof(sockaddr_in);
+  } else if (AddressLength == 16) {
+    MaxAllowLength = sizeof(sockaddr_in6);
+  }
+
+  if (auto Res = ::recvfrom(
+          toSocket(Handle), reinterpret_cast<char *>(TmpBuf.data()),
+          static_cast<int>(TmpBufSize), SysRiFlags,
+          reinterpret_cast<sockaddr *>(&SockAddrStorage), &MaxAllowLength);
+      unlikely(Res == SOCKET_ERROR)) {
+    return WasiUnexpect(fromWSALastError(WSAGetLastError()));
+  } else {
+    NRead = static_cast<__wasi_size_t>(Res);
+  }
+
+  if (AddressLength == 4) {
+    std::memcpy(Address,
+                &reinterpret_cast<sockaddr_in *>(&SockAddrStorage)->sin_addr,
+                AddressLength);
+  } else if (AddressLength == 16) {
+    std::memcpy(Address,
+                &reinterpret_cast<sockaddr_in6 *>(&SockAddrStorage)->sin6_addr,
+                AddressLength);
+  }
+
+  RoFlags = static_cast<__wasi_roflags_t>(0);
+  // TODO : check MSG_TRUNC
+
+  size_t BeginIdx = 0;
+  for (auto &IOV : RiData) {
+    std::copy(TmpBuf.data() + BeginIdx, TmpBuf.data() + BeginIdx + IOV.size(),
+              IOV.begin());
+    BeginIdx += IOV.size();
+  }
+
+  return {};
+}
+
+WasiExpect<void> INode::sockRecvFromV2(
+    Span<Span<uint8_t>> RiData, __wasi_riflags_t RiFlags, uint8_t *AddressBuf,
+    [[maybe_unused]] uint8_t AddressLength, uint32_t *PortPtr,
+    __wasi_size_t &NRead, __wasi_roflags_t &RoFlags) const noexcept {
   EnsureWSAStartup();
   // recvmsg is not available on WINDOWS. fall back to call recvfrom
 
@@ -2231,8 +2380,46 @@ WasiExpect<void> INode::sockSetOpt(__wasi_sock_opt_level_t SockOptLevel,
   return {};
 }
 
-WasiExpect<void> INode::sockGetLocalAddr(uint8_t *AddressBufPtr,
-                                         uint32_t *PortPtr) const noexcept {
+WasiExpect<void> INode::sockGetLocalAddrV1(uint8_t *AddressPtr,
+                                           uint32_t *AddrTypePtr,
+                                           uint32_t *PortPtr) const noexcept {
+  EnsureWSAStartup();
+
+  struct sockaddr_storage SocketAddr;
+  socklen_t Slen = sizeof(SocketAddr);
+  std::memset(&SocketAddr, 0, sizeof(SocketAddr));
+
+  if (auto Res = ::getsockname(
+          toSocket(Handle), reinterpret_cast<sockaddr *>(&SocketAddr), &Slen);
+      unlikely(Res == SOCKET_ERROR)) {
+    return WasiUnexpect(fromWSALastError(WSAGetLastError()));
+  }
+
+  size_t AddrLen = 4;
+  if (Slen != 16) {
+    AddrLen = 16;
+  }
+
+  if (SocketAddr.ss_family == AF_INET) {
+    *AddrTypePtr = 4;
+    auto SocketAddrv4 = reinterpret_cast<struct sockaddr_in *>(&SocketAddr);
+    *PortPtr = ntohs(SocketAddrv4->sin_port);
+    std::memcpy(AddressPtr, &(SocketAddrv4->sin_addr.s_addr), AddrLen);
+  } else if (SocketAddr.ss_family == AF_INET6) {
+    *AddrTypePtr = 6;
+    auto SocketAddrv6 = reinterpret_cast<struct sockaddr_in6 *>(&SocketAddr);
+
+    *PortPtr = ntohs(SocketAddrv6->sin6_port);
+    std::memcpy(AddressPtr, &(SocketAddrv6->sin6_addr.s6_addr), AddrLen);
+  } else {
+    return WasiUnexpect(__WASI_ERRNO_NOSYS);
+  }
+
+  return {};
+}
+
+WasiExpect<void> INode::sockGetLocalAddrV2(uint8_t *AddressBufPtr,
+                                           uint32_t *PortPtr) const noexcept {
   EnsureWSAStartup();
 
   auto AddrFamilyPtr = getAddressFamily(AddressBufPtr);
@@ -2267,8 +2454,15 @@ WasiExpect<void> INode::sockGetLocalAddr(uint8_t *AddressBufPtr,
   return {};
 }
 
-WasiExpect<void> INode::sockGetPeerAddr(uint8_t *AddressBufPtr,
-                                        uint32_t *PortPtr) const noexcept {
+WasiExpect<void> INode::sockGetPeerAddrV1(uint8_t *, uint32_t *,
+                                          uint32_t *) const noexcept {
+  EnsureWSAStartup();
+
+  return WasiUnexpect(__WASI_ERRNO_NOSYS);
+}
+
+WasiExpect<void> INode::sockGetPeerAddrV2(uint8_t *AddressBufPtr,
+                                          uint32_t *PortPtr) const noexcept {
   EnsureWSAStartup();
 
   auto AddrFamilyPtr = getAddressFamily(AddressBufPtr);

--- a/lib/host/wasi/vinode.cpp
+++ b/lib/host/wasi/vinode.cpp
@@ -361,9 +361,23 @@ VINode::sockOpen(VFS &FS, __wasi_address_family_t SysDomain,
   }
 }
 
+WasiExpect<std::shared_ptr<VINode>> VINode::sockAcceptV1() {
+  if (auto Res = Node.sockAcceptV1(); unlikely(!Res)) {
+    return WasiUnexpect(Res);
+  } else {
+    __wasi_rights_t Rights =
+        __WASI_RIGHTS_SOCK_RECV | __WASI_RIGHTS_SOCK_RECV_FROM |
+        __WASI_RIGHTS_SOCK_SEND | __WASI_RIGHTS_SOCK_SEND_TO |
+        __WASI_RIGHTS_SOCK_SHUTDOWN | __WASI_RIGHTS_POLL_FD_READWRITE |
+        __WASI_RIGHTS_FD_FDSTAT_SET_FLAGS;
+    return std::make_shared<VINode>(FS, std::move(*Res), Rights, Rights,
+                                    std::string());
+  }
+}
+
 WasiExpect<std::shared_ptr<VINode>>
-VINode::sockAccept(__wasi_fdflags_t FdFlags) {
-  if (auto Res = Node.sockAccept(FdFlags); unlikely(!Res)) {
+VINode::sockAcceptV2(__wasi_fdflags_t FdFlags) {
+  if (auto Res = Node.sockAcceptV2(FdFlags); unlikely(!Res)) {
     return WasiUnexpect(Res);
   } else {
     __wasi_rights_t Rights =

--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -1748,9 +1748,9 @@ Expect<uint32_t> WasiRandomGet::body(const Runtime::CallingFrame &Frame,
   return __WASI_ERRNO_SUCCESS;
 }
 
-Expect<uint32_t> WasiSockOpen::body(const Runtime::CallingFrame &Frame,
-                                    uint32_t AddressFamily, uint32_t SockType,
-                                    uint32_t /* Out */ RoFdPtr) {
+Expect<uint32_t> WasiSockOpenV1::body(const Runtime::CallingFrame &Frame,
+                                      uint32_t AddressFamily, uint32_t SockType,
+                                      uint32_t /* Out */ RoFdPtr) {
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -1787,9 +1787,9 @@ Expect<uint32_t> WasiSockOpen::body(const Runtime::CallingFrame &Frame,
   return __WASI_ERRNO_SUCCESS;
 }
 
-Expect<uint32_t> WasiSockBind::body(const Runtime::CallingFrame &Frame,
-                                    int32_t Fd, uint32_t AddressPtr,
-                                    uint32_t Port) {
+Expect<uint32_t> WasiSockBindV1::body(const Runtime::CallingFrame &Frame,
+                                      int32_t Fd, uint32_t AddressPtr,
+                                      uint32_t Port) {
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -1822,8 +1822,8 @@ Expect<uint32_t> WasiSockBind::body(const Runtime::CallingFrame &Frame,
   return __WASI_ERRNO_SUCCESS;
 }
 
-Expect<uint32_t> WasiSockListen::body(const Runtime::CallingFrame &, int32_t Fd,
-                                      int32_t Backlog) {
+Expect<uint32_t> WasiSockListenV1::body(const Runtime::CallingFrame &,
+                                        int32_t Fd, int32_t Backlog) {
   const __wasi_fd_t WasiFd = Fd;
   if (auto Res = Env.sockListen(WasiFd, Backlog); unlikely(!Res)) {
     return Res.error();
@@ -1831,9 +1831,32 @@ Expect<uint32_t> WasiSockListen::body(const Runtime::CallingFrame &, int32_t Fd,
   return __WASI_ERRNO_SUCCESS;
 }
 
-Expect<uint32_t> WasiSockAccept::body(const Runtime::CallingFrame &Frame,
-                                      int32_t Fd, uint32_t FsFlags,
-                                      uint32_t /* Out */ RoFdPtr) {
+Expect<uint32_t> WasiSockAcceptV1::body(const Runtime::CallingFrame &Frame,
+                                        int32_t Fd,
+                                        uint32_t /* Out */ RoFdPtr) {
+  // Check memory instance from module.
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return __WASI_ERRNO_FAULT;
+  }
+  __wasi_fd_t *const RoFd =
+      MemInst->getPointer<__wasi_fd_t *>(RoFdPtr, sizeof(__wasi_fd_t));
+  if (RoFd == nullptr) {
+    return __WASI_ERRNO_FAULT;
+  }
+  const __wasi_fd_t WasiFd = Fd;
+  if (auto Res = Env.sockAcceptV1(WasiFd); unlikely(!Res)) {
+    return Res.error();
+  } else {
+    *RoFd = *Res;
+  }
+
+  return __WASI_ERRNO_SUCCESS;
+}
+
+Expect<uint32_t> WasiSockAcceptV2::body(const Runtime::CallingFrame &Frame,
+    int32_t Fd, uint32_t FsFlags,
+    uint32_t /* Out */ RoFdPtr) {
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -1853,7 +1876,7 @@ Expect<uint32_t> WasiSockAccept::body(const Runtime::CallingFrame &Frame,
     WasiFdFlags = *Res;
   }
 
-  if (auto Res = Env.sockAccept(WasiFd, WasiFdFlags); unlikely(!Res)) {
+  if (auto Res = Env.sockAcceptV2(WasiFd, WasiFdFlags); unlikely(!Res)) {
     return Res.error();
   } else {
     *RoFd = *Res;
@@ -1862,9 +1885,9 @@ Expect<uint32_t> WasiSockAccept::body(const Runtime::CallingFrame &Frame,
   return __WASI_ERRNO_SUCCESS;
 }
 
-Expect<uint32_t> WasiSockConnect::body(const Runtime::CallingFrame &Frame,
-                                       int32_t Fd, uint32_t AddressPtr,
-                                       uint32_t Port) {
+Expect<uint32_t> WasiSockConnectV1::body(const Runtime::CallingFrame &Frame,
+                                         int32_t Fd, uint32_t AddressPtr,
+                                         uint32_t Port) {
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -1898,11 +1921,11 @@ Expect<uint32_t> WasiSockConnect::body(const Runtime::CallingFrame &Frame,
   return __WASI_ERRNO_SUCCESS;
 }
 
-Expect<uint32_t> WasiSockRecv::body(const Runtime::CallingFrame &Frame,
-                                    int32_t Fd, uint32_t RiDataPtr,
-                                    uint32_t RiDataLen, uint32_t RiFlags,
-                                    uint32_t /* Out */ RoDataLenPtr,
-                                    uint32_t /* Out */ RoFlagsPtr) {
+Expect<uint32_t> WasiSockRecvV1::body(const Runtime::CallingFrame &Frame,
+                                      int32_t Fd, uint32_t RiDataPtr,
+                                      uint32_t RiDataLen, uint32_t RiFlags,
+                                      uint32_t /* Out */ RoDataLenPtr,
+                                      uint32_t /* Out */ RoFlagsPtr) {
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -1970,13 +1993,13 @@ Expect<uint32_t> WasiSockRecv::body(const Runtime::CallingFrame &Frame,
   return __WASI_ERRNO_SUCCESS;
 }
 
-Expect<uint32_t> WasiSockRecvFrom::body(const Runtime::CallingFrame &Frame,
-                                        int32_t Fd, uint32_t RiDataPtr,
-                                        uint32_t RiDataLen, uint32_t AddressPtr,
-                                        uint32_t RiFlags,
-                                        uint32_t /* Out */ PortPtr,
-                                        uint32_t /* Out */ RoDataLenPtr,
-                                        uint32_t /* Out */ RoFlagsPtr) {
+Expect<uint32_t> WasiSockRecvFromV1::body(const Runtime::CallingFrame &Frame,
+                                          int32_t Fd, uint32_t RiDataPtr,
+                                          uint32_t RiDataLen,
+                                          uint32_t AddressPtr, uint32_t RiFlags,
+                                          uint32_t /* Out */ PortPtr,
+                                          uint32_t /* Out */ RoDataLenPtr,
+                                          uint32_t /* Out */ RoFlagsPtr) {
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -2068,10 +2091,10 @@ Expect<uint32_t> WasiSockRecvFrom::body(const Runtime::CallingFrame &Frame,
   return __WASI_ERRNO_SUCCESS;
 }
 
-Expect<uint32_t> WasiSockSend::body(const Runtime::CallingFrame &Frame,
-                                    int32_t Fd, uint32_t SiDataPtr,
-                                    uint32_t SiDataLen, uint32_t SiFlags,
-                                    uint32_t /* Out */ SoDataLenPtr) {
+Expect<uint32_t> WasiSockSendV1::body(const Runtime::CallingFrame &Frame,
+                                      int32_t Fd, uint32_t SiDataPtr,
+                                      uint32_t SiDataLen, uint32_t SiFlags,
+                                      uint32_t /* Out */ SoDataLenPtr) {
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -2134,11 +2157,11 @@ Expect<uint32_t> WasiSockSend::body(const Runtime::CallingFrame &Frame,
   return __WASI_ERRNO_SUCCESS;
 }
 
-Expect<uint32_t> WasiSockSendTo::body(const Runtime::CallingFrame &Frame,
-                                      int32_t Fd, uint32_t SiDataPtr,
-                                      uint32_t SiDataLen, uint32_t AddressPtr,
-                                      int32_t Port, uint32_t SiFlags,
-                                      uint32_t /* Out */ SoDataLenPtr) {
+Expect<uint32_t> WasiSockSendToV1::body(const Runtime::CallingFrame &Frame,
+                                        int32_t Fd, uint32_t SiDataPtr,
+                                        uint32_t SiDataLen, uint32_t AddressPtr,
+                                        int32_t Port, uint32_t SiFlags,
+                                        uint32_t /* Out */ SoDataLenPtr) {
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -2220,8 +2243,8 @@ Expect<uint32_t> WasiSockSendTo::body(const Runtime::CallingFrame &Frame,
   return __WASI_ERRNO_SUCCESS;
 }
 
-Expect<uint32_t> WasiSockShutdown::body(const Runtime::CallingFrame &,
-                                        int32_t Fd, uint32_t SdFlags) {
+Expect<uint32_t> WasiSockShutdownV1::body(const Runtime::CallingFrame &,
+                                          int32_t Fd, uint32_t SdFlags) {
   __wasi_sdflags_t WasiSdFlags;
   if (auto Res = cast<__wasi_sdflags_t>(SdFlags); unlikely(!Res)) {
     return Res.error();
@@ -2237,10 +2260,10 @@ Expect<uint32_t> WasiSockShutdown::body(const Runtime::CallingFrame &,
   return __WASI_ERRNO_SUCCESS;
 }
 
-Expect<uint32_t> WasiSockGetOpt::body(const Runtime::CallingFrame &Frame,
-                                      int32_t Fd, uint32_t SockOptLevel,
-                                      uint32_t SockOptName, uint32_t FlagPtr,
-                                      uint32_t FlagSizePtr) {
+Expect<uint32_t> WasiSockGetOptV1::body(const Runtime::CallingFrame &Frame,
+                                        int32_t Fd, uint32_t SockOptLevel,
+                                        uint32_t SockOptName, uint32_t FlagPtr,
+                                        uint32_t FlagSizePtr) {
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -2281,10 +2304,10 @@ Expect<uint32_t> WasiSockGetOpt::body(const Runtime::CallingFrame &Frame,
   return __WASI_ERRNO_SUCCESS;
 }
 
-Expect<uint32_t> WasiSockSetOpt::body(const Runtime::CallingFrame &Frame,
-                                      int32_t Fd, uint32_t SockOptLevel,
-                                      uint32_t SockOptName, uint32_t FlagPtr,
-                                      uint32_t FlagSize) {
+Expect<uint32_t> WasiSockSetOptV1::body(const Runtime::CallingFrame &Frame,
+                                        int32_t Fd, uint32_t SockOptLevel,
+                                        uint32_t SockOptName, uint32_t FlagPtr,
+                                        uint32_t FlagSize) {
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -2320,12 +2343,10 @@ Expect<uint32_t> WasiSockSetOpt::body(const Runtime::CallingFrame &Frame,
   return __WASI_ERRNO_SUCCESS;
 }
 
-Expect<uint32_t> WasiGetAddrinfo::body(const Runtime::CallingFrame &Frame,
-                                       uint32_t NodePtr, uint32_t NodeLen,
-                                       uint32_t ServicePtr, uint32_t ServiceLen,
-                                       uint32_t HintsPtr, uint32_t ResPtr,
-                                       uint32_t MaxResLength,
-                                       uint32_t ResLengthPtr) {
+Expect<uint32_t> WasiSockGetAddrinfoV1::body(
+    const Runtime::CallingFrame &Frame, uint32_t NodePtr, uint32_t NodeLen,
+    uint32_t ServicePtr, uint32_t ServiceLen, uint32_t HintsPtr,
+    uint32_t ResPtr, uint32_t MaxResLength, uint32_t ResLengthPtr) {
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -2447,9 +2468,9 @@ Expect<uint32_t> WasiGetAddrinfo::body(const Runtime::CallingFrame &Frame,
   return __WASI_ERRNO_SUCCESS;
 }
 
-Expect<uint32_t> WasiSockGetLocalAddr::body(const Runtime::CallingFrame &Frame,
-                                            int32_t Fd, uint32_t AddressPtr,
-                                            uint32_t PortPtr) {
+Expect<uint32_t>
+WasiSockGetLocalAddrV1::body(const Runtime::CallingFrame &Frame, int32_t Fd,
+                             uint32_t AddressPtr, uint32_t PortPtr) {
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
@@ -2484,9 +2505,9 @@ Expect<uint32_t> WasiSockGetLocalAddr::body(const Runtime::CallingFrame &Frame,
   return __WASI_ERRNO_SUCCESS;
 }
 
-Expect<uint32_t> WasiSockGetPeerAddr::body(const Runtime::CallingFrame &Frame,
-                                           int32_t Fd, uint32_t AddressPtr,
-                                           uint32_t PortPtr) {
+Expect<uint32_t> WasiSockGetPeerAddrV1::body(const Runtime::CallingFrame &Frame,
+                                             int32_t Fd, uint32_t AddressPtr,
+                                             uint32_t PortPtr) {
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;

--- a/lib/host/wasi/wasimodule.cpp
+++ b/lib/host/wasi/wasimodule.cpp
@@ -61,21 +61,32 @@ WasiModule::WasiModule() : ModuleInstance("wasi_snapshot_preview1") {
   addHostFunc("proc_raise", std::make_unique<WasiProcRaise>(Env));
   addHostFunc("sched_yield", std::make_unique<WasiSchedYield>(Env));
   addHostFunc("random_get", std::make_unique<WasiRandomGet>(Env));
-  addHostFunc("sock_open", std::make_unique<WasiSockOpen>(Env));
-  addHostFunc("sock_bind", std::make_unique<WasiSockBind>(Env));
-  addHostFunc("sock_connect", std::make_unique<WasiSockConnect>(Env));
-  addHostFunc("sock_listen", std::make_unique<WasiSockListen>(Env));
-  addHostFunc("sock_accept", std::make_unique<WasiSockAccept>(Env));
-  addHostFunc("sock_recv", std::make_unique<WasiSockRecv>(Env));
-  addHostFunc("sock_recv_from", std::make_unique<WasiSockRecvFrom>(Env));
-  addHostFunc("sock_send", std::make_unique<WasiSockSend>(Env));
-  addHostFunc("sock_send_to", std::make_unique<WasiSockSendTo>(Env));
-  addHostFunc("sock_shutdown", std::make_unique<WasiSockShutdown>(Env));
-  addHostFunc("sock_getsockopt", std::make_unique<WasiSockGetOpt>(Env));
-  addHostFunc("sock_setsockopt", std::make_unique<WasiSockSetOpt>(Env));
-  addHostFunc("sock_getlocaladdr", std::make_unique<WasiSockGetLocalAddr>(Env));
-  addHostFunc("sock_getpeeraddr", std::make_unique<WasiSockGetPeerAddr>(Env));
-  addHostFunc("sock_getaddrinfo", std::make_unique<WasiGetAddrinfo>(Env));
+  // To make the socket API compatible with the old one,
+  // we will duplicate all the API to V1 and V2.
+  // The V1 presents the original behavior before 0.12 release.
+  // On the other hand, the V2 presents the new behavior including
+  // the sock_accept is following the WASI spec, some of the API
+  // use a larger size for handling complex address type, e.g.
+  // AF_UNIX.
+  // By default, we will register V1 first, if the signatures are
+  // not the same as the wasm application imported, then V2 will
+  // replace instead.
+  addHostFunc("sock_open", std::make_unique<WasiSockOpenV1>(Env));
+  addHostFunc("sock_bind", std::make_unique<WasiSockBindV1>(Env));
+  addHostFunc("sock_connect", std::make_unique<WasiSockConnectV1>(Env));
+  addHostFunc("sock_listen", std::make_unique<WasiSockListenV1>(Env));
+  addHostFunc("sock_accept", std::make_unique<WasiSockAcceptV1>(Env));
+  addHostFunc("sock_recv", std::make_unique<WasiSockRecvV1>(Env));
+  addHostFunc("sock_recv_from", std::make_unique<WasiSockRecvFromV1>(Env));
+  addHostFunc("sock_send", std::make_unique<WasiSockSendV1>(Env));
+  addHostFunc("sock_send_to", std::make_unique<WasiSockSendToV1>(Env));
+  addHostFunc("sock_shutdown", std::make_unique<WasiSockShutdownV1>(Env));
+  addHostFunc("sock_getsockopt", std::make_unique<WasiSockGetOptV1>(Env));
+  addHostFunc("sock_setsockopt", std::make_unique<WasiSockSetOptV1>(Env));
+  addHostFunc("sock_getlocaladdr",
+              std::make_unique<WasiSockGetLocalAddrV1>(Env));
+  addHostFunc("sock_getpeeraddr", std::make_unique<WasiSockGetPeerAddrV1>(Env));
+  addHostFunc("sock_getaddrinfo", std::make_unique<WasiSockGetAddrinfoV1>(Env));
 }
 
 } // namespace Host

--- a/lib/host/wasi/wasimodule.cpp
+++ b/lib/host/wasi/wasimodule.cpp
@@ -80,13 +80,26 @@ WasiModule::WasiModule() : ModuleInstance("wasi_snapshot_preview1") {
   addHostFunc("sock_recv_from", std::make_unique<WasiSockRecvFromV1>(Env));
   addHostFunc("sock_send", std::make_unique<WasiSockSendV1>(Env));
   addHostFunc("sock_send_to", std::make_unique<WasiSockSendToV1>(Env));
-  addHostFunc("sock_shutdown", std::make_unique<WasiSockShutdownV1>(Env));
-  addHostFunc("sock_getsockopt", std::make_unique<WasiSockGetOptV1>(Env));
-  addHostFunc("sock_setsockopt", std::make_unique<WasiSockSetOptV1>(Env));
+  addHostFunc("sock_accept_v2", std::make_unique<WasiSockAcceptV2>(Env));
+  addHostFunc("sock_open_v2", std::make_unique<WasiSockOpenV2>(Env));
+  addHostFunc("sock_bind_v2", std::make_unique<WasiSockBindV2>(Env));
+  addHostFunc("sock_connect_v2", std::make_unique<WasiSockConnectV2>(Env));
+  addHostFunc("sock_listen_v2", std::make_unique<WasiSockListenV2>(Env));
+  addHostFunc("sock_recv_v2", std::make_unique<WasiSockRecvV2>(Env));
+  addHostFunc("sock_recv_from_v2", std::make_unique<WasiSockRecvFromV2>(Env));
+  addHostFunc("sock_send_v2", std::make_unique<WasiSockSendV2>(Env));
+  addHostFunc("sock_send_to_v2", std::make_unique<WasiSockSendToV2>(Env));
+  addHostFunc("sock_shutdown", std::make_unique<WasiSockShutdown>(Env));
+  addHostFunc("sock_getsockopt", std::make_unique<WasiSockGetOpt>(Env));
+  addHostFunc("sock_setsockopt", std::make_unique<WasiSockSetOpt>(Env));
   addHostFunc("sock_getlocaladdr",
               std::make_unique<WasiSockGetLocalAddrV1>(Env));
   addHostFunc("sock_getpeeraddr", std::make_unique<WasiSockGetPeerAddrV1>(Env));
-  addHostFunc("sock_getaddrinfo", std::make_unique<WasiSockGetAddrinfoV1>(Env));
+  addHostFunc("sock_getlocaladdr_v2",
+              std::make_unique<WasiSockGetLocalAddrV2>(Env));
+  addHostFunc("sock_getpeeraddr_v2",
+              std::make_unique<WasiSockGetPeerAddrV2>(Env));
+  addHostFunc("sock_getaddrinfo", std::make_unique<WasiSockGetAddrinfo>(Env));
 }
 
 } // namespace Host

--- a/test/host/socket/wasi_socket.cpp
+++ b/test/host/socket/wasi_socket.cpp
@@ -127,7 +127,7 @@ void allocateAddrinfoArray(WasmEdge::Runtime::Instance::MemoryInstance &MemInst,
 }
 } // namespace
 
-TEST(WasiTest, SocketUDP_4) {
+TEST(WasiSockTest, SocketUDP_4) {
   WasmEdge::Host::WASI::Environ Env;
   WasmEdge::Runtime::Instance::ModuleInstance Mod("");
   Mod.addHostMemory(
@@ -138,11 +138,11 @@ TEST(WasiTest, SocketUDP_4) {
   auto &MemInst = *MemInstPtr;
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
 
-  WasmEdge::Host::WasiSockOpen WasiSockOpen(Env);
+  WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
-  WasmEdge::Host::WasiSockBind WasiSockBind(Env);
-  WasmEdge::Host::WasiSockSendTo WasiSockSendTo(Env);
-  WasmEdge::Host::WasiSockRecvFrom WasiSockRecvFrom(Env);
+  WasmEdge::Host::WasiSockBindV1 WasiSockBind(Env);
+  WasmEdge::Host::WasiSockSendToV1 WasiSockSendTo(Env);
+  WasmEdge::Host::WasiSockRecvFromV1 WasiSockRecvFrom(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
 
@@ -329,7 +329,7 @@ TEST(WasiTest, SocketUDP_4) {
   }
 }
 
-TEST(WasiTest, SocketUDP_6) {
+TEST(WasiSockTest, SocketUDP_6) {
   if (!TestIPv6Enabled()) {
     GTEST_SKIP();
   }
@@ -344,11 +344,11 @@ TEST(WasiTest, SocketUDP_6) {
   auto &MemInst = *MemInstPtr;
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
 
-  WasmEdge::Host::WasiSockOpen WasiSockOpen(Env);
+  WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
-  WasmEdge::Host::WasiSockBind WasiSockBind(Env);
-  WasmEdge::Host::WasiSockSendTo WasiSockSendTo(Env);
-  WasmEdge::Host::WasiSockRecvFrom WasiSockRecvFrom(Env);
+  WasmEdge::Host::WasiSockBindV1 WasiSockBind(Env);
+  WasmEdge::Host::WasiSockSendToV1 WasiSockSendTo(Env);
+  WasmEdge::Host::WasiSockRecvFromV1 WasiSockRecvFrom(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
 
@@ -468,7 +468,7 @@ TEST(WasiTest, SocketUDP_6) {
   }
 }
 
-TEST(WasiTest, SocketUDP_4_Fallback) {
+TEST(WasiSockTest, SocketUDP_4_Fallback) {
   WasmEdge::Host::WASI::Environ Env;
   WasmEdge::Runtime::Instance::ModuleInstance Mod("");
   Mod.addHostMemory(
@@ -479,11 +479,11 @@ TEST(WasiTest, SocketUDP_4_Fallback) {
   auto &MemInst = *MemInstPtr;
 
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
-  WasmEdge::Host::WasiSockOpen WasiSockOpen(Env);
+  WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
-  WasmEdge::Host::WasiSockBind WasiSockBind(Env);
-  WasmEdge::Host::WasiSockSendTo WasiSockSendTo(Env);
-  WasmEdge::Host::WasiSockRecvFrom WasiSockRecvFrom(Env);
+  WasmEdge::Host::WasiSockBindV1 WasiSockBind(Env);
+  WasmEdge::Host::WasiSockSendToV1 WasiSockSendTo(Env);
+  WasmEdge::Host::WasiSockRecvFromV1 WasiSockRecvFrom(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
 
@@ -599,7 +599,7 @@ TEST(WasiTest, SocketUDP_4_Fallback) {
   }
 }
 
-TEST(WasiTest, SocketUDP_6_Fallback) {
+TEST(WasiSockTest, SocketUDP_6_Fallback) {
   if (!TestIPv6Enabled()) {
     GTEST_SKIP();
   }
@@ -615,11 +615,11 @@ TEST(WasiTest, SocketUDP_6_Fallback) {
 
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
 
-  WasmEdge::Host::WasiSockOpen WasiSockOpen(Env);
+  WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
-  WasmEdge::Host::WasiSockBind WasiSockBind(Env);
-  WasmEdge::Host::WasiSockSendTo WasiSockSendTo(Env);
-  WasmEdge::Host::WasiSockRecvFrom WasiSockRecvFrom(Env);
+  WasmEdge::Host::WasiSockBindV1 WasiSockBind(Env);
+  WasmEdge::Host::WasiSockSendToV1 WasiSockSendTo(Env);
+  WasmEdge::Host::WasiSockRecvFromV1 WasiSockRecvFrom(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
 
@@ -733,7 +733,7 @@ TEST(WasiTest, SocketUDP_6_Fallback) {
   }
 }
 
-TEST(WasiTest, SockOpt) {
+TEST(WasiSockTest, SockOpt) {
   WasmEdge::Host::WASI::Environ Env;
   WasmEdge::Runtime::Instance::ModuleInstance Mod("");
   Mod.addHostMemory(
@@ -744,9 +744,9 @@ TEST(WasiTest, SockOpt) {
   auto &MemInst = *MemInstPtr;
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
 
-  WasmEdge::Host::WasiSockOpen WasiSockOpen(Env);
-  WasmEdge::Host::WasiSockGetOpt WasiSockGetOpt(Env);
-  WasmEdge::Host::WasiSockSetOpt WasiSockSetOpt(Env);
+  WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
+  WasmEdge::Host::WasiSockGetOptV1 WasiSockGetOpt(Env);
+  WasmEdge::Host::WasiSockSetOptV1 WasiSockSetOpt(Env);
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
@@ -854,7 +854,7 @@ TEST(WasiTest, SockOpt) {
   }
 }
 
-TEST(WasiTest, SockGetLocalAddr_4) {
+TEST(WasiSockTest, SockGetLocalAddr_4) {
   WasmEdge::Host::WASI::Environ Env;
   WasmEdge::Runtime::Instance::ModuleInstance Mod("");
   Mod.addHostMemory(
@@ -865,9 +865,9 @@ TEST(WasiTest, SockGetLocalAddr_4) {
   auto &MemInst = *MemInstPtr;
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
 
-  WasmEdge::Host::WasiSockOpen WasiSockOpen(Env);
-  WasmEdge::Host::WasiSockBind WasiSockBind(Env);
-  WasmEdge::Host::WasiSockGetLocalAddr WasiSockGetLocalAddr(Env);
+  WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
+  WasmEdge::Host::WasiSockBindV1 WasiSockBind(Env);
+  WasmEdge::Host::WasiSockGetLocalAddrV1 WasiSockGetLocalAddr(Env);
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
@@ -940,7 +940,7 @@ TEST(WasiTest, SockGetLocalAddr_4) {
   }
 }
 
-TEST(WasiTest, SockGetLocalAddr_6) {
+TEST(WasiSockTest, SockGetLocalAddr_6) {
   if (!TestIPv6Enabled()) {
     GTEST_SKIP();
   }
@@ -955,9 +955,9 @@ TEST(WasiTest, SockGetLocalAddr_6) {
   auto &MemInst = *MemInstPtr;
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
 
-  WasmEdge::Host::WasiSockOpen WasiSockOpen(Env);
-  WasmEdge::Host::WasiSockBind WasiSockBind(Env);
-  WasmEdge::Host::WasiSockGetLocalAddr WasiSockGetLocalAddr(Env);
+  WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
+  WasmEdge::Host::WasiSockBindV1 WasiSockBind(Env);
+  WasmEdge::Host::WasiSockGetLocalAddrV1 WasiSockGetLocalAddr(Env);
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
@@ -1032,7 +1032,7 @@ TEST(WasiTest, SockGetLocalAddr_6) {
   }
 }
 
-TEST(WasiTest, GetAddrinfo) {
+TEST(WasiSockTest, GetAddrinfo) {
   WasmEdge::Host::WASI::Environ Env;
   WasmEdge::Runtime::Instance::ModuleInstance Mod("");
   Mod.addHostMemory(
@@ -1043,7 +1043,7 @@ TEST(WasiTest, GetAddrinfo) {
   auto &MemInst = *MemInstPtr;
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
 
-  WasmEdge::Host::WasiGetAddrinfo WasiGetAddrinfo(Env);
+  WasmEdge::Host::WasiSockGetAddrinfoV1 WasiGetAddrinfo(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
 

--- a/test/host/socket/wasi_socket.cpp
+++ b/test/host/socket/wasi_socket.cpp
@@ -127,7 +127,7 @@ void allocateAddrinfoArray(WasmEdge::Runtime::Instance::MemoryInstance &MemInst,
 }
 } // namespace
 
-TEST(WasiSockTest, SocketUDP_4) {
+TEST(WasiSockTest, SocketUDP_4V1) {
   WasmEdge::Host::WASI::Environ Env;
   WasmEdge::Runtime::Instance::ModuleInstance Mod("");
   Mod.addHostMemory(
@@ -143,6 +143,203 @@ TEST(WasiSockTest, SocketUDP_4) {
   WasmEdge::Host::WasiSockBindV1 WasiSockBind(Env);
   WasmEdge::Host::WasiSockSendToV1 WasiSockSendTo(Env);
   WasmEdge::Host::WasiSockRecvFromV1 WasiSockRecvFrom(Env);
+
+  std::array<WasmEdge::ValVariant, 1> Errno;
+
+  // Open and Close udp socket
+  {
+    uint32_t AddressFamily = __WASI_ADDRESS_FAMILY_INET4;
+    uint32_t SockType = __WASI_SOCK_TYPE_SOCK_DGRAM;
+    uint32_t Port = 12345;
+    uint32_t FdServerPtr = 0;
+    uint32_t FdClientPtr = 4;
+    uint32_t SendtoRetPtr = 8;
+    uint32_t RecvfromRetPtr = 12;
+    uint32_t FlagPtr = 16;
+    uint32_t AddrBufPtr = 100;
+    uint32_t AddrBuflen = 4;
+    uint32_t AddrPtr = 200;
+    uint32_t MsgInPackPtr = 900;
+    uint32_t MsgInPtr = 1000;
+    uint32_t MsgOutPackPtr = 1900;
+    uint32_t MsgOutPtr = 2000;
+
+    writeDummyMemoryContent(MemInst);
+    WasiSockOpen.run(CallFrame,
+                     std::array<WasmEdge::ValVariant, 3>{AddressFamily,
+                                                         SockType, FdServerPtr},
+                     Errno);
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    EXPECT_NE(*MemInst.getPointer<const uint32_t *>(FdServerPtr), UINT32_C(-1));
+
+    int32_t FdServer = *MemInst.getPointer<const int32_t *>(FdServerPtr);
+
+    WasiSockOpen.run(CallFrame,
+                     std::array<WasmEdge::ValVariant, 3>{AddressFamily,
+                                                         SockType, FdClientPtr},
+                     Errno);
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    EXPECT_NE(*MemInst.getPointer<const uint32_t *>(FdClientPtr), UINT32_C(-1));
+
+    int32_t FdClient = *MemInst.getPointer<const int32_t *>(FdClientPtr);
+
+    WasiSockOpen.run(CallFrame,
+                     std::array<WasmEdge::ValVariant, 3>{AddressFamily,
+                                                         SockType, FdClientPtr},
+                     Errno);
+    EXPECT_NE(*MemInst.getPointer<const uint32_t *>(FdClientPtr), UINT32_C(-1));
+
+    auto *AddrBuf =
+        MemInst.getPointer<uint8_t *>(AddrBufPtr, sizeof(uint8_t) * AddrBuflen);
+    auto *Addr = MemInst.getPointer<__wasi_address_t *>(
+        AddrPtr, sizeof(__wasi_address_t));
+
+    ::memset(AddrBuf, 0x00, AddrBuflen);
+    Addr->buf = AddrBufPtr;
+    Addr->buf_len = AddrBuflen;
+
+    WasiSockBind.run(
+        CallFrame, std::array<WasmEdge::ValVariant, 3>{FdServer, AddrPtr, Port},
+        Errno);
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+
+    const auto Msg1 = "hello, wasmedge."sv;
+    uint32_t Msg1Len = Msg1.size();
+    writeString(MemInst, Msg1, MsgInPtr);
+
+    auto *MsgInPack = MemInst.getPointer<__wasi_ciovec_t *>(
+        MsgInPackPtr, sizeof(__wasi_ciovec_t));
+    MsgInPack->buf = MsgInPtr;
+    MsgInPack->buf_len = Msg1Len;
+
+    auto *AddrBufSend =
+        MemInst.getPointer<uint32_t *>(AddrBufPtr, sizeof(uint32_t));
+    *AddrBufSend = htonl(INADDR_LOOPBACK);
+    Addr->buf_len = sizeof(uint32_t);
+
+    WasiSockSendTo.run(CallFrame,
+                       std::array<WasmEdge::ValVariant, 7>{
+                           FdClient, MsgInPackPtr, UINT32_C(1), AddrPtr,
+                           INT32_C(Port), UINT32_C(0), SendtoRetPtr},
+                       Errno);
+
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    uint32_t MaxMsgBufLen = 100;
+    auto *MsgBuf =
+        MemInst.getPointer<char *>(MsgOutPtr, sizeof(char) * MaxMsgBufLen);
+    ::memset(MsgBuf, 0x00, MaxMsgBufLen);
+
+    auto *MsgOutPack = MemInst.getPointer<__wasi_ciovec_t *>(
+        MsgOutPackPtr, sizeof(__wasi_ciovec_t));
+    MsgOutPack->buf = MsgOutPtr;
+    MsgOutPack->buf_len = MaxMsgBufLen;
+
+    Addr->buf_len = 4;
+
+    WasiSockRecvFrom.run(CallFrame,
+                         std::array<WasmEdge::ValVariant, 7>{
+                             FdServer, MsgOutPackPtr, UINT32_C(1), AddrPtr,
+                             UINT32_C(0), RecvfromRetPtr, FlagPtr},
+                         Errno);
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+
+    std::string_view MsgRecv{MsgBuf, Msg1.size()};
+    EXPECT_EQ(MsgRecv, Msg1);
+
+    WasiFdClose.run(CallFrame, std::array<WasmEdge::ValVariant, 1>{FdServer},
+                    Errno);
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    WasiFdClose.run(CallFrame, std::array<WasmEdge::ValVariant, 1>{FdClient},
+                    Errno);
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    Env.fini();
+  }
+  // False SockType
+  {
+    uint32_t AddressFamily = __WASI_ADDRESS_FAMILY_INET4;
+    uint32_t SockType = 3;
+
+    writeDummyMemoryContent(MemInst);
+    WasiSockOpen.run(CallFrame,
+                     std::array<WasmEdge::ValVariant, 3>{AddressFamily,
+                                                         SockType, UINT32_C(0)},
+                     Errno);
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_INVAL);
+    Env.fini();
+  }
+  // False AddressFamily
+  {
+    uint32_t AddressFamily = 3;
+    uint32_t SockType = __WASI_SOCK_TYPE_SOCK_DGRAM;
+
+    writeDummyMemoryContent(MemInst);
+    WasiSockOpen.run(CallFrame,
+                     std::array<WasmEdge::ValVariant, 3>{AddressFamily,
+                                                         SockType, UINT32_C(0)},
+                     Errno);
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_INVAL);
+    Env.fini();
+  }
+  // Invalid Address Length for Bind
+  {
+    uint32_t Fd = 0;
+    uint32_t Port = 12345;
+    uint8_t_ptr AddrBufPtr = 100;
+    uint32_t AddrBuflen = 7;
+    uint32_t AddrPtr = 200;
+    auto *AddrBuf =
+        MemInst.getPointer<uint8_t *>(AddrBufPtr, sizeof(uint8_t) * AddrBuflen);
+    auto *Addr = MemInst.getPointer<__wasi_address_t *>(
+        AddrPtr, sizeof(__wasi_address_t));
+
+    ::memset(AddrBuf, 0x00, AddrBuflen);
+    Addr->buf = AddrBufPtr;
+    Addr->buf_len = AddrBuflen;
+
+    WasiSockBind.run(CallFrame,
+                     std::array<WasmEdge::ValVariant, 3>{Fd, AddrPtr, Port},
+                     Errno);
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_INVAL);
+  }
+  // Invalid Fd for Bind
+  {
+    uint32_t Fd = 0;
+    uint32_t Port = 12345;
+    uint8_t_ptr AddrBufPtr = 100;
+    uint32_t AddrBuflen = 16;
+    uint32_t AddrPtr = 200;
+    auto *AddrBuf =
+        MemInst.getPointer<uint8_t *>(AddrBufPtr, sizeof(uint8_t) * AddrBuflen);
+    auto *Addr = MemInst.getPointer<__wasi_address_t *>(
+        AddrPtr, sizeof(__wasi_address_t));
+
+    ::memset(AddrBuf, 0x00, AddrBuflen);
+    Addr->buf = AddrBufPtr;
+    Addr->buf_len = AddrBuflen;
+
+    WasiSockBind.run(CallFrame,
+                     std::array<WasmEdge::ValVariant, 3>{Fd, AddrPtr, Port},
+                     Errno);
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_BADF);
+  }
+}
+
+TEST(WasiSockTest, SocketUDP_4V2) {
+  WasmEdge::Host::WASI::Environ Env;
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_TRUE(MemInstPtr != nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+
+  WasmEdge::Host::WasiSockOpenV2 WasiSockOpen(Env);
+  WasmEdge::Host::WasiFdClose WasiFdClose(Env);
+  WasmEdge::Host::WasiSockBindV2 WasiSockBind(Env);
+  WasmEdge::Host::WasiSockSendToV2 WasiSockSendTo(Env);
+  WasmEdge::Host::WasiSockRecvFromV2 WasiSockRecvFrom(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
 
@@ -344,11 +541,11 @@ TEST(WasiSockTest, SocketUDP_6) {
   auto &MemInst = *MemInstPtr;
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
 
-  WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
+  WasmEdge::Host::WasiSockOpenV2 WasiSockOpen(Env);
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
-  WasmEdge::Host::WasiSockBindV1 WasiSockBind(Env);
-  WasmEdge::Host::WasiSockSendToV1 WasiSockSendTo(Env);
-  WasmEdge::Host::WasiSockRecvFromV1 WasiSockRecvFrom(Env);
+  WasmEdge::Host::WasiSockBindV2 WasiSockBind(Env);
+  WasmEdge::Host::WasiSockSendToV2 WasiSockSendTo(Env);
+  WasmEdge::Host::WasiSockRecvFromV2 WasiSockRecvFrom(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
 
@@ -479,11 +676,11 @@ TEST(WasiSockTest, SocketUDP_4_Fallback) {
   auto &MemInst = *MemInstPtr;
 
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
-  WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
+  WasmEdge::Host::WasiSockOpenV2 WasiSockOpen(Env);
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
-  WasmEdge::Host::WasiSockBindV1 WasiSockBind(Env);
-  WasmEdge::Host::WasiSockSendToV1 WasiSockSendTo(Env);
-  WasmEdge::Host::WasiSockRecvFromV1 WasiSockRecvFrom(Env);
+  WasmEdge::Host::WasiSockBindV2 WasiSockBind(Env);
+  WasmEdge::Host::WasiSockSendToV2 WasiSockSendTo(Env);
+  WasmEdge::Host::WasiSockRecvFromV2 WasiSockRecvFrom(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
 
@@ -615,11 +812,11 @@ TEST(WasiSockTest, SocketUDP_6_Fallback) {
 
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
 
-  WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
+  WasmEdge::Host::WasiSockOpenV2 WasiSockOpen(Env);
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
-  WasmEdge::Host::WasiSockBindV1 WasiSockBind(Env);
-  WasmEdge::Host::WasiSockSendToV1 WasiSockSendTo(Env);
-  WasmEdge::Host::WasiSockRecvFromV1 WasiSockRecvFrom(Env);
+  WasmEdge::Host::WasiSockBindV2 WasiSockBind(Env);
+  WasmEdge::Host::WasiSockSendToV2 WasiSockSendTo(Env);
+  WasmEdge::Host::WasiSockRecvFromV2 WasiSockRecvFrom(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
 
@@ -744,9 +941,9 @@ TEST(WasiSockTest, SockOpt) {
   auto &MemInst = *MemInstPtr;
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
 
-  WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
-  WasmEdge::Host::WasiSockGetOptV1 WasiSockGetOpt(Env);
-  WasmEdge::Host::WasiSockSetOptV1 WasiSockSetOpt(Env);
+  WasmEdge::Host::WasiSockOpenV2 WasiSockOpen(Env);
+  WasmEdge::Host::WasiSockGetOpt WasiSockGetOpt(Env);
+  WasmEdge::Host::WasiSockSetOpt WasiSockSetOpt(Env);
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
@@ -865,9 +1062,9 @@ TEST(WasiSockTest, SockGetLocalAddr_4) {
   auto &MemInst = *MemInstPtr;
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
 
-  WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
-  WasmEdge::Host::WasiSockBindV1 WasiSockBind(Env);
-  WasmEdge::Host::WasiSockGetLocalAddrV1 WasiSockGetLocalAddr(Env);
+  WasmEdge::Host::WasiSockOpenV2 WasiSockOpen(Env);
+  WasmEdge::Host::WasiSockBindV2 WasiSockBind(Env);
+  WasmEdge::Host::WasiSockGetLocalAddrV2 WasiSockGetLocalAddr(Env);
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
@@ -955,9 +1152,9 @@ TEST(WasiSockTest, SockGetLocalAddr_6) {
   auto &MemInst = *MemInstPtr;
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
 
-  WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
-  WasmEdge::Host::WasiSockBindV1 WasiSockBind(Env);
-  WasmEdge::Host::WasiSockGetLocalAddrV1 WasiSockGetLocalAddr(Env);
+  WasmEdge::Host::WasiSockOpenV2 WasiSockOpen(Env);
+  WasmEdge::Host::WasiSockBindV2 WasiSockBind(Env);
+  WasmEdge::Host::WasiSockGetLocalAddrV2 WasiSockGetLocalAddr(Env);
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
@@ -1043,7 +1240,7 @@ TEST(WasiSockTest, GetAddrinfo) {
   auto &MemInst = *MemInstPtr;
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
 
-  WasmEdge::Host::WasiSockGetAddrinfoV1 WasiGetAddrinfo(Env);
+  WasmEdge::Host::WasiSockGetAddrinfo WasiGetAddrinfo(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
 

--- a/test/host/wasi/wasi.cpp
+++ b/test/host/wasi/wasi.cpp
@@ -588,7 +588,7 @@ TEST(WasiTest, ClockRes) {
   Env.fini();
 }
 
-TEST(WasiTest, PollOneoffSocket) {
+TEST(WasiTest, PollOneoffSocketV1) {
   enum class ServerAction {
     None,
     Stop,
@@ -601,7 +601,7 @@ TEST(WasiTest, PollOneoffSocket) {
   std::mutex Mutex;
   std::condition_variable ActionRequested;
   std::condition_variable ActionProcessed;
-  const std::array<uint8_t, 128> Address{1, 0, 127, 0, 0, 1};
+  const std::array<uint8_t, 4> Address{127, 0, 0, 1};
   const uint32_t Port = 18000;
 
   std::thread Server([&]() {
@@ -623,7 +623,7 @@ TEST(WasiTest, PollOneoffSocket) {
     WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
     WasmEdge::Host::WasiSockRecvV1 WasiSockRecv(Env);
     WasmEdge::Host::WasiSockSendV1 WasiSockSend(Env);
-    WasmEdge::Host::WasiSockSetOptV1 WasiSockSetOpt(Env);
+    WasmEdge::Host::WasiSockSetOpt WasiSockSetOpt(Env);
 
     std::array<WasmEdge::ValVariant, 1> Errno;
     const uint32_t FdPtr = 0;
@@ -699,11 +699,10 @@ TEST(WasiTest, PollOneoffSocket) {
         EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
 
         // accept port
-        EXPECT_TRUE(
-            WasiSockAccept.run(CallFrame,
-                               std::initializer_list<WasmEdge::ValVariant>{
-                                   ServerFd, UINT32_C(0), FdPtr},
-                               Errno));
+        EXPECT_TRUE(WasiSockAccept.run(
+            CallFrame,
+            std::initializer_list<WasmEdge::ValVariant>{ServerFd, FdPtr},
+            Errno));
         EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
         EXPECT_TRUE((MemInst.loadValue(ConnectionFd, FdPtr)));
 
@@ -1203,8 +1202,7 @@ TEST(WasiTest, PollOneoffSocket) {
   Server.join();
 }
 
-#if WASMEDGE_OS_LINUX
-TEST(WasiTest, EpollOneoffSocket) {
+TEST(WasiTest, PollOneoffSocketV2) {
   enum class ServerAction {
     None,
     Stop,
@@ -1217,7 +1215,7 @@ TEST(WasiTest, EpollOneoffSocket) {
   std::mutex Mutex;
   std::condition_variable ActionRequested;
   std::condition_variable ActionProcessed;
-  const std::array<uint8_t, 4> Address{127, 0, 0, 1};
+  const std::array<uint8_t, 128> Address{1, 0, 127, 0, 0, 1};
   const uint32_t Port = 18000;
 
   std::thread Server([&]() {
@@ -1233,13 +1231,13 @@ TEST(WasiTest, EpollOneoffSocket) {
 
     WasmEdge::Host::WasiFdClose WasiFdClose(Env);
     WasmEdge::Host::WasiFdFdstatSetFlags WasiFdFdstatSetFlags(Env);
-    WasmEdge::Host::WasiSockAcceptV1 WasiSockAccept(Env);
-    WasmEdge::Host::WasiSockBindV1 WasiSockBind(Env);
-    WasmEdge::Host::WasiSockListenV1 WasiSockListen(Env);
-    WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
-    WasmEdge::Host::WasiSockRecvV1 WasiSockRecv(Env);
-    WasmEdge::Host::WasiSockSendV1 WasiSockSend(Env);
-    WasmEdge::Host::WasiSockSetOptV1 WasiSockSetOpt(Env);
+    WasmEdge::Host::WasiSockAcceptV2 WasiSockAccept(Env);
+    WasmEdge::Host::WasiSockBindV2 WasiSockBind(Env);
+    WasmEdge::Host::WasiSockListenV2 WasiSockListen(Env);
+    WasmEdge::Host::WasiSockOpenV2 WasiSockOpen(Env);
+    WasmEdge::Host::WasiSockRecvV2 WasiSockRecv(Env);
+    WasmEdge::Host::WasiSockSendV2 WasiSockSend(Env);
+    WasmEdge::Host::WasiSockSetOpt WasiSockSetOpt(Env);
 
     std::array<WasmEdge::ValVariant, 1> Errno;
     const uint32_t FdPtr = 0;
@@ -1320,6 +1318,621 @@ TEST(WasiTest, EpollOneoffSocket) {
                                std::initializer_list<WasmEdge::ValVariant>{
                                    ServerFd, UINT32_C(0), FdPtr},
                                Errno));
+        EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+        EXPECT_TRUE((MemInst.loadValue(ConnectionFd, FdPtr)));
+
+        // close socket
+        EXPECT_TRUE(WasiFdClose.run(
+            CallFrame, std::initializer_list<WasmEdge::ValVariant>{ServerFd},
+            Errno));
+        EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+
+        // set nonblock flag
+        EXPECT_TRUE(WasiFdFdstatSetFlags.run(
+            CallFrame,
+            std::initializer_list<WasmEdge::ValVariant>{
+                ConnectionFd, static_cast<uint32_t>(__WASI_FDFLAGS_NONBLOCK)},
+            Errno));
+        EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+
+        continue;
+      }
+      case ServerAction::Send: {
+        const uint32_t IOVecSize = 1;
+        const uint32_t NWrittenPtr = 0;
+        const uint32_t IOVecPtr = NWrittenPtr + sizeof(__wasi_size_t);
+        const uint32_t DataPtr = IOVecPtr + sizeof(__wasi_ciovec_t) * IOVecSize;
+        const uint32_t SiFlags = 0;
+        const auto Data = "server"sv;
+        writeString(MemInst, Data, DataPtr);
+        auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
+            IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+        IOVec[0].buf = DataPtr;
+        IOVec[0].buf_len = Data.size();
+        EXPECT_TRUE(WasiSockSend.run(
+            CallFrame,
+            std::initializer_list<WasmEdge::ValVariant>{
+                ConnectionFd, IOVecPtr, IOVecSize, SiFlags, NWrittenPtr},
+            Errno));
+        EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+        __wasi_size_t NWritten;
+        EXPECT_TRUE((MemInst.loadValue(NWritten, NWrittenPtr)));
+        EXPECT_EQ(NWritten, Data.size());
+
+        ActionDone.store(true);
+        ActionProcessed.notify_one();
+        continue;
+      }
+      case ServerAction::Recv: {
+        // read data until buffer empty
+        while (true) {
+          const uint32_t IOVecSize = 1;
+          const uint32_t NReadPtr = 0;
+          const uint32_t RoFlagsPtr = NReadPtr + sizeof(__wasi_size_t);
+          const uint32_t IOVecPtr = RoFlagsPtr + sizeof(__wasi_size_t);
+          const uint32_t DataPtr =
+              IOVecPtr + sizeof(__wasi_iovec_t) * IOVecSize;
+          const uint32_t RiFlags = 0;
+          auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
+              IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+          IOVec[0].buf = DataPtr;
+          IOVec[0].buf_len = 32768;
+          EXPECT_TRUE(
+              WasiSockRecv.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   ConnectionFd, IOVecPtr, IOVecSize, RiFlags,
+                                   NReadPtr, RoFlagsPtr},
+                               Errno));
+          if (Errno[0].get<int32_t>() != __WASI_ERRNO_SUCCESS) {
+            EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_AGAIN);
+            break;
+          }
+        }
+
+        ActionDone.store(true);
+        ActionProcessed.notify_one();
+        continue;
+      }
+      }
+    }
+  });
+
+  WasmEdge::Host::WASI::Environ Env;
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_TRUE(MemInstPtr != nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+
+  WasmEdge::Host::WasiFdClose WasiFdClose(Env);
+  WasmEdge::Host::WasiFdFdstatSetFlags WasiFdFdstatSetFlags(Env);
+  WasmEdge::Host::WasiPollOneoff WasiPollOneoff(Env);
+  WasmEdge::Host::WasiSockConnectV2 WasiSockConnect(Env);
+  WasmEdge::Host::WasiSockOpenV2 WasiSockOpen(Env);
+  WasmEdge::Host::WasiSockRecvV2 WasiSockRecv(Env);
+  WasmEdge::Host::WasiSockSendV2 WasiSockSend(Env);
+
+  std::array<WasmEdge::ValVariant, 1> Errno;
+  const uint32_t FdPtr = 0;
+  const uint32_t AddressPtr = 4;
+
+  {
+    Env.init({}, "test"s, {}, {});
+
+    // open socket
+    EXPECT_TRUE(WasiSockOpen.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            static_cast<uint32_t>(__WASI_ADDRESS_FAMILY_INET4),
+            static_cast<uint32_t>(__WASI_SOCK_TYPE_SOCK_STREAM), FdPtr},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    int32_t Fd;
+    EXPECT_TRUE((MemInst.loadValue(Fd, FdPtr)));
+
+    {
+      std::unique_lock<std::mutex> Lock(Mutex);
+      ActionProcessed.wait(Lock, [&]() { return ActionDone.exchange(false); });
+    }
+
+    // connect server
+    writeAddress(MemInst, Address, AddressPtr);
+    EXPECT_TRUE(WasiSockConnect.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{Fd, AddressPtr, Port},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+
+    auto PollReadTimeout = [&]() {
+      const uint32_t Count = 2;
+      const uint32_t NEventsPtr = 0;
+      const uint32_t InPtr = NEventsPtr + sizeof(__wasi_size_t);
+      const uint32_t OutPtr = InPtr + sizeof(__wasi_subscription_t) * Count;
+      auto Subscriptions = MemInst.getPointer<__wasi_subscription_t *>(InPtr);
+      Subscriptions[0].userdata = 0x1010101010101010;
+      Subscriptions[0].u.tag = __WASI_EVENTTYPE_FD_READ;
+      Subscriptions[0].u.u.fd_read.file_descriptor = Fd;
+      Subscriptions[1].userdata = 0x2020202020202020;
+      Subscriptions[1].u.tag = __WASI_EVENTTYPE_CLOCK;
+      Subscriptions[1].u.u.clock.id = __WASI_CLOCKID_MONOTONIC;
+      Subscriptions[1].u.u.clock.timeout =
+          std::chrono::nanoseconds(std::chrono::milliseconds(100)).count();
+      Subscriptions[1].u.u.clock.precision = 1;
+      Subscriptions[1].u.u.clock.flags = static_cast<__wasi_subclockflags_t>(0);
+      EXPECT_TRUE(
+          WasiPollOneoff.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 InPtr, OutPtr, Count, NEventsPtr},
+                             Errno));
+      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+      __wasi_size_t NEvents;
+      EXPECT_TRUE((MemInst.loadValue(NEvents, NEventsPtr)));
+      EXPECT_EQ(NEvents, 1);
+      auto Events = MemInst.getPointer<__wasi_event_t *>(OutPtr);
+      EXPECT_EQ(Events[0].type, __WASI_EVENTTYPE_CLOCK);
+      EXPECT_EQ(Events[0].userdata, 0x2020202020202020);
+    };
+    auto PollRead = [&]() {
+      const uint32_t Count = 2;
+      const uint32_t NEventsPtr = 0;
+      const uint32_t InPtr = NEventsPtr + sizeof(__wasi_size_t);
+      const uint32_t OutPtr = InPtr + sizeof(__wasi_subscription_t) * Count;
+      auto Subscriptions = MemInst.getPointer<__wasi_subscription_t *>(InPtr);
+      Subscriptions[0].userdata = 0x1010101010101010;
+      Subscriptions[0].u.tag = __WASI_EVENTTYPE_FD_READ;
+      Subscriptions[0].u.u.fd_read.file_descriptor = Fd;
+      Subscriptions[1].userdata = 0x2020202020202020;
+      Subscriptions[1].u.tag = __WASI_EVENTTYPE_CLOCK;
+      Subscriptions[1].u.u.clock.id = __WASI_CLOCKID_MONOTONIC;
+      Subscriptions[1].u.u.clock.timeout =
+          std::chrono::nanoseconds(std::chrono::milliseconds(100)).count();
+      Subscriptions[1].u.u.clock.precision = 1;
+      Subscriptions[1].u.u.clock.flags = static_cast<__wasi_subclockflags_t>(0);
+      EXPECT_TRUE(
+          WasiPollOneoff.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 InPtr, OutPtr, Count, NEventsPtr},
+                             Errno));
+      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+      __wasi_size_t NEvents;
+      EXPECT_TRUE((MemInst.loadValue(NEvents, NEventsPtr)));
+      EXPECT_EQ(NEvents, 1);
+      auto Events = MemInst.getPointer<__wasi_event_t *>(OutPtr);
+      EXPECT_EQ(Events[0].type, __WASI_EVENTTYPE_FD_READ);
+      EXPECT_EQ(Events[0].userdata, 0x1010101010101010);
+      EXPECT_EQ(Events[0].fd_readwrite.flags, 0);
+    };
+    auto PollWriteTimeout = [&]() {
+      const uint32_t Count = 2;
+      const uint32_t NEventsPtr = 0;
+      const uint32_t InPtr = NEventsPtr + sizeof(__wasi_size_t);
+      const uint32_t OutPtr = InPtr + sizeof(__wasi_subscription_t) * Count;
+      auto Subscriptions = MemInst.getPointer<__wasi_subscription_t *>(InPtr);
+      Subscriptions[0].userdata = 0x1010101010101010;
+      Subscriptions[0].u.tag = __WASI_EVENTTYPE_FD_WRITE;
+      Subscriptions[0].u.u.fd_write.file_descriptor = Fd;
+      Subscriptions[1].userdata = 0x2020202020202020;
+      Subscriptions[1].u.tag = __WASI_EVENTTYPE_CLOCK;
+      Subscriptions[1].u.u.clock.id = __WASI_CLOCKID_MONOTONIC;
+      Subscriptions[1].u.u.clock.timeout =
+          std::chrono::nanoseconds(std::chrono::milliseconds(100)).count();
+      Subscriptions[1].u.u.clock.precision = 1;
+      Subscriptions[1].u.u.clock.flags = static_cast<__wasi_subclockflags_t>(0);
+      EXPECT_TRUE(
+          WasiPollOneoff.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 InPtr, OutPtr, Count, NEventsPtr},
+                             Errno));
+      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+      __wasi_size_t NEvents;
+      EXPECT_TRUE((MemInst.loadValue(NEvents, NEventsPtr)));
+      EXPECT_EQ(NEvents, 1);
+      auto Events = MemInst.getPointer<__wasi_event_t *>(OutPtr);
+      EXPECT_EQ(Events[0].type, __WASI_EVENTTYPE_CLOCK);
+      EXPECT_EQ(Events[0].userdata, 0x2020202020202020);
+    };
+    auto PollWrite = [&]() {
+      const uint32_t Count = 2;
+      const uint32_t NEventsPtr = 0;
+      const uint32_t InPtr = NEventsPtr + sizeof(__wasi_size_t);
+      const uint32_t OutPtr = InPtr + sizeof(__wasi_subscription_t) * Count;
+      auto Subscriptions = MemInst.getPointer<__wasi_subscription_t *>(InPtr);
+      Subscriptions[0].userdata = 0x1010101010101010;
+      Subscriptions[0].u.tag = __WASI_EVENTTYPE_FD_WRITE;
+      Subscriptions[0].u.u.fd_write.file_descriptor = Fd;
+      Subscriptions[1].userdata = 0x2020202020202020;
+      Subscriptions[1].u.tag = __WASI_EVENTTYPE_CLOCK;
+      Subscriptions[1].u.u.clock.id = __WASI_CLOCKID_MONOTONIC;
+      Subscriptions[1].u.u.clock.timeout =
+          std::chrono::nanoseconds(std::chrono::milliseconds(100)).count();
+      Subscriptions[1].u.u.clock.precision = 1;
+      Subscriptions[1].u.u.clock.flags = static_cast<__wasi_subclockflags_t>(0);
+      EXPECT_TRUE(
+          WasiPollOneoff.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 InPtr, OutPtr, Count, NEventsPtr},
+                             Errno));
+      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+      __wasi_size_t NEvents;
+      EXPECT_TRUE(MemInst.loadValue(NEvents, NEventsPtr));
+      EXPECT_EQ(NEvents, 1);
+      auto Events = MemInst.getPointer<__wasi_event_t *>(OutPtr);
+      EXPECT_EQ(Events[0].type, __WASI_EVENTTYPE_FD_WRITE);
+      EXPECT_EQ(Events[0].userdata, 0x1010101010101010);
+    };
+    auto PollReadWriteTimeout = [&]() {
+      const uint32_t Count = 3;
+      const uint32_t NEventsPtr = 0;
+      const uint32_t InPtr = NEventsPtr + sizeof(__wasi_size_t);
+      const uint32_t OutPtr = InPtr + sizeof(__wasi_subscription_t) * Count;
+      auto Subscriptions = MemInst.getPointer<__wasi_subscription_t *>(InPtr);
+      Subscriptions[0].userdata = 0x1010101010101010;
+      Subscriptions[0].u.tag = __WASI_EVENTTYPE_FD_READ;
+      Subscriptions[0].u.u.fd_read.file_descriptor = Fd;
+      Subscriptions[1].userdata = 0x2020202020202020;
+      Subscriptions[1].u.tag = __WASI_EVENTTYPE_FD_WRITE;
+      Subscriptions[1].u.u.fd_write.file_descriptor = Fd;
+      Subscriptions[2].userdata = 0x3030303030303030;
+      Subscriptions[2].u.tag = __WASI_EVENTTYPE_CLOCK;
+      Subscriptions[2].u.u.clock.id = __WASI_CLOCKID_MONOTONIC;
+      Subscriptions[2].u.u.clock.timeout =
+          std::chrono::nanoseconds(std::chrono::milliseconds(100)).count();
+      Subscriptions[2].u.u.clock.precision = 1;
+      Subscriptions[2].u.u.clock.flags = static_cast<__wasi_subclockflags_t>(0);
+      EXPECT_TRUE(
+          WasiPollOneoff.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 InPtr, OutPtr, Count, NEventsPtr},
+                             Errno));
+      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+      __wasi_size_t NEvents;
+      EXPECT_TRUE(MemInst.loadValue(NEvents, NEventsPtr));
+      EXPECT_EQ(NEvents, 1);
+      auto Events = MemInst.getPointer<__wasi_event_t *>(OutPtr);
+      EXPECT_EQ(Events[0].type, __WASI_EVENTTYPE_CLOCK);
+      EXPECT_EQ(Events[0].userdata, 0x3030303030303030);
+    };
+    auto PollReadWriteWrite = [&]() {
+      const uint32_t Count = 3;
+      const uint32_t NEventsPtr = 0;
+      const uint32_t InPtr = NEventsPtr + sizeof(__wasi_size_t);
+      const uint32_t OutPtr = InPtr + sizeof(__wasi_subscription_t) * Count;
+      auto Subscriptions = MemInst.getPointer<__wasi_subscription_t *>(InPtr);
+      Subscriptions[0].userdata = 0x1010101010101010;
+      Subscriptions[0].u.tag = __WASI_EVENTTYPE_FD_READ;
+      Subscriptions[0].u.u.fd_read.file_descriptor = Fd;
+      Subscriptions[1].userdata = 0x2020202020202020;
+      Subscriptions[1].u.tag = __WASI_EVENTTYPE_FD_WRITE;
+      Subscriptions[1].u.u.fd_write.file_descriptor = Fd;
+      Subscriptions[2].userdata = 0x3030303030303030;
+      Subscriptions[2].u.tag = __WASI_EVENTTYPE_CLOCK;
+      Subscriptions[2].u.u.clock.id = __WASI_CLOCKID_MONOTONIC;
+      Subscriptions[2].u.u.clock.timeout =
+          std::chrono::nanoseconds(std::chrono::milliseconds(100)).count();
+      Subscriptions[2].u.u.clock.precision = 1;
+      Subscriptions[2].u.u.clock.flags = static_cast<__wasi_subclockflags_t>(0);
+      EXPECT_TRUE(
+          WasiPollOneoff.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 InPtr, OutPtr, Count, NEventsPtr},
+                             Errno));
+      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+      __wasi_size_t NEvents;
+      EXPECT_TRUE(MemInst.loadValue(NEvents, NEventsPtr));
+      EXPECT_EQ(NEvents, 1);
+      auto Events = MemInst.getPointer<__wasi_event_t *>(OutPtr);
+      EXPECT_EQ(Events[0].type, __WASI_EVENTTYPE_FD_WRITE);
+      EXPECT_EQ(Events[0].userdata, 0x2020202020202020);
+    };
+    auto PollReadWriteReadWrite = [&]() {
+      const uint32_t Count = 3;
+      const uint32_t NEventsPtr = 0;
+      const uint32_t InPtr = NEventsPtr + sizeof(__wasi_size_t);
+      const uint32_t OutPtr = InPtr + sizeof(__wasi_subscription_t) * Count;
+      auto Subscriptions = MemInst.getPointer<__wasi_subscription_t *>(InPtr);
+      Subscriptions[0].userdata = 0x1010101010101010;
+      Subscriptions[0].u.tag = __WASI_EVENTTYPE_FD_READ;
+      Subscriptions[0].u.u.fd_read.file_descriptor = Fd;
+      Subscriptions[1].userdata = 0x2020202020202020;
+      Subscriptions[1].u.tag = __WASI_EVENTTYPE_FD_WRITE;
+      Subscriptions[1].u.u.fd_write.file_descriptor = Fd;
+      Subscriptions[2].userdata = 0x3030303030303030;
+      Subscriptions[2].u.tag = __WASI_EVENTTYPE_CLOCK;
+      Subscriptions[2].u.u.clock.id = __WASI_CLOCKID_MONOTONIC;
+      Subscriptions[2].u.u.clock.timeout =
+          std::chrono::nanoseconds(std::chrono::milliseconds(100)).count();
+      Subscriptions[2].u.u.clock.precision = 1;
+      Subscriptions[2].u.u.clock.flags = static_cast<__wasi_subclockflags_t>(0);
+      EXPECT_TRUE(
+          WasiPollOneoff.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 InPtr, OutPtr, Count, NEventsPtr},
+                             Errno));
+      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+      __wasi_size_t NEvents;
+      EXPECT_TRUE(MemInst.loadValue(NEvents, NEventsPtr));
+      EXPECT_EQ(NEvents, 2);
+      auto Events = MemInst.getPointer<__wasi_event_t *>(OutPtr);
+      EXPECT_EQ(Events[0].type, __WASI_EVENTTYPE_FD_READ);
+      EXPECT_EQ(Events[0].userdata, 0x1010101010101010);
+      EXPECT_EQ(Events[1].type, __WASI_EVENTTYPE_FD_WRITE);
+      EXPECT_EQ(Events[1].userdata, 0x2020202020202020);
+    };
+
+    // poll read and 100 milliseconds, expect timeout
+    PollReadTimeout();
+
+    // request server to send data
+    Action.store(ServerAction::Send);
+    ActionRequested.notify_one();
+    {
+      std::unique_lock<std::mutex> Lock(Mutex);
+      ActionProcessed.wait(Lock, [&]() { return ActionDone.exchange(false); });
+    }
+
+    // poll read and 100 milliseconds, expect read event
+    PollRead();
+
+    // read data
+    {
+      const uint32_t IOVecSize = 1;
+      const uint32_t NReadPtr = 0;
+      const uint32_t RoFlagsPtr = NReadPtr + sizeof(__wasi_size_t);
+      const uint32_t IOVecPtr = RoFlagsPtr + sizeof(__wasi_size_t);
+      const uint32_t DataPtr = IOVecPtr + sizeof(__wasi_iovec_t) * IOVecSize;
+      const uint32_t RiFlags = 0;
+      auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
+          IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+      IOVec[0].buf = DataPtr;
+      IOVec[0].buf_len = 256;
+      EXPECT_TRUE(WasiSockRecv.run(
+          CallFrame,
+          std::initializer_list<WasmEdge::ValVariant>{
+              Fd, IOVecPtr, IOVecSize, RiFlags, NReadPtr, RoFlagsPtr},
+          Errno));
+      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+      __wasi_size_t NRead;
+      EXPECT_TRUE(MemInst.loadValue(NRead, NReadPtr));
+      EXPECT_EQ(NRead, "server"sv.size());
+    }
+
+    // poll read and 100 milliseconds, expect timeout
+    PollReadTimeout();
+
+    // set nonblock flag
+    EXPECT_TRUE(WasiFdFdstatSetFlags.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            Fd, static_cast<uint32_t>(__WASI_FDFLAGS_NONBLOCK)},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+
+    // write data until buffer full
+    while (true) {
+      const uint32_t IOVecSize = 1;
+      const uint32_t NWrittenPtr = 0;
+      const uint32_t RoFlagsPtr = NWrittenPtr + sizeof(__wasi_size_t);
+      const uint32_t IOVecPtr = RoFlagsPtr + sizeof(__wasi_size_t);
+      const uint32_t DataPtr = IOVecPtr + sizeof(__wasi_iovec_t) * IOVecSize;
+      const uint32_t SiFlags = 0;
+      const auto Data = "somedata"sv;
+      writeString(MemInst, Data, DataPtr);
+      auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
+          IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+      IOVec[0].buf = DataPtr;
+      IOVec[0].buf_len = Data.size();
+      EXPECT_TRUE(
+          WasiSockSend.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               Fd, IOVecPtr, IOVecSize, SiFlags, NWrittenPtr},
+                           Errno));
+      if (Errno[0].get<int32_t>() != __WASI_ERRNO_SUCCESS) {
+        EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_AGAIN);
+        break;
+      }
+    }
+
+    // poll write and 100 milliseconds, expect timeout
+    PollWriteTimeout();
+
+    // request server to recv data
+    Action.store(ServerAction::Recv);
+    ActionRequested.notify_one();
+    {
+      std::unique_lock<std::mutex> Lock(Mutex);
+      ActionProcessed.wait(Lock, [&]() { return ActionDone.exchange(false); });
+    }
+
+    // poll write and 100 milliseconds, expect write
+    PollWrite();
+
+    // write data until buffer full
+    while (true) {
+      const uint32_t IOVecSize = 1;
+      const uint32_t NWrittenPtr = 0;
+      const uint32_t RoFlagsPtr = NWrittenPtr + sizeof(__wasi_size_t);
+      const uint32_t IOVecPtr = RoFlagsPtr + sizeof(__wasi_size_t);
+      const uint32_t DataPtr = IOVecPtr + sizeof(__wasi_iovec_t) * IOVecSize;
+      const uint32_t SiFlags = 0;
+      const auto Data = "somedata"sv;
+      writeString(MemInst, Data, DataPtr);
+      auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
+          IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+      IOVec[0].buf = DataPtr;
+      IOVec[0].buf_len = Data.size();
+      EXPECT_TRUE(
+          WasiSockSend.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               Fd, IOVecPtr, IOVecSize, SiFlags, NWrittenPtr},
+                           Errno));
+      if (Errno[0].get<int32_t>() != __WASI_ERRNO_SUCCESS) {
+        EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_AGAIN);
+        break;
+      }
+    }
+
+    // poll read, write and 100 milliseconds, expect timeout
+    PollReadWriteTimeout();
+
+    // request server to recv data
+    Action.store(ServerAction::Recv);
+    ActionRequested.notify_one();
+    {
+      std::unique_lock<std::mutex> Lock(Mutex);
+      ActionProcessed.wait(Lock, [&]() { return ActionDone.exchange(false); });
+    }
+
+    // poll read, write and 100 milliseconds, expect write
+    PollReadWriteWrite();
+
+    // request server to send data
+    Action.store(ServerAction::Send);
+    ActionRequested.notify_one();
+    {
+      std::unique_lock<std::mutex> Lock(Mutex);
+      ActionProcessed.wait(Lock, [&]() { return ActionDone.exchange(false); });
+    }
+
+    // The following code includes a sleep to prevent a possible delay when
+    // sending and recving data. There is a chance that PollOneoff may not
+    // immediately get the read event when it is called right after the server
+    // has sent the data. Without the sleep, there is a risk that the unit test
+    // may not pass. We found this problem on macOS.
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    // poll read, write and 100 milliseconds, expect read and write
+    PollReadWriteReadWrite();
+
+    // close socket
+    EXPECT_TRUE(WasiFdClose.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{Fd}, Errno));
+    Env.fini();
+  }
+
+  Action.store(ServerAction::Stop);
+  ActionRequested.notify_one();
+  Server.join();
+}
+
+#if WASMEDGE_OS_LINUX
+TEST(WasiTest, EpollOneoffSocketV1) {
+  enum class ServerAction {
+    None,
+    Stop,
+    Start,
+    Send,
+    Recv,
+  };
+  std::atomic<ServerAction> Action(ServerAction::Start);
+  std::atomic_bool ActionDone(false);
+  std::mutex Mutex;
+  std::condition_variable ActionRequested;
+  std::condition_variable ActionProcessed;
+  const std::array<uint8_t, 4> Address{127, 0, 0, 1};
+  const uint32_t Port = 18000;
+
+  std::thread Server([&]() {
+    WasmEdge::Host::WASI::Environ Env;
+    WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+    Mod.addHostMemory(
+        "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                      WasmEdge::AST::MemoryType(1)));
+    auto *MemInstPtr = Mod.findMemoryExports("memory");
+    ASSERT_TRUE(MemInstPtr != nullptr);
+    auto &MemInst = *MemInstPtr;
+    WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+
+    WasmEdge::Host::WasiFdClose WasiFdClose(Env);
+    WasmEdge::Host::WasiFdFdstatSetFlags WasiFdFdstatSetFlags(Env);
+    WasmEdge::Host::WasiSockAcceptV1 WasiSockAccept(Env);
+    WasmEdge::Host::WasiSockBindV1 WasiSockBind(Env);
+    WasmEdge::Host::WasiSockListenV1 WasiSockListen(Env);
+    WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
+    WasmEdge::Host::WasiSockRecvV1 WasiSockRecv(Env);
+    WasmEdge::Host::WasiSockSendV1 WasiSockSend(Env);
+    WasmEdge::Host::WasiSockSetOpt WasiSockSetOpt(Env);
+
+    std::array<WasmEdge::ValVariant, 1> Errno;
+    const uint32_t FdPtr = 0;
+    const uint32_t AddressPtr = 4;
+    const int32_t Backlog = 1;
+    int32_t ConnectionFd = -1;
+
+    Env.init({}, "test"s, {}, {});
+    while (true) {
+      {
+        std::unique_lock<std::mutex> Lock(Mutex);
+        ActionRequested.wait(Lock,
+                             [&]() { return Action != ServerAction::None; });
+      }
+      switch (Action.exchange(ServerAction::None, std::memory_order_acquire)) {
+      case ServerAction::None: {
+        continue;
+      }
+      case ServerAction::Stop: {
+        // close socket
+        EXPECT_TRUE(WasiFdClose.run(
+            CallFrame,
+            std::initializer_list<WasmEdge::ValVariant>{ConnectionFd}, Errno));
+        EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+
+        Env.fini();
+        return;
+      }
+      case ServerAction::Start: {
+        int32_t ServerFd = -1;
+        // open socket
+        EXPECT_TRUE(WasiSockOpen.run(
+            CallFrame,
+            std::initializer_list<WasmEdge::ValVariant>{
+                static_cast<uint32_t>(__WASI_ADDRESS_FAMILY_INET4),
+                static_cast<uint32_t>(__WASI_SOCK_TYPE_SOCK_STREAM), FdPtr},
+            Errno));
+        EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+        EXPECT_TRUE((MemInst.loadValue(ServerFd, FdPtr)));
+
+        // set socket options
+        const uint32_t SockOptionsPtr = 0;
+        const uint32_t One = 1;
+        MemInst.storeValue(One, SockOptionsPtr);
+        EXPECT_TRUE(WasiSockSetOpt.run(
+            CallFrame,
+            std::initializer_list<WasmEdge::ValVariant>{
+                ServerFd,
+                static_cast<uint32_t>(__WASI_SOCK_OPT_LEVEL_SOL_SOCKET),
+                static_cast<uint32_t>(__WASI_SOCK_OPT_SO_REUSEADDR),
+                static_cast<uint32_t>(SockOptionsPtr),
+                static_cast<uint32_t>(sizeof(One))},
+            Errno));
+        EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+
+        // bind port
+        writeAddress(MemInst, Address, AddressPtr);
+        EXPECT_TRUE(
+            WasiSockBind.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 ServerFd, AddressPtr, Port},
+                             Errno));
+        EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+
+        ActionDone.store(true);
+        ActionProcessed.notify_one();
+
+        // listen port
+        EXPECT_TRUE(WasiSockListen.run(
+            CallFrame,
+            std::initializer_list<WasmEdge::ValVariant>{ServerFd, Backlog},
+            Errno));
+        EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+
+        // accept port
+        EXPECT_TRUE(WasiSockAccept.run(
+            CallFrame,
+            std::initializer_list<WasmEdge::ValVariant>{ServerFd, FdPtr},
+            Errno));
         EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
         EXPECT_TRUE((MemInst.loadValue(ConnectionFd, FdPtr)));
 

--- a/test/host/wasi/wasi.cpp
+++ b/test/host/wasi/wasi.cpp
@@ -617,13 +617,13 @@ TEST(WasiTest, PollOneoffSocket) {
 
     WasmEdge::Host::WasiFdClose WasiFdClose(Env);
     WasmEdge::Host::WasiFdFdstatSetFlags WasiFdFdstatSetFlags(Env);
-    WasmEdge::Host::WasiSockAccept WasiSockAccept(Env);
-    WasmEdge::Host::WasiSockBind WasiSockBind(Env);
-    WasmEdge::Host::WasiSockListen WasiSockListen(Env);
-    WasmEdge::Host::WasiSockOpen WasiSockOpen(Env);
-    WasmEdge::Host::WasiSockRecv WasiSockRecv(Env);
-    WasmEdge::Host::WasiSockSend WasiSockSend(Env);
-    WasmEdge::Host::WasiSockSetOpt WasiSockSetOpt(Env);
+    WasmEdge::Host::WasiSockAcceptV1 WasiSockAccept(Env);
+    WasmEdge::Host::WasiSockBindV1 WasiSockBind(Env);
+    WasmEdge::Host::WasiSockListenV1 WasiSockListen(Env);
+    WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
+    WasmEdge::Host::WasiSockRecvV1 WasiSockRecv(Env);
+    WasmEdge::Host::WasiSockSendV1 WasiSockSend(Env);
+    WasmEdge::Host::WasiSockSetOptV1 WasiSockSetOpt(Env);
 
     std::array<WasmEdge::ValVariant, 1> Errno;
     const uint32_t FdPtr = 0;
@@ -796,10 +796,10 @@ TEST(WasiTest, PollOneoffSocket) {
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
   WasmEdge::Host::WasiFdFdstatSetFlags WasiFdFdstatSetFlags(Env);
   WasmEdge::Host::WasiPollOneoff WasiPollOneoff(Env);
-  WasmEdge::Host::WasiSockConnect WasiSockConnect(Env);
-  WasmEdge::Host::WasiSockOpen WasiSockOpen(Env);
-  WasmEdge::Host::WasiSockRecv WasiSockRecv(Env);
-  WasmEdge::Host::WasiSockSend WasiSockSend(Env);
+  WasmEdge::Host::WasiSockConnectV1 WasiSockConnect(Env);
+  WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
+  WasmEdge::Host::WasiSockRecvV1 WasiSockRecv(Env);
+  WasmEdge::Host::WasiSockSendV1 WasiSockSend(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
   const uint32_t FdPtr = 0;
@@ -1233,13 +1233,13 @@ TEST(WasiTest, EpollOneoffSocket) {
 
     WasmEdge::Host::WasiFdClose WasiFdClose(Env);
     WasmEdge::Host::WasiFdFdstatSetFlags WasiFdFdstatSetFlags(Env);
-    WasmEdge::Host::WasiSockAccept WasiSockAccept(Env);
-    WasmEdge::Host::WasiSockBind WasiSockBind(Env);
-    WasmEdge::Host::WasiSockListen WasiSockListen(Env);
-    WasmEdge::Host::WasiSockOpen WasiSockOpen(Env);
-    WasmEdge::Host::WasiSockRecv WasiSockRecv(Env);
-    WasmEdge::Host::WasiSockSend WasiSockSend(Env);
-    WasmEdge::Host::WasiSockSetOpt WasiSockSetOpt(Env);
+    WasmEdge::Host::WasiSockAcceptV1 WasiSockAccept(Env);
+    WasmEdge::Host::WasiSockBindV1 WasiSockBind(Env);
+    WasmEdge::Host::WasiSockListenV1 WasiSockListen(Env);
+    WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
+    WasmEdge::Host::WasiSockRecvV1 WasiSockRecv(Env);
+    WasmEdge::Host::WasiSockSendV1 WasiSockSend(Env);
+    WasmEdge::Host::WasiSockSetOptV1 WasiSockSetOpt(Env);
 
     std::array<WasmEdge::ValVariant, 1> Errno;
     const uint32_t FdPtr = 0;
@@ -1412,10 +1412,10 @@ TEST(WasiTest, EpollOneoffSocket) {
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
   WasmEdge::Host::WasiFdFdstatSetFlags WasiFdFdstatSetFlags(Env);
   WasmEdge::Host::WasiEpollOneoff WasiEpollOneoff(Env);
-  WasmEdge::Host::WasiSockConnect WasiSockConnect(Env);
-  WasmEdge::Host::WasiSockOpen WasiSockOpen(Env);
-  WasmEdge::Host::WasiSockRecv WasiSockRecv(Env);
-  WasmEdge::Host::WasiSockSend WasiSockSend(Env);
+  WasmEdge::Host::WasiSockConnectV1 WasiSockConnect(Env);
+  WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
+  WasmEdge::Host::WasiSockRecvV1 WasiSockRecv(Env);
+  WasmEdge::Host::WasiSockSendV1 WasiSockSend(Env);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
   const uint32_t FdPtr = 0;


### PR DESCRIPTION
To make our previous WASI socket functions can be compatible with the WASI spec one and the new WasmEdge WASI socket functions, we use a whitelist mechanism to filter those functions that have the same name but with different function signatures. However, this may increase the maintenance cost, so we are going to deprecate it in a future version.

Please notice that this is a workaround, and this behavior is not allowed by the Wasm spec. This is a final PR before the 0.12 release. So we should make sure that CI is grean and everything is compatible when enabling this feature.