### PR TITLE
[Docs] Remove alpha.2 postfix and unreleased tag

### DIFF
--- a/.CurrentChangelog.md
+++ b/.CurrentChangelog.md
@@ -107,4 +107,4 @@ Thank all the contributors that made this release possible!
 
 Abhinandan Udupa, Achille, Afshan Ahmed Khan, Daniel Golding, DarumaDocker, Draco, Harry Chiang, Justin Echternach, Kenvi Zhu, LFsWang, Leonid Pospelov, Lîm Tsú-thuàn, MediosZ, O3Ol, Officeyutong, Puelloc, Rafael Fernández López, Shen-Ta Hsieh, Shreyas Atre, Sylveon, Tatsuyuki Kobayashi, Vishv Salvi, Xin Liu, Xiongsheng Wang, YiYing He, alabulei1, dm4, hydai, jeongkyu, little-willy, michael1017, shun murakami, xxchan, 云微
 
-If you want to build from source, please use WasmEdge-0.12.0-alpha.2-src.tar.gz instead of the zip or tarball provided by GitHub directly.
+If you want to build from source, please use WasmEdge-0.12.0-src.tar.gz instead of the zip or tarball provided by GitHub directly.

--- a/Changelog.md
+++ b/Changelog.md
@@ -107,7 +107,7 @@ Thank all the contributors that made this release possible!
 
 Abhinandan Udupa, Achille, Afshan Ahmed Khan, Daniel Golding, DarumaDocker, Draco, Harry Chiang, Justin Echternach, Kenvi Zhu, LFsWang, Leonid Pospelov, Lîm Tsú-thuàn, MediosZ, O3Ol, Officeyutong, Puelloc, Rafael Fernández López, Shen-Ta Hsieh, Shreyas Atre, Sylveon, Tatsuyuki Kobayashi, Vishv Salvi, Xin Liu, Xiongsheng Wang, YiYing He, alabulei1, dm4, hydai, jeongkyu, little-willy, michael1017, shun murakami, xxchan, 云微
 
-If you want to build from source, please use WasmEdge-0.12.0-alpha.2-src.tar.gz instead of the zip or tarball provided by GitHub directly.
+If you want to build from source, please use WasmEdge-0.12.0-src.tar.gz instead of the zip or tarball provided by GitHub directly.
 
 ### 0.11.2 (2022-11-03)
 

--- a/docs/book/en/src/sdk/c/ref.md
+++ b/docs/book/en/src/sdk/c/ref.md
@@ -1,4 +1,4 @@
-# WasmEdge C 0.12.0 API Documentation (Unreleased)
+# WasmEdge C 0.12.0 API Documentation
 
 [WasmEdge C API](https://github.com/WasmEdge/WasmEdge/blob/master/include/api/wasmedge/wasmedge.h) denotes an interface to access the WasmEdge runtime. The following are the guides to working with the C APIs of WasmEdge.
 

--- a/docs/book/en/src/sdk/go/ref.md
+++ b/docs/book/en/src/sdk/go/ref.md
@@ -1,4 +1,4 @@
-# WasmEdge Go v0.12.0 API references (Unreleased)
+# WasmEdge Go v0.12.0 API references
 
 The following are the guides to working with the WasmEdge-Go SDK.
 


### PR DESCRIPTION
Hi @q82419 
Once you merge this PR, please add a tag for the 0.12 release.