### PR TITLE
[BUG] fix rights of pre-open fd cannot write and fix readonly flag parse.

### DIFF
--- a/lib/host/wasi/environ.cpp
+++ b/lib/host/wasi/environ.cpp
@@ -32,7 +32,8 @@ static inline constexpr const __wasi_rights_t kPreOpenBaseRights =
     __WASI_RIGHTS_PATH_RENAME_TARGET | __WASI_RIGHTS_PATH_FILESTAT_GET |
     __WASI_RIGHTS_PATH_FILESTAT_SET_TIMES | __WASI_RIGHTS_FD_FILESTAT_GET |
     __WASI_RIGHTS_FD_FILESTAT_SET_TIMES | __WASI_RIGHTS_PATH_SYMLINK |
-    __WASI_RIGHTS_PATH_REMOVE_DIRECTORY | __WASI_RIGHTS_PATH_UNLINK_FILE;
+    __WASI_RIGHTS_PATH_REMOVE_DIRECTORY | __WASI_RIGHTS_PATH_UNLINK_FILE |
+    __WASI_RIGHTS_PATH_FILESTAT_SET_SIZE;
 static inline constexpr const __wasi_rights_t kPreOpenInheritingRights =
     __WASI_RIGHTS_FD_DATASYNC | __WASI_RIGHTS_FD_READ | __WASI_RIGHTS_FD_SEEK |
     __WASI_RIGHTS_FD_FDSTAT_SET_FLAGS | __WASI_RIGHTS_FD_SYNC |
@@ -76,9 +77,9 @@ void Environ::init(Span<const std::string> Dirs, std::string ProgramName,
       // Handle the readonly flag
       bool ReadOnly = false;
       if (const auto ROPos = HostDir.find(':'); ROPos != std::string::npos) {
+        const auto Mode = HostDir.substr(ROPos + 1);
         HostDir = HostDir.substr(0, ROPos);
-        std::string Mode = HostDir.substr(ROPos + 1);
-        if (kReadOnly == HostDir.substr(ROPos + 1)) {
+        if (kReadOnly == Mode) {
           ReadOnly = true;
         }
       }


### PR DESCRIPTION
## Bug fix 1

The user code in c:
```c
#include <stdio.h>
#include <assert.h>

int main() {
	const char *fname = "./1.c";

	FILE *read = fopen(fname, "r");
	assert(read != NULL);
	fclose(read);
	printf("Read pass\n");
	
	FILE *write = fopen(fname, "w");
	assert(write != NULL);
	fclose(write);
	printf("Write pass\n");
	
	return 0;
}
```

Compile to wasm and run with WasmEdge (0.12.0 release):
```console
$ /opt/wasi-sdk/bin/clang ./1.c    
$ WasmEdge-0.12.0-Linux/bin/wasmedge --dir .:. ./a.out
Read pass
Assertion failed: write != NULL (./1.c: main: 13)
[2023-05-01 20:32:33.227] [error] execution failed: unreachable, Code: 0x89
[2023-05-01 20:32:33.227] [error]     In instruction: unreachable (0x00) , Bytecode offset: 0x00000555
[2023-05-01 20:32:33.227] [error]     When executing function name: "_start"
```

I saw the source code and found that ```kPreOpenBaseRights``` miss ```__WASI_RIGHTS_PATH_FILESTAT_SET_SIZE```, so add it and the user code can run:
```console
$ wasmedge --dir .:.: ./a.out
Read pass
Write pass
```

## Bug fix 2

```console
$ WasmEdge-0.12.0-Linux/bin/wasmedge --dir .:.:readonly ./a.out
terminate called after throwing an instance of 'std::out_of_range'
  what():  basic_string::substr: __pos (which is 2) > this->size() (which is 1)
[1]    97192 IOT instruction (core dumped)  WasmEdge-0.12.0-Linux/bin/wasmedge --dir .:.:readonly ./a.out
```

The WasmEdge cannot parse ```readonly``` flag because the string is out of range:
```c++
// file: lib/host/wasi/environ.cpp
HostDir = HostDir.substr(0, ROPos);    // cut the string
std::string Mode = HostDir.substr(ROPos + 1);   // read after cut, out of range
```

