### PR TITLE
[Proposal] Add exception handling proposal on interpreter mode

### DIFF
--- a/include/api/wasmedge/wasmedge.h
+++ b/include/api/wasmedge/wasmedge.h
@@ -100,6 +100,9 @@ typedef struct WasmEdge_MemoryTypeContext WasmEdge_MemoryTypeContext;
 /// Opaque struct of WasmEdge table type.
 typedef struct WasmEdge_TableTypeContext WasmEdge_TableTypeContext;
 
+/// Opaque struct of WasmEdge tag type.
+typedef struct WasmEdge_TagTypeContext WasmEdge_TagTypeContext;
+
 /// Opaque struct of WasmEdge global type.
 typedef struct WasmEdge_GlobalTypeContext WasmEdge_GlobalTypeContext;
 
@@ -136,6 +139,9 @@ typedef struct WasmEdge_TableInstanceContext WasmEdge_TableInstanceContext;
 
 /// Opaque struct of WasmEdge memory instance.
 typedef struct WasmEdge_MemoryInstanceContext WasmEdge_MemoryInstanceContext;
+
+/// Opaque struct of WasmEdge tag instance.
+typedef struct WasmEdge_TagInstanceContext WasmEdge_TagInstanceContext;
 
 /// Opaque struct of WasmEdge global instance.
 typedef struct WasmEdge_GlobalInstanceContext WasmEdge_GlobalInstanceContext;
@@ -1177,6 +1183,18 @@ WasmEdge_MemoryTypeDelete(WasmEdge_MemoryTypeContext *Cxt);
 
 // <<<<<<<< WasmEdge memory type functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
+// >>>>>>>> WasmEdge tag type functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+/// Get the function type from a tag type.
+///
+/// \param Cxt the WasmEdge_TagTypeContext.
+///
+/// \returns pointer to function type context of the tag type, NULL if failed.
+WASMEDGE_CAPI_EXPORT extern const WasmEdge_FunctionTypeContext *
+WasmEdge_TagTypeGetFunctionType(const WasmEdge_TagTypeContext *Cxt);
+
+// <<<<<<<< WasmEdge tag type functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
 // >>>>>>>> WasmEdge global type functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 /// Creation of the WasmEdge_GlobalTypeContext.
@@ -1302,6 +1320,22 @@ WASMEDGE_CAPI_EXPORT extern const WasmEdge_MemoryTypeContext *
 WasmEdge_ImportTypeGetMemoryType(const WasmEdge_ASTModuleContext *ASTCxt,
                                  const WasmEdge_ImportTypeContext *Cxt);
 
+/// Get the external value (which is tag type) from an import type.
+///
+/// The import type context should be the one queried from the AST module
+/// context, or this function will cause unexpected error.
+/// The tag type context links to the tag type in the import type context
+/// and the AST module context.
+///
+/// \param ASTCxt the WasmEdge_ASTModuleContext.
+/// \param Cxt the WasmEdge_ImportTypeContext which queried from the `ASTCxt`.
+///
+/// \returns the tag type. NULL if failed or the external type of the import
+/// type is not `WasmEdge_ExternalType_TagType`.
+WASMEDGE_CAPI_EXPORT extern const WasmEdge_TagTypeContext *
+WasmEdge_ImportTypeGetTagType(const WasmEdge_ASTModuleContext *ASTCxt,
+                              const WasmEdge_ImportTypeContext *Cxt);
+
 /// Get the external value (which is global type) from an import type.
 ///
 /// The import type context should be the one queried from the AST module
@@ -1392,6 +1426,22 @@ WasmEdge_ExportTypeGetTableType(const WasmEdge_ASTModuleContext *ASTCxt,
 WASMEDGE_CAPI_EXPORT extern const WasmEdge_MemoryTypeContext *
 WasmEdge_ExportTypeGetMemoryType(const WasmEdge_ASTModuleContext *ASTCxt,
                                  const WasmEdge_ExportTypeContext *Cxt);
+
+/// Get the external value (which is tag type) from an export type.
+///
+/// The export type context should be the one queried from the AST module
+/// context, or this function will cause unexpected error.
+/// The tag type context links to the tag type in the export type context
+/// and the AST module context.
+///
+/// \param ASTCxt the WasmEdge_ASTModuleContext.
+/// \param Cxt the WasmEdge_ExportTypeContext which queried from the `ASTCxt`.
+///
+/// \returns the tag type. NULL if failed or the external type of the export
+/// type is not `WasmEdge_ExternalType_Tag`.
+WASMEDGE_CAPI_EXPORT extern const WasmEdge_TagTypeContext *
+WasmEdge_ExportTypeGetTagType(const WasmEdge_ASTModuleContext *ASTCxt,
+                              const WasmEdge_ExportTypeContext *Cxt);
 
 /// Get the external value (which is global type) from an export type.
 ///
@@ -1789,7 +1839,7 @@ WasmEdge_StoreDelete(WasmEdge_StoreContext *Cxt);
 ///
 /// Create a module instance context with exported module name for host
 /// instances. Developer can use this API to create a module instance for
-/// collecting host functions, tables, memories, and globals.
+/// collecting host functions, tables, memories, tags, and globals.
 /// The caller owns the object and should call `WasmEdge_ModuleInstanceDelete`
 /// to destroy it.
 ///
@@ -1985,6 +2035,21 @@ WASMEDGE_CAPI_EXPORT extern WasmEdge_MemoryInstanceContext *
 WasmEdge_ModuleInstanceFindMemory(const WasmEdge_ModuleInstanceContext *Cxt,
                                   const WasmEdge_String Name);
 
+/// Get the exported tag instance context of a module instance.
+///
+/// The result tag instance context links to the tag instance in the
+/// module instance context and owned by the module instance context.
+///
+/// This function is thread-safe.
+///
+/// \param Cxt the WasmEdge_ModuleInstanceContext.
+/// \param Name the tag name WasmEdge_String.
+///
+/// \returns pointer to the tag instance context. NULL if not found.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_TagInstanceContext *
+WasmEdge_ModuleInstanceFindTag(const WasmEdge_ModuleInstanceContext *Cxt,
+                                  const WasmEdge_String Name);
+
 /// Get the exported global instance context of a module instance.
 ///
 /// The result global instance context links to the global instance in the
@@ -2086,6 +2151,35 @@ WASMEDGE_CAPI_EXPORT extern uint32_t WasmEdge_ModuleInstanceListMemoryLength(
 /// \returns actual exported memory list size.
 WASMEDGE_CAPI_EXPORT extern uint32_t
 WasmEdge_ModuleInstanceListMemory(const WasmEdge_ModuleInstanceContext *Cxt,
+                                  WasmEdge_String *Names, const uint32_t Len);
+
+/// Get the length of exported tag list of a module instance.
+///
+/// This function is thread-safe.
+///
+/// \param Cxt the WasmEdge_ModuleInstanceContext.
+///
+/// \returns length of the exported tag list.
+WASMEDGE_CAPI_EXPORT extern uint32_t WasmEdge_ModuleInstanceListTagLength(
+    const WasmEdge_ModuleInstanceContext *Cxt);
+
+/// List the exported tag names of a module instance.
+///
+/// The returned tag names filled into the `Names` array are linked to the
+/// exported names of tags of the module instance context, and the caller
+/// should __NOT__ call the `WasmEdge_StringDelete`.
+/// If the `Names` buffer length is smaller than the result of the exported
+/// tag list size, the overflowed return values will be discarded.
+///
+/// This function is thread-safe.
+///
+/// \param Cxt the WasmEdge_ModuleInstanceContext.
+/// \param [out] Names the output WasmEdge_String buffer of the tag names.
+/// \param Len the buffer length.
+///
+/// \returns actual exported tag list size.
+WASMEDGE_CAPI_EXPORT extern uint32_t
+WasmEdge_ModuleInstanceListTag(const WasmEdge_ModuleInstanceContext *Cxt,
                                   WasmEdge_String *Names, const uint32_t Len);
 
 /// Get the length of exported global list of a module instance.
@@ -2555,6 +2649,21 @@ WASMEDGE_CAPI_EXPORT extern void
 WasmEdge_MemoryInstanceDelete(WasmEdge_MemoryInstanceContext *Cxt);
 
 // <<<<<<<< WasmEdge memory instance functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>> WasmEdge tag instance functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+/// Get the tag type context from a tag instance.
+///
+/// The tag type context links to the tag type in the tag instance
+/// context and owned by the context.
+///
+/// \param Cxt the WasmEdge_TagInstanceContext.
+///
+/// \returns pointer to context, NULL if failed.
+WASMEDGE_CAPI_EXPORT extern const WasmEdge_TagTypeContext *
+WasmEdge_TagInstanceGetTagType(const WasmEdge_TagInstanceContext *Cxt);
+
+// <<<<<<<< WasmEdge tag instance functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 // >>>>>>>> WasmEdge global instance functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 

--- a/include/api/wasmedge/wasmedge.h
+++ b/include/api/wasmedge/wasmedge.h
@@ -2048,7 +2048,7 @@ WasmEdge_ModuleInstanceFindMemory(const WasmEdge_ModuleInstanceContext *Cxt,
 /// \returns pointer to the tag instance context. NULL if not found.
 WASMEDGE_CAPI_EXPORT extern WasmEdge_TagInstanceContext *
 WasmEdge_ModuleInstanceFindTag(const WasmEdge_ModuleInstanceContext *Cxt,
-                                  const WasmEdge_String Name);
+                               const WasmEdge_String Name);
 
 /// Get the exported global instance context of a module instance.
 ///
@@ -2160,8 +2160,8 @@ WasmEdge_ModuleInstanceListMemory(const WasmEdge_ModuleInstanceContext *Cxt,
 /// \param Cxt the WasmEdge_ModuleInstanceContext.
 ///
 /// \returns length of the exported tag list.
-WASMEDGE_CAPI_EXPORT extern uint32_t WasmEdge_ModuleInstanceListTagLength(
-    const WasmEdge_ModuleInstanceContext *Cxt);
+WASMEDGE_CAPI_EXPORT extern uint32_t
+WasmEdge_ModuleInstanceListTagLength(const WasmEdge_ModuleInstanceContext *Cxt);
 
 /// List the exported tag names of a module instance.
 ///
@@ -2180,7 +2180,7 @@ WASMEDGE_CAPI_EXPORT extern uint32_t WasmEdge_ModuleInstanceListTagLength(
 /// \returns actual exported tag list size.
 WASMEDGE_CAPI_EXPORT extern uint32_t
 WasmEdge_ModuleInstanceListTag(const WasmEdge_ModuleInstanceContext *Cxt,
-                                  WasmEdge_String *Names, const uint32_t Len);
+                               WasmEdge_String *Names, const uint32_t Len);
 
 /// Get the length of exported global list of a module instance.
 ///

--- a/include/ast/description.h
+++ b/include/ast/description.h
@@ -59,6 +59,8 @@ public:
   MemoryType &getExternalMemoryType() noexcept { return MemType; }
   const GlobalType &getExternalGlobalType() const noexcept { return GlobType; }
   GlobalType &getExternalGlobalType() noexcept { return GlobType; }
+  const Tag &getExternalTag() const noexcept { return Tg; }
+  Tag &getExternalTag() noexcept { return Tg; }
 
 private:
   /// \name Data of ImportDesc: Module name, External name, and content node.
@@ -68,6 +70,7 @@ private:
   TableType TabType;
   MemoryType MemType;
   GlobalType GlobType;
+  Tag Tg;
   /// @}
 };
 

--- a/include/ast/description.h
+++ b/include/ast/description.h
@@ -59,8 +59,8 @@ public:
   MemoryType &getExternalMemoryType() noexcept { return MemType; }
   const GlobalType &getExternalGlobalType() const noexcept { return GlobType; }
   GlobalType &getExternalGlobalType() noexcept { return GlobType; }
-  const Tag &getExternalTag() const noexcept { return Tg; }
-  Tag &getExternalTag() noexcept { return Tg; }
+  const TagType &getExternalTagType() const noexcept { return TgType; }
+  TagType &getExternalTagType() noexcept { return TgType; }
 
 private:
   /// \name Data of ImportDesc: Module name, External name, and content node.
@@ -70,7 +70,7 @@ private:
   TableType TabType;
   MemoryType MemType;
   GlobalType GlobType;
-  Tag Tg;
+  TagType TgType;
   /// @}
 };
 

--- a/include/ast/instruction.h
+++ b/include/ast/instruction.h
@@ -207,7 +207,7 @@ public:
   void setJumpCatchList(const std::vector<uint32_t> &CatchList) {
     reset();
     if (!CatchList.empty()) {
-      Data.TryBlock.JumpCatchListSize = CatchList.size();
+      Data.TryBlock.JumpCatchListSize = static_cast<uint32_t>(CatchList.size());
       Data.TryBlock.JumpCatchList = new uint32_t[CatchList.size()];
       Flags.IsAllocJumpCatchList = true;
       std::copy_n(CatchList.begin(), CatchList.size(),

--- a/include/ast/instruction.h
+++ b/include/ast/instruction.h
@@ -247,10 +247,6 @@ public:
     Data.TryBlock.COffset = Num;
   }
 
-  /// Getter of tag index.
-  uint32_t getTagIdx() const noexcept { return Data.Tag.TagIdx; }
-  uint32_t &getTagIdx() noexcept { return Data.Tag.TagIdx; }
-
   /// Getter and setter of the constant value.
   ValVariant getNum() const noexcept {
 #if defined(__x86_64__) || defined(__aarch64__) ||                             \
@@ -363,10 +359,6 @@ private:
       uint32_t COffset;
       BlockType ResType;
     } TryBlock;
-    // Type 11: Tag
-    struct {
-      uint32_t TagIdx;
-    } Tag;
   } Data;
   uint32_t Offset = 0;
   OpCode Code = OpCode::End;

--- a/include/ast/instruction.h
+++ b/include/ast/instruction.h
@@ -248,9 +248,7 @@ public:
   }
 
   /// Getter and setter of jump count to delegate instruction.
-  uint32_t getDelegateIdx() const noexcept {
-    return Data.TryBlock.DelegateIdx;
-  }
+  uint32_t getDelegateIdx() const noexcept { return Data.TryBlock.DelegateIdx; }
   void setDelegateIdx(const uint32_t Cnt) noexcept {
     Data.TryBlock.DelegateIdx = Cnt;
   }

--- a/include/ast/instruction.h
+++ b/include/ast/instruction.h
@@ -290,15 +290,15 @@ public:
 #endif
   }
 
-  /// Getter and setter of IsLast for End instruction.
+  /// Getter and setter of IsTryLast for End instruction.
   bool isTryLast() const noexcept { return Flags.IsTryLast; }
   void setTryLast(bool Last = true) noexcept { Flags.IsTryLast = Last; }
 
-  /// Getter and setter of IsLast for End instruction.
+  /// Getter and setter of IsCatchLast for End instruction.
   bool isCatchLast() const noexcept { return Flags.IsCatchLast; }
   void setCatchLast(bool Last = true) noexcept { Flags.IsCatchLast = Last; }
 
-  /// Getter and setter of IsLast for End instruction.
+  /// Getter and setter of IsDelegate for Try instruction.
   bool isDelegate() const noexcept { return Flags.IsDelegate; }
   void setDelegate(bool Last = true) noexcept { Flags.IsDelegate = Last; }
 

--- a/include/ast/module.h
+++ b/include/ast/module.h
@@ -63,6 +63,8 @@ public:
   DataSection &getDataSection() { return DataSec; }
   const DataCountSection &getDataCountSection() const { return DataCountSec; }
   DataCountSection &getDataCountSection() { return DataCountSec; }
+  const TagSection &getTagSection() const { return TagSec; }
+  TagSection &getTagSection() { return TagSec; }
   const AOTSection &getAOTSection() const { return AOTSec; }
   AOTSection &getAOTSection() { return AOTSec; }
 
@@ -124,6 +126,7 @@ private:
   CodeSection CodeSec;
   DataSection DataSec;
   DataCountSection DataCountSec;
+  TagSection TagSec;
   /// @}
 
   /// \name Data of AOT.

--- a/include/ast/section.h
+++ b/include/ast/section.h
@@ -232,13 +232,13 @@ private:
 class TagSection : public Section {
 public:
   /// Getter of content vector.
-  Span<const Tag> getContent() const noexcept { return Content; }
-  std::vector<Tag> &getContent() noexcept { return Content; }
+  Span<const TagType> getContent() const noexcept { return Content; }
+  std::vector<TagType> &getContent() noexcept { return Content; }
 
 private:
   /// \name Data of TagSection.
   /// @{
-  std::vector<Tag> Content;
+  std::vector<TagType> Content;
   /// @}
 };
 

--- a/include/ast/section.h
+++ b/include/ast/section.h
@@ -217,7 +217,7 @@ private:
 /// AST DataCountSection node.
 class DataCountSection : public Section {
 public:
-  /// Getter and of content.
+  /// Getter and setter of content.
   std::optional<uint32_t> getContent() const noexcept { return Content; }
   void setContent(uint32_t Val) noexcept { Content = Val; }
 
@@ -225,6 +225,20 @@ private:
   /// \name Data of DataCountSection.
   /// @{
   std::optional<uint32_t> Content = std::nullopt;
+  /// @}
+};
+
+/// AST TagSection node.
+class TagSection : public Section {
+public:
+  /// Getter of content vector.
+  Span<const Tag> getContent() const noexcept { return Content; }
+  std::vector<Tag> &getContent() noexcept { return Content; }
+
+private:
+  /// \name Data of TagSection.
+  /// @{
+  std::vector<Tag> Content;
   /// @}
 };
 

--- a/include/ast/type.h
+++ b/include/ast/type.h
@@ -206,5 +206,38 @@ private:
   /// @}
 };
 
+class TagType {
+public:
+  TagType() = delete;
+  TagType(const AST::FunctionType &FType) noexcept : Type(FType) {}
+  // Getter of FunctionType
+  FunctionType &getFunctionType() noexcept { return Type; }
+  const FunctionType &getFunctionType() const noexcept { return Type; }
+
+  // Getter of the size of value that is associated with the tag
+  size_t getAssocValSize() const noexcept {
+    return Type.getParamTypes().size();
+  }
+
+private:
+  FunctionType Type;
+};
+
+class Tag {
+public:
+  Tag() = default;
+  /// Getter and setter of Attribute.
+  uint8_t getAttribute() const noexcept { return Attribute; }
+  void setAttribute(uint8_t Attr) noexcept { Attribute = Attr; }
+
+  /// Getter and setter of TypeIdx.
+  uint32_t getTypeIdx() const noexcept { return TypeIdx; }
+  void setTypeIdx(uint32_t TyIdx) noexcept { TypeIdx = TyIdx; }
+
+private:
+  uint8_t Attribute;
+  uint32_t TypeIdx;
+};
+
 } // namespace AST
 } // namespace WasmEdge

--- a/include/ast/type.h
+++ b/include/ast/type.h
@@ -225,8 +225,8 @@ public:
   void setFuncType(FunctionType *FuncType) noexcept { Type = FuncType; }
 
   // Getter of the size of value that is associated with the tag.
-  size_t getAssocValSize() const noexcept {
-    return Type->getParamTypes().size();
+  uint32_t getAssocValSize() const noexcept {
+    return static_cast<uint32_t>(Type->getParamTypes().size());
   }
 
 private:

--- a/include/ast/type.h
+++ b/include/ast/type.h
@@ -208,24 +208,10 @@ private:
 
 class TagType {
 public:
-  TagType() = delete;
-  TagType(const AST::FunctionType &FType) noexcept : Type(FType) {}
-  // Getter of FunctionType
-  FunctionType &getFunctionType() noexcept { return Type; }
-  const FunctionType &getFunctionType() const noexcept { return Type; }
+  TagType() = default;
+  TagType(const TagType &T, const FunctionType *F) noexcept
+      : Attribute(T.getAttribute()), TypeIdx(T.getTypeIdx()), Type(F) {}
 
-  // Getter of the size of value that is associated with the tag
-  size_t getAssocValSize() const noexcept {
-    return Type.getParamTypes().size();
-  }
-
-private:
-  FunctionType Type;
-};
-
-class Tag {
-public:
-  Tag() = default;
   /// Getter and setter of Attribute.
   uint8_t getAttribute() const noexcept { return Attribute; }
   void setAttribute(uint8_t Attr) noexcept { Attribute = Attr; }
@@ -234,9 +220,19 @@ public:
   uint32_t getTypeIdx() const noexcept { return TypeIdx; }
   void setTypeIdx(uint32_t TyIdx) noexcept { TypeIdx = TyIdx; }
 
+  // Getter and setter of FunctionType.
+  const FunctionType &getFuncType() const noexcept { return *Type; }
+  void setFuncType(FunctionType *FuncType) noexcept { Type = FuncType; }
+
+  // Getter of the size of value that is associated with the tag.
+  size_t getAssocValSize() const noexcept {
+    return Type->getParamTypes().size();
+  }
+
 private:
   uint8_t Attribute;
   uint32_t TypeIdx;
+  const FunctionType *Type;
 };
 
 } // namespace AST

--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -968,7 +968,7 @@ E(Function, 0x00U, "function")
 E(Table, 0x01U, "table")
 E(Memory, 0x02U, "memory")
 E(Global, 0x03U, "global")
-E(Tag, 0x04, "tag")
+E(Tag, 0x04U, "tag")
 
 #undef E
 #endif // UseExternalType

--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -35,6 +35,7 @@ A(Sec_Element, "element section")
 A(Sec_Code, "code section")
 A(Sec_Data, "data section")
 A(Sec_DataCount, "data count section")
+A(Sec_Tag, "tag section")
 A(Desc_Import, "import description")
 A(Desc_Export, "export description")
 A(Seg_Global, "global segment")
@@ -63,6 +64,10 @@ O(Block, 0x02, "block")
 O(Loop, 0x03, "loop")
 O(If, 0x04, "if")
 O(Else, 0x05, "else")
+O(Try, 0x06, "try")
+O(Catch, 0x07, "catch")
+O(Throw, 0x08, "throw")
+O(Rethrow, 0x09, "rethrow")
 O(End, 0x0B, "end")
 O(Br, 0x0C, "br")
 O(Br_if, 0x0D, "br_if")
@@ -72,6 +77,8 @@ O(Call, 0x10, "call")
 O(Call_indirect, 0x11, "call_indirect")
 O(Return_call, 0x12, "return_call")
 O(Return_call_indirect, 0x13, "return_call_indirect")
+O(Delegate, 0x18, "delegate")
+O(Catch_all, 0x19, "catch_all")
 
 // Reference Instructions
 O(Ref__null, 0xD0, "ref.null")
@@ -783,6 +790,12 @@ E(InvalidMemPages, 0x53, "memory size must be at most 65536 pages (4GiB)")
 E(InvalidStartFunc, 0x54, "start function")
 // Invalid lane index
 E(InvalidLaneIdx, 0x55, "invalid lane index")
+// Tag index not defined
+E(InvalidTagIdx, 0x56, "unknown tag")
+// Invalid Tag type
+E(InvalidTag, 0x57, "non-empty tag result type")
+// Invalid rethrow label
+E(InvalidRethrowLabel, 0x58, "invalid rethrow label")
 // @}
 
 // Instantiation phase
@@ -835,6 +848,8 @@ E(RefTypeMismatch, 0x8E, "reference type mismatch")
 E(UnalignedAtomicAccess, 0x8F, "unaligned atomic")
 // wait32/wait64 on unshared memory
 E(ExpectSharedMemory, 0x90, "expected shared memory")
+// Uncaught Exception
+E(UncaughtException, 0x91, "uncaught exception")
 // @}
 
 #undef E
@@ -894,6 +909,8 @@ I(Global, "global")
 I(Element, "element")
 I(Data, "data")
 I(Lane, "lane")
+I(TagType, "tag type")
+I(Tag, "tag")
 
 #undef I
 #endif // UseIndexCategory
@@ -951,6 +968,7 @@ E(Function, 0x00U, "function")
 E(Table, 0x01U, "table")
 E(Memory, 0x02U, "memory")
 E(Global, 0x03U, "global")
+E(Tag, 0x04, "tag")
 
 #undef E
 #endif // UseExternalType

--- a/include/driver/tool.h
+++ b/include/driver/tool.h
@@ -60,6 +60,8 @@ struct DriverToolOptions {
         PropTailCall(PO::Description("Enable Tail-call proposal"sv)),
         PropExtendConst(PO::Description("Enable Extended-const proposal"sv)),
         PropThreads(PO::Description("Enable Threads proposal"sv)),
+        PropExceptionHandling(
+            PO::Description("Enable Exception handling proposal"sv)),
         PropAll(PO::Description("Enable all features"sv)),
         ConfEnableInstructionCounting(PO::Description(
             "Enable generating code for counting Wasm instructions executed."sv)),
@@ -103,6 +105,7 @@ struct DriverToolOptions {
   PO::Option<PO::Toggle> PropTailCall;
   PO::Option<PO::Toggle> PropExtendConst;
   PO::Option<PO::Toggle> PropThreads;
+  PO::Option<PO::Toggle> PropExceptionHandling;
   PO::Option<PO::Toggle> PropAll;
   PO::Option<PO::Toggle> ConfEnableInstructionCounting;
   PO::Option<PO::Toggle> ConfEnableGasMeasuring;

--- a/include/driver/tool.h
+++ b/include/driver/tool.h
@@ -141,6 +141,7 @@ struct DriverToolOptions {
         .add_option("enable-tail-call"sv, PropTailCall)
         .add_option("enable-extended-const"sv, PropExtendConst)
         .add_option("enable-threads"sv, PropThreads)
+        .add_option("enable-exception-handling"sv, PropExceptionHandling)
         .add_option("enable-all"sv, PropAll)
         .add_option("time-limit"sv, TimeLim)
         .add_option("gas-limit"sv, GasLim)

--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -227,6 +227,10 @@ private:
   Expect<void> instantiate(Runtime::Instance::ModuleInstance &ModInst,
                            const AST::MemorySection &MemSec);
 
+  /// Instantiateion of Tag Instances.
+  Expect<void> instantiate(Runtime::Instance::ModuleInstance &ModInst,
+                           const AST::TagSection &TagSec);
+
   /// Instantiation of Global Instances.
   Expect<void> instantiate(Runtime::StackManager &StackMgr,
                            Runtime::Instance::ModuleInstance &ModInst,
@@ -265,9 +269,16 @@ private:
 
   /// Helper function for branching to label.
   Expect<void> branchToLabel(Runtime::StackManager &StackMgr,
-                             uint32_t EraseBegin, uint32_t EraseEnd,
-                             int32_t PCOffset,
+                             uint32_t ValueStackEraseBegin,
+                             uint32_t ValueStackEraseEnd,
+                             uint32_t HandlerStackOffset,
+                             uint32_t CaughtStackOffset, int32_t PCOffset,
                              AST::InstrView::iterator &PC) noexcept;
+
+  /// Helper function for throwing an exception.
+  Expect<void> throwException(Runtime::StackManager &StackMgr,
+                              Runtime::Instance::TagInstance *,
+                              AST::InstrView::iterator &PC) noexcept;
   /// @}
 
   /// \name Helper Functions for getting instances.
@@ -279,6 +290,10 @@ private:
   /// Helper function for get memory instance by index.
   Runtime::Instance::MemoryInstance *
   getMemInstByIdx(Runtime::StackManager &StackMgr, const uint32_t Idx) const;
+
+  /// Helper function for get tag instance by index.
+  Runtime::Instance::TagInstance *
+  getTagInstByIdx(Runtime::StackManager &StackMgr, const uint32_t Idx) const;
 
   /// Helper function for get global instance by index.
   Runtime::Instance::GlobalInstance *
@@ -299,6 +314,15 @@ private:
   Expect<void> runIfElseOp(Runtime::StackManager &StackMgr,
                            const AST::Instruction &Instr,
                            AST::InstrView::iterator &PC) noexcept;
+  Expect<void> runTryOp(Runtime::StackManager &StackMgr,
+                        const AST::Instruction &Instr,
+                        AST::InstrView::iterator &PC) noexcept;
+  Expect<void> runThrowOp(Runtime::StackManager &StackMgr,
+                          const AST::Instruction &Instr,
+                          AST::InstrView::iterator &PC) noexcept;
+  Expect<void> runRethrowOp(Runtime::StackManager &StackMgr,
+                            const AST::Instruction &Instr,
+                            AST::InstrView::iterator &PC) noexcept;
   Expect<void> runBrOp(Runtime::StackManager &StackMgr,
                        const AST::Instruction &Instr,
                        AST::InstrView::iterator &PC) noexcept;

--- a/include/loader/loader.h
+++ b/include/loader/loader.h
@@ -184,6 +184,14 @@ private:
     }
     return {};
   }
+  /// @}
+
+  /// \name Helper function to set the function type for tag
+  /// @{
+  void setTagFunctionType(AST::TagSection &TagSec,
+                                  AST::ImportSection &ImportSec,
+                                  AST::TypeSection &TypeSec);
+  /// @}
 
   /// \name Load AST nodes functions
   /// @{
@@ -213,7 +221,7 @@ private:
   Expect<void> loadType(AST::MemoryType &MemType);
   Expect<void> loadType(AST::TableType &TabType);
   Expect<void> loadType(AST::GlobalType &GlobType);
-  Expect<void> loadTag(AST::Tag &TagToLoad);
+  Expect<void> loadType(AST::TagType &TgType);
   Expect<void> loadExpression(AST::Expression &Expr,
                               std::optional<uint64_t> SizeBound = std::nullopt);
   Expect<OpCode> loadOpCode();

--- a/include/loader/loader.h
+++ b/include/loader/loader.h
@@ -73,6 +73,9 @@ template <>
 inline ASTNodeAttr NodeAttrFromAST<AST::DataCountSection>() noexcept {
   return ASTNodeAttr::Sec_DataCount;
 }
+template <> inline ASTNodeAttr NodeAttrFromAST<AST::TagSection>() noexcept {
+  return ASTNodeAttr::Sec_Tag;
+}
 } // namespace
 
 /// Loader flow control class.
@@ -197,6 +200,7 @@ private:
   Expect<void> loadSection(AST::CodeSection &Sec);
   Expect<void> loadSection(AST::DataSection &Sec);
   Expect<void> loadSection(AST::DataCountSection &Sec);
+  Expect<void> loadSection(AST::TagSection &Sec);
   static Expect<void> loadSection(FileMgr &VecMgr, AST::AOTSection &Sec);
   Expect<void> loadSegment(AST::GlobalSegment &GlobSeg);
   Expect<void> loadSegment(AST::ElementSegment &ElemSeg);
@@ -209,6 +213,7 @@ private:
   Expect<void> loadType(AST::MemoryType &MemType);
   Expect<void> loadType(AST::TableType &TabType);
   Expect<void> loadType(AST::GlobalType &GlobType);
+  Expect<void> loadTag(AST::Tag &TagToLoad);
   Expect<void> loadExpression(AST::Expression &Expr,
                               std::optional<uint64_t> SizeBound = std::nullopt);
   Expect<OpCode> loadOpCode();

--- a/include/loader/loader.h
+++ b/include/loader/loader.h
@@ -189,8 +189,8 @@ private:
   /// \name Helper function to set the function type for tag
   /// @{
   void setTagFunctionType(AST::TagSection &TagSec,
-                                  AST::ImportSection &ImportSec,
-                                  AST::TypeSection &TypeSec);
+                          AST::ImportSection &ImportSec,
+                          AST::TypeSection &TypeSec);
   /// @}
 
   /// \name Load AST nodes functions

--- a/include/runtime/instance/module.h
+++ b/include/runtime/instance/module.h
@@ -22,6 +22,7 @@
 #include "runtime/instance/global.h"
 #include "runtime/instance/memory.h"
 #include "runtime/instance/table.h"
+#include "runtime/instance/tag.h"
 
 #include <atomic>
 #include <functional>
@@ -54,7 +55,8 @@ inline constexpr const bool IsEntityV =
     std::is_same_v<T, Instance::FunctionInstance> ||
     std::is_same_v<T, Instance::TableInstance> ||
     std::is_same_v<T, Instance::MemoryInstance> ||
-    std::is_same_v<T, Instance::GlobalInstance>;
+    std::is_same_v<T, Instance::GlobalInstance> ||
+    std::is_same_v<T, Instance::TagInstance>;
 
 /// Return true if T is an instance.
 template <typename T>
@@ -134,6 +136,10 @@ public:
     std::shared_lock Lock(Mutex);
     return unsafeFindExports(ExpMems, ExtName);
   }
+  TagInstance *findTagExports(std::string_view ExtName) const noexcept {
+    std::shared_lock Lock(Mutex);
+    return unsafeFindExports(ExpTags, ExtName);
+  }
   GlobalInstance *findGlobalExports(std::string_view ExtName) const noexcept {
     std::shared_lock Lock(Mutex);
     return unsafeFindExports(ExpGlobals, ExtName);
@@ -151,6 +157,10 @@ public:
   uint32_t getMemoryExportNum() const noexcept {
     std::shared_lock Lock(Mutex);
     return static_cast<uint32_t>(ExpMems.size());
+  }
+  uint32_t getTagExportNum() const noexcept {
+    std::shared_lock Lock(Mutex);
+    return static_cast<uint32_t>(ExpTags.size());
   }
   uint32_t getGlobalExportNum() const noexcept {
     std::shared_lock Lock(Mutex);
@@ -172,6 +182,11 @@ public:
   auto getMemoryExports(CallbackT &&CallBack) const noexcept {
     std::shared_lock Lock(Mutex);
     return std::forward<CallbackT>(CallBack)(ExpMems);
+  }
+  template <typename CallbackT>
+  auto getTagExports(CallbackT &&CallBack) const noexcept {
+    std::shared_lock Lock(Mutex);
+    return std::forward<CallbackT>(CallBack)(ExpTags);
   }
   template <typename CallbackT>
   auto getGlobalExports(CallbackT &&CallBack) const noexcept {
@@ -203,6 +218,10 @@ protected:
     std::unique_lock Lock(Mutex);
     unsafeAddInstance(OwnedMemInsts, MemInsts, std::forward<Args>(Values)...);
   }
+  template <typename... Args> void addTag(Args &&...Values) {
+    std::unique_lock Lock(Mutex);
+    unsafeAddInstance(OwnedTagInsts, TagInsts, std::forward<Args>(Values)...);
+  }
   template <typename... Args> void addGlobal(Args &&...Values) {
     std::unique_lock Lock(Mutex);
     unsafeAddInstance(OwnedGlobInsts, GlobInsts, std::forward<Args>(Values)...);
@@ -229,6 +248,10 @@ protected:
     std::unique_lock Lock(Mutex);
     unsafeImportInstance(MemInsts, Mem);
   }
+  void importTag(TagInstance *Tg) {
+    std::unique_lock Lock(Mutex);
+    unsafeImportInstance(TagInsts, Tg);
+  }
   void importGlobal(GlobalInstance *Glob) {
     std::unique_lock Lock(Mutex);
     ImpGlobalNum++;
@@ -251,6 +274,10 @@ protected:
   void exportGlobal(std::string_view Name, uint32_t Idx) {
     std::unique_lock Lock(Mutex);
     ExpGlobals.insert_or_assign(std::string(Name), GlobInsts[Idx]);
+  }
+  void exportTag(std::string_view Name, uint32_t Idx) {
+    std::unique_lock Lock(Mutex);
+    ExpTags.insert_or_assign(std::string(Name), TagInsts[Idx]);
   }
 
   /// Get function type by index.
@@ -293,6 +320,9 @@ protected:
   }
   MemoryInstance *unsafeGetMemory(uint32_t Idx) const noexcept {
     return MemInsts[Idx];
+  }
+  TagInstance *unsafeGetTag(uint32_t Idx) const noexcept {
+    return TagInsts[Idx];
   }
   Expect<GlobalInstance *> getGlobal(uint32_t Idx) const noexcept {
     std::shared_lock Lock(Mutex);
@@ -433,6 +463,7 @@ protected:
   std::vector<std::unique_ptr<Instance::FunctionInstance>> OwnedFuncInsts;
   std::vector<std::unique_ptr<Instance::TableInstance>> OwnedTabInsts;
   std::vector<std::unique_ptr<Instance::MemoryInstance>> OwnedMemInsts;
+  std::vector<std::unique_ptr<Instance::TagInstance>> OwnedTagInsts;
   std::vector<std::unique_ptr<Instance::GlobalInstance>> OwnedGlobInsts;
   std::vector<std::unique_ptr<Instance::ElementInstance>> OwnedElemInsts;
   std::vector<std::unique_ptr<Instance::DataInstance>> OwnedDataInsts;
@@ -441,6 +472,7 @@ protected:
   std::vector<FunctionInstance *> FuncInsts;
   std::vector<TableInstance *> TabInsts;
   std::vector<MemoryInstance *> MemInsts;
+  std::vector<TagInstance *> TagInsts;
   std::vector<GlobalInstance *> GlobInsts;
   std::vector<ElementInstance *> ElemInsts;
   std::vector<DataInstance *> DataInsts;
@@ -452,6 +484,7 @@ protected:
   std::map<std::string, FunctionInstance *, std::less<>> ExpFuncs;
   std::map<std::string, TableInstance *, std::less<>> ExpTables;
   std::map<std::string, MemoryInstance *, std::less<>> ExpMems;
+  std::map<std::string, TagInstance *, std::less<>> ExpTags;
   std::map<std::string, GlobalInstance *, std::less<>> ExpGlobals;
 
   /// Start function instance.

--- a/include/runtime/instance/tag.h
+++ b/include/runtime/instance/tag.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2022 Second State INC
+
+//===-- wasmedge/runtime/instance/tag.h - Tag Instance definition ---===//
+//
+// Part of the WasmEdge Project.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the tag instance definition in store manager.
+///
+//===----------------------------------------------------------------------===//
+#pragma once
+
+#include "ast/type.h"
+
+namespace WasmEdge {
+namespace Runtime {
+namespace Instance {
+
+class TagInstance {
+public:
+  TagInstance() = delete;
+  TagInstance(const AST::FunctionType &FType) noexcept : TgType(FType) {}
+
+  /// Getter of tag type.
+  const AST::TagType &getTagType() const noexcept { return TgType; }
+
+  size_t getAssocValSize() const noexcept { return TgType.getAssocValSize(); }
+
+private:
+  /// \name Data of tag instance.
+  /// @{
+  AST::TagType TgType;
+  /// @}
+};
+
+} // namespace Instance
+} // namespace Runtime
+} // namespace WasmEdge

--- a/include/runtime/instance/tag.h
+++ b/include/runtime/instance/tag.h
@@ -28,7 +28,7 @@ public:
   /// Getter of tag type.
   const AST::TagType &getTagType() const noexcept { return TgType; }
 
-  size_t getAssocValSize() const noexcept { return TgType.getAssocValSize(); }
+  uint32_t getAssocValSize() const noexcept { return TgType.getAssocValSize(); }
 
 private:
   /// \name Data of tag instance.

--- a/include/runtime/instance/tag.h
+++ b/include/runtime/instance/tag.h
@@ -22,7 +22,8 @@ namespace Instance {
 class TagInstance {
 public:
   TagInstance() = delete;
-  TagInstance(const AST::TagType &T, const AST::FunctionType* F) noexcept : TgType(T, F) {}
+  TagInstance(const AST::TagType &T, const AST::FunctionType *F) noexcept
+      : TgType(T, F) {}
 
   /// Getter of tag type.
   const AST::TagType &getTagType() const noexcept { return TgType; }

--- a/include/runtime/instance/tag.h
+++ b/include/runtime/instance/tag.h
@@ -22,7 +22,7 @@ namespace Instance {
 class TagInstance {
 public:
   TagInstance() = delete;
-  TagInstance(const AST::FunctionType &FType) noexcept : TgType(FType) {}
+  TagInstance(const AST::TagType &T, const AST::FunctionType* F) noexcept : TgType(T, F) {}
 
   /// Getter of tag type.
   const AST::TagType &getTagType() const noexcept { return TgType; }

--- a/include/runtime/stackmgr.h
+++ b/include/runtime/stackmgr.h
@@ -23,6 +23,8 @@ namespace Runtime {
 
 class StackManager {
 public:
+  using Value = ValVariant;
+
   struct Frame {
     Frame() = delete;
     Frame(const Instance::ModuleInstance *Mod, AST::InstrView::iterator FromIt,
@@ -35,7 +37,29 @@ public:
     uint32_t VPos;
   };
 
-  using Value = ValVariant;
+  struct Handler {
+    Handler(AST::InstrView::iterator E, uint32_t V, uint32_t F, uint32_t H,
+            uint32_t C)
+        : CatchCaluse(), EndIt(E), VPos(V), FPos(F), HPos(H), CPos(C) {}
+    // nullptr stands for catch all clause
+    std::vector<
+        std::pair<Runtime::Instance::TagInstance *, AST::InstrView::iterator>>
+        CatchCaluse;
+    AST::InstrView::iterator EndIt;
+    uint32_t VPos;
+    uint32_t FPos;
+    uint32_t HPos;
+    uint32_t CPos;
+  };
+
+  struct Exception {
+    Exception(Runtime::Instance::TagInstance *T, Span<Value> &V,
+              AST::InstrView::iterator E)
+        : TagInst(T), Val(V.begin(), V.end()), EndIt(E) {}
+    Runtime::Instance::TagInstance *TagInst;
+    std::vector<Value> Val;
+    AST::InstrView::iterator EndIt;
+  };
 
   /// Stack manager provides the stack control for Wasm execution with VALIDATED
   /// modules. All operations of instructions passed validation, therefore no
@@ -66,6 +90,11 @@ public:
   /// Push a new value entry to stack.
   template <typename T> void push(T &&Val) {
     ValueStack.push_back(std::forward<T>(Val));
+  }
+
+  /// Push a vector of value to stack
+  void pushValVec(const std::vector<Value> &ValVec) {
+    ValueStack.insert(ValueStack.end(), ValVec.begin(), ValVec.end());
   }
 
   /// Unsafe Pop and return the top entry.
@@ -111,20 +140,114 @@ public:
     return From;
   }
 
-  /// Unsafe erase stack.
-  void stackErase(uint32_t EraseBegin, uint32_t EraseEnd) noexcept {
+  // Push handler for try-delegate block
+  void pushHandler(AST::InstrView::iterator EndIt, uint32_t VSize,
+                   uint32_t HOffset, uint32_t COffset) noexcept {
+    // The POS is the stack size after jumping to the label
+    HandlerStack.emplace_back(EndIt, VSize, FrameStack.size(),
+                              HandlerStack.size() - HOffset,
+                              CaughtStack.size() - COffset);
+  }
+
+  // Push handler for try-catch block
+  void pushHandler(AST::InstrView::iterator EndIt,
+                   uint32_t BlockParamNum) noexcept {
+    HandlerStack.emplace_back(EndIt, ValueStack.size() - BlockParamNum,
+                              FrameStack.size(), HandlerStack.size(),
+                              CaughtStack.size());
+  }
+
+  // Push a handler to the current try block
+  void addCatchCaluseToLastHandler(Runtime::Instance::TagInstance *T,
+                                   AST::InstrView::iterator It) noexcept {
+    HandlerStack.back().CatchCaluse.emplace_back(T, It);
+  }
+
+  // Erase the stacks so that the exception handler is on the top of the stack
+  // Associated Value should remain on top of ValueStack.
+  Handler popToTopHandler(size_t AssocValSize) noexcept {
+    auto TopHandler = std::move(HandlerStack.back());
+    HandlerStack.pop_back();
+    assuming(ValueStack.size() - AssocValSize >= TopHandler.VPos);
+    ValueStack.erase(ValueStack.begin() + TopHandler.VPos,
+                     ValueStack.end() - AssocValSize);
+    FrameStack.erase(FrameStack.begin() + TopHandler.FPos, FrameStack.end());
+    HandlerStack.erase(HandlerStack.begin() + TopHandler.HPos,
+                       HandlerStack.end());
+    CaughtStack.erase(CaughtStack.begin() + TopHandler.CPos, CaughtStack.end());
+    return TopHandler;
+  }
+
+  // Unsafe pop top exception handler
+  AST::InstrView::iterator popHandler() noexcept {
+    auto EndIt = HandlerStack.back().EndIt;
+    HandlerStack.pop_back();
+    return EndIt;
+  }
+
+  // Check whether handler stack is empty
+  bool isHandlerStackEmpty() noexcept { return HandlerStack.empty(); }
+
+  // Push a caught exception to the stack
+  void pushCaught(Runtime::Instance::TagInstance *T, Span<Value> V,
+                  AST::InstrView::iterator E) noexcept {
+    CaughtStack.emplace_back(T, V, E);
+  }
+
+  // Unsafe pop top caught exception
+  AST::InstrView::iterator popCaught() noexcept {
+    auto EndIt = CaughtStack.back().EndIt;
+    CaughtStack.pop_back();
+    return EndIt;
+  }
+
+  /// Unsafe Getter of top N-th value entry of stack.
+  Exception &getCaughtTopN(uint32_t Offset) noexcept {
+    assuming(0 < Offset && Offset <= CaughtStack.size());
+    return *(CaughtStack.end() - Offset);
+  }
+
+  /// Unsafe erase value stack.
+  void eraseValueStack(uint32_t EraseBegin, uint32_t EraseEnd) noexcept {
     assuming(EraseEnd <= EraseBegin && EraseBegin <= ValueStack.size());
     ValueStack.erase(ValueStack.end() - EraseBegin,
                      ValueStack.end() - EraseEnd);
   }
 
+  // Unsafe erase top Num element of exception handler stack
+  void eraseHandlerStack(uint32_t Num) noexcept {
+    HandlerStack.erase(HandlerStack.end() - Num, HandlerStack.end());
+  }
+
+  // Unsafe erase top Num element of caught exception stack
+  void eraseCaughtStack(uint32_t Num) noexcept {
+    CaughtStack.erase(CaughtStack.end() - Num, CaughtStack.end());
+  }
+
   /// Unsafe leave top label.
-  AST::InstrView::iterator maybePopFrame(AST::InstrView::iterator PC) noexcept {
+  AST::InstrView::iterator
+  maybePopFrameOrHandlerOrCaught(AST::InstrView::iterator PC) noexcept {
     if (FrameStack.size() > 1 && PC->isLast()) {
       // Noted that there's always a base frame in stack.
       return popFrame();
     }
+    if (PC->isTryLast()) {
+      return popHandler();
+    }
+    if (PC->isCatchLast()) {
+      return popCaught();
+    }
     return PC;
+  }
+
+  // Unsafe leave try-block or catch-block
+  AST::InstrView::iterator
+  popHandlerOrCaught(AST::InstrView::iterator PC) noexcept {
+    if (PC->isTryLast()) {
+      return popHandler();
+    } else {
+      return popCaught();
+    }
   }
 
   /// Unsafe getter of module address.
@@ -144,6 +267,8 @@ private:
   /// @{
   std::vector<Value> ValueStack;
   std::vector<Frame> FrameStack;
+  std::vector<Handler> HandlerStack;
+  std::vector<Exception> CaughtStack;
   /// @}
 };
 

--- a/include/runtime/stackmgr.h
+++ b/include/runtime/stackmgr.h
@@ -162,10 +162,11 @@ public:
   // Push handler for try-catch block
   void pushHandler(AST::InstrView::iterator EndIt,
                    uint32_t BlockParamNum) noexcept {
-    HandlerStack.emplace_back(EndIt, ValueStack.size() - BlockParamNum,
-                              static_cast<uint32_t>(FrameStack.size()),
-                              static_cast<uint32_t>(HandlerStack.size()),
-                              static_cast<uint32_t>(CaughtStack.size()));
+    HandlerStack.emplace_back(
+        EndIt, static_cast<uint32_t>(ValueStack.size() - BlockParamNum),
+        static_cast<uint32_t>(FrameStack.size()),
+        static_cast<uint32_t>(HandlerStack.size()),
+        static_cast<uint32_t>(CaughtStack.size()));
   }
 
   // Push a handler to the current try block

--- a/include/runtime/stackmgr.h
+++ b/include/runtime/stackmgr.h
@@ -155,15 +155,17 @@ public:
     // The POS is the stack size after jumping to the label
     HandlerStack.emplace_back(
         EndIt, VSize, static_cast<uint32_t>(FrameStack.size()),
-        HandlerStack.size() - HOffset, CaughtStack.size() - COffset);
+        static_cast<uint32_t>(HandlerStack.size() - HOffset),
+        static_cast<uint32_t>(CaughtStack.size() - COffset));
   }
 
   // Push handler for try-catch block
   void pushHandler(AST::InstrView::iterator EndIt,
                    uint32_t BlockParamNum) noexcept {
     HandlerStack.emplace_back(EndIt, ValueStack.size() - BlockParamNum,
-                              FrameStack.size(), HandlerStack.size(),
-                              CaughtStack.size());
+                              static_cast<uint32_t>(FrameStack.size()),
+                              static_cast<uint32_t>(HandlerStack.size()),
+                              static_cast<uint32_t>(CaughtStack.size()));
   }
 
   // Push a handler to the current try block

--- a/include/runtime/stackmgr.h
+++ b/include/runtime/stackmgr.h
@@ -153,9 +153,9 @@ public:
   void pushHandler(AST::InstrView::iterator EndIt, uint32_t VSize,
                    uint32_t HOffset, uint32_t COffset) noexcept {
     // The POS is the stack size after jumping to the label
-    HandlerStack.emplace_back(EndIt, VSize, FrameStack.size(),
-                              HandlerStack.size() - HOffset,
-                              CaughtStack.size() - COffset);
+    HandlerStack.emplace_back(
+        EndIt, VSize, static_cast<uint32_t>(FrameStack.size()),
+        HandlerStack.size() - HOffset, CaughtStack.size() - COffset);
   }
 
   // Push handler for try-catch block

--- a/include/runtime/stackmgr.h
+++ b/include/runtime/stackmgr.h
@@ -174,7 +174,7 @@ public:
 
   // Erase the stacks so that the exception handler is on the top of the stack
   // Associated Value should remain on top of ValueStack.
-  Handler popToTopHandler(size_t AssocValSize) noexcept {
+  Handler popToTopHandler(uint32_t AssocValSize) noexcept {
     auto TopHandler = std::move(HandlerStack.back());
     HandlerStack.pop_back();
     assuming(ValueStack.size() - AssocValSize >= TopHandler.VPos);

--- a/include/runtime/stackmgr.h
+++ b/include/runtime/stackmgr.h
@@ -155,15 +155,15 @@ public:
     // The POS is the stack size after jumping to the label
     HandlerStack.emplace_back(
         EndIt, VSize, static_cast<uint32_t>(FrameStack.size()),
-        static_cast<uint32_t>(HandlerStack.size() - HOffset),
-        static_cast<uint32_t>(CaughtStack.size() - COffset));
+        static_cast<uint32_t>(HandlerStack.size()) - HOffset,
+        static_cast<uint32_t>(CaughtStack.size()) - COffset);
   }
 
   // Push handler for try-catch block
   void pushHandler(AST::InstrView::iterator EndIt,
                    uint32_t BlockParamNum) noexcept {
     HandlerStack.emplace_back(
-        EndIt, static_cast<uint32_t>(ValueStack.size() - BlockParamNum),
+        EndIt, static_cast<uint32_t>(ValueStack.size()) - BlockParamNum,
         static_cast<uint32_t>(FrameStack.size()),
         static_cast<uint32_t>(HandlerStack.size()),
         static_cast<uint32_t>(CaughtStack.size()));

--- a/include/validator/formchecker.h
+++ b/include/validator/formchecker.h
@@ -62,6 +62,7 @@ public:
   void addRef(const uint32_t FuncIdx);
   void addLocal(const ValType &V);
   void addLocal(const VType &V);
+  void addTag(const uint32_t TypeIdx);
 
   std::vector<VType> result() { return ValStack; }
   auto &getTypes() { return Types; }
@@ -69,6 +70,7 @@ public:
   auto &getTables() { return Tables; }
   auto &getMemories() { return Mems; }
   auto &getGlobals() { return Globals; }
+  auto &getTags() { return Tags; }
   uint32_t getNumImportFuncs() const { return NumImportFuncs; }
   uint32_t getNumImportGlobals() const { return NumImportGlobals; }
 
@@ -137,6 +139,7 @@ private:
   uint32_t NumImportGlobals = 0;
   std::vector<VType> Locals;
   std::vector<VType> Returns;
+  std::vector<uint32_t> Tags;
 
   /// Running stack.
   std::vector<CtrlFrame> CtrlStack;

--- a/include/validator/validator.h
+++ b/include/validator/validator.h
@@ -62,6 +62,7 @@ private:
   Expect<void> validate(const AST::DataSection &DataSec);
   Expect<void> validate(const AST::StartSection &StartSec);
   Expect<void> validate(const AST::ExportSection &ExportSec);
+  Expect<void> validate(const AST::TagSection &TagSec);
 
   /// Validate const expression
   Expect<void> validateConstExpr(AST::InstrView Instrs,

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -51,6 +51,9 @@ struct WasmEdge_TableTypeContext {};
 // WasmEdge_MemoryTypeContext implementation.
 struct WasmEdge_MemoryTypeContext {};
 
+// WasmEdge_TagTypeContext implementation.
+struct WasmEdge_TagTypeContext {};
+
 // WasmEdge_GlobalTypeContext implementation.
 struct WasmEdge_GlobalTypeContext {};
 
@@ -94,6 +97,9 @@ struct WasmEdge_TableInstanceContext {};
 
 // WasmEdge_MemoryInstanceContext implementation.
 struct WasmEdge_MemoryInstanceContext {};
+
+// WasmEdge_TagInstanceContext implementation.
+struct WasmEdge_TagInstanceContext {};
 
 // WasmEdge_GlobalInstanceContext implementation.
 struct WasmEdge_GlobalInstanceContext {};
@@ -310,6 +316,7 @@ CONVTO(TabType, AST::TableType, TableType, )
 CONVTO(TabType, AST::TableType, TableType, const)
 CONVTO(MemType, AST::MemoryType, MemoryType, )
 CONVTO(MemType, AST::MemoryType, MemoryType, const)
+CONVTO(TagType, AST::TagType, TagType, const)
 CONVTO(GlobType, AST::GlobalType, GlobalType, )
 CONVTO(GlobType, AST::GlobalType, GlobalType, const)
 CONVTO(ImpType, AST::ImportDesc, ImportType, const)
@@ -324,6 +331,7 @@ CONVTO(Func, Runtime::Instance::FunctionInstance, FunctionInstance, )
 CONVTO(Func, Runtime::Instance::FunctionInstance, FunctionInstance, const)
 CONVTO(Tab, Runtime::Instance::TableInstance, TableInstance, )
 CONVTO(Mem, Runtime::Instance::MemoryInstance, MemoryInstance, )
+CONVTO(Tag, Runtime::Instance::TagInstance, TagInstance, )
 CONVTO(Glob, Runtime::Instance::GlobalInstance, GlobalInstance, )
 CONVTO(CallFrame, Runtime::CallingFrame, CallingFrame, const)
 CONVTO(Plugin, Plugin::Plugin, Plugin, const)
@@ -344,6 +352,7 @@ CONVFROM(TabType, AST::TableType, TableType, )
 CONVFROM(TabType, AST::TableType, TableType, const)
 CONVFROM(MemType, AST::MemoryType, MemoryType, )
 CONVFROM(MemType, AST::MemoryType, MemoryType, const)
+CONVFROM(TagType, AST::TagType, TagType, const)
 CONVFROM(GlobType, AST::GlobalType, GlobalType, )
 CONVFROM(GlobType, AST::GlobalType, GlobalType, const)
 CONVFROM(ImpType, AST::ImportDesc, ImportType, const)
@@ -361,6 +370,7 @@ CONVFROM(Tab, Runtime::Instance::TableInstance, TableInstance, )
 CONVFROM(Tab, Runtime::Instance::TableInstance, TableInstance, const)
 CONVFROM(Mem, Runtime::Instance::MemoryInstance, MemoryInstance, )
 CONVFROM(Mem, Runtime::Instance::MemoryInstance, MemoryInstance, const)
+CONVFROM(Tag, Runtime::Instance::TagInstance, TagInstance, const)
 CONVFROM(Glob, Runtime::Instance::GlobalInstance, GlobalInstance, )
 CONVFROM(Glob, Runtime::Instance::GlobalInstance, GlobalInstance, const)
 CONVFROM(CallFrame, Runtime::CallingFrame, CallingFrame, const)
@@ -1180,6 +1190,18 @@ WasmEdge_MemoryTypeDelete(WasmEdge_MemoryTypeContext *Cxt) {
 
 // <<<<<<<< WasmEdge memory type functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
+// >>>>>>>> WasmEdge tag type functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+WASMEDGE_CAPI_EXPORT const WasmEdge_FunctionTypeContext *
+WasmEdge_TagTypeGetFunctionType(const WasmEdge_TagTypeContext *Cxt) {
+  if (Cxt) {
+    return toFuncTypeCxt(&fromTagTypeCxt(Cxt)->getFuncType());
+  }
+  return nullptr;
+}
+
+// <<<<<<<< WasmEdge tag type functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
 // >>>>>>>> WasmEdge global type functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 WASMEDGE_CAPI_EXPORT WasmEdge_GlobalTypeContext *
@@ -1278,6 +1300,16 @@ WasmEdge_ImportTypeGetMemoryType(const WasmEdge_ASTModuleContext *ASTCxt,
       fromImpTypeCxt(Cxt)->getExternalType() ==
           WasmEdge::ExternalType::Memory) {
     return toMemTypeCxt(&fromImpTypeCxt(Cxt)->getExternalMemoryType());
+  }
+  return nullptr;
+}
+
+WASMEDGE_CAPI_EXPORT const WasmEdge_TagTypeContext *
+WasmEdge_ImportTypeGetTagType(const WasmEdge_ASTModuleContext *ASTCxt,
+                              const WasmEdge_ImportTypeContext *Cxt) {
+  if (ASTCxt && Cxt &&
+      fromImpTypeCxt(Cxt)->getExternalType() == WasmEdge::ExternalType::Tag) {
+    return toTagTypeCxt(&fromImpTypeCxt(Cxt)->getExternalTagType());
   }
   return nullptr;
 }
@@ -1396,6 +1428,30 @@ WasmEdge_ExportTypeGetMemoryType(const WasmEdge_ASTModuleContext *ASTCxt,
       return nullptr;
     }
     return toMemTypeCxt(&MemTypes[ExtIdx]);
+  }
+  return nullptr;
+}
+
+WASMEDGE_CAPI_EXPORT const WasmEdge_TagTypeContext *
+WasmEdge_ExportTypeGetTagType(const WasmEdge_ASTModuleContext *ASTCxt,
+                              const WasmEdge_ExportTypeContext *Cxt) {
+  if (ASTCxt && Cxt &&
+      fromExpTypeCxt(Cxt)->getExternalType() == WasmEdge::ExternalType::Tag) {
+    // `external_index` = `tag_type_index` + `import_tag_nums`
+    uint32_t ExtIdx = fromExpTypeCxt(Cxt)->getExternalIndex();
+    const auto &ImpDescs =
+        fromASTModCxt(ASTCxt)->getImportSection().getContent();
+    for (auto &&ImpDesc : ImpDescs) {
+      if (ImpDesc.getExternalType() == WasmEdge::ExternalType::Tag) {
+        ExtIdx--;
+      }
+    }
+    // Get the tag type
+    const auto &TagDescs = fromASTModCxt(ASTCxt)->getTagSection().getContent();
+    if (ExtIdx >= TagDescs.size()) {
+      return nullptr;
+    }
+    return toTagTypeCxt(&TagDescs[ExtIdx]);
   }
   return nullptr;
 }
@@ -1876,6 +1932,15 @@ WasmEdge_ModuleInstanceFindMemory(const WasmEdge_ModuleInstanceContext *Cxt,
   return nullptr;
 }
 
+WASMEDGE_CAPI_EXPORT WasmEdge_TagInstanceContext *
+WasmEdge_ModuleInstanceFindTag(const WasmEdge_ModuleInstanceContext *Cxt,
+                               const WasmEdge_String Name) {
+  if (Cxt) {
+    return toTagCxt(fromModCxt(Cxt)->findTagExports(genStrView(Name)));
+  }
+  return nullptr;
+}
+
 WASMEDGE_CAPI_EXPORT WasmEdge_GlobalInstanceContext *
 WasmEdge_ModuleInstanceFindGlobal(const WasmEdge_ModuleInstanceContext *Cxt,
                                   const WasmEdge_String Name) {
@@ -1935,6 +2000,24 @@ WasmEdge_ModuleInstanceListMemory(const WasmEdge_ModuleInstanceContext *Cxt,
                                   WasmEdge_String *Names, const uint32_t Len) {
   if (Cxt) {
     return fromModCxt(Cxt)->getMemoryExports(
+        [&](auto &Map) { return fillMap(Map, Names, Len); });
+  }
+  return 0;
+}
+
+WASMEDGE_CAPI_EXPORT uint32_t WasmEdge_ModuleInstanceListTagLength(
+    const WasmEdge_ModuleInstanceContext *Cxt) {
+  if (Cxt) {
+    return fromModCxt(Cxt)->getTagExportNum();
+  }
+  return 0;
+}
+
+WASMEDGE_CAPI_EXPORT uint32_t
+WasmEdge_ModuleInstanceListTag(const WasmEdge_ModuleInstanceContext *Cxt,
+                               WasmEdge_String *Names, const uint32_t Len) {
+  if (Cxt) {
+    return fromModCxt(Cxt)->getTagExports(
         [&](auto &Map) { return fillMap(Map, Names, Len); });
   }
   return 0;
@@ -2232,6 +2315,18 @@ WasmEdge_MemoryInstanceDelete(WasmEdge_MemoryInstanceContext *Cxt) {
 }
 
 // <<<<<<<< WasmEdge memory instance functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>> WasmEdge tag instance functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+WASMEDGE_CAPI_EXPORT const WasmEdge_TagTypeContext *
+WasmEdge_TagInstanceGetTagType(const WasmEdge_TagInstanceContext *Cxt) {
+  if (Cxt) {
+    return toTagTypeCxt(&fromTagCxt(Cxt)->getTagType());
+  }
+  return nullptr;
+}
+
+// <<<<<<<< WasmEdge tag instance functions <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 // >>>>>>>> WasmEdge global instance functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 

--- a/lib/driver/runtimeTool.cpp
+++ b/lib/driver/runtimeTool.cpp
@@ -65,11 +65,15 @@ int Tool(struct DriverToolOptions &Opt) noexcept {
   if (Opt.PropThreads.value()) {
     Conf.addProposal(Proposal::Threads);
   }
+  if (Opt.PropExceptionHandling.value()) {
+    Conf.addProposal(Proposal::ExceptionHandling);
+  }
   if (Opt.PropAll.value()) {
     Conf.addProposal(Proposal::MultiMemories);
     Conf.addProposal(Proposal::TailCall);
     Conf.addProposal(Proposal::ExtendedConst);
     Conf.addProposal(Proposal::Threads);
+    Conf.addProposal(Proposal::ExceptionHandling);
   }
 
   std::optional<std::chrono::system_clock::time_point> Timeout;

--- a/lib/executor/CMakeLists.txt
+++ b/lib/executor/CMakeLists.txt
@@ -11,6 +11,7 @@ wasmedge_add_library(wasmedgeExecutor
   instantiate/data.cpp
   instantiate/export.cpp
   instantiate/module.cpp
+  instantiate/tag.cpp
   engine/proxy.cpp
   engine/controlInstr.cpp
   engine/tableInstr.cpp

--- a/lib/executor/engine/controlInstr.cpp
+++ b/lib/executor/engine/controlInstr.cpp
@@ -47,7 +47,8 @@ Expect<void> Executor::runTryOp(Runtime::StackManager &StackMgr,
     for (auto CatchOffset : Instr.getTryBlockJumpCatch()) {
       auto CatchInstrIt = PC + CatchOffset;
       StackMgr.addCatchCaluseToLastHandler(
-          getTagInstByIdx(StackMgr, CatchInstrIt->getTagIdx()), CatchInstrIt);
+          getTagInstByIdx(StackMgr, CatchInstrIt->getTargetIndex()),
+          CatchInstrIt);
     }
     if (auto CatchAllOffset = Instr.getTryBlockJumpCatchAll(); CatchAllOffset) {
       auto CatchAllInstrIt = PC + CatchAllOffset;
@@ -60,7 +61,7 @@ Expect<void> Executor::runTryOp(Runtime::StackManager &StackMgr,
 Expect<void> Executor::runThrowOp(Runtime::StackManager &StackMgr,
                                   const AST::Instruction &Instr,
                                   AST::InstrView::iterator &PC) noexcept {
-  auto *TagInst = getTagInstByIdx(StackMgr, Instr.getTagIdx());
+  auto *TagInst = getTagInstByIdx(StackMgr, Instr.getTargetIndex());
   return throwException(StackMgr, TagInst, PC);
 }
 

--- a/lib/executor/engine/controlInstr.cpp
+++ b/lib/executor/engine/controlInstr.cpp
@@ -33,12 +33,52 @@ Expect<void> Executor::runIfElseOp(Runtime::StackManager &StackMgr,
   return {};
 }
 
+Expect<void> Executor::runTryOp(Runtime::StackManager &StackMgr,
+                                const AST::Instruction &Instr,
+                                AST::InstrView::iterator &PC) noexcept {
+  if (Instr.isDelegate()) {
+    StackMgr.pushHandler(PC + Instr.getTryBlockJumpEnd(),
+                         Instr.getTryBlockVSize(), Instr.getTryBlockHOffset(),
+                         Instr.getTryBlockCOffset());
+
+  } else {
+    StackMgr.pushHandler(PC + Instr.getTryBlockJumpEnd(),
+                         Instr.getTryBlockBlockParamNum());
+    for (auto CatchOffset : Instr.getTryBlockJumpCatch()) {
+      auto CatchInstrIt = PC + CatchOffset;
+      StackMgr.addCatchCaluseToLastHandler(
+          getTagInstByIdx(StackMgr, CatchInstrIt->getTagIdx()), CatchInstrIt);
+    }
+    if (auto CatchAllOffset = Instr.getTryBlockJumpCatchAll(); CatchAllOffset) {
+      auto CatchAllInstrIt = PC + CatchAllOffset;
+      StackMgr.addCatchCaluseToLastHandler(nullptr, CatchAllInstrIt);
+    }
+  }
+  return {};
+}
+
+Expect<void> Executor::runThrowOp(Runtime::StackManager &StackMgr,
+                                  const AST::Instruction &Instr,
+                                  AST::InstrView::iterator &PC) noexcept {
+  auto *TagInst = getTagInstByIdx(StackMgr, Instr.getTagIdx());
+  return throwException(StackMgr, TagInst, PC);
+}
+
+Expect<void> Executor::runRethrowOp(Runtime::StackManager &StackMgr,
+                                    const AST::Instruction &Instr,
+                                    AST::InstrView::iterator &PC) noexcept {
+  auto Exception = StackMgr.getCaughtTopN(Instr.getJump().CaughtStackOffset);
+  StackMgr.pushValVec(Exception.Val);
+  return throwException(StackMgr, Exception.TagInst, PC);
+}
+
 Expect<void> Executor::runBrOp(Runtime::StackManager &StackMgr,
                                const AST::Instruction &Instr,
                                AST::InstrView::iterator &PC) noexcept {
-  return branchToLabel(StackMgr, Instr.getJump().StackEraseBegin,
-                       Instr.getJump().StackEraseEnd, Instr.getJump().PCOffset,
-                       PC);
+  auto &JumpDesc = Instr.getJump();
+  return branchToLabel(StackMgr, JumpDesc.ValueStackEraseBegin,
+                       JumpDesc.ValueStackEraseEnd, JumpDesc.HandlerStackOffset,
+                       JumpDesc.CaughtStackOffset, JumpDesc.PCOffset, PC);
 }
 
 Expect<void> Executor::runBrIfOp(Runtime::StackManager &StackMgr,
@@ -60,13 +100,16 @@ Expect<void> Executor::runBrTableOp(Runtime::StackManager &StackMgr,
   auto LabelTable = Instr.getLabelList();
   const auto LabelTableSize = static_cast<uint32_t>(LabelTable.size() - 1);
   if (Value < LabelTableSize) {
-    return branchToLabel(StackMgr, LabelTable[Value].StackEraseBegin,
-                         LabelTable[Value].StackEraseEnd,
-                         LabelTable[Value].PCOffset, PC);
+    auto &JumpDesc = LabelTable[Value];
+    return branchToLabel(StackMgr, JumpDesc.ValueStackEraseBegin,
+                         JumpDesc.ValueStackEraseEnd,
+                         JumpDesc.HandlerStackOffset,
+                         JumpDesc.CaughtStackOffset, JumpDesc.PCOffset, PC);
   }
-  return branchToLabel(StackMgr, LabelTable[LabelTableSize].StackEraseBegin,
-                       LabelTable[LabelTableSize].StackEraseEnd,
-                       LabelTable[LabelTableSize].PCOffset, PC);
+  auto &JumpDesc = LabelTable[LabelTableSize];
+  return branchToLabel(StackMgr, JumpDesc.ValueStackEraseBegin,
+                       JumpDesc.ValueStackEraseEnd, JumpDesc.HandlerStackOffset,
+                       JumpDesc.CaughtStackOffset, JumpDesc.PCOffset, PC);
 }
 
 Expect<void> Executor::runReturnOp(Runtime::StackManager &StackMgr,

--- a/lib/executor/engine/controlInstr.cpp
+++ b/lib/executor/engine/controlInstr.cpp
@@ -43,14 +43,14 @@ Expect<void> Executor::runTryOp(Runtime::StackManager &StackMgr,
 
   } else {
     StackMgr.pushHandler(PC + Instr.getTryBlockJumpEnd(),
-                         Instr.getTryBlockBlockParamNum());
-    for (auto CatchOffset : Instr.getTryBlockJumpCatch()) {
+                         Instr.getTryBlockParamNum());
+    for (auto CatchOffset : Instr.getJumpCatchList()) {
       auto CatchInstrIt = PC + CatchOffset;
       StackMgr.addCatchCaluseToLastHandler(
           getTagInstByIdx(StackMgr, CatchInstrIt->getTargetIndex()),
           CatchInstrIt);
     }
-    if (auto CatchAllOffset = Instr.getTryBlockJumpCatchAll(); CatchAllOffset) {
+    if (auto CatchAllOffset = Instr.getJumpCatchAll(); CatchAllOffset) {
       auto CatchAllInstrIt = PC + CatchAllOffset;
       StackMgr.addCatchCaluseToLastHandler(nullptr, CatchAllInstrIt);
     }

--- a/lib/executor/engine/engine.cpp
+++ b/lib/executor/engine/engine.cpp
@@ -117,8 +117,17 @@ Expect<void> Executor::execute(Runtime::StackManager &StackMgr,
       PC += PC->getJumpEnd();
       [[fallthrough]];
     case OpCode::End:
-      PC = StackMgr.maybePopFrame(PC);
+      PC = StackMgr.maybePopFrameOrHandlerOrCaught(PC);
       return {};
+    case OpCode::Try:
+      return runTryOp(StackMgr, Instr, PC);
+    case OpCode::Catch:
+      PC = StackMgr.popHandlerOrCaught(PC);
+      return {};
+    case OpCode::Throw:
+      return runThrowOp(StackMgr, Instr, PC);
+    case OpCode::Rethrow:
+      return runRethrowOp(StackMgr, Instr, PC);
     case OpCode::Br:
       return runBrOp(StackMgr, Instr, PC);
     case OpCode::Br_if:
@@ -135,6 +144,12 @@ Expect<void> Executor::execute(Runtime::StackManager &StackMgr,
       return runCallOp(StackMgr, Instr, PC, true);
     case OpCode::Return_call_indirect:
       return runCallIndirectOp(StackMgr, Instr, PC, true);
+    case OpCode::Delegate:
+      PC = StackMgr.popHandler();
+      return {};
+    case OpCode::Catch_all:
+      PC = StackMgr.popHandlerOrCaught(PC);
+      return {};
 
     // Reference Instructions
     case OpCode::Ref__null:

--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -182,7 +182,10 @@ Executor::enterFunction(Runtime::StackManager &StackMgr,
 }
 
 Expect<void> Executor::branchToLabel(Runtime::StackManager &StackMgr,
-                                     uint32_t EraseBegin, uint32_t EraseEnd,
+                                     uint32_t ValueStackEraseBegin,
+                                     uint32_t ValueStackEraseEnd,
+                                     uint32_t HandlerStackOffset,
+                                     uint32_t CaughtStackOffset,
                                      int32_t PCOffset,
                                      AST::InstrView::iterator &PC) noexcept {
   // Check stop token
@@ -191,10 +194,40 @@ Expect<void> Executor::branchToLabel(Runtime::StackManager &StackMgr,
     return Unexpect(ErrCode::Value::Interrupted);
   }
 
-  StackMgr.stackErase(EraseBegin, EraseEnd);
+  StackMgr.eraseValueStack(ValueStackEraseBegin, ValueStackEraseEnd);
+  StackMgr.eraseHandlerStack(HandlerStackOffset);
+  StackMgr.eraseCaughtStack(CaughtStackOffset);
   // PC need to -1 here because the PC will increase in the next iteration.
   PC += (PCOffset - 1);
   return {};
+}
+
+Expect<void> Executor::throwException(Runtime::StackManager &StackMgr,
+                                      Runtime::Instance::TagInstance *TagInst,
+                                      AST::InstrView::iterator &PC) noexcept {
+  while (!StackMgr.isHandlerStackEmpty()) {
+    auto AssocValSize = TagInst->getAssocValSize();
+    // The value that associated with the exception should remain on the stack
+    auto ExceptionHandler = StackMgr.popToTopHandler(AssocValSize);
+    if (!ExceptionHandler.CatchCaluse.empty()) {
+      for (auto &[CatchTagInst, StartIt] : ExceptionHandler.CatchCaluse) {
+        if (CatchTagInst == nullptr || TagInst == CatchTagInst) {
+          PC = StartIt;
+          StackMgr.pushCaught(TagInst, StackMgr.getTopSpan(AssocValSize),
+                              ExceptionHandler.EndIt);
+          if (CatchTagInst == nullptr) {
+            StackMgr.eraseValueStack(AssocValSize, 0);
+          }
+          return {};
+        }
+      }
+    } else {
+      // The stack has transformed to the state after jumping to the label by
+      // StackMgr.popToTopHandler(AssocValSize)
+      return throwException(StackMgr, TagInst, PC);
+    }
+  }
+  return Unexpect(ErrCode::Value::UncaughtException);
 }
 
 Runtime::Instance::TableInstance *
@@ -217,6 +250,17 @@ Executor::getMemInstByIdx(Runtime::StackManager &StackMgr,
     return nullptr;
   }
   return ModInst->unsafeGetMemory(Idx);
+}
+
+Runtime::Instance::TagInstance *
+Executor::getTagInstByIdx(Runtime::StackManager &StackMgr,
+                          const uint32_t Idx) const {
+  const auto *ModInst = StackMgr.getModule();
+  // When top frame is dummy frame, cannot find instance.
+  if (unlikely(ModInst == nullptr)) {
+    return nullptr;
+  }
+  return ModInst->unsafeGetTag(Idx);
 }
 
 Runtime::Instance::GlobalInstance *

--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -227,6 +227,7 @@ Expect<void> Executor::throwException(Runtime::StackManager &StackMgr,
       return throwException(StackMgr, TagInst, PC);
     }
   }
+  spdlog::error(ErrCode::Value::UncaughtException);
   return Unexpect(ErrCode::Value::UncaughtException);
 }
 

--- a/lib/executor/instantiate/export.cpp
+++ b/lib/executor/instantiate/export.cpp
@@ -33,6 +33,8 @@ Expect<void> Executor::instantiate(Runtime::Instance::ModuleInstance &ModInst,
     case ExternalType::Table:
       ModInst.exportTable(ExtName, ExtIdx);
       break;
+    case ExternalType::Tag:
+      ModInst.exportTag(ExtName, ExtIdx);
     default:
       break;
     }

--- a/lib/executor/instantiate/export.cpp
+++ b/lib/executor/instantiate/export.cpp
@@ -35,6 +35,7 @@ Expect<void> Executor::instantiate(Runtime::Instance::ModuleInstance &ModInst,
       break;
     case ExternalType::Tag:
       ModInst.exportTag(ExtName, ExtIdx);
+      break;
     default:
       break;
     }

--- a/lib/executor/instantiate/import.cpp
+++ b/lib/executor/instantiate/import.cpp
@@ -237,10 +237,10 @@ Expect<void> Executor::instantiate(Runtime::StoreManager &StoreMgr,
     }
     case ExternalType::Tag: {
       // Get tag type. External type checked in validation.
-      const auto &T = ImpDesc.getExternalTag();
+      const auto &T = ImpDesc.getExternalTagType();
       // Import matching.
       auto *TargetInst = TargetModInst->findTagExports(ExtName);
-      const auto &TargetType = TargetInst->getTagType().getFunctionType();
+      const auto &TargetType = TargetInst->getTagType().getFuncType();
       const auto *TType = *ModInst.getFuncType(T.getTypeIdx());
       if (TargetType != *TType) {
         return logMatchError(ModName, ExtName, ExtType, TType->getParamTypes(),

--- a/lib/executor/instantiate/import.cpp
+++ b/lib/executor/instantiate/import.cpp
@@ -70,6 +70,11 @@ checkImportMatched(std::string_view ModName, std::string_view ExtName,
       return {};
     }
     break;
+  case ExternalType::Tag:
+    if (auto Res = ModInst.findTagExports(ExtName); likely(Res != nullptr)) {
+      return {};
+    }
+    break;
   default:
     return logUnknownError(ModName, ExtName, ExtType);
   }
@@ -86,6 +91,9 @@ checkImportMatched(std::string_view ModName, std::string_view ExtName,
   if (ModInst.findMemoryExports(ExtName)) {
     return logMatchError(ModName, ExtName, ExtType, ExtType,
                          ExternalType::Memory);
+  }
+  if (ModInst.findTagExports(ExtName)) {
+    return logMatchError(ModName, ExtName, ExtType, ExtType, ExternalType::Tag);
   }
   if (ModInst.findGlobalExports(ExtName)) {
     return logMatchError(ModName, ExtName, ExtType, ExtType,
@@ -225,6 +233,22 @@ Expect<void> Executor::instantiate(Runtime::StoreManager &StoreMgr,
       }
       // Set the matched memory address to module instance.
       ModInst.importMemory(TargetInst);
+      break;
+    }
+    case ExternalType::Tag: {
+      // Get tag type. External type checked in validation.
+      const auto &T = ImpDesc.getExternalTag();
+      // Import matching.
+      auto *TargetInst = TargetModInst->findTagExports(ExtName);
+      const auto &TargetType = TargetInst->getTagType().getFunctionType();
+      const auto *TType = *ModInst.getFuncType(T.getTypeIdx());
+      if (TargetType != *TType) {
+        return logMatchError(ModName, ExtName, ExtType, TType->getParamTypes(),
+                             TType->getReturnTypes(),
+                             TargetType.getParamTypes(),
+                             TargetType.getReturnTypes());
+      }
+      ModInst.importTag(TargetInst);
       break;
     }
     case ExternalType::Global: {

--- a/lib/executor/instantiate/module.cpp
+++ b/lib/executor/instantiate/module.cpp
@@ -75,6 +75,11 @@ Executor::instantiate(Runtime::StoreManager &StoreMgr, const AST::Module &Mod,
   // This function will always success.
   instantiate(*ModInst, MemSec);
 
+  // Instantiate TagSection (TagSec)
+  const AST::TagSection &TagSec = Mod.getTagSection();
+  // This function will always success.
+  instantiate(*ModInst, TagSec);
+
   // Add a temp module to Store with only imported globals for initialization.
   std::unique_ptr<Runtime::Instance::ModuleInstance> TmpModInst =
       std::make_unique<Runtime::Instance::ModuleInstance>("");

--- a/lib/executor/instantiate/tag.cpp
+++ b/lib/executor/instantiate/tag.cpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2022 Second State INC
+
+#include "executor/executor.h"
+
+namespace WasmEdge {
+namespace Executor {
+
+// Instantiate tag instance. See "include/executor/executor.h".
+Expect<void> Executor::instantiate(Runtime::Instance::ModuleInstance &ModInst,
+                                   const AST::TagSection &TagSec) {
+
+  // Iterate through tags from tag section to instantiate
+  for (const auto &T : TagSec.getContent()) {
+    // Add Tag with corresponding Type.
+    auto TypePtr = *ModInst.getFuncType(T.getTypeIdx());
+    ModInst.addTag(*TypePtr);
+  }
+  return {};
+}
+
+} // namespace Executor
+} // namespace WasmEdge

--- a/lib/executor/instantiate/tag.cpp
+++ b/lib/executor/instantiate/tag.cpp
@@ -11,10 +11,10 @@ Expect<void> Executor::instantiate(Runtime::Instance::ModuleInstance &ModInst,
                                    const AST::TagSection &TagSec) {
 
   // Iterate through tags from tag section to instantiate
-  for (const auto &T : TagSec.getContent()) {
+  for (const auto &TgType : TagSec.getContent()) {
     // Add Tag with corresponding Type.
-    auto TypePtr = *ModInst.getFuncType(T.getTypeIdx());
-    ModInst.addTag(*TypePtr);
+    auto FuncTypePtr = *ModInst.getFuncType(TgType.getTypeIdx());
+    ModInst.addTag(TgType, FuncTypePtr);
   }
   return {};
 }

--- a/lib/loader/ast/description.cpp
+++ b/lib/loader/ast/description.cpp
@@ -67,6 +67,11 @@ Expect<void> Loader::loadDesc(AST::ImportDesc &ImpDesc) {
     return {};
   }
   case ExternalType::Tag: {
+    if (!Conf.hasProposal(Proposal::ExceptionHandling)) {
+      return logNeedProposal(ErrCode::Value::MalformedImportKind,
+                             Proposal::ExceptionHandling, FMgr.getLastOffset(),
+                             ASTNodeAttr::Module);
+    }
     // Read the Tag type node.
     return loadType(ImpDesc.getExternalTagType());
   }
@@ -99,7 +104,13 @@ Expect<void> Loader::loadDesc(AST::ExportDesc &ExpDesc) {
   case ExternalType::Table:
   case ExternalType::Memory:
   case ExternalType::Global:
+    break;
   case ExternalType::Tag:
+    if (!Conf.hasProposal(Proposal::ExceptionHandling)) {
+      return logNeedProposal(ErrCode::Value::MalformedImportKind,
+                             Proposal::ExceptionHandling, FMgr.getLastOffset(),
+                             ASTNodeAttr::Module);
+    }
     break;
   default:
     return logLoadError(ErrCode::Value::MalformedExportKind,

--- a/lib/loader/ast/description.cpp
+++ b/lib/loader/ast/description.cpp
@@ -67,8 +67,8 @@ Expect<void> Loader::loadDesc(AST::ImportDesc &ImpDesc) {
     return {};
   }
   case ExternalType::Tag: {
-    // Read the Tag node.
-    return loadTag(ImpDesc.getExternalTag());
+    // Read the Tag type node.
+    return loadType(ImpDesc.getExternalTagType());
   }
   default:
     return logLoadError(ErrCode::Value::MalformedImportKind,

--- a/lib/loader/ast/description.cpp
+++ b/lib/loader/ast/description.cpp
@@ -66,6 +66,10 @@ Expect<void> Loader::loadDesc(AST::ImportDesc &ImpDesc) {
     }
     return {};
   }
+  case ExternalType::Tag: {
+    // Read the Tag node.
+    return loadTag(ImpDesc.getExternalTag());
+  }
   default:
     return logLoadError(ErrCode::Value::MalformedImportKind,
                         FMgr.getLastOffset(), ASTNodeAttr::Desc_Import);
@@ -95,6 +99,7 @@ Expect<void> Loader::loadDesc(AST::ExportDesc &ExpDesc) {
   case ExternalType::Table:
   case ExternalType::Memory:
   case ExternalType::Global:
+  case ExternalType::Tag:
     break;
   default:
     return logLoadError(ErrCode::Value::MalformedExportKind,

--- a/lib/loader/ast/instruction.cpp
+++ b/lib/loader/ast/instruction.cpp
@@ -351,7 +351,7 @@ Expect<void> Loader::loadInstruction(AST::Instruction &Instr) {
 
   case OpCode::Catch:
   case OpCode::Throw:
-    return readU32(Instr.getTagIdx());
+    return readU32(Instr.getTargetIndex());
 
   // Reference Instructions.
   case OpCode::Ref__null:

--- a/lib/loader/ast/module.cpp
+++ b/lib/loader/ast/module.cpp
@@ -275,6 +275,9 @@ Expect<std::unique_ptr<AST::Module>> Loader::loadModule() {
     }
   }
 
+  setTagFunctionType(Mod->getTagSection(), Mod->getImportSection(),
+                     Mod->getTypeSection());
+
   // Verify the function section and code section are matched.
   if (Mod->getFunctionSection().getContent().size() !=
       Mod->getCodeSection().getContent().size()) {

--- a/lib/loader/ast/section.cpp
+++ b/lib/loader/ast/section.cpp
@@ -175,6 +175,15 @@ Expect<void> Loader::loadSection(AST::DataCountSection &Sec) {
   });
 }
 
+Expect<void> Loader::loadSection(AST::TagSection &Sec) {
+  return loadSectionContent(Sec, [this, &Sec]() {
+    return loadSectionContentVec(Sec,
+                                 [this](AST::Tag &TagToLoad) -> Expect<void> {
+                                   return loadTag(TagToLoad);
+                                 });
+  });
+}
+
 namespace {
 
 inline constexpr uint32_t HostVersion() noexcept {

--- a/lib/loader/ast/section.cpp
+++ b/lib/loader/ast/section.cpp
@@ -177,10 +177,8 @@ Expect<void> Loader::loadSection(AST::DataCountSection &Sec) {
 
 Expect<void> Loader::loadSection(AST::TagSection &Sec) {
   return loadSectionContent(Sec, [this, &Sec]() {
-    return loadSectionContentVec(Sec,
-                                 [this](AST::Tag &TagToLoad) -> Expect<void> {
-                                   return loadTag(TagToLoad);
-                                 });
+    return loadSectionContentVec(
+        Sec, [this](AST::TagType &TgType) { return loadType(TgType); });
   });
 }
 

--- a/lib/loader/ast/type.cpp
+++ b/lib/loader/ast/type.cpp
@@ -211,7 +211,7 @@ Expect<void> Loader::loadType(AST::GlobalType &GlobType) {
 }
 
 // Load binary to construct Tag node. See "include/loader/loader.h".
-Expect<void> Loader::loadTag(AST::Tag &TagToLoad) {
+Expect<void> Loader::loadType(AST::TagType &TgType) {
   if (auto Res = FMgr.readByte()) {
     // The preserved byte for future extension possibility for tag
     // It supports only 0x00 currently, which is for exception handling.
@@ -219,13 +219,13 @@ Expect<void> Loader::loadTag(AST::Tag &TagToLoad) {
       return logLoadError(ErrCode::Value::ExpectedZeroByte,
                           FMgr.getLastOffset(), ASTNodeAttr::Sec_Tag);
     }
-    TagToLoad.setAttribute(*Res);
+    TgType.setAttribute(*Res);
   } else {
     return logLoadError(Res.error(), FMgr.getLastOffset(),
                         ASTNodeAttr::Sec_Tag);
   }
   if (auto Res = FMgr.readU32()) {
-    TagToLoad.setTypeIdx(*Res);
+    TgType.setTypeIdx(*Res);
   } else {
     return logLoadError(Res.error(), FMgr.getLastOffset(),
                         ASTNodeAttr::Sec_Tag);

--- a/lib/loader/ast/type.cpp
+++ b/lib/loader/ast/type.cpp
@@ -210,5 +210,28 @@ Expect<void> Loader::loadType(AST::GlobalType &GlobType) {
   return {};
 }
 
+// Load binary to construct Tag node. See "include/loader/loader.h".
+Expect<void> Loader::loadTag(AST::Tag &TagToLoad) {
+  if (auto Res = FMgr.readByte()) {
+    // The preserved byte for future extension possibility for tag
+    // It supports only 0x00 currently, which is for exception handling.
+    if (unlikely(*Res != 0x00)) {
+      return logLoadError(ErrCode::Value::ExpectedZeroByte,
+                          FMgr.getLastOffset(), ASTNodeAttr::Sec_Tag);
+    }
+    TagToLoad.setAttribute(*Res);
+  } else {
+    return logLoadError(Res.error(), FMgr.getLastOffset(),
+                        ASTNodeAttr::Sec_Tag);
+  }
+  if (auto Res = FMgr.readU32()) {
+    TagToLoad.setTypeIdx(*Res);
+  } else {
+    return logLoadError(Res.error(), FMgr.getLastOffset(),
+                        ASTNodeAttr::Sec_Tag);
+  }
+  return {};
+}
+
 } // namespace Loader
 } // namespace WasmEdge

--- a/lib/loader/loader.cpp
+++ b/lib/loader/loader.cpp
@@ -223,8 +223,8 @@ Expect<RefType> Loader::checkRefTypeProposals(RefType RType, uint64_t Off,
 
 // Helper function to set the function type for tag
 void Loader::setTagFunctionType(AST::TagSection &TagSec,
-                                        AST::ImportSection &ImportSec,
-                                        AST::TypeSection &TypeSec) {
+                                AST::ImportSection &ImportSec,
+                                AST::TypeSection &TypeSec) {
   auto &TypeVec = TypeSec.getContent();
   for (auto &TgType : TagSec.getContent()) {
     auto TypeIdx = TgType.getTypeIdx();
@@ -234,7 +234,7 @@ void Loader::setTagFunctionType(AST::TagSection &TagSec,
     }
   }
   for (auto &Desc : ImportSec.getContent()) {
-    auto& TgType = Desc.getExternalTagType();
+    auto &TgType = Desc.getExternalTagType();
     auto TypeIdx = TgType.getTypeIdx();
     // Invalid type index would be checked during validation
     if (TypeIdx < TypeVec.size()) {

--- a/lib/loader/loader.cpp
+++ b/lib/loader/loader.cpp
@@ -221,5 +221,27 @@ Expect<RefType> Loader::checkRefTypeProposals(RefType RType, uint64_t Off,
   }
 }
 
+// Helper function to set the function type for tag
+void Loader::setTagFunctionType(AST::TagSection &TagSec,
+                                        AST::ImportSection &ImportSec,
+                                        AST::TypeSection &TypeSec) {
+  auto &TypeVec = TypeSec.getContent();
+  for (auto &TgType : TagSec.getContent()) {
+    auto TypeIdx = TgType.getTypeIdx();
+    // Invalid type index would be checked during validation
+    if (TypeIdx < TypeVec.size()) {
+      TgType.setFuncType(&TypeVec[TypeIdx]);
+    }
+  }
+  for (auto &Desc : ImportSec.getContent()) {
+    auto& TgType = Desc.getExternalTagType();
+    auto TypeIdx = TgType.getTypeIdx();
+    // Invalid type index would be checked during validation
+    if (TypeIdx < TypeVec.size()) {
+      TgType.setFuncType(&TypeVec[TypeIdx]);
+    }
+  }
+}
+
 } // namespace Loader
 } // namespace WasmEdge

--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -354,7 +354,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
           NonConstInstr.setTryBlockVSize(static_cast<uint32_t>(Locals.size()) +
                                          CtrlStack[*D + 1].Height);
         } else {
-          NonConstInstr.setTryBlockVSize(static_cast<uint32_t>(Locals.size()) + ValStack.size());
+          NonConstInstr.setTryBlockVSize(static_cast<uint32_t>(Locals.size()) +
+                                         ValStack.size());
         }
         // The try block itself may push an additional handler to stack
         NonConstInstr.setTryBlockHOffset(TryCnt);
@@ -373,7 +374,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
       return Unexpect(Res);
     }
     if (Instr.getOpCode() == OpCode::Try) {
-      const_cast<AST::Instruction &>(Instr).setTryBlockParamNum(static_cast<uint32_t>(T1.size()));
+      const_cast<AST::Instruction &>(Instr).setTryBlockParamNum(
+          static_cast<uint32_t>(T1.size()));
     }
     // Pop and check [t1*]
     if (auto Res = popTypes(T1); !Res) {

--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -350,7 +350,12 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
         // Delegate to the label itself, not before the label
         auto [TryCnt, CatchCnt] = countCtrlStackType(*D + 1);
         auto &NonConstInstr = const_cast<AST::Instruction &>(Instr);
-        NonConstInstr.setTryBlockVSize(CtrlStack[*D + 1].Height);
+        if (*D + 1 < CtrlStack.size()) {
+          NonConstInstr.setTryBlockVSize(Locals.size() +
+                                         CtrlStack[*D + 1].Height);
+        } else {
+          NonConstInstr.setTryBlockVSize(Locals.size() + ValStack.size());
+        }
         // The try block itself may push an additional handler to stack
         NonConstInstr.setTryBlockHOffset(TryCnt);
         NonConstInstr.setTryBlockCOffset(CatchCnt);

--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -351,11 +351,11 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
         auto [TryCnt, CatchCnt] = countCtrlStackType(*D + 1);
         auto &NonConstInstr = const_cast<AST::Instruction &>(Instr);
         if (*D + 1 < CtrlStack.size()) {
-          NonConstInstr.setTryBlockVSize(static_cast<uint32_t>(Locals.size()) +
-                                         CtrlStack[*D + 1].Height);
+          NonConstInstr.setTryBlockVSize(static_cast<uint32_t>(Locals.size() +
+                                         CtrlStack[*D + 1].Height));
         } else {
-          NonConstInstr.setTryBlockVSize(static_cast<uint32_t>(Locals.size()) +
-                                         ValStack.size());
+          NonConstInstr.setTryBlockVSize(static_cast<uint32_t>(Locals.size() +
+                                         ValStack.size()));
         }
         // The try block itself may push an additional handler to stack
         NonConstInstr.setTryBlockHOffset(TryCnt);

--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -402,7 +402,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
       const_cast<AST::Instruction &>(Instr).setTryLast();
     }
     if (auto Res = popCtrl()) {
-      auto N = Instr.getTagIdx();
+      auto N = Instr.getTargetIndex();
       if (N >= Tags.size()) {
         return logOutOfRange(ErrCode::Value::InvalidTagIdx,
                              ErrInfo::IndexCategory::Tag, N,
@@ -447,7 +447,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
     return {};
 
   case OpCode::Throw: {
-    auto N = Instr.getTagIdx();
+    auto N = Instr.getTargetIndex();
     if (N >= Tags.size()) {
       return logOutOfRange(ErrCode::Value::InvalidTagIdx,
                            ErrInfo::IndexCategory::Tag, N,

--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -351,11 +351,11 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
         auto [TryCnt, CatchCnt] = countCtrlStackType(*D + 1);
         auto &NonConstInstr = const_cast<AST::Instruction &>(Instr);
         if (*D + 1 < CtrlStack.size()) {
-          NonConstInstr.setTryBlockVSize(static_cast<uint32_t>(Locals.size() +
-                                         CtrlStack[*D + 1].Height));
+          NonConstInstr.setTryBlockVSize(
+              static_cast<uint32_t>(Locals.size() + CtrlStack[*D + 1].Height));
         } else {
-          NonConstInstr.setTryBlockVSize(static_cast<uint32_t>(Locals.size() +
-                                         ValStack.size()));
+          NonConstInstr.setTryBlockVSize(
+              static_cast<uint32_t>(Locals.size() + ValStack.size()));
         }
         // The try block itself may push an additional handler to stack
         NonConstInstr.setTryBlockHOffset(TryCnt);

--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -237,10 +237,10 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   auto countCtrlStackType =
       [this](uint32_t N) -> std::pair<uint32_t, uint32_t> {
     uint32_t CatchCnt = 0, TryCnt = 0;
-    for (auto it = CtrlStack.begin() + N; it != CtrlStack.end(); it++) {
-      if (it->Code == OpCode::Try)
+    for (auto It = CtrlStack.begin() + N; It != CtrlStack.end(); It++) {
+      if (It->Code == OpCode::Try)
         TryCnt++;
-      if (it->Code == OpCode::Catch || it->Code == OpCode::Catch_all) {
+      if (It->Code == OpCode::Catch || It->Code == OpCode::Catch_all) {
         CatchCnt++;
       }
     }

--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -344,7 +344,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
     [[fallthrough]];
   case OpCode::Try:
     if (Instr.getOpCode() == OpCode::Try && Instr.isDelegate()) {
-      if (auto D = checkCtrlStackDepth(Instr.getTryBlockDelegate()); !D) {
+      if (auto D = checkCtrlStackDepth(Instr.getDelegateIdx()); !D) {
         return Unexpect(D);
       } else {
         // Delegate to the label itself, not before the label
@@ -368,7 +368,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
       return Unexpect(Res);
     }
     if (Instr.getOpCode() == OpCode::Try) {
-      const_cast<AST::Instruction &>(Instr).setTryBlockBlockParamNum(T1.size());
+      const_cast<AST::Instruction &>(Instr).setTryBlockParamNum(T1.size());
     }
     // Pop and check [t1*]
     if (auto Res = popTypes(T1); !Res) {

--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -351,10 +351,10 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
         auto [TryCnt, CatchCnt] = countCtrlStackType(*D + 1);
         auto &NonConstInstr = const_cast<AST::Instruction &>(Instr);
         if (*D + 1 < CtrlStack.size()) {
-          NonConstInstr.setTryBlockVSize(Locals.size() +
+          NonConstInstr.setTryBlockVSize(static_cast<uint32_t>(Locals.size()) +
                                          CtrlStack[*D + 1].Height);
         } else {
-          NonConstInstr.setTryBlockVSize(Locals.size() + ValStack.size());
+          NonConstInstr.setTryBlockVSize(static_cast<uint32_t>(Locals.size()) + ValStack.size());
         }
         // The try block itself may push an additional handler to stack
         NonConstInstr.setTryBlockHOffset(TryCnt);
@@ -373,7 +373,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
       return Unexpect(Res);
     }
     if (Instr.getOpCode() == OpCode::Try) {
-      const_cast<AST::Instruction &>(Instr).setTryBlockParamNum(T1.size());
+      const_cast<AST::Instruction &>(Instr).setTryBlockParamNum(static_cast<uint32_t>(T1.size()));
     }
     // Pop and check [t1*]
     if (auto Res = popTypes(T1); !Res) {

--- a/lib/validator/validator.cpp
+++ b/lib/validator/validator.cpp
@@ -301,7 +301,7 @@ Expect<void> Validator::validate(const AST::ImportDesc &ImpDesc) {
     return {};
   }
   case ExternalType::Tag: {
-    const auto &T = ImpDesc.getExternalTag();
+    const auto &T = ImpDesc.getExternalTagType();
     // Tag type index must exist in context.
     auto TagTypeIdx = T.getTypeIdx();
     if (TagTypeIdx >= Checker.getTypes().size()) {

--- a/test/loader/descriptionTest.cpp
+++ b/test/loader/descriptionTest.cpp
@@ -179,7 +179,7 @@ TEST(DescriptionTest, LoadExportDesc) {
       0x0AU,                                           // Content size = 10
       0x01U,                                           // Vector length = 1
       0x06U, 0x4CU, 0x6FU, 0x61U, 0x64U, 0x65U, 0x72U, // External name: Loader
-      0x04U, 0x00U                                     // Invalid external type
+      0x05U, 0x00U                                     // Invalid external type
   };
   EXPECT_FALSE(Ldr.parseModule(prefixedVec(Vec)));
 

--- a/test/spec/CMakeLists.txt
+++ b/test/spec/CMakeLists.txt
@@ -80,7 +80,7 @@ function(wasmedge_copy_spec_testsuite proposal)
   message(STATUS "Copying test suite to ${CMAKE_CURRENT_BINARY_DIR}/testSuites/${proposal} -- done")
 endfunction()
 
-foreach(PROPOSAL core multi-memory tail-call extended-const threads)
+foreach(PROPOSAL core multi-memory tail-call extended-const threads exception-handling)
   wasmedge_copy_spec_testsuite(${PROPOSAL})
 endforeach()
 

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -244,7 +244,7 @@ static const TestsuiteProposal TestsuiteProposals[] = {
     {"tail-call"sv, {Proposal::TailCall}},
     {"extended-const"sv, {Proposal::ExtendedConst}},
     {"threads"sv, {Proposal::Threads}},
-    {"exception-handling"sv, {Proposal::ExceptionHandling}},
+    {"exception-handling"sv, {Proposal::ExceptionHandling, Proposal::TailCall}},
 };
 
 } // namespace

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -122,7 +122,7 @@ parseValueList(const simdjson::dom::array &Args) {
           I++;
         }
 #if defined(_MSC_VER) && !defined(__clang__) // MSVC
-        I64x2 = reinterpret_cast<WasmEdge::uint64x2_t&>(I32x4);
+        I64x2 = reinterpret_cast<WasmEdge::uint64x2_t &>(I32x4);
 #else
         I64x2 = reinterpret_cast<WasmEdge::uint64x2_t>(I32x4);
 #endif
@@ -136,7 +136,7 @@ parseValueList(const simdjson::dom::array &Args) {
           I++;
         }
 #if defined(_MSC_VER) && !defined(__clang__) // MSVC
-        I64x2 = reinterpret_cast<WasmEdge::uint64x2_t&>(I16x8);
+        I64x2 = reinterpret_cast<WasmEdge::uint64x2_t &>(I16x8);
 #else
         I64x2 = reinterpret_cast<WasmEdge::uint64x2_t>(I16x8);
 #endif
@@ -149,7 +149,7 @@ parseValueList(const simdjson::dom::array &Args) {
           I++;
         }
 #if defined(_MSC_VER) && !defined(__clang__) // MSVC
-        I64x2 = reinterpret_cast<WasmEdge::uint64x2_t&>(I8x16);
+        I64x2 = reinterpret_cast<WasmEdge::uint64x2_t &>(I8x16);
 #else
         I64x2 = reinterpret_cast<WasmEdge::uint64x2_t>(I8x16);
 #endif
@@ -244,7 +244,9 @@ static const TestsuiteProposal TestsuiteProposals[] = {
     {"tail-call"sv, {Proposal::TailCall}},
     {"extended-const"sv, {Proposal::ExtendedConst}},
     {"threads"sv, {Proposal::Threads}},
-    {"exception-handling"sv, {Proposal::ExceptionHandling, Proposal::TailCall}},
+    {"exception-handling"sv,
+     {Proposal::ExceptionHandling, Proposal::TailCall},
+     WasmEdge::SpecTest::TestMode::Interpreter},
 };
 
 } // namespace
@@ -375,8 +377,8 @@ bool SpecTest::compare(const std::pair<std::string, std::string> &Expected,
           static_cast<uint64_t>(Got.first.get<uint128_t>()),
           static_cast<uint64_t>(Got.first.get<uint128_t>() >> 64U)};
 #if defined(_MSC_VER) && !defined(__clang__) // MSVC
-      const auto VF = reinterpret_cast<const floatx4_t&>(V64);
-      const auto VI = reinterpret_cast<const uint32x4_t&>(V64);
+      const auto VF = reinterpret_cast<const floatx4_t &>(V64);
+      const auto VI = reinterpret_cast<const uint32x4_t &>(V64);
 #else
       const auto VF = reinterpret_cast<floatx4_t>(V64);
       const auto VI = reinterpret_cast<uint32x4_t>(V64);
@@ -399,8 +401,8 @@ bool SpecTest::compare(const std::pair<std::string, std::string> &Expected,
           static_cast<uint64_t>(Got.first.get<uint128_t>()),
           static_cast<uint64_t>(Got.first.get<uint128_t>() >> 64U)};
 #if defined(_MSC_VER) && !defined(__clang__) // MSVC
-      const auto VF = reinterpret_cast<const doublex2_t&>(V64);
-      const auto VI = reinterpret_cast<const uint64x2_t&>(V64);
+      const auto VF = reinterpret_cast<const doublex2_t &>(V64);
+      const auto VI = reinterpret_cast<const uint64x2_t &>(V64);
 #else
       const auto VF = reinterpret_cast<doublex2_t>(V64);
       const auto VI = reinterpret_cast<uint64x2_t>(V64);
@@ -423,7 +425,7 @@ bool SpecTest::compare(const std::pair<std::string, std::string> &Expected,
           static_cast<uint64_t>(Got.first.get<uint128_t>()),
           static_cast<uint64_t>(Got.first.get<uint128_t>() >> 64U)};
 #if defined(_MSC_VER) && !defined(__clang__) // MSVC
-      const auto V = reinterpret_cast<const uint8x16_t&>(V64);
+      const auto V = reinterpret_cast<const uint8x16_t &>(V64);
 #else
       const auto V = reinterpret_cast<uint8x16_t>(V64);
 #endif
@@ -440,7 +442,7 @@ bool SpecTest::compare(const std::pair<std::string, std::string> &Expected,
           static_cast<uint64_t>(Got.first.get<uint128_t>()),
           static_cast<uint64_t>(Got.first.get<uint128_t>() >> 64U)};
 #if defined(_MSC_VER) && !defined(__clang__) // MSVC
-      const auto V = reinterpret_cast<const uint16x8_t&>(V64);
+      const auto V = reinterpret_cast<const uint16x8_t &>(V64);
 #else
       const auto V = reinterpret_cast<uint16x8_t>(V64);
 #endif
@@ -457,7 +459,7 @@ bool SpecTest::compare(const std::pair<std::string, std::string> &Expected,
           static_cast<uint64_t>(Got.first.get<uint128_t>()),
           static_cast<uint64_t>(Got.first.get<uint128_t>() >> 64U)};
 #if defined(_MSC_VER) && !defined(__clang__) // MSVC
-      const auto V = reinterpret_cast<const uint32x4_t&>(V64);
+      const auto V = reinterpret_cast<const uint32x4_t &>(V64);
 #else
       const auto V = reinterpret_cast<uint32x4_t>(V64);
 #endif

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -611,13 +611,15 @@ void SpecTest::run(std::string_view Proposal, std::string_view UnitName) {
           stringContains(Text, WasmEdge::ErrCodeStr[Res.error().getEnum()]));
     }
   };
-  auto ExceptionInvoke = [&](const rapidjson::Value &Action,
+  auto ExceptionInvoke = [&](const simdjson::dom::object &Action,
                              uint64_t LineNumber) {
     const auto ModName = GetModuleName(Action);
-    const auto Field = Action["field"s].Get<std::string>();
-    const auto Params = parseValueList(Action["args"s]);
+    const std::string_view Field = Action["field"];
+    simdjson::dom::array Args = Action["args"];
+    const auto Params = parseValueList(Args);
 
-    if (auto Res = onInvoke(ModName, Field, Params.first, Params.second)) {
+    if (auto Res = onInvoke(ModName, std::string(Field), Params.first,
+                            Params.second)) {
       EXPECT_NE(LineNumber, LineNumber);
     } else {
       EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UncaughtException);
@@ -725,9 +727,9 @@ void SpecTest::run(std::string_view Proposal, std::string_view UnitName) {
         return;
       }
       case CommandID::AssertException: {
-        const auto &Action = Cmd["action"s];
-        const auto ActType = Action["type"].Get<std::string>();
-        const uint64_t LineNumber = Cmd["line"].Get<uint64_t>();
+        const simdjson::dom::object &Action = Cmd["action"];
+        const std::string_view ActType = Action["type"];
+        const uint64_t LineNumber = Cmd["line"];
         // TODO: Check expected exception type
         if (ActType == "invoke"sv) {
           ExceptionInvoke(Action, LineNumber);

--- a/test/spec/spectest.h
+++ b/test/spec/spectest.h
@@ -44,6 +44,7 @@ public:
     AssertInvalid,
     AssertUnlinkable,
     AssertUninstantiable,
+    AssertException,
   };
 
   enum class TestMode : uint8_t {


### PR DESCRIPTION
#2335 

## Note
We may now generated the wasm with exception handling by `emcc -O1 -fwasm-exceptions a.cpp -o a.wasm` and test it on the interpreter mode.

<details> 
  <summary> Example </summary>

```cpp
#include <cstdio>
#include <stdexcept>

double divideNumbers(double num1, double num2) {
    if (num2 == 0) {
        throw std::invalid_argument("Error: Division by zero");
    }
    if (num1 < 0 || num2 < 0) {
        throw std::domain_error("Error: Negative number");
    }
    return num1 / num2;
}

void testDivideNumbers(double num1, double num2) {
    try {
        double result = divideNumbers(num1, num2);
        printf("The result is: %f\n", result);
    } catch (const std::invalid_argument& e) {
        printf("Caught an invalid_argument exception in testDivideNumbers: %s\n", e.what());
        throw; // re-throwing the exception
    } catch (const std::domain_error& e) {
        printf("Caught a domain_error exception in testDivideNumbers: %s\n", e.what());
        throw std::runtime_error("New runtime_error from testDivideNumbers");
    }
}

void anotherTest(double num1, double num2) {
    try {
        testDivideNumbers(num1, num2);
    } catch (const std::invalid_argument& e) {
        printf("Caught an invalid_argument exception in anotherTest: %s\n", e.what());
        throw std::out_of_range("New out_of_range from anotherTest");
    } catch (const std::runtime_error& e) {
        printf("Caught a runtime_error exception in anotherTest: %s\n", e.what());
    }
}

int main() {
    try {
	double num1 = 10.0;
	double num2 = 3.0;
        anotherTest(num1, num2);
    } catch (const std::out_of_range& e) {
        printf("Caught an out_of_range exception in main: %s\n", e.what());
    } catch (...) {
        printf("Caught an unknown exception in main.\n");
    }

    try {
	double num1 = -10.0;
	double num2 = 0.0;
        anotherTest(num1, num2);
    } catch (const std::out_of_range& e) {
        printf("Caught an out_of_range exception in main: %s\n", e.what());
    } catch (...) {
        printf("Caught an unknown exception in main.\n");
    }

    try {
	double num1 = -10.0;
	double num2 = 3.0;
        anotherTest(num1, num2);
    } catch (const std::out_of_range& e) {
        printf("Caught an out_of_range exception in main: %s\n", e.what());
    } catch (...) {
        printf("Caught an unknown exception in main.\n");
    }
    return 0;
}
```

Output:
```
The result is: 3.333333
Caught an invalid_argument exception in testDivideNumbers: Error: Division by zero
Caught an invalid_argument exception in anotherTest: Error: Division by zero
Caught an out_of_range exception in main: New out_of_range from anotherTest
Caught a domain_error exception in testDivideNumbers: Error: Negative number
Caught a runtime_error exception in anotherTest: New runtime_error from testDivideNumbers
```

</details>

However, if I replace printf by cout, the execution may crash. It seems that cout may contain several complicated exception handling block. I think we can merge this first and solve this issue in the future.


## References
- [Webassembly Specifications with exception handling](https://webassembly.github.io/exception-handling/)
- [Exception handling proposal](https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/Exceptions.md)