### PR TITLE
[Rust] Introduce `fiber-for-wasmedge`

### DIFF
--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Rustfmt
         working-directory: bindings/rust/
-        run: cargo fmt --all -- --check
+        run: cargo +nightly fmt --all -- --check
 
       - name: Clippy
         working-directory: bindings/rust/
@@ -109,7 +109,7 @@ jobs:
 
       - name: Run cargo fmt
         working-directory: bindings/rust/
-        run: cargo fmt --all -- --check
+        run: cargo +nightly fmt --all -- --check
 
       - name: Clippy
         working-directory: bindings/rust/
@@ -162,9 +162,8 @@ jobs:
           components: rustfmt, clippy
 
       - name: Rustfmt
-        run: |
-          cd bindings/rust/
-          cargo fmt --all -- --check
+        working-directory: bindings/rust/
+        run: cargo +nightly fmt --all -- --check
 
       - name: Build WasmEdge with Release mode
         run: |
@@ -229,7 +228,7 @@ jobs:
 
       - name: Rustfmt
         working-directory: bindings/rust/
-        run: cargo fmt --all -- --check
+        run: cargo +nightly fmt --all -- --check
 
       - name: Clippy
         working-directory: bindings/rust/

--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        rust: [1.66, 1.67, 1.68]
+        rust: [1.68, 1.69]
     container:
       image: wasmedge/wasmedge:ubuntu-build-clang
 
@@ -76,6 +76,7 @@ jobs:
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           export LD_LIBRARY_PATH="$(pwd)/../../build/lib/api"
+          cargo +nightly -Z sparse-registry update
           cargo test --workspace --locked --features aot,async,ffi -- --test-threads=1
           cargo test --examples --locked --features aot,async,ffi -- --test-threads=1
 

--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -39,12 +39,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Rust-stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
-
       - name: Build WasmEdge with Release mode
         run: |
           apt update
@@ -52,6 +46,12 @@ jobs:
           cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_PLUGIN_PROCESS=On .
           cmake --build build
 
+      - name: Install Rust-nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: rustfmt, clippy
+    
       - name: Rustfmt
         working-directory: bindings/rust/
         run: cargo +nightly fmt --all -- --check
@@ -62,9 +62,14 @@ jobs:
           export WASMEDGE_DIR="$(pwd)/../../"
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
-          cargo clippy -V
-          cargo clippy --lib --examples --features aot,async,wasi_crypto,wasi_nn,wasmedge_process,ffi -- -D warnings
-
+          cargo +nightly clippy -V
+          cargo +nightly clippy --lib --examples --features aot,async,wasi_crypto,wasi_nn,wasmedge_process,ffi -- -D warnings
+    
+      - name: Install Rust-stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust }}
+  
       - name: Test Rust Bindings
         working-directory: bindings/rust/
         run: |

--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        rust: [1.68, 1.69]
+        rust: [1.69, 1.68]
     container:
       image: wasmedge/wasmedge:ubuntu-build-clang
 
@@ -86,19 +86,13 @@ jobs:
     strategy:
       matrix:
         os: [macos-11, macos-12]
-        rust: [1.66, 1.67, 1.68]
+        rust: [1.69, 1.68]
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Install Rust-stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
 
       - name: Install build tools
         run: brew install llvm@14 ninja boost cmake
@@ -112,6 +106,11 @@ jobs:
           cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release .
           cmake --build build
 
+      - name: Install Rust-nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy
+      
       - name: Run cargo fmt
         working-directory: bindings/rust/
         run: cargo +nightly fmt --all -- --check
@@ -122,9 +121,14 @@ jobs:
           export WASMEDGE_DIR="$(pwd)/../../"
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
-          cargo clippy -V
-          cargo clippy --lib --examples --features aot,async,ffi -- -D warnings
+          cargo +nightly clippy -V
+          cargo +nightly clippy --lib --examples --features aot,async,ffi -- -D warnings
 
+      - name: Install Rust-stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust }}
+  
       - name: Test Rust Bindings
         working-directory: bindings/rust/
         run: |
@@ -132,6 +136,7 @@ jobs:
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           export DYLD_LIBRARY_PATH="$(pwd)/../../build/lib/api"
+          cargo +nightly -Z sparse-registry update
           cargo test --workspace --locked --features aot,async,ffi -- --test-threads=1
           cargo test --examples --locked --features aot,async,ffi -- --test-threads=1
 
@@ -140,7 +145,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        rust: [1.66, 1.67, 1.68]
+        rust: [1.69, 1.68]
     env:
       WASMEDGE_DIR: ${{ github.workspace }}
       WASMEDGE_BUILD_DIR: ${{ github.workspace }}\build
@@ -160,16 +165,6 @@ jobs:
         with:
           sdk-version: 19041
 
-      - name: Install Rust-stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
-
-      - name: Rustfmt
-        working-directory: bindings/rust/
-        run: cargo +nightly fmt --all -- --check
-
       - name: Build WasmEdge with Release mode
         run: |
           $vsPath = (vswhere -latest -property installationPath)
@@ -185,15 +180,29 @@ jobs:
           cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release "-DCMAKE_SYSTEM_VERSION=$cmake_sys_version" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL "-DLLVM_DIR=$llvm_dir" -DWASMEDGE_BUILD_PACKAGE="ZIP" .
           cmake --build build
 
+      - name: Install Rust-nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy
+      
+      - name: Rustfmt
+        working-directory: bindings/rust/
+        run: cargo +nightly fmt --all -- --check
+  
       - name: Clippy
         run: |
           $vsPath = (vswhere -latest -property installationPath)
           Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
           cd bindings/rust/
-          cargo clippy -V
-          cargo clippy --lib --examples --features aot,async,ffi -- -D warnings
-
+          cargo +nightly clippy -V
+          cargo +nightly clippy --lib --examples --features aot,async,ffi -- -D warnings
+  
+      - name: Install Rust-stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust }}
+  
       - name: Test Rust Bindings
         run: |
           $vsPath = (vswhere -latest -property installationPath)
@@ -201,6 +210,7 @@ jobs:
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
           $env:Path="$env:Path;C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin;D:\a\WasmEdge\WasmEdge\build\lib\api"
           cd bindings\rust
+          cargo +nightly -Z sparse-registry update
           cargo test --workspace --features aot,async,ffi --locked -- --test-threads=1
           cargo test --examples --features aot,async,ffi --locked -- --test-threads=1
 
@@ -209,19 +219,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.66, 1.67, 1.68]
+        rust: [1.69, 1.68]
     container:
       image: fedora:latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Install Rust-stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
 
       - name: Build WasmEdge with Release mode
         run: |
@@ -231,6 +235,11 @@ jobs:
           cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_PLUGIN_PROCESS=On -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_PACKAGE="TGZ;DEB;RPM" .
           cmake --build build
 
+      - name: Install Rust-nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy
+  
       - name: Rustfmt
         working-directory: bindings/rust/
         run: cargo +nightly fmt --all -- --check
@@ -241,9 +250,14 @@ jobs:
           export WASMEDGE_DIR="$(pwd)/../../"
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
-          cargo clippy -V
-          cargo clippy --lib --examples --features aot,async,wasi_crypto,wasi_nn,wasmedge_process,ffi -- -D warnings
-
+          cargo +nightly clippy -V
+          cargo +nightly clippy --lib --examples --features aot,async,wasi_crypto,wasi_nn,wasmedge_process,ffi -- -D warnings
+      
+      - name: Install Rust-stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust }}
+  
       - name: Test Rust Bindings
         working-directory: bindings/rust/
         run: |
@@ -251,5 +265,6 @@ jobs:
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           export WASMEDGE_PLUGIN_PATH="$(pwd)/../../build/plugins/wasmedge_process"
           export LD_LIBRARY_PATH="$(pwd)/../../build/lib/api"
+          cargo +nightly -Z sparse-registry update
           cargo test --workspace --locked --features aot,async,ffi -- --test-threads=1
           cargo test --examples --locked --features aot,async,ffi -- --test-threads=1

--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -49,7 +49,6 @@ jobs:
       - name: Install Rust-nightly
         uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
     
       - name: Rustfmt

--- a/.github/workflows/rust-standalone.yml
+++ b/.github/workflows/rust-standalone.yml
@@ -28,11 +28,10 @@ jobs:
           sudo apt-get install -y gcc g++
           sudo apt-get install -y libssl-dev pkg-config gh
 
-      - name: Install Rust v1.65
+      - name: Install Rust v1.68
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.65
-          components: rustfmt, clippy
+          toolchain: 1.68
 
       - name: Run in the standalone mode
         working-directory: bindings/rust/
@@ -42,6 +41,7 @@ jobs:
           export CXX=clang++
           export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
           export WASMEDGE_DIR="$(pwd)/../../"
+          cargo +nightly -Z sparse-registry update
           cargo test -p wasmedge-sdk --all --examples --features standalone
 
   build_ubuntu_2004:
@@ -61,11 +61,10 @@ jobs:
           sudo apt-get install -y gcc g++
           sudo apt-get install -y libssl-dev pkg-config gh
 
-      - name: Install Rust v1.65
+      - name: Install Rust v1.68
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.65
-          components: rustfmt, clippy
+          toolchain: 1.68
 
       - name: Run in the standalone mode
         working-directory: bindings/rust/
@@ -75,6 +74,7 @@ jobs:
           export CXX=clang++
           export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
           export WASMEDGE_DIR="$(pwd)/../../"
+          cargo +nightly -Z sparse-registry update
           cargo test -p wasmedge-sdk --all --examples --features standalone
 
   build_macos:
@@ -90,11 +90,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Rust v1.65
+      - name: Install Rust v1.68
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.65
-          components: rustfmt, clippy
+          toolchain: 1.68
 
       - name: Install build tools
         run: brew install llvm@14 ninja boost cmake
@@ -107,4 +106,5 @@ jobs:
           export CXX=clang++
           export DYLD_LIBRARY_PATH="/Users/runner/.wasmedge/lib"
           export WASMEDGE_DIR="$(pwd)/../../"
+          cargo +nightly -Z sparse-registry update
           cargo test -p wasmedge-sdk --all --examples --features standalone

--- a/.github/workflows/rust-static-lib.yml
+++ b/.github/workflows/rust-static-lib.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        rust: [1.66, 1.67, 1.68]
+        rust: [1.69, 1.68]
     container:
       image: wasmedge/wasmedge:latest
 
@@ -39,12 +39,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Rust-stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
-
       - name: Build WasmEdge with Release mode
         run: |
           apt update
@@ -52,22 +46,33 @@ jobs:
           cmake cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_LINK_LLVM_STATIC=ON -DWASMEDGE_BUILD_SHARED_LIB=OFF -DWASMEDGE_BUILD_STATIC_LIB=ON -DWASMEDGE_LINK_TOOLS_STATIC=ON -DWASMEDGE_BUILD_PLUGINS=OFF .
           cmake --build build
 
+      - name: Install Rust-nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy
+      
       - name: Rustfmt
         working-directory: bindings/rust/
-        run: cargo fmt --all -- --check
+        run: cargo +nightly fmt --all -- --check
 
       - name: Clippy
         working-directory: bindings/rust/
         run: |
           export WASMEDGE_DIR="$(pwd)/../../"
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
-          cargo clippy -V
-          cargo clippy --lib --examples --features static -- -D warnings
-
+          cargo +nightly clippy -V
+          cargo +nightly clippy --lib --examples --features static -- -D warnings
+ 
+      - name: Install Rust-stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust }}
+    
       - name: Test Rust Bindings
         working-directory: bindings/rust/
         run: |
           export WASMEDGE_DIR="$(pwd)/../../"
           export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
+          cargo +nightly -Z sparse-registry update
           cargo test --workspace --features static --locked -- --test-threads=1
           cargo test --examples --features static --locked -- --test-threads=1

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,0 @@
-format_macro_matchers = true
-imports_granularity = "Crate"
-edition = "2018"

--- a/bindings/rust/wasmedge-sys/Cargo.toml
+++ b/bindings/rust/wasmedge-sys/Cargo.toml
@@ -21,7 +21,7 @@ rand = "0.8.4"
 thiserror = "1.0.30"
 wasmedge-macro = {workspace = true}
 wasmedge-types = {workspace = true}
-fiber-for-wasmedge = {path = "/root/workspace/me/fiber-for-wasmedge", optional = true}
+fiber-for-wasmedge = {version = "8.0.1", optional = true}
 wat = "1.0"
 
 [build-dependencies]

--- a/bindings/rust/wasmedge-sys/Cargo.toml
+++ b/bindings/rust/wasmedge-sys/Cargo.toml
@@ -21,7 +21,7 @@ rand = "0.8.4"
 thiserror = "1.0.30"
 wasmedge-macro = {workspace = true}
 wasmedge-types = {workspace = true}
-wasmtime-fiber = {version = "6", optional = true}
+fiber-for-wasmedge = {path = "/root/workspace/me/fiber-for-wasmedge", optional = true}
 wat = "1.0"
 
 [build-dependencies]
@@ -34,7 +34,7 @@ tokio = {version = "1", features = ["full"]}
 
 [features]
 aot = []
-async = ["dep:wasmtime-fiber"]
+async = ["dep:fiber-for-wasmedge"]
 default = []
 ffi = []
 standalone = []

--- a/bindings/rust/wasmedge-sys/src/async.rs
+++ b/bindings/rust/wasmedge-sys/src/async.rs
@@ -1,13 +1,13 @@
 //! Defines data structure for WasmEdge async mechanism.
 
 use crate::ASYNC_STATE;
+use fiber_for_wasmedge::{Fiber, FiberStack, Suspend};
 use std::{
     future::Future,
     pin::Pin,
     ptr,
     task::{Context, Poll},
 };
-use fiber_for_wasmedge::{Fiber, FiberStack, Suspend};
 
 /// Defines a FiberFuture.
 pub(crate) struct FiberFuture<'a> {

--- a/bindings/rust/wasmedge-sys/src/async.rs
+++ b/bindings/rust/wasmedge-sys/src/async.rs
@@ -7,7 +7,7 @@ use std::{
     ptr,
     task::{Context, Poll},
 };
-use wasmtime_fiber::{Fiber, FiberStack, Suspend};
+use fiber_for_wasmedge::{Fiber, FiberStack, Suspend};
 
 /// Defines a FiberFuture.
 pub(crate) struct FiberFuture<'a> {

--- a/bindings/rust/wasmedge-sys/src/plugin.rs
+++ b/bindings/rust/wasmedge-sys/src/plugin.rs
@@ -452,7 +452,6 @@ impl PluginDescriptor {
 
 #[cfg(test)]
 mod tests {
-    use crate::WasmValue;
 
     #[cfg(all(
         target_os = "linux",


### PR DESCRIPTION
In this PR, the following major changes are involved:

- Replaced `wasmtime-fiber` with `fiber-for-wasmedge`.
- Updated `bindings-rust` workflow to use `rust-1.68/1.69`.
- Updated `rust-static-lib` workflow to use `rust-1.68/1.69`.
- Updated `rust-standalone` workflow to use `rust-1.68/1.69`