### PR TITLE
[Rust] Introduce the `NeverType` type

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -3,5 +3,5 @@ exclude = ["build/", "utils/"]
 members = ["wasmedge-sys", "wasmedge-types", "wasmedge-sdk", "wasmedge-macro"]
 
 [workspace.dependencies]
-wasmedge-macro = {path = "wasmedge-macro", version = "0.3"}
+wasmedge-macro = {path = "wasmedge-macro", version = "0.4"}
 wasmedge-types = {path = "wasmedge-types", version = "0.4"}

--- a/bindings/rust/wasmedge-macro/Cargo.toml
+++ b/bindings/rust/wasmedge-macro/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "wasmedge-macro"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/WasmEdge/blob/master/bindings/rust/wasmedge-macro"
-version = "0.3.0"
+version = "0.4.0"
 
 [lib]
 proc-macro = true

--- a/bindings/rust/wasmedge-macro/src/lib.rs
+++ b/bindings/rust/wasmedge-macro/src/lib.rs
@@ -297,6 +297,8 @@ fn expand_async_host_func_with_two_args(item_fn: &syn::ItemFn) -> proc_macro2::T
         // replace the first argument
         *first = parse_quote!(frame: wasmedge_sdk::CallingFrame);
     }
+    // insert the third argument
+    fn_inputs.push(parse_quote!(_data: *mut std::os::raw::c_void));
 
     // * prepare the function body
     let fn_block = &item_fn.block;
@@ -600,7 +602,10 @@ fn sys_expand_async_host_func(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2:
 fn sys_expand_async_host_func_with_two_args(item_fn: &syn::ItemFn) -> proc_macro2::TokenStream {
     let fn_name_ident = &item_fn.sig.ident;
     let fn_visibility = &item_fn.vis;
-    let fn_inputs = item_fn.sig.inputs.clone();
+
+    // insert the third argument
+    let mut fn_inputs = item_fn.sig.inputs.clone();
+    fn_inputs.push(parse_quote!(_data: *mut std::os::raw::c_void));
 
     let fn_block = &item_fn.block;
 

--- a/bindings/rust/wasmedge-macro/src/lib.rs
+++ b/bindings/rust/wasmedge-macro/src/lib.rs
@@ -412,7 +412,9 @@ fn sys_expand_host_func(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2::Token
     let ret = match item_fn.sig.inputs.len() {
         2 => {
             // insert the third argument
-            let wrapper_fn_inputs = item_fn.sig.inputs.clone();
+            // let wrapper_fn_inputs = item_fn.sig.inputs.clone();
+            let mut wrapper_fn_inputs = item_fn.sig.inputs.clone();
+            wrapper_fn_inputs.push(parse_quote!(_data: *mut std::os::raw::c_void));
 
             quote!(
                 #wrapper_fn_visibility fn #wrapper_fn_name_ident (#wrapper_fn_inputs) #wrapper_fn_return {
@@ -422,6 +424,77 @@ fn sys_expand_host_func(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2::Token
                     }
 
                     #inner_fn_name_ident(#arg1, #arg2)
+                }
+            )
+        }
+        3 => {
+            let data_arg = item_fn.sig.inputs.last().unwrap().clone();
+            let ty_ptr = match &data_arg {
+                FnArg::Typed(PatType { ref ty, .. }) => match **ty {
+                    syn::Type::Reference(syn::TypeReference { ref elem, .. }) => syn::TypePtr {
+                        star_token: parse_quote!(*),
+                        const_token: None,
+                        mutability: Some(parse_quote!(mut)),
+                        elem: elem.clone(),
+                    },
+                    syn::Type::Path(syn::TypePath { ref path, .. }) => match path.segments.last() {
+                        Some(segment) => {
+                            let id = segment.ident.to_string();
+                            match id == "Option" {
+                                true => match segment.arguments {
+                                    syn::PathArguments::AngleBracketed(
+                                        syn::AngleBracketedGenericArguments { ref args, .. },
+                                    ) => {
+                                        let last_generic_arg = args.last();
+                                        match last_generic_arg {
+                                            Some(arg) => match arg {
+                                                syn::GenericArgument::Type(ty) => match ty {
+                                                    syn::Type::Reference(syn::TypeReference {
+                                                        ref elem,
+                                                        ..
+                                                    }) => syn::TypePtr {
+                                                        star_token: parse_quote!(*),
+                                                        const_token: None,
+                                                        mutability: Some(parse_quote!(mut)),
+                                                        elem: elem.clone(),
+                                                    },
+                                                    _ => panic!("Not found syn::Type::Reference"),
+                                                },
+                                                _ => {
+                                                    panic!("Not found syn::GenericArgument::Type")
+                                                }
+                                            },
+                                            None => panic!("Not found the last GenericArgument"),
+                                        }
+                                    }
+                                    _ => panic!("Not found syn::PathArguments::AngleBracketed"),
+                                },
+                                false => panic!("Not found segment ident: Option"),
+                            }
+                        }
+                        None => panic!("Not found path segments"),
+                    },
+                    _ => panic!("Unsupported syn::Type type"),
+                },
+                _ => panic!("Unsupported syn::FnArg type"),
+            };
+
+            // inputs of wrapper function
+            let mut wrapper_fn_inputs = item_fn.sig.inputs.clone();
+            wrapper_fn_inputs.pop();
+            wrapper_fn_inputs.push(parse_quote!(data: *mut std::os::raw::c_void));
+
+            // generate token stream
+            quote!(
+                #wrapper_fn_visibility fn #wrapper_fn_name_ident (#wrapper_fn_inputs) #wrapper_fn_return {
+                    // define inner function
+                    fn #inner_fn_name_ident (#inner_fn_inputs) #inner_fn_return {
+                        #inner_fn_block
+                    }
+
+                    let data = unsafe { &mut *(data as #ty_ptr) };
+
+                    #inner_fn_name_ident(#arg1, #arg2, data)
                 }
             )
         }

--- a/bindings/rust/wasmedge-sdk/Cargo.toml
+++ b/bindings/rust/wasmedge-sdk/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "wasmedge-sdk"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/WasmEdge/blob/master/bindings/rust/wasmedge-sdk"
-version = "0.8.1"
+version = "0.9.0"
 
 [dependencies]
 anyhow = "1.0"
@@ -16,7 +16,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 thiserror = "1.0.30"
 wasmedge-macro = {workspace = true}
-wasmedge-sys = {path = "../wasmedge-sys", version = "0.13", default-features = false}
+wasmedge-sys = {path = "../wasmedge-sys", version = "0.14", default-features = false}
 wasmedge-types = {workspace = true}
 wat = "1.0"
 

--- a/bindings/rust/wasmedge-sdk/examples/create_host_func_in_host_func.rs
+++ b/bindings/rust/wasmedge-sdk/examples/create_host_func_in_host_func.rs
@@ -1,6 +1,6 @@
 use wasmedge_sdk::{
     error::HostFuncError, host_function, params, Caller, Executor, Func, ImportObjectBuilder,
-    ValType, VmBuilder, WasmVal, WasmValue,
+    NeverType, ValType, VmBuilder, WasmVal, WasmValue,
 };
 
 #[host_function]
@@ -39,7 +39,7 @@ fn func(_caller: Caller, _input: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostF
         }
 
         // create a host function
-        let result = Func::wrap::<(i32, i32), i32>(real_add);
+        let result = Func::wrap::<(i32, i32), i32, NeverType>(real_add, None);
         assert!(result.is_ok());
         let func = result.unwrap();
 
@@ -62,7 +62,7 @@ fn func(_caller: Caller, _input: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostF
 fn main() -> anyhow::Result<()> {
     // create an import module
     let import = ImportObjectBuilder::new()
-        .with_func::<(), ()>("outer-func", func)?
+        .with_func::<(), (), NeverType>("outer-func", func, None)?
         .build("extern")?;
 
     let _ = VmBuilder::new()

--- a/bindings/rust/wasmedge-sdk/examples/create_import_object.rs
+++ b/bindings/rust/wasmedge-sdk/examples/create_import_object.rs
@@ -5,8 +5,8 @@
 
 use wasmedge_sdk::{
     error::HostFuncError, host_function, types::Val, Caller, Global, GlobalType,
-    ImportObjectBuilder, Memory, MemoryType, Mutability, RefType, Table, TableType, ValType,
-    WasmValue,
+    ImportObjectBuilder, Memory, MemoryType, Mutability, NeverType, RefType, Table, TableType,
+    ValType, WasmValue,
 };
 
 #[cfg_attr(test, test)]
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let module_name = "extern";
     let _import = ImportObjectBuilder::new()
         // add a function
-        .with_func::<(i32, i32), i32>("add", real_add)?
+        .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)?
         // add a global
         .with_global("global", global_const)?
         // add a memory

--- a/bindings/rust/wasmedge-sdk/examples/hello_world.rs
+++ b/bindings/rust/wasmedge-sdk/examples/hello_world.rs
@@ -1,6 +1,6 @@
 use wasmedge_sdk::{
     error::HostFuncError, host_function, params, wat2wasm, Caller, ImportObjectBuilder, Module,
-    VmBuilder, WasmValue,
+    NeverType, VmBuilder, WasmValue,
 };
 
 // We define a function to act as our "env" "say_hello" function imported in the
@@ -16,7 +16,7 @@ pub fn say_hello(_caller: Caller, _args: Vec<WasmValue>) -> Result<Vec<WasmValue
 fn main() -> anyhow::Result<()> {
     // create an import module
     let import = ImportObjectBuilder::new()
-        .with_func::<(), ()>("say_hello", say_hello)?
+        .with_func::<(), (), NeverType>("say_hello", say_hello, None)?
         .build("env")?;
 
     let wasm_bytes = wat2wasm(

--- a/bindings/rust/wasmedge-sdk/examples/host_func_with_custom_error.rs
+++ b/bindings/rust/wasmedge-sdk/examples/host_func_with_custom_error.rs
@@ -19,7 +19,7 @@ use wasmedge_sdk::{
     error::{HostFuncError, WasmEdgeError},
     host_function, params,
     types::ExternRef,
-    Caller, ImportObjectBuilder, ValType, VmBuilder, WasmVal, WasmValue,
+    Caller, ImportObjectBuilder, NeverType, ValType, VmBuilder, WasmVal, WasmValue,
 };
 
 // Define custom error type
@@ -96,7 +96,7 @@ fn real_add(_caller: Caller, input: Vec<WasmValue>) -> Result<Vec<WasmValue>, Ho
 fn main() -> anyhow::Result<()> {
     // create import module
     let import = ImportObjectBuilder::new()
-        .with_func::<(ExternRef, i32, i32), i32>("add", real_add)?
+        .with_func::<(ExternRef, i32, i32), i32, NeverType>("add", real_add, None)?
         .build("extern_module")?;
 
     // create a vm instance

--- a/bindings/rust/wasmedge-sdk/examples/table.rs
+++ b/bindings/rust/wasmedge-sdk/examples/table.rs
@@ -3,7 +3,7 @@
 
 use wasmedge_sdk::{
     error::HostFuncError, host_function, params, types::Val, wat2wasm, Caller, Executor, Func,
-    Module, RefType, Store, TableType, ValType, WasmVal, WasmValue,
+    Module, NeverType, RefType, Store, TableType, ValType, WasmVal, WasmValue,
 };
 
 #[cfg_attr(test, test)]
@@ -109,7 +109,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     // create a host function over host_callback
-    let func = Func::wrap::<(i32, i32), i32>(Box::new(host_callback))?;
+    let func = Func::wrap::<(i32, i32), i32, NeverType>(Box::new(host_callback), None)?;
 
     // set the function at index 1 in the table
     guest_table.set(1, Val::FuncRef(Some(func.as_ref())))?;
@@ -122,7 +122,7 @@ fn main() -> anyhow::Result<()> {
     // * growing a table
 
     // We again construct a `Function` over our host_callback.
-    let func = Func::wrap::<(i32, i32), i32>(Box::new(host_callback))?;
+    let func = Func::wrap::<(i32, i32), i32, NeverType>(Box::new(host_callback), None)?;
 
     // And grow the table by 3 elements, filling in our host_callback in all the
     // new elements of the table.
@@ -145,7 +145,7 @@ fn main() -> anyhow::Result<()> {
     assert_eq!(returns[0].to_i32(), 18);
 
     // Now overwrite index 0 with our host_callback.
-    let func = Func::wrap::<(i32, i32), i32>(Box::new(host_callback))?;
+    let func = Func::wrap::<(i32, i32), i32, NeverType>(Box::new(host_callback), None)?;
     guest_table.set(0, Val::FuncRef(Some(func.as_ref())))?;
     // And verify that it does what we expect.
     let returns = call_via_table.run(&executor, params!(0, 2, 7))?;

--- a/bindings/rust/wasmedge-sdk/examples/table_and_funcref.rs
+++ b/bindings/rust/wasmedge-sdk/examples/table_and_funcref.rs
@@ -6,8 +6,8 @@ use wasmedge_sdk::{
     error::HostFuncError,
     host_function, params,
     types::Val,
-    Caller, Executor, Func, ImportObjectBuilder, RefType, Store, Table, TableType, ValType,
-    WasmVal, WasmValue,
+    Caller, Executor, Func, ImportObjectBuilder, NeverType, RefType, Store, Table, TableType,
+    ValType, WasmVal, WasmValue,
 };
 
 #[host_function]
@@ -70,7 +70,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("Not found table instance named 'my-table'");
 
     // create a host function
-    let host_func = Func::wrap::<(i32, i32), i32>(Box::new(real_add))?;
+    let host_func = Func::wrap::<(i32, i32), i32, NeverType>(Box::new(real_add), None)?;
 
     // store the reference to host_func at the given index of the table instance
     table.set(3, Val::FuncRef(Some(host_func.as_ref())))?;

--- a/bindings/rust/wasmedge-sdk/src/externals/function.rs
+++ b/bindings/rust/wasmedge-sdk/src/externals/function.rs
@@ -158,6 +158,7 @@ impl Func {
         real_func: impl Fn(
                 CallingFrame,
                 Vec<WasmValue>,
+                *mut std::os::raw::c_void,
             ) -> Box<
                 dyn std::future::Future<
                         Output = Result<Vec<WasmValue>, crate::error::HostFuncError>,

--- a/bindings/rust/wasmedge-sdk/src/externals/table.rs
+++ b/bindings/rust/wasmedge-sdk/src/externals/table.rs
@@ -123,8 +123,8 @@ mod tests {
         config::{CommonConfigOptions, ConfigBuilder},
         error::HostFuncError,
         types::Val,
-        CallingFrame, Executor, ImportObjectBuilder, RefType, Statistics, Store, ValType,
-        WasmValue,
+        CallingFrame, Executor, ImportObjectBuilder, NeverType, RefType, Statistics, Store,
+        ValType, WasmValue,
     };
 
     #[test]
@@ -151,7 +151,7 @@ mod tests {
 
         // create an import object
         let result = ImportObjectBuilder::new()
-            .with_func::<(i32, i32), i32>("add", real_add)
+            .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
             .expect("failed to add host func")
             .with_table("table", table)
             .expect("failed to add table")
@@ -257,6 +257,7 @@ mod tests {
     fn real_add(
         _frame: CallingFrame,
         inputs: Vec<WasmValue>,
+        _data: *mut std::os::raw::c_void,
     ) -> std::result::Result<Vec<WasmValue>, HostFuncError> {
         if inputs.len() != 2 {
             return Err(HostFuncError::User(1));

--- a/bindings/rust/wasmedge-sdk/src/import.rs
+++ b/bindings/rust/wasmedge-sdk/src/import.rs
@@ -193,6 +193,7 @@ impl ImportObjectBuilder {
         real_func: impl Fn(
                 CallingFrame,
                 Vec<WasmValue>,
+                *mut std::os::raw::c_void,
             ) -> Box<
                 dyn std::future::Future<
                         Output = Result<Vec<WasmValue>, crate::error::HostFuncError>,

--- a/bindings/rust/wasmedge-sdk/src/instance.rs
+++ b/bindings/rust/wasmedge-sdk/src/instance.rs
@@ -195,8 +195,8 @@ mod tests {
         error::HostFuncError,
         types::Val,
         CallingFrame, Executor, FuncTypeBuilder, Global, GlobalType, ImportObjectBuilder, Memory,
-        MemoryType, Module, Mutability, RefType, Statistics, Store, Table, TableType, ValType,
-        WasmValue,
+        MemoryType, Module, Mutability, NeverType, RefType, Statistics, Store, Table, TableType,
+        ValType, WasmValue,
     };
 
     #[test]
@@ -247,7 +247,7 @@ mod tests {
 
         // create an ImportModule instance
         let result = ImportObjectBuilder::new()
-            .with_func::<(i32, i32), i32>("add", real_add)
+            .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
             .expect("failed to add host function")
             .with_global("global", global_const)
             .expect("failed to add const global")
@@ -368,6 +368,7 @@ mod tests {
     fn real_add(
         _frame: CallingFrame,
         inputs: Vec<WasmValue>,
+        _data: *mut std::os::raw::c_void,
     ) -> std::result::Result<Vec<WasmValue>, HostFuncError> {
         if inputs.len() != 2 {
             return Err(HostFuncError::User(1));

--- a/bindings/rust/wasmedge-sdk/src/lib.rs
+++ b/bindings/rust/wasmedge-sdk/src/lib.rs
@@ -37,7 +37,7 @@
 //!  ```rust
 //!  use wasmedge_sdk::{
 //!      error::HostFuncError, host_function, params, wat2wasm, Caller, ImportObjectBuilder, Module,
-//!      VmBuilder, WasmValue,
+//!      VmBuilder, WasmValue, NeverType
 //!  };
 //!  
 //!  // We define a function to act as our "env" "say_hello" function imported in the
@@ -53,7 +53,7 @@
 //!  fn main() -> anyhow::Result<()> {
 //!      // create an import module
 //!      let import = ImportObjectBuilder::new()
-//!          .with_func::<(), ()>("say_hello", say_hello)?
+//!          .with_func::<(), (), NeverType>("say_hello", say_hello, None)?
 //!          .build("env")?;
 //!  
 //!      let wasm_bytes = wat2wasm(
@@ -150,6 +150,8 @@ pub use wasmedge_types::{
 };
 
 pub use wasmedge_macro::{async_host_function, host_function};
+
+pub use wasmedge_sys::NeverType;
 
 /// WebAssembly value type.
 pub type WasmValue = wasmedge_sys::types::WasmValue;

--- a/bindings/rust/wasmedge-sdk/src/store.rs
+++ b/bindings/rust/wasmedge-sdk/src/store.rs
@@ -139,7 +139,7 @@ mod tests {
         error::HostFuncError,
         types::Val,
         CallingFrame, Executor, Global, GlobalType, ImportObjectBuilder, Memory, MemoryType,
-        Module, Mutability, RefType, Statistics, Table, TableType, ValType, WasmValue,
+        Module, Mutability, NeverType, RefType, Statistics, Table, TableType, ValType, WasmValue,
     };
 
     #[test]
@@ -189,7 +189,7 @@ mod tests {
 
         // create an ImportModule instance
         let result = ImportObjectBuilder::new()
-            .with_func::<(i32, i32), i32>("add", real_add)
+            .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
             .expect("failed to add host function")
             .with_global("global", global_const)
             .expect("failed to add const global")
@@ -368,7 +368,7 @@ mod tests {
 
         // create an ImportModule instance
         let result = ImportObjectBuilder::new()
-            .with_func::<(i32, i32), i32>("add", real_add)
+            .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
             .expect("failed to add host function")
             .with_global("global", global_const)
             .expect("failed to add const global")
@@ -418,6 +418,7 @@ mod tests {
     fn real_add(
         _frame: CallingFrame,
         inputs: Vec<WasmValue>,
+        _data: *mut std::os::raw::c_void,
     ) -> std::result::Result<Vec<WasmValue>, HostFuncError> {
         if inputs.len() != 2 {
             return Err(HostFuncError::User(1));

--- a/bindings/rust/wasmedge-sdk/src/vm.rs
+++ b/bindings/rust/wasmedge-sdk/src/vm.rs
@@ -778,7 +778,7 @@ mod tests {
         params,
         types::Val,
         wat2wasm, AsInstance, CallingFrame, Global, GlobalType, ImportObjectBuilder, Memory,
-        MemoryType, Mutability, RefType, Table, TableType, ValType, WasmValue,
+        MemoryType, Mutability, NeverType, RefType, Table, TableType, ValType, WasmValue,
     };
 
     #[test]
@@ -1238,7 +1238,7 @@ mod tests {
 
         // create an ImportModule instance
         let result = ImportObjectBuilder::new()
-            .with_func::<(i32, i32), i32>("add", real_add)
+            .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
             .expect("failed to add host function")
             .with_global("global", global_const)
             .expect("failed to add const global")
@@ -1433,6 +1433,7 @@ mod tests {
     fn real_add(
         _frame: CallingFrame,
         inputs: Vec<WasmValue>,
+        _data: *mut std::os::raw::c_void,
     ) -> std::result::Result<Vec<WasmValue>, HostFuncError> {
         if inputs.len() != 2 {
             return Err(HostFuncError::User(1));

--- a/bindings/rust/wasmedge-sys/Cargo.toml
+++ b/bindings/rust/wasmedge-sys/Cargo.toml
@@ -10,7 +10,7 @@ links = "wasmedge"
 name = "wasmedge-sys"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/WasmEdge/blob/master/bindings/rust/wasmedge-sys"
-version = "0.13.1"
+version = "0.14.0"
 
 [dependencies]
 fiber-for-wasmedge = {version = "8.0.1", optional = true}

--- a/bindings/rust/wasmedge-sys/Cargo.toml
+++ b/bindings/rust/wasmedge-sys/Cargo.toml
@@ -25,7 +25,7 @@ wasmedge-types = {workspace = true}
 wat = "1.0"
 
 [build-dependencies]
-bindgen = {version = "0.61", default-features = false, features = ["runtime"]}
+bindgen = {version = "0.65", default-features = false, features = ["runtime"]}
 cmake = "0.1"
 
 [dev-dependencies]

--- a/bindings/rust/wasmedge-sys/examples/async_host_func.rs
+++ b/bindings/rust/wasmedge-sys/examples/async_host_func.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // create a host function
         let async_host_func = Function::create_async(
             &func_ty,
-            |_frame, _input| {
+            |_frame, _input, _data| {
                 Box::new(async {
                     println!("Hello, world!");
                     tokio::time::sleep(std::time::Duration::from_secs(1)).await;

--- a/bindings/rust/wasmedge-sys/examples/context_data_to_host_func.rs
+++ b/bindings/rust/wasmedge-sys/examples/context_data_to_host_func.rs
@@ -1,0 +1,91 @@
+use wasmedge_macro::sys_host_function;
+use wasmedge_sys::{CallingFrame, Executor, FuncType, Function, WasmValue};
+use wasmedge_types::{error::HostFuncError, ValType};
+
+#[derive(Debug)]
+struct Data<T, S> {
+    _x: i32,
+    _y: String,
+    _v: Vec<T>,
+    _s: Vec<S>,
+}
+
+#[sys_host_function]
+fn real_add(
+    _frame: CallingFrame,
+    input: Vec<WasmValue>,
+    data: &mut Data<i32, &str>,
+) -> Result<Vec<WasmValue>, HostFuncError> {
+    println!("Rust: Entering Rust function real_add");
+
+    println!("data: {data:?}");
+
+    if input.len() != 2 {
+        return Err(HostFuncError::User(1));
+    }
+
+    let a = if input[0].ty() == ValType::I32 {
+        input[0].to_i32()
+    } else {
+        return Err(HostFuncError::User(2));
+    };
+
+    let b = if input[1].ty() == ValType::I32 {
+        input[1].to_i32()
+    } else {
+        return Err(HostFuncError::User(3));
+    };
+
+    let c = a + b;
+    println!("Rust: calcuating in real_add c: {c:?}");
+
+    println!("Rust: Leaving Rust function real_add");
+    Ok(vec![WasmValue::from_i32(c)])
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut data: Data<i32, &str> = Data {
+        _x: 12,
+        _y: "hello".to_string(),
+        _v: vec![1, 2, 3],
+        _s: vec!["macos", "linux", "windows"],
+    };
+
+    // create a FuncType
+    let result = FuncType::create(vec![ValType::I32; 2], vec![ValType::I32]);
+    assert!(result.is_ok());
+    let func_ty = result.unwrap();
+    // create a host function
+    let result = Function::create(&func_ty, Box::new(real_add), Some(&mut data), 0);
+    assert!(result.is_ok());
+    let host_func = result.unwrap();
+
+    // get func type
+    let result = host_func.ty();
+    assert!(result.is_ok());
+    let ty = result.unwrap();
+
+    // check parameters
+    assert_eq!(ty.params_len(), 2);
+    let param_tys = ty.params_type_iter().collect::<Vec<_>>();
+    assert_eq!(param_tys, vec![ValType::I32; 2]);
+
+    // check returns
+    assert_eq!(ty.returns_len(), 1);
+    let return_tys = ty.returns_type_iter().collect::<Vec<_>>();
+    assert_eq!(return_tys, vec![ValType::I32]);
+
+    // run this function
+    let result = Executor::create(None, None);
+    assert!(result.is_ok());
+    let mut executor = result.unwrap();
+    let result = host_func.call(
+        &mut executor,
+        vec![WasmValue::from_i32(1), WasmValue::from_i32(2)],
+    );
+    assert!(result.is_ok());
+    let returns = result.unwrap();
+    assert_eq!(returns[0].to_i32(), 3);
+
+    Ok(())
+}

--- a/bindings/rust/wasmedge-sys/examples/func_call_across_different_modes.rs
+++ b/bindings/rust/wasmedge-sys/examples/func_call_across_different_modes.rs
@@ -4,7 +4,7 @@ use wasmedge_macro::sys_host_function;
 #[cfg(feature = "aot")]
 use wasmedge_sys::{
     AsImport, Compiler, Config, Executor, FuncType, Function, ImportModule, ImportObject, Loader,
-    Store, Validator,
+    NeverType, Store, Validator,
 };
 use wasmedge_sys::{CallingFrame, WasmValue};
 use wasmedge_types::error::HostFuncError;
@@ -49,12 +49,14 @@ fn interpreter_call_aot() -> Result<(), Box<dyn std::error::Error>> {
 
     // import host_print_i32 as a host function
     let func_ty = FuncType::create([ValType::I32], [])?;
-    let host_func_print_i32 = Function::create(&func_ty, Box::new(host_print_i32), 0)?;
+    let host_func_print_i32 =
+        Function::create::<NeverType>(&func_ty, Box::new(host_print_i32), None, 0)?;
     import.add_func("host_printI32", host_func_print_i32);
 
     // import host_print_f64 as a host function
     let func_ty = FuncType::create([ValType::F64], [])?;
-    let host_func_print_f64 = Function::create(&func_ty, Box::new(host_print_f64), 0)?;
+    let host_func_print_f64 =
+        Function::create::<NeverType>(&func_ty, Box::new(host_print_f64), None, 0)?;
     import.add_func("host_printF64", host_func_print_f64);
 
     // register the import module
@@ -136,12 +138,14 @@ fn aot_call_interpreter() -> Result<(), Box<dyn std::error::Error>> {
 
     // import host_print_i32 as a host function
     let func_ty = FuncType::create([ValType::I32], [])?;
-    let host_func_print_i32 = Function::create(&func_ty, Box::new(host_print_i32), 0)?;
+    let host_func_print_i32 =
+        Function::create::<NeverType>(&func_ty, Box::new(host_print_i32), None, 0)?;
     import.add_func("host_printI32", host_func_print_i32);
 
     // import host_print_f64 as a host function
     let func_ty = FuncType::create([ValType::F64], [])?;
-    let host_func_print_f64 = Function::create(&func_ty, Box::new(host_print_f64), 0)?;
+    let host_func_print_f64 =
+        Function::create::<NeverType>(&func_ty, Box::new(host_print_f64), None, 0)?;
     import.add_func("host_printF64", host_func_print_f64);
 
     // register the import module

--- a/bindings/rust/wasmedge-sys/examples/hostfunc.rs
+++ b/bindings/rust/wasmedge-sys/examples/hostfunc.rs
@@ -20,7 +20,7 @@
 use wasmedge_macro::sys_host_function;
 use wasmedge_sys::{
     AsImport, CallingFrame, Config, Executor, FuncType, Function, ImportModule, ImportObject,
-    Loader, Store, Validator, WasmValue,
+    Loader, NeverType, Store, Validator, WasmValue,
 };
 use wasmedge_types::{error::HostFuncError, wat2wasm, ValType};
 
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         vec![ValType::ExternRef, ValType::I32, ValType::I32],
         vec![ValType::I32],
     )?;
-    let host_func = Function::create(&func_ty, Box::new(real_add), 0)?;
+    let host_func = Function::create::<NeverType>(&func_ty, Box::new(real_add), None, 0)?;
 
     // create an ImportObject module
     let mut import = ImportModule::create("extern_module")?;

--- a/bindings/rust/wasmedge-sys/examples/hostfunc2.rs
+++ b/bindings/rust/wasmedge-sys/examples/hostfunc2.rs
@@ -14,7 +14,7 @@
 use wasmedge_macro::sys_host_function;
 use wasmedge_sys::{
     AsImport, CallingFrame, Config, Executor, FuncType, Function, ImportModule, ImportObject,
-    Loader, Store, Validator, WasmValue,
+    Loader, NeverType, Store, Validator, WasmValue,
 };
 use wasmedge_types::{error::HostFuncError, wat2wasm, ValType};
 
@@ -56,7 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     assert!(result.is_ok());
     let func_ty = result.unwrap();
-    let result = Function::create(&func_ty, Box::new(real_add), 0);
+    let result = Function::create::<NeverType>(&func_ty, Box::new(real_add), None, 0);
     assert!(result.is_ok());
     let host_func = result.unwrap();
     import.add_func("add", host_func);

--- a/bindings/rust/wasmedge-sys/examples/table_and_funcref.rs
+++ b/bindings/rust/wasmedge-sys/examples/table_and_funcref.rs
@@ -7,7 +7,7 @@
 use wasmedge_macro::sys_host_function;
 use wasmedge_sys::{
     AsImport, CallingFrame, Config, Executor, FuncType, Function, ImportModule, ImportObject,
-    Store, Table, TableType, WasmValue,
+    NeverType, Store, Table, TableType, WasmValue,
 };
 use wasmedge_types::{error::HostFuncError, RefType, ValType};
 
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // create a FuncType
     let func_ty = FuncType::create(vec![ValType::I32; 2], vec![ValType::I32])?;
     // create a host function
-    let host_func = Function::create(&func_ty, Box::new(real_add), 0)?;
+    let host_func = Function::create::<NeverType>(&func_ty, Box::new(real_add), None, 0)?;
 
     // create a TableType instance
     let ty = TableType::create(RefType::FuncRef, 10, Some(20))?;

--- a/bindings/rust/wasmedge-sys/src/executor.rs
+++ b/bindings/rust/wasmedge-sys/src/executor.rs
@@ -353,13 +353,14 @@ unsafe impl Sync for InnerExecutor {}
 mod tests {
     use super::*;
     use crate::{
-        AsImport, CallingFrame, Config, FuncType, Function, Global, GlobalType, ImportModule,
-        MemType, Memory, Statistics, Table, TableType,
+        instance::function::NeverType, AsImport, CallingFrame, Config, FuncType, Function, Global,
+        GlobalType, ImportModule, MemType, Memory, Statistics, Table, TableType,
     };
     use std::{
         sync::{Arc, Mutex},
         thread,
     };
+    use wasmedge_macro::sys_host_function;
     use wasmedge_types::{error::HostFuncError, Mutability, RefType, ValType};
 
     #[test]
@@ -437,7 +438,7 @@ mod tests {
         let result = FuncType::create([ValType::ExternRef, ValType::I32], [ValType::I32]);
         assert!(result.is_ok());
         let func_ty = result.unwrap();
-        let result = Function::create(&func_ty, Box::new(real_add), 0);
+        let result = Function::create::<NeverType>(&func_ty, Box::new(real_add), None, 0);
         assert!(result.is_ok());
         let host_func = result.unwrap();
         // add the function into the import_obj module
@@ -555,7 +556,11 @@ mod tests {
         handle.join().unwrap();
     }
 
-    fn real_add(_: CallingFrame, inputs: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
+    #[sys_host_function]
+    fn real_add(
+        _frame: CallingFrame,
+        inputs: Vec<WasmValue>,
+    ) -> Result<Vec<WasmValue>, HostFuncError> {
         if inputs.len() != 2 {
             return Err(HostFuncError::User(1));
         }

--- a/bindings/rust/wasmedge-sys/src/instance/module.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/module.rs
@@ -933,13 +933,14 @@ impl ImportObject {
 mod tests {
     use super::*;
     use crate::{
-        CallingFrame, Config, Executor, FuncType, GlobalType, ImportModule, MemType, Store,
-        TableType, WasmValue,
+        instance::function::NeverType, CallingFrame, Config, Executor, FuncType, GlobalType,
+        ImportModule, MemType, Store, TableType, WasmValue,
     };
     use std::{
         sync::{Arc, Mutex},
         thread,
     };
+    use wasmedge_macro::sys_host_function;
     use wasmedge_types::{error::HostFuncError, Mutability, RefType, ValType};
 
     #[test]
@@ -956,7 +957,7 @@ mod tests {
         let result = FuncType::create([ValType::ExternRef, ValType::I32], [ValType::I32]);
         assert!(result.is_ok());
         let func_ty = result.unwrap();
-        let result = Function::create(&func_ty, Box::new(real_add), 0);
+        let result = Function::create::<NeverType>(&func_ty, Box::new(real_add), None, 0);
         assert!(result.is_ok());
         let host_func = result.unwrap();
         // add the host function
@@ -1025,7 +1026,7 @@ mod tests {
         let result = FuncType::create(vec![ValType::I32; 2], vec![ValType::I32]);
         assert!(result.is_ok());
         let func_ty = result.unwrap();
-        let result = Function::create(&func_ty, Box::new(real_add), 0);
+        let result = Function::create::<NeverType>(&func_ty, Box::new(real_add), None, 0);
         assert!(result.is_ok());
         let host_func = result.unwrap();
         import.add_func("add", host_func);
@@ -1174,7 +1175,7 @@ mod tests {
         let result = FuncType::create(vec![ValType::I32; 2], vec![ValType::I32]);
         assert!(result.is_ok());
         let func_ty = result.unwrap();
-        let result = Function::create(&func_ty, Box::new(real_add), 0);
+        let result = Function::create::<NeverType>(&func_ty, Box::new(real_add), None, 0);
         assert!(result.is_ok());
         let host_func = result.unwrap();
         import.add_func("add", host_func);
@@ -1296,7 +1297,7 @@ mod tests {
         let result = FuncType::create(vec![ValType::I32; 2], vec![ValType::I32]);
         assert!(result.is_ok());
         let func_ty = result.unwrap();
-        let result = Function::create(&func_ty, Box::new(real_add), 0);
+        let result = Function::create::<NeverType>(&func_ty, Box::new(real_add), None, 0);
         assert!(result.is_ok());
         let host_func = result.unwrap();
         import.add_func("add", host_func);
@@ -1393,7 +1394,7 @@ mod tests {
         let result = FuncType::create(vec![ValType::I32; 2], vec![ValType::I32]);
         assert!(result.is_ok());
         let func_ty = result.unwrap();
-        let result = Function::create(&func_ty, Box::new(real_add), 0);
+        let result = Function::create::<NeverType>(&func_ty, Box::new(real_add), None, 0);
         assert!(result.is_ok());
         let host_func = result.unwrap();
         import.add_func("add", host_func);
@@ -1453,7 +1454,11 @@ mod tests {
         assert_eq!(ty.max(), Some(20));
     }
 
-    fn real_add(_: CallingFrame, inputs: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
+    #[sys_host_function]
+    fn real_add(
+        _frame: CallingFrame,
+        inputs: Vec<WasmValue>,
+    ) -> Result<Vec<WasmValue>, HostFuncError> {
         if inputs.len() != 2 {
             return Err(HostFuncError::User(1));
         }
@@ -1491,7 +1496,7 @@ mod tests {
             let result = FuncType::create([ValType::ExternRef, ValType::I32], [ValType::I32]);
             assert!(result.is_ok());
             let func_ty = result.unwrap();
-            let result = Function::create(&func_ty, Box::new(real_add), 0);
+            let result = Function::create::<NeverType>(&func_ty, Box::new(real_add), None, 0);
             assert!(result.is_ok());
             let host_func = result.unwrap();
             // add the host function

--- a/bindings/rust/wasmedge-sys/src/instance/table.rs
+++ b/bindings/rust/wasmedge-sys/src/instance/table.rs
@@ -278,11 +278,12 @@ unsafe impl Sync for InnerTableType {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CallingFrame, FuncType, Function};
+    use crate::{instance::function::NeverType, CallingFrame, FuncType, Function};
     use std::{
         sync::{Arc, Mutex},
         thread,
     };
+    use wasmedge_macro::sys_host_function;
     use wasmedge_types::{error::HostFuncError, RefType, ValType};
 
     #[test]
@@ -345,7 +346,7 @@ mod tests {
         assert!(result.is_ok());
         let func_ty = result.unwrap();
         // create a host function
-        let result = Function::create(&func_ty, Box::new(real_add), 0);
+        let result = Function::create::<NeverType>(&func_ty, Box::new(real_add), None, 0);
         assert!(result.is_ok());
         let host_func = result.unwrap();
 
@@ -486,7 +487,11 @@ mod tests {
         assert_eq!(table_cloned.capacity(), 10);
     }
 
-    fn real_add(_: CallingFrame, input: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
+    #[sys_host_function]
+    fn real_add(
+        _frame: CallingFrame,
+        input: Vec<WasmValue>,
+    ) -> Result<Vec<WasmValue>, HostFuncError> {
         println!("Rust: Entering Rust function real_add");
 
         if input.len() != 2 {

--- a/bindings/rust/wasmedge-sys/src/lib.rs
+++ b/bindings/rust/wasmedge-sys/src/lib.rs
@@ -93,7 +93,7 @@ pub use executor::Executor;
 pub use frame::CallingFrame;
 #[doc(inline)]
 pub use instance::{
-    function::{FuncRef, FuncType, Function},
+    function::{FuncRef, FuncType, Function, NeverType},
     global::{Global, GlobalType},
     memory::{MemType, Memory},
     module::{AsImport, AsInstance, ImportModule, ImportObject, Instance, WasiModule},
@@ -113,7 +113,11 @@ use wasmedge_types::{error, WasmEdgeResult};
 
 /// Type alias for a boxed native function. This type is used in thread-safe cases.
 pub type BoxedFn = Box<
-    dyn Fn(CallingFrame, Vec<WasmValue>) -> Result<Vec<WasmValue>, error::HostFuncError>
+    dyn Fn(
+            CallingFrame,
+            Vec<WasmValue>,
+            *mut std::os::raw::c_void,
+        ) -> Result<Vec<WasmValue>, error::HostFuncError>
         + Send
         + Sync,
 >;

--- a/bindings/rust/wasmedge-sys/src/store.rs
+++ b/bindings/rust/wasmedge-sys/src/store.rs
@@ -125,7 +125,9 @@ unsafe impl Sync for InnerStore {}
 mod tests {
     use super::Store;
     use crate::{
-        instance::{Function, Global, GlobalType, MemType, Memory, Table, TableType},
+        instance::{
+            function::NeverType, Function, Global, GlobalType, MemType, Memory, Table, TableType,
+        },
         types::WasmValue,
         AsImport, CallingFrame, Config, Engine, Executor, FuncType, ImportModule, ImportObject,
         Loader, Validator,
@@ -134,6 +136,7 @@ mod tests {
         sync::{Arc, Mutex},
         thread,
     };
+    use wasmedge_macro::sys_host_function;
     use wasmedge_types::{error::HostFuncError, Mutability, RefType, ValType};
 
     #[test]
@@ -160,7 +163,7 @@ mod tests {
         let result = FuncType::create(vec![ValType::I32; 2], vec![ValType::I32]);
         assert!(result.is_ok());
         let func_ty = result.unwrap();
-        let result = Function::create(&func_ty, Box::new(real_add), 0);
+        let result = Function::create::<NeverType>(&func_ty, Box::new(real_add), None, 0);
         assert!(result.is_ok());
         let host_func = result.unwrap();
         import.add_func("add", host_func);
@@ -246,7 +249,7 @@ mod tests {
             let result = FuncType::create(vec![ValType::I32; 2], vec![ValType::I32]);
             assert!(result.is_ok());
             let func_ty = result.unwrap();
-            let result = Function::create(&func_ty, Box::new(real_add), 0);
+            let result = Function::create::<NeverType>(&func_ty, Box::new(real_add), None, 0);
             assert!(result.is_ok());
             let host_func = result.unwrap();
             import.add_func("add", host_func);
@@ -336,7 +339,11 @@ mod tests {
         Ok(())
     }
 
-    fn real_add(_: CallingFrame, inputs: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
+    #[sys_host_function]
+    fn real_add(
+        _frame: CallingFrame,
+        inputs: Vec<WasmValue>,
+    ) -> Result<Vec<WasmValue>, HostFuncError> {
         if inputs.len() != 2 {
             return Err(HostFuncError::User(1));
         }

--- a/bindings/rust/wasmedge-sys/tests/common.rs
+++ b/bindings/rust/wasmedge-sys/tests/common.rs
@@ -1,4 +1,7 @@
-use wasmedge_sys::{AsImport, CallingFrame, FuncType, Function, ImportModule, WasmValue};
+use wasmedge_macro::sys_host_function;
+use wasmedge_sys::{
+    AsImport, CallingFrame, FuncType, Function, ImportModule, NeverType, WasmValue,
+};
 use wasmedge_types::{error::HostFuncError, ValType};
 
 pub fn create_extern_module(name: impl AsRef<str>) -> ImportModule {
@@ -10,7 +13,7 @@ pub fn create_extern_module(name: impl AsRef<str>) -> ImportModule {
     // add host function: "func-add"
     let result = FuncType::create(vec![ValType::ExternRef, ValType::I32], vec![ValType::I32]);
     let func_ty = result.unwrap();
-    let result = Function::create(&func_ty, Box::new(extern_add), 0);
+    let result = Function::create::<NeverType>(&func_ty, Box::new(extern_add), None, 0);
     assert!(result.is_ok());
     let host_func = result.unwrap();
     import.add_func("func-add", host_func);
@@ -18,7 +21,7 @@ pub fn create_extern_module(name: impl AsRef<str>) -> ImportModule {
     // add host function: "func-sub"
     let result = FuncType::create(vec![ValType::ExternRef, ValType::I32], vec![ValType::I32]);
     let func_ty = result.unwrap();
-    let result = Function::create(&func_ty, Box::new(extern_sub), 0);
+    let result = Function::create::<NeverType>(&func_ty, Box::new(extern_sub), None, 0);
     assert!(result.is_ok());
     let host_func = result.unwrap();
     import.add_func("func-sub", host_func);
@@ -26,7 +29,7 @@ pub fn create_extern_module(name: impl AsRef<str>) -> ImportModule {
     // add host function: "func-mul"
     let result = FuncType::create(vec![ValType::ExternRef, ValType::I32], vec![ValType::I32]);
     let func_ty = result.unwrap();
-    let result = Function::create(&func_ty, Box::new(extern_mul), 0);
+    let result = Function::create::<NeverType>(&func_ty, Box::new(extern_mul), None, 0);
     assert!(result.is_ok());
     let host_func = result.unwrap();
     import.add_func("func-mul", host_func);
@@ -34,7 +37,7 @@ pub fn create_extern_module(name: impl AsRef<str>) -> ImportModule {
     // add host function: "func-div"
     let result = FuncType::create(vec![ValType::ExternRef, ValType::I32], vec![ValType::I32]);
     let func_ty = result.unwrap();
-    let result = Function::create(&func_ty, Box::new(extern_div), 0);
+    let result = Function::create::<NeverType>(&func_ty, Box::new(extern_div), None, 0);
     assert!(result.is_ok());
     let host_func = result.unwrap();
     import.add_func("func-div", host_func);
@@ -43,7 +46,7 @@ pub fn create_extern_module(name: impl AsRef<str>) -> ImportModule {
     let result = FuncType::create([], [ValType::I32]);
     assert!(result.is_ok());
     let func_ty = result.unwrap();
-    let result = Function::create(&func_ty, Box::new(extern_term), 0);
+    let result = Function::create::<NeverType>(&func_ty, Box::new(extern_term), None, 0);
     let host_func = result.unwrap();
     import.add_func("func-term", host_func);
 
@@ -51,14 +54,18 @@ pub fn create_extern_module(name: impl AsRef<str>) -> ImportModule {
     let result = FuncType::create([], [ValType::I32]);
     assert!(result.is_ok());
     let func_ty = result.unwrap();
-    let result = Function::create(&func_ty, Box::new(extern_fail), 0);
+    let result = Function::create::<NeverType>(&func_ty, Box::new(extern_fail), None, 0);
     let host_func = result.unwrap();
     import.add_func("func-fail", host_func);
 
     import
 }
 
-fn extern_add(_: CallingFrame, inputs: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
+#[sys_host_function]
+fn extern_add(
+    _frame: CallingFrame,
+    inputs: Vec<WasmValue>,
+) -> Result<Vec<WasmValue>, HostFuncError> {
     let val1 = if inputs[0].ty() == ValType::ExternRef {
         inputs[0]
     } else {
@@ -77,7 +84,11 @@ fn extern_add(_: CallingFrame, inputs: Vec<WasmValue>) -> Result<Vec<WasmValue>,
     Ok(vec![WasmValue::from_i32(val1 + val2)])
 }
 
-fn extern_sub(_: CallingFrame, inputs: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
+#[sys_host_function]
+fn extern_sub(
+    _frame: CallingFrame,
+    inputs: Vec<WasmValue>,
+) -> Result<Vec<WasmValue>, HostFuncError> {
     let val1 = if inputs[0].ty() == ValType::ExternRef {
         inputs[0]
     } else {
@@ -97,7 +108,11 @@ fn extern_sub(_: CallingFrame, inputs: Vec<WasmValue>) -> Result<Vec<WasmValue>,
     Ok(vec![WasmValue::from_i32(val1 - val2)])
 }
 
-fn extern_mul(_: CallingFrame, inputs: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
+#[sys_host_function]
+fn extern_mul(
+    _frame: CallingFrame,
+    inputs: Vec<WasmValue>,
+) -> Result<Vec<WasmValue>, HostFuncError> {
     let val1 = if inputs[0].ty() == ValType::ExternRef {
         inputs[0]
     } else {
@@ -116,7 +131,11 @@ fn extern_mul(_: CallingFrame, inputs: Vec<WasmValue>) -> Result<Vec<WasmValue>,
     Ok(vec![WasmValue::from_i32(val1 * val2)])
 }
 
-fn extern_div(_: CallingFrame, inputs: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
+#[sys_host_function]
+fn extern_div(
+    _frame: CallingFrame,
+    inputs: Vec<WasmValue>,
+) -> Result<Vec<WasmValue>, HostFuncError> {
     let val1 = if inputs[0].ty() == ValType::ExternRef {
         inputs[0]
     } else {
@@ -135,10 +154,18 @@ fn extern_div(_: CallingFrame, inputs: Vec<WasmValue>) -> Result<Vec<WasmValue>,
     Ok(vec![WasmValue::from_i32(val1 / val2)])
 }
 
-fn extern_term(_: CallingFrame, _inputs: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
+#[sys_host_function]
+fn extern_term(
+    _frame: CallingFrame,
+    _inputs: Vec<WasmValue>,
+) -> Result<Vec<WasmValue>, HostFuncError> {
     Ok(vec![WasmValue::from_i32(1234)])
 }
 
-fn extern_fail(_: CallingFrame, _inputs: Vec<WasmValue>) -> Result<Vec<WasmValue>, HostFuncError> {
+#[sys_host_function]
+fn extern_fail(
+    _frame: CallingFrame,
+    _inputs: Vec<WasmValue>,
+) -> Result<Vec<WasmValue>, HostFuncError> {
     Err(HostFuncError::User(2))
 }

--- a/bindings/rust/wasmedge-sys/tests/test_aot.rs
+++ b/bindings/rust/wasmedge-sys/tests/test_aot.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "aot")]
+use wasmedge_macro::sys_host_function;
+#[cfg(feature = "aot")]
 use wasmedge_sys::{
     AsImport, CallingFrame, Compiler, Config, Executor, FuncType, Function, ImportModule,
-    ImportObject, Loader, Store, Validator, WasmValue,
+    ImportObject, Loader, NeverType, Store, Validator, WasmValue,
 };
 #[cfg(feature = "aot")]
 use wasmedge_types::{error::HostFuncError, CompilerOptimizationLevel, CompilerOutputFormat};
@@ -91,7 +93,7 @@ fn create_spec_test_module() -> ImportModule {
     let result = FuncType::create([], []);
     assert!(result.is_ok());
     let func_ty = result.unwrap();
-    let result = Function::create(&func_ty, Box::new(spec_test_print), 0);
+    let result = Function::create::<NeverType>(&func_ty, Box::new(spec_test_print), None, 0);
     assert!(result.is_ok());
     let host_func = result.unwrap();
     // add host function "print"
@@ -100,6 +102,7 @@ fn create_spec_test_module() -> ImportModule {
 }
 
 #[cfg(feature = "aot")]
+#[sys_host_function]
 fn spec_test_print(
     _frame: CallingFrame,
     _inputs: Vec<WasmValue>,


### PR DESCRIPTION
In this PR, the `NeverType` type is introduced as a workaround solution to support the generic context data argument of host functions. This solution will be used until the official never type `!` in Rust is stable.

Note that the new type is only available for defining `sync` host functions. For `async` host functions, it will be used after the in-progress new `async` design is stable.