### PR TITLE
[Utils] Installer: Fix error message

### DIFF
--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -23,7 +23,7 @@ on:
       - 'utils/install.py'
 
 env:
-  INSTALL_PY_URL: https://raw.githubusercontent.com/SAtacker/WasmEdge/installer_fix/utils/install.py
+  INSTALL_PY_URL: https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.py
 
 jobs:
   linux:

--- a/utils/install.py
+++ b/utils/install.py
@@ -1240,6 +1240,18 @@ class Compat:
                 set(self.extensions)
                 <= set(SUPPORTED_EXTENSIONS[self.platform + self.machine])
             ):
+                logging.error("Supported platforms and corresponding extensions:")
+                for key in SUPPORTED_EXTENSIONS:
+                    _extensions = None
+                    if len(SUPPORTED_EXTENSIONS[key]) >= 1:
+                        _extensions = ",".join(SUPPORTED_EXTENSIONS[key])
+                    else:
+                        _extensions = "None"
+                    logging.error(
+                        "Platform: {0} Supported Extensions: {1}".format(
+                            key, _extensions
+                        )
+                    )
                 reraise(
                     Exception(
                         "Extensions not supported: {0}. Supported extensions: {1}".format(

--- a/utils/installer_changes.sh
+++ b/utils/installer_changes.sh
@@ -11,7 +11,7 @@ test_diff_env() {
     echo "Testing path: $_path_ args: $_common_args_"
     bash ./utils/install.sh.old -p "$_path_" $_common_args_
     cp "$_path_"/env "$HOME"/env.old
-    INSTALL_PY_URL="https://raw.githubusercontent.com/SAtacker/WasmEdge/installer_fix/utils/install.py" bash ./utils/install.sh -p "$_path_" $_common_args_
+    INSTALL_PY_URL="https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.py" bash ./utils/install.sh -p "$_path_" $_common_args_
     cp "$_path_"/env "$HOME"/env
     diff -u \
         <(sed '1,/Please/d' "$HOME"/env.old | sed -e 's/\/\//\//g' |


### PR DESCRIPTION
- The TensorFlow extensions on macOS only support x86_64. So the error message should be only working on x86_64 macOS platforms.
- Fix https://github.com/WasmEdge/WasmEdge/issues/2477

Signed-off-by: Shreyas Atre <shreyasatre16@gmail.com>
