### PR TITLE
Refactor Poller interface for reusing same object

### DIFF
--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -37,7 +37,6 @@ inline constexpr const int32_t kMaxSaDataLen = 26;
 } // namespace detail
 
 class EVPoller;
-class EVEpoller;
 class Environ {
 public:
   ~Environ() noexcept;
@@ -839,16 +838,11 @@ public:
 
   /// Concurrently poll for the occurrence of a set of events.
   ///
+  /// @param[in] Trigger Requesting level-trigger or edge-trigger notification.
   /// @param[in] NSubscriptions Both the number of subscriptions and events.
   /// @return Poll helper or WASI error.
-  WasiExpect<EVPoller> pollOneoff(__wasi_size_t NSubscriptions) noexcept;
-
-  /// Concurrently poll for the occurrence of a set of events in edge-triggered
-  /// mode.
-  ///
-  /// @param[in] NSubscriptions Both the number of subscriptions and events.
-  /// @return Poll helper or WASI error.
-  WasiExpect<EVEpoller> epollOneoff(__wasi_size_t NSubscriptions) noexcept;
+  WasiExpect<EVPoller> pollOneoff(TriggerType Trigger,
+                                  __wasi_size_t NSubscriptions) noexcept;
 
   /// Terminate the process normally. An exit code of 0 indicates successful
   /// termination of the program. The meanings of other values is dependent on
@@ -1243,12 +1237,7 @@ private:
   mutable std::shared_mutex FdMutex; ///< Protect FdMap
   std::unordered_map<__wasi_fd_t, std::shared_ptr<VINode>> FdMap;
 
-  // unique epoll fd;
-  int RegistrationFd = -1;
-  std::unordered_map<int, uint32_t> Registration;
-
   friend class EVPoller;
-  friend class EVEpoller;
 
   std::shared_ptr<VINode> getNodeOrNull(__wasi_fd_t Fd) const {
     std::shared_lock Lock(FdMutex);
@@ -1275,7 +1264,9 @@ private:
 
 class EVPoller : private VPoller {
 public:
+  using VPoller::clear;
   using VPoller::clock;
+  using VPoller::trigger;
   using VPoller::wait;
 
   EVPoller(VPoller &&P, Environ &E) : VPoller(std::move(P)), Env(E) {}
@@ -1309,63 +1300,12 @@ private:
   Environ &Env;
 };
 
-class EVEpoller : private VEpoller {
-public:
-  using VEpoller::CallbackType;
-  using VEpoller::clock;
-  using VEpoller::getFd;
-  using VEpoller::wait;
-
-  EVEpoller(VEpoller &&P, Environ &E) : VEpoller(std::move(P)), Env(E) {}
-
-  WasiExpect<void> clock(__wasi_clockid_t Clock, __wasi_timestamp_t Timeout,
-                         __wasi_timestamp_t Precision,
-                         __wasi_subclockflags_t Flags,
-                         __wasi_userdata_t UserData) noexcept {
-    return VEpoller::clock(Clock, Timeout, Precision, Flags, UserData);
-  }
-
-  WasiExpect<void> read(__wasi_fd_t Fd, __wasi_userdata_t UserData) noexcept {
-    auto Node = Env.getNodeOrNull(Fd);
-    if (unlikely(!Node)) {
-      return WasiUnexpect(__WASI_ERRNO_BADF);
-    } else {
-      return VEpoller::read(Node, UserData, Env.Registration);
-    }
-  }
-
-  WasiExpect<void> write(__wasi_fd_t Fd, __wasi_userdata_t UserData) noexcept {
-    auto Node = Env.getNodeOrNull(Fd);
-    if (unlikely(!Node)) {
-      return WasiUnexpect(__WASI_ERRNO_BADF);
-    } else {
-      return VEpoller::write(Node, UserData, Env.Registration);
-    }
-  }
-  WasiExpect<void> wait(CallbackType Callback) noexcept {
-    return VEpoller::wait(Callback, Env.Registration);
-  }
-
-  int getFd() noexcept { return VEpoller::getFd(); }
-
-private:
-  Environ &Env;
-};
-
 inline WasiExpect<EVPoller>
-Environ::pollOneoff(__wasi_size_t NSubscriptions) noexcept {
-  return VINode::pollOneoff(NSubscriptions).map([this](VPoller &&P) {
+Environ::pollOneoff(TriggerType Trigger,
+                    __wasi_size_t NSubscriptions) noexcept {
+  return VINode::pollOneoff(Trigger, NSubscriptions).map([this](VPoller &&P) {
     return EVPoller(std::move(P), *this);
   });
-}
-
-inline WasiExpect<EVEpoller>
-Environ::epollOneoff(__wasi_size_t NSubscriptions) noexcept {
-  auto Evepoller =
-      VINode::epollOneoff(NSubscriptions, RegistrationFd)
-          .map([this](VEpoller &&P) { return EVEpoller(std::move(P), *this); });
-  RegistrationFd = Evepoller.value().getFd();
-  return Evepoller;
 }
 
 } // namespace WASI

--- a/include/host/wasi/inode.h
+++ b/include/host/wasi/inode.h
@@ -806,6 +806,7 @@ private:
     OptionalEvent *WriteEvent = nullptr;
   };
   std::unordered_map<int, FdData> FdDatas;
+  std::unordered_map<int, FdData> OldFdDatas;
 #endif
 
 #if WASMEDGE_OS_LINUX

--- a/include/host/wasi/vinode.h
+++ b/include/host/wasi/vinode.h
@@ -778,17 +778,16 @@ private:
       uint8_t VFSFlags = 0, uint8_t LinkCount = 0);
 };
 
-class VPoller : private Poller {
+class VPoller : protected Poller {
 public:
   using Poller::clock;
   using Poller::error;
   using Poller::ok;
+  using Poller::Poller;
   using Poller::prepare;
   using Poller::reset;
   using Poller::result;
   using Poller::wait;
-
-  VPoller() noexcept = default;
 
   void read(std::shared_ptr<VINode> Fd, TriggerType Trigger,
             __wasi_userdata_t UserData) noexcept {

--- a/include/host/wasi/wasifunc.h
+++ b/include/host/wasi/wasifunc.h
@@ -321,18 +321,10 @@ public:
                         uint32_t PathPtr, uint32_t PathLen);
 };
 
-class WasiPollOneoff : public Wasi<WasiPollOneoff> {
+template <WASI::TriggerType Trigger>
+class WasiPollOneoff : public Wasi<WasiPollOneoff<Trigger>> {
 public:
-  WasiPollOneoff(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
-
-  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t InPtr,
-                        uint32_t OutPtr, uint32_t NSubscriptions,
-                        uint32_t /* Out */ NEventsPtr);
-};
-
-class WasiEpollOneoff : public Wasi<WasiEpollOneoff> {
-public:
-  WasiEpollOneoff(WASI::Environ &HostEnv) : Wasi(HostEnv) {}
+  WasiPollOneoff(WASI::Environ &HostEnv) : Wasi<WasiPollOneoff>(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t InPtr,
                         uint32_t OutPtr, uint32_t NSubscriptions,

--- a/lib/host/wasi/environ.cpp
+++ b/lib/host/wasi/environ.cpp
@@ -134,13 +134,6 @@ void Environ::fini() noexcept {
   EnvironVariables.clear();
   Arguments.clear();
   FdMap.clear();
-  Registration.clear();
-#if WASMEDGE_OS_LINUX || WASMEDGE_OS_MACOS
-  if (RegistrationFd >= 0) {
-    close(RegistrationFd);
-    RegistrationFd = -1;
-  }
-#endif
 }
 
 Environ::~Environ() noexcept { fini(); }

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -801,25 +801,14 @@ WasiExpect<void> INode::pathUnlinkFile(std::string Path) const noexcept {
   return {};
 }
 
-WasiExpect<Poller> INode::pollOneoff(__wasi_size_t NSubscriptions) noexcept {
+WasiExpect<Poller> INode::pollOneoff(WASI::TriggerType Trigger,
+                                     __wasi_size_t NSubscriptions) noexcept {
   try {
     Poller P(NSubscriptions);
     if (unlikely(!P.ok())) {
       return WasiUnexpect(fromErrNo(errno));
     }
-    return P;
-  } catch (std::bad_alloc &) {
-    return WasiUnexpect(__WASI_ERRNO_NOMEM);
-  }
-}
-
-WasiExpect<Epoller> INode::epollOneoff(__wasi_size_t NSubscriptions,
-                                       int Fd) noexcept {
-  try {
-    Epoller P(NSubscriptions, Fd);
-    if (unlikely(!P.ok())) {
-      return WasiUnexpect(fromErrNo(errno));
-    }
+    P.trigger(Trigger);
     return P;
   } catch (std::bad_alloc &) {
     return WasiUnexpect(__WASI_ERRNO_NOMEM);
@@ -1725,79 +1714,6 @@ WasiExpect<void> Poller::Timer::create(__wasi_clockid_t Clock,
 }
 #endif
 
-#if __GLIBC_PREREQ(2, 8)
-WasiExpect<void> Epoller::Timer::create(__wasi_clockid_t Clock,
-                                        __wasi_timestamp_t Timeout,
-                                        __wasi_timestamp_t,
-                                        __wasi_subclockflags_t Flags) noexcept {
-  Fd = timerfd_create(toClockId(Clock), TFD_NONBLOCK | TFD_CLOEXEC);
-  if (unlikely(Fd < 0)) {
-    return WasiUnexpect(fromErrNo(errno));
-  }
-
-  int SysFlags = 0;
-  if (Flags & __WASI_SUBCLOCKFLAGS_SUBSCRIPTION_CLOCK_ABSTIME) {
-    SysFlags |= TFD_TIMER_ABSTIME;
-  }
-  itimerspec Spec{toTimespec(0), toTimespec(Timeout)};
-  if (auto Res = timerfd_settime(Fd, SysFlags, &Spec, nullptr);
-      unlikely(Res < 0)) {
-    return WasiUnexpect(fromErrNo(errno));
-  }
-
-  return {};
-}
-#else
-WasiExpect<void> Epoller::Timer::create(__wasi_clockid_t Clock,
-                                        __wasi_timestamp_t Timeout,
-                                        __wasi_timestamp_t,
-                                        __wasi_subclockflags_t Flags) noexcept {
-  FdHolder Timer, Notify;
-  {
-    int PipeFd[2] = {-1, -1};
-
-    if (auto Res = ::pipe(PipeFd); unlikely(Res != 0)) {
-      return WasiUnexpect(fromErrNo(errno));
-    }
-    Timer.emplace(PipeFd[0]);
-    Notify.emplace(PipeFd[1]);
-  }
-
-  timer_t TId;
-  {
-    sigevent Event;
-    Event.sigev_notify = SIGEV_THREAD;
-    Event.sigev_notify_function = &sigevCallback;
-    Event.sigev_value.sival_int = Notify.Fd;
-    Event.sigev_notify_attributes = nullptr;
-
-    if (unlikely(::fcntl(Timer.Fd, F_SETFD, FD_CLOEXEC) != 0 ||
-                 ::fcntl(Notify.Fd, F_SETFD, FD_CLOEXEC) != 0 ||
-                 ::timer_create(toClockId(Clock), &Event, &TId) < 0)) {
-      return WasiUnexpect(fromErrNo(errno));
-    }
-  }
-
-  TimerHolder TimerId(TId);
-  {
-    int SysFlags = 0;
-    if (Flags & __WASI_SUBCLOCKFLAGS_SUBSCRIPTION_CLOCK_ABSTIME) {
-      SysFlags |= TIMER_ABSTIME;
-    }
-    itimerspec Spec{toTimespec(0), toTimespec(Timeout)};
-    if (auto Res = ::timer_settime(TId, SysFlags, &Spec, nullptr);
-        unlikely(Res < 0)) {
-      return WasiUnexpect(fromErrNo(errno));
-    }
-  }
-
-  this->FdHolder::operator=(std::move(Timer));
-  this->Notify = std::move(Notify);
-  this->TimerId = std::move(TimerId);
-  return {};
-}
-#endif
-
 Poller::Poller(__wasi_size_t Count)
     : FdHolder(
 #if __GLIBC_PREREQ(2, 9)
@@ -1815,26 +1731,7 @@ Poller::Poller(__wasi_size_t Count)
   Events.reserve(Count);
 }
 
-Epoller::Epoller(__wasi_size_t Count, int fd) {
-  if (fd == -1) {
-#if __GLIBC_PREREQ(2, 9)
-    auto new_fd = ::epoll_create1(EPOLL_CLOEXEC);
-#else
-    auto new_fd = ::epoll_create(Count);
-#endif
-    emplace(new_fd);
-  } else {
-    emplace(fd);
-  }
-  Cleanup = false;
-#if !__GLIBC_PREREQ(2, 9)
-  if (auto Res = ::fcntl(Fd, F_SETFD, FD_CLOEXEC); unlikely(Res != 0)) {
-    reset();
-    return;
-  }
-#endif
-  Events.reserve(Count);
-}
+void Poller::clear() noexcept {}
 
 WasiExpect<void> Poller::clock(__wasi_clockid_t Clock,
                                __wasi_timestamp_t Timeout,
@@ -1888,6 +1785,9 @@ WasiExpect<void> Poller::read(const INode &Fd,
 
   epoll_event EPollEvent;
   EPollEvent.events = EPOLLIN;
+  if (Trigger == TriggerType::Edge) {
+    EPollEvent.events |= EPOLLET;
+  }
 #if defined(EPOLLRDHUP)
   EPollEvent.events |= EPOLLRDHUP;
 #endif
@@ -1925,6 +1825,9 @@ WasiExpect<void> Poller::write(const INode &Fd,
   }
   epoll_event EPollEvent;
   EPollEvent.events = EPOLLOUT;
+  if (Trigger == TriggerType::Edge) {
+    EPollEvent.events |= EPOLLET;
+  }
 #if defined(EPOLLRDHUP)
   EPollEvent.events |= EPOLLRDHUP;
 #endif
@@ -2020,252 +1923,6 @@ WasiExpect<void> Poller::wait(CallbackType Callback) noexcept {
       ProcessEvent(Callback, EPollEvent, Iter->second.WriteIndex);
     }
   }
-  return {};
-}
-
-WasiExpect<void> Epoller::clock(__wasi_clockid_t Clock,
-                                __wasi_timestamp_t Timeout,
-                                __wasi_timestamp_t Precision,
-                                __wasi_subclockflags_t Flags,
-                                __wasi_userdata_t UserData) noexcept {
-  try {
-    Events.push_back({UserData,
-                      __WASI_ERRNO_SUCCESS,
-                      __WASI_EVENTTYPE_CLOCK,
-                      {0, static_cast<__wasi_eventrwflags_t>(0)}});
-    Timers.emplace_back();
-  } catch (std::bad_alloc &) {
-    return WasiUnexpect(__WASI_ERRNO_NOMEM);
-  }
-
-  auto &Timer = Timers.back();
-  if (auto Res = Timer.create(Clock, Timeout, Precision, Flags);
-      unlikely(!Res)) {
-    return WasiUnexpect(Res);
-  }
-
-  epoll_event EPollEvent;
-  EPollEvent.events = EPOLLIN;
-#if defined(EPOLLRDHUP)
-  EPollEvent.events |= EPOLLRDHUP;
-#endif
-  EPollEvent.data.fd = Timer.Fd;
-  auto [Iter, Added] = FdDatas.emplace(Timer.Fd, FdData(EPollEvent.events));
-  assuming(Added);
-  if (auto Res = ::epoll_ctl(this->Fd, EPOLL_CTL_ADD, Timer.Fd, &EPollEvent);
-      unlikely(Res < 0)) {
-    FdDatas.erase(Iter);
-    return WasiUnexpect(fromErrNo(errno));
-  }
-  Iter->second.ReadIndex = Events.size() - 1;
-  return {};
-}
-
-WasiExpect<void>
-Epoller::read(const INode &Fd, __wasi_userdata_t UserData,
-              std::unordered_map<int, uint32_t> &Registration) noexcept {
-  try {
-    Events.push_back({UserData,
-                      __WASI_ERRNO_SUCCESS,
-                      __WASI_EVENTTYPE_FD_READ,
-                      {0, static_cast<__wasi_eventrwflags_t>(0)}});
-  } catch (std::bad_alloc &) {
-    return WasiUnexpect(__WASI_ERRNO_NOMEM);
-  }
-
-  epoll_event EPollEvent;
-  EPollEvent.events = EPOLLET | EPOLLIN;
-#if defined(EPOLLRDHUP)
-  EPollEvent.events |= EPOLLRDHUP;
-#endif
-  EPollEvent.data.fd = Fd.Fd;
-  // insert read with fd * 2
-  auto CurrentEvents = EPollEvent.events;
-  auto [IterGlobal, AddedGlobal] =
-      Registration.emplace(Fd.Fd * 2, CurrentEvents);
-  auto [Iter, Added] = FdDatas.emplace(Fd.Fd, FdData(EPollEvent.events));
-  auto WriteFlag = Registration.count(Fd.Fd * 2 + 1);
-  if (AddedGlobal) {
-    if (WriteFlag) {
-      auto WriteEvent = Registration.at(Fd.Fd * 2 + 1);
-      EPollEvent.events |= WriteEvent;
-      if (auto Res = ::epoll_ctl(this->Fd, EPOLL_CTL_MOD, Fd.Fd, &EPollEvent);
-          unlikely(Res < 0)) {
-        return WasiUnexpect(fromErrNo(errno));
-      }
-    } else {
-      if (likely(Added)) {
-        if (auto Res = ::epoll_ctl(this->Fd, EPOLL_CTL_ADD, Fd.Fd, &EPollEvent);
-            unlikely(Res < 0)) {
-          FdDatas.erase(Iter);
-          Registration.erase(IterGlobal);
-          return WasiUnexpect(fromErrNo(errno));
-        } else {
-          EPollEvent.events |= Iter->second.Events;
-          if (auto Res =
-                  ::epoll_ctl(this->Fd, EPOLL_CTL_MOD, Fd.Fd, &EPollEvent);
-              unlikely(Res < 0)) {
-            return WasiUnexpect(fromErrNo(errno));
-          }
-        }
-      }
-    }
-  }
-  Iter->second.Events = EPollEvent.events;
-  Iter->second.ReadIndex = Events.size() - 1;
-  return {};
-}
-
-WasiExpect<void>
-Epoller::write(const INode &Fd, __wasi_userdata_t UserData,
-               std::unordered_map<int, uint32_t> &Registration) noexcept {
-
-  try {
-    Events.push_back({UserData,
-                      __WASI_ERRNO_SUCCESS,
-                      __WASI_EVENTTYPE_FD_WRITE,
-                      {0, static_cast<__wasi_eventrwflags_t>(0)}});
-  } catch (std::bad_alloc &) {
-    return WasiUnexpect(__WASI_ERRNO_NOMEM);
-  }
-  epoll_event EPollEvent;
-  EPollEvent.events = EPOLLET | EPOLLOUT;
-#if defined(EPOLLRDHUP)
-  EPollEvent.events |= EPOLLRDHUP;
-#endif
-  EPollEvent.data.fd = Fd.Fd;
-  // insert write with fd * 2 + 1
-  auto CurrentEvents = EPollEvent.events;
-  auto [IterGlobal, AddedGlobal] =
-      Registration.emplace(Fd.Fd * 2 + 1, CurrentEvents);
-  auto ReadFlag = Registration.count(Fd.Fd * 2);
-  auto [Iter, Added] = FdDatas.emplace(Fd.Fd, FdData(EPollEvent.events));
-  if (AddedGlobal) {
-    if (ReadFlag) {
-      auto ReadEvent = Registration.at(Fd.Fd * 2);
-      EPollEvent.events |= ReadEvent;
-      if (auto Res = ::epoll_ctl(this->Fd, EPOLL_CTL_MOD, Fd.Fd, &EPollEvent);
-          unlikely(Res < 0)) {
-        return WasiUnexpect(fromErrNo(errno));
-      }
-    } else {
-      if (likely(Added)) {
-        if (auto Res = ::epoll_ctl(this->Fd, EPOLL_CTL_ADD, Fd.Fd, &EPollEvent);
-            unlikely(Res < 0)) {
-          FdDatas.erase(Iter);
-          Registration.erase(IterGlobal);
-          return WasiUnexpect(fromErrNo(errno));
-        }
-      } else {
-        EPollEvent.events |= Iter->second.Events;
-        if (auto Res = ::epoll_ctl(this->Fd, EPOLL_CTL_MOD, Fd.Fd, &EPollEvent);
-            unlikely(Res < 0)) {
-          return WasiUnexpect(fromErrNo(errno));
-        }
-      }
-    }
-  }
-  Iter->second.Events = EPollEvent.events;
-  Iter->second.WriteIndex = Events.size() - 1;
-  return {};
-}
-
-WasiExpect<void>
-Epoller::wait(CallbackType Callback,
-              std::unordered_map<int, uint32_t> &Registration) noexcept {
-  std::vector<struct epoll_event> EPollEvents;
-  try {
-    EPollEvents.resize(Events.size());
-  } catch (std::bad_alloc &) {
-    return WasiUnexpect(__WASI_ERRNO_NOMEM);
-  }
-  std::vector<int> SavedFds;
-  for (auto Pair : Registration) {
-    if (Pair.first % 2 == 0) {
-      SavedFds.emplace_back(Pair.first / 2);
-    }
-  }
-  std::vector<int> IncomingFds;
-  IncomingFds.reserve(FdDatas.size());
-  for (const auto &[key, value] : FdDatas) {
-    IncomingFds.push_back(key);
-  }
-
-  std::sort(SavedFds.begin(), SavedFds.end());
-  std::sort(IncomingFds.begin(), IncomingFds.end());
-
-  std::vector<int> Difference;
-  std::set_difference(SavedFds.begin(), SavedFds.end(), IncomingFds.begin(),
-                      IncomingFds.end(), std::back_inserter(Difference));
-
-  for (auto Fd : Difference) {
-    ::epoll_ctl(this->Fd, EPOLL_CTL_DEL, Fd, nullptr);
-    Registration.erase(Fd * 2);
-    Registration.erase(Fd * 2 + 1);
-  }
-
-  const int Count =
-      ::epoll_wait(Fd, EPollEvents.data(), EPollEvents.size(), -1);
-  if (unlikely(Count < 0)) {
-    return WasiUnexpect(fromErrNo(errno));
-  }
-  auto ProcessEvent = [this](CallbackType &Callback,
-                             const struct epoll_event &EPollEvent,
-                             const uint64_t Index) {
-    auto Flags = static_cast<__wasi_eventrwflags_t>(0);
-    __wasi_filesize_t NBytes = 0;
-    switch (Events[Index].type) {
-    case __WASI_EVENTTYPE_CLOCK:
-      break;
-    case __WASI_EVENTTYPE_FD_READ: {
-      if (EPollEvent.events & EPOLLHUP) {
-        Flags |= __WASI_EVENTRWFLAGS_FD_READWRITE_HANGUP;
-      }
-      int ReadBufUsed = 0;
-      if (auto Res = ::ioctl(Fd, FIONREAD, &ReadBufUsed); unlikely(Res == 0)) {
-        break;
-      }
-      NBytes = ReadBufUsed;
-      break;
-    }
-    case __WASI_EVENTTYPE_FD_WRITE: {
-      if (EPollEvent.events & EPOLLHUP) {
-        Flags |= __WASI_EVENTRWFLAGS_FD_READWRITE_HANGUP;
-      }
-      int WriteBufSize = 0;
-      socklen_t IntSize = sizeof(WriteBufSize);
-      if (auto Res =
-              ::getsockopt(Fd, SOL_SOCKET, SO_SNDBUF, &WriteBufSize, &IntSize);
-          unlikely(Res != 0)) {
-        break;
-      }
-      int WriteBufUsed = 0;
-      if (auto Res = ::ioctl(Fd, TIOCOUTQ, &WriteBufUsed); unlikely(Res != 0)) {
-        break;
-      }
-      NBytes = WriteBufSize - WriteBufUsed;
-      break;
-    }
-    }
-
-    Callback(Events[Index].userdata, __WASI_ERRNO_SUCCESS, Events[Index].type,
-             NBytes, Flags);
-  };
-
-  for (int I = 0; I < Count; ++I) {
-    const auto &EPollEvent = EPollEvents[I];
-    const auto Iter = FdDatas.find(EPollEvent.data.fd);
-    assuming(Iter != FdDatas.end());
-    if (EPollEvent.events & EPOLLIN) {
-      assuming(Iter->second.ReadIndex < Events.size());
-      ProcessEvent(Callback, EPollEvent, Iter->second.ReadIndex);
-    }
-    if (EPollEvent.events & EPOLLOUT) {
-      assuming(Iter->second.WriteIndex < Events.size());
-      ProcessEvent(Callback, EPollEvent, Iter->second.WriteIndex);
-    }
-  }
-
   return {};
 }
 

--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -759,20 +759,6 @@ WasiExpect<void> INode::pathUnlinkFile(std::string Path) const noexcept {
   return {};
 }
 
-WasiExpect<Poller> INode::pollOneoff(WASI::TriggerType Trigger,
-                                     __wasi_size_t NSubscriptions) noexcept {
-  try {
-    Poller P(NSubscriptions);
-    if (unlikely(!P.ok())) {
-      return WasiUnexpect(fromErrNo(errno));
-    }
-    P.trigger(Trigger);
-    return std::move(P);
-  } catch (std::bad_alloc &) {
-    return WasiUnexpect(__WASI_ERRNO_NOMEM);
-  }
-}
-
 WasiExpect<INode> INode::sockOpen(__wasi_address_family_t AddressFamily,
                                   __wasi_sock_type_t SockType) noexcept {
 
@@ -1513,142 +1499,248 @@ WasiExpect<void> INode::updateStat() const noexcept {
   return {};
 }
 
-Poller::Poller(__wasi_size_t Count) : FdHolder(::kqueue()) {
-  Events.reserve(Count);
-}
+Poller::Poller() noexcept : FdHolder(::kqueue()) {}
 
-void Poller::clear() noexcept {}
-
-WasiExpect<void> Poller::clock(__wasi_clockid_t, __wasi_timestamp_t Timeout,
-                               __wasi_timestamp_t, __wasi_subclockflags_t Flags,
-                               __wasi_userdata_t UserData) noexcept {
+WasiExpect<void> Poller::prepare(Span<__wasi_event_t> E) noexcept {
+  WasiEvents = E;
   try {
-    Events.push_back({UserData,
-                      __WASI_ERRNO_SUCCESS,
-                      __WASI_EVENTTYPE_CLOCK,
-                      {0, static_cast<__wasi_eventrwflags_t>(0)}});
+    Events.reserve(E.size());
+    KEvents.reserve(Events.size());
   } catch (std::bad_alloc &) {
     return WasiUnexpect(__WASI_ERRNO_NOMEM);
   }
 
-  int SysFlags = NOTE_NSECONDS;
+  return {};
+}
+
+void Poller::clock(__wasi_clockid_t, __wasi_timestamp_t Timeout,
+                   __wasi_timestamp_t, __wasi_subclockflags_t Flags,
+                   __wasi_userdata_t UserData) noexcept {
+  assuming(Events.size() < WasiEvents.size());
+  auto &Event = Events.emplace_back();
+  Event.Valid = false;
+  Event.userdata = UserData;
+  Event.type = __WASI_EVENTTYPE_CLOCK;
+
+  const uint64_t Ident = NextTimerId++;
+
+  uint32_t FFlags = NOTE_NSECONDS;
   if (Flags & __WASI_SUBCLOCKFLAGS_SUBSCRIPTION_CLOCK_ABSTIME) {
     // TODO: Implement
+    Event.Valid = true;
+    Event.error = __WASI_ERRNO_NOSYS;
+    return;
   }
 
   struct kevent KEvent;
-  EV_SET(&KEvent, 0, EVFILT_TIMER, EV_ADD | EV_ENABLE | EV_ONESHOT, SysFlags,
-         Timeout, reinterpret_cast<void *>(Events.size() - 1));
+  EV_SET(&KEvent, Ident, EVFILT_TIMER, EV_ADD | EV_ENABLE, FFlags, Timeout,
+         &Event);
 
   if (const auto Ret = ::kevent(Fd, &KEvent, 1, nullptr, 0, nullptr);
       unlikely(Ret < 0)) {
-    return WasiUnexpect(fromErrNo(errno));
+    Event.Valid = true;
+    Event.error = fromErrNo(errno);
+    return;
   }
-
-  return {};
 }
 
-WasiExpect<void> Poller::read(const INode &Node,
-                              __wasi_userdata_t UserData) noexcept {
+void Poller::read(const INode &Node, TriggerType Trigger,
+                  __wasi_userdata_t UserData) noexcept {
+  assuming(Events.size() < WasiEvents.size());
+  auto &Event = Events.emplace_back();
+  Event.Valid = false;
+  Event.userdata = UserData;
+  Event.type = __WASI_EVENTTYPE_FD_READ;
+
+  assuming(Node.Fd != Fd);
   try {
-    Events.push_back({UserData,
-                      __WASI_ERRNO_SUCCESS,
-                      __WASI_EVENTTYPE_FD_READ,
-                      {0, static_cast<__wasi_eventrwflags_t>(0)}});
+    auto [Iter, Added] = FdDatas.try_emplace(Node.Fd);
+
+    if (unlikely(!Added && Iter->second.ReadEvent != nullptr)) {
+      Event.Valid = true;
+      Event.error = __WASI_ERRNO_EXIST;
+      return;
+    }
+    Iter->second.ReadEvent = &Event;
+
+    uint16_t Flags = EV_ADD | EV_ENABLE;
+    if (Trigger == TriggerType::Edge) {
+      Flags |= EV_CLEAR;
+    }
+
+    struct kevent KEvent;
+    EV_SET(&KEvent, Node.Fd, EVFILT_READ, Flags, 0, 0, &Event);
+
+    if (const auto Ret = ::kevent(Fd, &KEvent, 1, nullptr, 0, nullptr);
+        unlikely(Ret < 0)) {
+      if (Added) {
+        FdDatas.erase(Iter);
+      } else {
+        Iter->second.ReadEvent = nullptr;
+      }
+      Event.Valid = true;
+      Event.error = fromErrNo(errno);
+      return;
+    }
   } catch (std::bad_alloc &) {
-    return WasiUnexpect(__WASI_ERRNO_NOMEM);
+    Event.Valid = true;
+    Event.error = __WASI_ERRNO_NOMEM;
+    return;
   }
-
-  struct kevent KEvent;
-  EV_SET(&KEvent, Node.Fd, EVFILT_READ, EV_ADD | EV_ENABLE | EV_ONESHOT, 0, 0,
-         reinterpret_cast<void *>(Events.size() - 1));
-
-  if (const auto Ret = ::kevent(Fd, &KEvent, 1, nullptr, 0, nullptr);
-      unlikely(Ret < 0)) {
-    return WasiUnexpect(fromErrNo(errno));
-  }
-
-  return {};
 }
 
-WasiExpect<void> Poller::write(const INode &Node,
-                               __wasi_userdata_t UserData) noexcept {
+void Poller::write(const INode &Node, TriggerType Trigger,
+                   __wasi_userdata_t UserData) noexcept {
+  assuming(Events.size() < WasiEvents.size());
+  auto &Event = Events.emplace_back();
+  Event.Valid = false;
+  Event.userdata = UserData;
+  Event.type = __WASI_EVENTTYPE_FD_WRITE;
+
+  assuming(Node.Fd != Fd);
   try {
-    Events.push_back({UserData,
-                      __WASI_ERRNO_SUCCESS,
-                      __WASI_EVENTTYPE_FD_WRITE,
-                      {0, static_cast<__wasi_eventrwflags_t>(0)}});
+    auto [Iter, Added] = FdDatas.try_emplace(Node.Fd);
+
+    if (unlikely(!Added && Iter->second.WriteEvent != nullptr)) {
+      Event.Valid = true;
+      Event.error = __WASI_ERRNO_EXIST;
+      return;
+    }
+    Iter->second.WriteEvent = &Event;
+
+    uint16_t Flags = EV_ADD | EV_ENABLE;
+    if (Trigger == TriggerType::Edge) {
+      Flags |= EV_CLEAR;
+    }
+
+    struct kevent KEvent;
+    EV_SET(&KEvent, Node.Fd, EVFILT_WRITE, Flags, 0, 0, &Event);
+
+    if (const auto Ret = ::kevent(Fd, &KEvent, 1, nullptr, 0, nullptr);
+        unlikely(Ret < 0)) {
+      if (Added) {
+        FdDatas.erase(Iter);
+      } else {
+        Iter->second.WriteEvent = nullptr;
+      }
+      Event.Valid = true;
+      Event.error = fromErrNo(errno);
+      return;
+    }
   } catch (std::bad_alloc &) {
-    return WasiUnexpect(__WASI_ERRNO_NOMEM);
+    Event.Valid = true;
+    Event.error = __WASI_ERRNO_NOMEM;
+    return;
   }
-
-  struct kevent KEvent;
-  EV_SET(&KEvent, Node.Fd, EVFILT_WRITE, EV_ADD | EV_ENABLE | EV_ONESHOT, 0, 0,
-         reinterpret_cast<void *>(Events.size() - 1));
-
-  if (const auto Ret = ::kevent(Fd, &KEvent, 1, nullptr, 0, nullptr);
-      unlikely(Ret < 0)) {
-    return WasiUnexpect(fromErrNo(errno));
-  }
-
-  return {};
 }
 
-WasiExpect<void> Poller::wait(CallbackType Callback) noexcept {
-  std::vector<struct kevent> KEvents;
-  try {
-    KEvents.resize(Events.size());
-  } catch (std::bad_alloc &) {
-    return WasiUnexpect(__WASI_ERRNO_NOMEM);
-  }
-  const auto Count =
+void Poller::wait() noexcept {
+  using namespace std::literals;
+  KEvents.resize(Events.size());
+  const int Count =
       ::kevent(Fd, nullptr, 0, KEvents.data(), KEvents.size(), nullptr);
   if (unlikely(Count < 0)) {
-    return WasiUnexpect(fromErrNo(errno));
+    const auto Error = fromErrNo(errno);
+    for (auto &Event : Events) {
+      Event.Valid = true;
+      Event.error = Error;
+    }
+    return;
   }
 
   for (int I = 0; I < Count; ++I) {
     auto &KEvent = KEvents[I];
-    const auto Index = reinterpret_cast<size_t>(KEvent.udata);
-    __wasi_filesize_t NBytes = 0;
-    auto Flags = static_cast<__wasi_eventrwflags_t>(0);
-    switch (Events[Index].type) {
+    auto &Event = *reinterpret_cast<OptionalEvent *>(KEvent.udata);
+    Event.Valid = true;
+    Event.error = __WASI_ERRNO_SUCCESS;
+    switch (Event.type) {
     case __WASI_EVENTTYPE_CLOCK:
       break;
     case __WASI_EVENTTYPE_FD_READ: {
+      Event.fd_readwrite.flags = static_cast<__wasi_eventrwflags_t>(0);
       if (KEvent.flags & EV_EOF) {
-        Flags |= __WASI_EVENTRWFLAGS_FD_READWRITE_HANGUP;
+        Event.fd_readwrite.flags |= __WASI_EVENTRWFLAGS_FD_READWRITE_HANGUP;
       }
+      bool UnknownNBytes = false;
       int ReadBufUsed = 0;
-      if (auto Res = ioctl(Fd, FIONREAD, &ReadBufUsed); unlikely(Res == 0)) {
-        break;
+      if (auto Res = ::ioctl(KEvent.ident, FIONREAD, &ReadBufUsed);
+          unlikely(Res == 0)) {
+        UnknownNBytes = true;
       }
-      NBytes = ReadBufUsed;
+      if (UnknownNBytes) {
+        Event.fd_readwrite.nbytes = 1;
+      } else {
+        Event.fd_readwrite.nbytes = ReadBufUsed;
+      }
       break;
     }
     case __WASI_EVENTTYPE_FD_WRITE: {
+      Event.fd_readwrite.flags = static_cast<__wasi_eventrwflags_t>(0);
       if (KEvent.flags & EV_EOF) {
-        Flags |= __WASI_EVENTRWFLAGS_FD_READWRITE_HANGUP;
+        Event.fd_readwrite.flags |= __WASI_EVENTRWFLAGS_FD_READWRITE_HANGUP;
       }
+      bool UnknownNBytes = false;
       int WriteBufSize = 0;
       socklen_t IntSize = sizeof(WriteBufSize);
-      if (auto Res =
-              getsockopt(Fd, SOL_SOCKET, SO_SNDBUF, &WriteBufSize, &IntSize);
+      if (auto Res = ::getsockopt(KEvent.ident, SOL_SOCKET, SO_SNDBUF,
+                                  &WriteBufSize, &IntSize);
           unlikely(Res != 0)) {
-        break;
+        UnknownNBytes = true;
       }
       int WriteBufUsed = 0;
-      if (auto Res = ioctl(Fd, TIOCOUTQ, &WriteBufUsed); unlikely(Res != 0)) {
-        break;
+      if (auto Res = ::ioctl(KEvent.ident, TIOCOUTQ, &WriteBufUsed);
+          unlikely(Res != 0)) {
+        UnknownNBytes = true;
       }
-      NBytes = WriteBufSize - WriteBufUsed;
+      if (UnknownNBytes) {
+        Event.fd_readwrite.nbytes = 1;
+      } else {
+        Event.fd_readwrite.nbytes = WriteBufSize - WriteBufUsed;
+      }
       break;
     }
     }
-    Callback(Events[Index].userdata, __WASI_ERRNO_SUCCESS, Events[Index].type,
-             NBytes, Flags);
   }
-  return {};
+
+  for (const auto &[NodeFd, FdData] : FdDatas) {
+    if (FdData.ReadEvent) {
+      struct kevent KEvent;
+      EV_SET(&KEvent, NodeFd, EVFILT_READ, EV_DELETE, 0, 0, nullptr);
+      if (const auto Ret = ::kevent(Fd, &KEvent, 1, nullptr, 0, nullptr);
+          unlikely(Ret < 0)) {
+        spdlog::warn("kevent({}, {{{}, EVFILT_READ, EV_DELETE}}) failed: {}"sv,
+                     Fd, NodeFd, fromErrNo(errno));
+      }
+    }
+    if (FdData.WriteEvent) {
+      struct kevent KEvent;
+      EV_SET(&KEvent, NodeFd, EVFILT_WRITE, EV_DELETE, 0, 0, nullptr);
+      if (const auto Ret = ::kevent(Fd, &KEvent, 1, nullptr, 0, nullptr);
+          unlikely(Ret < 0)) {
+        spdlog::warn("kevent({}, {{{}, EVFILT_WRITE, EV_DELETE}}) failed: {}"sv,
+                     Fd, NodeFd, fromErrNo(errno));
+      }
+    }
+  }
+  for (uint64_t I = 0; I < NextTimerId; ++I) {
+    struct kevent KEvent;
+    EV_SET(&KEvent, I, EVFILT_TIMER, EV_DELETE, 0, 0, nullptr);
+    if (const auto Ret = ::kevent(Fd, &KEvent, 1, nullptr, 0, nullptr);
+        unlikely(Ret < 0)) {
+      spdlog::warn("kevent({}, {{{}, EVFILT_TIMER, EV_DELETE}}) failed: {}"sv,
+                   Fd, I, fromErrNo(errno));
+    }
+  }
+
+  FdDatas.clear();
+  KEvents.clear();
+  NextTimerId = 0;
+  return;
+}
+
+void Poller::reset() noexcept {
+  WasiEvents = {};
+  Events.clear();
 }
 
 WasiExpect<void> INode::getAddrinfo(std::string_view Node,
@@ -1733,6 +1825,8 @@ WasiExpect<void> INode::getAddrinfo(std::string_view Node,
 
   return {};
 }
+
+bool Poller::ok() noexcept { return FdHolder::ok(); }
 
 } // namespace WASI
 } // namespace Host

--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -1499,7 +1499,7 @@ WasiExpect<void> INode::updateStat() const noexcept {
   return {};
 }
 
-Poller::Poller() noexcept : FdHolder(::kqueue()) {}
+Poller::Poller(PollerContext &C) noexcept : FdHolder(::kqueue()), Ctx(C) {}
 
 WasiExpect<void> Poller::prepare(Span<__wasi_event_t> E) noexcept {
   WasiEvents = E;

--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -1526,10 +1526,13 @@ void Poller::clock(__wasi_clockid_t, __wasi_timestamp_t Timeout,
 
   uint32_t FFlags = NOTE_NSECONDS;
   if (Flags & __WASI_SUBCLOCKFLAGS_SUBSCRIPTION_CLOCK_ABSTIME) {
-    // TODO: Implement
+#ifdef NOTE_ABSOLUTE
+    FFlags |= NOTE_ABSOLUTE;
+#else
     Event.Valid = true;
     Event.error = __WASI_ERRNO_NOSYS;
     return;
+#endif
   }
 
   struct kevent KEvent;

--- a/lib/host/wasi/inode-win.cpp
+++ b/lib/host/wasi/inode-win.cpp
@@ -2533,7 +2533,7 @@ WasiExpect<__wasi_filesize_t> INode::filesize() const noexcept {
 
 bool INode::canBrowse() const noexcept { return false; }
 
-Poller::Poller() noexcept {}
+Poller::Poller(PollerContext &C) noexcept : Ctx(C) {}
 
 WasiExpect<void> Poller::prepare(Span<__wasi_event_t> E) noexcept {
   WasiEvents = E;

--- a/lib/host/wasi/inode-win.cpp
+++ b/lib/host/wasi/inode-win.cpp
@@ -1700,11 +1700,8 @@ WasiExpect<void> INode::pathUnlinkFile(std::string Path) const noexcept {
   return {};
 }
 
-WasiExpect<Poller> INode::pollOneoff(__wasi_size_t) noexcept {
-  return WasiUnexpect(__WASI_ERRNO_NOSYS);
-}
-
-WasiExpect<Epoller> INode::epollOneoff(__wasi_size_t, int) noexcept {
+WasiExpect<Poller> INode::pollOneoff(WASI::TriggerType Trigger,
+                                     __wasi_size_t) noexcept {
   return WasiUnexpect(__WASI_ERRNO_NOSYS);
 }
 
@@ -2542,6 +2539,8 @@ WasiExpect<__wasi_filesize_t> INode::filesize() const noexcept {
 bool INode::canBrowse() const noexcept { return false; }
 
 Poller::Poller(__wasi_size_t Count) { Events.reserve(Count); }
+
+void Poller::clear() noexcept {}
 
 WasiExpect<void> Poller::clock(__wasi_clockid_t, __wasi_timestamp_t,
                                __wasi_timestamp_t, __wasi_subclockflags_t,

--- a/lib/host/wasi/inode-win.cpp
+++ b/lib/host/wasi/inode-win.cpp
@@ -1700,11 +1700,6 @@ WasiExpect<void> INode::pathUnlinkFile(std::string Path) const noexcept {
   return {};
 }
 
-WasiExpect<Poller> INode::pollOneoff(WASI::TriggerType Trigger,
-                                     __wasi_size_t) noexcept {
-  return WasiUnexpect(__WASI_ERRNO_NOSYS);
-}
-
 static bool EnsureWSAStartup() {
   static bool WSALoad = false;
   static WSADATA WSAData;
@@ -2538,50 +2533,37 @@ WasiExpect<__wasi_filesize_t> INode::filesize() const noexcept {
 
 bool INode::canBrowse() const noexcept { return false; }
 
-Poller::Poller(__wasi_size_t Count) { Events.reserve(Count); }
+Poller::Poller() noexcept {}
 
-void Poller::clear() noexcept {}
-
-WasiExpect<void> Poller::clock(__wasi_clockid_t, __wasi_timestamp_t,
-                               __wasi_timestamp_t, __wasi_subclockflags_t,
-                               __wasi_userdata_t) noexcept {
-  return WasiUnexpect(__WASI_ERRNO_NOSYS);
+WasiExpect<void> Poller::prepare(Span<__wasi_event_t> E) noexcept {
+  WasiEvents = E;
+  return {};
 }
 
-WasiExpect<void> Poller::read(const INode &, __wasi_userdata_t) noexcept {
-  return WasiUnexpect(__WASI_ERRNO_NOSYS);
+void Poller::clock(__wasi_clockid_t, __wasi_timestamp_t, __wasi_timestamp_t,
+                   __wasi_subclockflags_t,
+                   __wasi_userdata_t UserData) noexcept {
+  error(UserData, __WASI_ERRNO_NOSYS, __WASI_EVENTTYPE_CLOCK);
 }
 
-WasiExpect<void> Poller::write(const INode &, __wasi_userdata_t) noexcept {
-  return WasiUnexpect(__WASI_ERRNO_NOSYS);
+void Poller::read(const INode &, TriggerType,
+                  __wasi_userdata_t UserData) noexcept {
+  error(UserData, __WASI_ERRNO_NOSYS, __WASI_EVENTTYPE_FD_READ);
 }
 
-WasiExpect<void> Poller::wait(CallbackType) noexcept {
-  return WasiUnexpect(__WASI_ERRNO_NOSYS);
+void Poller::write(const INode &, TriggerType,
+                   __wasi_userdata_t UserData) noexcept {
+  error(UserData, __WASI_ERRNO_NOSYS, __WASI_EVENTTYPE_FD_WRITE);
 }
 
-Epoller::Epoller(__wasi_size_t Count, int) { Events.reserve(Count); }
+void Poller::wait() noexcept {}
 
-WasiExpect<void> Epoller::clock(__wasi_clockid_t, __wasi_timestamp_t,
-                                __wasi_timestamp_t, __wasi_subclockflags_t,
-                                __wasi_userdata_t) noexcept {
-  return WasiUnexpect(__WASI_ERRNO_NOSYS);
+void Poller::reset() noexcept {
+  WasiEvents = {};
+  Events.clear();
 }
 
-WasiExpect<void> Epoller::read(const INode &, __wasi_userdata_t,
-                               std::unordered_map<int, uint32_t> &) noexcept {
-  return WasiUnexpect(__WASI_ERRNO_NOSYS);
-}
-
-WasiExpect<void> Epoller::write(const INode &, __wasi_userdata_t,
-                                std::unordered_map<int, uint32_t> &) noexcept {
-  return WasiUnexpect(__WASI_ERRNO_NOSYS);
-}
-
-WasiExpect<void> Epoller::wait(CallbackType,
-                               std::unordered_map<int, uint32_t> &) noexcept {
-  return WasiUnexpect(__WASI_ERRNO_NOSYS);
-}
+bool Poller::ok() noexcept { return false; }
 
 } // namespace WASI
 } // namespace Host

--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -1453,11 +1453,10 @@ Expect<uint32_t> WasiPathUnlinkFile::body(const Runtime::CallingFrame &Frame,
   }
   return __WASI_ERRNO_SUCCESS;
 }
-
-Expect<uint32_t> WasiPollOneoff::body(const Runtime::CallingFrame &Frame,
-                                      uint32_t InPtr, uint32_t OutPtr,
-                                      uint32_t NSubscriptions,
-                                      uint32_t /* Out */ NEventsPtr) {
+template <WASI::TriggerType Trigger>
+Expect<uint32_t> WasiPollOneoff<Trigger>::body(
+    const Runtime::CallingFrame &Frame, uint32_t InPtr, uint32_t OutPtr,
+    uint32_t NSubscriptions, uint32_t /* Out */ NEventsPtr) {
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -1485,7 +1484,7 @@ Expect<uint32_t> WasiPollOneoff::body(const Runtime::CallingFrame &Frame,
 
   __wasi_size_t EventCount = 0;
 
-  if (auto Poll = Env.pollOneoff(WasiNSub); unlikely(!Poll)) {
+  if (auto Poll = this->Env.pollOneoff(Trigger, WasiNSub); unlikely(!Poll)) {
     return Poll.error();
   } else {
     // Validate contents
@@ -1578,129 +1577,8 @@ Expect<uint32_t> WasiPollOneoff::body(const Runtime::CallingFrame &Frame,
   return __WASI_ERRNO_SUCCESS;
 }
 
-Expect<uint32_t> WasiEpollOneoff::body(const Runtime::CallingFrame &Frame,
-                                       uint32_t InPtr, uint32_t OutPtr,
-                                       uint32_t NSubscriptions,
-                                       uint32_t /* Out */ NEventsPtr) {
-  // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
-  if (MemInst == nullptr) {
-    return __WASI_ERRNO_FAULT;
-  }
-
-  const __wasi_size_t WasiNSub = NSubscriptions;
-
-  auto *const SubscriptionArray =
-      MemInst->getPointer<const __wasi_subscription_t *>(InPtr, WasiNSub);
-  if (unlikely(SubscriptionArray == nullptr)) {
-    return __WASI_ERRNO_FAULT;
-  }
-
-  auto *const EventArray =
-      MemInst->getPointer<__wasi_event_t *>(OutPtr, WasiNSub);
-  if (unlikely(EventArray == nullptr)) {
-    return __WASI_ERRNO_FAULT;
-  }
-
-  auto *const NEvents = MemInst->getPointer<__wasi_size_t *>(NEventsPtr);
-  if (unlikely(NEvents == nullptr)) {
-    return __WASI_ERRNO_FAULT;
-  }
-
-  __wasi_size_t EventCount = 0;
-
-  if (auto Poll = Env.epollOneoff(WasiNSub); unlikely(!Poll)) {
-    return Poll.error();
-  } else {
-    // Validate contents
-    const Span<const __wasi_subscription_t> Subs(SubscriptionArray, WasiNSub);
-    Span<__wasi_event_t> Events(EventArray, WasiNSub);
-    auto Record = [&Events, &EventCount](
-                      __wasi_userdata_t UserData, __wasi_errno_t Errno,
-                      __wasi_eventtype_t EventType, __wasi_filesize_t NBytes,
-                      __wasi_eventrwflags_t Flags) {
-      auto &Event = Events[EventCount];
-      Event.userdata = UserData;
-      Event.error = Errno;
-      Event.type = EventType;
-      if (Errno == __WASI_ERRNO_SUCCESS &&
-          (EventType &
-           (__WASI_EVENTTYPE_FD_READ | __WASI_EVENTTYPE_FD_WRITE))) {
-        Event.fd_readwrite.nbytes = NBytes;
-        Event.fd_readwrite.flags = Flags;
-      }
-      ++EventCount;
-    };
-    for (auto &Sub : Subs) {
-      const __wasi_userdata_t WasiUserData = Sub.userdata;
-      const __wasi_eventrwflags_t NoFlags =
-          static_cast<__wasi_eventrwflags_t>(0);
-
-      __wasi_eventtype_t Type;
-      if (auto Res = cast<__wasi_eventtype_t>(Sub.u.tag); unlikely(!Res)) {
-        Record(WasiUserData, Res.error(), Sub.u.tag, 0, NoFlags);
-        continue;
-      } else {
-        Type = *Res;
-      }
-
-      switch (Type) {
-      case __WASI_EVENTTYPE_CLOCK: {
-        __wasi_clockid_t WasiClockId;
-        if (auto Res = cast<__wasi_clockid_t>(Sub.u.u.clock.id);
-            unlikely(!Res)) {
-          Record(WasiUserData, Res.error(), Sub.u.tag, 0, NoFlags);
-          continue;
-        } else {
-          WasiClockId = *Res;
-        }
-
-        __wasi_subclockflags_t WasiFlags;
-        if (auto Res = cast<__wasi_subclockflags_t>(Sub.u.u.clock.flags);
-            unlikely(!Res)) {
-          Record(WasiUserData, Res.error(), Sub.u.tag, 0, NoFlags);
-          continue;
-        } else {
-          WasiFlags = *Res;
-        }
-
-        const __wasi_timestamp_t WasiTimeout = Sub.u.u.clock.timeout;
-        const __wasi_timestamp_t WasiPrecision = Sub.u.u.clock.precision;
-
-        if (auto Res = Poll->clock(WasiClockId, WasiTimeout, WasiPrecision,
-                                   WasiFlags, WasiUserData);
-            unlikely(!Res)) {
-          Record(WasiUserData, Res.error(), Sub.u.tag, 0, NoFlags);
-        }
-        continue;
-      }
-      case __WASI_EVENTTYPE_FD_READ: {
-        const __wasi_fd_t WasiFd = Sub.u.u.fd_read.file_descriptor;
-        if (auto Res = Poll->read(WasiFd, WasiUserData); unlikely(!Res)) {
-          Record(WasiUserData, Res.error(), Sub.u.tag, 0, NoFlags);
-        }
-        continue;
-      }
-      case __WASI_EVENTTYPE_FD_WRITE: {
-        const __wasi_fd_t WasiFd = Sub.u.u.fd_write.file_descriptor;
-        if (auto Res = Poll->write(WasiFd, WasiUserData); unlikely(!Res)) {
-          Record(WasiUserData, Res.error(), Sub.u.tag, 0, NoFlags);
-        }
-        continue;
-      }
-      default:
-        assumingUnreachable();
-      }
-    }
-
-    if (auto Res = Poll->wait(Record); unlikely(!Res)) {
-      return Res.error();
-    }
-  }
-
-  *NEvents = EventCount;
-  return __WASI_ERRNO_SUCCESS;
-}
+template class WasiPollOneoff<WASI::TriggerType::Level>;
+template class WasiPollOneoff<WASI::TriggerType::Edge>;
 
 Expect<void> WasiProcExit::body(const Runtime::CallingFrame &,
                                 uint32_t ExitCode) {

--- a/lib/host/wasi/wasimodule.cpp
+++ b/lib/host/wasi/wasimodule.cpp
@@ -55,8 +55,10 @@ WasiModule::WasiModule() : ModuleInstance("wasi_snapshot_preview1") {
   addHostFunc("path_rename", std::make_unique<WasiPathRename>(Env));
   addHostFunc("path_symlink", std::make_unique<WasiPathSymlink>(Env));
   addHostFunc("path_unlink_file", std::make_unique<WasiPathUnlinkFile>(Env));
-  addHostFunc("poll_oneoff", std::make_unique<WasiPollOneoff>(Env));
-  addHostFunc("epoll_oneoff", std::make_unique<WasiEpollOneoff>(Env));
+  addHostFunc("poll_oneoff",
+              std::make_unique<WasiPollOneoff<WASI::TriggerType::Level>>(Env));
+  addHostFunc("epoll_oneoff",
+              std::make_unique<WasiPollOneoff<WASI::TriggerType::Edge>>(Env));
   addHostFunc("proc_exit", std::make_unique<WasiProcExit>(Env));
   addHostFunc("proc_raise", std::make_unique<WasiProcRaise>(Env));
   addHostFunc("sched_yield", std::make_unique<WasiSchedYield>(Env));

--- a/test/host/wasi/wasi.cpp
+++ b/test/host/wasi/wasi.cpp
@@ -792,7 +792,8 @@ TEST(WasiTest, PollOneoffSocketV1) {
 
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
   WasmEdge::Host::WasiFdFdstatSetFlags WasiFdFdstatSetFlags(Env);
-  WasmEdge::Host::WasiPollOneoff WasiPollOneoff(Env);
+  WasmEdge::Host::WasiPollOneoff<WasmEdge::Host::WASI::TriggerType::Level>
+      WasiPollOneoff(Env);
   WasmEdge::Host::WasiSockConnectV1 WasiSockConnect(Env);
   WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
   WasmEdge::Host::WasiSockRecvV1 WasiSockRecv(Env);
@@ -1407,7 +1408,8 @@ TEST(WasiTest, PollOneoffSocketV2) {
 
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
   WasmEdge::Host::WasiFdFdstatSetFlags WasiFdFdstatSetFlags(Env);
-  WasmEdge::Host::WasiPollOneoff WasiPollOneoff(Env);
+  WasmEdge::Host::WasiPollOneoff<WasmEdge::Host::WASI::TriggerType::Level>
+      WasiPollOneoff(Env);
   WasmEdge::Host::WasiSockConnectV2 WasiSockConnect(Env);
   WasmEdge::Host::WasiSockOpenV2 WasiSockOpen(Env);
   WasmEdge::Host::WasiSockRecvV2 WasiSockRecv(Env);
@@ -2022,7 +2024,8 @@ TEST(WasiTest, EpollOneoffSocketV1) {
 
   WasmEdge::Host::WasiFdClose WasiFdClose(Env);
   WasmEdge::Host::WasiFdFdstatSetFlags WasiFdFdstatSetFlags(Env);
-  WasmEdge::Host::WasiEpollOneoff WasiEpollOneoff(Env);
+  WasmEdge::Host::WasiPollOneoff<WasmEdge::Host::WASI::TriggerType::Edge>
+      WasiPollOneoff(Env);
   WasmEdge::Host::WasiSockConnectV1 WasiSockConnect(Env);
   WasmEdge::Host::WasiSockOpenV1 WasiSockOpen(Env);
   WasmEdge::Host::WasiSockRecvV1 WasiSockRecv(Env);
@@ -2076,10 +2079,10 @@ TEST(WasiTest, EpollOneoffSocketV1) {
       Subscriptions[1].u.u.clock.precision = 1;
       Subscriptions[1].u.u.clock.flags = static_cast<__wasi_subclockflags_t>(0);
       EXPECT_TRUE(
-          WasiEpollOneoff.run(CallFrame,
-                              std::initializer_list<WasmEdge::ValVariant>{
-                                  InPtr, OutPtr, Count, NEventsPtr},
-                              Errno));
+          WasiPollOneoff.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 InPtr, OutPtr, Count, NEventsPtr},
+                             Errno));
       EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
       __wasi_size_t NEvents;
       EXPECT_TRUE((MemInst.loadValue(NEvents, NEventsPtr)));
@@ -2105,10 +2108,10 @@ TEST(WasiTest, EpollOneoffSocketV1) {
       Subscriptions[1].u.u.clock.precision = 1;
       Subscriptions[1].u.u.clock.flags = static_cast<__wasi_subclockflags_t>(0);
       EXPECT_TRUE(
-          WasiEpollOneoff.run(CallFrame,
-                              std::initializer_list<WasmEdge::ValVariant>{
-                                  InPtr, OutPtr, Count, NEventsPtr},
-                              Errno));
+          WasiPollOneoff.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 InPtr, OutPtr, Count, NEventsPtr},
+                             Errno));
       EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
       __wasi_size_t NEvents;
       EXPECT_TRUE((MemInst.loadValue(NEvents, NEventsPtr)));
@@ -2135,10 +2138,10 @@ TEST(WasiTest, EpollOneoffSocketV1) {
       Subscriptions[1].u.u.clock.precision = 1;
       Subscriptions[1].u.u.clock.flags = static_cast<__wasi_subclockflags_t>(0);
       EXPECT_TRUE(
-          WasiEpollOneoff.run(CallFrame,
-                              std::initializer_list<WasmEdge::ValVariant>{
-                                  InPtr, OutPtr, Count, NEventsPtr},
-                              Errno));
+          WasiPollOneoff.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 InPtr, OutPtr, Count, NEventsPtr},
+                             Errno));
       EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
       __wasi_size_t NEvents;
       EXPECT_TRUE((MemInst.loadValue(NEvents, NEventsPtr)));
@@ -2164,10 +2167,10 @@ TEST(WasiTest, EpollOneoffSocketV1) {
       Subscriptions[1].u.u.clock.precision = 1;
       Subscriptions[1].u.u.clock.flags = static_cast<__wasi_subclockflags_t>(0);
       EXPECT_TRUE(
-          WasiEpollOneoff.run(CallFrame,
-                              std::initializer_list<WasmEdge::ValVariant>{
-                                  InPtr, OutPtr, Count, NEventsPtr},
-                              Errno));
+          WasiPollOneoff.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 InPtr, OutPtr, Count, NEventsPtr},
+                             Errno));
       EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
       __wasi_size_t NEvents;
       EXPECT_TRUE(MemInst.loadValue(NEvents, NEventsPtr));
@@ -2196,10 +2199,10 @@ TEST(WasiTest, EpollOneoffSocketV1) {
       Subscriptions[2].u.u.clock.precision = 1;
       Subscriptions[2].u.u.clock.flags = static_cast<__wasi_subclockflags_t>(0);
       EXPECT_TRUE(
-          WasiEpollOneoff.run(CallFrame,
-                              std::initializer_list<WasmEdge::ValVariant>{
-                                  InPtr, OutPtr, Count, NEventsPtr},
-                              Errno));
+          WasiPollOneoff.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 InPtr, OutPtr, Count, NEventsPtr},
+                             Errno));
       EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
       __wasi_size_t NEvents;
       EXPECT_TRUE(MemInst.loadValue(NEvents, NEventsPtr));
@@ -2228,10 +2231,10 @@ TEST(WasiTest, EpollOneoffSocketV1) {
       Subscriptions[2].u.u.clock.precision = 1;
       Subscriptions[2].u.u.clock.flags = static_cast<__wasi_subclockflags_t>(0);
       EXPECT_TRUE(
-          WasiEpollOneoff.run(CallFrame,
-                              std::initializer_list<WasmEdge::ValVariant>{
-                                  InPtr, OutPtr, Count, NEventsPtr},
-                              Errno));
+          WasiPollOneoff.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 InPtr, OutPtr, Count, NEventsPtr},
+                             Errno));
       EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
       __wasi_size_t NEvents;
       EXPECT_TRUE(MemInst.loadValue(NEvents, NEventsPtr));
@@ -2260,10 +2263,10 @@ TEST(WasiTest, EpollOneoffSocketV1) {
       Subscriptions[2].u.u.clock.precision = 1;
       Subscriptions[2].u.u.clock.flags = static_cast<__wasi_subclockflags_t>(0);
       EXPECT_TRUE(
-          WasiEpollOneoff.run(CallFrame,
-                              std::initializer_list<WasmEdge::ValVariant>{
-                                  InPtr, OutPtr, Count, NEventsPtr},
-                              Errno));
+          WasiPollOneoff.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 InPtr, OutPtr, Count, NEventsPtr},
+                             Errno));
       EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
       __wasi_size_t NEvents;
       EXPECT_TRUE(MemInst.loadValue(NEvents, NEventsPtr));


### PR DESCRIPTION
* Remove duplicate code on poll_oneoff with edge-trigger config
* Refactor Poller interface for reusing same object
  * Use a pool for reusing Poller
* Lazy removing events on reused Poller
* Reuse timerfd
  * Add `PollerContext` for holding `Timer` pool in `Environ`
* Support absolute time flags for `poll_oneoff` in MacOS
  * Turn on Edge-trigger test in MacOS
  * Extract `sleep_for` in test