### PR TITLE
[WASI] Use StaticVector to speedup CI in debug version

### DIFF
--- a/include/runtime/instance/memory.h
+++ b/include/runtime/instance/memory.h
@@ -223,13 +223,32 @@ public:
   /// Get pointer to specific offset of memory.
   template <typename T>
   typename std::enable_if_t<std::is_pointer_v<T>, T>
-  getPointer(uint32_t Offset, uint32_t Size = 1) const noexcept {
+  getPointer(uint32_t Offset) const noexcept {
     using Type = std::remove_pointer_t<T>;
-    uint32_t ByteSize = static_cast<uint32_t>(sizeof(Type)) * Size;
+    uint32_t ByteSize = static_cast<uint32_t>(sizeof(Type));
     if (unlikely(!checkAccessBound(Offset, ByteSize))) {
       return nullptr;
     }
     return reinterpret_cast<T>(&DataPtr[Offset]);
+  }
+
+  /// Get array of object at specific offset of memory.
+  template <typename T>
+  Span<T> getSpan(uint32_t Offset, uint32_t Size) const noexcept {
+    uint32_t ByteSize = static_cast<uint32_t>(sizeof(T) * Size);
+    if (unlikely(!checkAccessBound(Offset, ByteSize))) {
+      return Span<T>();
+    }
+    return Span<T>(reinterpret_cast<T *>(&DataPtr[Offset]), Size);
+  }
+
+  /// Get array of object at specific offset of memory.
+  std::string_view getStringView(uint32_t Offset,
+                                 uint32_t Size) const noexcept {
+    if (unlikely(!checkAccessBound(Offset, Size))) {
+      return {};
+    }
+    return {reinterpret_cast<const char *>(&DataPtr[Offset]), Size};
   }
 
   /// Template of loading bytes and convert to a value.

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -2134,7 +2134,10 @@ WasmEdge_MemoryInstanceGetPointer(WasmEdge_MemoryInstanceContext *Cxt,
                                   const uint32_t Offset,
                                   const uint32_t Length) {
   if (Cxt) {
-    return fromMemCxt(Cxt)->getPointer<uint8_t *>(Offset, Length);
+    const auto S = fromMemCxt(Cxt)->getSpan<uint8_t>(Offset, Length);
+    if (S.size() == Length) {
+      return S.data();
+    }
   }
   return nullptr;
 }
@@ -2143,7 +2146,10 @@ WASMEDGE_CAPI_EXPORT const uint8_t *WasmEdge_MemoryInstanceGetPointerConst(
     const WasmEdge_MemoryInstanceContext *Cxt, const uint32_t Offset,
     const uint32_t Length) {
   if (Cxt) {
-    return fromMemCxt(Cxt)->getPointer<const uint8_t *>(Offset, Length);
+    const auto S = fromMemCxt(Cxt)->getSpan<const uint8_t>(Offset, Length);
+    if (S.size() == Length) {
+      return S.data();
+    }
   }
   return nullptr;
 }

--- a/plugins/wasi_crypto/asymmetric_common/func.cpp
+++ b/plugins/wasi_crypto/asymmetric_common/func.cpp
@@ -19,14 +19,12 @@ Expect<uint32_t> KeypairGenerate::body(const Runtime::CallingFrame &Frame,
   checkExist(MemInst);
 
   const __wasi_size_t WasiAlgLen = AlgLen;
-  auto *const Alg = MemInst->getPointer<const char *>(AlgPtr, WasiAlgLen);
-  checkExist(Alg);
+  const auto Alg = MemInst->getStringView(AlgPtr, WasiAlgLen);
+  checkRangeExist(Alg, WasiAlgLen);
 
   AsymmetricCommon::Algorithm WasiAlg;
   if (auto Res = cast<__wasi_algorithm_type_e_t>(AlgType).and_then(
-          [Alg, WasiAlgLen](auto WasiAlgType) {
-            return tryFrom(WasiAlgType, {Alg, WasiAlgLen});
-          });
+          [Alg](auto WasiAlgType) { return tryFrom(WasiAlgType, Alg); });
       unlikely(!Res)) {
     return Res.error();
   } else {
@@ -59,14 +57,12 @@ Expect<uint32_t> KeypairImport::body(const Runtime::CallingFrame &Frame,
   checkExist(MemInst);
 
   const __wasi_size_t WasiAlgLen = AlgLen;
-  auto *const Alg = MemInst->getPointer<const char *>(AlgPtr, WasiAlgLen);
-  checkExist(Alg);
+  const auto Alg = MemInst->getStringView(AlgPtr, WasiAlgLen);
+  checkRangeExist(Alg, WasiAlgLen);
 
   AsymmetricCommon::Algorithm WasiAlg;
   if (auto Res = cast<__wasi_algorithm_type_e_t>(AlgType).and_then(
-          [Alg, WasiAlgLen](auto WasiAlgType) {
-            return tryFrom(WasiAlgType, {Alg, WasiAlgLen});
-          });
+          [Alg](auto WasiAlgType) { return tryFrom(WasiAlgType, Alg); });
       unlikely(!Res)) {
     return Res.error();
   } else {
@@ -74,9 +70,9 @@ Expect<uint32_t> KeypairImport::body(const Runtime::CallingFrame &Frame,
   }
 
   const __wasi_size_t WasiEncodedLen = EncodedLen;
-  auto *const Encoded =
-      MemInst->getPointer<const uint8_t *>(EncodedPtr, WasiEncodedLen);
-  checkExist(Encoded);
+  const auto Encoded =
+      MemInst->getSpan<const uint8_t>(EncodedPtr, WasiEncodedLen);
+  checkRangeExist(Encoded, WasiEncodedLen);
 
   const auto WasiEncoding = cast<__wasi_keypair_encoding_e_t>(Encoding);
   checkExist(WasiEncoding);
@@ -84,8 +80,7 @@ Expect<uint32_t> KeypairImport::body(const Runtime::CallingFrame &Frame,
   auto *const KpHandle = MemInst->getPointer<__wasi_keypair_t *>(KpHandlePtr);
   checkExist(KpHandle);
 
-  if (auto Res =
-          Ctx.keypairImport(WasiAlg, {Encoded, WasiEncodedLen}, *WasiEncoding);
+  if (auto Res = Ctx.keypairImport(WasiAlg, Encoded, *WasiEncoding);
       unlikely(!Res)) {
     return Res.error();
   } else {
@@ -103,14 +98,12 @@ Expect<uint32_t> KeypairGenerateManaged::body(
   checkExist(MemInst);
 
   const __wasi_size_t WasiAlgLen = AlgLen;
-  auto *const Alg = MemInst->getPointer<const char *>(AlgPtr, WasiAlgLen);
-  checkExist(Alg);
+  const auto Alg = MemInst->getStringView(AlgPtr, WasiAlgLen);
+  checkRangeExist(Alg, WasiAlgLen);
 
   AsymmetricCommon::Algorithm WasiAlg;
   if (auto Res = cast<__wasi_algorithm_type_e_t>(AlgType).and_then(
-          [Alg, WasiAlgLen](auto WasiAlgType) {
-            return tryFrom(WasiAlgType, {Alg, WasiAlgLen});
-          });
+          [Alg](auto WasiAlgType) { return tryFrom(WasiAlgType, Alg); });
       unlikely(!Res)) {
     return Res.error();
   } else {
@@ -143,11 +136,10 @@ Expect<uint32_t> KeypairStoreManaged::body(const Runtime::CallingFrame &Frame,
   checkExist(MemInst);
 
   const __wasi_size_t WasiKpIdMaxLen = KpIdMaxLen;
-  auto *const KpId = MemInst->getPointer<uint8_t *>(KpIdPtr, WasiKpIdMaxLen);
-  checkExist(KpId);
+  const auto KpId = MemInst->getSpan<uint8_t>(KpIdPtr, WasiKpIdMaxLen);
+  checkRangeExist(KpId, WasiKpIdMaxLen);
 
-  if (auto Res = Ctx.keypairStoreManaged(SecretsManagerHandle, KpHandle,
-                                         {KpId, WasiKpIdMaxLen});
+  if (auto Res = Ctx.keypairStoreManaged(SecretsManagerHandle, KpHandle, KpId);
       unlikely(!Res)) {
     return Res.error();
   }
@@ -186,8 +178,8 @@ Expect<uint32_t> KeypairId::body(const Runtime::CallingFrame &Frame,
   checkExist(MemInst);
 
   const __wasi_size_t WasiKpIdMaxLen = KpIdMaxLen;
-  auto *const KpId = MemInst->getPointer<uint8_t *>(KpIdPtr, WasiKpIdMaxLen);
-  checkExist(KpId);
+  const auto KpId = MemInst->getSpan<uint8_t>(KpIdPtr, WasiKpIdMaxLen);
+  checkRangeExist(KpId, WasiKpIdMaxLen);
 
   auto *const Size = MemInst->getPointer<__wasi_size_t *>(SizePtr);
   checkExist(Size);
@@ -195,8 +187,7 @@ Expect<uint32_t> KeypairId::body(const Runtime::CallingFrame &Frame,
   auto *const Version = MemInst->getPointer<__wasi_version_t *>(KpVersionPtr);
   checkExist(Version);
 
-  if (auto Res = Ctx.keypairId(KpHandle, {KpId, WasiKpIdMaxLen});
-      unlikely(!Res)) {
+  if (auto Res = Ctx.keypairId(KpHandle, KpId); unlikely(!Res)) {
     return Res.error();
   } else {
     auto [ResSize, ResVersion] = *Res;
@@ -223,14 +214,13 @@ Expect<uint32_t> KeypairFromId::body(const Runtime::CallingFrame &Frame,
   checkExist(MemInst);
 
   const __wasi_size_t WasiKpIdLen = KpIdLen;
-  auto *const KpId = MemInst->getPointer<const uint8_t *>(KpIdPtr, WasiKpIdLen);
-  checkExist(KpId);
+  const auto KpId = MemInst->getSpan<uint8_t>(KpIdPtr, WasiKpIdLen);
+  checkRangeExist(KpId, WasiKpIdLen);
 
   auto *const KpHandle = MemInst->getPointer<__wasi_keypair_t *>(KpHandlePtr);
   checkExist(KpHandle);
 
-  if (auto Res = Ctx.keypairFromId(SecretsManagerHandle, {KpId, WasiKpIdLen},
-                                   KpVersion);
+  if (auto Res = Ctx.keypairFromId(SecretsManagerHandle, KpId, KpVersion);
       unlikely(!Res)) {
     return Res.error();
   } else {
@@ -339,14 +329,12 @@ Expect<uint32_t> PublickeyImport::body(const Runtime::CallingFrame &Frame,
   checkExist(MemInst);
 
   const __wasi_size_t WasiAlgLen = AlgLen;
-  auto *const Alg = MemInst->getPointer<const char *>(AlgPtr, WasiAlgLen);
-  checkExist(Alg);
+  const auto Alg = MemInst->getStringView(AlgPtr, WasiAlgLen);
+  checkRangeExist(Alg, WasiAlgLen);
 
   AsymmetricCommon::Algorithm WasiAlg;
   if (auto Res = cast<__wasi_algorithm_type_e_t>(AlgType).and_then(
-          [Alg, WasiAlgLen](auto WasiAlgType) {
-            return tryFrom(WasiAlgType, {Alg, WasiAlgLen});
-          });
+          [Alg](auto WasiAlgType) { return tryFrom(WasiAlgType, Alg); });
       unlikely(!Res)) {
     return Res.error();
   } else {
@@ -354,9 +342,9 @@ Expect<uint32_t> PublickeyImport::body(const Runtime::CallingFrame &Frame,
   }
 
   const __wasi_size_t WasiEncodedLen = EncodedLen;
-  auto *const Encoded =
-      MemInst->getPointer<const uint8_t *>(EncodedPtr, WasiEncodedLen);
-  checkExist(Encoded);
+  const auto Encoded =
+      MemInst->getSpan<const uint8_t>(EncodedPtr, WasiEncodedLen);
+  checkRangeExist(Encoded, WasiEncodedLen);
 
   __wasi_publickey_encoding_e_t WasiPkEncoding;
   if (auto Res = cast<__wasi_publickey_encoding_e_t>(Encoding); !Res) {
@@ -368,8 +356,7 @@ Expect<uint32_t> PublickeyImport::body(const Runtime::CallingFrame &Frame,
   auto *const PkHandle = MemInst->getPointer<__wasi_publickey_t *>(PkHandlePtr);
   checkExist(PkHandle);
 
-  if (auto Res = Ctx.publickeyImport(WasiAlg, {Encoded, WasiEncodedLen},
-                                     WasiPkEncoding);
+  if (auto Res = Ctx.publickeyImport(WasiAlg, Encoded, WasiPkEncoding);
       unlikely(!Res)) {
     return Res.error();
   } else {
@@ -452,14 +439,12 @@ Expect<uint32_t> SecretkeyImport::body(const Runtime::CallingFrame &Frame,
   checkExist(MemInst);
 
   const __wasi_size_t WasiAlgLen = AlgLen;
-  auto *const Alg = MemInst->getPointer<const char *>(AlgPtr, WasiAlgLen);
-  checkExist(Alg);
+  const auto Alg = MemInst->getStringView(AlgPtr, WasiAlgLen);
+  checkRangeExist(Alg, WasiAlgLen);
 
   AsymmetricCommon::Algorithm WasiAlg;
   if (auto Res = cast<__wasi_algorithm_type_e_t>(AlgType).and_then(
-          [Alg, WasiAlgLen](auto WasiAlgType) {
-            return tryFrom(WasiAlgType, {Alg, WasiAlgLen});
-          });
+          [Alg](auto WasiAlgType) { return tryFrom(WasiAlgType, Alg); });
       unlikely(!Res)) {
     return Res.error();
   } else {
@@ -467,9 +452,9 @@ Expect<uint32_t> SecretkeyImport::body(const Runtime::CallingFrame &Frame,
   }
 
   const __wasi_size_t WasiEncodedLen = EncodedLen;
-  auto *const Encoded =
-      MemInst->getPointer<const uint8_t *>(EncodedPtr, WasiEncodedLen);
-  checkExist(Encoded);
+  const auto Encoded =
+      MemInst->getSpan<const uint8_t>(EncodedPtr, WasiEncodedLen);
+  checkRangeExist(Encoded, WasiEncodedLen);
 
   auto WasiEncoding = cast<__wasi_secretkey_encoding_e_t>(Encoding);
   if (!WasiEncoding) {
@@ -479,8 +464,7 @@ Expect<uint32_t> SecretkeyImport::body(const Runtime::CallingFrame &Frame,
   auto *const SkHandle = MemInst->getPointer<__wasi_secretkey_t *>(SkHandlePtr);
   checkExist(SkHandle);
 
-  if (auto Res = Ctx.secretkeyImport(WasiAlg, {Encoded, WasiEncodedLen},
-                                     *WasiEncoding);
+  if (auto Res = Ctx.secretkeyImport(WasiAlg, Encoded, *WasiEncoding);
       unlikely(!Res)) {
     return Res.error();
   } else {

--- a/plugins/wasi_crypto/common/func.cpp
+++ b/plugins/wasi_crypto/common/func.cpp
@@ -37,14 +37,14 @@ Expect<uint32_t> ArrayOutputPull::body(const Runtime::CallingFrame &Frame,
   checkExist(MemInst);
 
   const __wasi_size_t WasiBufLen = BufLen;
-  auto *const Buf = MemInst->getPointer<uint8_t *>(BufPtr, WasiBufLen);
-  checkExist(Buf);
+  const auto Buf = MemInst->getSpan<uint8_t>(BufPtr, WasiBufLen);
+  checkRangeExist(Buf, WasiBufLen);
 
   auto *const Size = MemInst->getPointer<__wasi_size_t *>(SizePtr);
   checkExist(Size);
 
-  if (auto Res = Ctx.arrayOutputPull(ArrayOutputHandle, {Buf, WasiBufLen})
-                     .and_then(toWasiSize);
+  if (auto Res =
+          Ctx.arrayOutputPull(ArrayOutputHandle, Buf).and_then(toWasiSize);
       unlikely(!Res)) {
     return Res.error();
   } else {
@@ -99,17 +99,14 @@ Expect<uint32_t> OptionsSet::body(const Runtime::CallingFrame &Frame,
   checkExist(MemInst);
 
   const __wasi_size_t WasiNameLen = NameLen;
-  auto *const Name = MemInst->getPointer<const char *>(NamePtr, WasiNameLen);
-  checkExist(Name);
+  const auto Name = MemInst->getStringView(NamePtr, WasiNameLen);
+  checkRangeExist(Name, WasiNameLen);
 
   const __wasi_size_t WasiValueLen = ValueLen;
-  auto *const Value =
-      MemInst->getPointer<const uint8_t *>(ValuePtr, WasiValueLen);
-  checkExist(Value);
+  const auto Value = MemInst->getSpan<const uint8_t>(ValuePtr, WasiValueLen);
+  checkRangeExist(Value, WasiValueLen);
 
-  if (auto Res = Ctx.optionsSet(OptionsHandle, {Name, WasiNameLen},
-                                {Value, WasiValueLen});
-      unlikely(!Res)) {
+  if (auto Res = Ctx.optionsSet(OptionsHandle, Name, Value); unlikely(!Res)) {
     return Res.error();
   }
 
@@ -124,10 +121,10 @@ Expect<uint32_t> OptionsSetU64::body(const Runtime::CallingFrame &Frame,
   checkExist(MemInst);
 
   const __wasi_size_t WasiNameLen = NameLen;
-  auto *const Name = MemInst->getPointer<const char *>(NamePtr, WasiNameLen);
-  checkExist(Name);
+  const auto Name = MemInst->getStringView(NamePtr, WasiNameLen);
+  checkRangeExist(Name, WasiNameLen);
 
-  if (auto Res = Ctx.optionsSetU64(OptionsHandle, {Name, WasiNameLen}, Value);
+  if (auto Res = Ctx.optionsSetU64(OptionsHandle, Name, Value);
       unlikely(!Res)) {
     return Res.error();
   }
@@ -144,15 +141,14 @@ Expect<uint32_t> OptionsSetGuestBuffer::body(const Runtime::CallingFrame &Frame,
   checkExist(MemInst);
 
   const __wasi_size_t WasiNameLen = NameLen;
-  auto *const Name = MemInst->getPointer<const char *>(NamePtr, WasiNameLen);
-  checkExist(Name);
+  const auto Name = MemInst->getStringView(NamePtr, WasiNameLen);
+  checkRangeExist(Name, WasiNameLen);
 
   const __wasi_size_t WasiBufLen = BufLen;
-  auto *const Buf = MemInst->getPointer<uint8_t *>(BufPtr, WasiBufLen);
-  checkExist(Buf);
+  const auto Buf = MemInst->getSpan<uint8_t>(BufPtr, WasiBufLen);
+  checkRangeExist(Buf, WasiBufLen);
 
-  if (auto Res = Ctx.optionsSetGuestBuffer(OptionsHandle, {Name, WasiNameLen},
-                                           {Buf, WasiBufLen});
+  if (auto Res = Ctx.optionsSetGuestBuffer(OptionsHandle, Name, Buf);
       unlikely(!Res)) {
     return Res.error();
   }
@@ -204,12 +200,11 @@ SecretsManagerInvalidate::body(const Runtime::CallingFrame &Frame,
   checkExist(MemInst);
 
   const __wasi_size_t WasiKeyIdLen = KeyIdLen;
-  auto *const KeyId =
-      MemInst->getPointer<const uint8_t *>(KeyIdPtr, WasiKeyIdLen);
-  checkExist(KeyId);
+  const auto KeyId = MemInst->getSpan<const uint8_t>(KeyIdPtr, WasiKeyIdLen);
+  checkRangeExist(KeyId, WasiKeyIdLen);
 
-  if (auto Res = Ctx.secretsManagerInvalidate(SecretsManagerHandle,
-                                              {KeyId, WasiKeyIdLen}, Version);
+  if (auto Res =
+          Ctx.secretsManagerInvalidate(SecretsManagerHandle, KeyId, Version);
       unlikely(!Res)) {
     return Res.error();
   }

--- a/plugins/wasi_crypto/kx/func.cpp
+++ b/plugins/wasi_crypto/kx/func.cpp
@@ -59,16 +59,15 @@ Expect<uint32_t> Decapsulate::body(const Runtime::CallingFrame &Frame,
   checkExist(MemInst);
 
   const __wasi_size_t WasiEncapsulatedSecretLen = EncapsulatedSecretLen;
-  auto *const EncapsulatedSecret = MemInst->getPointer<const uint8_t *>(
+  const auto EncapsulatedSecret = MemInst->getSpan<const uint8_t>(
       EncapsulatedSecretPtr, WasiEncapsulatedSecretLen);
 
-  checkExist(EncapsulatedSecret);
+  checkRangeExist(EncapsulatedSecret, WasiEncapsulatedSecretLen);
 
   auto *const Secret = MemInst->getPointer<__wasi_array_output_t *>(SecretPtr);
   checkExist(Secret);
 
-  if (auto Res = Ctx.kxDecapsulate(
-          SkHandle, {EncapsulatedSecret, WasiEncapsulatedSecretLen});
+  if (auto Res = Ctx.kxDecapsulate(SkHandle, EncapsulatedSecret);
       unlikely(!Res)) {
     return Res.error();
   } else {

--- a/plugins/wasi_crypto/signatures/func.cpp
+++ b/plugins/wasi_crypto/signatures/func.cpp
@@ -44,20 +44,20 @@ Expect<uint32_t> Import::body(const Runtime::CallingFrame &Frame,
   checkExist(MemInst);
 
   const __wasi_size_t WasiAlgLen = AlgLen;
-  auto *const Alg = MemInst->getPointer<const char *>(AlgPtr, WasiAlgLen);
-  checkExist(Alg);
+  const auto Alg = MemInst->getStringView(AlgPtr, WasiAlgLen);
+  checkRangeExist(Alg, WasiAlgLen);
 
   Algorithm WasiAlg;
-  if (auto Res = tryFrom<Algorithm>({Alg, AlgLen}); unlikely(!Res)) {
+  if (auto Res = tryFrom<Algorithm>(Alg); unlikely(!Res)) {
     return Res.error();
   } else {
     WasiAlg = *Res;
   }
 
   const __wasi_size_t WasiEncodedLen = EncodedLen;
-  auto *const Encoded =
-      MemInst->getPointer<const uint8_t *>(EncodedPtr, WasiEncodedLen);
-  checkExist(Encoded);
+  const auto Encoded =
+      MemInst->getSpan<const uint8_t>(EncodedPtr, WasiEncodedLen);
+  checkRangeExist(Encoded, WasiEncodedLen);
 
   __wasi_signature_encoding_e_t WasiEncoding;
   if (auto Res = cast<__wasi_signature_encoding_e_t>(Encoding);
@@ -71,8 +71,7 @@ Expect<uint32_t> Import::body(const Runtime::CallingFrame &Frame,
       MemInst->getPointer<__wasi_signature_t *>(SigHandlePtr);
   checkExist(SigHandle);
 
-  if (auto Res =
-          Ctx.signatureImport(WasiAlg, {Encoded, WasiEncodedLen}, WasiEncoding);
+  if (auto Res = Ctx.signatureImport(WasiAlg, Encoded, WasiEncoding);
       unlikely(!Res)) {
     return Res.error();
   } else {
@@ -108,12 +107,10 @@ Expect<uint32_t> StateUpdate::body(const Runtime::CallingFrame &Frame,
   checkExist(MemInst);
 
   const __wasi_size_t WasiInputSize = InputSize;
-  auto *const Input =
-      MemInst->getPointer<const uint8_t *>(InputPtr, WasiInputSize);
-  checkExist(Input);
+  const auto Input = MemInst->getSpan<const uint8_t>(InputPtr, WasiInputSize);
+  checkRangeExist(Input, WasiInputSize);
 
-  if (auto Res =
-          Ctx.signatureStateUpdate(SigStateHandle, {Input, WasiInputSize});
+  if (auto Res = Ctx.signatureStateUpdate(SigStateHandle, Input);
       unlikely(!Res)) {
     return Res.error();
   }
@@ -182,11 +179,10 @@ VerificationStateUpdate::body(const Runtime::CallingFrame &Frame,
   checkExist(MemInst);
 
   const __wasi_size_t WasiInputSize = InputSize;
-  auto *const Input = MemInst->getPointer<const uint8_t *>(InputPtr, InputSize);
-  checkExist(Input);
+  const auto Input = MemInst->getSpan<const uint8_t>(InputPtr, WasiInputSize);
+  checkRangeExist(Input, WasiInputSize);
 
-  if (auto Res = Ctx.signatureVerificationStateUpdate(SigStateHandle,
-                                                      {Input, WasiInputSize});
+  if (auto Res = Ctx.signatureVerificationStateUpdate(SigStateHandle, Input);
       unlikely(!Res)) {
     return Res.error();
   }

--- a/plugins/wasi_crypto/utils/hostfunction.h
+++ b/plugins/wasi_crypto/utils/hostfunction.h
@@ -158,6 +158,14 @@ tryFrom(std::string_view RawAlgStr) noexcept;
     }                                                                          \
   } while (0)
 
+/// Check Span exist or return `_algorithm_failure`.
+#define checkRangeExist(Expr, Size)                                            \
+  do {                                                                         \
+    if (unlikely((Expr).size() != (Size))) {                                   \
+      return __WASI_CRYPTO_ERRNO_ALGORITHM_FAILURE;                            \
+    }                                                                          \
+  } while (0)
+
 } // namespace WasiCrypto
 } // namespace Host
 } // namespace WasmEdge

--- a/plugins/wasm_bpf/func-bpf-buffer-poll.cpp
+++ b/plugins/wasm_bpf/func-bpf-buffer-poll.cpp
@@ -15,7 +15,7 @@ inline const auto *toCallFrameCxt(const Runtime::CallingFrame *Cxt) noexcept {
 Expect<int32_t> BpfBufferPoll::body(const Runtime::CallingFrame &Frame,
                                     handle_t program, int32_t fd,
                                     int32_t sample_func, uint32_t ctx,
-                                    uint32_t data, int32_t max_size,
+                                    uint32_t data, uint32_t max_size,
                                     int32_t timeout_ms) {
   auto c_ctx = toCallFrameCxt(&Frame);
   auto c_module = WasmEdge_CallingFrameGetModuleInstance(c_ctx);
@@ -36,12 +36,12 @@ Expect<int32_t> BpfBufferPoll::body(const Runtime::CallingFrame &Frame,
   if (program_ptr == state->handles.end()) {
     return Unexpect(ErrCode::Value::HostFuncError);
   }
-  auto data_buf = memory->getPointer<char *>(data, max_size);
-  if (!data_buf) {
+  auto data_buf = memory->getSpan<char>(data, max_size);
+  if (data_buf.size() != max_size) {
     return Unexpect(ErrCode::Value::HostFuncError);
   }
   return program_ptr->second->bpf_buffer_poll(c_executor, c_module, fd,
-                                              sample_func, ctx, data_buf,
+                                              sample_func, ctx, data_buf.data(),
                                               max_size, timeout_ms, data);
 }
 

--- a/plugins/wasm_bpf/func-bpf-buffer-poll.h
+++ b/plugins/wasm_bpf/func-bpf-buffer-poll.h
@@ -30,7 +30,7 @@ public:
   WasmEdge::Expect<int32_t> body(const WasmEdge::Runtime::CallingFrame &Frame,
                                  handle_t program, int32_t fd,
                                  int32_t sample_func, uint32_t ctx,
-                                 uint32_t data, int32_t max_size,
+                                 uint32_t data, uint32_t max_size,
                                  int32_t timeout_ms);
 
 private:

--- a/plugins/wasm_bpf/func-bpf-map-operate.cpp
+++ b/plugins/wasm_bpf/func-bpf-map-operate.cpp
@@ -12,9 +12,10 @@ namespace WasmEdge {
 namespace Host {
 
 #define ensure_memory_size(var, offset, size)                                  \
-  void *var = memory->getPointer<char *>(offset, size);                        \
-  if (!var)                                                                    \
-    return Unexpect(ErrCode::Value::HostFuncError);
+  const auto var##_span = memory->getSpan<char>(offset, size);                 \
+  if (var##_span.size() != size)                                               \
+    return Unexpect(ErrCode::Value::HostFuncError);                            \
+  const auto var = var##_span.data();
 Expect<int32_t>
 BpfMapOperate::body(const WasmEdge::Runtime::CallingFrame &Frame, int32_t fd,
                     int32_t cmd, uint32_t key, uint32_t value,

--- a/plugins/wasm_bpf/func-load-bpf-object.cpp
+++ b/plugins/wasm_bpf/func-load-bpf-object.cpp
@@ -12,13 +12,13 @@ Expect<handle_t> LoadBpfObject::body(const Runtime::CallingFrame &Frame,
   if (unlikely(!memory)) {
     return Unexpect(ErrCode::Value::HostFuncError);
   }
-  char *const object_buffer = memory->getPointer<char *>(obj_buf, obj_buf_sz);
-  if (!object_buffer) {
+  const auto object_buffer = memory->getSpan<char>(obj_buf, obj_buf_sz);
+  if (object_buffer.size() != obj_buf_sz) {
     return Unexpect(ErrCode::Value::HostFuncError);
   }
   auto program = std::make_unique<wasm_bpf_program>();
   int32_t res =
-      program->load_bpf_object(object_buffer, static_cast<size_t>(obj_buf_sz));
+      program->load_bpf_object(object_buffer.data(), object_buffer.size());
   if (res < 0)
     return 0;
   auto key = reinterpret_cast<uint64_t>(program.get());

--- a/plugins/wasm_bpf/util.cpp
+++ b/plugins/wasm_bpf/util.cpp
@@ -18,7 +18,7 @@ Expect<const char *> read_c_str(Runtime::Instance::MemoryInstance *memory,
     tail++;
   }
   uint32_t len = tail - ptr + 1;
-  return memory->getPointer<const char *>(ptr, len);
+  return memory->getSpan<const char>(ptr, len).data();
 }
 
 } // namespace Host

--- a/test/host/wasi/wasi.cpp
+++ b/test/host/wasi/wasi.cpp
@@ -45,9 +45,8 @@ void writeAddress(WasmEdge::Runtime::Instance::MemoryInstance &MemInst,
   WasiAddress.buf = BufPtr;
   WasiAddress.buf_len = Address.size();
 
-  std::memcpy(
-      MemInst.getPointer<__wasi_address_t *>(Ptr, sizeof(__wasi_address_t)),
-      &WasiAddress, sizeof(__wasi_address_t));
+  std::memcpy(MemInst.getPointer<__wasi_address_t *>(Ptr), &WasiAddress,
+              sizeof(__wasi_address_t));
 }
 
 __wasi_errno_t convertErrno(int SysErrno) noexcept {
@@ -738,8 +737,7 @@ TEST(WasiTest, PollOneoffSocketV1) {
         const uint32_t SiFlags = 0;
         const auto Data = "server"sv;
         writeString(MemInst, Data, DataPtr);
-        auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
-            IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+        auto IOVec = MemInst.getSpan<__wasi_ciovec_t>(IOVecPtr, IOVecSize);
         IOVec[0].buf = DataPtr;
         IOVec[0].buf_len = Data.size();
         EXPECT_TRUE(WasiSockSend.run(
@@ -766,8 +764,7 @@ TEST(WasiTest, PollOneoffSocketV1) {
           const uint32_t DataPtr =
               IOVecPtr + sizeof(__wasi_iovec_t) * IOVecSize;
           const uint32_t RiFlags = 0;
-          auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
-              IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+          auto IOVec = MemInst.getSpan<__wasi_ciovec_t>(IOVecPtr, IOVecSize);
           IOVec[0].buf = DataPtr;
           IOVec[0].buf_len = 32768;
           EXPECT_TRUE(
@@ -1078,8 +1075,7 @@ TEST(WasiTest, PollOneoffSocketV1) {
       const uint32_t IOVecPtr = RoFlagsPtr + sizeof(__wasi_size_t);
       const uint32_t DataPtr = IOVecPtr + sizeof(__wasi_iovec_t) * IOVecSize;
       const uint32_t RiFlags = 0;
-      auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
-          IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+      auto IOVec = MemInst.getSpan<__wasi_ciovec_t>(IOVecPtr, IOVecSize);
       IOVec[0].buf = DataPtr;
       IOVec[0].buf_len = 256;
       EXPECT_TRUE(WasiSockRecv.run(
@@ -1114,8 +1110,7 @@ TEST(WasiTest, PollOneoffSocketV1) {
       const uint32_t SiFlags = 0;
       const auto Data = "somedata"sv;
       writeString(MemInst, Data, DataPtr);
-      auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
-          IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+      auto IOVec = MemInst.getSpan<__wasi_ciovec_t>(IOVecPtr, IOVecSize);
       IOVec[0].buf = DataPtr;
       IOVec[0].buf_len = Data.size();
       EXPECT_TRUE(
@@ -1153,8 +1148,7 @@ TEST(WasiTest, PollOneoffSocketV1) {
       const uint32_t SiFlags = 0;
       const auto Data = "somedata"sv;
       writeString(MemInst, Data, DataPtr);
-      auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
-          IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+      auto IOVec = MemInst.getSpan<__wasi_ciovec_t>(IOVecPtr, IOVecSize);
       IOVec[0].buf = DataPtr;
       IOVec[0].buf_len = Data.size();
       EXPECT_TRUE(
@@ -1349,8 +1343,7 @@ TEST(WasiTest, PollOneoffSocketV2) {
         const uint32_t SiFlags = 0;
         const auto Data = "server"sv;
         writeString(MemInst, Data, DataPtr);
-        auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
-            IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+        auto IOVec = MemInst.getSpan<__wasi_ciovec_t>(IOVecPtr, IOVecSize);
         IOVec[0].buf = DataPtr;
         IOVec[0].buf_len = Data.size();
         EXPECT_TRUE(WasiSockSend.run(
@@ -1377,8 +1370,7 @@ TEST(WasiTest, PollOneoffSocketV2) {
           const uint32_t DataPtr =
               IOVecPtr + sizeof(__wasi_iovec_t) * IOVecSize;
           const uint32_t RiFlags = 0;
-          auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
-              IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+          auto IOVec = MemInst.getSpan<__wasi_ciovec_t>(IOVecPtr, IOVecSize);
           IOVec[0].buf = DataPtr;
           IOVec[0].buf_len = 32768;
           EXPECT_TRUE(
@@ -1689,8 +1681,7 @@ TEST(WasiTest, PollOneoffSocketV2) {
       const uint32_t IOVecPtr = RoFlagsPtr + sizeof(__wasi_size_t);
       const uint32_t DataPtr = IOVecPtr + sizeof(__wasi_iovec_t) * IOVecSize;
       const uint32_t RiFlags = 0;
-      auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
-          IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+      auto IOVec = MemInst.getSpan<__wasi_ciovec_t>(IOVecPtr, IOVecSize);
       IOVec[0].buf = DataPtr;
       IOVec[0].buf_len = 256;
       EXPECT_TRUE(WasiSockRecv.run(
@@ -1725,8 +1716,7 @@ TEST(WasiTest, PollOneoffSocketV2) {
       const uint32_t SiFlags = 0;
       const auto Data = "somedata"sv;
       writeString(MemInst, Data, DataPtr);
-      auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
-          IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+      auto IOVec = MemInst.getSpan<__wasi_ciovec_t>(IOVecPtr, IOVecSize);
       IOVec[0].buf = DataPtr;
       IOVec[0].buf_len = Data.size();
       EXPECT_TRUE(
@@ -1764,8 +1754,7 @@ TEST(WasiTest, PollOneoffSocketV2) {
       const uint32_t SiFlags = 0;
       const auto Data = "somedata"sv;
       writeString(MemInst, Data, DataPtr);
-      auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
-          IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+      auto IOVec = MemInst.getSpan<__wasi_ciovec_t>(IOVecPtr, IOVecSize);
       IOVec[0].buf = DataPtr;
       IOVec[0].buf_len = Data.size();
       EXPECT_TRUE(
@@ -1959,8 +1948,7 @@ TEST(WasiTest, EpollOneoffSocketV1) {
         const uint32_t SiFlags = 0;
         const auto Data = "server"sv;
         writeString(MemInst, Data, DataPtr);
-        auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
-            IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+        auto IOVec = MemInst.getSpan<__wasi_ciovec_t>(IOVecPtr, IOVecSize);
         IOVec[0].buf = DataPtr;
         IOVec[0].buf_len = Data.size();
         EXPECT_TRUE(WasiSockSend.run(
@@ -1987,8 +1975,7 @@ TEST(WasiTest, EpollOneoffSocketV1) {
           const uint32_t DataPtr =
               IOVecPtr + sizeof(__wasi_iovec_t) * IOVecSize;
           const uint32_t RiFlags = 0;
-          auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
-              IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+          auto IOVec = MemInst.getSpan<__wasi_ciovec_t>(IOVecPtr, IOVecSize);
           IOVec[0].buf = DataPtr;
           IOVec[0].buf_len = 32768;
           EXPECT_TRUE(
@@ -2299,8 +2286,7 @@ TEST(WasiTest, EpollOneoffSocketV1) {
       const uint32_t IOVecPtr = RoFlagsPtr + sizeof(__wasi_size_t);
       const uint32_t DataPtr = IOVecPtr + sizeof(__wasi_iovec_t) * IOVecSize;
       const uint32_t RiFlags = 0;
-      auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
-          IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+      auto IOVec = MemInst.getSpan<__wasi_ciovec_t>(IOVecPtr, IOVecSize);
       IOVec[0].buf = DataPtr;
       IOVec[0].buf_len = 256;
       EXPECT_TRUE(WasiSockRecv.run(
@@ -2335,8 +2321,7 @@ TEST(WasiTest, EpollOneoffSocketV1) {
       const uint32_t SiFlags = 0;
       const auto Data = "somedata"sv;
       writeString(MemInst, Data, DataPtr);
-      auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
-          IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+      auto IOVec = MemInst.getSpan<__wasi_ciovec_t>(IOVecPtr, IOVecSize);
       IOVec[0].buf = DataPtr;
       IOVec[0].buf_len = Data.size();
       EXPECT_TRUE(
@@ -2374,8 +2359,7 @@ TEST(WasiTest, EpollOneoffSocketV1) {
       const uint32_t SiFlags = 0;
       const auto Data = "somedata"sv;
       writeString(MemInst, Data, DataPtr);
-      auto *IOVec = MemInst.getPointer<__wasi_ciovec_t *>(
-          IOVecPtr, sizeof(__wasi_ciovec_t) * IOVecSize);
+      auto IOVec = MemInst.getSpan<__wasi_ciovec_t>(IOVecPtr, IOVecSize);
       IOVec[0].buf = DataPtr;
       IOVec[0].buf_len = Data.size();
       EXPECT_TRUE(
@@ -2786,7 +2770,7 @@ TEST(WasiTest, SymbolicLink) {
         std::initializer_list<WasmEdge::ValVariant>{OldPathPtr, UINT32_C(0), Fd,
                                                     NewPathPtr, UINT32_C(0)},
         Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_FAULT);
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_NOENT);
     Env.fini();
   }
 
@@ -2796,7 +2780,19 @@ TEST(WasiTest, SymbolicLink) {
     EXPECT_TRUE(WasiPathSymlink.run(
         CallFrame,
         std::initializer_list<WasmEdge::ValVariant>{OldPathPtr, UINT32_C(0), Fd,
+                                                    NewPathPtr, UINT32_C(1)},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_FAULT);
+    EXPECT_TRUE(WasiPathSymlink.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{OldPathPtr, UINT32_C(1), Fd,
                                                     NewPathPtr, UINT32_C(0)},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_FAULT);
+    EXPECT_TRUE(WasiPathSymlink.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{OldPathPtr, UINT32_C(1), Fd,
+                                                    NewPathPtr, UINT32_C(1)},
         Errno));
     EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_FAULT);
     Env.fini();

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -69,7 +69,7 @@ void writeFatPointer(WasmEdge::Runtime::Instance::MemoryInstance &MemInst,
 }
 
 template <typename T>
-std::vector<size_t> classSort(const std::vector<T> &Array) {
+std::vector<size_t> classSort(WasmEdge::Span<const T> Array) {
   std::vector<size_t> Indices(Array.size());
   std::iota(Indices.begin(), Indices.end(), 0);
   std::sort(Indices.begin(), Indices.end(),
@@ -472,9 +472,8 @@ TEST(WasiNNTest, OpenVINOBackend) {
         Errno));
     EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
     EXPECT_EQ(*MemInst.getPointer<uint32_t *>(BuilderPtr), UINT32_C(4004));
-    std::vector<float> OutputClassification(
-        MemInst.getPointer<float *>(StorePtr, 1001) + 1,
-        MemInst.getPointer<float *>(StorePtr, 1001) + 1001);
+    const auto OutputClassification =
+        MemInst.getSpan<const float>(StorePtr, 1001).subspan(1);
     std::vector<size_t> SortedIndex, CorrectClasses{963, 762, 909, 926, 567};
     SortedIndex = classSort<float>(OutputClassification);
     // The probability of class i is placed at buffer[i].
@@ -837,9 +836,8 @@ TEST(WasiNNTest, PyTorchBackend) {
         Errno));
     EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
     EXPECT_EQ(*MemInst.getPointer<uint32_t *>(BuilderPtr), UINT32_C(4000));
-    std::vector<float> OutputClassification(
-        MemInst.getPointer<float *>(StorePtr, 1000),
-        MemInst.getPointer<float *>(StorePtr, 1000) + 1000);
+    const auto OutputClassification =
+        MemInst.getSpan<const float>(StorePtr, 1000);
     std::vector<size_t> SortedIndex, CorrectClasses{954, 940, 951, 950, 953};
     SortedIndex = classSort<float>(OutputClassification);
     // The probability of class i is placed at buffer[i].
@@ -1194,9 +1192,8 @@ TEST(WasiNNTest, TFLiteBackend) {
         Errno));
     EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
     EXPECT_EQ(*MemInst.getPointer<uint32_t *>(BuilderPtr), UINT32_C(965));
-    std::vector<uint8_t> OutputClassification(
-        MemInst.getPointer<uint8_t *>(StorePtr, 965),
-        MemInst.getPointer<uint8_t *>(StorePtr, 965) + 965);
+    const auto OutputClassification =
+        MemInst.getSpan<const uint8_t>(StorePtr, 965);
     std::vector<size_t> SortedIndex, CorrectClasses{166, 158, 34, 778, 819};
     // FIXME: classSort causing segmentation fault
     SortedIndex = classSort<uint8_t>(OutputClassification);


### PR DESCRIPTION
* Add `getSpan` `getStringView` method in `MemoryInstance`
  * Remove `getPointer` with length argument.
  * Change all relative calls to `getPointer` to `getSpan` or `getStringView`
  * Change WASI `path_symlink` error reporting behaviors on invalid string pointers