### PR TITLE
Fix Wasmedge-Process documents grammar/instruction

### DIFF
--- a/docs/book/en/src/contribute/build_from_src/plugin_wasmedge_process.md
+++ b/docs/book/en/src/contribute/build_from_src/plugin_wasmedge_process.md
@@ -2,17 +2,17 @@
 
 ## Prerequisites
 
-The prerequisites of the WasmEdge-Process plug-in is the same as the [WasmEdge building environment on the Linux platforms](linux.md).
+The prerequisite of the WasmEdge-Process plug-in is the same as the [WasmEdge building environment on the Linux platforms](linux.md).
 
 ## Build WasmEdge with WasmEdge-Process Plug-in
 
-To enable the WasmEdge WasmEdge-HttpsReq, developers need to [building the WasmEdge from source](linux.md) with the cmake option `-DWASMEDGE_PLUGIN_PROCESS=On`.
+To enable the WasmEdge WasmEdge-Process, developers need to [build the WasmEdge from the source](linux.md) with the cmake option `-DWASMEDGE_PLUGIN_PROCESS=On`.
 
 ```bash
 cd <path/to/your/wasmedge/source/folder>
 mkdir -p build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_PLUGIN_PROCESS=On .. && make -j
-# For the WasmEdge-HttpsReq plugin, you should install this project.
+# For the WasmEdge-Process plugin, you should install this project.
 cmake --install .
 ```
 


### PR DESCRIPTION
This is a small fix of Wasmedge-Process document.

1. Turn `WasmEdge-HttpsReq` => `Wasmedge-Process`.
2. Correct the grammar mistakes by using Grammarly.