### PR TITLE
[Test] Fix socket test on macos.

### DIFF
--- a/.github/workflows/reusable-build-on-macos.yml
+++ b/.github/workflows/reusable-build-on-macos.yml
@@ -49,13 +49,7 @@ jobs:
         run: |
           export DYLD_LIBRARY_PATH="$(pwd)/build/lib/api:$DYLD_LIBRARY_PATH"
           cd build
-          ctest -E wasiSocketTests
-      - name: Test WasmEdge (continue on error)
-        continue-on-error: true
-        run: |
-          export DYLD_LIBRARY_PATH="$(pwd)/build/lib/api:$DYLD_LIBRARY_PATH"
-          cd build
-          ctest -R wasiSocketTests
+          ctest
       - name: Create package tarball
         run: |
           cmake --build build --target package

--- a/.github/workflows/reusable-build-on-macos.yml
+++ b/.github/workflows/reusable-build-on-macos.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           export DYLD_LIBRARY_PATH="$(pwd)/build/lib/api:$DYLD_LIBRARY_PATH"
           cd build
-          ctest -VV -R wasiSocketTests
+          ctest -R wasiSocketTests
       - name: Create package tarball
         run: |
           cmake --build build --target package

--- a/.github/workflows/reusable-build-on-macos.yml
+++ b/.github/workflows/reusable-build-on-macos.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           export DYLD_LIBRARY_PATH="$(pwd)/build/lib/api:$DYLD_LIBRARY_PATH"
           cd build
-          ctest -R wasiSocketTests
+          ctest -VV -R wasiSocketTests
       - name: Create package tarball
         run: |
           cmake --build build --target package

--- a/.github/workflows/reusable-build-on-ubuntu.yml
+++ b/.github/workflows/reusable-build-on-ubuntu.yml
@@ -54,7 +54,6 @@ jobs:
           cd build
           ./tools/wasmedge/wasmedge -v
           ctest
-          ctest -VV -R wasiSocketTests
           cd -
       - name: Build WasmEdge using ${{ matrix.compiler }} with Coverage mode
         if: ${{ matrix.coverage }}

--- a/.github/workflows/reusable-build-on-ubuntu.yml
+++ b/.github/workflows/reusable-build-on-ubuntu.yml
@@ -54,6 +54,7 @@ jobs:
           cd build
           ./tools/wasmedge/wasmedge -v
           ctest
+          ctest -VV -R wasiSocketTests
           cd -
       - name: Build WasmEdge using ${{ matrix.compiler }} with Coverage mode
         if: ${{ matrix.coverage }}

--- a/test/host/socket/wasi_socket.cpp
+++ b/test/host/socket/wasi_socket.cpp
@@ -995,7 +995,12 @@ TEST(WasiSockTest, SockOpt) {
                        Errno);
 
     EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
-    EXPECT_TRUE(*MemInst.getPointer<const int32_t *>(ResBufPtr));
+#if WASMEDGE_OS_MACOS
+    EXPECT_TRUE(
+        static_cast<bool>(*MemInst.getPointer<decltype(&Opt)>(ResBufPtr)));
+#else
+    EXPECT_TRUE(*MemInst.getPointer<const bool *>(ResBufPtr));
+#endif
 
     WasiFdClose.run(CallFrame, std::array<WasmEdge::ValVariant, 1>{Fd}, Errno);
     EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);

--- a/test/host/socket/wasi_socket.cpp
+++ b/test/host/socket/wasi_socket.cpp
@@ -995,7 +995,6 @@ TEST(WasiSockTest, SockOpt) {
                        Errno);
 
     EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
-    // reinterpreting uint8_t* to bool* is a undefined behavior.
     EXPECT_TRUE(
         static_cast<bool>(*MemInst.getPointer<decltype(&Opt)>(ResBufPtr)));
 
@@ -1272,11 +1271,7 @@ TEST(WasiSockTest, GetAddrinfo) {
       EXPECT_NE(ResItem->ai_addrlen, 0);
       auto *TmpSockAddr =
           MemInst.getPointer<__wasi_sockaddr_t *>(ResItem->ai_addr);
-#if WASMEDGE_OS_MACOS
-      EXPECT_EQ(TmpSockAddr->sa_data_len, 15);
-#else
       EXPECT_EQ(TmpSockAddr->sa_data_len, 14);
-#endif
       EXPECT_EQ(MemInst.getSpan<char>(TmpSockAddr->sa_data,
                                       TmpSockAddr->sa_data_len)[0],
                 'i');
@@ -1323,11 +1318,7 @@ TEST(WasiSockTest, GetAddrinfo) {
                  "google.com");
     auto *WasiSockAddr =
         MemInst.getPointer<__wasi_sockaddr_t *>(ResHead->ai_addr);
-#if WASMEDGE_OS_MACOS
-    EXPECT_EQ(WasiSockAddr->sa_data_len, 15);
-#else
     EXPECT_EQ(WasiSockAddr->sa_data_len, 14);
-#endif
   }
 }
 

--- a/test/host/socket/wasi_socket.cpp
+++ b/test/host/socket/wasi_socket.cpp
@@ -995,19 +995,9 @@ TEST(WasiSockTest, SockOpt) {
                        Errno);
 
     EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
-    auto res = MemInst.getBytes(ResBufPtr, 4).value();
-    for (auto s : res) {
-      printf("resbuf: %d\n", s);
-    }
-    std::cout << "int32: " << *MemInst.getPointer<decltype(&Opt)>(ResBufPtr)
-              << " bool: " << *MemInst.getPointer<const bool *>(ResBufPtr)
-              << std::endl;
-#if WASMEDGE_OS_MACOS
+    // reinterpreting uint8_t* to bool* is a undefined behavior.
     EXPECT_TRUE(
         static_cast<bool>(*MemInst.getPointer<decltype(&Opt)>(ResBufPtr)));
-#else
-    EXPECT_TRUE(*MemInst.getPointer<const bool *>(ResBufPtr));
-#endif
 
     WasiFdClose.run(CallFrame, std::array<WasmEdge::ValVariant, 1>{Fd}, Errno);
     EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);

--- a/test/host/socket/wasi_socket.cpp
+++ b/test/host/socket/wasi_socket.cpp
@@ -1270,7 +1270,11 @@ TEST(WasiSockTest, GetAddrinfo) {
       EXPECT_NE(ResItem->ai_addrlen, 0);
       auto *TmpSockAddr =
           MemInst.getPointer<__wasi_sockaddr_t *>(ResItem->ai_addr);
-      EXPECT_EQ(TmpSockAddr->sa_data_len, 14);
+      #if WASMEDGE_OS_MACOS
+        EXPECT_EQ(TmpSockAddr->sa_data_len, 15);
+      #else 
+        EXPECT_EQ(TmpSockAddr->sa_data_len, 14);
+      #endif
       EXPECT_EQ(MemInst.getSpan<char>(TmpSockAddr->sa_data,
                                       TmpSockAddr->sa_data_len)[0],
                 'i');
@@ -1317,7 +1321,11 @@ TEST(WasiSockTest, GetAddrinfo) {
                  "google.com");
     auto *WasiSockAddr =
         MemInst.getPointer<__wasi_sockaddr_t *>(ResHead->ai_addr);
-    EXPECT_EQ(WasiSockAddr->sa_data_len, 14);
+      #if WASMEDGE_OS_MACOS
+        EXPECT_EQ(WasiSockAddr->sa_data_len, 15);
+      #else 
+        EXPECT_EQ(WasiSockAddr->sa_data_len, 14);
+      #endif
   }
 }
 

--- a/test/host/socket/wasi_socket.cpp
+++ b/test/host/socket/wasi_socket.cpp
@@ -1270,11 +1270,11 @@ TEST(WasiSockTest, GetAddrinfo) {
       EXPECT_NE(ResItem->ai_addrlen, 0);
       auto *TmpSockAddr =
           MemInst.getPointer<__wasi_sockaddr_t *>(ResItem->ai_addr);
-      #if WASMEDGE_OS_MACOS
-        EXPECT_EQ(TmpSockAddr->sa_data_len, 15);
-      #else 
-        EXPECT_EQ(TmpSockAddr->sa_data_len, 14);
-      #endif
+#if WASMEDGE_OS_MACOS
+      EXPECT_EQ(TmpSockAddr->sa_data_len, 15);
+#else
+      EXPECT_EQ(TmpSockAddr->sa_data_len, 14);
+#endif
       EXPECT_EQ(MemInst.getSpan<char>(TmpSockAddr->sa_data,
                                       TmpSockAddr->sa_data_len)[0],
                 'i');
@@ -1321,11 +1321,11 @@ TEST(WasiSockTest, GetAddrinfo) {
                  "google.com");
     auto *WasiSockAddr =
         MemInst.getPointer<__wasi_sockaddr_t *>(ResHead->ai_addr);
-      #if WASMEDGE_OS_MACOS
-        EXPECT_EQ(WasiSockAddr->sa_data_len, 15);
-      #else 
-        EXPECT_EQ(WasiSockAddr->sa_data_len, 14);
-      #endif
+#if WASMEDGE_OS_MACOS
+    EXPECT_EQ(WasiSockAddr->sa_data_len, 15);
+#else
+    EXPECT_EQ(WasiSockAddr->sa_data_len, 14);
+#endif
   }
 }
 

--- a/test/host/socket/wasi_socket.cpp
+++ b/test/host/socket/wasi_socket.cpp
@@ -995,6 +995,13 @@ TEST(WasiSockTest, SockOpt) {
                        Errno);
 
     EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    auto res = MemInst.getBytes(ResBufPtr, 4).value();
+    for (auto s : res) {
+      printf("resbuf: %d\n", s);
+    }
+    std::cout << "int32: " << *MemInst.getPointer<decltype(&Opt)>(ResBufPtr)
+              << " bool: " << *MemInst.getPointer<const bool *>(ResBufPtr)
+              << std::endl;
 #if WASMEDGE_OS_MACOS
     EXPECT_TRUE(
         static_cast<bool>(*MemInst.getPointer<decltype(&Opt)>(ResBufPtr)));


### PR DESCRIPTION
# Overview
This PR fixes potential errors of sockets on macOS.
## 
`sizeof(sockaddr_in) - sizeof(sockaddr_in::sin_family);` on Linux is 14 but on macOS it's 15.
That's because sin_family on Linux is unsigned long, but __uint8_t on macOS.
Adding a condition to handle this on both platforms.
