### PR TITLE
[AOT] Support exception handling, stack unwinding across AOT binary

### DIFF
--- a/include/loader/shared_library.h
+++ b/include/loader/shared_library.h
@@ -97,8 +97,13 @@ private:
   uint64_t IntrinsicsAddress = 0;
   std::vector<uintptr_t> TypesAddress;
   std::vector<uintptr_t> CodesAddress;
-#if WASMEDGE_OS_WINDOWS
-  void *PDataAddress = 0;
+#if WASMEDGE_OS_LINUX
+  void *EHFrameAddress = nullptr;
+#elif WASMEDGE_OS_MACOS
+  uint8_t *EHFrameAddress = nullptr;
+  uint32_t EHFrameSize = 0;
+#elif WASMEDGE_OS_WINDOWS
+  void *PDataAddress = nullptr;
   uint32_t PDataSize = 0;
 #endif
 };

--- a/include/system/fault.h
+++ b/include/system/fault.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include "common/errcode.h"
-
 #include <csetjmp>
 
 namespace WasmEdge {

--- a/lib/executor/engine/proxy.cpp
+++ b/lib/executor/engine/proxy.cpp
@@ -18,11 +18,7 @@ struct Executor::ProxyHelper<Expect<RetT> (Executor::*)(Runtime::StackManager &,
                                                         ArgsT...) noexcept> {
   template <Expect<RetT> (Executor::*Func)(Runtime::StackManager &,
                                            ArgsT...) noexcept>
-  static auto proxy(ArgsT... Args)
-#if !WASMEDGE_OS_WINDOWS
-      noexcept
-#endif
-  {
+  static auto proxy(ArgsT... Args) {
     Expect<RetT> Res = (This->*Func)(*CurrentStack, Args...);
     if (unlikely(!Res)) {
       Fault::emitFault(Res.error());

--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -131,20 +131,23 @@ Executor::enterFunction(Runtime::StackManager &StackMgr,
       prepare(StackMgr, ModInst->MemoryPtrs.data(), ModInst->GlobalPtrs.data());
     }
 
-    {
+    try {
       // Get symbol and execute the function.
       Fault FaultHandler;
       uint32_t Code = PREPARE_FAULT(FaultHandler);
-      if (auto Err = ErrCode(static_cast<ErrCategory>(Code >> 24), Code);
-          unlikely(Err != ErrCode::Value::Success)) {
+      if (Code != 0) {
+        throw ErrCode(static_cast<ErrCategory>(Code >> 24), Code);
+      }
+      auto &Wrapper = FuncType.getSymbol();
+      Wrapper(&ExecutionContext, Func.getSymbol().get(), Args.data(),
+              Rets.data());
+    } catch (const ErrCode &Err) {
+      if (unlikely(Err != ErrCode::Value::Success)) {
         if (Err != ErrCode::Value::Terminated) {
           spdlog::error(Err);
         }
         return Unexpect(Err);
       }
-      auto &Wrapper = FuncType.getSymbol();
-      Wrapper(&ExecutionContext, Func.getSymbol().get(), Args.data(),
-              Rets.data());
     }
 
     // Push returns back to stack.

--- a/lib/loader/shared_library.cpp
+++ b/lib/loader/shared_library.cpp
@@ -21,6 +21,13 @@
 #error Unsupported os!
 #endif
 
+#if WASMEDGE_OS_LINUX || WASMEDGE_OS_MACOS
+extern "C" {
+extern void __register_frame(void *);
+extern void __deregister_frame(void *);
+}
+#endif
+
 namespace {
 inline constexpr uint64_t roundDownPageBoundary(const uint64_t Value) {
 // ARM64 Mac has a special page size
@@ -112,7 +119,16 @@ Expect<void> SharedLibrary::load(const AST::AOTSection &AOTSec) noexcept {
       break;
     case 3: // BSS
       break;
-#if WASMEDGE_OS_WINDOWS
+#if WASMEDGE_OS_LINUX
+    case 4: // EHFrame
+      EHFrameAddress = reinterpret_cast<void *>(Binary + Offset);
+      break;
+#elif WASMEDGE_OS_MACOS
+    case 4: // EHFrame
+      EHFrameAddress = reinterpret_cast<uint8_t *>(Binary + Offset);
+      EHFrameSize = Size;
+      break;
+#elif WASMEDGE_OS_WINDOWS
     case 4: // PData
       PDataAddress = reinterpret_cast<void *>(Binary + Offset);
       PDataSize =
@@ -136,7 +152,24 @@ Expect<void> SharedLibrary::load(const AST::AOTSection &AOTSec) noexcept {
   TypesAddress = AOTSec.getTypesAddress();
   CodesAddress = AOTSec.getCodesAddress();
 
-#if WASMEDGE_OS_WINDOWS
+#if WASMEDGE_OS_LINUX
+  if (EHFrameAddress) {
+    __register_frame(EHFrameAddress);
+  }
+#elif WASMEDGE_OS_MACOS
+  if (EHFrameAddress) {
+    auto Iter = EHFrameAddress;
+    const auto End = EHFrameAddress + EHFrameSize - 4;
+
+    while (Iter < End) {
+      if (Iter != EHFrameAddress) {
+        __register_frame(Iter);
+      }
+      const uint32_t Length = *reinterpret_cast<const uint32_t *>(Iter);
+      Iter += Length + 4;
+    }
+  }
+#elif WASMEDGE_OS_WINDOWS
   if (PDataSize != 0) {
     winapi::RtlAddFunctionTable(
         static_cast<winapi::PRUNTIME_FUNCTION_>(PDataAddress), PDataSize,
@@ -149,7 +182,24 @@ Expect<void> SharedLibrary::load(const AST::AOTSection &AOTSec) noexcept {
 
 void SharedLibrary::unload() noexcept {
   if (Binary) {
-#if WASMEDGE_OS_WINDOWS
+#if WASMEDGE_OS_LINUX
+    if (EHFrameAddress) {
+      __deregister_frame(EHFrameAddress);
+    }
+#elif WASMEDGE_OS_MACOS
+    if (EHFrameAddress) {
+      auto Iter = EHFrameAddress;
+      const auto End = EHFrameAddress + EHFrameSize - 4;
+
+      while (Iter < End) {
+        if (Iter != EHFrameAddress) {
+          __deregister_frame(Iter);
+        }
+        const uint32_t Length = *reinterpret_cast<const uint32_t *>(Iter);
+        Iter += Length + 4;
+      }
+    }
+#elif WASMEDGE_OS_WINDOWS
     if (PDataSize != 0) {
       winapi::RtlDeleteFunctionTable(
           static_cast<winapi::PRUNTIME_FUNCTION_>(PDataAddress));

--- a/lib/system/fault.cpp
+++ b/lib/system/fault.cpp
@@ -25,8 +25,7 @@ std::atomic_uint handlerCount = 0;
 thread_local Fault *localHandler = nullptr;
 
 #if defined(SA_SIGINFO)
-[[noreturn]] void signalHandler(int Signal, siginfo_t *Siginfo [[maybe_unused]],
-                                void *) noexcept {
+void signalHandler(int Signal, siginfo_t *Siginfo, void *) {
   {
     // Unblock current signal
     sigset_t Set;


### PR DESCRIPTION
* Use hidden function `__register_frame` and `__deregister_frame` in libgcc and libunwind to apply FDE data in `.eh_frame` section