### PR TITLE
[WASI-NN] Fix parse WASMEDGE_PLUGIN_WASI_NN_BACKEND build flags

### DIFF
--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2019-2022 Second State INC
 
+# Change "," into ";" to support <backend_name1>,<backend_name2>
+string(REPLACE "," ";" WASMEDGE_PLUGIN_WASI_NN_BACKEND "${WASMEDGE_PLUGIN_WASI_NN_BACKEND}")
+
 # Add backends building flags.
 foreach(BACKEND ${WASMEDGE_PLUGIN_WASI_NN_BACKEND})
   string(TOLOWER ${BACKEND} BACKEND)


### PR DESCRIPTION
This PR has a small patch to fix cmake error when building multiple backends.

Before:
```shell
$ cmake .. -DWASMEDGE_PLUGIN_WASI_NN_BACKEND="TensorflowLite,pytorch"
......
CMake Error at cmake/WASINNDeps.cmake:111 (message):
  WASI-NN: backend tensorflowlite,pytorch not found or unimplemented.
Call Stack (most recent call first):
  plugins/wasi_nn/CMakeLists.txt:39 (include)
```

The cmake list separator is ```;``` instead of ```,```, so we can replace ```,``` to ```;```. Then it can support build instructions in [doc](https://github.com/WasmEdge/WasmEdge/blob/ed588d7fcd2b5e3393317208319d4eacfd2d33a3/docs/book/en/src/contribute/build_from_src.md?plain=1#L58). Thanks.


