### PR TITLE
[CI] Add release workflows for `wasm_bpf` plugin, and the reletad installing script

### DIFF
--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -152,13 +152,15 @@ jobs:
     env:
       output_prefix: build/plugins
       test_prefix: build/test/plugins
-      build_options: -DWASMEDGE_PLUGIN_WASI_CRYPTO=ON -DWASMEDGE_PLUGIN_WASI_LOGGING=ON -DWASMEDGE_PLUGIN_PROCESS=ON -DWASMEDGE_PLUGIN_TENSORFLOW=ON -DWASMEDGE_PLUGIN_TENSORFLOWLITE=ON -DWASMEDGE_PLUGIN_IMAGE=ON
-      tar_names: wasi_crypto wasi_logging wasmedge_process wasmedge_tensorflow wasmedge_tensorflowlite wasmedge_image
-      test_bins: wasiCryptoTests wasiLoggingTests wasmedgeProcessTests wasmedgeTensorflowTests wasmedgeTensorflowLiteTests wasmedgeImageTests
-      output_bins: libwasmedgePluginWasiCrypto.so libwasmedgePluginWasiLogging.so libwasmedgePluginWasmEdgeProcess.so libwasmedgePluginWasmEdgeTensorflow.so libwasmedgePluginWasmEdgeTensorflowLite.so libwasmedgePluginWasmEdgeImage.so
+      build_options: -DWASMEDGE_PLUGIN_WASI_CRYPTO=ON -DWASMEDGE_PLUGIN_WASI_LOGGING=ON -DWASMEDGE_PLUGIN_PROCESS=ON -DWASMEDGE_PLUGIN_TENSORFLOW=ON -DWASMEDGE_PLUGIN_TENSORFLOWLITE=ON -DWASMEDGE_PLUGIN_IMAGE=ON -DWASMEDGE_PLUGIN_WASM_BPF=ON
+      tar_names: wasi_crypto wasi_logging wasmedge_process wasmedge_tensorflow wasmedge_tensorflowlite wasmedge_image wasm_bpf
+      test_bins: wasiCryptoTests wasiLoggingTests wasmedgeProcessTests wasmedgeTensorflowTests wasmedgeTensorflowLiteTests wasmedgeImageTests wasmBpfTests
+      output_bins: libwasmedgePluginWasiCrypto.so libwasmedgePluginWasiLogging.so libwasmedgePluginWasmEdgeProcess.so libwasmedgePluginWasmEdgeTensorflow.so libwasmedgePluginWasmEdgeTensorflowLite.so libwasmedgePluginWasmEdgeImage.so libwasmedgePluginWasmBpf.so
     needs: [get_version_v2]
     container:
       image: wasmedge/wasmedge:${{ matrix.docker_tag }}
+      # Required for mounting debugfs
+      options: --privileged
     steps:
       - uses: actions/checkout@v3
         with:
@@ -167,6 +169,10 @@ jobs:
         run: |
           apt update
           apt install -y libssl-dev
+          apt install -y libelf-dev zlib1g-dev pkg-config
+          apt install -y clang liblld-14-dev llvm
+          # Running tests of wasm_bpf requires proper ebpf running environment
+          mount -t debugfs none /sys/kernel/debug
       - name: Build plugins using ${{ matrix.compiler }} with ${{ matrix.build_type }} mode
         shell: bash
         run: |
@@ -186,6 +192,7 @@ jobs:
           do
             echo "Testing ${plugin_array[$i]} :"
             cd ${test_prefix}/${plugin_array[$i]}
+            # Tests of wasm_bpf require root privilege
             ./${testbin_array[$i]}
             cd -
           done
@@ -230,6 +237,11 @@ jobs:
         with:
           name: WasmEdge-plugin-wasmedge_image-${{ needs.get_version_v2.outputs.version }}-ubuntu22.04-${{ matrix.compiler }}.tar.gz
           path: plugin_wasmedge_image.tar.gz
+      - name: Upload artifact - wasm_bpf
+        uses: actions/upload-artifact@v3
+        with:
+          name: WasmEdge-plugin-wasm_bpf-${{ needs.get_version_v2.outputs.version }}-ubuntu22.04-${{ matrix.compiler }}.tar.gz
+          path: plugin_wasm_bpf.tar.gz
 
   # Due to the dependencies and exclusions of WASI-NN, build them saperately.
   build_manylinux_wasi_nn:
@@ -322,13 +334,15 @@ jobs:
     env:
       output_prefix: build/plugins
       test_prefix: build/test/plugins
-      build_options: -DWASMEDGE_PLUGIN_WASI_CRYPTO=ON -DWASMEDGE_PLUGIN_WASI_LOGGING=ON -DWASMEDGE_PLUGIN_PROCESS=ON -DWASMEDGE_PLUGIN_TENSORFLOW=ON -DWASMEDGE_PLUGIN_TENSORFLOWLITE=ON -DWASMEDGE_PLUGIN_IMAGE=ON
-      tar_names: wasi_crypto wasi_logging wasmedge_process wasmedge_tensorflow wasmedge_tensorflowlite wasmedge_image
-      test_bins: wasiCryptoTests wasiLoggingTests wasmedgeProcessTests wasmedgeTensorflowTests wasmedgeTensorflowLiteTests wasmedgeImageTests
-      output_bins: libwasmedgePluginWasiCrypto.so libwasmedgePluginWasiLogging.so libwasmedgePluginWasmEdgeProcess.so libwasmedgePluginWasmEdgeTensorflow.so libwasmedgePluginWasmEdgeTensorflowLite.so libwasmedgePluginWasmEdgeImage.so
+      build_options: -DWASMEDGE_PLUGIN_WASI_CRYPTO=ON -DWASMEDGE_PLUGIN_WASI_LOGGING=ON -DWASMEDGE_PLUGIN_PROCESS=ON -DWASMEDGE_PLUGIN_TENSORFLOW=ON -DWASMEDGE_PLUGIN_TENSORFLOWLITE=ON -DWASMEDGE_PLUGIN_IMAGE=ON -DWASMEDGE_PLUGIN_WASM_BPF=ON -DWASMEDGE_PLUGIN_WASM_BPF_BUILD_LIBBPF_WITH_PKG_CONF=OFF
+      tar_names: wasi_crypto wasi_logging wasmedge_process wasmedge_tensorflow wasmedge_tensorflowlite wasmedge_image wasm_bpf
+      test_bins: wasiCryptoTests wasiLoggingTests wasmedgeProcessTests wasmedgeTensorflowTests wasmedgeTensorflowLiteTests wasmedgeImageTests wasmBpfTests
+      output_bins: libwasmedgePluginWasiCrypto.so libwasmedgePluginWasiLogging.so libwasmedgePluginWasmEdgeProcess.so libwasmedgePluginWasmEdgeTensorflow.so libwasmedgePluginWasmEdgeTensorflowLite.so libwasmedgePluginWasmEdgeImage.so libwasmedgePluginWasmBpf.so
     needs: [get_version_v2]
     container:
       image: wasmedge/wasmedge:${{ matrix.docker_tag }}
+      # Required by mounting debugfs
+      options: --privileged
     steps:
       - uses: actions/checkout@v3
         with:
@@ -338,6 +352,10 @@ jobs:
           yum update -y
           yum install -y zlib-devel zlib-static
           bash ./utils/wasi-crypto/build-openssl.sh
+          bash ./utils/wasm_bpf/install-clang.sh
+
+          # Running tests of wasm_bpf requires proper ebpf running environment
+          mount -t debugfs none /sys/kernel/debug
       - name: Build and test plugins using g++ with ${{ matrix.build_type }} mode
         shell: bash
         run: |
@@ -401,6 +419,12 @@ jobs:
         with:
           name: WasmEdge-plugin-wasmedge_image-${{ needs.get_version_v2.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
           path: plugin_wasmedge_image.tar.gz
+      - name: Upload artifact - wasm_bpf
+        uses: actions/upload-artifact@v3
+        with:
+          name: WasmEdge-plugin-wasm_bpf-${{ needs.get_version_v2.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
+          path: plugin_wasm_bpf.tar.gz
+  
 
   build_macos:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,9 +185,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       output_prefix: build/plugins
-      build_options: -DWASMEDGE_PLUGIN_WASI_CRYPTO=ON -DWASMEDGE_PLUGIN_WASI_LOGGING=ON -DWASMEDGE_PLUGIN_PROCESS=ON -DWASMEDGE_PLUGIN_TENSORFLOW=ON -DWASMEDGE_PLUGIN_TENSORFLOWLITE=ON -DWASMEDGE_PLUGIN_IMAGE=ON
-      tar_names: wasi_crypto wasi_logging wasmedge_process wasmedge_tensorflow wasmedge_tensorflowlite wasmedge_image
-      output_bins: libwasmedgePluginWasiCrypto.so libwasmedgePluginWasiLogging.so libwasmedgePluginWasmEdgeProcess.so libwasmedgePluginWasmEdgeTensorflow.so libwasmedgePluginWasmEdgeTensorflowLite.so libwasmedgePluginWasmEdgeImage.so
+      build_options: -DWASMEDGE_PLUGIN_WASI_CRYPTO=ON -DWASMEDGE_PLUGIN_WASI_LOGGING=ON -DWASMEDGE_PLUGIN_PROCESS=ON -DWASMEDGE_PLUGIN_TENSORFLOW=ON -DWASMEDGE_PLUGIN_TENSORFLOWLITE=ON -DWASMEDGE_PLUGIN_IMAGE=ON -DWASMEDGE_PLUGIN_WASM_BPF=ON
+      tar_names: wasi_crypto wasi_logging wasmedge_process wasmedge_tensorflow wasmedge_tensorflowlite wasmedge_image wasm_bpf
+      output_bins: libwasmedgePluginWasiCrypto.so libwasmedgePluginWasiLogging.so libwasmedgePluginWasmEdgeProcess.so libwasmedgePluginWasmEdgeTensorflow.so libwasmedgePluginWasmEdgeTensorflowLite.so libwasmedgePluginWasmEdgeImage.so libwasmedgePluginWasmBpf.so
     needs: create_release
     container:
       image: wasmedge/wasmedge:latest
@@ -200,6 +200,7 @@ jobs:
         run: |
           apt update
           apt install -y libssl-dev
+          apt install -y libelf-dev zlib1g-dev pkg-config
       - name: Build plugins
         shell: bash
         run: |
@@ -276,6 +277,15 @@ jobs:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
           asset_path: plugin_wasmedge_image.tar.gz
           asset_name: WasmEdge-plugin-wasmedge_image-${{ needs.create_release.outputs.version }}-ubuntu22.04_x86_64.tar.gz
+          asset_content_type: application/x-gzip
+      - name: Upload wasm_bpf plugin tar.gz package
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: plugin_wasm_bpf.tar.gz
+          asset_name: WasmEdge-plugin-wasm_bpf-${{ needs.create_release.outputs.version }}-ubuntu22.04_x86_64.tar.gz
           asset_content_type: application/x-gzip
 
   build_and_upload_wasinn_manylinux:
@@ -368,9 +378,9 @@ jobs:
     runs-on: ${{ matrix.host_runner }}
     env:
       output_prefix: build/plugins
-      build_options: -DWASMEDGE_PLUGIN_WASI_CRYPTO=ON -DWASMEDGE_PLUGIN_WASI_LOGGING=ON -DWASMEDGE_PLUGIN_PROCESS=ON -DWASMEDGE_PLUGIN_TENSORFLOW=ON -DWASMEDGE_PLUGIN_TENSORFLOWLITE=ON -DWASMEDGE_PLUGIN_IMAGE=ON
-      tar_names: wasi_crypto wasi_logging wasmedge_process wasmedge_tensorflow wasmedge_tensorflowlite wasmedge_image
-      output_bins: libwasmedgePluginWasiCrypto.so libwasmedgePluginWasiLogging.so libwasmedgePluginWasmEdgeProcess.so libwasmedgePluginWasmEdgeTensorflow.so libwasmedgePluginWasmEdgeTensorflowLite.so libwasmedgePluginWasmEdgeImage.so
+      build_options: -DWASMEDGE_PLUGIN_WASI_CRYPTO=ON -DWASMEDGE_PLUGIN_WASI_LOGGING=ON -DWASMEDGE_PLUGIN_PROCESS=ON -DWASMEDGE_PLUGIN_TENSORFLOW=ON -DWASMEDGE_PLUGIN_TENSORFLOWLITE=ON -DWASMEDGE_PLUGIN_IMAGE=ON -DWASMEDGE_PLUGIN_WASM_BPF=ON -DWASMEDGE_PLUGIN_WASM_BPF_BUILD_LIBBPF_WITH_PKG_CONF=OFF
+      tar_names: wasi_crypto wasi_logging wasmedge_process wasmedge_tensorflow wasmedge_tensorflowlite wasmedge_image wasm_bpf
+      output_bins: libwasmedgePluginWasiCrypto.so libwasmedgePluginWasiLogging.so libwasmedgePluginWasmEdgeProcess.so libwasmedgePluginWasmEdgeTensorflow.so libwasmedgePluginWasmEdgeTensorflowLite.so libwasmedgePluginWasmEdgeImage.so libwasmedgePluginWasmBpf.so
     needs: create_release
     container:
       image: wasmedge/wasmedge:${{ matrix.docker_tag }}
@@ -461,7 +471,16 @@ jobs:
           asset_path: plugin_wasmedge_image.tar.gz
           asset_name: WasmEdge-plugin-wasmedge_image-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
           asset_content_type: application/x-gzip
-
+      - name: Upload wasm_bpf plugin tar.gz package
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: plugin_wasm_bpf.tar.gz
+          asset_name: WasmEdge-plugin-wasm_bpf-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
+          asset_content_type: application/x-gzip
+  
   build_and_upload_plugin_macos:
     strategy:
       matrix:

--- a/plugins/wasm_bpf/CMakeLists.txt
+++ b/plugins/wasm_bpf/CMakeLists.txt
@@ -6,28 +6,40 @@
 # - ${LIBBPF_SOURCE_DIR}
 # - FetchContent
 
+option(WASMEDGE_PLUGIN_WASM_BPF_BUILD_LIBBPF_WITH_PKG_CONF "Build libbpf with pkg-config. If disabled, the headers and  libs of libz and libelf should be placed at correct places" YES)
+
 message(STATUS "Trying to get libbpf..")
+message(STATUS "Build libbpf with pkg-config: ${WASMEDGE_PLUGIN_WASM_BPF_BUILD_LIBBPF_WITH_PKG_CONF}")
 set(LIBBPF_FOUND FALSE)
 
 # A wrapper function to add libbpf located at a local path as a dependency
-function(AddLibbpfAsExternal SOURCE_ROOT)
+function(AddLibbpfAsExternal SOURCE_ROOT WITH_PKG_CONF)
   include(ExternalProject)
+  set(LIBBPF_SO_PATH ${SOURCE_ROOT}/src/build/libbpf.so)
+  set(LIBBPF_INCLUDE_DIRS_LOCAL "${SOURCE_ROOT}/src/root/usr/include" "${SOURCE_ROOT}/include/uapi" "${SOURCE_ROOT}/include")
+  set(LIBBPF_INCLUDE_DIRS ${LIBBPF_INCLUDE_DIRS_LOCAL} PARENT_SCOPE)
+
+  set(LIBBPF_LIBRARIES ${LIBBPF_SO_PATH} PARENT_SCOPE)
+  set(LIBBPF_LIBRARIES_STATIC ${SOURCE_ROOT}/src/build/libbpf.a PARENT_SCOPE)
+
+  if(${WITH_PKG_CONF})
+    set(PKGCONF_PREFIX "")
+  else()
+    set(PKGCONF_PREFIX "NO_PKG_CONFIG=1")
+    set(LIBBPF_DEP_LIBRARIES "elf" "z" PARENT_SCOPE)
+  endif()
+  message(STATUS "SOURCE_ROOT=${SOURCE_ROOT}")
   ExternalProject_Add(libbpf
     PREFIX libbpf
     SOURCE_DIR ${SOURCE_ROOT}
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND "make" "-C" "${SOURCE_ROOT}/src"
-    INSTALL_COMMAND ""
+    CONFIGURE_COMMAND "mkdir" "build" "root"
+    BUILD_COMMAND "${PKGCONF_PREFIX}" "OBJDIR=${SOURCE_ROOT}/src/build" "DESTDIR=${SOURCE_ROOT}/src/root" "CFLAGS=-fPIC" "make" "-C" "${SOURCE_ROOT}/src" "install"
+    INSTALL_COMMAND "cp" "${LIBBPF_SO_PATH}" "${CMAKE_CURRENT_BINARY_DIR}/libbpf.so"
     BUILD_IN_SOURCE TRUE
+    BUILD_BYPRODUCTS ${LIBBPF_SO_PATH} ${SOURCE_ROOT}/src/build/libbpf.a
   )
-  set(LIBBPF_SO_PATH ${SOURCE_ROOT}/src/libbpf.so)
-  set(LIBBPF_INCLUDE_DIRS ${SOURCE_ROOT}/src PARENT_SCOPE)
-  set(LIBBPF_LIBRARIES ${LIBBPF_SO_PATH} PARENT_SCOPE)
-  set(LIBBPF_TARGET_NAME libbpf PARENT_SCOPE)
-  file(COPY_FILE ${LIBBPF_SO_PATH} ${CMAKE_CURRENT_BINARY_DIR}/libbpf.so)
 
-  # Copy libbpf.so to the place where libwasmedgePluginWasmBpf.so exists
-  message(STATUS "Copied libbpf.so from ${LIBBPF_SO_PATH} to ${CMAKE_CURRENT_BINARY_DIR}/libbpf.so")
+  set(LIBBPF_TARGET_NAME libbpf PARENT_SCOPE)
 endfunction()
 
 # Try PkgConfig
@@ -38,11 +50,19 @@ if(NOT ${LIBBPF_FOUND})
     message(STATUS "Try to get libbpf through PkgConfig")
 
     # It will set LIBBPF_FOUND for us
-    pkg_check_modules(LIBBPF libbpf>=1.2 IMPORTED_TARGET)
+    pkg_check_modules(LIBBPF libbpf>=1.2.0 IMPORTED_TARGET)
     set(LIBBPF_TARGET_NAME "PkgConfig::LIBBPF")
+    message(STATUS "LIBBPF_FOUND=${LIBBPF_FOUND}")
+
+    if(${LIBBPF_FOUND})
+      SET(LIBBPF_FOUND TRUE)
+    else()
+      SET(LIBBPF_FOUND FALSE)
+    endif()
 
     if(${LIBBPF_FOUND})
       message(STATUS "libbpf found using PkgConfig")
+      set(LIBBPF_SOURCE "pkgconf")
     else()
       message(STATUS "libbpf not found using pkgconfig")
     endif()
@@ -56,9 +76,10 @@ if(NOT ${LIBBPF_FOUND})
   message(STATUS "Try to get libbpf through the pre-defined LIBBPF_SOURCE_DIR")
 
   if(DEFINED LIBBPF_SOURCE_DIR)
-    AddLibbpfAsExternal(${LIBBPF_SOURCE_DIR})
+    AddLibbpfAsExternal(${LIBBPF_SOURCE_DIR} ${WASMEDGE_PLUGIN_WASM_BPF_BUILD_LIBBPF_WITH_PKG_CONF})
     set(LIBBPF_FOUND TRUE)
     message(STATUS "libbpf found using LIBBPF_SOURCE_DIR")
+    set(LIBBPF_SOURCE "sourcedir")
   else()
     message(STATUS "LIBBPF_SOURCE_DIR not defined")
   endif()
@@ -83,8 +104,9 @@ if(NOT ${LIBBPF_FOUND})
 
   set(LIBBPF_DOWNLOAD_SOURCE_DIR "${libbpf_SOURCE_DIR}")
   message(DEBUG "libbpf saved at: ${LIBBPF_DOWNLOAD_SOURCE_DIR}")
-  AddLibbpfAsExternal(${LIBBPF_DOWNLOAD_SOURCE_DIR})
+  AddLibbpfAsExternal(${LIBBPF_DOWNLOAD_SOURCE_DIR} ${WASMEDGE_PLUGIN_WASM_BPF_BUILD_LIBBPF_WITH_PKG_CONF})
   set(LIBBPF_FOUND TRUE)
+  set(LIBBPF_SOURCE "fetch-content")
 endif()
 
 # If we cannot find libbpf..
@@ -92,16 +114,22 @@ if(NOT ${LIBBPF_FOUND})
   message(FATAL_ERROR "Could not find libbpf")
 endif()
 
-message(DEBUG "LIBBPF_INCLUDE_DIRS=${LIBBPF_INCLUDE_DIRS}")
-message(DEBUG "LIBBPF_LIBRARIES=${LIBBPF_LIBRARIES}")
-message(DEBUG "LIBBPF_TARGET_NAME=${LIBBPF_TARGET_NAME}")
+if(${WASMEDGE_PLUGIN_WASM_BPF_BUILD_LIBBPF_WITH_PKG_CONF})
+  # Find the dependencies `libelf` and `libz` of libbpf
+  find_package(PkgConfig)
 
-# Find the dependencies `libelf` and `libz` of libbpf
-find_package(PkgConfig)
+  pkg_check_modules(LIBBPF_DEP REQUIRED libelf zlib)
 
-pkg_check_modules(LIBBPF_DEP REQUIRED libelf zlib)
+  message(STATUS "(From PKGCONF) LIBBPF_DEP_LIBRARIES=${LIBBPF_DEP_LIBRARIES}")
+endif()
 
-message(DEBUG "LIBBPF_DEP_LIBRARIES=${LIBBPF_DEP_LIBRARIES}")
+message(STATUS "LIBBPF_INCLUDE_DIRS=${LIBBPF_INCLUDE_DIRS}")
+message(STATUS "LIBBPF_LIBRARIES=${LIBBPF_LIBRARIES}")
+message(STATUS "LIBBPF_TARGET_NAME=${LIBBPF_TARGET_NAME}")
+message(STATUS "LIBBPF_LIBRARIES_STATIC=${LIBBPF_LIBRARIES_STATIC}")
+message(STATUS "LIBBPF_SOURCE=${LIBBPF_SOURCE}")
+message(STATUS "LIBBPF_DEP_LIBRARIES=${LIBBPF_DEP_LIBRARIES}")
+message(STATUS "LIBBPF_DEP_LIBRARIES_STATIC=${LIBBPF_DEP_LIBRARIES_STATIC}")
 
 wasmedge_add_library(wasmedgePluginWasmBpf
   SHARED
@@ -117,11 +145,28 @@ wasmedge_add_library(wasmedgePluginWasmBpf
 )
 
 add_dependencies(wasmedgePluginWasmBpf ${LIBBPF_TARGET_NAME})
-target_link_libraries(wasmedgePluginWasmBpf PUBLIC ${LIBBPF_LIBRARIES} ${LIBBPF_DEP_LIBRARIES})
+
+if("${LIBBPF_SOURCE}" STREQUAL "pkgconf")
+  message(STATUS "Link libbpf dynamically")
+  target_link_libraries(wasmedgePluginWasmBpf PUBLIC ${LIBBPF_LIBRARIES} ${LIBBPF_DEP_LIBRARIES})
+else()
+  # Link libbpf statically if we don't use pkgconf, because under this case libbpf is not installed systemwide
+  message(STATUS "Link libbpf statically")
+  target_link_libraries(wasmedgePluginWasmBpf PUBLIC ${LIBBPF_LIBRARIES_STATIC} ${LIBBPF_DEP_LIBRARIES})
+endif()
+
 target_include_directories(wasmedgePluginWasmBpf PUBLIC ${LIBBPF_INCLUDE_DIRS})
+
 
 set_target_properties(wasmedgePluginWasmBpf PROPERTIES
   CXX_STANDARD 17
+  # Allow tests accessing plugin class functions
+  CXX_VISIBILITY_PRESET default
+  VISIBILITY_INLINES_HIDDEN OFF
+)
+# Fix undefined reference issue of `fmt::v9::formatter<WasmEdge::ErrInfo::InfoBoundary, char, void>::format(WasmEdge::ErrInfo::InfoBoundary const&, fmt::v9::basic_format_context<fmt::v9::appender, char>&) const`
+target_link_libraries(wasmedgePluginWasmBpf
+  PUBLIC wasmedgeCommon
 )
 
 target_compile_options(wasmedgePluginWasmBpf
@@ -141,12 +186,10 @@ if(WASMEDGE_LINK_PLUGINS_STATIC)
   target_link_libraries(wasmedgePluginWasmBpf
     PRIVATE
     wasmedgeCAPI
-    ${LIBBPF_LIBRARIES}
   )
 else()
   target_link_libraries(wasmedgePluginWasmBpf
     PRIVATE
     wasmedge_shared
-    ${LIBBPF_LIBRARIES}
   )
 endif()

--- a/plugins/wasm_bpf/bpf-api.h
+++ b/plugins/wasm_bpf/bpf-api.h
@@ -7,10 +7,18 @@
 #include "runtime/instance/module.h"
 #include "wasmedge/wasmedge.h"
 
+#pragma GCC diagnostic push
+#ifdef __clang__
+// Allow compilation using clang
+#pragma GCC diagnostic warning "-Wextern-c-compat"
+
+#endif
 extern "C" {
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
 }
+
+#pragma GCC diagnostic pop
 
 #define POLL_TIMEOUT_MS 100
 #define PERF_BUFFER_PAGES 64

--- a/plugins/wasm_bpf/func-bpf-map-operate.cpp
+++ b/plugins/wasm_bpf/func-bpf-map-operate.cpp
@@ -11,9 +11,9 @@ extern "C" {
 namespace WasmEdge {
 namespace Host {
 
-#define ensure_memory_size(var, offset, size)                                  \
-  const auto var##_span = memory->getSpan<char>(offset, size);                 \
-  if (var##_span.size() != size)                                               \
+#define ensure_memory_size(var, offset, expected_size)                         \
+  const auto var##_span = memory->getSpan<char>(offset, expected_size);        \
+  if (var##_span.size() != expected_size)                                      \
     return Unexpect(ErrCode::Value::HostFuncError);                            \
   const auto var = var##_span.data();
 Expect<int32_t>
@@ -39,7 +39,7 @@ BpfMapOperate::body(const WasmEdge::Runtime::CallingFrame &Frame, int32_t fd,
   auto key_size = map_info.key_size;
   auto value_size = map_info.value_size;
 
-  switch ((bpf_map_cmd)cmd) {
+  switch ((bpf_cmd)cmd) {
   case BPF_MAP_GET_NEXT_KEY: {
     ensure_memory_size(key_ptr, key, key_size);
     ensure_memory_size(next_key_ptr, next_key, key_size);

--- a/test/plugins/wasm_bpf/CMakeLists.txt
+++ b/test/plugins/wasm_bpf/CMakeLists.txt
@@ -23,17 +23,20 @@ target_include_directories(wasmBpfTests
 target_link_libraries(wasmBpfTests
   PRIVATE
   ${GTEST_BOTH_LIBRARIES}
+  wasmedgePluginWasmBpf
 )
 # Link to the WasmEdge library
 if(WASMEDGE_LINK_PLUGINS_STATIC)
   target_link_libraries(wasmBpfTests
     PRIVATE
     wasmedgeCAPI
+    wasmedgeExecutor
   )
 else()
   target_link_libraries(wasmBpfTests
     PRIVATE
     wasmedge_shared
+    wasmedgeExecutor
   )
 endif()
 

--- a/test/plugins/wasm_bpf/simple_ringbuf_test.cpp
+++ b/test/plugins/wasm_bpf/simple_ringbuf_test.cpp
@@ -56,7 +56,7 @@ class PollCallbackFunction
         if (data_sz < static_cast<uint32_t>(sizeof(uint32_t))) {
             return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
         }
-        const uint32_t* dataPtr = memory->getPointer<const uint32_t*>(data, 1);
+        const uint32_t* dataPtr = memory->getSpan<const uint32_t>(data, 1).data();
         if (unlikely(!dataPtr)) {
             return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
         }

--- a/test/plugins/wasm_bpf/wasm_bpf.cpp
+++ b/test/plugins/wasm_bpf/wasm_bpf.cpp
@@ -102,7 +102,7 @@ public:
     if (data_sz < static_cast<uint32_t>(sizeof(event))) {
       return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
     }
-    const event *dataPtr = memory->getPointer<const event *>(data, 1);
+    const event *dataPtr = memory->getSpan<const event>(data, 1).data();
     if (unlikely(!dataPtr)) {
       return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
     }

--- a/utils/install.py
+++ b/utils/install.py
@@ -300,11 +300,13 @@ WASI_NN_OPENVINO = "wasi_nn-openvino"
 WASI_CRYPTO = "wasi_crypto"
 WASI_NN_PYTORCH = "wasi_nn-pytorch"
 WASI_NN_TENSORFLOW_LITE = "wasi_nn-tensorflowlite"
+WASM_BPF = "wasm_bpf"
 PLUGINS_AVAILABLE = [
     WASI_NN_OPENVINO,
     WASI_CRYPTO,
     WASI_NN_PYTORCH,
     WASI_NN_TENSORFLOW_LITE,
+    WASM_BPF
 ]
 
 SUPPORTTED_PLUGINS = {
@@ -322,6 +324,8 @@ SUPPORTTED_PLUGINS = {
     + "aarch64"
     + WASI_NN_TENSORFLOW_LITE: VersionString("0.11.2-alpha.1"),
     "ubuntu20.04" + "x86_64" + WASI_NN_TENSORFLOW_LITE: VersionString("0.11.2-rc.1"),
+    "ubuntu20.04" + "x86_64" + WASM_BPF: VersionString("0.13.0"),
+    "manylinux2014" + "x86_64" + WASM_BPF: VersionString("0.13.0"),
 }
 
 HOME = expanduser("~")

--- a/utils/wasm_bpf/install-clang.sh
+++ b/utils/wasm_bpf/install-clang.sh
@@ -1,0 +1,8 @@
+curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.6/llvm-project-16.0.6.src.tar.xz -O
+tar --xz -xvf llvm-project-16.0.6.src.tar.xz > /dev/null
+cd llvm-project-16.0.6.src
+cmake -S llvm -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j
+cd build
+make install
+clang --version 


### PR DESCRIPTION
Turn draft now. Will be ready for review when `build-extensions.yml` was updated

This PR did:
- Modifies `release.yml` to build and publish the `wasm_bpf` plugin on Ubuntu and `manylinux`
- Modifies the `install.py` to support installing `wasm_bpf` through the installation script
- Adapted the CMake script of `wasm_bpf` to the CI building process
- Fixes stuff related to a break change (The removal of `MemoryInstance::getPointer`)