### PR TITLE
Grant socket FDs the ability to fd_read and fd_write

### DIFF
--- a/lib/host/wasi/vinode.cpp
+++ b/lib/host/wasi/vinode.cpp
@@ -349,7 +349,8 @@ VINode::sockOpen(VFS &FS, __wasi_address_family_t SysDomain,
         __WASI_RIGHTS_SOCK_RECV | __WASI_RIGHTS_SOCK_RECV_FROM |
         __WASI_RIGHTS_SOCK_SEND | __WASI_RIGHTS_SOCK_SEND_TO |
         __WASI_RIGHTS_SOCK_SHUTDOWN | __WASI_RIGHTS_SOCK_BIND |
-        __WASI_RIGHTS_POLL_FD_READWRITE | __WASI_RIGHTS_FD_FDSTAT_SET_FLAGS;
+        __WASI_RIGHTS_POLL_FD_READWRITE | __WASI_RIGHTS_FD_FDSTAT_SET_FLAGS |
+        __WASI_RIGHTS_FD_READ | __WASI_RIGHTS_FD_WRITE;
     return std::make_shared<VINode>(FS, std::move(*Res), Rights, Rights);
   }
 }
@@ -363,7 +364,8 @@ VINode::sockAccept(__wasi_fdflags_t FdFlags) {
         __WASI_RIGHTS_SOCK_RECV | __WASI_RIGHTS_SOCK_RECV_FROM |
         __WASI_RIGHTS_SOCK_SEND | __WASI_RIGHTS_SOCK_SEND_TO |
         __WASI_RIGHTS_SOCK_SHUTDOWN | __WASI_RIGHTS_POLL_FD_READWRITE |
-        __WASI_RIGHTS_FD_FDSTAT_SET_FLAGS;
+        __WASI_RIGHTS_FD_FDSTAT_SET_FLAGS | __WASI_RIGHTS_FD_READ |
+        __WASI_RIGHTS_FD_WRITE;
     return std::make_shared<VINode>(FS, std::move(*Res), Rights, Rights,
                                     std::string());
   }


### PR DESCRIPTION
This PR grants socket FDs the right to `fd_read` and `fd_write`.

Previously you could only call `sock_recv` and `sock_send`.

This matches POSIX where you can `read(2)` and `write(2)` on a socket FD, as well as `recv(2)` and `send(2)`.

For context, [Golang](https://go.dev) will soon be able to natively build WASM/WASI applications via `GOOS=wasip1 GOARCH=wasm go build -o module.wasm ...`. See https://tip.golang.org/doc/go1.21#wasip1. Internally, Go uses `fd_read` and `fd_write` regardless of whether it's a file or socket. For compatibility, WasmEdge needs these additional rights for socket FDs.

This fixes #659 (see [this comment](https://github.com/WasmEdge/WasmEdge/issues/659#issuecomment-974877813)).