### PR TITLE
[Misc] use std::boyer_moore_horspool_searcher instead of boost one

### DIFF
--- a/.github/workflows/IWYU_scan.yml
+++ b/.github/workflows/IWYU_scan.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Install requirements
       run: |
         dnf update -y
-        dnf install -y cmake ninja-build boost llvm llvm-devel lld-devel clang git file rpm-build dpkg-dev clang-devel spdlog-devel
+        dnf install -y cmake ninja-build llvm llvm-devel lld-devel clang git file rpm-build dpkg-dev clang-devel spdlog-devel
         curl -L -O https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/0.20.zip
         unzip 0.20.zip
         mkdir build && cd build
@@ -99,7 +99,7 @@ jobs:
     - name: Build and scan WasmEdge with IWYU
       shell: bash
       run: |
-        brew install llvm ninja boost cmake
+        brew install llvm ninja cmake
         export LLVM_DIR="/usr/local/opt/llvm/lib/cmake"
         export Clang_DIR="/usr/local/opt/llvm/lib/cmake/clang"
         export CC=clang

--- a/.github/workflows/bindings-java.yml
+++ b/.github/workflows/bindings-java.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Install build tools
         run: |
-          brew install llvm ninja boost cmake
+          brew install llvm ninja cmake
 
       - name: Build WasmEdge with Release mode
         run: |

--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -419,7 +419,7 @@ jobs:
           fetch-depth: 0
       - name: Build and install dependencies
         run: |
-          brew install llvm ninja boost cmake openssl
+          brew install llvm ninja cmake openssl
       - name: Build WasmEdge plugins using clang++ with ${{ matrix.build_type }} mode
         shell: bash
         run: |

--- a/.github/workflows/build_for_openwrt.yml
+++ b/.github/workflows/build_for_openwrt.yml
@@ -91,7 +91,6 @@ jobs:
         CONFIG_TARGET_ARCH_PACKAGES="x86_64"
         CONFIG_PACKAGE_libpthread=y
         CONFIG_PACKAGE_libstdcpp=y
-        CONFIG_PACKAGE_boost=y
         CONFIG_PACKAGE_WasmEdge=y
         EOF
         sed -i 's/^[ \t]*//g' ./.config

--- a/.github/workflows/build_for_riscv.yml
+++ b/.github/workflows/build_for_riscv.yml
@@ -60,7 +60,7 @@ jobs:
         install: |
           apt-get update -q -y
           apt-get install -q -y git cmake g++ dpkg
-          apt-get install -q -y software-properties-common libboost-all-dev
+          apt-get install -q -y software-properties-common
           apt-get install -q -y llvm-12-dev liblld-12-dev
         run: |
           mkdir -p build && cd build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -443,7 +443,7 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         run: |
-          brew install llvm ninja boost cmake openssl
+          brew install llvm ninja cmake openssl
       - name: Build plugins
         shell: bash
         run: |

--- a/.github/workflows/reusable-build-on-fedora.yml
+++ b/.github/workflows/reusable-build-on-fedora.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependency
         run: |
           dnf update -y
-          dnf install -y cmake ninja-build boost llvm llvm-devel lld-devel clang git file rpm-build dpkg-dev spdlog-devel
+          dnf install -y cmake ninja-build llvm llvm-devel lld-devel clang git file rpm-build dpkg-dev spdlog-devel
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/reusable-build-on-macos.yml
+++ b/.github/workflows/reusable-build-on-macos.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
       - name: Setup build environment
         run: |
-          brew install llvm ninja boost cmake
+          brew install llvm ninja cmake
       - name: Set environment variables for release
         if: ${{ inputs.release }}
         run: |

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -54,7 +54,7 @@ jobs:
         lsb_release -a
         sudo apt-get update
         sudo apt-get upgrade -y
-        sudo apt-get install -y software-properties-common libboost-all-dev llvm-11-dev liblld-11-dev liblld-11 clang-11 tar libssl-dev
+        sudo apt-get install -y software-properties-common llvm-11-dev liblld-11-dev liblld-11 clang-11 tar libssl-dev
         curl -sSL "https://github.com/facebook/infer/releases/download/v1.1.0/infer-linux64-v1.1.0.tar.xz" | sudo tar -C /opt -xJ && sudo ln -s "/opt/infer-linux64-v1.1.0/bin/infer" /usr/local/bin/infer
 
     - name: Generate compilation database

--- a/.github/workflows/wasi-testsuite.yml
+++ b/.github/workflows/wasi-testsuite.yml
@@ -47,7 +47,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         working-directory: WasmEdge
         run: |
-          brew install llvm ninja boost cmake
+          brew install llvm ninja cmake
           export LLVM_DIR="/usr/local/opt/llvm/lib/cmake"
           export CC=clang
           export CXX=clang++

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,22 +43,6 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Filesystem REQUIRED Final Experimental)
 find_package(Threads REQUIRED)
 
-find_package(Boost QUIET)
-if(${Boost_FOUND})
-else()
-  FetchContent_Declare(
-    Boost
-    URL https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2
-    URL_HASH SHA256=f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41
-  )
-  set(BOOST_ENABLE_CMAKE ON)
-  set(BOOST_RUNTIME_LINK static)
-  FetchContent_MakeAvailable(Boost)
-  add_library(Boost_boost INTERFACE)
-  add_library(Boost::boost ALIAS Boost_boost)
-  target_include_directories(Boost_boost INTERFACE ${boost_SOURCE_DIR})
-endif()
-
 # List of WasmEdge options
 option(WASMEDGE_BUILD_TESTS "Generate build targets for the wasmedge unit tests." OFF)
 option(WASMEDGE_BUILD_COVERAGE "Generate coverage report. Require WASMEDGE_BUILD_TESTS." OFF)

--- a/docs/book/en/src/sdk/node.md
+++ b/docs/book/en/src/sdk/node.md
@@ -56,7 +56,7 @@ npm install -g rustwasmc # Append --unsafe-perm if permission denied
 # OS dependencies for WasmEdge
 sudo apt-get update
 sudo apt-get -y upgrade
-sudo apt install -y build-essential curl wget git vim libboost-all-dev llvm-dev liblld-10-dev
+sudo apt install -y build-essential curl wget git vim llvm-dev liblld-10-dev
 
 # Install the nodejs addon for WasmEdge
 npm install wasmedge-core

--- a/docs/book/zh-TW/src/extend/build.md
+++ b/docs/book/zh-TW/src/extend/build.md
@@ -50,8 +50,7 @@ docker pull wasmedge/wasmedge # 等同於 wasmedge/wasmedge:latest
 # 工具和函式庫
 sudo apt install -y \
     software-properties-common \
-    cmake \
-    libboost-all-dev
+    cmake
 
 # 需要 llvm 來支援 wasmedgec 工具
 sudo apt install -y \

--- a/docs/book/zh/src/embed/node.md
+++ b/docs/book/zh/src/embed/node.md
@@ -55,7 +55,7 @@ $ npm install -g rustwasmc # 如果权限有问题，加上 --unsafe-perm
 # WasmEdge 需要的系统依赖
 $ sudo apt-get update
 $ sudo apt-get -y upgrade
-$ sudo apt install -y build-essential curl wget git vim libboost-all-dev llvm-dev liblld-10-dev
+$ sudo apt install -y build-essential curl wget git vim llvm-dev liblld-10-dev
 
 # 安装 WasmEdge 需要的 nodejs addon 
 $ npm install wasmedge-core

--- a/docs/book/zh/src/extend/build.md
+++ b/docs/book/zh/src/extend/build.md
@@ -46,8 +46,7 @@ docker pull wasmedge/wasmedge # 等同于 wasmedge/wasmedge:latest
 # 工具和库
 sudo apt install -y \
     software-properties-common \
-    cmake \
-    libboost-all-dev
+    cmake
 
 # 你需要 llvm 来支持 wasmedgec 工具
 sudo apt install -y \

--- a/docs/book/zh/src/extend/build_on_mac.md
+++ b/docs/book/zh/src/extend/build_on_mac.md
@@ -29,7 +29,7 @@ WasmEdge 会基于最新版本的 LLVM 来创建我们的每日构建。如果�
 
 ```bash
 # 工具和库
-$ brew install boost cmake ninja llvm@12
+$ brew install cmake ninja llvm@12
 # 使用 brew 版本的 llvm，而不是系统自带的 LLVM。
 $ export PATH="/usr/local/opt/llvm@12/bin:$PATH"
 $ export LDFLAGS="-L/usr/local/opt/llvm@12/lib -Wl，-rpath，/usr/local/opt/llvm@12/lib"

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,6 @@
           src = ./.;
 
           buildInputs = with pkgs; [
-            boost
             cmake
             llvmPackages.clang-unwrapped
             llvmPackages.lld

--- a/fossa-deps.yml
+++ b/fossa-deps.yml
@@ -1,9 +1,4 @@
 remote-dependencies:
-  - name: "Boost"
-    version: "1.76"
-    url: "https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2"
-    metadata:
-      homepage: "https://www.boost.org/"
   - name: "GoogleTest"
     version: "1.11.0"
     url: "https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz"

--- a/lib/driver/fuzzPO.cpp
+++ b/lib/driver/fuzzPO.cpp
@@ -7,11 +7,10 @@
 #include "common/version.h"
 #include "po/argument_parser.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <iostream>
 #include <vector>
-
-#include <boost/algorithm/searching/boyer_moore_horspool.hpp>
 
 namespace WasmEdge {
 namespace Driver {
@@ -122,13 +121,13 @@ int FuzzPO(const uint8_t *Data, size_t Size) noexcept {
 
   static constexpr const std::array<char, 4> Separator = {'\xde', '\xad',
                                                           '\xbe', '\xef'};
-  static const boost::algorithm::boyer_moore_horspool Searcher(
-      Separator.begin(), Separator.end());
+  static const std::boyer_moore_horspool_searcher Searcher(Separator.begin(),
+                                                           Separator.end());
   Span<const char> RawArgs(reinterpret_cast<const char *>(Data), Size);
   std::vector<std::string> ArgvStr;
   std::vector<const char *> Argv;
   while (!RawArgs.empty()) {
-    const auto It = Searcher(RawArgs.begin(), RawArgs.end()).first;
+    const auto It = std::search(RawArgs.begin(), RawArgs.end(), Searcher);
     ArgvStr.emplace_back(RawArgs.begin(), It);
     RawArgs = RawArgs.subspan(std::min<size_t>(
         std::distance(RawArgs.begin(), It) + 4, RawArgs.size()));

--- a/lib/host/wasi/CMakeLists.txt
+++ b/lib/host/wasi/CMakeLists.txt
@@ -25,7 +25,6 @@ target_include_directories(wasmedgeHostModuleWasi
 target_link_libraries(wasmedgeHostModuleWasi
   PUBLIC
   Threads::Threads
-  Boost::boost
   wasmedgeSystem
 )
 

--- a/lib/loader/CMakeLists.txt
+++ b/lib/loader/CMakeLists.txt
@@ -36,6 +36,5 @@ target_link_libraries(wasmedgeLoader
   PUBLIC
   wasmedgeCommon
   wasmedgeLoaderFileMgr
-  Boost::boost
   std::filesystem
 )

--- a/lib/system/CMakeLists.txt
+++ b/lib/system/CMakeLists.txt
@@ -16,5 +16,4 @@ target_include_directories(wasmedgeSystem
 target_link_libraries(wasmedgeSystem
   PUBLIC
   wasmedgeCommon
-  Boost::boost
 )

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -34,7 +34,6 @@ add_test(wasmedgeAPIUnitTests wasmedgeAPIUnitTests)
 target_link_libraries(wasmedgeAPIUnitTests
   PRIVATE
   std::filesystem
-  Boost::boost
   ${GTEST_BOTH_LIBRARIES}
   wasmedgeAPITestHelpers
   wasmedge_shared

--- a/utils/docker/Dockerfile.base
+++ b/utils/docker/Dockerfile.base
@@ -12,7 +12,6 @@ RUN apt update && apt upgrade -y \
 	ninja-build \
 	curl \
 	git \
-	libboost-all-dev \
 	llvm-15-dev \
 	liblld-15-dev
 

--- a/utils/docker/Dockerfile.ubuntu2004_x86_64
+++ b/utils/docker/Dockerfile.ubuntu2004_x86_64
@@ -12,7 +12,6 @@ RUN apt update && apt upgrade -y \
 	curl \
 	git \
 	dpkg-dev \
-	libboost-all-dev \
 	llvm-12-dev \
 	liblld-12-dev \
 	gcc \

--- a/utils/docker/Dockerfile.ubuntu2104_armv7l
+++ b/utils/docker/Dockerfile.ubuntu2104_armv7l
@@ -18,7 +18,6 @@ RUN apt update && apt upgrade -y \
 	g++-multilib \
 	git \
 	llvm-12-dev \
-	libboost-all-dev \
 	liblld-12-dev \
 	libssl-dev \
 	ninja-build \

--- a/utils/docker/build-manylinux.sh
+++ b/utils/docker/build-manylinux.sh
@@ -2,10 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # SPDX-FileCopyrightText: 2019-2022 Second State INC
 
-curl -s -L -O --remote-name-all https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.bz2
-echo "a6e1ab9b0860e6a2881dd7b21fe9f737a095e5f33a3a874afc6a345228597ee6  boost_1_82_0.tar.bz2" | sha256sum -c
 git config --global --add safe.directory $(pwd)
-bzip2 -dc boost_1_82_0.tar.bz2 | tar -xf -
 
 CMAKE_BUILD_TYPE="Release"
 IS_BUILD_TARGET=true
@@ -38,7 +35,7 @@ for i in "$@"; do
 done
 
 if $IS_NINJA; then
-  if ! cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DWASMEDGE_BUILD_PACKAGE="TGZ;TBZ2;TXZ;TZST;RPM;DEB" -DBoost_NO_SYSTEM_PATHS=TRUE -DBOOST_INCLUDEDIR=$(pwd)/boost_1_82_0/ ${CMAKE_OPTS} .; then
+  if ! cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DWASMEDGE_BUILD_PACKAGE="TGZ;TBZ2;TXZ;TZST;RPM;DEB" ${CMAKE_OPTS} .; then
     echo === CMakeOutput.log ===
     cat build/CMakeFiles/CMakeOutput.log
     echo === CMakeError.log ===
@@ -49,7 +46,7 @@ else
   rm -rf build
   mkdir build
   cd build
-  if ! cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DWASMEDGE_BUILD_PACKAGE="TGZ;TBZ2;TXZ;TZST;RPM;DEB" -DBoost_NO_SYSTEM_PATHS=TRUE -DBOOST_INCLUDEDIR=$(pwd)/../boost_1_82_0/ ${CMAKE_OPTS} ..; then
+  if ! cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DWASMEDGE_BUILD_PACKAGE="TGZ;TBZ2;TXZ;TZST;RPM;DEB" ${CMAKE_OPTS} ..; then
     cd ..
     echo === CMakeOutput.log ===
     cat build/CMakeFiles/CMakeOutput.log

--- a/utils/ohos/build_for_ohos.sh
+++ b/utils/ohos/build_for_ohos.sh
@@ -6,7 +6,6 @@ OHOS_DIR_PATH=$1
 WASMEDGE_ROOT_PATH=$(dirname $(dirname $(pwd)))
 
 export PATH=$PATH:${OHOS_DIR_PATH}/prebuilts/clang/ohos/linux-x86_64/llvm/bin:${OHOS_DIR_PATH}/prebuilts/cmake/linux-x86/bin/
-export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:${OHOS_DIR_PATH}/third_party/boost/
 
 cp ./configuration/* ${WASMEDGE_ROOT_PATH}
 
@@ -14,7 +13,7 @@ cd ${WASMEDGE_ROOT_PATH}
 
 mkdir build
 cd build
-if ! cmake .. -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_AOT_RUNTIME=OFF -DWASMEDGE_BUILD_ON_OHOS=ON -DOHOS_DIR_PATH=${OHOS_DIR_PATH} -DOHOS_SYSROOT_PATH="${OHOS_DIR_PATH}/out/ohos-arm-release/obj/third_party/musl/" -DBoost_NO_SYSTEM_PATHS=TRUE -DBOOST_INCLUDEDIR="${OHOS_DIR_PATH}/third_party/boost/"; then
+if ! cmake .. -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_AOT_RUNTIME=OFF -DWASMEDGE_BUILD_ON_OHOS=ON -DOHOS_DIR_PATH=${OHOS_DIR_PATH} -DOHOS_SYSROOT_PATH="${OHOS_DIR_PATH}/out/ohos-arm-release/obj/third_party/musl/"; then
     echo === CMakeOutput.log ===
     cat build/CMakeFiles/CMakeOutput.log
     echo === CMakeError.log ===

--- a/utils/ohos/configuration/BUILD.gn
+++ b/utils/ohos/configuration/BUILD.gn
@@ -10,7 +10,6 @@ config("WASMEDGE_CFLAGS"){
         "$WASMEDGE_ROOT_DIR/include",
         "$WASMEDGE_ROOT_DIR/build/include",
         "$WASMEDGE_ROOT_DIR/build/_deps/spdlog-src/include",
-        "//third_party/boost",
         "$WASMEDGE_ROOT_DIR/thirdparty"
     ]
     cflags = [

--- a/utils/ohos/configuration/CMakeLists.txt
+++ b/utils/ohos/configuration/CMakeLists.txt
@@ -66,23 +66,6 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Filesystem REQUIRED Final Experimental)
 find_package(Threads REQUIRED)
 
-find_package(Boost QUIET)
-if(${Boost_FOUND})
-else()
-  FetchContent_Declare(
-    Boost
-    URL https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2
-    URL_HASH SHA256=f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41
-  )
-  set(BOOST_ENABLE_CMAKE ON)
-  set(BOOST_RUNTIME_LINK static)
-  set(BUILD_TESTING OFF)
-  FetchContent_MakeAvailable(Boost)
-  add_library(Boost_boost INTERFACE)
-  add_library(Boost::boost ALIAS Boost_boost)
-  target_include_directories(Boost_boost INTERFACE ${boost_SOURCE_DIR})
-endif()
-
 include(Helper)
 
 # List of WasmEdge options


### PR DESCRIPTION
Since we removed all of the boost related part, we can also drop the boost dependency.

Fixes #2258