### PR TITLE
Replace the broken release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,9 +70,9 @@ jobs:
     uses: ./.github/workflows/reusable-build-on-macos.yml
     with:
       version: ${{ needs.get_version_v2.outputs.version }}
-      matrix: "[{'name':'MacOS 11 (x86_64)','runner':'macos-11','darwin_version':20},
-                {'name':'MacOS 12 (x86_64)','runner':'macos-12','darwin_version':21},
-                {'name':'MacOS 13 (arm64)','runner':'mac-arm64','darwin_version':22}]"
+      matrix: "[{'name':'MacOS 11 (x86_64)','runner':'macos-11','darwin_version':20,'arch':'x86_64'},
+                {'name':'MacOS 12 (x86_64)','runner':'macos-12','darwin_version':21,'arch':'x86_64'},
+                {'name':'MacOS 13 (arm64)','runner':'mac-arm64','darwin_version':22,'arch':'aarch64'}]"
 
   build_on_manylinux_2014:
     needs: [get_version_v2, lint]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
   create_release:
     name: Create Release
     runs-on: ubuntu-latest
-    container:
-      image: wasmedge/wasmedge:ubuntu-build-gcc
     outputs:
       version: ${{ steps.prep.outputs.version }}
       upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -30,21 +28,13 @@ jobs:
       - name: Get version
         id: prep
         run: |
-          # Retrieve annotated tags. Details: https://github.com/actions/checkout/issues/290
-          git config --global --add safe.directory $(pwd)
-          git fetch --tags --force
-          echo "version=$(git describe --match '[0-9].[0-9]*' --tag)" >> $GITHUB_OUTPUT
+          echo "version=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: WasmEdge ${{ steps.prep.outputs.version }}
-          body_path: .CurrentChangelog.md
-          draft: true
-          prerelease: true
+        run: |
+          gh release create ${{ steps.prep.outputs.version }} --draft  --notes-file .CurrentChangelog.md --prerelease --title "WasmEdge ${{ steps.prep.outputs.version }}" --verify-tag
 
   create_source_tarball:
     needs: create_release
@@ -52,7 +42,6 @@ jobs:
     with:
       version: ${{ needs.create_release.outputs.version }}
       release: true
-      upload_asset_url: ${{ needs.create_release.outputs.upload_url }}
     secrets: inherit
 
   build_on_macos:
@@ -63,7 +52,6 @@ jobs:
       matrix: "[{'name':'MacOS 11 (x86_64)','runner':'macos-11','darwin_version':20},
                 {'name':'MacOS 13 (arm64)','runner':'mac-arm64','darwin_version':22}]"
       release: true
-      upload_asset_url: ${{ needs.create_release.outputs.upload_url }}
     secrets: inherit
 
   build_on_ubuntu_20_04:
@@ -73,7 +61,6 @@ jobs:
       version: ${{ needs.create_release.outputs.version }}
       matrix: "[{'name':'ubuntu-20.04','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-20.04-build-clang'}]"
       release: true
-      upload_asset_url: ${{ needs.create_release.outputs.upload_url }}
     secrets: inherit
 
   build_on_manylinux2014:
@@ -84,7 +71,6 @@ jobs:
       matrix: "[{'name':'manylinux 2014 x86_64','runner':'ubuntu-latest','docker_tag':'manylinux2014_x86_64'},
                 {'name':'manylinux 2014 aarch64','runner':'linux-arm64','docker_tag':'manylinux2014_aarch64'}]"
       release: true
-      upload_asset_url: ${{ needs.create_release.outputs.upload_url }}
     secrets: inherit
 
   build_on_windows:
@@ -93,7 +79,6 @@ jobs:
     with:
       version: ${{ needs.create_release.outputs.version }}
       release: true
-      upload_asset_url: ${{ needs.create_release.outputs.upload_url }}
     secrets: inherit
 
   build_on_android:
@@ -102,7 +87,6 @@ jobs:
     with:
       version: ${{ needs.create_release.outputs.version }}
       release: true
-      upload_asset_url: ${{ needs.create_release.outputs.upload_url }}
     secrets: inherit
 
   build_and_upload_wasinn_ubuntu:
@@ -128,6 +112,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
+          git config --global --add safe.directory $(pwd)
           apt update
           apt install unzip
           bash utils/wasi-nn/install-openvino.sh
@@ -153,33 +138,32 @@ jobs:
             cp -f ${output_dir}/${output_bin} ${output_bin}
             tar -zcvf plugin_${plugin_array[$i]}.tar.gz ${output_bin}
           done
+      - name: Install gh
+        run: |
+          type -p curl >/dev/null || (apt update && apt install curl -y)
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+          && apt update \
+          && apt install gh -y
       - name: Upload wasi_nn-pytorch plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasi_nn-pytorch.tar.gz
-          asset_name: WasmEdge-plugin-wasi_nn-pytorch-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasi_nn-pytorch.tar.gz WasmEdge-plugin-wasi_nn-pytorch-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasi_nn-pytorch-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz --clobber
       - name: Upload wasi_nn-openvino plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasi_nn-openvino.tar.gz
-          asset_name: WasmEdge-plugin-wasi_nn-openvino-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasi_nn-openvino.tar.gz WasmEdge-plugin-wasi_nn-openvino-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasi_nn-openvino-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz --clobber
       - name: Upload wasi_nn-tensorflowlite plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasi_nn-tensorflowlite.tar.gz
-          asset_name: WasmEdge-plugin-wasi_nn-tensorflowlite-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasi_nn-tensorflowlite.tar.gz WasmEdge-plugin-wasi_nn-tensorflowlite-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasi_nn-tensorflowlite-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz --clobber
 
   build_and_upload_plugin_ubuntu:
     name: Build and upload plugins on Ubuntu 20.04
@@ -199,6 +183,7 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         run: |
+          git config --global --add safe.directory $(pwd)
           apt update
           apt install -y libssl-dev
       - name: Build plugins
@@ -225,60 +210,50 @@ jobs:
             cp ${output_prefix}/${plugin_array[$i]}/${outbin_array[$i]} ${outbin_array[$i]}
             tar -zcvf plugin_${plugin_array[$i]}.tar.gz ${outbin_array[$i]}
           done
+      - name: Install gh
+        run: |
+          type -p curl >/dev/null || (apt update && apt install curl -y)
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+          && apt update \
+          && apt install gh -y
       - name: Upload wasi_crypto plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasi_crypto.tar.gz
-          asset_name: WasmEdge-plugin-wasi_crypto-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasi_crypto.tar.gz WasmEdge-plugin-wasi_crypto-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasi_crypto-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz --clobber
       - name: Upload wasi_logging plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasi_logging.tar.gz
-          asset_name: WasmEdge-plugin-wasi_logging-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasi_logging.tar.gz WasmEdge-plugin-wasi_logging-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasi_logging-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz --clobber
       - name: Upload wasmedge_process plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasmedge_process.tar.gz
-          asset_name: WasmEdge-plugin-wasmedge_process-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasmedge_process.tar.gz WasmEdge-plugin-wasmedge_process-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_process-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz --clobber
       - name: Upload wasmedge_tensorflow plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasmedge_tensorflow.tar.gz
-          asset_name: WasmEdge-plugin-wasmedge_tensorflow-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasmedge_tensorflow.tar.gz WasmEdge-plugin-wasmedge_tensorflow-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_tensorflow-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz --clobber
       - name: Upload wasmedge_tensorflowlite plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasmedge_tensorflowlite.tar.gz
-          asset_name: WasmEdge-plugin-wasmedge_tensorflowlite-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasmedge_tensorflowlite.tar.gz WasmEdge-plugin-wasmedge_tensorflowlite-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_tensorflowlite-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz --clobber
       - name: Upload wasmedge_image plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasmedge_image.tar.gz
-          asset_name: WasmEdge-plugin-wasmedge_image-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasmedge_image.tar.gz WasmEdge-plugin-wasmedge_image-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_image-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz --clobber
 
   build_and_upload_wasinn_manylinux:
     strategy:
@@ -314,6 +289,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
+          git config --global --add safe.directory $(pwd)
           mkdir -p build
           bash ./utils/wasi-nn/install-pytorch.sh --disable-cxx11-abi
       - name: Build WASI-NN plugin
@@ -336,25 +312,24 @@ jobs:
             cp -f ${output_dir}/${output_bin} ${output_bin}
             tar -zcvf plugin_${plugin_array[$i]}.tar.gz ${output_bin}
           done
+      - name: Install gh on manylinux
+        run: |
+          type -p yum-config-manager >/dev/null || sudo yum install yum-utils
+          yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+          yum install -y gh
       - name: Upload WasmEdge wasi_nn-pytorch plugin tar.gz package
         if: contains(matrix.docker_tag, 'manylinux2014_x86_64')
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasi_nn-pytorch.tar.gz
-          asset_name: WasmEdge-plugin-wasi_nn-pytorch-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasi_nn-pytorch.tar.gz WasmEdge-plugin-wasi_nn-pytorch-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasi_nn-pytorch-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz --clobber
       - name: Upload WasmEdge wasi_nn-tensorflowlite plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasi_nn-tensorflowlite.tar.gz
-          asset_name: WasmEdge-plugin-wasi_nn-tensorflowlite-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasi_nn-tensorflowlite.tar.gz WasmEdge-plugin-wasi_nn-tensorflowlite-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasi_nn-tensorflowlite-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz --clobber
 
   build_and_upload_plugin_manylinux:
     strategy:
@@ -383,6 +358,7 @@ jobs:
           fetch-depth: 0
       - name: Build and install dependencies
         run: |
+          git config --global --add safe.directory $(pwd)
           yum update -y
           yum install -y zlib-devel zlib-static
           bash ./utils/wasi-crypto/build-openssl.sh
@@ -410,60 +386,47 @@ jobs:
             cp ${output_prefix}/${plugin_array[$i]}/${outbin_array[$i]} ${outbin_array[$i]}
             tar -zcvf plugin_${plugin_array[$i]}.tar.gz ${outbin_array[$i]}
           done
+      - name: Install gh on manylinux
+        run: |
+          type -p yum-config-manager >/dev/null || sudo yum install yum-utils
+          yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+          yum install -y gh
       - name: Upload wasi_crypto plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasi_crypto.tar.gz
-          asset_name: WasmEdge-plugin-wasi_crypto-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasi_crypto.tar.gz WasmEdge-plugin-wasi_crypto-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasi_crypto-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz --clobber
       - name: Upload wasi_logging plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasi_logging.tar.gz
-          asset_name: WasmEdge-plugin-wasi_logging-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasi_logging.tar.gz WasmEdge-plugin-wasi_logging-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasi_logging-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz --clobber
       - name: Upload wasmedge_process plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasmedge_process.tar.gz
-          asset_name: WasmEdge-plugin-wasmedge_process-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasmedge_process.tar.gz WasmEdge-plugin-wasmedge_process-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_process-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz --clobber
       - name: Upload wasmedge_tensorflow plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasmedge_tensorflow.tar.gz
-          asset_name: WasmEdge-plugin-wasmedge_tensorflow-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasmedge_tensorflow.tar.gz WasmEdge-plugin-wasmedge_tensorflow-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_tensorflow-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz --clobber
       - name: Upload wasmedge_tensorflowlite plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasmedge_tensorflowlite.tar.gz
-          asset_name: WasmEdge-plugin-wasmedge_tensorflowlite-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasmedge_tensorflowlite.tar.gz WasmEdge-plugin-wasmedge_tensorflowlite-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_tensorflowlite-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz --clobber
       - name: Upload wasmedge_image plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasmedge_image.tar.gz
-          asset_name: WasmEdge-plugin-wasmedge_image-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasmedge_image.tar.gz WasmEdge-plugin-wasmedge_image-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_image-${{ needs.create_release.outputs.version }}-${{ matrix.docker_tag }}.tar.gz --clobber
 
   build_and_upload_plugin_macos:
     strategy:
@@ -492,6 +455,7 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         run: |
+          git config --global --add safe.directory $(pwd)
           brew install llvm ninja cmake openssl
       - name: Build plugins
         shell: bash
@@ -521,50 +485,35 @@ jobs:
             tar -zcvf plugin_${plugin_array[$i]}.tar.gz ${outbin_array[$i]}
           done
       - name: Upload wasi_crypto plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasi_crypto.tar.gz
-          asset_name: WasmEdge-plugin-wasi_crypto-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasi_crypto.tar.gz WasmEdge-plugin-wasi_crypto-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasi_crypto-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz --clobber
       - name: Upload wasi_logging plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasi_logging.tar.gz
-          asset_name: WasmEdge-plugin-wasi_logging-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasi_logging.tar.gz WasmEdge-plugin-wasi_logging-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasi_logging-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz --clobber
       - name: Upload wasmedge_tensorflow plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasmedge_tensorflow.tar.gz
-          asset_name: WasmEdge-plugin-wasmedge_tensorflow-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasmedge_tensorflow.tar.gz WasmEdge-plugin-wasmedge_tensorflow-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_tensorflow-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz --clobber
       - name: Upload wasmedge_tensorflowlite plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasmedge_tensorflowlite.tar.gz
-          asset_name: WasmEdge-plugin-wasmedge_tensorflowlite-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasmedge_tensorflowlite.tar.gz WasmEdge-plugin-wasmedge_tensorflowlite-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_tensorflowlite-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz --clobber
       - name: Upload wasmedge_image plugin tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: plugin_wasmedge_image.tar.gz
-          asset_name: WasmEdge-plugin-wasmedge_image-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv plugin_wasmedge_image.tar.gz WasmEdge-plugin-wasmedge_image-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_image-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz --clobber
 
   build_manylinux2014_runtime_only:
     name: Build runtime only on manylinux2014 platform
@@ -577,21 +526,24 @@ jobs:
         uses: actions/checkout@v3
       - name: Build runtime only manylinux2014 package
         run: |
+          git config --global --add safe.directory $(pwd)
           bash utils/docker/build-manylinux.sh -DWASMEDGE_BUILD_AOT_RUNTIME=OFF
       - name: Upload ${{ matrix.name }} tar.gz package to artifact
         uses: actions/upload-artifact@v3
         with:
           name: build_manylinux2014_runtime_only
           path: build/WasmEdge-${{ needs.create_release.outputs.version }}-Linux.tar.gz
+      - name: Install gh on manylinux
+        run: |
+          type -p yum-config-manager >/dev/null || sudo yum install yum-utils
+          yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+          yum install -y gh
       - name: Upload ${{ matrix.name }} tar.gz package
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: build/WasmEdge-${{ needs.create_release.outputs.version }}-Linux.tar.xz
-          asset_name: WasmEdge-runtime-only-${{ needs.create_release.outputs.version }}-manylinux2014_x86_64.tar.xz
-          asset_content_type: application/x-gzip
+        run: |
+          mv build/WasmEdge-${{ needs.create_release.outputs.version }}-Linux.tar.xz WasmEdge-runtime-only-${{ needs.create_release.outputs.version }}-manylinux2014_x86_64.tar.xz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-runtime-only-${{ needs.create_release.outputs.version }}-manylinux2014_x86_64.tar.xz --clobber
 
   build_docker_slim_images:
     strategy:
@@ -617,6 +569,7 @@ jobs:
           path: utils/docker
       - name: Install requirements
         run: |
+          git config --global --add safe.directory $(pwd)
           curl -sL https://raw.githubusercontent.com/slimtoolkit/slim/master/scripts/install-slim.sh | sudo -E bash -
       - name: Prepare docker env
         id: docker_env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,10 +109,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Grant the safe directory for git
+        run: |
+          git config --global --add safe.directory $(pwd)
       - name: Install dependencies
         shell: bash
         run: |
-          git config --global --add safe.directory $(pwd)
           apt update
           apt install unzip
           bash utils/wasi-nn/install-openvino.sh
@@ -181,9 +183,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install dependencies
+      - name: Grant the safe directory for git
         run: |
           git config --global --add safe.directory $(pwd)
+      - name: Install dependencies
+        run: |
           apt update
           apt install -y libssl-dev
       - name: Build plugins
@@ -286,10 +290,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Grant the safe directory for git
+        run: |
+          git config --global --add safe.directory $(pwd)
       - name: Install dependencies
         shell: bash
         run: |
-          git config --global --add safe.directory $(pwd)
           mkdir -p build
           bash ./utils/wasi-nn/install-pytorch.sh --disable-cxx11-abi
       - name: Build WASI-NN plugin
@@ -356,9 +362,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Build and install dependencies
+      - name: Grant the safe directory for git
         run: |
           git config --global --add safe.directory $(pwd)
+      - name: Build and install dependencies
+        run: |
           yum update -y
           yum install -y zlib-devel zlib-static
           bash ./utils/wasi-crypto/build-openssl.sh
@@ -455,9 +463,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install dependencies
+      - name: Grant the safe directory for git
         run: |
           git config --global --add safe.directory $(pwd)
+      - name: Install dependencies
+        run: |
           brew install llvm ninja cmake openssl
       - name: Build plugins
         shell: bash
@@ -526,9 +536,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Build runtime only manylinux2014 package
+      - name: Grant the safe directory for git
         run: |
           git config --global --add safe.directory $(pwd)
+      - name: Build runtime only manylinux2014 package
+        run: |
           bash utils/docker/build-manylinux.sh -DWASMEDGE_BUILD_AOT_RUNTIME=OFF
       - name: Upload ${{ matrix.name }} tar.gz package to artifact
         uses: actions/upload-artifact@v3
@@ -569,9 +581,11 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: utils/docker
-      - name: Install requirements
+      - name: Grant the safe directory for git
         run: |
           git config --global --add safe.directory $(pwd)
+      - name: Install requirements
+        run: |
           curl -sL https://raw.githubusercontent.com/slimtoolkit/slim/master/scripts/install-slim.sh | sudo -E bash -
       - name: Prepare docker env
         id: docker_env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,10 +436,12 @@ jobs:
             system: MacOS 11
             host_runner: macos-11
             darwin_version: darwin_20
+            arch: x86_64
           - name: Plugins_MacOS_aarch64
             system: MacOS 13 (aarch64)
             host_runner: mac-arm64
             darwin_version: darwin_22
+            arch: aarch64
     name: Build and upload plugins on ${{ matrix.system }}
     runs-on: ${{ matrix.host_runner }}
     env:
@@ -488,32 +490,32 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mv plugin_wasi_crypto.tar.gz WasmEdge-plugin-wasi_crypto-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz
-          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasi_crypto-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz --clobber
+          mv plugin_wasi_crypto.tar.gz WasmEdge-plugin-wasi_crypto-${{ needs.create_release.outputs.version }}-darwin_${{ matrix.arch }}.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasi_crypto-${{ needs.create_release.outputs.version }}-darwin_${{ matrix.arch }}.tar.gz --clobber
       - name: Upload wasi_logging plugin tar.gz package
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mv plugin_wasi_logging.tar.gz WasmEdge-plugin-wasi_logging-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz
-          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasi_logging-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz --clobber
+          mv plugin_wasi_logging.tar.gz WasmEdge-plugin-wasi_logging-${{ needs.create_release.outputs.version }}-darwin_${{ matrix.arch }}.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasi_logging-${{ needs.create_release.outputs.version }}-darwin_${{ matrix.arch }}.tar.gz --clobber
       - name: Upload wasmedge_tensorflow plugin tar.gz package
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mv plugin_wasmedge_tensorflow.tar.gz WasmEdge-plugin-wasmedge_tensorflow-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz
-          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_tensorflow-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz --clobber
+          mv plugin_wasmedge_tensorflow.tar.gz WasmEdge-plugin-wasmedge_tensorflow-${{ needs.create_release.outputs.version }}-darwin_${{ matrix.arch }}.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_tensorflow-${{ needs.create_release.outputs.version }}-darwin_${{ matrix.arch }}.tar.gz --clobber
       - name: Upload wasmedge_tensorflowlite plugin tar.gz package
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mv plugin_wasmedge_tensorflowlite.tar.gz WasmEdge-plugin-wasmedge_tensorflowlite-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz
-          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_tensorflowlite-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz --clobber
+          mv plugin_wasmedge_tensorflowlite.tar.gz WasmEdge-plugin-wasmedge_tensorflowlite-${{ needs.create_release.outputs.version }}-darwin_${{ matrix.arch }}.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_tensorflowlite-${{ needs.create_release.outputs.version }}-darwin_${{ matrix.arch }}.tar.gz --clobber
       - name: Upload wasmedge_image plugin tar.gz package
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mv plugin_wasmedge_image.tar.gz WasmEdge-plugin-wasmedge_image-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz
-          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_image-${{ needs.create_release.outputs.version }}-darwin_x86_64.tar.gz --clobber
+          mv plugin_wasmedge_image.tar.gz WasmEdge-plugin-wasmedge_image-${{ needs.create_release.outputs.version }}-darwin_${{ matrix.arch }}.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_image-${{ needs.create_release.outputs.version }}-darwin_${{ matrix.arch }}.tar.gz --clobber
 
   build_manylinux2014_runtime_only:
     name: Build runtime only on manylinux2014 platform

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,8 @@ jobs:
     uses: ./.github/workflows/reusable-build-on-macos.yml
     with:
       version: ${{ needs.create_release.outputs.version }}
-      matrix: "[{'name':'MacOS 11 (x86_64)','runner':'macos-11','darwin_version':20},
-                {'name':'MacOS 13 (arm64)','runner':'mac-arm64','darwin_version':22}]"
+      matrix: "[{'name':'MacOS 11 (x86_64)','runner':'macos-11','darwin_version':20,'arch':'x86_64'},
+                {'name':'MacOS 13 (arm64)','runner':'mac-arm64','darwin_version':22,'arch':'aarch64'}]"
       release: true
     secrets: inherit
 

--- a/.github/workflows/reusable-build-on-android.yml
+++ b/.github/workflows/reusable-build-on-android.yml
@@ -46,11 +46,14 @@ jobs:
           path: build/WasmEdge-${{ inputs.version }}-Android.tar.gz
       - name: Upload tar.gz package
         if: ${{ inputs.release }}
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ inputs.upload_asset_url }}
-          asset_name: WasmEdge-${{ inputs.version }}-android_aarch64.tar.gz
-          asset_path: build/WasmEdge-${{ inputs.version }}-Android.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          type -p curl >/dev/null || (apt update && apt install curl -y)
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+          && apt update \
+          && apt install gh -y
+          mv build/WasmEdge-${{ inputs.version }}-Android.tar.gz WasmEdge-${{ inputs.version }}-android_aarch64.tar.gz
+          gh release upload ${{ inputs.version }} WasmEdge-${{ inputs.version }}-android_aarch64.tar.gz --clobber

--- a/.github/workflows/reusable-build-on-android.yml
+++ b/.github/workflows/reusable-build-on-android.yml
@@ -31,9 +31,11 @@ jobs:
           cp -r cmake-3.22.2-linux-x86_64/share /usr/local
           curl -sLO https://dl.google.com/android/repository/android-ndk-r23b-linux.zip
           unzip -q android-ndk-r23b-linux.zip
-      - name: Build WasmEdge
+      - name: Grant the safe directory for git
         run: |
           git config --global --add safe.directory $(pwd)
+      - name: Build WasmEdge
+        run: |
           export ANDROID_NDK_HOME=$(pwd)/android-ndk-r23b/
           cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_PACKAGE="TGZ" -DWASMEDGE_BUILD_AOT_RUNTIME=OFF -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=23 -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a -DCMAKE_ANDROID_NDK=$ANDROID_NDK_HOME -DCMAKE_ANDROID_STL_TYPE=c++_static
           cmake --build build

--- a/.github/workflows/reusable-build-on-fedora.yml
+++ b/.github/workflows/reusable-build-on-fedora.yml
@@ -25,9 +25,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Build WasmEdge
+      - name: Grant the safe directory for git
         run: |
           git config --global --add safe.directory $(pwd)
+      - name: Build WasmEdge
+        run: |
           cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_PACKAGE="TGZ;DEB;RPM" .
           cmake --build build
       - name: Test WasmEdge

--- a/.github/workflows/reusable-build-on-macos.yml
+++ b/.github/workflows/reusable-build-on-macos.yml
@@ -11,8 +11,6 @@ on:
         required: true
       release:
         type: boolean
-      upload_asset_url:
-        type: string
 
 jobs:
   build_on_macos:
@@ -80,11 +78,8 @@ jobs:
           path: build/WasmEdge-${{ inputs.version }}-Darwin.tar.gz
       - name: Upload package tarball
         if: ${{ inputs.release }}
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ inputs.upload_asset_url }}
-          asset_name: WasmEdge-${{ inputs.version }}-darwin_x86_64.tar.gz
-          asset_path: build/WasmEdge-${{ inputs.version }}-Darwin.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv build/WasmEdge-${{ inputs.version }}-Darwin.tar.gz WasmEdge-${{ inputs.version }}-darwin_x86_64.tar.gz
+          gh release upload ${{ inputs.version }} WasmEdge-${{ inputs.version }}-darwin_x86_64.tar.gz --clobber

--- a/.github/workflows/reusable-build-on-macos.yml
+++ b/.github/workflows/reusable-build-on-macos.yml
@@ -74,12 +74,12 @@ jobs:
         if: ${{ !inputs.release }}
         uses: actions/upload-artifact@v3
         with:
-          name: WasmEdge-${{ inputs.version }}-darwin_${{ matrix.darwin_version }}_x86_64.tar.gz
+          name: WasmEdge-${{ inputs.version }}-darwin_${{ matrix.darwin_version }}_${{ matrix.arch }}.tar.gz
           path: build/WasmEdge-${{ inputs.version }}-Darwin.tar.gz
       - name: Upload package tarball
         if: ${{ inputs.release }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mv build/WasmEdge-${{ inputs.version }}-Darwin.tar.gz WasmEdge-${{ inputs.version }}-darwin_x86_64.tar.gz
-          gh release upload ${{ inputs.version }} WasmEdge-${{ inputs.version }}-darwin_x86_64.tar.gz --clobber
+          mv build/WasmEdge-${{ inputs.version }}-Darwin.tar.gz WasmEdge-${{ inputs.version }}-darwin_${{ matrix.arch }}.tar.gz
+          gh release upload ${{ inputs.version }} WasmEdge-${{ inputs.version }}-darwin_${{ matrix.arch }}.tar.gz --clobber

--- a/.github/workflows/reusable-build-on-manylinux.yml
+++ b/.github/workflows/reusable-build-on-manylinux.yml
@@ -11,8 +11,6 @@ on:
         required: true
       release:
         type: boolean
-      upload_asset_url:
-        type: string
 
 jobs:
   build_on_manylinux:
@@ -36,39 +34,30 @@ jobs:
         with:
           path: build/WasmEdge-${{ inputs.version }}-Linux.tar.gz
           name: WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.tar.gz
+      - name: Install gh on manylinux
+        if: ${{ inputs.release }}
+        run: |
+          type -p yum-config-manager >/dev/null || sudo yum install yum-utils
+          yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+          yum install -y gh
       - name: Upload rpm package
         if: ${{ inputs.release }}
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ inputs.upload_asset_url }}
-          asset_path: build/WasmEdge-${{ inputs.version }}-Linux.rpm
-          asset_name: WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.rpm
-          asset_content_type: application/x-rpm
-      - name: Sleep 5 second to avoid GitHub ECONNRESET error
         run: |
-          sleep 5
+          mv build/WasmEdge-${{ inputs.version }}-Linux.rpm WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.rpm
+          gh release upload ${{ inputs.version }} WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.rpm --clobber
       - name: Upload tar.gz package
         if: ${{ inputs.release }}
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ inputs.upload_asset_url }}
-          asset_path: build/WasmEdge-${{ inputs.version }}-Linux.tar.gz
-          asset_name: WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.tar.gz
-          asset_content_type: application/x-gzip
-      - name: Sleep 5 second to avoid GitHub ECONNRESET error
         run: |
-          sleep 5
+          mv build/WasmEdge-${{ inputs.version }}-Linux.tar.gz WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.tar.gz
+          gh release upload ${{ inputs.version }} WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.tar.gz --clobber
       - name: Upload tar.xz package
         if: ${{ inputs.release }}
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ inputs.upload_asset_url }}
-          asset_path: build/WasmEdge-${{ inputs.version }}-Linux.tar.xz
-          asset_name: WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.tar.xz
-          asset_content_type: application/x-xz
+        run: |
+          mv build/WasmEdge-${{ inputs.version }}-Linux.tar.xz WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.tar.xz
+          gh release upload ${{ inputs.version }} WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.tar.xz --clobber

--- a/.github/workflows/reusable-build-on-ubuntu.yml
+++ b/.github/workflows/reusable-build-on-ubuntu.yml
@@ -11,8 +11,6 @@ on:
         required: true
       release:
         type: boolean
-      upload_asset_url:
-        type: string
 
 jobs:
   build_on_ubuntu:
@@ -72,14 +70,17 @@ jobs:
           path: build/WasmEdge-${{ inputs.version }}-Linux.tar.gz
       - name: Upload package tarball
         if: ${{ inputs.release }}
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ inputs.upload_asset_url }}
-          asset_path: build/WasmEdge-${{ inputs.version }}-Linux.tar.gz
-          asset_name: WasmEdge-${{ inputs.version }}-ubuntu20.04_x86_64.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          type -p curl >/dev/null || (apt update && apt install curl -y)
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+          && apt update \
+          && apt install gh -y
+          mv build/WasmEdge-${{ inputs.version }}-Linux.tar.gz WasmEdge-${{ inputs.version }}-ubuntu20.04_x86_64.tar.gz
+          gh release upload ${{ inputs.version }} WasmEdge-${{ inputs.version }}-ubuntu20.04_x86_64.tar.gz --clobber
       - name: Create and upload coverage report to Codecov
         if: ${{ matrix.coverage }}
         uses: codecov/codecov-action@v3

--- a/.github/workflows/reusable-build-on-ubuntu.yml
+++ b/.github/workflows/reusable-build-on-ubuntu.yml
@@ -31,13 +31,15 @@ jobs:
         if: ${{ matrix.tests }}
         run: |
           echo "BUILD_TESTS=ON" | tee -a $GITHUB_ENV
+      - name: Grant the safe directory for git
+        run: |
+          git config --global --add safe.directory $(pwd)
       - name: Build WasmEdge using ${{ matrix.compiler }} with ${{ matrix.build_type }} mode
         if: ${{ ! matrix.coverage }}
         shell: bash
         env:
           CMAKE_BUILD_TYPE: ${{ matrix.build_type }}
         run: |
-          git config --global --add safe.directory $(pwd)
           if [[ "${{ matrix.compiler }}" == "clang++" ]]; then
             cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DWASMEDGE_LINK_LLVM_STATIC=ON -DWASMEDGE_BUILD_TESTS=$BUILD_TESTS -DWASMEDGE_BUILD_PACKAGE="TGZ" ${{ matrix.options }} .
           else
@@ -58,7 +60,6 @@ jobs:
         run: |
           apt update
           apt install -y gcovr
-          git config --global --add safe.directory $(pwd)
           cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_COVERAGE=ON .
           cmake --build build
           LD_LIBRARY_PATH=$(pwd)/build/lib/api cmake --build build --target codecov

--- a/.github/workflows/reusable-build-on-windows.yml
+++ b/.github/workflows/reusable-build-on-windows.yml
@@ -8,8 +8,6 @@ on:
         required: true
       release:
         type: boolean
-      upload_asset_url:
-        type: string
 
 jobs:
   build_on_windows:
@@ -84,21 +82,15 @@ jobs:
           path: build\\WasmEdge-${{ env.product_version }}-windows.msi
       - name: Upload Windows 10 zip package
         if: ${{ inputs.release }}
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ inputs.upload_asset_url }}
-          asset_name: WasmEdge-${{ inputs.version }}-windows.zip
-          asset_path: build\\WasmEdge-${{ inputs.version }}-Windows.zip
-          asset_content_type: application/zip
+        run: |
+          mv build\\WasmEdge-${{ inputs.version }}-Windows.zip WasmEdge-${{ inputs.version }}-windows.zip
+          gh release upload ${{ inputs.version }} WasmEdge-${{ inputs.version }}-windows.zip --clobber
       - name: Upload Windows installer
         if: ${{ inputs.release }}
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ inputs.upload_asset_url }}
-          asset_name: WasmEdge-${{ env.product_version }}-windows.msi
-          asset_path: build\\WasmEdge-${{ env.product_version }}-windows.msi
-          asset_content_type: application/octet-stream
+        run: |
+          mv build\\WasmEdge-${{ env.product_version }}-windows.msi WasmEdge-${{ env.product_version }}-windows.msi
+          gh release upload ${{ inputs.version }} WasmEdge-${{ env.product_version }}-windows.msi --clobber

--- a/.github/workflows/reusable-create-source-tarball.yml
+++ b/.github/workflows/reusable-create-source-tarball.yml
@@ -8,8 +8,6 @@ on:
         required: true
       release:
         type: boolean
-      upload_asset_url:
-        type: string
 
 jobs:
   create_source_tarball:
@@ -42,11 +40,8 @@ jobs:
           path: WasmEdge-${{ inputs.version }}.tar.gz
       - name: Upload source tarball
         if: ${{ inputs.release }} # Only for release
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ inputs.upload_asset_url }}
-          asset_name: WasmEdge-${{ inputs.version }}-src.tar.gz
-          asset_path: WasmEdge-${{ inputs.version }}.tar.gz
-          asset_content_type: application/x-gzip
+        run: |
+          mv WasmEdge-${{ inputs.version }}.tar.gz WasmEdge-${{ inputs.version }}-src.tar.gz
+          gh release upload ${{ inputs.version }} WasmEdge-${{ inputs.version }}-src.tar.gz --clobber


### PR DESCRIPTION
`actions/create-release` and `actions/upload-release-asset` are deprecated workflow actions. Since GitHub no longer maintains them, some existing issues will never be fixed in the future.
To resolve this problem, we decide to use `gh`, the GitHub CLI tool, instead.