### PR TITLE
[CI] Use arm64 arch name on macOS instead of aarch64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
       version: ${{ needs.get_version_v2.outputs.version }}
       matrix: "[{'name':'MacOS 11 (x86_64)','runner':'macos-11','darwin_version':20,'arch':'x86_64'},
                 {'name':'MacOS 12 (x86_64)','runner':'macos-12','darwin_version':21,'arch':'x86_64'},
-                {'name':'MacOS 13 (arm64)','runner':'mac-arm64','darwin_version':22,'arch':'aarch64'}]"
+                {'name':'MacOS 13 (arm64)','runner':'mac-arm64','darwin_version':22,'arch':'arm64'}]"
 
   build_on_manylinux_2014:
     needs: [get_version_v2, lint]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     with:
       version: ${{ needs.create_release.outputs.version }}
       matrix: "[{'name':'MacOS 11 (x86_64)','runner':'macos-11','darwin_version':20,'arch':'x86_64'},
-                {'name':'MacOS 13 (arm64)','runner':'mac-arm64','darwin_version':22,'arch':'aarch64'}]"
+                {'name':'MacOS 13 (arm64)','runner':'mac-arm64','darwin_version':22,'arch':'arm64'}]"
       release: true
     secrets: inherit
 
@@ -445,11 +445,11 @@ jobs:
             host_runner: macos-11
             darwin_version: darwin_20
             arch: x86_64
-          - name: Plugins_MacOS_aarch64
-            system: MacOS 13 (aarch64)
+          - name: Plugins_MacOS_arm64
+            system: MacOS 13 (arm64)
             host_runner: mac-arm64
             darwin_version: darwin_22
-            arch: aarch64
+            arch: arm64
     name: Build and upload plugins on ${{ matrix.system }}
     runs-on: ${{ matrix.host_runner }}
     env:


### PR DESCRIPTION
Fixes #2641 