### PR TITLE
[WASI]: Unify the write and the read function.

### DIFF
--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -1203,6 +1203,7 @@ public:
   using VPoller::clock;
   using VPoller::error;
   using VPoller::prepare;
+  using VPoller::process;
   using VPoller::reset;
   using VPoller::result;
   using VPoller::VPoller;
@@ -1239,6 +1240,24 @@ public:
       VPoller::error(UserData, __WASI_ERRNO_BADF, __WASI_EVENTTYPE_FD_WRITE);
     } else {
       VPoller::write(Node, Trigger, UserData);
+    }
+  }
+
+  void process(__wasi_fd_t Fd, TriggerType Trigger, bool ReadFlag,
+               bool WriteFlag, __wasi_userdata_t ReadUserData,
+               __wasi_userdata_t WriteUserData) noexcept {
+    if (auto Node = env().getNodeOrNull(Fd); unlikely(!Node)) {
+      if (ReadFlag) {
+        VPoller::error(ReadUserData, __WASI_ERRNO_BADF,
+                       __WASI_EVENTTYPE_FD_READ);
+      }
+      if (WriteFlag) {
+        VPoller::error(WriteUserData, __WASI_ERRNO_BADF,
+                       __WASI_EVENTTYPE_FD_WRITE);
+      }
+    } else {
+      VPoller::process(Node, Trigger, ReadFlag, WriteFlag, ReadUserData,
+                       WriteUserData);
     }
   }
 

--- a/include/host/wasi/inode.h
+++ b/include/host/wasi/inode.h
@@ -876,13 +876,9 @@ public:
   /// Concurrently poll for events.
   void wait() noexcept;
 
-#if WASMEDGE_OS_LINUX
-  void process(const INode &Fd [[maybe_unused]],
-               TriggerType Trigger [[maybe_unused]],
-               bool ReadFlag [[maybe_unused]], bool WriteFlag [[maybe_unused]],
-               __wasi_userdata_t ReadUserData [[maybe_unused]],
-               __wasi_userdata_t WriteUserData [[maybe_unused]]) noexcept;
-#endif
+  void process(const INode &Fd, TriggerType Trigger, bool ReadFlag,
+               bool WriteFlag, __wasi_userdata_t ReadUserData,
+               __wasi_userdata_t WriteUserData) noexcept;
 
   /// Return number of events.
   ///

--- a/include/host/wasi/inode.h
+++ b/include/host/wasi/inode.h
@@ -876,6 +876,14 @@ public:
   /// Concurrently poll for events.
   void wait() noexcept;
 
+#if WASMEDGE_OS_LINUX
+  void process(const INode &Fd [[maybe_unused]],
+               TriggerType Trigger [[maybe_unused]],
+               bool ReadFlag [[maybe_unused]], bool WriteFlag [[maybe_unused]],
+               __wasi_userdata_t ReadUserData [[maybe_unused]],
+               __wasi_userdata_t WriteUserData [[maybe_unused]]) noexcept;
+#endif
+
   /// Return number of events.
   ///
   /// @return Number of event occurred

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -1598,13 +1598,9 @@ void Poller::clock(__wasi_clockid_t Clock, __wasi_timestamp_t Timeout,
   }
 }
 
-void Poller::process(const INode &Node [[maybe_unused]],
-                     TriggerType Trigger [[maybe_unused]],
-                     bool ReadFlag [[maybe_unused]],
-                     bool WriteFlag [[maybe_unused]],
-                     __wasi_userdata_t ReadUserData [[maybe_unused]],
-                     __wasi_userdata_t WriteUserData
-                     [[maybe_unused]]) noexcept {
+void Poller::process(const INode &Node, TriggerType Trigger, bool ReadFlag,
+                     bool WriteFlag, __wasi_userdata_t ReadUserData,
+                     __wasi_userdata_t WriteUserData) noexcept {
 
   if (ReadFlag && WriteFlag) {
     assuming(Events.size() < WasiEvents.size());

--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -1377,6 +1377,19 @@ void Poller::clock(__wasi_clockid_t, __wasi_timestamp_t Timeout,
   }
 }
 
+void Poller::process(const INode &Node, TriggerType Trigger, bool ReadFlag,
+                     bool WriteFlag, __wasi_userdata_t ReadUserData,
+                     __wasi_userdata_t WriteUserData) noexcept {
+  if (ReadFlag && WriteFlag) {
+    Poller::read(Node, Trigger, ReadUserData);
+    Poller::write(Node, Trigger, WriteUserData);
+  } else if (ReadFlag) {
+    Poller::read(Node, Trigger, ReadUserData);
+  } else if (WriteFlag) {
+    Poller::write(Node, Trigger, WriteUserData);
+  }
+}
+
 void Poller::read(const INode &Node, TriggerType Trigger,
                   __wasi_userdata_t UserData) noexcept {
   assuming(Events.size() < WasiEvents.size());

--- a/lib/host/wasi/inode-win.cpp
+++ b/lib/host/wasi/inode-win.cpp
@@ -2255,7 +2255,18 @@ void Poller::clock(__wasi_clockid_t Clock, __wasi_timestamp_t Timeout,
     MinimumTimeout = SysTimeout;
   }
 }
-
+void Poller::process(const INode &Node, TriggerType Trigger, bool ReadFlag,
+                     bool WriteFlag, __wasi_userdata_t ReadUserData,
+                     __wasi_userdata_t WriteUserData) noexcept {
+  if (ReadFlag && WriteFlag) {
+    Poller::read(Node, Trigger, ReadUserData);
+    Poller::write(Node, Trigger, WriteUserData);
+  } else if (ReadFlag) {
+    Poller::read(Node, Trigger, ReadUserData);
+  } else if (WriteFlag) {
+    Poller::write(Node, Trigger, WriteUserData);
+  }
+}
 void Poller::read(const INode &Node, TriggerType Trigger,
                   __wasi_userdata_t UserData) noexcept {
   if (Node.Type != HandleHolder::HandleType::NormalSocket ||


### PR DESCRIPTION
This PR trys to unify the read and write function to address the issue when using epoll.
The current implementation causes epoll being triggered endlessly.