### PR TITLE
[BUILDFIX] support fmtlib 10

### DIFF
--- a/include/executor/engine/atomic.ipp
+++ b/include/executor/engine/atomic.ipp
@@ -42,7 +42,7 @@ TypeT<T> Executor::runAtomicWaitOp(Runtime::StackManager &StackMgr,
 
   if (auto Res = atomicWait<T>(MemInst, Address, RawValue.get<T>(), Timeout);
       unlikely(!Res)) {
-    spdlog::error(Res.error());
+    spdlog::error(static_cast<uint32_t>(Res.error()));
     spdlog::error(
         ErrInfo::InfoInstruction(Instr.getOpCode(), Instr.getOffset()));
     return Unexpect(Res);

--- a/include/loader/loader.h
+++ b/include/loader/loader.h
@@ -105,14 +105,14 @@ private:
   /// @{
   inline auto logLoadError(ErrCode Code, uint64_t Off,
                            ASTNodeAttr Node) const noexcept {
-    spdlog::error(Code);
+    spdlog::error(static_cast<uint32_t>(Code));
     spdlog::error(ErrInfo::InfoLoading(Off));
     spdlog::error(ErrInfo::InfoAST(Node));
     return Unexpect(Code);
   }
   inline auto logNeedProposal(ErrCode Code, Proposal Prop, uint64_t Off,
                               ASTNodeAttr Node) const noexcept {
-    spdlog::error(Code);
+    spdlog::error(static_cast<uint32_t>(Code));
     spdlog::error(ErrInfo::InfoProposal(Prop));
     spdlog::error(ErrInfo::InfoLoading(Off));
     spdlog::error(ErrInfo::InfoAST(Node));

--- a/lib/executor/engine/threadInstr.cpp
+++ b/lib/executor/engine/threadInstr.cpp
@@ -36,7 +36,7 @@ Executor::runAtomicNotifyOp(Runtime::StackManager &StackMgr,
 
   uint32_t Count = RawCount.get<uint32_t>();
   if (auto Res = atomicNotify(MemInst, Address, Count); unlikely(!Res)) {
-    spdlog::error(Res.error());
+    spdlog::error(static_cast<uint32_t>(Res.error()));
     spdlog::error(
         ErrInfo::InfoInstruction(Instr.getOpCode(), Instr.getOffset()));
     return Unexpect(Res);

--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -80,7 +80,7 @@ Executor::enterFunction(Runtime::StackManager &StackMgr,
     if (!Ret) {
       if (Ret.error() == ErrCode::Value::HostFuncError ||
           Ret.error().getCategory() != ErrCategory::WASM) {
-        spdlog::error(Ret.error());
+        spdlog::error(static_cast<uint32_t>(Ret.error()));
       }
       return Unexpect(Ret);
     }
@@ -132,7 +132,7 @@ Executor::enterFunction(Runtime::StackManager &StackMgr,
       if (auto Err = ErrCode(static_cast<ErrCategory>(Code >> 24), Code);
           unlikely(Err != ErrCode::Value::Success)) {
         if (Err != ErrCode::Value::Terminated) {
-          spdlog::error(Err);
+          spdlog::error(static_cast<uint32_t>(Err));
         }
         return Unexpect(Err);
       }

--- a/lib/host/wasi/environ.cpp
+++ b/lib/host/wasi/environ.cpp
@@ -102,7 +102,7 @@ void Environ::init(Span<const std::string> Dirs, std::string ProgramName,
       if (auto Res = VINode::bind(BaseRights, InheritingRights,
                                   std::move(GuestDir), std::move(HostDir));
           unlikely(!Res)) {
-        spdlog::error("Bind guest directory failed:{}", Res.error());
+        spdlog::error("Bind guest directory failed:{}", static_cast<uint32_t>(Res.error()));
         continue;
       } else {
         PreopenedDirs.emplace_back(std::move(*Res));

--- a/lib/loader/ast/module.cpp
+++ b/lib/loader/ast/module.cpp
@@ -288,7 +288,7 @@ Expect<std::unique_ptr<AST::Module>> Loader::loadModule() {
     if (auto Res = Library->load(Mod->getAOTSection()); unlikely(!Res)) {
       spdlog::error("    AOT section -- library load failed:{} , use "
                     "interpreter mode instead.",
-                    Res.error());
+                    static_cast<uint32_t>(Res.error()));
       FallBackInterpreter = true;
     }
 

--- a/lib/loader/ast/section.cpp
+++ b/lib/loader/ast/section.cpp
@@ -78,7 +78,7 @@ Expect<void> Loader::loadSection(AST::FunctionSection &Sec) {
           if (auto Res = FMgr.readU32()) {
             FuncIdx = *Res;
           } else {
-            spdlog::error(Res.error());
+            spdlog::error(static_cast<uint32_t>(Res.error()));
             spdlog::error(ErrInfo::InfoLoading(FMgr.getLastOffset()));
             return Unexpect(Res);
           }
@@ -215,8 +215,8 @@ inline constexpr uint8_t HostArchType() noexcept {
 // to the interpreter mode with info level log.
 Expect<void> Loader::loadSection(FileMgr &VecMgr, AST::AOTSection &Sec) {
   if (auto Res = VecMgr.readU32(); unlikely(!Res)) {
-    spdlog::info(Res.error());
-    spdlog::info("    AOT binary version read error:{}", Res.error());
+    spdlog::info(static_cast<uint32_t>(Res.error()));
+    spdlog::info("    AOT binary version read error:{}", static_cast<uint32_t>(Res.error()));
     return Unexpect(Res);
   } else {
     Sec.setVersion(*Res);
@@ -228,8 +228,8 @@ Expect<void> Loader::loadSection(FileMgr &VecMgr, AST::AOTSection &Sec) {
   }
 
   if (auto Res = VecMgr.readByte(); unlikely(!Res)) {
-    spdlog::info(Res.error());
-    spdlog::info("    AOT os type read error:{}", Res.error());
+    spdlog::info(static_cast<uint32_t>(Res.error()));
+    spdlog::info("    AOT os type read error:{}", static_cast<uint32_t>(Res.error()));
     return Unexpect(Res);
   } else {
     Sec.setOSType(*Res);
@@ -241,8 +241,8 @@ Expect<void> Loader::loadSection(FileMgr &VecMgr, AST::AOTSection &Sec) {
   }
 
   if (auto Res = VecMgr.readByte(); unlikely(!Res)) {
-    spdlog::info(Res.error());
-    spdlog::info("    AOT arch type read error:{}", Res.error());
+    spdlog::info(static_cast<uint32_t>(Res.error()));
+    spdlog::info("    AOT arch type read error:{}", static_cast<uint32_t>(Res.error()));
     return Unexpect(Res);
   } else {
     Sec.setArchType(*Res);
@@ -254,22 +254,22 @@ Expect<void> Loader::loadSection(FileMgr &VecMgr, AST::AOTSection &Sec) {
   }
 
   if (auto Res = VecMgr.readU64(); unlikely(!Res)) {
-    spdlog::info(Res.error());
-    spdlog::info("    AOT version address read error:{}", Res.error());
+    spdlog::info(static_cast<uint32_t>(Res.error()));
+    spdlog::info("    AOT version address read error:{}", static_cast<uint32_t>(Res.error()));
     return Unexpect(Res);
   } else {
     Sec.setVersionAddress(*Res);
   }
   if (auto Res = VecMgr.readU64(); unlikely(!Res)) {
-    spdlog::info(Res.error());
-    spdlog::info("    AOT intrinsics address read error:{}", Res.error());
+    spdlog::info(static_cast<uint32_t>(Res.error()));
+    spdlog::info("    AOT intrinsics address read error:{}", static_cast<uint32_t>(Res.error()));
     return Unexpect(Res);
   } else {
     Sec.setIntrinsicsAddress(*Res);
   }
   if (auto Res = VecMgr.readU64(); unlikely(!Res)) {
-    spdlog::info(Res.error());
-    spdlog::info("    AOT types size read error:{}", Res.error());
+    spdlog::info(static_cast<uint32_t>(Res.error()));
+    spdlog::info("    AOT types size read error:{}", static_cast<uint32_t>(Res.error()));
     return Unexpect(Res);
   } else {
     const uint64_t Size = *Res;
@@ -282,16 +282,16 @@ Expect<void> Loader::loadSection(FileMgr &VecMgr, AST::AOTSection &Sec) {
   }
   for (size_t I = 0; I < Sec.getTypesAddress().size(); ++I) {
     if (auto Res = VecMgr.readU64(); unlikely(!Res)) {
-      spdlog::info(Res.error());
-      spdlog::info("    AOT type address read error:{}", Res.error());
+      spdlog::info(static_cast<uint32_t>(Res.error()));
+      spdlog::info("    AOT type address read error:{}", static_cast<uint32_t>(Res.error()));
       return Unexpect(Res);
     } else {
       Sec.getTypesAddress()[I] = *Res;
     }
   }
   if (auto Res = VecMgr.readU64(); unlikely(!Res)) {
-    spdlog::info(Res.error());
-    spdlog::info("    AOT code size read error:{}", Res.error());
+    spdlog::info(static_cast<uint32_t>(Res.error()));
+    spdlog::info("    AOT code size read error:{}", static_cast<uint32_t>(Res.error()));
     return Unexpect(Res);
   } else {
     const uint64_t Size = *Res;
@@ -304,8 +304,8 @@ Expect<void> Loader::loadSection(FileMgr &VecMgr, AST::AOTSection &Sec) {
   }
   for (size_t I = 0; I < Sec.getCodesAddress().size(); ++I) {
     if (auto Res = VecMgr.readU64(); unlikely(!Res)) {
-      spdlog::info(Res.error());
-      spdlog::info("    AOT code address read error:{}", Res.error());
+      spdlog::info(static_cast<uint32_t>(Res.error()));
+      spdlog::info("    AOT code address read error:{}", static_cast<uint32_t>(Res.error()));
       return Unexpect(Res);
     } else {
       const uint64_t Address = *Res;
@@ -314,8 +314,8 @@ Expect<void> Loader::loadSection(FileMgr &VecMgr, AST::AOTSection &Sec) {
   }
 
   if (auto Res = VecMgr.readU32(); unlikely(!Res)) {
-    spdlog::info(Res.error());
-    spdlog::info("    AOT section count read error:{}", Res.error());
+    spdlog::info(static_cast<uint32_t>(Res.error()));
+    spdlog::info("    AOT section count read error:{}", static_cast<uint32_t>(Res.error()));
     return Unexpect(Res);
   } else {
     const uint32_t Size = *Res;
@@ -329,30 +329,30 @@ Expect<void> Loader::loadSection(FileMgr &VecMgr, AST::AOTSection &Sec) {
 
   for (auto &Section : Sec.getSections()) {
     if (auto Res = VecMgr.readByte(); unlikely(!Res)) {
-      spdlog::info(Res.error());
-      spdlog::info("    AOT section type read error:{}", Res.error());
+      spdlog::info(static_cast<uint32_t>(Res.error()));
+      spdlog::info("    AOT section type read error:{}", static_cast<uint32_t>(Res.error()));
       return Unexpect(Res);
     } else {
       std::get<0>(Section) = *Res;
     }
     if (auto Res = VecMgr.readU64(); unlikely(!Res)) {
-      spdlog::info(Res.error());
-      spdlog::info("    AOT section offset read error:{}", Res.error());
+      spdlog::info(static_cast<uint32_t>(Res.error()));
+      spdlog::info("    AOT section offset read error:{}", static_cast<uint32_t>(Res.error()));
       return Unexpect(Res);
     } else {
       std::get<1>(Section) = *Res;
     }
     if (auto Res = VecMgr.readU64(); unlikely(!Res)) {
-      spdlog::info(Res.error());
-      spdlog::info("    AOT section size read error:{}", Res.error());
+      spdlog::info(static_cast<uint32_t>(Res.error()));
+      spdlog::info("    AOT section size read error:{}", static_cast<uint32_t>(Res.error()));
       return Unexpect(Res);
     } else {
       std::get<2>(Section) = *Res;
     }
     uint32_t ContentSize;
     if (auto Res = VecMgr.readU32(); unlikely(!Res)) {
-      spdlog::info(Res.error());
-      spdlog::info("    AOT section data size read error:{}", Res.error());
+      spdlog::info(static_cast<uint32_t>(Res.error()));
+      spdlog::info("    AOT section data size read error:{}", static_cast<uint32_t>(Res.error()));
       return Unexpect(Res);
     } else {
       ContentSize = *Res;
@@ -368,8 +368,8 @@ Expect<void> Loader::loadSection(FileMgr &VecMgr, AST::AOTSection &Sec) {
       }
     }
     if (auto Res = VecMgr.readBytes(ContentSize); unlikely(!Res)) {
-      spdlog::info(Res.error());
-      spdlog::info("    AOT section data read error:{}", Res.error());
+      spdlog::info(static_cast<uint32_t>(Res.error()));
+      spdlog::info("    AOT section data read error:{}", static_cast<uint32_t>(Res.error()));
       return Unexpect(Res);
     } else {
       std::get<3>(Section) = std::move(*Res);

--- a/lib/loader/loader.cpp
+++ b/lib/loader/loader.cpp
@@ -67,7 +67,7 @@ Loader::parseModule(const std::filesystem::path &FilePath) {
   std::lock_guard Lock(Mutex);
   // Set path and check the header.
   if (auto Res = FMgr.setPath(FilePath); !Res) {
-    spdlog::error(Res.error());
+    spdlog::error(static_cast<uint32_t>(Res.error()));
     spdlog::error(ErrInfo::InfoFile(FilePath));
     return Unexpect(Res);
   }

--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -19,7 +19,7 @@ namespace {
 // Helper function for printing error log of index out of range.
 auto logOutOfRange(ErrCode Code, ErrInfo::IndexCategory Cate, uint32_t Idx,
                    uint32_t Bound) {
-  spdlog::error(Code);
+  spdlog::error(static_cast<uint32_t>(Code));
   spdlog::error(ErrInfo::InfoForbidIndex(Cate, Idx, Bound));
   return Unexpect(Code);
 }


### PR DESCRIPTION
With fmtlib 10, fmt::format() does not handle WasmEdge::ErrCode as it is. Pass this class to cast operator so that fmtlib 10 can handle this.

Closes #2646 .