### PR TITLE
[Examples] Replace wasmedgec with wasmedge compile

### DIFF
--- a/examples/capi/mandelbrot-set-in-threads/Makefile
+++ b/examples/capi/mandelbrot-set-in-threads/Makefile
@@ -11,7 +11,7 @@ mandelbrot.wat: mandelbrot.wasm
 	wasm2wat --enable-all mandelbrot.wasm -o mandelbrot.wat
 
 mandelbrot.so: mandelbrot.wasm
-	wasmedgec --enable-threads mandelbrot.wasm mandelbrot.so
+	wasmedge compile --enable-threads mandelbrot.wasm mandelbrot.so
 
 main: main.cc
 	clang++ -lwasmedge -std=c++17 -pthread -o $@ $^

--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -61,7 +61,7 @@ WasmEdge
 3
 
 # Run it in the AOT mode
-$ wasmedgec hello.wasm hello.aot.wasm
+$ wasmedge compile hello.wasm hello.aot.wasm
 $ wasmedge hello.aot.wasm WasmEdge 1 2 3
 hello
 WasmEdge


### PR DESCRIPTION
Replace "wasmedgec" invocations with "wasmedge compile" per the recent WasmEdge tool unification.