### PR TITLE
[WASI] Fix blocking when multiple requests have the same fds.

### DIFF
--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -1249,8 +1249,7 @@ public:
   }
 
   void close(__wasi_fd_t Fd) noexcept {
-    if (auto Node = env().getNodeOrNull(Fd); unlikely(!Node)) {
-    } else {
+    if (auto Node = env().getNodeOrNull(Fd); likely(!!Node)) {
       VPoller::close(Node);
     }
   }

--- a/include/host/wasi/inode.h
+++ b/include/host/wasi/inode.h
@@ -873,6 +873,7 @@ public:
   void write(const INode &Fd, TriggerType Trigger,
              __wasi_userdata_t UserData) noexcept;
 
+  void fdClose(const INode &Fd) noexcept;
   /// Concurrently poll for events.
   void wait() noexcept;
 

--- a/include/host/wasi/inode.h
+++ b/include/host/wasi/inode.h
@@ -873,7 +873,7 @@ public:
   void write(const INode &Fd, TriggerType Trigger,
              __wasi_userdata_t UserData) noexcept;
 
-  void fdClose(const INode &Fd) noexcept;
+  void close(const INode &Fd) noexcept;
   /// Concurrently poll for events.
   void wait() noexcept;
 

--- a/include/host/wasi/vinode.h
+++ b/include/host/wasi/vinode.h
@@ -729,8 +729,8 @@ private:
 class VPoller : protected Poller {
 public:
   using Poller::clock;
+  using Poller::close;
   using Poller::error;
-  using Poller::fdClose;
   using Poller::ok;
   using Poller::Poller;
   using Poller::prepare;
@@ -760,9 +760,7 @@ public:
     }
   }
 
-  void fdClose(std::shared_ptr<VINode> Fd) noexcept {
-    Poller::fdClose(Fd->Node);
-  }
+  void close(std::shared_ptr<VINode> Fd) noexcept { Poller::close(Fd->Node); }
 };
 
 } // namespace WASI

--- a/include/host/wasi/vinode.h
+++ b/include/host/wasi/vinode.h
@@ -730,6 +730,7 @@ class VPoller : protected Poller {
 public:
   using Poller::clock;
   using Poller::error;
+  using Poller::fdClose;
   using Poller::ok;
   using Poller::Poller;
   using Poller::prepare;
@@ -757,6 +758,10 @@ public:
     } else {
       Poller::write(Fd->Node, Trigger, UserData);
     }
+  }
+
+  void fdClose(std::shared_ptr<VINode> Fd) noexcept {
+    Poller::fdClose(Fd->Node);
   }
 };
 

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -1598,7 +1598,7 @@ void Poller::clock(__wasi_clockid_t Clock, __wasi_timestamp_t Timeout,
   }
 }
 
-void Poller::fdClose(const INode &Node) noexcept {
+void Poller::close(const INode &Node) noexcept {
   FdDatas.erase(Node.Fd);
   OldFdDatas.erase(Node.Fd);
 }

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -1598,6 +1598,11 @@ void Poller::clock(__wasi_clockid_t Clock, __wasi_timestamp_t Timeout,
   }
 }
 
+void Poller::fdClose(const INode &Node) noexcept {
+  FdDatas.erase(Node.Fd);
+  OldFdDatas.erase(Node.Fd);
+}
+
 void Poller::read(const INode &Node, TriggerType Trigger,
                   __wasi_userdata_t UserData) noexcept {
   assuming(Events.size() < WasiEvents.size());

--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -1377,7 +1377,7 @@ void Poller::clock(__wasi_clockid_t, __wasi_timestamp_t Timeout,
   }
 }
 
-void Poller::fdClose(const INode &Node [[maybe_unused]]) noexcept {}
+void Poller::close(const INode &Node [[maybe_unused]]) noexcept {}
 
 void Poller::read(const INode &Node, TriggerType Trigger,
                   __wasi_userdata_t UserData) noexcept {

--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -1377,6 +1377,8 @@ void Poller::clock(__wasi_clockid_t, __wasi_timestamp_t Timeout,
   }
 }
 
+void Poller::fdClose(const INode &Node [[maybe_unused]]) noexcept {}
+
 void Poller::read(const INode &Node, TriggerType Trigger,
                   __wasi_userdata_t UserData) noexcept {
   assuming(Events.size() < WasiEvents.size());

--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -1377,7 +1377,7 @@ void Poller::clock(__wasi_clockid_t, __wasi_timestamp_t Timeout,
   }
 }
 
-void Poller::close(const INode &Node [[maybe_unused]]) noexcept {}
+void Poller::close(const INode &) noexcept {}
 
 void Poller::read(const INode &Node, TriggerType Trigger,
                   __wasi_userdata_t UserData) noexcept {

--- a/lib/host/wasi/inode-win.cpp
+++ b/lib/host/wasi/inode-win.cpp
@@ -2256,7 +2256,7 @@ void Poller::clock(__wasi_clockid_t Clock, __wasi_timestamp_t Timeout,
   }
 }
 
-void Poller::fdClose(const INode &Node [[maybe_unused]]) noexcept {}
+void Poller::close(const INode &Node [[maybe_unused]]) noexcept {}
 
 void Poller::read(const INode &Node, TriggerType Trigger,
                   __wasi_userdata_t UserData) noexcept {

--- a/lib/host/wasi/inode-win.cpp
+++ b/lib/host/wasi/inode-win.cpp
@@ -2256,7 +2256,7 @@ void Poller::clock(__wasi_clockid_t Clock, __wasi_timestamp_t Timeout,
   }
 }
 
-void Poller::close(const INode &Node [[maybe_unused]]) noexcept {}
+void Poller::close(const INode &) noexcept {}
 
 void Poller::read(const INode &Node, TriggerType Trigger,
                   __wasi_userdata_t UserData) noexcept {

--- a/lib/host/wasi/inode-win.cpp
+++ b/lib/host/wasi/inode-win.cpp
@@ -2256,6 +2256,8 @@ void Poller::clock(__wasi_clockid_t Clock, __wasi_timestamp_t Timeout,
   }
 }
 
+void Poller::fdClose(const INode &Node [[maybe_unused]]) noexcept {}
+
 void Poller::read(const INode &Node, TriggerType Trigger,
                   __wasi_userdata_t UserData) noexcept {
   if (Node.Type != HandleHolder::HandleType::NormalSocket ||

--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -560,6 +560,13 @@ Expect<uint32_t> WasiFdAllocate::body(const Runtime::CallingFrame &, int32_t Fd,
 Expect<uint32_t> WasiFdClose::body(const Runtime::CallingFrame &, int32_t Fd) {
   const __wasi_fd_t WasiFd = Fd;
 
+  if (auto Poll = this->Env.acquirePollerOnly(); unlikely(!Poll)) {
+  } else {
+    auto &Poller = *Poll;
+    Poller.fdClose(WasiFd);
+    this->Env.releasePoller(std::move(Poller));
+  }
+
   if (auto Res = Env.fdClose(WasiFd); unlikely(!Res)) {
     return Res.error();
   }

--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -560,11 +560,11 @@ Expect<uint32_t> WasiFdAllocate::body(const Runtime::CallingFrame &, int32_t Fd,
 Expect<uint32_t> WasiFdClose::body(const Runtime::CallingFrame &, int32_t Fd) {
   const __wasi_fd_t WasiFd = Fd;
 
-  Env.close(WasiFd);
-
   if (auto Res = Env.fdClose(WasiFd); unlikely(!Res)) {
     return Res.error();
   }
+
+  Env.close(WasiFd);
   return __WASI_ERRNO_SUCCESS;
 }
 

--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -560,7 +560,7 @@ Expect<uint32_t> WasiFdAllocate::body(const Runtime::CallingFrame &, int32_t Fd,
 Expect<uint32_t> WasiFdClose::body(const Runtime::CallingFrame &, int32_t Fd) {
   const __wasi_fd_t WasiFd = Fd;
 
-  this->Env.close(WasiFd);
+  Env.close(WasiFd);
 
   if (auto Res = Env.fdClose(WasiFd); unlikely(!Res)) {
     return Res.error();

--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -560,12 +560,7 @@ Expect<uint32_t> WasiFdAllocate::body(const Runtime::CallingFrame &, int32_t Fd,
 Expect<uint32_t> WasiFdClose::body(const Runtime::CallingFrame &, int32_t Fd) {
   const __wasi_fd_t WasiFd = Fd;
 
-  if (auto Poll = this->Env.acquirePollerOnly(); unlikely(!Poll)) {
-  } else {
-    auto &Poller = *Poll;
-    Poller.fdClose(WasiFd);
-    this->Env.releasePoller(std::move(Poller));
-  }
+  this->Env.close(WasiFd);
 
   if (auto Res = Env.fdClose(WasiFd); unlikely(!Res)) {
     return Res.error();


### PR DESCRIPTION
Fix this CI error. https://github.com/WasmEdge/wasmedge_hyper_demo/actions/runs/5511875753/jobs/10047996074

This PR remove the unused file descriptor from FdDatas when the socket is closed.