### PR TITLE
Add a flag to disable libtinfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ option(WASMEDGE_PLUGIN_PROCESS "Enable WasmEdge process plugin." OFF)
 option(WASMEDGE_PLUGIN_IMAGE "Enable WasmEdge image plugin." OFF)
 option(WASMEDGE_PLUGIN_TENSORFLOW "Enable WasmEdge TensorFlow plugin." OFF)
 option(WASMEDGE_PLUGIN_TENSORFLOWLITE "Enable WasmEdge TensorFlow-Lite plugin." OFF)
+option(WASMEDGE_DISABLE_LIBTINFO "Disable linking against libtinfo when linking LLVM" OFF)
 
 if(WASMEDGE_BUILD_TOOLS AND WASMEDGE_BUILD_FUZZING)
   message(FATAL_ERROR "wasmedge tool and fuzzing tool are exclusive options.")

--- a/cmake/Helper.cmake
+++ b/cmake/Helper.cmake
@@ -218,16 +218,18 @@ if((WASMEDGE_LINK_LLVM_STATIC OR WASMEDGE_BUILD_STATIC_LIB) AND WASMEDGE_BUILD_A
       # Therefore, libz and libtinfo can be statically linked.
       find_package(ZLIB REQUIRED)
       get_filename_component(ZLIB_PATH "${ZLIB_LIBRARIES}" DIRECTORY)
-      list(APPEND WASMEDGE_LLVM_LINK_STATIC_COMPONENTS
-        ${ZLIB_PATH}/libz.a
-        ${ZLIB_PATH}/libtinfo.a
-      )
+      list(APPEND WASMEDGE_LLVM_LINK_STATIC_COMPONENTS ${ZLIB_PATH}/libz.a)
+      if(NOT WASMEDGE_DISABLE_LIBTINFO)
+        list(APPEND WASMEDGE_LLVM_LINK_STATIC_COMPONENTS ${ZLIB_PATH}/libtinfo.a)
+      endif()
     else()
       # If not build static lib, dynamic link libz and libtinfo.
       list(APPEND WASMEDGE_LLVM_LINK_SHARED_COMPONENTS
         z
-        tinfo
       )
+      if(NOT WASMEDGE_DISABLE_LIBTINFO)
+        list(APPEND WASMEDGE_LLVM_LINK_SHARED_COMPONENTS tinfo)
+      endif()
     endif()
   endif()
 endif()


### PR DESCRIPTION
We build our libraries from source and libtinfo doesn't seem to be
required and isn't built in when we build zlib.

Add a cmake flag to disable needing that library
