### PR TITLE
Fixed build fail in Xcode

### DIFF
--- a/lib/host/wasi/CMakeLists.txt
+++ b/lib/host/wasi/CMakeLists.txt
@@ -17,6 +17,12 @@ wasmedge_add_library(wasmedgeHostModuleWasi
   ${WASMEDGE_WASI_SRCS}
 )
 
+if("${CMAKE_GENERATOR}" STREQUAL "Xcode")
+  target_compile_options(wasmedgeHostModuleWasi PRIVATE
+    -Wno-shorten-64-to-32
+  )
+endif()
+
 target_include_directories(wasmedgeHostModuleWasi
   PUBLIC
   ${PROJECT_SOURCE_DIR}/thirdparty


### PR DESCRIPTION
Fixed #2713

The patch allows the Xcode project generated by WasmEdge to be built successfully, which means it can be easily ported to the iOS platform.





