### PR TITLE
[AOT] Fix fallback impl of `compileVectorExtAddPairwise`.

### DIFF
--- a/lib/aot/compiler.cpp
+++ b/lib/aot/compiler.cpp
@@ -4376,8 +4376,10 @@ private:
           // If the XOP, SSSE3, or SSE2 is not supported on the x86_64 platform
           // or the NEON is not supported on the aarch64 platform,
           // then fallback to this.
-          const auto Width = LLContext.getInt32(
+          auto Width = LLVM::Value::getConstInt(
+              ExtTy.getElementType(),
               VectorTy.getElementType().getIntegerBitWidth());
+          Width = Builder.createVectorSplat(ExtTy.getVectorSize(), Width);
           auto EV = Builder.createBitCast(V, ExtTy);
           LLVM::Value L, R;
           if (Signed) {


### PR DESCRIPTION
LLVM vector shift operator (e.g., [ashr](https://llvm.org/docs/LangRef.html#ashr-instruction)) requires two operands of the same type. Use a `splat` instruction to convert the shift count to vector type.

The tests that cover this is passed because of the alternate implementation using SSE on x64_64. These implementations come before the fallback impl but guarded by feature checking (check for SSE on x64_64, NEON on aarch64). The problem is confirmed by removing other implementations (two `ifdef` parts in the same function) and rerun the tests.
![image](https://github.com/WasmEdge/WasmEdge/assets/23314210/2d52fa15-6f1f-40ef-abc4-8845c581710c)

After applying this fix, these tests are passed (still keep other impl removed). (Under Linux in docker image wasmedge/wasmedge:latest)
