### PR TITLE
[WASI-NN] PyTorch Backend - Fallback Error Message Correction for Tuple type Output Tensors

### DIFF
--- a/plugins/wasi_nn/torch.cpp
+++ b/plugins/wasi_nn/torch.cpp
@@ -146,8 +146,8 @@ Expect<ErrNo> compute(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
     auto OutTensor = RawOutput.toTensor();
     CxtRef.TorchOutputs.push_back(OutTensor.clone());
   } else {
-    spdlog::error("[WASI-NN] PyTorch backend only supports output a tensor "
-                  "or a list of tensor");
+    spdlog::error("[WASI-NN] PyTorch backend only supports output a tensor, "
+                  "a list of tensor or a tuple of tensor");
     return ErrNo::InvalidArgument;
   }
   return ErrNo::Success;


### PR DESCRIPTION
Correct fallback error message after adding support for tuple-type output tensors in PyTorch for Wasi-NN