### PR TITLE
[Test] add tests for wasi-nn ggml backend

### DIFF
--- a/test/plugins/wasi_nn/CMakeLists.txt
+++ b/test/plugins/wasi_nn/CMakeLists.txt
@@ -54,6 +54,16 @@ foreach(BACKEND ${WASMEDGE_PLUGIN_WASI_NN_BACKEND})
     if(NOT CHECKSUM_IMAGE STREQUAL "ad51c39cfe35d2ef35c4052b78cb3c55")
       message(FATAL_ERROR "downloaded bird.jpg fixture with wrong md5") 
     endif()
+  elseif(BACKEND STREQUAL "ggml")
+  message( STATUS "Download ML artifacts to ${CMAKE_CURRENT_BINARY_DIR}/wasinn_ggml_fixtures")
+    execute_process(
+      COMMAND bash ${CMAKE_SOURCE_DIR}/utils/wasi-nn/download-ggml-fixtures.sh ${CMAKE_CURRENT_BINARY_DIR}/wasinn_ggml_fixtures
+      RESULT_VARIABLE DOWNLOAD_ERROR
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    file(MD5 ${CMAKE_CURRENT_BINARY_DIR}/wasinn_ggml_fixtures/orca-mini-3b.ggmlv3.q4_0.bin CHECKSUM_MODEL)
+    if(NOT CHECKSUM_MODEL STREQUAL "6a087f7f4598fad0bb70e6cb4023645e")
+      message(FATAL_ERROR "orca-mini-3b.ggmlv3.q4_0.bin downloaded with wrong md5")
+    endif()
   else()
     # Add the other backend test files fetching here.
   endif()

--- a/utils/wasi-nn/download-ggml-fixtures.sh
+++ b/utils/wasi-nn/download-ggml-fixtures.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# SPDX-FileCopyrightText: 2019-2023 Second State INC
+
+TODIR=$1
+if [[ $# -eq 0 ]]; then
+    TODIR=.
+fi
+MODEL=orca-mini-3b.ggmlv3.q4_0.bin
+FIXTURE=https://huggingface.co/TheBloke/orca_mini_3B-GGML/resolve/main/$MODEL
+if [ ! -d $TODIR ]; then
+    mkdir $TODIR
+fi
+
+if [ ! -f $TODIR/$MODEL ]; then
+    curl -sL $FIXTURE -o $TODIR/$MODEL
+fi


### PR DESCRIPTION
- Add tests for wasi-nn GGML backend
- Use 1.8GB model `orca-mini-3b.ggmlv3.q4_0.bin` for testing to reduce memory usage on CI