### PR TITLE
[CI] Fix the broken installation of OpenVINO

### DIFF
--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -84,7 +84,7 @@ jobs:
       tar_names: wasi_nn-pytorch wasi_nn-openvino wasi_nn-tensorflowlite wasi_nn-ggml
       test_bin: wasiNNTests
       output_bin: libwasmedgePluginWasiNN.so
-      OPENVINO_VERSION: "2023.0.0"
+      OPENVINO_VERSION: "2023.1.0"
       OPENVINO_YEAR: "2023"
       PYTORCH_VERSION: "1.8.2"
       PYTORCH_INSTALL_TO: "."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
       build_options: -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=PyTorch -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=OpenVINO -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=TensorFlowLite -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=GGML
       tar_names: wasi_nn-pytorch wasi_nn-openvino wasi_nn-tensorflowlite wasi_nn-ggml
       output_bin: libwasmedgePluginWasiNN.so
-      OPENVINO_VERSION: "2023.0.0"
+      OPENVINO_VERSION: "2023.1.0"
       OPENVINO_YEAR: "2023"
       PYTORCH_VERSION: "1.8.2"
       PYTORCH_INSTALL_TO: "."

--- a/utils/wasi-nn/install-openvino.sh
+++ b/utils/wasi-nn/install-openvino.sh
@@ -3,10 +3,10 @@
 # SPDX-FileCopyrightText: 2019-2022 Second State INC
 
 set -e
-echo "Installing OpenVINO with version 2023.0.0"
+echo "Installing OpenVINO with version 2023.1.0"
 wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
 apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
 echo "deb https://apt.repos.intel.com/openvino/2023 ubuntu20 main" | tee /etc/apt/sources.list.d/intel-openvino-2023.list
 apt update
-apt-get -y install openvino-2023.0.2
+apt-get -y install openvino-2023.1.0
 ldconfig


### PR DESCRIPTION
See:
https://github.com/WasmEdge/WasmEdge/actions/runs/6368783459/job/17288429949

```

Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
OK
deb https://apt.repos.intel.com/openvino/2023 ubuntu20 main

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Get:1 https://apt.repos.intel.com/openvino/2023 ubuntu20 InRelease [7776 B]
Hit:2 http://security.ubuntu.com/ubuntu jammy-security InRelease
Err:1 https://apt.repos.intel.com/openvino/2023 ubuntu20 InRelease
  The following signatures were invalid: EXPKEYSIG ACFA9FC57E6C5DBE Intel(R) Software Development Products
Hit:3 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:5 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Reading package lists...
W: https://apt.repos.intel.com/openvino/2023/dists/ubuntu20/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
W: GPG error: https://apt.repos.intel.com/openvino/2023 ubuntu20 InRelease: The following signatures were invalid: EXPKEYSIG ACFA9FC57E6C5DBE Intel(R) Software Development Products
E: The repository 'https://apt.repos.intel.com/openvino/2023 ubuntu20 InRelease' is not signed.
Error: Process completed with exit code 100.
```