### PR TITLE
Added top-level read-only permission to github tokens for all workflows

### DIFF
--- a/.github/workflows/IWYU_scan.yml
+++ b/.github/workflows/IWYU_scan.yml
@@ -31,6 +31,8 @@ on:
       - "tools/**"
       - "CMakeLists.txt"
 
+permissions: read-all
+
 jobs:
   get_version:
     name: Retrieve version information

--- a/.github/workflows/bindings-java.yml
+++ b/.github/workflows/bindings-java.yml
@@ -22,6 +22,8 @@ on:
       - "include/api/wasmedge/**"
       - "lib/api/**"
 
+permissions: read-all
+
 jobs:
   build_ubuntu:
     name: Ubuntu 22.04

--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -33,6 +33,8 @@ on:
       - "utils/wasi-nn/**"
       - "utils/wasi-crypto/**"
 
+permissions: read-all
+
 jobs:
   # TODO: Refactor `lint` with `on.workflow_run`
   # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,8 @@ on:
       - "CMakeLists.txt"
       - "cmake/**"
 
+permissions: read-all
+
 jobs:
   # TODO: Refactor `lint` with `on.workflow_run`
   # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow

--- a/.github/workflows/build_for_nix.yml
+++ b/.github/workflows/build_for_nix.yml
@@ -31,6 +31,8 @@ on:
       - "CMakeLists.txt"
       - "cmake/**"
 
+permissions: read-all
+
 jobs:
   build_nix:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_for_openwrt.yml
+++ b/.github/workflows/build_for_openwrt.yml
@@ -33,6 +33,8 @@ on:
       - "CMakeLists.txt"
       - "cmake/**"
 
+permissions: read-all
+
 jobs:
   # TODO: Refactor `lint` with `on.workflow_run`
   # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow

--- a/.github/workflows/build_for_riscv.yml
+++ b/.github/workflows/build_for_riscv.yml
@@ -33,6 +33,8 @@ on:
       - "CMakeLists.txt"
       - "cmake/**"
 
+permissions: read-all
+
 jobs:
   # TODO: Refactor `lint` with `on.workflow_run`
   # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,6 +45,8 @@ on:
   schedule:
     - cron: '15 18 * * 6'
 
+permissions: read-all
+
 jobs:
   # TODO: Refactor `lint` with `on.workflow_run`
   # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,8 @@ on:
   schedule:
     - cron: "0 0 */7 * *"
 
+permissions: read-all
+
 jobs:
   prep:
     name: Prepare docker env

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,6 +2,8 @@ name: "Pull Request Labeler"
 on:
 - pull_request_target
 
+permissions: read-all
+
 jobs:
   triage:
     permissions:

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -20,6 +20,8 @@ on:
     paths:
       - 'docs/**'
 
+permissions: read-all
+
 jobs:
   lint-markdown:
     if: ${{ github.event_name != 'push' }}

--- a/.github/workflows/misc-linters.yml
+++ b/.github/workflows/misc-linters.yml
@@ -6,6 +6,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   misc:
     name: misc linters

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -11,6 +11,8 @@ on:
     types:
       - completed
 
+permissions: read-all
+
 jobs:
   post_ubuntu_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ on:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+*"
 
+permissions: read-all
+
 jobs:
   create_release:
     name: Create Release

--- a/.github/workflows/reusable-build-on-alpine-static.yml
+++ b/.github/workflows/reusable-build-on-alpine-static.yml
@@ -9,6 +9,8 @@ on:
       release:
         type: boolean
 
+permissions: read-all
+
 jobs:
   build_on_debian_static:
     name: Build on Alpine (static lib)

--- a/.github/workflows/reusable-build-on-android.yml
+++ b/.github/workflows/reusable-build-on-android.yml
@@ -11,6 +11,8 @@ on:
       upload_asset_url:
         type: string
 
+permissions: read-all
+
 jobs:
   build_on_android:
     name: Build on Android

--- a/.github/workflows/reusable-build-on-debian-static.yml
+++ b/.github/workflows/reusable-build-on-debian-static.yml
@@ -9,6 +9,8 @@ on:
       release:
         type: boolean
 
+permissions: read-all
+
 jobs:
   build_on_debian_static:
     name: Build on Debian (static lib)

--- a/.github/workflows/reusable-build-on-fedora.yml
+++ b/.github/workflows/reusable-build-on-fedora.yml
@@ -11,6 +11,8 @@ on:
       upload_asset_url:
         type: string
 
+permissions: read-all
+
 jobs:
   build_fedora:
     name: Fedora latest

--- a/.github/workflows/reusable-build-on-macos.yml
+++ b/.github/workflows/reusable-build-on-macos.yml
@@ -12,6 +12,8 @@ on:
       release:
         type: boolean
 
+permissions: read-all
+
 jobs:
   build_on_macos:
     strategy:

--- a/.github/workflows/reusable-build-on-manylinux.yml
+++ b/.github/workflows/reusable-build-on-manylinux.yml
@@ -12,6 +12,8 @@ on:
       release:
         type: boolean
 
+permissions: read-all
+
 jobs:
   build_on_manylinux:
     strategy:

--- a/.github/workflows/reusable-build-on-ubuntu.yml
+++ b/.github/workflows/reusable-build-on-ubuntu.yml
@@ -12,6 +12,8 @@ on:
       release:
         type: boolean
 
+permissions: read-all
+
 jobs:
   build_on_ubuntu:
     strategy:

--- a/.github/workflows/reusable-build-on-windows-msvc.yml
+++ b/.github/workflows/reusable-build-on-windows-msvc.yml
@@ -9,6 +9,8 @@ on:
       release:
         type: boolean
 
+permissions: read-all
+
 jobs:
   build_on_windows:
     name: Build on Windows Server 2022

--- a/.github/workflows/reusable-build-on-windows.yml
+++ b/.github/workflows/reusable-build-on-windows.yml
@@ -9,6 +9,8 @@ on:
       release:
         type: boolean
 
+permissions: read-all
+
 jobs:
   build_on_windows:
     name: Build on Windows Server 2022

--- a/.github/workflows/reusable-call-linter.yml
+++ b/.github/workflows/reusable-call-linter.yml
@@ -3,6 +3,8 @@ name: Clang-Format
 on:
   workflow_call:
 
+permissions: read-all
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-create-source-tarball.yml
+++ b/.github/workflows/reusable-create-source-tarball.yml
@@ -9,6 +9,8 @@ on:
       release:
         type: boolean
 
+permissions: read-all
+
 jobs:
   create_source_tarball:
     name: Create source tarball

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -39,6 +39,8 @@ on:
       - "CMakeLists.txt"
       - "cmake/**"
 
+permissions: read-all
+
 jobs:
   static_analysis:
     name: Run Static Code Analysis using Infer

--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -25,6 +25,8 @@ on:
 env:
   INSTALL_PY_PATH: utils/install.py
 
+permissions: read-all
+
 jobs:
   linux:
     strategy:

--- a/.github/workflows/test-python-install-script.yml
+++ b/.github/workflows/test-python-install-script.yml
@@ -22,6 +22,8 @@ on:
       - 'utils/uninstall.sh'
       - 'utils/install.py'
 
+permissions: read-all
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/wasi-testsuite.yml
+++ b/.github/workflows/wasi-testsuite.yml
@@ -22,6 +22,8 @@ on:
       - "include/host/wasi/**"
       - "thirdparty/wasi/**"
 
+permissions: read-all
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/witx.yml
+++ b/.github/workflows/witx.yml
@@ -16,6 +16,8 @@ on:
     paths:
       - 'docs/witx/**'
 
+permissions: read-all
+
 jobs:
   gen_doc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Issue:**  #2979

**Steps taken:** 
As described by the **remediation steps**  in the documentation of [ossf scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions), the following changes have been performed:
* Added ```permissions: read-only``` at the top-level to every workflow of the repository
* The following change should not break existing workflow jobs as job-specific permissions are specified in the job description itself.
* This change will only ensure that new jobs created within the workflow will have read-only permission if no permissions are specified at the job-level

**Results:**
When checked for the score of ```Token-Permissions``` check, the initial result was 0/10, with details like (for all workflow files):
```
Warn: no topLevel permission defined: .github/workflows/IWYU_scan.yml
```
After changes:
The score for Token-Permission check: 10/10
![image](https://github.com/WasmEdge/WasmEdge/assets/56017960/d8c8ff44-a244-4d14-b649-291ae83c5afd)
