### PR TITLE
[AOT] Add support for LLVM 17

### DIFF
--- a/cmake/Helper.cmake
+++ b/cmake/Helper.cmake
@@ -39,9 +39,14 @@ else()
 
   if(NOT WASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_CUBLAS)
     list(APPEND WASMEDGE_CFLAGS
-       -Werror
-       -Wno-error=pedantic
+      -Werror
+      -Wno-error=pedantic
     )
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 13)
+      list(APPEND WASMEDGE_CFLAGS
+        -Wno-error=dangling-reference
+      )
+    endif()
   endif()
 
   if(WASMEDGE_ENABLE_UB_SANITIZER)

--- a/lib/aot/compiler.cpp
+++ b/lib/aot/compiler.cpp
@@ -29,6 +29,15 @@
 #if LLVM_VERSION_MAJOR >= 14
 #include <lld/Common/CommonLinkerContext.h>
 #endif
+#if LLVM_VERSION_MAJOR >= 17
+#if WASMEDGE_OS_MACOS
+LLD_HAS_DRIVER(macho)
+#elif WASMEDGE_OS_LINUX
+LLD_HAS_DRIVER(elf)
+#elif WASMEDGE_OS_WINDOWS
+LLD_HAS_DRIVER(coff)
+#endif
+#endif
 
 #if WASMEDGE_OS_MACOS
 #include <sys/utsname.h>
@@ -136,6 +145,28 @@ static inline constexpr const bool kForceDivCheck = true;
 static inline constexpr const uint32_t kValSize = sizeof(WasmEdge::ValVariant);
 
 // Translate Compiler::OptimizationLevel to llvm::PassBuilder version
+#if LLVM_VERSION_MAJOR >= 13
+static inline const char *
+toLLVMLevel(WasmEdge::CompilerConfigure::OptimizationLevel Level) noexcept {
+  using OL = WasmEdge::CompilerConfigure::OptimizationLevel;
+  switch (Level) {
+  case OL::O0:
+    return "default<O0>,function(tailcallelim)";
+  case OL::O1:
+    return "default<O1>";
+  case OL::O2:
+    return "default<O2>";
+  case OL::O3:
+    return "default<O3>";
+  case OL::Os:
+    return "default<Os>";
+  case OL::Oz:
+    return "default<Oz>";
+  default:
+    assumingUnreachable();
+  }
+}
+#else
 static inline std::pair<unsigned int, unsigned int>
 toLLVMLevel(WasmEdge::CompilerConfigure::OptimizationLevel Level) noexcept {
   using OL = WasmEdge::CompilerConfigure::OptimizationLevel;
@@ -156,6 +187,8 @@ toLLVMLevel(WasmEdge::CompilerConfigure::OptimizationLevel Level) noexcept {
     assumingUnreachable();
   }
 }
+#endif
+
 static inline LLVMCodeGenOptLevel toLLVMCodeGenLevel(
     WasmEdge::CompilerConfigure::OptimizationLevel Level) noexcept {
   using OL = WasmEdge::CompilerConfigure::OptimizationLevel;
@@ -5307,17 +5340,24 @@ Expect<void> Compiler::compile(Span<const Byte> Data, const AST::Module &Module,
           LLVMRelocPIC, LLVMCodeModelDefault);
     }
 
+#if LLVM_VERSION_MAJOR >= 13
+    {
+      auto PBO = LLVM::PassBuilderOptions::create();
+      LLVM::Error Error = PBO.runPasses(
+          LLModule,
+          toLLVMLevel(Conf.getCompilerConfigure().getOptimizationLevel()), TM);
+      if (Error) {
+        spdlog::error("{}"sv, Error.message().string_view());
+      }
+    }
+#else
     {
       auto FP = LLVM::PassManager::createForModule(LLModule);
       auto MP = LLVM::PassManager::create();
 
       TM.addAnalysisPasses(MP);
       TM.addAnalysisPasses(FP);
-      if (Conf.getCompilerConfigure().getOptimizationLevel() ==
-          CompilerConfigure::OptimizationLevel::O0) {
-        FP.addTailCallEliminationPass();
-        MP.addAlwaysInlinerPass();
-      } else {
+      {
         auto PMB = LLVM::PassManagerBuilder::create();
         auto [OptLevel, SizeLevel] =
             toLLVMLevel(Conf.getCompilerConfigure().getOptimizationLevel());
@@ -5325,6 +5365,10 @@ Expect<void> Compiler::compile(Span<const Byte> Data, const AST::Module &Module,
         PMB.setSizeLevel(SizeLevel);
         PMB.populateFunctionPassManager(FP);
         PMB.populateModulePassManager(MP);
+      }
+      if (Conf.getCompilerConfigure().getOptimizationLevel() ==
+          CompilerConfigure::OptimizationLevel::O0) {
+        FP.addTailCallEliminationPass();
       }
 
       FP.initializeFunctionPassManager();
@@ -5335,6 +5379,7 @@ Expect<void> Compiler::compile(Span<const Byte> Data, const AST::Module &Module,
       FP.finalizeFunctionPassManager();
       MP.runPassManager(LLModule);
     }
+#endif
 
     // Set initializer for constant value
     if (auto IntrinsicsTable = LLModule.getNamedGlobal("intrinsics")) {


### PR DESCRIPTION
* Use pipeline description string for llvm 13 and above.
* Add definition for LLD 17
* Suppress gcc 13.1 warning in spdlog/fmt
    - See https://github.com/fmtlib/fmt/issues/3415