### PR TITLE
[CI] Fix release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
         shell: bash
         run: |
           apt update
-          apt install unzip libopenblas-dev pkg-config
+          apt install -y unzip libopenblas-dev pkg-config
           bash utils/wasi-nn/install-openvino.sh
           bash utils/wasi-nn/install-pytorch.sh
       - name: Build WASI-NN plugin
@@ -211,7 +211,7 @@ jobs:
       output_bins: libwasmedgePluginWasiCrypto.so libwasmedgePluginWasiLogging.so libwasmedge_rustls.so libwasmedgePluginWasmEdgeProcess.so libwasmedgePluginWasmEdgeTensorflow.so libwasmedgePluginWasmEdgeTensorflowLite.so libwasmedgePluginWasmEdgeImage.so libwasmedgePluginWasmBpf.so libwasmedgePluginWasmEdgeOpenCVMini.so libwasmedgePluginWasmEdgeZlib.so
     needs: create_release
     container:
-      image: wasmedge/wasmedge:ubuntu-20.04-build-clang
+      image: wasmedge/wasmedge:ubuntu-20.04-build-clang-deps
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -226,7 +226,6 @@ jobs:
           apt install -y libssl-dev cmake g++ wget unzip
           apt install -y libelf-dev zlib1g-dev pkg-config
           apt install -y cargo
-          bash utils/opencvmini/install-opencvmini.sh
       - name: Build plugins
         shell: bash
         run: |
@@ -411,10 +410,10 @@ jobs:
         include:
           - name: Plugins_x86_64
             host_runner: ubuntu-latest
-            docker_tag: manylinux2014_x86_64
+            docker_tag: manylinux2014_x86_64-deps
           - name: Plugins_aarch64
             host_runner: linux-arm64
-            docker_tag: manylinux2014_aarch64
+            docker_tag: manylinux2014_aarch64-deps
     name: Build and upload plugins on ${{ matrix.docker_tag }}
     runs-on: ${{ matrix.host_runner }}
     env:
@@ -446,7 +445,6 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
           source "$HOME/.cargo/env"
           bash ./utils/wasi-crypto/build-openssl.sh
-          bash utils/opencvmini/install-opencvmini.sh
       - name: Build plugins
         shell: bash
         run: |

--- a/.github/workflows/reusable-build-on-windows-msvc.yml
+++ b/.github/workflows/reusable-build-on-windows-msvc.yml
@@ -73,24 +73,24 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: WasmEdge-${{ inputs.version }}-windows-msvc.zip
-          path: build\\WasmEdge-${{ inputs.version }}-Windows-msvc.zip
+          path: build\\WasmEdge-${{ inputs.version }}-Windows.zip
       - name: Upload Windows installer
         if: ${{ !inputs.release }}
         uses: actions/upload-artifact@v3
         with:
           name: WasmEdge-${{ env.product_version }}-windows-msvc.msi
-          path: build\\WasmEdge-${{ env.product_version }}-windows-msvc.msi
+          path: build\\WasmEdge-${{ env.product_version }}-windows.msi
       - name: Upload Windows 10 zip package
         if: ${{ inputs.release }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mv build\\WasmEdge-${{ inputs.version }}-Windows-msvc.zip WasmEdge-${{ inputs.version }}-windows-msvc.zip
+          mv build\\WasmEdge-${{ inputs.version }}-Windows.zip WasmEdge-${{ inputs.version }}-windows-msvc.zip
           gh release upload ${{ inputs.version }} WasmEdge-${{ inputs.version }}-windows-msvc.zip --clobber
       - name: Upload Windows installer
         if: ${{ inputs.release }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mv build\\WasmEdge-${{ env.product_version }}-windows-msvc.msi WasmEdge-${{ env.product_version }}-windows-msvc.msi
+          mv build\\WasmEdge-${{ env.product_version }}-windows.msi WasmEdge-${{ env.product_version }}-windows-msvc.msi
           gh release upload ${{ inputs.version }} WasmEdge-${{ env.product_version }}-windows-msvc.msi --clobber


### PR DESCRIPTION
1. Fix the wrong Windows MSVC path names.
2. Add missing `-y` flag when installing packages with `apt install`