### PR TITLE
[Misc] Remove render:bash from the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,7 +37,6 @@ body:
         2. Execute with flags '....'
         3. Execute with inputs '....'
         4. Get error
-      render: bash
     validations:
       required: true
   - type: textarea
@@ -47,7 +46,6 @@ body:
       description: If applicable, add screenshots to help explain your problem.
       value: |
         ![DESCRIPTION](LINK.png)
-      render: bash
     validations:
       required: false
   - type: textarea
@@ -55,7 +53,6 @@ body:
     attributes:
       label: "Any logs you want to share for showing the specific issue"
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-      render: bash
     validations:
       required: false
   - type: dropdown


### PR DESCRIPTION
This will prevent adding the code block on users' input.