### PR TITLE
Fix failures on wasi testsuite

### DIFF
--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -830,6 +830,10 @@ public:
     if (!VINode::isPathValid(NewPath)) {
       return WasiUnexpect(__WASI_ERRNO_INVAL);
     }
+    // forbid absolute path
+    if (!OldPath.empty() && OldPath[0] == '/') {
+      return WasiUnexpect(__WASI_ERRNO_INVAL);
+    }
     auto NewNode = getNodeOrNull(New);
     return VINode::pathSymlink(OldPath, std::move(NewNode), NewPath);
   }

--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -433,9 +433,10 @@ public:
     } else {
       if (const auto &Path = Node->name(); Path.empty()) {
         return WasiUnexpect(__WASI_ERRNO_INVAL);
+      } else if (Buffer.size() < Path.size()) {
+        return WasiUnexpect(__WASI_ERRNO_NAMETOOLONG);
       } else {
-        std::copy_n(Path.begin(), std::min(Path.size(), Buffer.size()),
-                    Buffer.begin());
+        std::copy_n(Path.begin(), Path.size(), Buffer.begin());
       }
     }
     return {};

--- a/include/host/wasi/vinode.h
+++ b/include/host/wasi/vinode.h
@@ -719,11 +719,27 @@ private:
   /// @param[in] LookupFlags WASI lookup flags.
   /// @param[in] VFSFlags Internal lookup flags.
   /// @param[in] LinkCount Counting symbolic link lookup times.
+  /// @param[in] FollowTrailingSlashes If Path ends with slash, open it and set
+  /// Path to ".".
   /// @return Allocated buffer, or WASI error.
   static WasiExpect<std::vector<char>> resolvePath(
       std::shared_ptr<VINode> &Fd, std::string_view &Path,
       __wasi_lookupflags_t LookupFlags = __WASI_LOOKUPFLAGS_SYMLINK_FOLLOW,
-      VFS::Flags VFSFlags = static_cast<VFS::Flags>(0), uint8_t LinkCount = 0);
+      VFS::Flags VFSFlags = static_cast<VFS::Flags>(0), uint8_t LinkCount = 0,
+      bool FollowTrailingSlashes = true);
+
+  /// Proxy function for `resolvePath`.
+  /// @param[in,out] Fd Fd. Return parent of last part if found.
+  /// @param[in,out] Path path. Return last part of path if found.
+  /// @param[in] FollowTrailingSlashes If Path ends with slash, open it and set
+  /// Path to ".".
+  /// @return Allocated buffer, or WASI error.
+  static inline WasiExpect<std::vector<char>>
+  resolvePath(std::shared_ptr<VINode> &Fd, std::string_view &Path,
+              bool FollowTrailingSlashes) {
+    return resolvePath(Fd, Path, __WASI_LOOKUPFLAGS_SYMLINK_FOLLOW,
+                       static_cast<VFS::Flags>(0), 0, FollowTrailingSlashes);
+  }
 };
 
 class VPoller : protected Poller {

--- a/lib/host/wasi/vinode.cpp
+++ b/lib/host/wasi/vinode.cpp
@@ -238,7 +238,8 @@ WasiExpect<void> VINode::pathReadlink(std::shared_ptr<VINode> Fd,
                                       std::string_view Path, Span<char> Buffer,
                                       __wasi_size_t &NRead) {
   std::vector<char> PathBuffer;
-  if (auto Res = resolvePath(Fd, Path); unlikely(!Res)) {
+  if (auto Res = resolvePath(Fd, Path, static_cast<__wasi_lookupflags_t>(0));
+      unlikely(!Res)) {
     return WasiUnexpect(Res);
   } else if (!Fd->can(__WASI_RIGHTS_PATH_READLINK)) {
     return WasiUnexpect(__WASI_ERRNO_NOTCAPABLE);

--- a/lib/host/wasi/vinode.cpp
+++ b/lib/host/wasi/vinode.cpp
@@ -206,7 +206,7 @@ VINode::pathOpen(std::shared_ptr<VINode> Fd, std::string_view Path,
     RequiredRights |= __WASI_RIGHTS_PATH_CREATE_FILE;
   }
   if (OpenFlags & __WASI_OFLAGS_TRUNC) {
-    RequiredInheritingRights |= __WASI_RIGHTS_PATH_FILESTAT_SET_SIZE;
+    RequiredRights |= __WASI_RIGHTS_PATH_FILESTAT_SET_SIZE;
   }
   if (FdFlags & __WASI_FDFLAGS_RSYNC) {
     RequiredInheritingRights |= __WASI_RIGHTS_FD_SYNC;

--- a/lib/host/wasi/vinode.cpp
+++ b/lib/host/wasi/vinode.cpp
@@ -188,6 +188,9 @@ VINode::pathOpen(std::shared_ptr<VINode> Fd, std::string_view Path,
                  __wasi_rights_t FsRightsInheriting, __wasi_fdflags_t FdFlags) {
   if (OpenFlags & __WASI_OFLAGS_DIRECTORY) {
     FsRightsBase &= ~__WASI_RIGHTS_FD_SEEK;
+  } else {
+    FsRightsBase &= ~__WASI_RIGHTS_PATH_FILESTAT_GET;
+    FsRightsInheriting &= ~__WASI_RIGHTS_PATH_FILESTAT_GET;
   }
 
   __wasi_rights_t RequiredRights = __WASI_RIGHTS_PATH_OPEN;

--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -198,8 +198,18 @@ cast<__wasi_fstflags_t>(uint64_t FdFlags) noexcept {
   const auto Mask = __WASI_FSTFLAGS_ATIM | __WASI_FSTFLAGS_ATIM_NOW |
                     __WASI_FSTFLAGS_MTIM | __WASI_FSTFLAGS_MTIM_NOW;
   if ((WasiRawTypeT<__wasi_fstflags_t>(FdFlags) & ~Mask) == 0) {
-    return static_cast<__wasi_fstflags_t>(FdFlags);
+    const auto WasiFstFlags = static_cast<__wasi_fstflags_t>(FdFlags);
+    if ((WasiFstFlags & __WASI_FSTFLAGS_ATIM) &&
+        (WasiFstFlags & __WASI_FSTFLAGS_ATIM_NOW)) {
+      return WASI::WasiUnexpect(__WASI_ERRNO_INVAL);
+    }
+    if ((WasiFstFlags & __WASI_FSTFLAGS_MTIM) &&
+        (WasiFstFlags & __WASI_FSTFLAGS_MTIM_NOW)) {
+      return WASI::WasiUnexpect(__WASI_ERRNO_INVAL);
+    }
+    return WasiFstFlags;
   }
+
   return WASI::WasiUnexpect(__WASI_ERRNO_INVAL);
 }
 


### PR DESCRIPTION
* Check `filestat_set_times` for invalid flags
* Check `fd_prestat_dir_name` buffer size
* Fix `path_open` for removing path relative rights on file
* Fix `path_open` for checking `O_TRUNC` rights
* Fix `path_readlink` to not following symbolic link
* Fix `path_unlink_file` for trailing slash path
  * unix `rmdir` didn't support "." path