### PR TITLE
[Misc] Add compiler warning option `-Wshadow` and `-Wshadow-field`

### DIFF
--- a/cmake/Helper.cmake
+++ b/cmake/Helper.cmake
@@ -35,6 +35,7 @@ else()
   list(APPEND WASMEDGE_CFLAGS
     -Wall
     -Wextra
+    -Wshadow-field
   )
 
   if(NOT WASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_CUBLAS)
@@ -59,7 +60,9 @@ else()
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  list(APPEND WASMEDGE_CFLAGS -Wno-c++20-designator)
+  list(APPEND WASMEDGE_CFLAGS
+    -Wno-c++20-designator
+  )
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -87,7 +90,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     )
   elseif(NOT CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     list(APPEND WASMEDGE_CFLAGS
-      -Wno-error=shadow-field
       -Wno-reserved-identifier
     )
   endif()

--- a/cmake/Helper.cmake
+++ b/cmake/Helper.cmake
@@ -16,7 +16,7 @@ if(CMAKE_BUILD_TYPE STREQUAL Release OR CMAKE_BUILD_TYPE STREQUAL RelWithDebInfo
   endif()
 endif()
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   list(APPEND WASMEDGE_CFLAGS
     /std:c++17
     /WX
@@ -35,8 +35,6 @@ else()
   list(APPEND WASMEDGE_CFLAGS
     -Wall
     -Wextra
-    -Wshadow
-    -Wshadow-field
   )
 
   if(NOT WASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_CUBLAS)
@@ -44,9 +42,57 @@ else()
       -Werror
       -Wno-error=pedantic
     )
-    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 13)
+  endif()
+
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 13)
       list(APPEND WASMEDGE_CFLAGS
         -Wno-error=dangling-reference
+        -Wno-error=psabi
+      )
+    endif()
+    list(APPEND WASMEDGE_CFLAGS
+      -Wshadow
+    )
+  endif()
+
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0.0)
+      list(APPEND WASMEDGE_CFLAGS
+        -Wno-error=return-std-move-in-c++11
+      )
+    endif()
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 10)
+      list(APPEND WASMEDGE_CFLAGS
+        -Wno-error=psabi
+      )
+    endif()
+
+    list(APPEND WASMEDGE_CFLAGS
+      -Wshadow
+      -Wno-c++20-designator
+      -Wno-c99-extensions
+      -Wno-covered-switch-default
+      -Wno-documentation-unknown-command
+      -Wno-error=nested-anon-types
+      -Wno-error=old-style-cast
+      -Wno-error=unused-command-line-argument
+      -Wno-error=unknown-warning-option
+      -Wno-ctad-maybe-unsupported
+      -Wno-gnu-anonymous-struct
+      -Wno-keyword-macro
+      -Wno-language-extension-token
+      -Wno-newline-eof
+      -Wno-shadow-field-in-constructor
+      -Wno-signed-enum-bitfield
+      -Wno-switch-enum
+      -Wno-undefined-func-template
+      -Wshadow-field
+    )
+
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      list(APPEND WASMEDGE_CFLAGS
+        -Wno-reserved-identifier
       )
     endif()
   endif()
@@ -54,51 +100,11 @@ else()
   if(WASMEDGE_ENABLE_UB_SANITIZER)
     list(APPEND WASMEDGE_CFLAGS -fsanitize=undefined)
   endif()
-
-  if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-    list(APPEND WASMEDGE_CFLAGS -Wno-psabi)
-  endif()
-endif()
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  list(APPEND WASMEDGE_CFLAGS
-    -Wno-c++20-designator
-  )
-endif()
-
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  list(APPEND WASMEDGE_CFLAGS
-    -Wno-c99-extensions
-    -Wno-covered-switch-default
-    -Wno-documentation-unknown-command
-    -Wno-error=nested-anon-types
-    -Wno-error=old-style-cast
-    -Wno-error=unused-command-line-argument
-    -Wno-error=unknown-warning-option
-    -Wno-ctad-maybe-unsupported
-    -Wno-gnu-anonymous-struct
-    -Wno-keyword-macro
-    -Wno-language-extension-token
-    -Wno-newline-eof
-    -Wno-shadow-field-in-constructor
-    -Wno-signed-enum-bitfield
-    -Wno-switch-enum
-    -Wno-undefined-func-template
-  )
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0.0)
-    list(APPEND WASMEDGE_CFLAGS
-      -Wno-error=return-std-move-in-c++11
-    )
-  elseif(NOT CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-    list(APPEND WASMEDGE_CFLAGS
-      -Wno-reserved-identifier
-    )
-  endif()
 endif()
 
 if(WIN32)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_ENABLE_EXTENDED_ALIGNED_STORAGE -DNOMINMAX -D_ITERATOR_DEBUG_LEVEL=0)
-  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     list(APPEND WASMEDGE_CFLAGS
       "/EHa"
       -Wno-c++98-compat

--- a/cmake/Helper.cmake
+++ b/cmake/Helper.cmake
@@ -35,6 +35,7 @@ else()
   list(APPEND WASMEDGE_CFLAGS
     -Wall
     -Wextra
+    -Wshadow
     -Wshadow-field
   )
 

--- a/cmake/Helper.cmake
+++ b/cmake/Helper.cmake
@@ -69,36 +69,41 @@ else()
     endif()
 
     list(APPEND WASMEDGE_CFLAGS
-      -Wshadow
-      -Wno-c++20-designator
-      -Wno-c99-extensions
-      -Wno-covered-switch-default
-      -Wno-documentation-unknown-command
+      -Wc++20-designator
+      -Wno-error=switch-enum
+      -Wno-error=covered-switch-default
+      -Wno-error=documentation-unknown-command
+      -Wno-error=ctad-maybe-unsupported
+      -Wno-error=undefined-func-template
+      -Wno-error=newline-eof
+      -Wno-error=keyword-macro
       -Wno-error=nested-anon-types
       -Wno-error=old-style-cast
       -Wno-error=unused-command-line-argument
       -Wno-error=unknown-warning-option
-      -Wno-ctad-maybe-unsupported
-      -Wno-gnu-anonymous-struct
-      -Wno-keyword-macro
-      -Wno-language-extension-token
-      -Wno-newline-eof
-      -Wno-shadow-field-in-constructor
-      -Wno-signed-enum-bitfield
-      -Wno-switch-enum
-      -Wno-undefined-func-template
+      -Wc99-extensions
+      -Wgnu-anonymous-struct
+      -Wlanguage-extension-token
+      -Wsigned-enum-bitfield
+      -Wshadow
       -Wshadow-field
+      -Wshadow-field-in-constructor
+      -Wno-exit-time-destructors
+      -Wno-global-constructors
+      -Wno-error=used-but-marked-unused
     )
 
     if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
       list(APPEND WASMEDGE_CFLAGS
-        -Wno-reserved-identifier
+        -Wno-error=reserved-identifier
       )
     endif()
   endif()
 
   if(WASMEDGE_ENABLE_UB_SANITIZER)
-    list(APPEND WASMEDGE_CFLAGS -fsanitize=undefined)
+    list(APPEND WASMEDGE_CFLAGS
+      -fsanitize=undefined
+    )
   endif()
 endif()
 
@@ -109,8 +114,6 @@ if(WIN32)
       "/EHa"
       -Wno-c++98-compat
       -Wno-c++98-compat-pedantic
-      -Wno-exit-time-destructors
-      -Wno-global-constructors
       -Wno-used-but-marked-unused
       -Wno-nonportable-system-include-path
       -Wno-float-equal

--- a/include/aot/compiler.h
+++ b/include/aot/compiler.h
@@ -27,7 +27,7 @@ namespace AOT {
 /// Compiling Module into loadable executable binary.
 class Compiler {
 public:
-  Compiler(const Configure &Conf) noexcept : Context(nullptr), Conf(Conf) {}
+  Compiler(const Configure &C) noexcept : Context(nullptr), Conf(C) {}
 
   Expect<void> compile(Span<const Byte> Data, const AST::Module &Module,
                        std::filesystem::path OutputPath) noexcept;

--- a/include/common/enum_errcode.hpp
+++ b/include/common/enum_errcode.hpp
@@ -119,8 +119,8 @@ public:
 
 private:
   union InnerT {
-    constexpr InnerT(uint32_t Num): Num(Num) {}
-    constexpr InnerT(ErrCode::Value Code): Code(Code) {}
+    constexpr InnerT(uint32_t N): Num(N) {}
+    constexpr InnerT(ErrCode::Value C): Code(C) {}
     uint32_t Num;
     ErrCode::Value Code;
   } Inner;

--- a/include/common/errinfo.h
+++ b/include/common/errinfo.h
@@ -252,7 +252,7 @@ struct InfoBoundary {
 
 struct InfoProposal {
   InfoProposal() = delete;
-  InfoProposal(Proposal P) noexcept : P(P) {}
+  InfoProposal(Proposal Pr) noexcept : P(Pr) {}
 
   Proposal P;
 };

--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -125,8 +125,8 @@ private:
 /// Executor flow control class.
 class Executor {
 public:
-  Executor(const Configure &Conf, Statistics::Statistics *S = nullptr) noexcept
-      : Conf(Conf) {
+  Executor(const Configure &C, Statistics::Statistics *S = nullptr) noexcept
+      : Conf(C) {
     if (Conf.getStatisticsConfigure().isInstructionCounting() ||
         Conf.getStatisticsConfigure().isCostMeasuring() ||
         Conf.getStatisticsConfigure().isTimeMeasuring()) {

--- a/include/host/wasi/inode.h
+++ b/include/host/wasi/inode.h
@@ -819,7 +819,7 @@ private:
 class PollerContext;
 class Poller
 #if WASMEDGE_OS_LINUX || WASMEDGE_OS_MACOS
-    : public FdHolder
+    : private FdHolder
 #endif
 {
 public:

--- a/include/host/wasi/inode.h
+++ b/include/host/wasi/inode.h
@@ -66,8 +66,8 @@ struct FdHolder {
       reset();
     }
   }
-  explicit constexpr FdHolder(int Fd, bool Cleanup = true) noexcept
-      : Fd(Fd), Cleanup(Cleanup) {}
+  explicit constexpr FdHolder(int FdVal, bool DoCleanup = true) noexcept
+      : Fd(FdVal), Cleanup(DoCleanup) {}
   constexpr bool ok() const noexcept { return Fd >= 0; }
   void reset() noexcept;
   int release() noexcept { return std::exchange(Fd, -1); }

--- a/include/loader/loader.h
+++ b/include/loader/loader.h
@@ -78,9 +78,9 @@ inline ASTNodeAttr NodeAttrFromAST<AST::DataCountSection>() noexcept {
 /// Loader flow control class.
 class Loader {
 public:
-  Loader(const Configure &Conf,
+  Loader(const Configure &C,
          const AST::Module::IntrinsicsTable *IT = nullptr) noexcept
-      : Conf(Conf), LMgr(IT), IntrinsicsTable(IT) {}
+      : Conf(C), LMgr(IT), IntrinsicsTable(IT) {}
   ~Loader() noexcept = default;
 
   /// Load data from file path.

--- a/include/po/argument_parser.h
+++ b/include/po/argument_parser.h
@@ -80,7 +80,7 @@ private:
       add_option("help"sv, *HelpOpt);
     }
     SubCommandDescriptor(SubCommand &SC) noexcept : SubCommandDescriptor() {
-      this->SC = &SC;
+      this->SubCmd = &SC;
     }
 
     template <typename... ArgsT>
@@ -179,7 +179,7 @@ private:
     consume_argument(ArgumentDescriptor &CurrentDesc,
                      std::string_view Argument) noexcept;
 
-    SubCommand *SC = nullptr;
+    SubCommand *SubCmd = nullptr;
     std::vector<std::string_view> SubCommandNames;
     std::vector<const char *> ProgramNames;
     std::vector<ArgumentDescriptor> ArgumentDescriptors;

--- a/include/po/helper.h
+++ b/include/po/helper.h
@@ -15,17 +15,17 @@ namespace WasmEdge {
 namespace PO {
 
 struct Description {
-  Description(std::string_view Value) noexcept : Value(std::move(Value)) {}
+  Description(std::string_view V) noexcept : Value(std::move(V)) {}
   std::string_view Value;
 };
 
 struct MetaVar {
-  MetaVar(std::string_view Value) noexcept : Value(std::move(Value)) {}
+  MetaVar(std::string_view V) noexcept : Value(std::move(V)) {}
   std::string_view Value;
 };
 
 template <typename T> struct DefaultValue {
-  DefaultValue(T Value) noexcept : Value(std::move(Value)) {}
+  DefaultValue(T V) noexcept : Value(std::move(V)) {}
   T Value;
 };
 

--- a/include/validator/validator.h
+++ b/include/validator/validator.h
@@ -27,7 +27,7 @@ namespace Validator {
 /// Validator flow control class.
 class Validator {
 public:
-  Validator(const Configure &Conf) noexcept : Conf(Conf) {}
+  Validator(const Configure &C) noexcept : Conf(C) {}
   ~Validator() noexcept = default;
 
   /// Validate AST::Component.

--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -177,7 +177,7 @@ WasiExpect<void> INode::fdAllocate(__wasi_filesize_t Offset,
   if (auto Res = ::fcntl(Fd, F_PREALLOCATE, &Store); unlikely(Res < 0)) {
     // Try to allocate sparse space.
     Store.fst_flags = F_ALLOCATEALL;
-    if (auto Res = ::fcntl(Fd, F_PREALLOCATE, &Store); unlikely(Res < 0)) {
+    if (auto Res2 = ::fcntl(Fd, F_PREALLOCATE, &Store); unlikely(Res2 < 0)) {
       return WasiUnexpect(fromErrNo(errno));
     }
   }

--- a/lib/host/wasi/vinode.cpp
+++ b/lib/host/wasi/vinode.cpp
@@ -23,9 +23,9 @@ static inline constexpr const uint8_t kMaxNestedLinks = 8;
 
 }
 
-VINode::VINode(INode Node, __wasi_rights_t FRB, __wasi_rights_t FRI,
+VINode::VINode(INode No, __wasi_rights_t FRB, __wasi_rights_t FRI,
                std::string N)
-    : Node(std::move(Node)), FsRightsBase(FRB), FsRightsInheriting(FRI),
+    : Node(std::move(No)), FsRightsBase(FRB), FsRightsInheriting(FRI),
       Name(std::move(N)) {}
 
 std::shared_ptr<VINode> VINode::stdIn(__wasi_rights_t FRB,

--- a/lib/po/argument_parser.cpp
+++ b/lib/po/argument_parser.cpp
@@ -61,7 +61,7 @@ cxx20::expected<bool, Error> ArgumentParser::SubCommandDescriptor::parse(
           if (auto Iter = SubCommandMap.find(Arg);
               Iter != SubCommandMap.end()) {
             auto &Child = this[Iter->second];
-            Child.SC->select();
+            Child.SubCmd->select();
             return Child.parse(Out, ProgramNames, Argc, Argv, ArgI, VersionOpt);
           }
         }
@@ -188,7 +188,7 @@ void ArgumentParser::SubCommandDescriptor::help(std::FILE *Out) const noexcept {
         First = false;
       }
       fmt::print(Out, "{}\n"sv, RESET_COLOR);
-      indent_output(Out, kIndent, 2, 80, this[Offset].SC->description());
+      indent_output(Out, kIndent, 2, 80, this[Offset].SubCmd->description());
       fmt::print(Out, "\n"sv);
     }
     fmt::print(Out, "\n"sv);

--- a/lib/vm/vm.cpp
+++ b/lib/vm/vm.cpp
@@ -33,18 +33,18 @@ createPluginModule(std::string_view PName, std::string_view MName) {
 }
 } // namespace
 
-VM::VM(const Configure &Conf)
-    : Conf(Conf), Stage(VMStage::Inited),
-      LoaderEngine(Conf, &Executor::Executor::Intrinsics),
-      ValidatorEngine(Conf), ExecutorEngine(Conf, &Stat),
+VM::VM(const Configure &C)
+    : Conf(C), Stage(VMStage::Inited),
+      LoaderEngine(C, &Executor::Executor::Intrinsics), ValidatorEngine(C),
+      ExecutorEngine(C, &Stat),
       Store(std::make_unique<Runtime::StoreManager>()), StoreRef(*Store.get()) {
   unsafeInitVM();
 }
 
-VM::VM(const Configure &Conf, Runtime::StoreManager &S)
-    : Conf(Conf), Stage(VMStage::Inited),
-      LoaderEngine(Conf, &Executor::Executor::Intrinsics),
-      ValidatorEngine(Conf), ExecutorEngine(Conf, &Stat), StoreRef(S) {
+VM::VM(const Configure &C, Runtime::StoreManager &S)
+    : Conf(C), Stage(VMStage::Inited),
+      LoaderEngine(C, &Executor::Executor::Intrinsics), ValidatorEngine(C),
+      ExecutorEngine(C, &Stat), StoreRef(S) {
   unsafeInitVM();
 }
 

--- a/test/api/APIAOTCoreTest.cpp
+++ b/test/api/APIAOTCoreTest.cpp
@@ -54,8 +54,7 @@ TEST_P(CoreCompileTest, TestSuites) {
   WasmEdge_ModuleInstanceContext *TestModCxt = createSpecTestModule();
   WasmEdge_VMRegisterModuleFromImport(VM, TestModCxt);
 
-  auto Compile = [&, Conf = std::cref(Conf)](
-                     const std::string &Filename) -> Expect<std::string> {
+  auto Compile = [&](const std::string &Filename) -> Expect<std::string> {
     auto Path = std::filesystem::u8path(Filename);
     Path.replace_extension(std::filesystem::u8path(WASMEDGE_LIB_EXTENSION));
     const auto SOPath = Path.u8string();

--- a/test/expected/assignment.cpp
+++ b/test/expected/assignment.cpp
@@ -77,7 +77,7 @@ TEST(AssignmentTest, AssignmentDeletion) {
 TEST(AssignmentTest, AssignmentThrowRecovery) {
   struct throw_move {
     int v;
-    throw_move(int v) noexcept : v(v) {}
+    throw_move(int val) noexcept : v(val) {}
     throw_move(const throw_move &) noexcept = default;
     [[noreturn]] throw_move(throw_move &&) noexcept(false) { throw 0; }
     throw_move &operator=(const throw_move &) noexcept = default;

--- a/test/expected/issues.cpp
+++ b/test/expected/issues.cpp
@@ -152,8 +152,8 @@ TEST(RegressionTest, Issue89) {
 struct S {
   int i = 0;
   int j = 0;
-  S(int i) : i(i) {}
-  S(int i, int j) : i(i), j(j) {}
+  S(int x) : i(x) {}
+  S(int x, int y) : i(x), j(y) {}
 };
 
 TEST(RegressionTest, Issue107) {

--- a/test/expected/swap.cpp
+++ b/test/expected/swap.cpp
@@ -5,11 +5,11 @@
 #include <type_traits>
 
 struct no_throw {
-  no_throw(std::string i) : i(i) {}
+  no_throw(std::string s) : i(s) {}
   std::string i;
 };
 struct canthrow_move {
-  canthrow_move(std::string i) : i(i) {}
+  canthrow_move(std::string s) : i(s) {}
   canthrow_move(canthrow_move const &) = default;
   canthrow_move(canthrow_move &&other) noexcept(false) : i(other.i) {}
   canthrow_move &operator=(canthrow_move &&) = default;
@@ -17,7 +17,7 @@ struct canthrow_move {
 };
 
 template <bool should_throw = false> struct willthrow_move {
-  willthrow_move(std::string i) : i(i) {}
+  willthrow_move(std::string s) : i(s) {}
   willthrow_move(willthrow_move const &) = default;
   willthrow_move(willthrow_move &&other) : i(other.i) {
     if (should_throw)

--- a/test/plugins/unittest/testplugin.cpp
+++ b/test/plugins/unittest/testplugin.cpp
@@ -32,21 +32,22 @@ create(const Plugin::PluginModule::ModuleDescriptor *) noexcept {
   return new WasmEdgePluginTestModule;
 }
 
+Plugin::PluginModule::ModuleDescriptor ModuleDescriptor[] = {
+    {
+        /* Name */ "wasmedge_plugintest_cpp_module",
+        /* Description */ "This is for the plugin tests in WasmEdge.",
+        /* Create */ create,
+    },
+};
+
 Plugin::Plugin::PluginDescriptor Descriptor{
-    .Name = "wasmedge_plugintest_cpp",
-    .Description = "",
-    .APIVersion = Plugin::Plugin::CurrentAPIVersion,
-    .Version = {0, 10, 0, 0},
-    .ModuleCount = 1,
-    .ModuleDescriptions =
-        (Plugin::PluginModule::ModuleDescriptor[]){
-            {
-                .Name = "wasmedge_plugintest_cpp_module",
-                .Description = "This is for the plugin tests in WasmEdge.",
-                .Create = create,
-            },
-        },
-    .AddOptions = addOptions,
+    /* Name */ "wasmedge_plugintest_cpp",
+    /* Description */ "",
+    /* APIVersion */ Plugin::Plugin::CurrentAPIVersion,
+    /* Version */ {0, 10, 0, 0},
+    /* ModuleCount */ 1,
+    /* ModuleDescriptions */ ModuleDescriptor,
+    /* AddOptions */ addOptions,
 };
 
 } // namespace

--- a/test/po/po.cpp
+++ b/test/po/po.cpp
@@ -21,11 +21,12 @@ struct Param {
   std::vector<int> C;
   std::vector<const char *> F;
   std::vector<const char *> Args;
-  Param(bool R, bool A, int B, std::vector<int> C, std::vector<const char *> F,
-        std::vector<const char *> Args)
-      : R(R), A(A), B(B), C(std::move(C)), F(std::move(F)),
-        Args(std::move(Args)) {}
-  Param(bool R, std::vector<const char *> Args) : R(R), Args(std::move(Args)) {}
+  Param(bool R_, bool A_, int B_, std::vector<int> C_,
+        std::vector<const char *> F_, std::vector<const char *> Args_)
+      : R(R_), A(A_), B(B_), C(std::move(C_)), F(std::move(F_)),
+        Args(std::move(Args_)) {}
+  Param(bool R_, std::vector<const char *> Args_)
+      : R(R_), Args(std::move(Args_)) {}
 };
 
 class GeneralOptions : public ::testing::TestWithParam<Param> {


### PR DESCRIPTION
* Prevent `Fd` in INode leaking to Poller interface
* Remove unused `Conf`
  * Add warning for declaration shadowing another declaration.