### PR TITLE
[WASI-NN] Add single token inference

### DIFF
--- a/plugins/wasi_nn/ggml.h
+++ b/plugins/wasi_nn/ggml.h
@@ -7,6 +7,7 @@
 #include "types.h"
 
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
+#include <common.h>
 #include <llama.h>
 #endif
 
@@ -43,6 +44,12 @@ public:
   std::vector<llama_token> LlamaInputs;
   std::string LlamaOutputs;
   std::vector<llama_token> LlamaOutputTokens;
+  // Preserve for computing single token
+  llama_context *LlamaContext = nullptr;
+  struct llama_sampling_context *LlamaSampling = nullptr;
+  std::vector<llama_token> LlamaEmbd;
+  int LlamaNPast;
+  int LlamaNConsumed;
 };
 #else
 struct Graph {};
@@ -66,6 +73,12 @@ Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
                                 uint32_t ContextId, uint32_t Index,
                                 Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept;
+Expect<WASINN::ErrNo> getOutputSingle(WASINN::WasiNNEnvironment &Env,
+                                      uint32_t ContextId, uint32_t Index,
+                                      Span<uint8_t> OutBuffer,
+                                      uint32_t &BytesWritten) noexcept;
 Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
                               uint32_t ContextId) noexcept;
+Expect<WASINN::ErrNo> computeSingle(WASINN::WasiNNEnvironment &Env,
+                                    uint32_t ContextId) noexcept;
 } // namespace WasmEdge::Host::WASINN::GGML

--- a/plugins/wasi_nn/types.h
+++ b/plugins/wasi_nn/types.h
@@ -18,6 +18,7 @@ enum class ErrNo : uint32_t {
   UnsupportedOperation = 6, // Unsupported Operation.
   TooLarge = 7,             // Too Large.
   NotFound = 8,             // Not Found.
+  EndOfSequence = 9,        // End of Sequence Found.
 };
 
 enum class TensorType : uint8_t { F16 = 0, F32 = 1, U8 = 2, I32 = 3 };

--- a/plugins/wasi_nn/wasinnfunc.h
+++ b/plugins/wasi_nn/wasinnfunc.h
@@ -106,9 +106,40 @@ private:
                                  uint32_t BytesWrittenPtr);
 };
 
+class WasiNNGetOutputSingle : public WasiNN<WasiNNGetOutputSingle> {
+public:
+  WasiNNGetOutputSingle(WASINN::WasiNNEnvironment &HostEnv) : WasiNN(HostEnv) {}
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t Context,
+                        uint32_t Index, uint32_t OutBufferPtr,
+                        uint32_t OutBufferMaxSize, uint32_t BytesWrittenPtr) {
+    return bodyImpl(Frame, Context, Index, OutBufferPtr, OutBufferMaxSize,
+                    BytesWrittenPtr)
+        .map(castErrNo);
+  }
+
+private:
+  Expect<WASINN::ErrNo> bodyImpl(const Runtime::CallingFrame &Frame,
+                                 uint32_t Context, uint32_t Index,
+                                 uint32_t OutBufferPtr,
+                                 uint32_t OutBufferMaxSize,
+                                 uint32_t BytesWrittenPtr);
+};
+
 class WasiNNCompute : public WasiNN<WasiNNCompute> {
 public:
   WasiNNCompute(WASINN::WasiNNEnvironment &HostEnv) : WasiNN(HostEnv) {}
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t Context) {
+    return bodyImpl(Frame, Context).map(castErrNo);
+  }
+
+private:
+  Expect<WASINN::ErrNo> bodyImpl(const Runtime::CallingFrame &Frame,
+                                 uint32_t Context);
+};
+
+class WasiNNComputeSingle : public WasiNN<WasiNNComputeSingle> {
+public:
+  WasiNNComputeSingle(WASINN::WasiNNEnvironment &HostEnv) : WasiNN(HostEnv) {}
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t Context) {
     return bodyImpl(Frame, Context).map(castErrNo);
   }

--- a/plugins/wasi_nn/wasinnmodule.cpp
+++ b/plugins/wasi_nn/wasinnmodule.cpp
@@ -16,7 +16,10 @@ WasiNNModule::WasiNNModule() : ModuleInstance("wasi_ephemeral_nn") {
               std::make_unique<WasiNNInitExecCtx>(Env));
   addHostFunc("set_input", std::make_unique<WasiNNSetInput>(Env));
   addHostFunc("get_output", std::make_unique<WasiNNGetOutput>(Env));
+  addHostFunc("get_output_single",
+              std::make_unique<WasiNNGetOutputSingle>(Env));
   addHostFunc("compute", std::make_unique<WasiNNCompute>(Env));
+  addHostFunc("compute_single", std::make_unique<WasiNNComputeSingle>(Env));
 }
 
 } // namespace Host


### PR DESCRIPTION
This pull request is for adding the function of single token inference. To implement this function, we need to make modifications to 3 different repositories:

1. wasmedge-wasi-nn: Add two host functions `compute_single` and `get_output_single`
   - PR: https://github.com/second-state/wasmedge-wasi-nn/pull/3
2. WasmEdge: Implement the two WASI-NN functions `compute_single` and `get_output_single`
   - PR: https://github.com/WasmEdge/WasmEdge/pull/3103
3. WasmEdge-WASINN-examples: Add examples for single token inference
   - PR: https://github.com/second-state/WasmEdge-WASINN-examples/pull/75