### PR TITLE
Fix large timestamp causing overflow

### DIFF
--- a/lib/host/wasi/linux.h
+++ b/lib/host/wasi/linux.h
@@ -264,7 +264,7 @@ inline constexpr clockid_t toClockId(__wasi_clockid_t Clock) noexcept {
 
 inline constexpr timespec toTimespec(__wasi_timestamp_t Timestamp) noexcept {
   using namespace std::chrono;
-  const auto Total = nanoseconds(Timestamp);
+  const auto Total = duration<uint64_t, std::nano>(Timestamp);
   const auto Second = duration_cast<seconds>(Total);
   const auto Nano = Total - Second;
   timespec Result{};


### PR DESCRIPTION
This commit fixes a bug in `toTimespec`.  The duration overflows with a large timestamp because `std::chrono::nanoseconds` is signed 64-bit integer.  Instead, we should explicitly use `uint64_t` because `__wasi_timestamp_t` is unsigned 64-bit.

fixes #3105