### PR TITLE
[Tools] --version: add plugin versions

### DIFF
--- a/include/plugin/plugin.h
+++ b/include/plugin/plugin.h
@@ -136,6 +136,8 @@ public:
   WASMEDGE_EXPORT const PluginModule *
   findModule(std::string_view Name) const noexcept;
 
+  std::filesystem::path path() const noexcept { return Path; }
+
 private:
   static std::vector<Plugin> &PluginRegistory;
   static std::unordered_map<std::string_view, std::size_t> &PluginNameLookup;

--- a/lib/driver/uniTool.cpp
+++ b/lib/driver/uniTool.cpp
@@ -53,6 +53,13 @@ int UniTool(int Argc, const char *Argv[], const ToolType ToolSelect) noexcept {
   }
   if (Parser.isVersion()) {
     std::cout << Argv[0] << " version "sv << kVersionString << '\n';
+    for (const auto &Plugin : Plugin::Plugin::plugins()) {
+      auto PluginVersion = Plugin.version();
+      std::cout << Plugin.path().string() << " (plugin \""sv << Plugin.name()
+                << "\") version "sv << PluginVersion.Major << '.'
+                << PluginVersion.Minor << '.' << PluginVersion.Patch << '.'
+                << PluginVersion.Build << '\n';
+    }
     return EXIT_SUCCESS;
   }
   if (Parser.isHelp()) {


### PR DESCRIPTION
The plugin versions can be now shown via the `wasmedge --version` CLI.

e.g.,
```console
$ /tmp/wasmedge/bin/wasmedge --version
/tmp/wasmedge/bin/wasmedge version 0.13.5-XX-gXXXXXXXX
/private/tmp/wasmedge/lib/../plugin/libwasmedgePluginWasiNN.dylib (plugin "wasi_nn") version 0.10.1.0
```