### PR TITLE
[CI] Fix incorrect ABI in MSVC build (#3113)

### DIFF
--- a/lib/executor/engine/proxy.cpp
+++ b/lib/executor/engine/proxy.cpp
@@ -27,7 +27,9 @@ struct Executor::ProxyHelper<Expect<RetT> (Executor::*)(Runtime::StackManager &,
     if (unlikely(!Res)) {
       Fault::emitFault(Res.error());
     }
-    if constexpr (!std::is_void_v<RetT>) {
+    if constexpr (std::is_same_v<RetT, RefVariant>) {
+      return (*Res).Ptr;
+    } else if constexpr (!std::is_void_v<RetT>) {
       return *Res;
     }
   }


### PR DESCRIPTION
The `ProxyHelper::proxy` function may directly return `RefVariant`. Directly returning a C++ struct makes the ABI unstable. Fixed https://github.com/WasmEdge/WasmEdge/issues/3113