### PR TITLE
[WIP][Wasi] add Wasi-Socket

### DIFF
--- a/include/host/preview2/wasi-sockets/api.h
+++ b/include/host/preview2/wasi-sockets/api.h
@@ -1,0 +1,194 @@
+// SPDX_License_Identifier: Apache-2.0
+// SPDX_FileCopyrightText: 2019-2022 Second State INC
+
+#pragma once
+#include "common/variant.h"
+#include <cstdint>
+#include <wasi/api.hpp>
+
+namespace WasmEdge {
+namespace Host {
+
+enum __wasi_sockets_errno_t : uint8_t {
+  /// Unknown error
+  __WASI_SOCKETS_ERRNO_UNKNOW,
+
+  /// Access denied.
+  ///
+  /// POSIX equivalent: EACCES, EPERM
+  __WASI_SOCKETS_ERRNO_ACCESS_DENIED,
+
+  /// The operation is not supported.
+  ///
+  /// POSIX equivalent: EOPNOTSUPP
+  __WASI_SOCKETS_ERRNO_NOT_SUPPORTED,
+
+  /// One of the arguments is invalid.
+  ///
+  /// POSIX equivalent: EINVAL
+  __WASI_SOCKETS_ERRNO_INVALID_ARGUMENT,
+
+  /// Not enough memory to complete the operation.
+  ///
+  /// POSIX equivalent: ENOMEM, ENOBUFS, EAI_MEMORY
+  __WASI_SOCKETS_ERRNO_OUT_OF_MEMORY,
+
+  /// The operation timed out before it could finish completely.
+  __WASI_SOCKETS_ERRNO_TIMEOUT,
+
+  /// This operation is incompatible with another asynchronous operation that is
+  /// already in progress.
+  __WASI_SOCKETS_ERRNO_CONCURRENCY_CONFLICT,
+
+  /// Trying to finish an asynchronous operation that:
+  /// - has not been started yet, or:
+  /// - was already finished by a previous `finish-*` call.
+  ///
+  /// Note: this is scheduled to be removed when `future`s are natively
+  /// supported.
+  __WASI_SOCKETS_ERRNO_NOT_IN_PROGRESS,
+
+  /// The operation has been aborted because it could not be completed
+  /// immediately.
+  ///
+  /// Note: this is scheduled to be removed when `future`s are natively
+  /// supported.
+  __WASI_SOCKETS_ERRNO_WOULD_BLOCK,
+
+  // ### TCP & UDP SOCKET ERRORS ###
+
+  /// The operation is not valid in the socket's current state.
+  __WASI_SOCKETS_ERRNO_INVALID_STATE,
+
+  /// A new socket resource could not be created because of a system limit.
+  __WASI_SOCKETS_ERRNO_NEW_SOCKET_LIMIT,
+
+  /// A bind operation failed because the provided address is not an address
+  /// that the `network` can bind to.
+  __WASI_SOCKETS_ERRNO_ADDRESS_NOT_BINDABLE,
+
+  /// A bind operation failed because the provided address is already in use or
+  /// because there are no ephemeral ports available.
+  __WASI_SOCKETS_ERRNO_ADDRESS_IN_USE,
+
+  /// The remote address is not reachable
+  __WASI_SOCKETS_ERRNO_REMOTE_UNREACHABLE,
+
+  // ### TCP SOCKET ERRORS ###
+
+  /// The connection was forcefully rejected
+  __WASI_SOCKETS_ERRNO_CONNECTION_REFUSED,
+
+  /// The connection was reset.
+  __WASI_SOCKETS_ERRNO_CONNECTION_RESET,
+
+  /// The connection was aborted.
+  __WASI_SOCKETS_ERRNO_CONNECTION_ABORTED,
+
+  // ### UDP SOCKET ERRORS ###
+  __WASI_SOCKETS_ERRNO_DATAGRAM_TOO_LARGE,
+
+  // ### NAME LOOKUP ERRORS ###
+
+  /// Name does not exist or has no suitable associated IP addresses.
+  __WASI_SOCKETS_ERRNO_NAME_UNRESOLVABLE,
+
+  /// A temporary failure in name resolution occurred.
+  __WASI_SOCKETS_ERRNO_TEMPORARY_RESOLVER_FAILURE,
+
+  /// A permanent failure in name resolution occurred.
+  __WASI_SOCKETS_ERRNO_PERMANENT_RESOLVER_FAILURE,
+};
+
+using __wasi_handle_t = uint32_t;
+using __wasi_udp_socket_handle_t = __wasi_handle_t;
+using __wasi_tcp_socket_handle_t = __wasi_handle_t;
+using __wasi_udp_own_incoming_datagram_stream_handle_t = __wasi_handle_t;
+using __wasi_udp_own_outgoing_datagram_stream_handle_t = __wasi_handle_t;
+using __wasi_tcp_own_incoming_datagram_stream_handle_t = __wasi_handle_t;
+using __wasi_tcp_own_outgoing_datagram_stream_handle_t = __wasi_handle_t;
+using __wasi_resolve_address_stream_handle_t = __wasi_handle_t;
+
+template <typename T> struct __wasi_sockets_ret_t {
+  bool IsErr;
+  union {
+    T Res;
+    __wasi_sockets_errno_t Err;
+  } Val;
+};
+
+template <> struct __wasi_sockets_ret_t<void> {
+  bool IsErr;
+  union {
+    __wasi_sockets_errno_t Err;
+  } Val;
+};
+
+enum __wasi_sockets_ip_address_family_t : uint8_t {
+  __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv4 = 0,
+  __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6 = 1
+};
+
+enum __wasi_sockets_type_t : uint8_t {
+  __WASI_SOCKETS_TYPE_DGRAM = 1,
+  __WASI_SOCKETS_TYPE_STREAM = 2
+};
+
+struct __wasi_sockets_ipv4_address_t {
+  uint8_t Addr[4];
+};
+static_assert(sizeof(__wasi_sockets_ipv4_address_t) == 4,
+              "__wasi_sockets_ipv4_address size");
+struct __wasi_sockets_ipv6_address_t {
+  uint16_t Addr[8];
+};
+static_assert(sizeof(__wasi_sockets_ipv6_address_t) == 16,
+              "__wasi_sockets_ipv6_address size");
+
+struct __wasi_sockets_ip_address_t {
+  __wasi_sockets_ip_address_family_t AddressFamily;
+  union {
+    __wasi_sockets_ipv4_address_t IPv4;
+    __wasi_sockets_ipv6_address_t IPv6;
+  } Val;
+};
+
+struct __wasi_sockets_ipv4_socket_address_t {
+  uint16_t Port;
+  __wasi_sockets_ipv4_address_t Address;
+};
+
+struct __wasi_sockets_ipv6_socket_address_t {
+  uint16_t Port;
+  uint32_t FlowInfo;
+  __wasi_sockets_ipv6_address_t Address;
+  uint32_t ScopeId;
+};
+
+struct __wasi_sockets_ip_socket_address_t {
+  __wasi_sockets_ip_address_family_t AddressFamily;
+  union {
+    __wasi_sockets_ipv4_socket_address_t IPv4;
+    __wasi_sockets_ipv6_socket_address_t IPv6;
+  } Val;
+};
+
+struct __wasi_sockets_udp_incoming_datagram_stream_t {
+  __wasi_udp_own_incoming_datagram_stream_handle_t InHandle;
+  __wasi_udp_own_outgoing_datagram_stream_handle_t OutHandle;
+};
+
+struct __wasi_sockets_tcp_incoming_datagram_stream_t {
+  __wasi_tcp_own_incoming_datagram_stream_handle_t InHandle;
+  __wasi_tcp_own_outgoing_datagram_stream_handle_t OutHandle;
+};
+
+struct __wasi_sockets_tcp_accept_tuple_t {
+  __wasi_tcp_socket_handle_t Socket;
+  __wasi_tcp_own_incoming_datagram_stream_handle_t InHandle;
+  __wasi_tcp_own_outgoing_datagram_stream_handle_t OutHandle;
+};
+
+struct __wasi_sockets_udp_datagram {};
+} // namespace Host
+} // namespace WasmEdge

--- a/include/host/preview2/wasi-sockets/base.h
+++ b/include/host/preview2/wasi-sockets/base.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "common/errcode.h"
+#include "host/preview2/wasi-sockets/env.h"
+#include "runtime/callingframe.h"
+#include "runtime/hostfunc.h"
+
+namespace WasmEdge {
+namespace Host {
+
+template <typename T> class WasiSockets : public Runtime::HostFunction<T> {
+public:
+  WasiSockets(WasiSocketsEnvironment &HostEnv)
+      : Runtime::HostFunction<T>(0), Env(HostEnv) {}
+
+protected:
+  WasiSocketsEnvironment &Env;
+};
+
+} // namespace Host
+} // namespace WasmEdge

--- a/include/host/preview2/wasi-sockets/env.h
+++ b/include/host/preview2/wasi-sockets/env.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#include "host/preview2/wasi-sockets/api.h"
+#include "host/preview2/wasi-sockets/resource_table.h"
+#include "host/wasi/environ.h"
+#include <functional>
+
+namespace WasmEdge {
+namespace Host {
+
+namespace WasiSocket {
+namespace Network {
+struct Network : public ResourceElementBase {
+  bool AllowIPNameCheck;
+  bool
+  CheckAddress([[maybe_unused]] const __wasi_sockets_ip_address_t &Address) {
+    return true;
+  }
+  std::function<bool(const __wasi_sockets_ip_address_t &)> GetChecker() {
+    return [this](const __wasi_sockets_ip_address_t &Addr) -> bool {
+      return this->CheckAddress(Addr);
+    };
+  }
+  Network() : ResourceElementBase() {}
+};
+} // namespace Network
+namespace UDP {
+enum class SocketState { Default, BindStarted, Bound, Connected };
+
+struct UDPSocket : public ResourceElementBase {
+  __wasi_fd_t Fd;
+  __wasi_sockets_ip_address_family_t AddressFamily;
+  SocketState State;
+  bool IPv6Only;
+  std::function<bool(const __wasi_sockets_ip_address_t &)> AddressChecker;
+
+  std::list<HandleT> Children;
+  std::list<HandleT> *GetChildren() override { return &Children; };
+
+  static bool DefaultAddressChecker(const __wasi_sockets_ip_address_t &) {
+    return true;
+  };
+
+  UDPSocket(__wasi_fd_t Fd, __wasi_sockets_ip_address_family_t AddressFamily,
+            SocketState State)
+      : ResourceElementBase(), Fd(Fd), AddressFamily(AddressFamily),
+        State(State), IPv6Only(true), AddressChecker(DefaultAddressChecker) {}
+};
+
+struct IncomingDatagramStream : public ResourceElementBase {
+  __wasi_fd_t Fd;
+  __wasi_sockets_ip_socket_address_t RemoteAddress;
+
+  IncomingDatagramStream(__wasi_fd_t Fd,
+                         __wasi_sockets_ip_socket_address_t RemoteAddress)
+      : ResourceElementBase(), Fd(Fd), RemoteAddress(RemoteAddress) {}
+};
+
+struct OutgoingDatagramStream : public ResourceElementBase {
+  __wasi_fd_t Fd;
+  __wasi_sockets_ip_socket_address_t RemoteAddress;
+  __wasi_sockets_ip_address_family_t AddressFamily;
+
+  OutgoingDatagramStream(__wasi_fd_t Fd,
+                         __wasi_sockets_ip_socket_address_t RemoteAddress,
+                         __wasi_sockets_ip_address_family_t AddressFamily)
+      : ResourceElementBase(), Fd(Fd), RemoteAddress(RemoteAddress),
+        AddressFamily(AddressFamily) {}
+};
+
+} // namespace UDP
+namespace TCP {
+enum class TCPSocketState {
+  Default,
+  BindStarted,
+  Bound,
+  ListenStarted,
+  Listening,
+  Connecting,
+  ConnectReady,
+  ConnectFailed,
+  Connected
+};
+
+struct TCPSocket : public ResourceElementBase {
+  __wasi_fd_t Fd;
+  __wasi_sockets_ip_address_family_t AddressFamily;
+  std::atomic<TCPSocketState> State;
+  int32_t ListenBacklogSize;
+  bool IPv6Only;
+
+  // According
+  // https://github.com/rust-lang/rust/blob/master/library/std/src/sys_common/net.rs
+  // ListenBacklogSize default for most platform is 128
+  TCPSocket(__wasi_fd_t Fd, __wasi_sockets_ip_address_family_t AddressFamily,
+            TCPSocketState State)
+      : Fd(Fd), AddressFamily(AddressFamily), State(State),
+        ListenBacklogSize(128), IPv6Only(false) {}
+};
+} // namespace TCP
+namespace IpNameLookup {
+struct ResolveAddressStream : public ResourceElementBase {
+  std::atomic<bool> IsReady;
+  std::string Query;
+  std::vector<__wasi_sockets_ip_address_t> Resolved;
+  bool Invalid;
+
+  ResolveAddressStream(std::string_view Query)
+      : IsReady(false), Query(Query), Resolved(), Invalid(false) {}
+};
+} // namespace IpNameLookup
+} // namespace WasiSocket
+
+class WasiSocketsEnvironment : public WASI::Environ {
+public:
+  WasiSocketsEnvironment() noexcept {}
+  ResourceTable Table;
+};
+
+} // namespace Host
+} // namespace WasmEdge

--- a/include/host/preview2/wasi-sockets/ip-name-lookup/wasifunc.h
+++ b/include/host/preview2/wasi-sockets/ip-name-lookup/wasifunc.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2022 Second State INC
+
+#pragma once
+
+#include "host/preview2/wasi-sockets/api.h"
+#include "host/preview2/wasi-sockets/base.h"
+#include "host/preview2/wasi-sockets/variant_helper.h"
+#include "host/wasi/wasibase.h"
+
+#include <cstdint>
+
+namespace WasmEdge {
+namespace Host {
+namespace WasiSocket {
+namespace IpNameLookup {
+
+class ResolveAddresses : public WasiSockets<ResolveAddresses> {
+public:
+  ResolveAddresses(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t StrPtr, uint32_t StrLen, uint32_t RetBufPtr);
+};
+
+class ResolveNextAddress : public WasiSockets<ResolveNextAddress> {
+public:
+  ResolveNextAddress(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class ResolveDrop : public WasiSockets<ResolveDrop> {
+public:
+  ResolveDrop(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle);
+};
+
+} // namespace IpNameLookup
+} // namespace WasiSocket
+} // namespace Host
+} // namespace WasmEdge

--- a/include/host/preview2/wasi-sockets/resource_table.h
+++ b/include/host/preview2/wasi-sockets/resource_table.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <cstdint>
+#include <list>
+#include <map>
+#include <random>
+#include <utility>
+
+namespace WasmEdge {
+namespace Host {
+
+class ResourceElementBase {
+public:
+  using HandleT = std::uint32_t;
+  HandleT Parent;
+  ResourceElementBase() {}
+  virtual ~ResourceElementBase(){};
+  virtual std::list<HandleT> *GetChildren() { return nullptr; };
+};
+
+class ResourceTable {
+public:
+  using HandleT = ResourceElementBase::HandleT;
+  static const HandleT NullParent = UINT32_MAX;
+  HandleT GetNewHandle() {
+    static std::random_device Rd;
+    static std::default_random_engine Engine(Rd());
+    static std::uniform_int_distribution<HandleT> Dis(1, UINT32_MAX - 1);
+
+    HandleT Res = 0;
+    do {
+      Res = Dis(Engine);
+    } while (Table.find(Res) != Table.end());
+    return Res;
+  }
+
+  template <typename T, typename... Args>
+  HandleT Push(HandleT Parent, Args &&...args) {
+    // Note: this is not thread safe
+    HandleT Handle = GetNewHandle();
+    auto Ptr = std::make_unique<T>(std::forward<Args>(args)...);
+    Ptr->Parent = Parent;
+    Table.emplace(Handle, std::move(Ptr));
+    return Handle;
+  }
+
+  template <typename T> T *GetById(HandleT Index) {
+    auto Res = Table.find(Index);
+    if (Res == Table.end()) {
+      return nullptr;
+    }
+    // if type not matched, it return nullptr and it is fine
+    return dynamic_cast<T *>(Res->second.get());
+  }
+
+  // TODO: delayed drop
+  bool Drop(HandleT Index) {
+    auto Res = Table.find(Index);
+    if (Res == Table.end())
+      return false;
+
+    if (auto List = Res->second->GetChildren(); List != nullptr) {
+      for (auto Childres : *List) {
+        Drop(Childres);
+      }
+    }
+    return Table.erase(Index);
+  }
+
+private:
+  std::map<HandleT, std::unique_ptr<ResourceElementBase>> Table;
+};
+} // namespace Host
+} // namespace WasmEdge

--- a/include/host/preview2/wasi-sockets/tcp/wasifunc.h
+++ b/include/host/preview2/wasi-sockets/tcp/wasifunc.h
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2022 Second State INC
+
+#pragma once
+
+#include "host/preview2/wasi-sockets/api.h"
+#include "host/preview2/wasi-sockets/base.h"
+#include "host/preview2/wasi-sockets/variant_helper.h"
+#include "host/wasi/wasibase.h"
+
+#include <cstdint>
+
+namespace WasmEdge {
+namespace Host {
+namespace WasiSocket {
+namespace TCP {
+// Wasi-Socket
+
+class CreateTCPSocket : public WasiSockets<CreateTCPSocket> {
+public:
+  CreateTCPSocket(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, int32_t AddressFamily,
+                    uint32_t RetBufPtr);
+};
+
+class StartBind : public WasiSockets<StartBind> {
+public:
+  StartBind(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t NetHandle, __VARG_12_UINTS, uint32_t RetBufPtr);
+};
+
+class FinishBind : public WasiSockets<FinishBind> {
+public:
+  FinishBind(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class StartConnect : public WasiSockets<StartConnect> {
+public:
+  StartConnect(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t NetHandle, __VARG_12_UINTS, uint32_t RetBufPtr);
+};
+
+class FinishConnect : public WasiSockets<FinishConnect> {
+public:
+  FinishConnect(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class StartListen : public WasiSockets<StartListen> {
+public:
+  StartListen(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class FinishListen : public WasiSockets<FinishListen> {
+public:
+  FinishListen(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class Accept : public WasiSockets<Accept> {
+public:
+  Accept(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class LocalAddress : public WasiSockets<LocalAddress> {
+public:
+  LocalAddress(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class RemoteAddress : public WasiSockets<RemoteAddress> {
+public:
+  RemoteAddress(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class Islistening : public WasiSockets<Islistening> {
+public:
+  Islistening(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t Handle);
+};
+
+class AddressFamily : public WasiSockets<AddressFamily> {
+public:
+  AddressFamily(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t Handle);
+};
+
+class IPv6Only : public WasiSockets<IPv6Only> {
+public:
+  IPv6Only(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class SetIPv6Only : public WasiSockets<SetIPv6Only> {
+public:
+  SetIPv6Only(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t Val, uint32_t RetBufPtr);
+};
+
+class SetListenBacklogSize : public WasiSockets<SetListenBacklogSize> {
+public:
+  SetListenBacklogSize(WasiSocketsEnvironment &HostEnv)
+      : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint64_t Val, uint32_t RetBufPtr);
+};
+
+class KeepAliveEnabled : public WasiSockets<KeepAliveEnabled> {
+public:
+  KeepAliveEnabled(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class SetKeepAliveEnabled : public WasiSockets<SetKeepAliveEnabled> {
+public:
+  SetKeepAliveEnabled(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t Val, uint32_t RetBufPtr);
+};
+
+class KeepAliveIdleTime : public WasiSockets<KeepAliveIdleTime> {
+public:
+  KeepAliveIdleTime(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class SetKeepAliveIdleTime : public WasiSockets<SetKeepAliveIdleTime> {
+public:
+  SetKeepAliveIdleTime(WasiSocketsEnvironment &HostEnv)
+      : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint64_t Val, uint32_t RetBufPtr);
+};
+
+class KeepAliveInterval : public WasiSockets<KeepAliveInterval> {
+public:
+  KeepAliveInterval(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class SetKeepAliveInterval : public WasiSockets<SetKeepAliveInterval> {
+public:
+  SetKeepAliveInterval(WasiSocketsEnvironment &HostEnv)
+      : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint64_t Val, uint32_t RetBufPtr);
+};
+
+class KeepAliveCount : public WasiSockets<KeepAliveCount> {
+public:
+  KeepAliveCount(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class SetKeepAliveCount : public WasiSockets<SetKeepAliveCount> {
+public:
+  SetKeepAliveCount(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t Val, uint32_t RetBufPtr);
+};
+
+class HopLimit : public WasiSockets<HopLimit> {
+public:
+  HopLimit(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class SetHopLimit : public WasiSockets<SetHopLimit> {
+public:
+  SetHopLimit(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t Val, uint32_t RetBufPtr);
+};
+
+class GetReceiveBufferSize : public WasiSockets<GetReceiveBufferSize> {
+public:
+  GetReceiveBufferSize(WasiSocketsEnvironment &HostEnv)
+      : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class SetReceiveBufferSize : public WasiSockets<SetReceiveBufferSize> {
+public:
+  SetReceiveBufferSize(WasiSocketsEnvironment &HostEnv)
+      : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint64_t Val, uint32_t RetBufPtr);
+};
+
+class GetSendBufferSize : public WasiSockets<GetSendBufferSize> {
+public:
+  GetSendBufferSize(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class SetSendBufferSize : public WasiSockets<SetSendBufferSize> {
+public:
+  SetSendBufferSize(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint64_t Val, uint32_t RetBufPtr);
+};
+
+class Shutdown : public WasiSockets<Shutdown> {
+public:
+  Shutdown(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t How, uint32_t RetBufPtr);
+};
+} // namespace TCP
+} // namespace WasiSocket
+} // namespace Host
+} // namespace WasmEdge

--- a/include/host/preview2/wasi-sockets/udp/wasifunc.h
+++ b/include/host/preview2/wasi-sockets/udp/wasifunc.h
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2022 Second State INC
+
+#pragma once
+
+#include "host/preview2/wasi-sockets/api.h"
+#include "host/preview2/wasi-sockets/base.h"
+#include "host/preview2/wasi-sockets/variant_helper.h"
+#include "host/wasi/wasibase.h"
+
+#include <cstdint>
+
+namespace WasmEdge {
+namespace Host {
+namespace WasiSocket {
+namespace UDP {
+// Wasi-Socket
+
+class CreateUDPSocket : public WasiSockets<CreateUDPSocket> {
+public:
+  CreateUDPSocket(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, int32_t AddressFamily,
+                    uint32_t RetBufPtr);
+};
+
+class StartBind : public WasiSockets<StartBind> {
+public:
+  StartBind(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t NetHandle, __VARG_12_UINTS, uint32_t RetBufPtr);
+};
+
+class FinishBind : public WasiSockets<FinishBind> {
+public:
+  FinishBind(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class Stream : public WasiSockets<Stream> {
+public:
+  Stream(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    __VARG_12_UINTS, uint32_t RetBufPtr);
+};
+
+class LocalAddress : public WasiSockets<LocalAddress> {
+public:
+  LocalAddress(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class RemoteAddress : public WasiSockets<RemoteAddress> {
+public:
+  RemoteAddress(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class AddressFamily : public WasiSockets<AddressFamily> {
+public:
+  AddressFamily(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t Handle);
+};
+
+// https://github.com/WebAssembly/wasi-sockets/pull/93
+// IPv6 Only function deleted, but maybe turn back...
+class IPv6Only : public WasiSockets<IPv6Only> {
+public:
+  IPv6Only(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class SetIPv6Only : public WasiSockets<SetIPv6Only> {
+public:
+  SetIPv6Only(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t Val, uint32_t RetBufPtr);
+};
+
+class UnicastHopLimit : public WasiSockets<UnicastHopLimit> {
+public:
+  UnicastHopLimit(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class SetUnicastHopLimit : public WasiSockets<SetUnicastHopLimit> {
+public:
+  SetUnicastHopLimit(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t Val, uint32_t RetBufPtr);
+};
+
+class GetReceiveBufferSize : public WasiSockets<GetReceiveBufferSize> {
+public:
+  GetReceiveBufferSize(WasiSocketsEnvironment &HostEnv)
+      : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class SetReceiveBufferSize : public WasiSockets<SetReceiveBufferSize> {
+public:
+  SetReceiveBufferSize(WasiSocketsEnvironment &HostEnv)
+      : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint64_t Val, uint32_t RetBufPtr);
+};
+
+class GetSendBufferSize : public WasiSockets<GetSendBufferSize> {
+public:
+  GetSendBufferSize(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint32_t RetBufPtr);
+};
+
+class SetSendBufferSize : public WasiSockets<SetSendBufferSize> {
+public:
+  SetSendBufferSize(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint64_t Val, uint32_t RetBufPtr);
+};
+
+class UDPSocketsSubscribe : public WasiSockets<UDPSocketsSubscribe> {
+public:
+  UDPSocketsSubscribe(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t Handle);
+};
+
+class UDPSocketsDrop : public WasiSockets<UDPSocketsDrop> {
+public:
+  UDPSocketsDrop(WasiSocketsEnvironment &HostEnv) : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle);
+};
+
+class IncomingDatagramStreamReceive
+    : public WasiSockets<IncomingDatagramStreamReceive> {
+public:
+  IncomingDatagramStreamReceive(WasiSocketsEnvironment &HostEnv)
+      : WasiSockets(HostEnv) {}
+
+  Expect<void> body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                    uint64_t MaxResults, uint32_t RetBufPtr);
+};
+
+// subscribe: func() -> pollable;
+//  only for preview2 and remove for preview3
+
+} // namespace UDP
+} // namespace WasiSocket
+} // namespace Host
+} // namespace WasmEdge

--- a/include/host/preview2/wasi-sockets/util.h
+++ b/include/host/preview2/wasi-sockets/util.h
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2022 Second State INC
+#pragma once
+
+#include "common/expected.h"
+#include "host/preview2/wasi-sockets/api.h"
+#include "host/preview2/wasi-sockets/variant_helper.h"
+#include "host/wasi/environ.h"
+#include "host/wasi/error.h"
+
+#include <limits>
+#include <numeric>
+#include <type_traits>
+
+namespace WasmEdge {
+namespace Host {
+namespace WasiSocket {
+
+template <typename T> struct WasiRawType {
+  using Type = std::underlying_type_t<T>;
+};
+template <> struct WasiRawType<uint8_t> {
+  using Type = uint8_t;
+};
+template <> struct WasiRawType<uint16_t> {
+  using Type = uint16_t;
+};
+template <> struct WasiRawType<uint32_t> {
+  using Type = uint32_t;
+};
+template <> struct WasiRawType<uint64_t> {
+  using Type = uint64_t;
+};
+
+template <typename T> using WasiRawTypeT = typename WasiRawType<T>::Type;
+
+template <typename T> WASI::WasiExpect<T> cast(uint64_t) noexcept;
+
+template <>
+WASI::WasiExpect<__wasi_sockets_ip_address_family_t>
+cast<__wasi_sockets_ip_address_family_t>(uint64_t Family) noexcept {
+  switch (WasiRawTypeT<__wasi_sockets_ip_address_family_t>(Family)) {
+  case __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv4:
+    return __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv4;
+  case __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6:
+    return __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6;
+  default:
+    return WASI::WasiUnexpect(__WASI_ERRNO_INVAL);
+  }
+}
+
+// TODO: fill this
+__wasi_sockets_errno_t toSockErrCode(__wasi_errno_t Err) {
+  switch (Err) {
+  case __WASI_ERRNO_AGAIN:
+  case __WASI_ERRNO_INTR:
+    // case __WASI_ERRNO_WOULDBLOCK:
+    return __WASI_SOCKETS_ERRNO_WOULD_BLOCK;
+  case __WASI_ERRNO_PERM:
+  case __WASI_ERRNO_ACCES:
+    return __WASI_SOCKETS_ERRNO_ACCESS_DENIED;
+  case __WASI_ERRNO_ADDRINUSE:
+    return __WASI_SOCKETS_ERRNO_ADDRESS_IN_USE;
+  case __WASI_ERRNO_ADDRNOTAVAIL:
+    return __WASI_SOCKETS_ERRNO_ADDRESS_NOT_BINDABLE;
+  case __WASI_ERRNO_ALREADY:
+    return __WASI_SOCKETS_ERRNO_CONCURRENCY_CONFLICT;
+  case __WASI_ERRNO_TIMEDOUT:
+    return __WASI_SOCKETS_ERRNO_TIMEOUT;
+  case __WASI_ERRNO_CONNREFUSED:
+    return __WASI_SOCKETS_ERRNO_CONNECTION_REFUSED;
+  case __WASI_ERRNO_CONNRESET:
+    return __WASI_SOCKETS_ERRNO_CONNECTION_RESET;
+  case __WASI_ERRNO_CONNABORTED:
+    return __WASI_SOCKETS_ERRNO_CONNECTION_REFUSED;
+  case __WASI_ERRNO_INVAL:
+    return __WASI_SOCKETS_ERRNO_INVALID_ARGUMENT;
+  case __WASI_ERRNO_HOSTUNREACH:
+  // case __WASI_ERRNO_HOSTDOWN:
+  case __WASI_ERRNO_NETDOWN:
+  case __WASI_ERRNO_NETUNREACH:
+  case __WASI_ERRNO_NOENT:
+    return __WASI_SOCKETS_ERRNO_REMOTE_UNREACHABLE;
+  case __WASI_ERRNO_ISCONN:
+  case __WASI_ERRNO_NOTCONN:
+  case __WASI_ERRNO_DESTADDRREQ:
+    return __WASI_SOCKETS_ERRNO_INVALID_STATE;
+  case __WASI_ERRNO_NFILE:
+  case __WASI_ERRNO_MFILE:
+    return __WASI_SOCKETS_ERRNO_NEW_SOCKET_LIMIT;
+  case __WASI_ERRNO_MSGSIZE:
+    return __WASI_SOCKETS_ERRNO_DATAGRAM_TOO_LARGE;
+  case __WASI_ERRNO_NOMEM:
+  case __WASI_ERRNO_NOBUFS:
+    return __WASI_SOCKETS_ERRNO_OUT_OF_MEMORY;
+  // case __WASI_ERRNO_OPNOTSUPP:
+  case __WASI_ERRNO_NOPROTOOPT:
+  case __WASI_ERRNO_NOTSUP:
+  // case __WASI_ERRNO_PFNOSUPPORT:
+  case __WASI_ERRNO_PROTONOSUPPORT:
+  case __WASI_ERRNO_PROTOTYPE:
+  case __WASI_ERRNO_AFNOSUPPORT:
+    return __WASI_SOCKETS_ERRNO_NOT_SUPPORTED;
+  default:
+    return __WASI_SOCKETS_ERRNO_UNKNOW;
+  }
+}
+
+WASI::WasiExpect<__wasi_sockets_ip_socket_address_t>
+    PackIPSocketAddress(__VARG_12_UINTS);
+bool ValidateAddressFamily(const __wasi_sockets_ip_socket_address_t &);
+
+template <typename T>
+Expect<void> SocketsErr(__wasi_sockets_ret_t<T> &Buf,
+                        __wasi_sockets_errno_t SocketErrcode) {
+  Buf.IsErr = true;
+  Buf.Val.Err = SocketErrcode;
+  return {};
+}
+
+template <typename T>
+Expect<void> SocketsErr(__wasi_sockets_ret_t<T> &Buf,
+                        __wasi_errno_t WasiErrcode) {
+  Buf.IsErr = true;
+  Buf.Val.Err = toSockErrCode(WasiErrcode);
+  return {};
+}
+
+template <typename T> Expect<void> SocketsOk(__wasi_sockets_ret_t<T> &Buf) {
+  Buf.IsErr = false;
+  return {};
+}
+
+__wasi_sockets_ip_address_t
+Addr(const __wasi_sockets_ip_socket_address_t &SocketAddr);
+} // namespace WasiSocket
+} // namespace Host
+} // namespace WasmEdge

--- a/include/host/preview2/wasi-sockets/variant_helper.h
+++ b/include/host/preview2/wasi-sockets/variant_helper.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2022 Second State INC
+#pragma once
+
+#include <cstdint>
+// Some Hack for Variant on Args
+#define __VARG_12_UINTS                                                        \
+  uint32_t V1, uint32_t V2, uint32_t V3, uint32_t V4, uint32_t V5,             \
+      uint32_t V6, uint32_t V7, uint32_t V8, uint32_t V9, uint32_t V10,        \
+      uint32_t V11, uint32_t V12
+
+#define __V_12_UINTS V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12

--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -6,6 +6,7 @@
 #include "common/defines.h"
 #include "common/errcode.h"
 #include "common/span.h"
+#include "host/preview2/wasi-sockets/api.h"
 #include "host/wasi/clock.h"
 #include "host/wasi/error.h"
 #include "host/wasi/vfs.h"
@@ -1149,6 +1150,285 @@ public:
       return Node->sockGetPeerAddr(AddressFamilyPtr, Address, PortPtr);
     }
   }
+
+  // Above socket functions are for wasi preview 2
+
+  // sockOpenPV2 Create a non-block socket fd
+  // TODO: remove __wasi_address_family_t
+  WasiExpect<__wasi_fd_t>
+  sockOpenPV2(__wasi_sockets_ip_address_family_t AddressFamily,
+              __wasi_sockets_type_t SockType) noexcept {
+
+    std::shared_ptr<VINode> Node;
+    if (auto Res = VINode::sockOpenPV2(AddressFamily, SockType);
+        unlikely(!Res)) {
+      return WasiUnexpect(Res);
+    } else {
+      Node = std::move(*Res);
+    }
+
+    return generateRandomFdToNode(Node);
+  }
+
+  WasiExpect<void>
+  sockBindPV2(__wasi_fd_t Fd,
+              const __wasi_sockets_ip_socket_address_t &Address) noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockBindPV2(Address);
+    }
+  }
+
+  WasiExpect<void>
+  sockConnectPV2(__wasi_fd_t Fd,
+                 const __wasi_sockets_ip_socket_address_t &Address) noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockConnectPV2(Address);
+    }
+  }
+
+  WasiExpect<void> sockGetLocalAddrPV2(
+      __wasi_fd_t Fd,
+      __wasi_sockets_ip_socket_address_t &Address) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockGetLocalAddrPV2(Address);
+    }
+  }
+
+  WasiExpect<void> sockGetPeerAddrPV2(
+      __wasi_fd_t Fd,
+      __wasi_sockets_ip_socket_address_t &Address) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockGetPeerAddrPV2(Address);
+    }
+  }
+
+  WasiExpect<void> sockUDPDisconnect(__wasi_fd_t Fd) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockUDPDisconnect();
+    }
+  }
+
+  WasiExpect<void> sockSetIPv6V6only(__wasi_fd_t Fd,
+                                     bool IsV6only) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockSetIPv6V6only(IsV6only);
+    }
+  }
+
+  WasiExpect<uint8_t> sockGetIPTTL(__wasi_fd_t Fd) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockGetIPTTL();
+    }
+  }
+
+  WasiExpect<void> sockSetIPTTL(__wasi_fd_t Fd, uint8_t TTL) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockSetIPTTL(TTL);
+    }
+  }
+
+  WasiExpect<uint8_t> sockGetIPv6UnicastHops(__wasi_fd_t Fd) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockGetIPv6UnicastHops();
+    }
+  }
+
+  WasiExpect<void> sockSetIPv6UnicastHops(__wasi_fd_t Fd,
+                                          uint8_t TTL) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockSetIPv6UnicastHops(TTL);
+    }
+  }
+
+  WasiExpect<uint64_t> sockGetRecvBufferSize(__wasi_fd_t Fd) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockGetRecvBufferSize();
+    }
+  }
+
+  WasiExpect<void> sockSetRecvBufferSize(__wasi_fd_t Fd,
+                                         uint64_t Size) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockSetRecvBufferSize(Size);
+    }
+  }
+
+  WasiExpect<uint64_t> sockGetSendBufferSize(__wasi_fd_t Fd) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockGetSendBufferSize();
+    }
+  }
+
+  WasiExpect<void> sockSetSendBufferSize(__wasi_fd_t Fd,
+                                         uint64_t Size) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockSetSendBufferSize(Size);
+    }
+  }
+
+  WasiExpect<uint32_t> sockGetKeepAlive(__wasi_fd_t Fd) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockGetKeepAlive();
+    }
+  }
+
+  WasiExpect<void> sockSetKeepAlive(__wasi_fd_t Fd,
+                                    uint32_t Val) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockSetKeepAlive(Val);
+    }
+  }
+
+  WasiExpect<uint32_t> sockGetKeepIdle(__wasi_fd_t Fd) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockGetKeepIdle();
+    }
+  }
+
+  WasiExpect<void> sockSetKeepIdle(__wasi_fd_t Fd,
+                                   uint32_t Val) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockSetKeepIdle(Val);
+    }
+  }
+
+  WasiExpect<uint32_t> sockGetAliveInterval(__wasi_fd_t Fd) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockGetAliveInterval();
+    }
+  }
+
+  WasiExpect<void> sockSetAliveInterval(__wasi_fd_t Fd,
+                                        uint32_t Val) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockSetAliveInterval(Val);
+    }
+  }
+
+  WasiExpect<uint32_t> sockGetKeepAliveCount(__wasi_fd_t Fd) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockGetKeepAliveCount();
+    }
+  }
+
+  WasiExpect<void> sockSetKeepAliveCount(__wasi_fd_t Fd,
+                                         uint32_t Val) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockSetKeepAliveCount(Val);
+    }
+  }
+
+  WasiExpect<void> sockShutdownPV2(__wasi_fd_t Fd,
+                                   __wasi_sdflags_t SdFlags) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockShutdownPV2(SdFlags);
+    }
+  }
+
+  WasiExpect<void> sockRecvPV2(__wasi_fd_t Fd, Span<uint8_t> Buffer,
+                               __wasi_size_t &NRead) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockRecvPV2(Buffer, NRead);
+    }
+  }
+
+  WasiExpect<void> sockGetaddrinfoPV2(
+      std::string_view String,
+      std::vector<__wasi_sockets_ip_address_t> &Addresses) noexcept {
+    if (auto Res = VINode::sockGetaddrinfoPV2(String, Addresses);
+        unlikely(!Res)) {
+      return WasiUnexpect(Res);
+    }
+    return {};
+  }
+
+  /*WasiExpect<uint64_t> sockGetAliveIdleTime(__wasi_fd_t Fd) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return WasiUnexpect(__WASI_ERRNO_BADF);
+    } else {
+      return Node->sockGetAliveIdleTime();
+    }
+  }
+
+  WasiExpect<uint64_t> sockSetAliveIdleTime(__wasi_fd_t Fd, uint32_t Val) const
+  noexcept { auto Node = getNodeOrNull(Fd); if (unlikely(!Node)) { return
+  WasiUnexpect(__WASI_ERRNO_BADF); } else { return
+  Node->sockSetAliveIdleTime(Val);
+    }
+  }*/
 
   WasiExpect<uint64_t> getNativeHandler(__wasi_fd_t Fd) const noexcept {
     auto Node = getNodeOrNull(Fd);

--- a/include/host/wasi/inode.h
+++ b/include/host/wasi/inode.h
@@ -6,6 +6,7 @@
 #include "common/defines.h"
 #include "common/errcode.h"
 #include "common/span.h"
+#include "host/preview2/wasi-sockets/api.h"
 #include "host/wasi/error.h"
 #include "host/wasi/vfs.h"
 #include <functional>
@@ -774,6 +775,41 @@ public:
                                    Span<uint8_t> Address,
                                    uint16_t *PortPtr) const noexcept;
 
+  static WasiExpect<INode>
+  sockOpenPV2(__wasi_sockets_ip_address_family_t SysDomain,
+              __wasi_sockets_type_t SockType) noexcept;
+  WasiExpect<void>
+  sockBindPV2(const __wasi_sockets_ip_socket_address_t &Address) noexcept;
+  WasiExpect<void>
+  sockConnectPV2(const __wasi_sockets_ip_socket_address_t &Address) noexcept;
+  WasiExpect<void> sockGetLocalAddrPV2(
+      __wasi_sockets_ip_socket_address_t &Address) const noexcept;
+  WasiExpect<void> sockGetPeerAddrPV2(
+      __wasi_sockets_ip_socket_address_t &Address) const noexcept;
+  WasiExpect<void> sockUDPDisconnect() const noexcept;
+  WasiExpect<void> sockSetIPv6V6only(bool IsV6only) const noexcept;
+  WasiExpect<uint8_t> sockGetIPTTL() const noexcept;
+  WasiExpect<void> sockSetIPTTL(uint8_t TTL) const noexcept;
+  WasiExpect<uint8_t> sockGetIPv6UnicastHops() const noexcept;
+  WasiExpect<void> sockSetIPv6UnicastHops(uint8_t TTL) const noexcept;
+  WasiExpect<uint64_t> sockGetRecvBufferSize() const noexcept;
+  WasiExpect<void> sockSetRecvBufferSize(uint64_t Size) const noexcept;
+  WasiExpect<uint64_t> sockGetSendBufferSize() const noexcept;
+  WasiExpect<void> sockSetSendBufferSize(uint64_t Size) const noexcept;
+  WasiExpect<uint32_t> sockGetKeepAlive() const noexcept;
+  WasiExpect<void> sockSetKeepAlive(uint32_t Size) const noexcept;
+  WasiExpect<uint32_t> sockGetKeepIdle() const noexcept;
+  WasiExpect<void> sockSetKeepIdle(uint32_t Sec) const noexcept;
+  WasiExpect<uint32_t> sockGetAliveInterval() const noexcept;
+  WasiExpect<void> sockSetAliveInterval(uint32_t Sec) const noexcept;
+  WasiExpect<uint32_t> sockGetKeepAliveCount() const noexcept;
+  WasiExpect<void> sockSetKeepAliveCount(uint32_t Val) const noexcept;
+  WasiExpect<void> sockShutdownPV2(__wasi_sdflags_t SdFlags) const noexcept;
+  WasiExpect<void> sockRecvPV2(Span<uint8_t> Buffer,
+                               __wasi_size_t &NRead) const noexcept;
+  static WasiExpect<void> sockGetaddrinfoPV2(
+      std::string_view String,
+      std::vector<__wasi_sockets_ip_address_t> &Addresses) noexcept;
   /// File type.
   WasiExpect<__wasi_filetype_t> filetype() const noexcept;
 

--- a/include/host/wasi/vinode.h
+++ b/include/host/wasi/vinode.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "common/filesystem.h"
+#include "host/preview2/wasi-sockets/api.h"
 #include "host/wasi/error.h"
 #include "host/wasi/inode.h"
 #include "host/wasi/vfs.h"
@@ -661,6 +662,115 @@ public:
                                    uint16_t *PortPtr) const noexcept {
     return Node.sockGetPeerAddr(AddressFamilyPtr, Address, PortPtr);
   }
+
+  static WasiExpect<std::shared_ptr<VINode>>
+  sockOpenPV2(__wasi_sockets_ip_address_family_t SysDomain,
+              __wasi_sockets_type_t SockType);
+
+  WasiExpect<void>
+  sockBindPV2(const __wasi_sockets_ip_socket_address_t &Address) noexcept {
+    return Node.sockBindPV2(Address);
+  }
+
+  WasiExpect<void>
+  sockConnectPV2(const __wasi_sockets_ip_socket_address_t &Address) noexcept {
+    return Node.sockConnectPV2(Address);
+  }
+
+  WasiExpect<void>
+  sockGetLocalAddrPV2(__wasi_sockets_ip_socket_address_t &Address) noexcept {
+    return Node.sockGetLocalAddrPV2(Address);
+  }
+
+  WasiExpect<void>
+  sockGetPeerAddrPV2(__wasi_sockets_ip_socket_address_t &Address) noexcept {
+    return Node.sockGetPeerAddrPV2(Address);
+  }
+
+  WasiExpect<void> sockUDPDisconnect() noexcept {
+    return Node.sockUDPDisconnect();
+  }
+
+  WasiExpect<void> sockSetIPv6V6only(bool IsV6only) const noexcept {
+    return Node.sockSetIPv6V6only(IsV6only);
+  }
+
+  WasiExpect<uint8_t> sockGetIPTTL() const noexcept {
+    return Node.sockGetIPTTL();
+  }
+
+  WasiExpect<void> sockSetIPTTL(uint8_t TTL) const noexcept {
+    return Node.sockSetIPTTL(TTL);
+  }
+
+  WasiExpect<uint8_t> sockGetIPv6UnicastHops() const noexcept {
+    return Node.sockGetIPv6UnicastHops();
+  }
+
+  WasiExpect<void> sockSetIPv6UnicastHops(uint8_t TTL) const noexcept {
+    return Node.sockSetIPv6UnicastHops(TTL);
+  }
+
+  WasiExpect<uint64_t> sockGetRecvBufferSize() const noexcept {
+    return Node.sockGetRecvBufferSize();
+  }
+
+  WasiExpect<void> sockSetRecvBufferSize(uint64_t Size) const noexcept {
+    return Node.sockSetRecvBufferSize(Size);
+  }
+
+  WasiExpect<uint64_t> sockGetSendBufferSize() const noexcept {
+    return Node.sockGetSendBufferSize();
+  }
+
+  WasiExpect<void> sockSetSendBufferSize(uint64_t Size) const noexcept {
+    return Node.sockSetSendBufferSize(Size);
+  }
+
+  WasiExpect<uint32_t> sockGetKeepAlive() const noexcept {
+    return Node.sockGetKeepAlive();
+  }
+
+  WasiExpect<void> sockSetKeepAlive(uint64_t Size) const noexcept {
+    return Node.sockSetKeepAlive(Size);
+  }
+
+  WasiExpect<uint32_t> sockGetKeepIdle() const noexcept {
+    return Node.sockGetKeepIdle();
+  }
+
+  WasiExpect<void> sockSetKeepIdle(uint32_t Sec) const noexcept {
+    return Node.sockSetKeepIdle(Sec);
+  }
+
+  WasiExpect<uint32_t> sockGetAliveInterval() const noexcept {
+    return Node.sockGetAliveInterval();
+  }
+
+  WasiExpect<void> sockSetAliveInterval(uint32_t Sec) const noexcept {
+    return Node.sockSetAliveInterval(Sec);
+  }
+
+  WasiExpect<uint32_t> sockGetKeepAliveCount() const noexcept {
+    return Node.sockGetKeepAliveCount();
+  }
+
+  WasiExpect<void> sockSetKeepAliveCount(uint32_t Val) const noexcept {
+    return Node.sockSetKeepAliveCount(Val);
+  }
+
+  WasiExpect<void> sockShutdownPV2(__wasi_sdflags_t SdFlags) const noexcept {
+    return Node.sockShutdownPV2(SdFlags);
+  }
+
+  WasiExpect<void> sockRecvPV2(Span<uint8_t> Buffer,
+                               __wasi_size_t &NRead) const noexcept {
+    return Node.sockRecvPV2(Buffer, NRead);
+  }
+
+  static WasiExpect<void>
+  sockGetaddrinfoPV2(std::string_view String,
+                     std::vector<__wasi_sockets_ip_address_t> &Addresses);
 
   __wasi_rights_t fsRightsBase() const noexcept { return FsRightsBase; }
 

--- a/lib/host/preview2/CMakeLists.txt
+++ b/lib/host/preview2/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2019-2022 Second State INC
 
-add_subdirectory(wasi)
-add_subdirectory(preview2)
+add_subdirectory(wasi-sockets)

--- a/lib/host/preview2/wasi-sockets/CMakeLists.txt
+++ b/lib/host/preview2/wasi-sockets/CMakeLists.txt
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2019-2022 Second State INC
+
+wasmedge_add_library(wasmedgeHostModuleWasiSockets
+  wasifunc.cpp
+  inode-linux.cpp
+  udp.cpp
+  tcp.cpp
+  ipnamelookup.cpp
+  util.cpp
+  ${WASMEDGE_WASI_SRCS}
+)
+
+target_include_directories(wasmedgeHostModuleWasiSockets
+  PUBLIC
+  ${PROJECT_SOURCE_DIR}/thirdparty
+)
+
+target_link_libraries(wasmedgeHostModuleWasiSockets
+  PUBLIC
+  Threads::Threads
+  wasmedgeSystem
+)
+
+#if(WIN32)
+#  target_link_libraries(wasmedgeHostModuleWasiSockets
+#  PRIVATE
+#  ntdll
+#  wsock32
+#  ws2_32
+#  pathcch
+#  shlwapi
+#)
+#endif()

--- a/lib/host/preview2/wasi-sockets/inode-linux.cpp
+++ b/lib/host/preview2/wasi-sockets/inode-linux.cpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2022 Second State INC
+
+#include "common/defines.h"
+#if WASMEDGE_OS_LINUX
+
+#include "../../wasi/linux.h"
+#include "common/errcode.h"
+#include "common/variant.h"
+#include "host/wasi/environ.h"
+#include "host/wasi/inode.h"
+#include "host/wasi/vfs.h"
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <new>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace WasmEdge {
+namespace Host {
+namespace WASI {} // namespace WASI
+} // namespace Host
+} // namespace WasmEdge
+#endif

--- a/lib/host/preview2/wasi-sockets/ipnamelookup.cpp
+++ b/lib/host/preview2/wasi-sockets/ipnamelookup.cpp
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2022 Second State INC
+
+#include "common/log.h"
+#include "executor/executor.h"
+#include "host/preview2/wasi-sockets/api.h"
+#include "host/preview2/wasi-sockets/ip-name-lookup/wasifunc.h"
+#include "host/preview2/wasi-sockets/resource_table.h"
+#include "host/preview2/wasi-sockets/util.h"
+#include "host/wasi/environ.h"
+#include "runtime/instance/memory.h"
+#include <atomic>
+#include <deque>
+
+namespace WasmEdge {
+namespace Host {
+namespace WasiSocket {
+namespace IpNameLookup {
+
+static void WasiSocketsResolveAddressesBlock(WasiSocketsEnvironment &Env,
+                                             ResolveAddressStream &Data) {
+  do {
+    auto Res = Env.sockGetaddrinfoPV2(Data.Query, Data.Resolved);
+    if (!Res) {
+      Data.Invalid = true;
+    }
+  } while (false);
+  Data.IsReady = true;
+};
+
+Expect<void> ResolveAddresses::body(const Runtime::CallingFrame &Frame,
+                                    uint32_t Handle, uint32_t StrPtr,
+                                    uint32_t StrLen, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  (void)Handle;
+
+  auto RetBuf = MemInst->getPointer<
+      __wasi_sockets_ret_t<__wasi_resolve_address_stream_handle_t> *>(
+      RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  std::string_view Query = MemInst->getStringView(StrPtr, StrLen);
+
+  // TODO: check access
+  auto ResHandle =
+      Env.Table.Push<ResolveAddressStream>(ResourceTable::NullParent, Query);
+  std::thread AsyncTask(
+      WasiSocketsResolveAddressesBlock, std::ref(Env),
+      std::ref(*Env.Table.GetById<ResolveAddressStream>(ResHandle)));
+  AsyncTask.detach();
+  RetBuf->Val.Res = ResHandle;
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> ResolveNextAddress::body(const Runtime::CallingFrame &Frame,
+                                      uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf =
+      MemInst->getPointer<__wasi_sockets_ret_t<__wasi_sockets_ip_address_t> *>(
+          RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto *Data = Env.Table.GetById<ResolveAddressStream>(Handle);
+  if (Data == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  if (!Data->IsReady) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_WOULD_BLOCK);
+  }
+
+  if (Data->Resolved.size() == 0) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_NAME_UNRESOLVABLE);
+  }
+
+  RetBuf->Val.Res = Data->Resolved.back();
+  Data->Resolved.pop_back();
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> ResolveDrop::body(const Runtime::CallingFrame &, uint32_t Handle) {
+  auto *Data = Env.Table.GetById<ResolveAddressStream>(Handle);
+  if (Data == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  if (Data->IsReady) {
+    Env.Table.Drop(Handle);
+  } // TODO: can not remove because it is still used in the other thread
+
+  return {};
+}
+} // namespace IpNameLookup
+} // namespace WasiSocket
+} // namespace Host
+} // namespace WasmEdge

--- a/lib/host/preview2/wasi-sockets/tcp.cpp
+++ b/lib/host/preview2/wasi-sockets/tcp.cpp
@@ -1,0 +1,991 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2022 Second State INC
+
+#include "common/log.h"
+#include "executor/executor.h"
+#include "host/preview2/wasi-sockets/api.h"
+#include "host/preview2/wasi-sockets/resource_table.h"
+#include "host/preview2/wasi-sockets/tcp/wasifunc.h"
+#include "host/preview2/wasi-sockets/util.h"
+#include "host/wasi/environ.h"
+#include "runtime/instance/memory.h"
+#include <atomic>
+
+namespace WasmEdge {
+namespace Host {
+namespace WasiSocket {
+namespace TCP {
+Expect<void> CreateTCPSocket::body(const Runtime::CallingFrame &Frame,
+                                   int32_t AddressFamily, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf =
+      MemInst->getPointer<__wasi_sockets_ret_t<__wasi_handle_t> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  __wasi_sockets_ip_address_family_t WasiAddressFamily;
+  if (auto Res = cast<__wasi_sockets_ip_address_family_t>(AddressFamily);
+      unlikely(!Res)) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_NOT_SUPPORTED);
+  } else {
+    WasiAddressFamily = *Res;
+  }
+
+  __wasi_fd_t SockFd;
+  if (auto Res = Env.sockOpenPV2(WasiAddressFamily, __WASI_SOCKETS_TYPE_STREAM);
+      unlikely(!Res)) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    SockFd = *Res;
+  }
+
+  // On IPv6 sockets, IPV6_V6ONLY is enabled by default and can't be configured
+  // otherwise.
+  if (WasiAddressFamily == __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6) {
+    if (auto Res = Env.sockSetIPv6V6only(SockFd, true); unlikely(!Res)) {
+      return SocketsErr(*RetBuf, Res.error());
+    }
+  }
+
+  auto Handle =
+      Env.Table.Push<TCPSocket>(ResourceTable::NullParent, SockFd,
+                                WasiAddressFamily, TCPSocketState::Default);
+  RetBuf->Val.Res = Handle;
+  return SocketsOk(*RetBuf);
+}
+
+// FIXME
+Expect<void> StartBind::body(const Runtime::CallingFrame &Frame,
+                             uint32_t Handle, uint32_t NetHandle,
+                             __VARG_12_UINTS, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  auto NetworkData = Env.Table.GetById<Network::Network>(NetHandle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  __wasi_sockets_ip_socket_address_t IPSocketAddress;
+  if (auto Res = PackIPSocketAddress(__V_12_UINTS); unlikely(!Res)) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    IPSocketAddress = *Res;
+  }
+
+  if (unlikely(!ValidateAddressFamily(IPSocketAddress))) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_ARGUMENT);
+  }
+
+  // TODO: use NetworkData check Address
+  (void)NetworkData;
+
+  switch (SocketData->State) {
+  case TCPSocketState::Default:
+    SocketData->State = TCPSocketState::BindStarted;
+    break;
+  case TCPSocketState::BindStarted:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_CONCURRENCY_CONFLICT);
+  default:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_STATE);
+  }
+
+  if (auto Res = Env.sockBindPV2(SocketData->Fd, IPSocketAddress); !Res) {
+    if (Res.error() == __WASI_ERRNO_AFNOSUPPORT) {
+      return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_ARGUMENT);
+    } else {
+      return SocketsErr(*RetBuf, Res.error());
+    }
+  }
+
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> FinishBind::body(const Runtime::CallingFrame &Frame,
+                              uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  switch (SocketData->State) {
+  case TCPSocketState::BindStarted:
+    SocketData->State = TCPSocketState::Bound;
+    return SocketsOk(*RetBuf);
+  default:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_NOT_IN_PROGRESS);
+  }
+}
+
+Expect<void> StartConnect::body(const Runtime::CallingFrame &Frame,
+                                uint32_t Handle, uint32_t NetHandle,
+                                __VARG_12_UINTS, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  auto NetworkData = Env.Table.GetById<Network::Network>(NetHandle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  __wasi_sockets_ip_socket_address_t IPSocketAddress;
+  if (auto Res = PackIPSocketAddress(__V_12_UINTS); unlikely(!Res)) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    IPSocketAddress = *Res;
+  }
+
+  if (unlikely(!ValidateAddressFamily(IPSocketAddress))) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_ARGUMENT);
+  }
+
+  // TODO: use NetworkData check Address
+  (void)NetworkData;
+
+  switch (SocketData->State) {
+  case TCPSocketState::Default:
+    break;
+  case TCPSocketState::BindStarted:
+  case TCPSocketState::Connecting:
+  case TCPSocketState::ConnectReady:
+  case TCPSocketState::ListenStarted:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_CONCURRENCY_CONFLICT);
+  default:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_STATE);
+  }
+
+  /*if (auto Res =
+          Env.sockConnect(SocketData->Fd, SocketData->AddressFamily, Buf, Port);
+      !Res) {
+    if (Res.error() == __WASI_ERRNO_INPROGRESS) {
+      SocketData->State = TCPSocketState::Connecting;
+      RetBuf->IsErr = false;
+    } else if (Res.error() == __WASI_ERRNO_AFNOSUPPORT) {
+      RetBuf->IsErr = true;
+      RetBuf->Val.Err = __WASI_SOCKETS_ERRNO_INVALID_ARGUMENT;
+    } else {
+      RetBuf->IsErr = true;
+      RetBuf->Val.Err = toSockErrCode(Res.error());
+    }
+  } else {
+    SocketData->State = TCPSocketState::ConnectReady;
+    RetBuf->IsErr = false;
+  }*/
+
+  return {};
+}
+
+// FIXME
+Expect<void> FinishConnect::body(const Runtime::CallingFrame &Frame,
+                                 uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<
+      __wasi_sockets_ret_t<__wasi_sockets_tcp_incoming_datagram_stream_t> *>(
+      RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  switch (SocketData->State) {
+  case TCPSocketState::ConnectReady:
+    break;
+  case TCPSocketState::Connecting: {
+    // Do a test check state
+    // TODO: it need Poll in wasi io....
+    break;
+  }
+  default:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_STATE);
+  }
+
+  SocketData->State = TCPSocketState::Connected;
+  RetBuf->Val.Res.InHandle = 0;
+  RetBuf->Val.Res.OutHandle = 0;
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> StartListen::body(const Runtime::CallingFrame &Frame,
+                               uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  switch (SocketData->State) {
+  case TCPSocketState::Bound:
+    break;
+  case TCPSocketState::ListenStarted:
+  case TCPSocketState::Connecting:
+  case TCPSocketState::ConnectReady:
+  case TCPSocketState::BindStarted:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_CONCURRENCY_CONFLICT);
+  default:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_STATE);
+  }
+
+  if (auto Res = Env.sockListen(SocketData->Fd, SocketData->ListenBacklogSize);
+      !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  }
+  SocketData->State = TCPSocketState::ListenStarted;
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> FinishListen::body(const Runtime::CallingFrame &Frame,
+                                uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  switch (SocketData->State) {
+  case TCPSocketState::ListenStarted:
+    break;
+  default:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_NOT_IN_PROGRESS);
+  }
+
+  SocketData->State = TCPSocketState::Listening;
+  return SocketsOk(*RetBuf);
+}
+
+// FIXME
+Expect<void> Accept::body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                          uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<
+      __wasi_sockets_ret_t<__wasi_sockets_tcp_accept_tuple_t> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  switch (SocketData->State) {
+  case TCPSocketState::Listening:
+    break;
+  default:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_STATE);
+  }
+
+  int32_t RemoteSockFd = 0;
+  if (auto Res = Env.sockAccept(SocketData->Fd, __WASI_FDFLAGS_NONBLOCK);
+      !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    RemoteSockFd = Res.value();
+  }
+
+  // TODO: get RemoteSockFd's address family
+  RetBuf->Val.Res.Socket = Env.Table.Push<TCPSocket>(
+      ResourceTable::NullParent, RemoteSockFd,
+      /*FIXME*/ SocketData->AddressFamily, TCPSocketState::Connected);
+  RetBuf->Val.Res.InHandle = 0;
+  RetBuf->Val.Res.OutHandle = 0;
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> LocalAddress::body(const Runtime::CallingFrame &Frame,
+                                uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<
+      __wasi_sockets_ret_t<__wasi_sockets_ip_socket_address_t> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  switch (SocketData->State) {
+  case TCPSocketState::Default:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_STATE);
+  case TCPSocketState::Connecting:
+  case TCPSocketState::ConnectReady:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_CONCURRENCY_CONFLICT);
+  default:
+    break;
+  }
+
+  if (auto Res = Env.sockGetLocalAddrPV2(SocketData->Fd, RetBuf->Val.Res);
+      unlikely(!Res)) {
+    return SocketsErr(*RetBuf, Res.error());
+  }
+
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> RemoteAddress::body(const Runtime::CallingFrame &Frame,
+                                 uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<
+      __wasi_sockets_ret_t<__wasi_sockets_ip_socket_address_t> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  switch (SocketData->State) {
+  case TCPSocketState::Connected:
+    break;
+  case TCPSocketState::Connecting:
+  case TCPSocketState::ConnectReady:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_CONCURRENCY_CONFLICT);
+  default:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_STATE);
+  }
+
+  if (auto Res = Env.sockGetPeerAddrPV2(SocketData->Fd, RetBuf->Val.Res);
+      unlikely(!Res)) {
+    return SocketsErr(*RetBuf, Res.error());
+  }
+
+  return SocketsOk(*RetBuf);
+}
+
+Expect<uint32_t> Islistening::body(const Runtime::CallingFrame &,
+                                   uint32_t Handle) {
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  return SocketData->State == TCPSocketState::Listening ? 1 : 0;
+}
+
+Expect<uint32_t> AddressFamily::body(const Runtime::CallingFrame &,
+                                     uint32_t Handle) {
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  return SocketData->AddressFamily;
+}
+
+Expect<void> IPv6Only::body(const Runtime::CallingFrame &, uint32_t, uint32_t) {
+  return WASI::WasiUnexpect(__WASI_ERRNO_NOSYS);
+  /*auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<bool> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (SocketData->AddressFamily == __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6) {
+    RetBuf->IsErr = false;
+    RetBuf->Val.Res = SocketData->IPv6Only;
+  } else {
+    RetBuf->IsErr = true;
+    RetBuf->Val.Err = __WASI_SOCKETS_ERRNO_NOT_SUPPORTED;
+  }
+  return {};*/
+}
+
+Expect<void> SetIPv6Only::body(const Runtime::CallingFrame &, uint32_t,
+                               uint32_t, uint32_t) {
+  return WASI::WasiUnexpect(__WASI_ERRNO_NOSYS);
+  /*auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (SocketData->AddressFamily != __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6) {
+    RetBuf->IsErr = true;
+    RetBuf->Val.Err = __WASI_SOCKETS_ERRNO_NOT_SUPPORTED;
+    return {};
+  }
+
+  switch (SocketData->State) {
+  case TCPSocketState::Default:
+    break;
+  case TCPSocketState::BindStarted:
+    RetBuf->IsErr = true;
+    RetBuf->Val.Err = __WASI_SOCKETS_ERRNO_CONCURRENCY_CONFLICT;
+    return {};
+  default:
+    RetBuf->IsErr = true;
+    RetBuf->Val.Err = __WASI_SOCKETS_ERRNO_INVALID_STATE;
+    return {};
+  }
+
+  if (auto Res = Env.sockSetIPv6V6only(SocketData->Fd, Val); !Res) {
+    RetBuf->IsErr = true;
+    RetBuf->Val.Err = toSockErrCode(Res.error());
+  } else {
+    RetBuf->IsErr = false;
+    SocketData->IPv6Only = Val;
+  }
+  return {};*/
+}
+
+Expect<void> SetListenBacklogSize::body(const Runtime::CallingFrame &Frame,
+                                        uint32_t Handle, uint64_t Val,
+                                        uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  switch (SocketData->State) {
+  case TCPSocketState::Default:
+  case TCPSocketState::BindStarted:
+  case TCPSocketState::Bound:
+  case TCPSocketState::Listening:
+    break;
+  case TCPSocketState::Connecting:
+  case TCPSocketState::ConnectReady:
+  case TCPSocketState::ListenStarted:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_CONCURRENCY_CONFLICT);
+  default:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_STATE);
+  }
+
+  if (Val == 0) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_ARGUMENT);
+  }
+
+  Val = std::min<uint64_t>(Val, INT32_MAX);
+
+  SocketData->ListenBacklogSize = Val;
+  // TODO: Update it if TCPSocketState is Listening. it maybe fail, but it is
+  // fine
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> KeepAliveEnabled::body(const Runtime::CallingFrame &Frame,
+                                    uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<bool> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (auto Res = Env.sockGetKeepAlive(SocketData->Fd); !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    RetBuf->Val.Res = !!Res.value();
+  }
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> SetKeepAliveEnabled::body(const Runtime::CallingFrame &Frame,
+                                       uint32_t Handle, uint32_t Val,
+                                       uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (SocketData->AddressFamily != __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_NOT_SUPPORTED);
+  }
+
+  if (auto Res = Env.sockSetKeepAlive(SocketData->Fd, Val); !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  }
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> KeepAliveIdleTime::body(const Runtime::CallingFrame &Frame,
+                                     uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf =
+      MemInst->getPointer<__wasi_sockets_ret_t<uint64_t> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (auto Res = Env.sockGetKeepIdle(SocketData->Fd); !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    RetBuf->Val.Res = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                          std::chrono::seconds(Res.value()))
+                          .count();
+  }
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> SetKeepAliveIdleTime::body(const Runtime::CallingFrame &Frame,
+                                        uint32_t Handle, uint64_t Val,
+                                        uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  uint32_t Sec = std::chrono::duration_cast<std::chrono::seconds>(
+                     std::chrono::nanoseconds(Val))
+                     .count();
+  if (auto Res = Env.sockSetKeepIdle(SocketData->Fd, Sec); !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  }
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> KeepAliveInterval::body(const Runtime::CallingFrame &Frame,
+                                     uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf =
+      MemInst->getPointer<__wasi_sockets_ret_t<uint64_t> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (auto Res = Env.sockGetAliveInterval(SocketData->Fd); !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    RetBuf->Val.Res = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                          std::chrono::seconds(Res.value()))
+                          .count();
+  }
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> SetKeepAliveInterval::body(const Runtime::CallingFrame &Frame,
+                                        uint32_t Handle, uint64_t Val,
+                                        uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  uint32_t Sec = std::chrono::duration_cast<std::chrono::seconds>(
+                     std::chrono::nanoseconds(Val))
+                     .count();
+  if (auto Res = Env.sockSetAliveInterval(SocketData->Fd, Sec); !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  }
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> KeepAliveCount::body(const Runtime::CallingFrame &Frame,
+                                  uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf =
+      MemInst->getPointer<__wasi_sockets_ret_t<uint32_t> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (auto Res = Env.sockGetKeepAliveCount(SocketData->Fd); !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    RetBuf->Val.Res = Res.value();
+  }
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> SetKeepAliveCount::body(const Runtime::CallingFrame &Frame,
+                                     uint32_t Handle, uint32_t Val,
+                                     uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (auto Res = Env.sockSetKeepAliveCount(SocketData->Fd, Val); !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  }
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> HopLimit::body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                            uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<uint8_t> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (SocketData->AddressFamily == __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv4) {
+    if (auto Res = Env.sockGetIPTTL(SocketData->Fd); !Res) {
+      return SocketsErr(*RetBuf, Res.error());
+    } else {
+      RetBuf->Val.Res = Res.value();
+      return SocketsOk(*RetBuf);
+    }
+  } else if (SocketData->AddressFamily ==
+             __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6) {
+    if (auto Res = Env.sockGetIPv6UnicastHops(SocketData->Fd); !Res) {
+      return SocketsErr(*RetBuf, Res.error());
+    } else {
+      RetBuf->Val.Res = Res.value();
+      return SocketsOk(*RetBuf);
+    }
+  } else {
+    __builtin_unreachable();
+  }
+  return {};
+}
+
+Expect<void> SetHopLimit::body(const Runtime::CallingFrame &Frame,
+                               uint32_t Handle, uint32_t Val,
+                               uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (SocketData->AddressFamily == __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv4) {
+    if (auto Res = Env.sockSetIPTTL(SocketData->Fd, Val); !Res) {
+      return SocketsErr(*RetBuf, Res.error());
+    } else {
+      return SocketsOk(*RetBuf);
+    }
+  } else if (SocketData->AddressFamily ==
+             __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6) {
+    if (auto Res = Env.sockSetIPv6UnicastHops(SocketData->Fd, Val); !Res) {
+      return SocketsErr(*RetBuf, Res.error());
+    } else {
+      return SocketsOk(*RetBuf);
+    }
+  } else {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_NOT_SUPPORTED);
+  }
+}
+
+Expect<void> GetReceiveBufferSize::body(const Runtime::CallingFrame &Frame,
+                                        uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf =
+      MemInst->getPointer<__wasi_sockets_ret_t<uint64_t> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (auto Res = Env.sockGetRecvBufferSize(SocketData->Fd); !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    RetBuf->Val.Res = Res.value();
+    return SocketsOk(*RetBuf);
+  }
+}
+
+Expect<void> SetReceiveBufferSize::body(const Runtime::CallingFrame &Frame,
+                                        uint32_t Handle, uint64_t Val,
+                                        uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (auto Res = Env.sockSetRecvBufferSize(SocketData->Fd, Val); !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    return SocketsOk(*RetBuf);
+  }
+}
+
+Expect<void> GetSendBufferSize::body(const Runtime::CallingFrame &Frame,
+                                     uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf =
+      MemInst->getPointer<__wasi_sockets_ret_t<uint64_t> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (auto Res = Env.sockGetSendBufferSize(SocketData->Fd); !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    RetBuf->Val.Res = Res.value();
+    return SocketsOk(*RetBuf);
+  }
+}
+
+Expect<void> SetSendBufferSize::body(const Runtime::CallingFrame &Frame,
+                                     uint32_t Handle, uint64_t Val,
+                                     uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (auto Res = Env.sockSetSendBufferSize(SocketData->Fd, Val); !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    return SocketsOk(*RetBuf);
+  }
+  return {};
+}
+
+Expect<void> Shutdown::body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                            uint32_t How, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<TCPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (auto Res = Env.sockShutdown(SocketData->Fd, __wasi_sdflags_t(How));
+      !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    return SocketsOk(*RetBuf);
+  }
+  return {};
+}
+} // namespace TCP
+} // namespace WasiSocket
+} // namespace Host
+} // namespace WasmEdge

--- a/lib/host/preview2/wasi-sockets/udp.cpp
+++ b/lib/host/preview2/wasi-sockets/udp.cpp
@@ -1,0 +1,607 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2022 Second State INC
+
+#include "common/log.h"
+#include "executor/executor.h"
+#include "host/preview2/wasi-sockets/api.h"
+#include "host/preview2/wasi-sockets/resource_table.h"
+#include "host/preview2/wasi-sockets/udp/wasifunc.h"
+#include "host/preview2/wasi-sockets/util.h"
+#include "host/wasi/environ.h"
+#include "runtime/instance/memory.h"
+#include <atomic>
+
+namespace WasmEdge {
+namespace Host {
+namespace WasiSocket {
+namespace UDP {
+Expect<void> CreateUDPSocket::body(const Runtime::CallingFrame &Frame,
+                                   int32_t AddressFamily, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf =
+      MemInst->getPointer<__wasi_sockets_ret_t<__wasi_handle_t> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  __wasi_sockets_ip_address_family_t WasiAddressFamily;
+  if (auto Res = cast<__wasi_sockets_ip_address_family_t>(AddressFamily);
+      unlikely(!Res)) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_NOT_SUPPORTED);
+  } else {
+    WasiAddressFamily = *Res;
+  }
+
+  __wasi_fd_t SockFd;
+  if (auto Res = Env.sockOpenPV2(WasiAddressFamily, __WASI_SOCKETS_TYPE_DGRAM);
+      unlikely(!Res)) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    SockFd = *Res;
+  }
+
+  // On IPv6 sockets, IPV6_V6ONLY is enabled by default and can't be configured
+  // otherwise.
+  if (WasiAddressFamily == __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6) {
+    if (auto Res = Env.sockSetIPv6V6only(SockFd, true); unlikely(!Res)) {
+      return SocketsErr(*RetBuf, Res.error());
+    }
+  }
+
+  auto Handle =
+      Env.Table.Push<UDPSocket>(ResourceTable::NullParent, SockFd,
+                                WasiAddressFamily, SocketState::Default);
+  RetBuf->Val.Res = Handle;
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> StartBind::body(const Runtime::CallingFrame &Frame,
+                             uint32_t Handle, uint32_t NetHandle,
+                             __VARG_12_UINTS, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<UDPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  auto NetworkData = Env.Table.GetById<Network::Network>(NetHandle);
+  if (NetworkData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  __wasi_sockets_ip_socket_address_t IPSocketAddress;
+  if (auto Res = PackIPSocketAddress(__V_12_UINTS); unlikely(!Res)) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    IPSocketAddress = *Res;
+  }
+
+  if (unlikely(!ValidateAddressFamily(IPSocketAddress))) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_ARGUMENT);
+  }
+
+  switch (SocketData->State) {
+  case SocketState::Default:
+    break;
+  case SocketState::BindStarted:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_CONCURRENCY_CONFLICT);
+  default:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_STATE);
+  }
+
+  SocketData->AddressChecker = NetworkData->GetChecker();
+  if (unlikely(!SocketData->AddressChecker(Addr(IPSocketAddress)))) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (auto Res = Env.sockBindPV2(SocketData->Fd, IPSocketAddress);
+      unlikely(!Res)) {
+    if (Res.error() == __WASI_ERRNO_AFNOSUPPORT) {
+      return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_ARGUMENT);
+    }
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    SocketData->State = SocketState::BindStarted;
+    return SocketsOk(*RetBuf);
+  }
+}
+
+Expect<void> FinishBind::body(const Runtime::CallingFrame &Frame,
+                              uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<UDPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  switch (SocketData->State) {
+  case SocketState::BindStarted:
+    break;
+  default:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_NOT_IN_PROGRESS);
+  }
+
+  SocketData->State = SocketState::Bound;
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> Stream::body(const Runtime::CallingFrame &Frame, uint32_t Handle,
+                          __VARG_12_UINTS, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<
+      __wasi_sockets_ret_t<__wasi_sockets_udp_incoming_datagram_stream_t> *>(
+      RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<UDPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (auto Children = SocketData->GetChildren(); Children) {
+    for (auto CHandle : *Children) {
+      if (Env.Table.GetById<IncomingDatagramStream>(CHandle) ||
+          Env.Table.GetById<OutgoingDatagramStream>(CHandle)) {
+        // UDP streams not dropped yet
+        return WASI::WasiUnexpect(__WASI_ERRNO_NOTSUP);
+      }
+    }
+  }
+
+  __wasi_sockets_ip_socket_address_t IPSocketAddress;
+  if (auto Res = PackIPSocketAddress(__V_12_UINTS); unlikely(!Res)) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    IPSocketAddress = *Res;
+  }
+
+  switch (SocketData->State) {
+  case SocketState::Bound:
+  case SocketState::Connected:
+    break;
+  default:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_STATE);
+  }
+
+  // Disconnect first
+  if (SocketData->State == SocketState::Connected) {
+    if (auto Res = Env.sockUDPDisconnect(SocketData->Fd); unlikely(!Res)) {
+      return SocketsErr(*RetBuf, Res.error());
+    }
+    SocketData->State = SocketState::Bound;
+  }
+
+  if (unlikely(!ValidateAddressFamily(IPSocketAddress))) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_ARGUMENT);
+  }
+
+  if (unlikely(!SocketData->AddressChecker(Addr(IPSocketAddress)))) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (auto Res = Env.sockConnectPV2(SocketData->Fd, IPSocketAddress);
+      unlikely(!Res)) {
+    if (Res.error() == __WASI_ERRNO_AFNOSUPPORT) {
+      return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_ARGUMENT);
+    } else if (Res.error() == __WASI_ERRNO_INPROGRESS) {
+      return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_UNKNOW);
+    }
+    return SocketsErr(*RetBuf, Res.error());
+  }
+
+  SocketData->State = SocketState::Connected;
+
+  RetBuf->Val.Res.InHandle = Env.Table.Push<IncomingDatagramStream>(
+      Handle, SocketData->Fd, IPSocketAddress);
+  RetBuf->Val.Res.OutHandle = Env.Table.Push<OutgoingDatagramStream>(
+      Handle, SocketData->Fd, IPSocketAddress, SocketData->AddressFamily);
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> LocalAddress::body(const Runtime::CallingFrame &Frame,
+                                uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<
+      __wasi_sockets_ret_t<__wasi_sockets_ip_socket_address_t> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<UDPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  switch (SocketData->State) {
+  case SocketState::Bound:
+  case SocketState::Connected:
+    break;
+  case SocketState::BindStarted:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_CONCURRENCY_CONFLICT);
+  default:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_STATE);
+  }
+
+  if (auto Res = Env.sockGetLocalAddrPV2(SocketData->Fd, RetBuf->Val.Res);
+      unlikely(!Res)) {
+    return SocketsErr(*RetBuf, Res.error());
+  }
+
+  return SocketsOk(*RetBuf);
+}
+
+Expect<void> RemoteAddress::body(const Runtime::CallingFrame &Frame,
+                                 uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<
+      __wasi_sockets_ret_t<__wasi_sockets_ip_socket_address_t> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<UDPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  switch (SocketData->State) {
+  case SocketState::Connected:
+    break;
+  default:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_STATE);
+  }
+
+  if (auto Res = Env.sockGetPeerAddrPV2(SocketData->Fd, RetBuf->Val.Res);
+      unlikely(!Res)) {
+    return SocketsErr(*RetBuf, Res.error());
+  }
+
+  return SocketsOk(*RetBuf);
+}
+
+Expect<uint32_t> AddressFamily::body(const Runtime::CallingFrame &,
+                                     uint32_t Handle) {
+  auto SocketData = Env.Table.GetById<UDPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  } else {
+    return uint32_t(SocketData->AddressFamily);
+  }
+}
+
+// https://github.com/WebAssembly/wasi-sockets/pull/93
+// IPv6 Only function deleted, but maybe turn back...
+Expect<void> IPv6Only::body(const Runtime::CallingFrame &, uint32_t, uint32_t) {
+  return WASI::WasiUnexpect(__WASI_ERRNO_NOSYS);
+  /*auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<bool> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<UDPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (SocketData->AddressFamily != __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_NOT_SUPPORTED);
+  }
+
+  RetBuf->Val.Res = SocketData->IPv6Only;
+  return SocketsOk(*RetBuf);*/
+}
+
+Expect<void> SetIPv6Only::body(const Runtime::CallingFrame &, uint32_t,
+                               uint32_t, uint32_t) {
+  return WASI::WasiUnexpect(__WASI_ERRNO_NOSYS);
+  /*auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<UDPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (SocketData->AddressFamily != __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_NOT_SUPPORTED);
+  }
+
+  switch (SocketData->State) {
+  case SocketState::Default:
+    break;
+  case SocketState::BindStarted:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_CONCURRENCY_CONFLICT);
+  default:
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_INVALID_STATE);
+  }
+
+  if (auto Res = Env.sockSetIPv6V6only(SocketData->Fd, Val); !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  }
+
+  SocketData->IPv6Only = Val;
+  return SocketsOk(*RetBuf);*/
+}
+
+Expect<void> UnicastHopLimit::body(const Runtime::CallingFrame &Frame,
+                                   uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<uint8_t> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<UDPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (SocketData->AddressFamily == __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv4) {
+    if (auto Res = Env.sockGetIPTTL(SocketData->Fd); !Res) {
+      return SocketsErr(*RetBuf, Res.error());
+    } else {
+      RetBuf->Val.Res = Res.value();
+      return SocketsOk(*RetBuf);
+    }
+  } else if (SocketData->AddressFamily ==
+             __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6) {
+    if (auto Res = Env.sockGetIPv6UnicastHops(SocketData->Fd); !Res) {
+      return SocketsErr(*RetBuf, Res.error());
+    } else {
+      RetBuf->Val.Res = Res.value();
+      return SocketsOk(*RetBuf);
+    }
+  } else {
+    __builtin_unreachable();
+  }
+  return {};
+}
+
+Expect<void> SetUnicastHopLimit::body(const Runtime::CallingFrame &Frame,
+                                      uint32_t Val, uint32_t Handle,
+                                      uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<UDPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (SocketData->AddressFamily == __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv4) {
+    if (auto Res = Env.sockSetIPTTL(SocketData->Fd, Val); !Res) {
+      return SocketsErr(*RetBuf, Res.error());
+    } else {
+      return SocketsOk(*RetBuf);
+    }
+  } else if (SocketData->AddressFamily ==
+             __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6) {
+    if (auto Res = Env.sockSetIPv6UnicastHops(SocketData->Fd, Val); !Res) {
+      return SocketsErr(*RetBuf, Res.error());
+    } else {
+      return SocketsOk(*RetBuf);
+    }
+  } else {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_NOT_SUPPORTED);
+  }
+}
+
+Expect<void> GetReceiveBufferSize::body(const Runtime::CallingFrame &Frame,
+                                        uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf =
+      MemInst->getPointer<__wasi_sockets_ret_t<uint64_t> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<UDPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (auto Res = Env.sockGetRecvBufferSize(SocketData->Fd); !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    RetBuf->Val.Res = Res.value();
+    return SocketsOk(*RetBuf);
+  }
+}
+
+Expect<void> SetReceiveBufferSize::body(const Runtime::CallingFrame &Frame,
+                                        uint32_t Handle, uint64_t Val,
+                                        uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<UDPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (auto Res = Env.sockSetRecvBufferSize(SocketData->Fd, Val); !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    return SocketsOk(*RetBuf);
+  }
+}
+
+Expect<void> GetSendBufferSize::body(const Runtime::CallingFrame &Frame,
+                                     uint32_t Handle, uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf =
+      MemInst->getPointer<__wasi_sockets_ret_t<uint64_t> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<UDPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (auto Res = Env.sockGetSendBufferSize(SocketData->Fd); !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    RetBuf->Val.Res = Res.value();
+    return SocketsOk(*RetBuf);
+  }
+}
+
+Expect<void> SetSendBufferSize::body(const Runtime::CallingFrame &Frame,
+                                     uint32_t Handle, uint64_t Val,
+                                     uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto SocketData = Env.Table.GetById<UDPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return SocketsErr(*RetBuf, __WASI_SOCKETS_ERRNO_ACCESS_DENIED);
+  }
+
+  if (auto Res = Env.sockSetSendBufferSize(SocketData->Fd, Val); !Res) {
+    return SocketsErr(*RetBuf, Res.error());
+  } else {
+    return SocketsOk(*RetBuf);
+  }
+  return {};
+}
+
+// FIXME
+Expect<uint32_t> UDPSocketsSubscribe::body(const Runtime::CallingFrame &,
+                                           uint32_t Handle) {
+  auto SocketData = Env.Table.GetById<UDPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+  return 0;
+}
+
+Expect<void> UDPSocketsDrop::body(const Runtime::CallingFrame &,
+                                  uint32_t Handle) {
+  auto SocketData = Env.Table.GetById<UDPSocket>(Handle);
+  if (SocketData == nullptr) {
+    return {};
+  }
+
+  if (auto Res = Env.fdClose(SocketData->Fd); unlikely(!Res)) {
+    return {};
+  }
+
+  Env.Table.Drop(Handle);
+  return {};
+}
+
+Expect<void>
+IncomingDatagramStreamReceive::body(const Runtime::CallingFrame &Frame,
+                                    uint32_t Handle, uint64_t MaxResults,
+                                    uint32_t RetBufPtr) {
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto RetBuf = MemInst->getPointer<__wasi_sockets_ret_t<void> *>(RetBufPtr);
+  if (RetBuf == nullptr) {
+    return WASI::WasiUnexpect(__WASI_ERRNO_FAULT);
+  }
+
+  auto InStreamData = Env.Table.GetById<IncomingDatagramStream>(Handle);
+  if (InStreamData == nullptr) {
+    return {};
+  }
+
+  std::vector<uint8_t> Buf(MaxResults);
+  uint32_t NRead;
+  if (auto Res = Env.sockRecvPV2(InStreamData->Fd, Buf, NRead);
+      unlikely(!Res)) {
+    return SocketsErr(*RetBuf, Res.error());
+  }
+  return {};
+}
+
+} // namespace UDP
+} // namespace WasiSocket
+} // namespace Host
+} // namespace WasmEdge

--- a/lib/host/preview2/wasi-sockets/util.cpp
+++ b/lib/host/preview2/wasi-sockets/util.cpp
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2022 Second State INC
+
+#include "host/preview2/wasi-sockets/util.h"
+#include "host/preview2/wasi-sockets/api.h"
+#include "host/preview2/wasi-sockets/variant_helper.h"
+#include "host/wasi/error.h"
+
+#include <tuple>
+
+namespace WasmEdge {
+namespace Host {
+namespace WasiSocket {
+
+WASI::WasiExpect<__wasi_sockets_ip_socket_address_t>
+PackIPSocketAddress(__VARG_12_UINTS) {
+  __wasi_sockets_ip_socket_address_t Res{};
+  switch (V1) {
+  case 0: // IPv4
+    Res.AddressFamily = __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv4;
+    Res.Val.IPv4.Port = V2;
+    Res.Val.IPv4.Address.Addr[0] = V3;
+    Res.Val.IPv4.Address.Addr[1] = V4;
+    Res.Val.IPv4.Address.Addr[2] = V5;
+    Res.Val.IPv4.Address.Addr[3] = V6;
+    break;
+  case 1: // IPv6
+    Res.AddressFamily = __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6;
+    Res.Val.IPv6.Port = V2;
+    Res.Val.IPv6.FlowInfo = V3;
+    Res.Val.IPv6.Address.Addr[0] = V4;
+    Res.Val.IPv6.Address.Addr[1] = V5;
+    Res.Val.IPv6.Address.Addr[2] = V6;
+    Res.Val.IPv6.Address.Addr[3] = V7;
+    Res.Val.IPv6.Address.Addr[4] = V8;
+    Res.Val.IPv6.Address.Addr[5] = V9;
+    Res.Val.IPv6.Address.Addr[6] = V10;
+    Res.Val.IPv6.Address.Addr[7] = V11;
+    Res.Val.IPv6.ScopeId = V12;
+    break;
+  default:
+    return WASI::WasiUnexpect(__WASI_ERRNO_INVAL);
+  }
+  return Res;
+}
+
+bool ValidateAddressFamily(const __wasi_sockets_ip_socket_address_t &Address) {
+  if (Address.AddressFamily == __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv4) {
+    return true;
+  } else if (Address.AddressFamily == __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6) {
+    // reject IPv4-*compatible* IPv6 addresses.
+    // TODO
+    return true;
+  }
+  return false;
+}
+
+__wasi_sockets_ip_address_t
+Addr(const __wasi_sockets_ip_socket_address_t &SocketAddr) {
+  __wasi_sockets_ip_address_t Res;
+  Res.AddressFamily = SocketAddr.AddressFamily;
+  if (SocketAddr.AddressFamily == __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv4) {
+    Res.Val.IPv4 = SocketAddr.Val.IPv4.Address;
+  } else if (SocketAddr.AddressFamily ==
+             __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6) {
+    Res.Val.IPv6 = SocketAddr.Val.IPv6.Address;
+  } else {
+    __builtin_unreachable();
+  }
+  return Res;
+}
+} // namespace WasiSocket
+} // namespace Host
+} // namespace WasmEdge

--- a/lib/host/preview2/wasi-sockets/wasifunc.cpp
+++ b/lib/host/preview2/wasi-sockets/wasifunc.cpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2022 Second State INC
+
+#include "host/preview2/wasi-sockets/udp/wasifunc.h"
+#include "common/log.h"
+#include "executor/executor.h"
+#include "host/preview2/wasi-sockets/api.h"
+#include "host/wasi/environ.h"
+#include "runtime/instance/memory.h"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <numeric>
+#include <type_traits>
+#include <vector>
+
+namespace WasmEdge {
+namespace Host {
+namespace WasiSocket {
+namespace {} // namespace
+
+} // namespace WasiSocket
+} // namespace Host
+} // namespace WasmEdge

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -1370,6 +1370,487 @@ INode::sockGetPeerAddr(__wasi_address_family_t *AddressFamilyPtr,
   }
 }
 
+/// PV2 functions
+
+// Convert __wasi_sockets_ip_socket_address_t to native socket address with
+// necessary endian conversion
+
+static VarAddrT
+sockAddressAssignHelper(const __wasi_sockets_ip_socket_address_t &Address) {
+  VarAddrT Addr;
+  if (Address.AddressFamily == __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv4) {
+    auto &ServerAddr4 = Addr.emplace<sockaddr_in>();
+    auto &IPv4Addr = Address.Val.IPv4;
+
+    ServerAddr4.sin_family = AF_INET;
+    ServerAddr4.sin_port = htons(IPv4Addr.Port);
+
+    assuming(sizeof(IPv4Addr.Address) == sizeof(in_addr));
+    std::memcpy(&ServerAddr4.sin_addr, &IPv4Addr.Address, sizeof(in_addr));
+  } else if (Address.AddressFamily == __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6) {
+    auto &ServerAddr6 = Addr.emplace<sockaddr_in6>();
+    auto &IPv6Addr = Address.Val.IPv6;
+
+    ServerAddr6.sin6_family = AF_INET6;
+    ServerAddr6.sin6_port = htons(IPv6Addr.Port);
+    ServerAddr6.sin6_flowinfo = htonl(IPv6Addr.FlowInfo);
+    ServerAddr6.sin6_scope_id = htonl(IPv6Addr.ScopeId);
+
+    assuming(sizeof(IPv6Addr.Address) == sizeof(in6_addr));
+    std::memcpy(&ServerAddr6.sin6_addr, &IPv6Addr.Address, sizeof(in6_addr));
+  } else {
+    assumingUnreachable();
+  }
+
+  return Addr;
+}
+
+static WasiExpect<__wasi_sockets_ip_socket_address_t>
+sockAddressAssignHelper(const sockaddr *Addr) {
+  __wasi_sockets_ip_socket_address_t Buf;
+  if (Addr == nullptr)
+    return WasiUnexpect(__WASI_ERRNO_NOTSUP);
+
+  switch (Addr->sa_family) {
+  case AF_INET: {
+    auto SocketAddr4 = reinterpret_cast<const sockaddr_in &>(Addr);
+
+    Buf.AddressFamily = __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv4;
+    Buf.Val.IPv4.Port = ntohs(SocketAddr4.sin_port);
+
+    assuming(sizeof(Buf.Val.IPv4.Address) == sizeof(in_addr));
+    std::memcpy(&Buf.Val.IPv4.Address, &SocketAddr4.sin_addr, sizeof(in_addr));
+    break;
+  }
+  case AF_INET6: {
+    auto SocketAddr6 = reinterpret_cast<const sockaddr_in6 &>(Addr);
+
+    Buf.AddressFamily = __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6;
+    Buf.Val.IPv6.FlowInfo = ntohl(SocketAddr6.sin6_flowinfo);
+    Buf.Val.IPv6.Port = ntohs(SocketAddr6.sin6_port);
+    Buf.Val.IPv6.ScopeId = ntohl(SocketAddr6.sin6_scope_id);
+
+    assuming(sizeof(Buf.Val.IPv6.Address) == sizeof(in6_addr));
+    std::memcpy(&Buf.Val.IPv6.Address, &SocketAddr6.sin6_addr,
+                sizeof(in6_addr));
+    break;
+  }
+  default:
+    return WasiUnexpect(__WASI_ERRNO_NOTSUP);
+  }
+  return Buf;
+}
+
+static WasiExpect<__wasi_sockets_ip_socket_address_t>
+sockAddressAssignHelper(const sockaddr_storage &Addr) {
+  return sockAddressAssignHelper(reinterpret_cast<const sockaddr *>(&Addr));
+}
+
+WasiExpect<INode>
+INode::sockOpenPV2(__wasi_sockets_ip_address_family_t AddressFamily,
+                   __wasi_sockets_type_t SockType) noexcept {
+  int SysProtocol = 0;
+  int SysDomain = 0;
+  int SysType = 0;
+
+  switch (AddressFamily) {
+  case __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv4:
+    SysDomain = AF_INET;
+    break;
+  case __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6:
+    SysDomain = AF_INET6;
+    break;
+  default:
+    return WasiUnexpect(__WASI_ERRNO_INVAL);
+  }
+
+  switch (SockType) {
+  case __WASI_SOCKETS_TYPE_DGRAM:
+    SysType = SOCK_DGRAM;
+    SysProtocol = IPPROTO_UDP;
+    break;
+  case __WASI_SOCKETS_TYPE_STREAM:
+    SysType = SOCK_STREAM;
+    SysProtocol = IPPROTO_TCP;
+    break;
+  default:
+    return WasiUnexpect(__WASI_ERRNO_INVAL);
+  }
+
+  // In wasi-sockets preview 2, it should be unblocked.
+#ifdef SOCK_CLOEXEC
+  SysType |= SOCK_CLOEXEC;
+#endif
+
+#ifdef SOCK_NONBLOCK
+  SysType |= SOCK_NONBLOCK;
+#endif
+
+  if (auto NewFd = ::socket(SysDomain, SysType, SysProtocol);
+      unlikely(NewFd < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  } else {
+    return INode(NewFd);
+  }
+}
+
+WasiExpect<void>
+INode::sockBindPV2(const __wasi_sockets_ip_socket_address_t &Address) noexcept {
+  auto AddressBuffer = sockAddressAssignHelper(Address);
+
+  auto ServerAddr = std::visit(VarAddrBuf(), AddressBuffer);
+  int Size = std::visit(VarAddrSize(), AddressBuffer);
+
+  if (auto Res = ::bind(Fd, ServerAddr, Size); unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+  return {};
+}
+
+WasiExpect<void> INode::sockConnectPV2(
+    const __wasi_sockets_ip_socket_address_t &Address) noexcept {
+  auto AddressBuffer = sockAddressAssignHelper(Address);
+
+  auto ClientAddr = std::visit(VarAddrBuf(), AddressBuffer);
+  int Size = std::visit(VarAddrSize(), AddressBuffer);
+
+  if (auto Res = ::connect(Fd, ClientAddr, Size); unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return {};
+}
+
+WasiExpect<void> INode::sockGetLocalAddrPV2(
+    __wasi_sockets_ip_socket_address_t &Address) const noexcept {
+  sockaddr_storage SocketAddr = {};
+  socklen_t Slen = std::max(sizeof(sockaddr_in), sizeof(sockaddr_in6));
+
+  if (auto Res =
+          ::getsockname(Fd, reinterpret_cast<sockaddr *>(&SocketAddr), &Slen);
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  if (auto Res = sockAddressAssignHelper(SocketAddr); unlikely(!Res)) {
+    return WasiUnexpect(Res.error());
+  } else {
+    Address = *Res;
+  }
+
+  return {};
+}
+
+WasiExpect<void> INode::sockGetPeerAddrPV2(
+    __wasi_sockets_ip_socket_address_t &Address) const noexcept {
+  sockaddr_storage SocketAddr = {};
+  socklen_t Slen = std::max(sizeof(sockaddr_in), sizeof(sockaddr_in6));
+
+  if (auto Res =
+          ::getpeername(Fd, reinterpret_cast<sockaddr *>(&SocketAddr), &Slen);
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  if (auto Res = sockAddressAssignHelper(SocketAddr); unlikely(!Res)) {
+    return WasiUnexpect(Res.error());
+  } else {
+    Address = *Res;
+  }
+
+  return {};
+}
+
+// https://man7.org/linux/man-pages/man2/connect.2.html
+// Note: MacOS version should handle INVAL/AFNOSUPPORT as success
+WasiExpect<void> INode::sockUDPDisconnect() const noexcept {
+  sockaddr ZeroAddr{};
+  ZeroAddr.sa_family = AF_UNSPEC;
+
+  if (auto Res = ::connect(Fd, &ZeroAddr, sizeof(ZeroAddr));
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return {};
+}
+
+WasiExpect<void> INode::sockSetIPv6V6only(bool IsV6only) const noexcept {
+  if (auto Res = ::setsockopt(Fd, IPPROTO_IPV6, IPV6_V6ONLY, &IsV6only,
+                              sizeof(IsV6only));
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return {};
+}
+
+WasiExpect<uint8_t> INode::sockGetIPTTL() const noexcept {
+  uint8_t Buf;
+  socklen_t BufSize = sizeof(Buf);
+  if (auto Res = ::getsockopt(Fd, IPPROTO_IP, IP_TTL, &Buf, &BufSize);
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return Buf;
+}
+
+WasiExpect<void> INode::sockSetIPTTL(uint8_t TTL) const noexcept {
+  if (TTL == 0) {
+    return WasiUnexpect(__WASI_ERRNO_INVAL);
+  }
+  if (auto Res = ::setsockopt(Fd, IPPROTO_IP, IP_TTL, &TTL, sizeof(TTL));
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return {};
+}
+
+WasiExpect<uint8_t> INode::sockGetIPv6UnicastHops() const noexcept {
+  uint8_t Buf;
+  socklen_t BufSize = sizeof(Buf);
+  if (auto Res =
+          ::getsockopt(Fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS, &Buf, &BufSize);
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return Buf;
+}
+
+WasiExpect<void> INode::sockSetIPv6UnicastHops(uint8_t TTL) const noexcept {
+  if (TTL == 0) {
+    return WasiUnexpect(__WASI_ERRNO_INVAL);
+  }
+  if (auto Res =
+          ::setsockopt(Fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS, &TTL, sizeof(TTL));
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return {};
+}
+
+WasiExpect<uint64_t> INode::sockGetRecvBufferSize() const noexcept {
+  uint64_t Buf;
+  socklen_t BufSize = sizeof(Buf);
+  if (auto Res = ::getsockopt(Fd, SOL_SOCKET, SO_RCVBUF, &Buf, &BufSize);
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  // Linux will return doubled value
+  // https://linux.die.net/man/7/socket
+  return Buf / 2;
+}
+
+WasiExpect<uint64_t> INode::sockGetSendBufferSize() const noexcept {
+  uint64_t Buf;
+  socklen_t BufSize = sizeof(Buf);
+  if (auto Res = ::getsockopt(Fd, SOL_SOCKET, SO_SNDBUF, &Buf, &BufSize);
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  // Linux will return doubled value
+  // https://linux.die.net/man/7/socket
+  return Buf / 2;
+}
+
+WasiExpect<void> INode::sockSetRecvBufferSize(uint64_t Size) const noexcept {
+  if (Size == 0) {
+    return WasiUnexpect(__WASI_ERRNO_INVAL);
+  }
+  if (auto Res = ::setsockopt(Fd, SOL_SOCKET, SO_RCVBUF, &Size, sizeof(Size));
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return {};
+}
+
+WasiExpect<void> INode::sockSetSendBufferSize(uint64_t Size) const noexcept {
+  if (Size == 0) {
+    return WasiUnexpect(__WASI_ERRNO_INVAL);
+  }
+  if (auto Res = ::setsockopt(Fd, SOL_SOCKET, SO_SNDBUF, &Size, sizeof(Size));
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return {};
+}
+
+WasiExpect<uint32_t> INode::sockGetKeepAlive() const noexcept {
+  bool Buf;
+  socklen_t BufSize = sizeof(Buf);
+  if (auto Res = ::getsockopt(Fd, SOL_SOCKET, SO_SNDBUF, &Buf, &BufSize);
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return Buf;
+}
+
+WasiExpect<void> INode::sockSetKeepAlive(uint32_t Size) const noexcept {
+  if (Size == 0) {
+    return WasiUnexpect(__WASI_ERRNO_INVAL);
+  }
+
+  bool Opt = !!Size;
+  if (auto Res = ::setsockopt(Fd, SOL_SOCKET, SO_RCVBUF, &Opt, sizeof(Opt));
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return {};
+}
+
+WasiExpect<uint32_t> INode::sockGetKeepIdle() const noexcept {
+  uint32_t Buf;
+  socklen_t BufSize = sizeof(Buf);
+  if (auto Res = ::getsockopt(Fd, IPPROTO_TCP, TCP_KEEPIDLE, &Buf, &BufSize);
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return Buf;
+}
+
+WasiExpect<void> INode::sockSetKeepIdle(uint32_t Sec) const noexcept {
+  uint32_t Opt = Sec;
+  if (auto Res = ::setsockopt(Fd, IPPROTO_TCP, TCP_KEEPIDLE, &Opt, sizeof(Opt));
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return {};
+}
+
+WasiExpect<uint32_t> INode::sockGetAliveInterval() const noexcept {
+  uint32_t Buf;
+  socklen_t BufSize = sizeof(Buf);
+  if (auto Res = ::getsockopt(Fd, IPPROTO_TCP, TCP_KEEPINTVL, &Buf, &BufSize);
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return Buf;
+}
+
+WasiExpect<void> INode::sockSetAliveInterval(uint32_t Sec) const noexcept {
+  uint32_t Opt = Sec;
+  if (auto Res =
+          ::setsockopt(Fd, IPPROTO_TCP, TCP_KEEPINTVL, &Opt, sizeof(Opt));
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return {};
+}
+
+WasiExpect<uint32_t> INode::sockGetKeepAliveCount() const noexcept {
+  uint32_t Buf;
+  socklen_t BufSize = sizeof(Buf);
+  if (auto Res = ::getsockopt(Fd, IPPROTO_TCP, TCP_KEEPCNT, &Buf, &BufSize);
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return Buf;
+}
+
+WasiExpect<void> INode::sockSetKeepAliveCount(uint32_t Val) const noexcept {
+  uint32_t Opt = Val;
+  if (auto Res = ::setsockopt(Fd, IPPROTO_TCP, TCP_KEEPCNT, &Opt, sizeof(Opt));
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return {};
+}
+
+WasiExpect<void>
+INode::sockShutdownPV2(__wasi_sdflags_t SdFlags) const noexcept {
+  int SysFlags = 0;
+  if (SdFlags == __WASI_SDFLAGS_RD) {
+    SysFlags = SHUT_RD;
+  } else if (SdFlags == __WASI_SDFLAGS_WR) {
+    SysFlags = SHUT_WR;
+  } else if (SdFlags == (__WASI_SDFLAGS_RD | __WASI_SDFLAGS_WR)) {
+    SysFlags = SHUT_RDWR;
+  }
+
+  if (auto Res = ::shutdown(Fd, SysFlags); unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return {};
+}
+
+WasiExpect<void> INode::sockRecvPV2(Span<uint8_t> Buffer,
+                                    __wasi_size_t &NRead) const noexcept {
+  int Flags = 0;
+
+  NRead = 0;
+  while (Buffer.size() != 0) {
+    if (auto Res = ::recv(Fd, Buffer.data(), Buffer.size(), Flags);
+        unlikely(Res < 0)) {
+      if (errno == EWOULDBLOCK) {
+        break;
+      }
+      return WasiUnexpect(fromErrNo(errno));
+    } else {
+      Buffer = Buffer.subspan(Res);
+      NRead += Res;
+    }
+  }
+
+  return {};
+}
+
+// Reference:
+// https://github.com/rust-lang/rust/blob/master/library/std/src/sys_common/net.rs#L196
+WasiExpect<void> INode::sockGetaddrinfoPV2(
+    std::string_view String,
+    std::vector<__wasi_sockets_ip_address_t> &Addresses) noexcept {
+  addrinfo Hints{};
+  addrinfo *Resolved = nullptr, *Ptr = nullptr;
+
+  Hints.ai_socktype = SOCK_STREAM;
+  if (auto Res = ::getaddrinfo(String.data(), nullptr, &Hints, &Resolved);
+      unlikely(Res < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  Ptr = Resolved;
+  Addresses.clear();
+  while (Ptr != nullptr) {
+    if (Ptr->ai_addr) {
+      if (auto Res = sockAddressAssignHelper(Ptr->ai_addr); Res) {
+        __wasi_sockets_ip_address_t IP;
+        IP.AddressFamily = Res->AddressFamily;
+        if (Res->AddressFamily == __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv4) {
+          IP.Val.IPv4 = Res->Val.IPv4.Address;
+        } else if (Res->AddressFamily ==
+                   __WASI_SOCKETS_IP_ADDRESS_FAMILY_IPv6) {
+          IP.Val.IPv6 = Res->Val.IPv6.Address;
+        } else {
+          __builtin_unreachable();
+        }
+
+        Addresses.emplace_back(std::move(IP));
+      }
+    }
+    Ptr = Ptr->ai_next;
+  }
+
+  ::freeaddrinfo(Resolved);
+  return {};
+}
+
 __wasi_filetype_t INode::unsafeFiletype() const noexcept {
   return fromFileType(static_cast<mode_t>(Stat->st_mode));
 }

--- a/lib/host/wasi/linux.h
+++ b/lib/host/wasi/linux.h
@@ -33,6 +33,7 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <sys/socket.h>
 
 #include <sys/stat.h>

--- a/lib/host/wasi/vinode.cpp
+++ b/lib/host/wasi/vinode.cpp
@@ -357,6 +357,32 @@ VINode::sockOpen(__wasi_address_family_t SysDomain,
 }
 
 WasiExpect<std::shared_ptr<VINode>>
+VINode::sockOpenPV2(__wasi_sockets_ip_address_family_t SysDomain,
+                    __wasi_sockets_type_t SockType) {
+  if (auto Res = INode::sockOpenPV2(SysDomain, SockType); unlikely(!Res)) {
+    return WasiUnexpect(Res);
+  } else {
+    __wasi_rights_t Rights =
+        __WASI_RIGHTS_SOCK_OPEN | __WASI_RIGHTS_SOCK_CLOSE |
+        __WASI_RIGHTS_SOCK_RECV | __WASI_RIGHTS_SOCK_RECV_FROM |
+        __WASI_RIGHTS_SOCK_SEND | __WASI_RIGHTS_SOCK_SEND_TO |
+        __WASI_RIGHTS_SOCK_SHUTDOWN | __WASI_RIGHTS_SOCK_BIND |
+        __WASI_RIGHTS_POLL_FD_READWRITE | __WASI_RIGHTS_FD_FDSTAT_SET_FLAGS |
+        __WASI_RIGHTS_FD_READ | __WASI_RIGHTS_FD_WRITE;
+    return std::make_shared<VINode>(std::move(*Res), Rights, Rights);
+  }
+}
+
+WasiExpect<void> VINode::sockGetaddrinfoPV2(
+    std::string_view String,
+    std::vector<__wasi_sockets_ip_address_t> &Addresses) {
+  if (auto Res = INode::sockGetaddrinfoPV2(String, Addresses); unlikely(!Res)) {
+    return WasiUnexpect(Res);
+  }
+  return {};
+}
+
+WasiExpect<std::shared_ptr<VINode>>
 VINode::sockAccept(__wasi_fdflags_t FdFlags) {
   if (auto Res = Node.sockAccept(FdFlags); unlikely(!Res)) {
     return WasiUnexpect(Res);


### PR DESCRIPTION
# Wasi threads

# framework
- [ ] resource manager
- [ ] access control
  - [ ] enable/disable network
  - [ ] network allow ip check
## network
- [ ] network (resource)
  - [ ] `instance`
  - [ ] `drop`
  

## udp-create-socket

- [x] `create_udp_socket(address-family)`

## udp

- [ ] udpsocket (resource)
  - [ ] `instance`
  - [x] `drop`
  - [ ] `subscribe`  (poll function, will remove in preview 3)
  - [x] `start_bind(address, address-family)`
    - [x] `check ip is allowed`
  - [x] `finish_bind(handle)`
  - [x] `stream(remote-address)`
    - [x] `check child stream (resource)`
    - [x] `check remote address allowed`
  - [x] `local_address()`
  - [x] `remote_address()`
  - [x] `AddressFamily()`
  - [x] `UnicastHopLimit()`
  - [x] `SetUnicastHopLimit()`
  - [x] `GetReceiveBufferSize()`
  - [x] `SetReceiveBufferSize`()
  - [x] `GetSendBufferSize()`
  - [x] `SetSendBufferSize()`
  
- [ ] `incoming-datagram-stream`
  - [ ] `instance (user can not use this)`
  - [ ] `drop`
  - [ ] `subscribe`  (poll function, will remove in preview 3)
  - [ ] `receive(max-results)`

- [ ] `outgoing-datagram-stream`
  - [ ] `instance (user can not use this)`
  - [ ] `drop`
  - [ ] `subscribe`  (poll function, will remove in preview 3)
  - [ ] `check-send()`
  - [ ] `send(list)`

## tcp-create-socket

- [x] `create_tcp_socket(address-family)`

## tcp

- [ ] `tcp-socket`
  - [ ] `instance`
  - [ ] `drop`
  - [ ] `subscribe`  (poll function, will remove in preview 3)
  - [x] `start-bind`
  - [x] `finish-bind`
  - [ ] `start-connect`
  - [ ] `finish-connect`
  - [x] `start-listen`
  - [x] `finish-listen`
  - [ ] `accept`
  - [x] `local-address`
  - [x] `remote-address`
  - [x] `is_listening`
  - [x] `address_family`
  - [ ] `set_listen_backlog_size`
  - [x] `keep-alive-enabled`
  - [x] `set-keep-alive-enabled`
  - [x] `keep-alive-idle-time`
  - [x] `setkeep-alive-idle-time`
  - [x] `keep-alive-interval`
  - [x] `set-keep-alive-interval`
  - [x] `keep-alive-count`
  - [x] `set-keep-alive-count`
  - [x] `hop-limit`
  - [x] `set-hop-limit`
  - [x] `receive-buffer-size`
  - [x] `set-receive-buffer-size`
  - [x] `send-buffer-size`
  - [x] `set-send-buffer-size`
  - [ ] `shutdown`

## IpNameLookup
- [ ] `resolve-addresses`
- [ ] `resolve-address-stream`
  - [ ] `instance`
  - [ ] `drop`
  - [ ] `subscribe`  (poll function, will remove in preview 3)
  - [ ] `resolve-next-address`
