### PR TITLE
Upgrade openvino 2.0

### DIFF
--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -84,8 +84,8 @@ jobs:
     env:
       output_dir: build/plugins/wasi_nn
       test_dir: build/test/plugins/wasi_nn
-      build_options: -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=PyTorch -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=TensorFlowLite -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=GGML
-      tar_names: wasi_nn-pytorch wasi_nn-tensorflowlite wasi_nn-ggml
+      build_options: -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=PyTorch -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=OpenVINO -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=TensorFlowLite -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=GGML
+      tar_names: wasi_nn-pytorch wasi_nn-openvino wasi_nn-tensorflowlite wasi_nn-ggml
       test_bin: wasiNNTests
       output_bin: libwasmedgePluginWasiNN.so
       OPENVINO_VERSION: "2023.0.2"
@@ -107,6 +107,7 @@ jobs:
         run: |
           apt update
           apt install -y unzip libopenblas-dev pkg-config protobuf-compiler-grpc libgrpc-dev libgrpc++-dev
+          bash utils/wasi-nn/install-openvino.sh
           bash utils/wasi-nn/install-pytorch.sh
       - name: Build and test WASI-NN using ${{ matrix.compiler }} with ${{ matrix.build_type }} mode
         shell: bash
@@ -151,6 +152,11 @@ jobs:
         with:
           name: WasmEdge-plugin-wasi_nn-pytorch-${{ needs.get_version.outputs.version }}-ubuntu22.04-${{ matrix.compiler }}.tar.gz
           path: plugin_wasi_nn-pytorch.tar.gz
+      - name: Upload artifact - wasi_nn-openvino
+        uses: actions/upload-artifact@v3
+        with:
+          name: WasmEdge-plugin-wasi_nn-openvino-${{ needs.get_version.outputs.version }}-ubuntu22.04-${{ matrix.compiler }}.tar.gz
+          path: plugin_wasi_nn-openvino.tar.gz
       - name: Upload artifact - wasi_nn-tensorflowlite
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,8 +123,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       output_dir: build/plugins/wasi_nn
-      build_options: -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=PyTorch -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=TensorFlowLite -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=GGML
-      tar_names: wasi_nn-pytorch wasi_nn-tensorflowlite wasi_nn-ggml
+      build_options: -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=PyTorch -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=OpenVINO -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=TensorFlowLite -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=GGML
+      tar_names: wasi_nn-pytorch wasi_nn-openvino wasi_nn-tensorflowlite wasi_nn-ggml
       output_bin: libwasmedgePluginWasiNN.so
       OPENVINO_VERSION: "2023.0.2"
       OPENVINO_YEAR: "2023"
@@ -146,6 +146,7 @@ jobs:
         run: |
           apt update
           apt install -y unzip libopenblas-dev pkg-config protobuf-compiler-grpc libgrpc-dev libgrpc++-dev
+          bash utils/wasi-nn/install-openvino.sh
           bash utils/wasi-nn/install-pytorch.sh
       - name: Build WASI-NN plugin
         shell: bash
@@ -181,6 +182,12 @@ jobs:
         run: |
           mv plugin_wasi_nn-pytorch.tar.gz WasmEdge-plugin-wasi_nn-pytorch-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
           gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasi_nn-pytorch-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz --clobber
+      - name: Upload wasi_nn-openvino plugin tar.gz package
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mv plugin_wasi_nn-openvino.tar.gz WasmEdge-plugin-wasi_nn-openvino-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasi_nn-openvino-${{ needs.create_release.outputs.version }}-ubuntu20.04_x86_64.tar.gz --clobber
       - name: Upload wasi_nn-tensorflowlite plugin tar.gz package
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/plugins/wasi_nn/openvino.cpp
+++ b/plugins/wasi_nn/openvino.cpp
@@ -10,12 +10,6 @@ namespace WasmEdge::Host::WASINN::OpenVINO {
 Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
                            Span<const Span<uint8_t>> Builders,
                            WASINN::Device Device, uint32_t &GraphId) noexcept {
-  // The OpenVINO core must be initialized in constructor.
-  if (unlikely(Env.OpenVINOCore == nullptr)) {
-    spdlog::error("[WASI-NN] OpenVINO core not initialized.");
-    return WASINN::ErrNo::MissingMemory;
-  }
-
   // The graph builder length must be 2.
   if (Builders.size() != 2) {
     spdlog::error("[WASI-NN] Wrong GraphBuilder Length {:d}, expect 2",
@@ -33,134 +27,25 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
   Env.NNGraph.emplace_back(Backend::OpenVINO);
   auto &GraphRef = Env.NNGraph.back().get<Graph>();
 
-  // Create the weights blob memory.
-  tensor_desc_t WeightsDesc{
-      layout_e::ANY, {1, {Weight.size()}}, precision_e::U8};
-  IEStatusCode Status =
-      ie_blob_make_memory(&WeightsDesc, &(GraphRef.OpenVINOWeightBlob));
-  if (Status != IEStatusCode::OK) {
-    spdlog::error(
-        "[WASI-NN] Unable to create the model's weight blob, error code: {}",
-        Status);
+  // Store device information
+  GraphRef.TargetDevice = Device;
+
+  try {
+    std::string ModelString(reinterpret_cast<const char *>(XML.data()),
+                            XML.size());
+    GraphRef.OpenVINOIWeightTensor =
+        ov::Tensor(ov::element::Type_t::u8, {Weight.size()});
+    std::copy_n(Weight.data(), Weight.size(),
+                static_cast<uint8_t *>(GraphRef.OpenVINOIWeightTensor.data()));
+    GraphRef.OpenVINOModel = Env.OpenVINOCore.read_model(
+        ModelString, GraphRef.OpenVINOIWeightTensor);
+  } catch (const std::exception &EX) {
+    spdlog::error("[WASI-NN] Model Load Exception: {}", EX.what());
     Env.NNGraph.pop_back();
-    return WASINN::ErrNo::Busy;
+    return WASINN::ErrNo::RuntimeError;
   }
-
-  // Copy the weights buffer to the blob.
-  ie_blob_buffer_t BlobBuffer;
-  Status = ie_blob_get_buffer(GraphRef.OpenVINOWeightBlob, &BlobBuffer);
-  if (unlikely(Status != IEStatusCode::OK)) {
-    spdlog::error(
-        "[WASI-NN] Unable to find the weight blob's buffer, error code: {}",
-        Status);
-    Env.NNGraph.pop_back();
-    return WASINN::ErrNo::MissingMemory;
-  }
-  std::copy_n(Weight.data(), Weight.size(),
-              static_cast<uint8_t *>(BlobBuffer.buffer));
-
-  // Read network from memory.
-  Status = ie_core_read_network_from_memory(
-      Env.OpenVINOCore, XML.data(), XML.size(), GraphRef.OpenVINOWeightBlob,
-      &(GraphRef.OpenVINONetwork));
-  if (Status != IEStatusCode::OK) {
-    spdlog::error("[WASI-NN] Unable to read network from the XML and "
-                  "Weights, error code: {}",
-                  Status);
-    Env.NNGraph.pop_back();
-    return WASINN::ErrNo::Busy;
-  }
-
-  // Get the network input and output size.
-  size_t NetworkInputSize = 0;
-  Status =
-      ie_network_get_inputs_number(GraphRef.OpenVINONetwork, &NetworkInputSize);
-  if (unlikely(Status != IEStatusCode::OK)) {
-    spdlog::error("[WASI-NN] Unable to get the inputs number from the "
-                  "network, error code: {}",
-                  Status);
-    Env.NNGraph.pop_back();
-    return WASINN::ErrNo::MissingMemory;
-  }
-  spdlog::debug("[WASI-NN] Got input size: {}", NetworkInputSize);
-  size_t NetworkOutputSize = 0;
-  Status = ie_network_get_outputs_number(GraphRef.OpenVINONetwork,
-                                         &NetworkOutputSize);
-  if (unlikely(Status != IEStatusCode::OK)) {
-    spdlog::error("[WASI-NN] Unable to get the outputs number from the "
-                  "network, error code: {}",
-                  Status);
-    Env.NNGraph.pop_back();
-    return WASINN::ErrNo::MissingMemory;
-  }
-  spdlog::debug("[WASI-NN] Got output size: {}", NetworkOutputSize);
-
-  // Get and store the input and output names.
-  GraphRef.OpenVINOInputNames.resize(NetworkInputSize, nullptr);
-  for (size_t I = 0; I < NetworkInputSize; I++) {
-    Status = ie_network_get_input_name(GraphRef.OpenVINONetwork, I,
-                                       &(GraphRef.OpenVINOInputNames[I]));
-    if (Status != IEStatusCode::OK) {
-      spdlog::error("[WASI-NN] Unable to find input name correctly with "
-                    "Index {}, error code: {}",
-                    I, Status);
-      Env.NNGraph.pop_back();
-      return WASINN::ErrNo::MissingMemory;
-    }
-    spdlog::debug("[WASI-NN] Got input name: {}",
-                  GraphRef.OpenVINOInputNames[I]);
-  }
-  GraphRef.OpenVINOOutputNames.resize(NetworkOutputSize, nullptr);
-  for (size_t I = 0; I < NetworkOutputSize; I++) {
-    Status = ie_network_get_output_name(GraphRef.OpenVINONetwork, I,
-                                        &(GraphRef.OpenVINOOutputNames[I]));
-    if (Status != IEStatusCode::OK) {
-      spdlog::error("[WASI-NN] Unable to find output name correctly with "
-                    "Index {}, error code: {}",
-                    I, Status);
-      Env.NNGraph.pop_back();
-      return WASINN::ErrNo::MissingMemory;
-    }
-    spdlog::debug("[WASI-NN] Got output name: {}",
-                  GraphRef.OpenVINOOutputNames[I]);
-  }
-
-  // Set the input layout.
-  // FIXME: this is a temporary workaround. We need a more eligant way to
-  // specify the layout in the long run. However, without this newer versions
-  // of OpenVINO will fail due to parameter mismatch.
-  for (size_t I = 0; I < NetworkInputSize; I++) {
-    // More layouts should be supported.
-    Status = ie_network_set_input_layout(GraphRef.OpenVINONetwork,
-                                         GraphRef.OpenVINOInputNames[I],
-                                         layout_e::NHWC);
-    spdlog::debug("[WASI-NN] Setting [{}] to NHWC",
-                  GraphRef.OpenVINOInputNames[I]);
-    if (Status != IEStatusCode::OK) {
-      spdlog::error("[WASI-NN] Unable to set input layout with the input "
-                    "name {}, error code: {}",
-                    GraphRef.OpenVINOInputNames[I], Status);
-      Env.NNGraph.pop_back();
-      return WASINN::ErrNo::MissingMemory;
-    }
-  }
-
-  // Load network.
-  ie_config_t Config = {nullptr, nullptr, nullptr};
-  Status = ie_core_load_network(Env.OpenVINOCore, GraphRef.OpenVINONetwork,
-                                fmt::format("{}"sv, Device).c_str(), &Config,
-                                &GraphRef.OpenVINOExecNetwork);
-  if (Status != IEStatusCode::OK) {
-    spdlog::error(
-        "[WASI-NN] Unable to create executable Network, error code: {}",
-        Status);
-    Env.NNGraph.pop_back();
-    return WASINN::ErrNo::Busy;
-  }
-
   // Store the loaded graph.
   GraphId = Env.NNGraph.size() - 1;
-
   return WASINN::ErrNo::Success;
 }
 
@@ -169,21 +54,12 @@ Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
                                   uint32_t &ContextId) noexcept {
   // Check the network and the execution network with the graph ID.
   auto &GraphRef = Env.NNGraph[GraphId].get<Graph>();
-  if (GraphRef.OpenVINONetwork == nullptr ||
-      GraphRef.OpenVINOExecNetwork == nullptr) {
+  if (GraphRef.OpenVINOModel == nullptr) {
     spdlog::error("[WASI-NN] Model for Graph:{} is empty!", GraphId);
     return WASINN::ErrNo::MissingMemory;
   }
-
   // Create context.
   Env.NNContext.emplace_back(GraphId, Env.NNGraph[GraphId]);
-  auto &CtxRef = Env.NNContext.back().get<Context>();
-  if (CtxRef.OpenVINOInferRequest == nullptr) {
-    spdlog::error("[WASI-NN] Unable to create openvino context");
-    Env.NNContext.pop_back();
-    return WASINN::ErrNo::Busy;
-  }
-
   ContextId = Env.NNContext.size() - 1;
   return WASINN::ErrNo::Success;
 }
@@ -193,26 +69,17 @@ Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
                                const TensorData &Tensor) noexcept {
   auto &CxtRef = Env.NNContext[ContextId].get<Context>();
   auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
-  // Check the infer request and the network.
-  auto *Network = GraphRef.OpenVINONetwork;
-  if (Network == nullptr || CxtRef.OpenVINOInferRequest == nullptr) {
+
+  if (GraphRef.OpenVINOModel == nullptr) {
     spdlog::error("[WASI-NN] The founded openvino session is empty");
     return WASINN::ErrNo::MissingMemory;
   }
 
-  // Check the input index.
-  if (GraphRef.OpenVINOInputNames.size() <= Index) {
-    spdlog::error("[WASI-NN] The input index {} exceeds the inputs number {}.",
-                  Index, GraphRef.OpenVINOInputNames.size());
-    return WASINN::ErrNo::InvalidArgument;
-  }
-  char *InputName = GraphRef.OpenVINOInputNames[Index];
-
   if (Tensor.Dimension.size() > 8) {
-    spdlog::error(
-        "[WASI-NN] Tensor dimension is out of range, expect it under 8-dim, "
-        "but got {}-dim.",
-        Tensor.Dimension.size());
+    spdlog::error("[WASI-NN] Tensor dimension is out of range, expect "
+                  "it under 8-dim, "
+                  "but got {}-dim.",
+                  Tensor.Dimension.size());
     return WASINN::ErrNo::InvalidArgument;
   }
   if (Tensor.RType != WASINN::TensorType::F32) {
@@ -221,96 +88,38 @@ Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
     return WASINN::ErrNo::InvalidArgument;
   }
 
-  // Set the input resize algorithm.
-  // Mark the input as resizable by setting a resize algorithm.
-  // In this case we will be able to set an input blob of any shape to an
-  // infer request. Resizing and layout conversions are executed automatically
-  // when inferring.
-  IEStatusCode Status = ie_network_set_input_resize_algorithm(
-      Network, InputName, RESIZE_BILINEAR);
-  if (Status != IEStatusCode::OK) {
-    spdlog::error(
-        "[WASI-NN] Unable to set input resize correctly, error code: {}",
-        Status);
+  // Check the input index.
+  if (GraphRef.OpenVINOModel->inputs().size() <= Index) {
+    spdlog::error("[WASI-NN] The input index {} exceeds the inputs number {}.",
+                  Index, GraphRef.OpenVINOModel->inputs().size());
     return WASINN::ErrNo::InvalidArgument;
   }
 
-  // Set the input layout.
-  // More layouts should be supported.
-  Status = ie_network_set_input_layout(Network, InputName, layout_e::NHWC);
-  if (Status != IEStatusCode::OK) {
-    spdlog::error(
-        "[WASI-NN] Unable to set input layout correctly, error code: {}",
-        Status);
-    return WASINN::ErrNo::InvalidArgument;
+  try {
+    ov::element::Type InputType = ov::element::f32;
+    ov::Shape InputShape = {1, 224, 224, 3};
+    ov::Tensor InputTensor =
+        ov::Tensor(InputType, InputShape, Tensor.Tensor.data());
+    const ov::Layout InputLayout{"NHWC"};
+    ov::preprocess::PrePostProcessor PPP(GraphRef.OpenVINOModel);
+    PPP.input()
+        .tensor()
+        .set_shape(InputShape)
+        .set_element_type(InputType)
+        .set_layout(InputLayout);
+    PPP.input().preprocess().resize(
+        ov::preprocess::ResizeAlgorithm::RESIZE_LINEAR);
+    PPP.input().model().set_layout("NCHW");
+    PPP.output().tensor().set_element_type(ov::element::f32);
+    auto model = PPP.build();
+    ov::CompiledModel CompiledModel =
+        Env.OpenVINOCore.compile_model(model, "CPU");
+    CxtRef.OpenVINOInferRequest = CompiledModel.create_infer_request();
+    CxtRef.OpenVINOInferRequest.set_input_tensor(Index, InputTensor);
+  } catch (const std::exception &EX) {
+    spdlog::error("[WASI-NN] Set Input Exception: {}", EX.what());
+    return WASINN::ErrNo::RuntimeError;
   }
-
-  // Set the input precision.
-  // More types should be supported.
-  Status =
-      ie_network_set_input_precision(Network, InputName, precision_e::FP32);
-  if (Status != IEStatusCode::OK) {
-    spdlog::error(
-        "[WASI-NN] Unable to set input precision correctly, error code: {}",
-        Status);
-    return WASINN::ErrNo::InvalidArgument;
-  }
-
-  // Set the dimensions and the tensor description.
-  dimensions_t Dimens;
-  Dimens.ranks = Tensor.Dimension.size();
-  for (size_t I = 0; I < Dimens.ranks; I++) {
-    Dimens.dims[I] = static_cast<size_t>(Tensor.Dimension[I]);
-  }
-  tensor_desc_t TensorDesc = {layout_e::NHWC, Dimens, precision_e::FP32};
-
-  // Create the input blob memory.
-  ie_blob_t *InputBlob = nullptr;
-  Status = ie_blob_make_memory(&TensorDesc, &InputBlob);
-  if (Status != IEStatusCode::OK) {
-    spdlog::error("[WASI-NN] Unable to allocated input tensor correctly, "
-                  "error code: {}",
-                  Status);
-    return WASINN::ErrNo::Busy;
-  }
-
-  // Get the blob buffer size and compare with the tensor size.
-  int BlobSize;
-  Status = ie_blob_size(InputBlob, &BlobSize);
-  if (unlikely(Status != IEStatusCode::OK)) {
-    spdlog::error("[WASI-NN] Unable to get the input blob size, error code: {}",
-                  Status);
-    return WASINN::ErrNo::Busy;
-  }
-  if (unlikely(static_cast<uint32_t>(BlobSize * 4) != Tensor.Tensor.size())) {
-    spdlog::error("[WASI-NN] Blob size {} and the Tensor size {} not matched.",
-                  BlobSize * 4, Tensor.Tensor.size());
-  }
-
-  // Copy the data into the input blob buffer.
-  ie_blob_buffer_t BlobBuffer;
-  Status = ie_blob_get_buffer(InputBlob, &BlobBuffer);
-  if (unlikely(Status != IEStatusCode::OK)) {
-    spdlog::error("[WASI-NN] Unable to find input tensor buffer");
-    ie_blob_free(&InputBlob);
-    return WASINN::ErrNo::MissingMemory;
-  }
-  std::copy_n(Tensor.Tensor.data(), Tensor.Tensor.size(),
-              static_cast<uint8_t *>(BlobBuffer.buffer));
-
-  // Set input blob.
-  Status = ie_infer_request_set_blob(CxtRef.OpenVINOInferRequest, InputName,
-                                     InputBlob);
-  if (Status != IEStatusCode::OK) {
-    spdlog::error("[WASI-NN] Unable to set input tensor to model correctly, "
-                  "error code: {}",
-                  Status);
-    ie_blob_free(&InputBlob);
-    return WASINN::ErrNo::Busy;
-  }
-
-  ie_blob_free(&InputBlob);
-
   return WASINN::ErrNo::Success;
 }
 
@@ -320,70 +129,36 @@ Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
                                 uint32_t &BytesWritten) noexcept {
   auto &CxtRef = Env.NNContext[ContextId].get<Context>();
   auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
-  auto *Network = GraphRef.OpenVINONetwork;
 
   // Check the output index.
-  if (GraphRef.OpenVINOOutputNames.size() <= Index) {
+  if (GraphRef.OpenVINOModel->outputs().size() <= Index) {
     spdlog::error(
         "[WASI-NN] The output index {} exceeds the outputs number {}.", Index,
-        GraphRef.OpenVINOOutputNames.size());
-    return WASINN::ErrNo::InvalidArgument;
-  }
-  char *OutputName = GraphRef.OpenVINOOutputNames[Index];
-
-  // Set output precision.
-  IEStatusCode Status =
-      ie_network_set_output_precision(Network, OutputName, precision_e::FP32);
-  if (Status != IEStatusCode::OK) {
-    spdlog::error(
-        "[WASI-NN] Unable to set output precision correctly with Index:{}",
-        Index);
+        GraphRef.OpenVINOModel->outputs().size());
     return WASINN::ErrNo::InvalidArgument;
   }
 
-  // Get output blob buffer.
-  ie_blob_t *OutputBlob = nullptr;
-  Status = ie_infer_request_get_blob(CxtRef.OpenVINOInferRequest, OutputName,
-                                     &OutputBlob);
-  if (Status != IEStatusCode::OK) {
-    spdlog::error("[WASI-NN] Unable to retrieve output tensor correctly",
-                  Index);
-    return WASINN::ErrNo::InvalidArgument;
+  try {
+    const ov::Tensor &OutputTensor =
+        CxtRef.OpenVINOInferRequest.get_output_tensor(Index);
+    BytesWritten = OutputTensor.get_byte_size();
+    std::copy_n(static_cast<const uint8_t *>(OutputTensor.data()), BytesWritten,
+                OutBuffer.data());
+  } catch (const std::exception &EX) {
+    spdlog::error("[WASI-NN] Get Output Exception: {}", EX.what());
+    return WASINN::ErrNo::RuntimeError;
   }
-
-  // Get the blob size and copy the output buffer.
-  int BlobSize;
-  Status = ie_blob_size(OutputBlob, &BlobSize);
-  ie_blob_buffer_t BlobCBuffer;
-  Status = ie_blob_get_cbuffer(OutputBlob, &BlobCBuffer);
-  if (Status != IEStatusCode::OK) {
-    spdlog::error("[WASI-NN] Unable to retrieve output tensor correctly",
-                  Index);
-    ie_blob_free(&OutputBlob);
-    return WASINN::ErrNo::MissingMemory;
-  }
-  uint32_t BytesToWrite =
-      std::min(static_cast<size_t>(BlobSize * 4), OutBuffer.size());
-  std::copy_n(static_cast<const uint8_t *>(BlobCBuffer.cbuffer), BytesToWrite,
-              OutBuffer.data());
-
-  // Write the bytes written result.
-  BytesWritten = BytesToWrite;
-
-  ie_blob_free(&OutputBlob);
-
   return WASINN::ErrNo::Success;
 }
 
 Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
                               uint32_t ContextId) noexcept {
   auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  IEStatusCode Status = ie_infer_request_infer(CxtRef.OpenVINOInferRequest);
-  if (Status != IEStatusCode::OK) {
-    spdlog::error(
-        "[WASI-NN] Unable to perform computation correctly, error code: {}",
-        Status);
-    return WASINN::ErrNo::Busy;
+  try {
+    CxtRef.OpenVINOInferRequest.infer();
+  } catch (const std::exception &EX) {
+    spdlog::error("[WASI-NN] Infer Request Exception: {}", EX.what());
+    return WASINN::ErrNo::RuntimeError;
   }
   return WASINN::ErrNo::Success;
 }

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -166,7 +166,8 @@ TEST(WasiNNTest, OpenVINOBackend) {
         std::initializer_list<WasmEdge::ValVariant>{
             LoadEntryPtr, UINT32_C(2), UINT32_C(0), UINT32_C(0), BuilderPtr},
         Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Busy));
+    EXPECT_EQ(Errno[0].get<int32_t>(),
+              static_cast<uint32_t>(ErrNo::RuntimeError));
   }
 
   // Test: load -- graph id ptr out of bounds.
@@ -422,7 +423,8 @@ TEST(WasiNNTest, OpenVINOBackend) {
     EXPECT_TRUE(HostFuncCompute.run(
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0)},
         Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Busy));
+    EXPECT_EQ(Errno[0].get<int32_t>(),
+              static_cast<uint32_t>(ErrNo::RuntimeError));
   }
   // Swap back.
   NNGraphTmp.swap(NNMod->getEnv().NNGraph);

--- a/utils/wasi-nn/install-openvino.sh
+++ b/utils/wasi-nn/install-openvino.sh
@@ -8,5 +8,5 @@ wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PU
 apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
 echo "deb https://apt.repos.intel.com/openvino/2023 ubuntu20 main" | tee /etc/apt/sources.list.d/intel-openvino-2023.list
 apt update
-apt-get -y install openvino-2023.0.2
+apt-get -y install openvino-2023.2.0
 ldconfig


### PR DESCRIPTION
Some points of my confusion during the work integration to 2.0 API. 

I noticed that the shape of the input tensor passed from WebAssembly (wasm) is NHWC, but the tensor dimensions in the parameters are given as [1, 3, 224, 224], leading to parsing errors. 
Currently, I manually hardcode {1, 224, 224, 3} in `openvino.cpp` to bypass this issue. 

@apepkuss , could you please take a look at the original example and check if the processing of image to tensor is handled correctly? Or if there's any misunderstanding on my part, please help correct me. Thanks!

Fix #3140