### PR TITLE
Fix the linking error with simdjson

### DIFF
--- a/plugins/wasi_nn/CMakeLists.txt
+++ b/plugins/wasi_nn/CMakeLists.txt
@@ -143,7 +143,7 @@ target_include_directories(wasmedgePluginWasiNN
 
 if(BACKEND STREQUAL "ggml")
   target_include_directories(wasmedgePluginWasiNN PUBLIC ${CMAKE_BINARY_DIR}/_deps/llama-src)
-  target_link_libraries(wasmedgePluginWasiNN PRIVATE common simdjson)
+  target_link_libraries(wasmedgePluginWasiNN PRIVATE common simdjson::simdjson)
   if(WASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_METAL)
     add_custom_command(
       TARGET wasmedgePluginWasiNN

--- a/test/spec/CMakeLists.txt
+++ b/test/spec/CMakeLists.txt
@@ -86,7 +86,7 @@ wasmedge_add_library(wasmedgeTestSpec
 
 target_link_libraries(wasmedgeTestSpec
   PRIVATE
-  simdjson
+  simdjson::simdjson
   PUBLIC
   std::filesystem
   wasmedgeCommon


### PR DESCRIPTION
Fix #2791 

The issue was due to simdjson being exported with a namespace, which led to `find_package` successfully locating simdjson but failing to link the library without specifying the namespace. Prefixing simdjson with its namespace in `target_link_libraries` resolves this linking issue.