### PR TITLE
[WASI-NN] ggml: add llava support

### DIFF
--- a/plugins/wasi_nn/CMakeLists.txt
+++ b/plugins/wasi_nn/CMakeLists.txt
@@ -49,7 +49,7 @@ if(BACKEND STREQUAL "ggml")
   FetchContent_Declare(
     llama
     GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-    GIT_TAG        b2037
+    GIT_TAG        b2220
     PATCH_COMMAND  test -f ggml.patched || git apply ${CMAKE_SOURCE_DIR}/thirdparty/ggml/ggml.patch && ${CMAKE_COMMAND} -E touch ggml.patched
     GIT_SHALLOW    FALSE
   )

--- a/plugins/wasi_nn/CMakeLists.txt
+++ b/plugins/wasi_nn/CMakeLists.txt
@@ -12,6 +12,8 @@ if(BACKEND STREQUAL "ggml")
   if(WASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_CUBLAS)
     message(STATUS "WASI-NN GGML LLAMA backend: Enable LLAMA_CUBLAS")
     set(LLAMA_CUBLAS ON)
+    # We need to set GGML_USE_CUBLAS for clip from llava.
+    add_compile_definitions(GGML_USE_CUBLAS)
     # If CUBLAS is ON, then OpenBLAS should be OFF.
     set(WASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_BLAS OFF)
   else()
@@ -142,8 +144,31 @@ target_include_directories(wasmedgePluginWasiNN
 )
 
 if(BACKEND STREQUAL "ggml")
-  target_include_directories(wasmedgePluginWasiNN PUBLIC ${CMAKE_BINARY_DIR}/_deps/llama-src)
-  target_link_libraries(wasmedgePluginWasiNN PRIVATE common simdjson::simdjson)
+  # Setup llava from llama.cpp
+  wasmedge_add_library(llava OBJECT
+    ${CMAKE_BINARY_DIR}/_deps/llama-src/examples/llava/clip.cpp
+    ${CMAKE_BINARY_DIR}/_deps/llama-src/examples/llava/llava.cpp
+  )
+  target_link_libraries(llava PRIVATE ggml llama)
+  target_include_directories(llava PUBLIC
+    ${CMAKE_BINARY_DIR}/_deps/llama-src
+    ${CMAKE_BINARY_DIR}/_deps/llama-src/common
+    ${CMAKE_BINARY_DIR}/_deps/llama-src/examples/llava
+  )
+  target_compile_options(llava PRIVATE
+    -Wno-error=unused-function
+    -Wno-error=unused-variable
+    -Wno-unused-function
+    -Wno-unused-variable
+  )
+  wasmedge_setup_target(llava)
+
+  # Setup include and link from llama.cpp
+  target_include_directories(wasmedgePluginWasiNN PUBLIC
+    ${CMAKE_BINARY_DIR}/_deps/llama-src
+    ${CMAKE_BINARY_DIR}/_deps/llama-src/examples/llava
+  )
+  target_link_libraries(wasmedgePluginWasiNN PRIVATE common simdjson::simdjson llava)
   if(WASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_METAL)
     add_custom_command(
       TARGET wasmedgePluginWasiNN

--- a/plugins/wasi_nn/ggml.cpp
+++ b/plugins/wasi_nn/ggml.cpp
@@ -639,7 +639,7 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
       if (GraphRef.CtxSize < 4096) {
         spdlog::info(
             "[WASI-NN] GGML backend: Context size is {}, "
-            "we recommand context size >= 2048 when using llava-v1.5 "
+            "we recommend context size >= 2048 when using llava-v1.5 "
             "and context size >= 4096 when using llava-v1.6 for better results."sv,
             GraphRef.CtxSize);
       }
@@ -999,7 +999,7 @@ Expect<ErrNo> computeSingle(WasiNNEnvironment &Env,
                                  GraphRef.BatchSize, &CxtRef.LlamaNPast);
       if (!EvalImageStatus) {
         spdlog::error(
-            "[WASI-NN] GGML backend: failed to evaluate embed image tokens ."sv);
+            "[WASI-NN] GGML backend: failed to evaluate embed image tokens."sv);
         return ErrNo::RuntimeError;
       }
       ReturnCode =

--- a/plugins/wasi_nn/ggml.cpp
+++ b/plugins/wasi_nn/ggml.cpp
@@ -6,9 +6,11 @@
 
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
 #include "simdjson.h"
+#include <clip.h>
 #include <common.h>
 #include <cstdlib>
 #include <llama.h>
+#include <llava.h>
 #include <sstream>
 #endif
 
@@ -27,8 +29,29 @@ Expect<ErrNo> parseMetadata(Graph &GraphRef, const std::string &Metadata,
   }
 
   // Get metadata from the json.
-  // Need to update Model:
-  // * n_gpu_layers
+
+  // Currently supported metadata:
+  // Plugin parameters (used by this plugin):
+  //   enable-log: bool
+  //   enable-debug-log: bool
+  //   stream-stdout: bool
+  //   embedding: bool
+  //   n-predict: uint64_t
+  //   reverse-prompt: string
+  //   mmproj: string
+  //   image: string
+  // Model parameters (need to reload the model if updated):
+  //   n-gpu-layers: int64_t
+  // Context parameters (used by the llama context):
+  //   ctx-size: uint64_t
+  //   batch-size: uint64_t
+  //   threads: uint64_t
+  // Sampling parameters (used by the llama sampling context).
+  //   temp: double
+  //   top-p: double
+  //   repeat-penalty: double
+  //   presence-penalty: double
+  //   frequency-penalty: double
 
   // Get the current llama parameters.
   llama_model_params ModelParams = llama_model_default_params();
@@ -86,6 +109,26 @@ Expect<ErrNo> parseMetadata(Graph &GraphRef, const std::string &Metadata,
     }
     GraphRef.ReversePrompt = ReversePrompt;
   }
+  if (Doc.at_key("mmproj").error() == simdjson::SUCCESS) {
+    std::string_view MMProjModelPath;
+    auto Err = Doc["mmproj"].get<std::string_view>().get(MMProjModelPath);
+    if (Err) {
+      spdlog::error(
+          "[WASI-NN] GGML backend: Unable to retrieve the mmproj option."sv);
+      return ErrNo::InvalidArgument;
+    }
+    GraphRef.MMProjModelPath = MMProjModelPath;
+  }
+  if (Doc.at_key("image").error() == simdjson::SUCCESS) {
+    std::string_view ImagePath;
+    auto Err = Doc["image"].get<std::string_view>().get(ImagePath);
+    if (Err) {
+      spdlog::error(
+          "[WASI-NN] GGML backend: Unable to retrieve the image option."sv);
+      return ErrNo::InvalidArgument;
+    }
+    GraphRef.ImagePath = ImagePath;
+  }
 
   // The model parameters.
   if (Doc.at_key("n-gpu-layers").error() == simdjson::SUCCESS) {
@@ -122,6 +165,7 @@ Expect<ErrNo> parseMetadata(Graph &GraphRef, const std::string &Metadata,
       return ErrNo::InvalidArgument;
     }
   }
+
   // The sampling parameters.
   if (Doc.at_key("temp").error() == simdjson::SUCCESS) {
     auto Err = Doc["temp"].get<double>().get(GraphRef.Temp);
@@ -172,6 +216,23 @@ Expect<ErrNo> parseMetadata(Graph &GraphRef, const std::string &Metadata,
     *IsModelUpdated = true;
   }
 
+  return ErrNo::Success;
+}
+
+Expect<ErrNo> setupGPTParam(Graph &GraphRef, gpt_params &GPTParams) {
+  GPTParams.sparams.temp = GraphRef.Temp;
+  GPTParams.sparams.top_p = GraphRef.TopP;
+  GPTParams.sparams.penalty_repeat = GraphRef.RepeatPenalty;
+  GPTParams.sparams.penalty_present = GraphRef.PresencePenalty;
+  return ErrNo::Success;
+}
+
+Expect<ErrNo> setupContextParam(Graph &GraphRef,
+                                llama_context_params &ContextParams) {
+  ContextParams.n_ctx = GraphRef.CtxSize;
+  ContextParams.n_batch = GraphRef.BatchSize;
+  ContextParams.n_threads = GraphRef.Threads;
+  ContextParams.n_threads_batch = GraphRef.Threads;
   return ErrNo::Success;
 }
 
@@ -312,6 +373,48 @@ Expect<ErrNo> getEmbedding(WasiNNEnvironment &Env,
   return ErrNo::Success;
 }
 
+ErrNo EvaluateTokens(Graph &GraphRef, struct llama_context *LlamaContext,
+                     std::vector<llama_token> Tokens, int &NPast) noexcept {
+  uint32_t NCtx = llama_n_ctx(LlamaContext);
+
+  // End the inference if the context is full.
+  if (NPast + static_cast<uint32_t>(Tokens.size()) > NCtx) {
+    if (GraphRef.EnableLog) {
+      spdlog::info(
+          "[WASI-NN] GGML backend: the context if full ({} / {} tokens). Please increase your context size."sv,
+          NPast + static_cast<uint32_t>(Tokens.size()), NCtx);
+    }
+    return ErrNo::ContextFull;
+  }
+
+  for (int I = 0; I < static_cast<int>(Tokens.size());
+       I += GraphRef.BatchSize) {
+    int NEval = static_cast<int>(Tokens.size()) - I;
+    if (NEval > static_cast<int>(GraphRef.BatchSize)) {
+      NEval = GraphRef.BatchSize;
+    }
+    // llama_batch_get_one(*token, n_tokens, position, sequence_id)
+    // This will return batch for single sequence of tokens starting at
+    // position.
+    const llama_seq_id SequenceId = 0;
+    auto Status =
+        llama_decode(LlamaContext,
+                     llama_batch_get_one(&Tokens[I], NEval, NPast, SequenceId));
+    if (Status == 1) {
+      spdlog::error(
+          "[WASI-NN] GGML backend: failed to llama_decode: try reducing the size of the batch or increasing the size of context"sv);
+      return ErrNo::RuntimeError;
+    } else if (Status < 0) {
+      spdlog::error(
+          "[WASI-NN] GGML backend: failed to llama_decode: internal fatal error. Please open an issue on GitHub"sv);
+      return ErrNo::RuntimeError;
+    }
+    NPast += NEval;
+  }
+
+  return ErrNo::Success;
+}
+
 } // namespace details
 
 Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
@@ -323,9 +426,12 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
   // Initialize the plugin parameters.
   auto ContextDefault = llama_context_default_params();
   GraphRef.EnableLog = false;
+  GraphRef.EnableDebugLog = false;
   GraphRef.StreamStdout = false;
-  GraphRef.ReversePrompt = ""sv;
   GraphRef.NPredict = ContextDefault.n_ctx;
+  GraphRef.ReversePrompt = ""sv;
+  GraphRef.MMProjModelPath = ""sv;
+  GraphRef.ImagePath = ""sv;
   // Initialize the model parameters.
   GraphRef.NGPULayers = 0;
 #ifdef __APPLE__
@@ -503,13 +609,8 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
     spdlog::info("[WASI-NN][Debug] GGML backend: init llama context"sv);
   }
   llama_context_params ContextParams = llama_context_default_params();
-  ContextParams.n_ctx = GraphRef.CtxSize;
-  ContextParams.n_batch = GraphRef.BatchSize;
-  ContextParams.n_threads = GraphRef.Threads;
-  ContextParams.n_threads_batch = GraphRef.Threads;
-  ContextParams.embedding = GraphRef.Embedding;
-
-  auto *LlamaContext =
+  details::setupContextParam(GraphRef, ContextParams);
+  auto LlamaContext =
       llama_new_context_with_model(GraphRef.LlamaModel, ContextParams);
   if (GraphRef.EnableDebugLog) {
     spdlog::info("[WASI-NN][Debug] GGML backend: init llama context...Done"sv);
@@ -522,8 +623,64 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
   const bool AddBos = llama_should_add_bos_token(GraphRef.LlamaModel);
   const std::string Prompt(reinterpret_cast<char *>(Tensor.Tensor.data()),
                            Tensor.Tensor.size());
-  CxtRef.LlamaInputs = llama_tokenize(LlamaContext, Prompt, AddBos, true);
-  CxtRef.LlamaNInputs = CxtRef.LlamaInputs.size();
+  if (GraphRef.MMProjModelPath == ""sv) {
+    // Text only prompt.
+    CxtRef.LlamaInputs = llama_tokenize(LlamaContext, Prompt, AddBos, true);
+    CxtRef.LlamaNInputs = CxtRef.LlamaInputs.size();
+  } else {
+    // Handle llava format prompt.
+
+    // Show some warnings.
+    if (GraphRef.EnableLog) {
+      if (GraphRef.ImagePath == ""sv) {
+        spdlog::info(
+            "[WASI-NN] GGML backend: Image path is not set, will process as text-only prompt"sv);
+      }
+      if (GraphRef.CtxSize < 4096) {
+        spdlog::info(
+            "[WASI-NN] GGML backend: Context size is {}, "
+            "we recommand context size >= 2048 when using llava-v1.5 "
+            "and context size >= 4096 when using llava-v1.6 for better results."sv,
+            GraphRef.CtxSize);
+      }
+    }
+
+    // We split prompt by <image> as placeholder and save the position.
+    const std::string_view PromptPlaceholder = "<image>";
+    auto PlaceholderPosition = Prompt.find(PromptPlaceholder);
+    if (PlaceholderPosition == std::string::npos) {
+      spdlog::error(
+          "[WASI-NN] GGML backend: Error: unable to find the placeholder in the llava prompt."sv);
+      return ErrNo::InvalidArgument;
+    }
+    std::string PromptBeforeImage = Prompt.substr(0, PlaceholderPosition);
+    std::string PromptAfterImage =
+        Prompt.substr(PlaceholderPosition + PromptPlaceholder.length());
+    std::vector<llama_token> EmbdInputBeforeImage =
+        llama_tokenize(LlamaContext, PromptBeforeImage, AddBos, true);
+    std::vector<llama_token> EmbdInputAfterImage =
+        llama_tokenize(LlamaContext, PromptAfterImage, false, true);
+    CxtRef.LlavaImagePosition = EmbdInputBeforeImage.size();
+    CxtRef.LlamaInputs.reserve(EmbdInputBeforeImage.size() +
+                               EmbdInputAfterImage.size());
+    CxtRef.LlamaInputs.insert(CxtRef.LlamaInputs.end(),
+                              EmbdInputBeforeImage.begin(),
+                              EmbdInputBeforeImage.end());
+    CxtRef.LlamaInputs.insert(CxtRef.LlamaInputs.end(),
+                              EmbdInputAfterImage.begin(),
+                              EmbdInputAfterImage.end());
+
+    // Load image for llava.
+    int LlavaVerbosity = 0;
+    if (GraphRef.EnableLog) {
+      LlavaVerbosity = 1;
+    }
+    auto ClipContext =
+        clip_model_load(GraphRef.MMProjModelPath.c_str(), LlavaVerbosity);
+    CxtRef.LlavaImageEmbd = llava_image_embed_make_with_filename(
+        ClipContext, GraphRef.Threads, GraphRef.ImagePath.c_str());
+    clip_free(ClipContext);
+  }
   if (GraphRef.EnableDebugLog) {
     spdlog::info("[WASI-NN][Debug] GGML backend: set the input...Done"sv);
   }
@@ -597,35 +754,22 @@ Expect<ErrNo> compute(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
         "[WASI-NN][Debug] GGML backend: clear the previous output and tokens...Done"sv);
   }
 
-  // Main predict loop.
-  if (GraphRef.EnableDebugLog) {
-    spdlog::info("[WASI-NN][Debug] GGML backend: enter main predict loop"sv);
-  }
+  // Initialize the llama context.
   gpt_params GPTParams;
-  GPTParams.sparams.temp = GraphRef.Temp;
-  GPTParams.sparams.top_p = GraphRef.TopP;
-  GPTParams.sparams.penalty_repeat = GraphRef.RepeatPenalty;
-  GPTParams.sparams.penalty_present = GraphRef.PresencePenalty;
-  GPTParams.sparams.penalty_freq = GraphRef.FrequencyPenalty;
+  llama_context_params ContextParams = llama_context_default_params();
+  details::setupGPTParam(GraphRef, GPTParams);
+  details::setupContextParam(GraphRef, ContextParams);
+  auto LlamaContext =
+      llama_new_context_with_model(GraphRef.LlamaModel, ContextParams);
   struct llama_sampling_context *CtxSampling =
       llama_sampling_init(GPTParams.sparams);
-  std::vector<llama_token> Embd;
-  uint64_t NPast = 0;
-  uint64_t NConsumed = 0;
+  // Prepare variables;
+  int32_t NPast = 0;
   int32_t NRemain = GraphRef.NPredict;
-  // Initialize the llama context.
-  llama_context_params ContextParams = llama_context_default_params();
-  ContextParams.n_ctx = GraphRef.CtxSize;
-  ContextParams.n_batch = GraphRef.BatchSize;
-  auto *LlamaContext =
-      llama_new_context_with_model(GraphRef.LlamaModel, ContextParams);
-
   // Get the context size.
   const uint64_t NCtx = llama_n_ctx(LlamaContext);
   // Minus 4 for the special tokens. (Such as <BOS>, <EOS>, ... tokens.)
   const uint64_t MaxTokensListSize = NCtx - 4;
-  // Use the const sequence id here.
-  const llama_seq_id SequenceId = 0;
   // Return value.
   auto ReturnCode = ErrNo::Success;
 
@@ -639,109 +783,91 @@ Expect<ErrNo> compute(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
     return ErrNo::PromptTooLong;
   }
 
-  // Main predict loop.
-  while (NRemain > 0) {
-    // Preidct
-    if (!Embd.empty()) {
-      // Input too long.
-      if (static_cast<uint64_t>(Embd.size()) > MaxTokensListSize) {
-        if (GraphRef.EnableLog) {
-          spdlog::info(
-              "[WASI-NN] GGML backend: the prompt is too long. Your input has {} tokens. Please reduce it to {} tokens."sv,
-              Embd.size(), MaxTokensListSize);
-        }
-        ReturnCode = ErrNo::PromptTooLong;
-        break;
-      }
-
-      // We do not swap context here. End the inference if the context is full.
-      if (NPast + static_cast<uint64_t>(Embd.size()) > NCtx) {
-        if (GraphRef.EnableLog) {
-          spdlog::info(
-              "[WASI-NN] GGML backend: the context if full ({} / {} tokens). Please increase your ctx-size."sv,
-              NPast + static_cast<int>(Embd.size()), NCtx);
-        }
-        ReturnCode = ErrNo::ContextFull;
-        break;
-      }
-
-      // Evaluate tokens in batches.
-      for (int I = 0; I < static_cast<int>(Embd.size());
-           I += GraphRef.BatchSize) {
-        uint64_t NEval = static_cast<uint64_t>(Embd.size()) - I;
-        if (NEval > static_cast<uint64_t>(GraphRef.BatchSize)) {
-          NEval = GraphRef.BatchSize;
-        }
-        // llama_batch_get_one(*token, n_tokens, position, sequence_id)
-        // This will return batch for single sequence of tokens starting at
-        // position.
-        auto Status =
-            llama_decode(LlamaContext, llama_batch_get_one(&Embd[I], NEval,
-                                                           NPast, SequenceId));
-        if (Status == 1) {
-          spdlog::error(
-              "[WASI-NN] GGML backend: failed to llama_decode: try reducing the size of the batch or increasing the size of context"sv);
-          return ErrNo::RuntimeError;
-        }
-        if (Status < 0) {
-          spdlog::error(
-              "[WASI-NN] GGML backend: failed to llama_decode: internal fatal error. Please open an issue on GitHub"sv);
-          return ErrNo::RuntimeError;
-        }
-
-        NPast += NEval;
-      }
+  // Evaluate input tokens.
+  if (CxtRef.LlavaImageEmbd == nullptr) {
+    // Text only prompt.
+    ReturnCode = details::EvaluateTokens(GraphRef, LlamaContext,
+                                         CxtRef.LlamaInputs, NPast);
+    if (ReturnCode != ErrNo::Success) {
+      spdlog::error(
+          "[WASI-NN] GGML backend: failed to evaluate input tokens."sv);
+      return ReturnCode;
     }
+  } else {
+    // Llava format prompt with image data.
+    std::vector<llama_token> EmbdInputBeforeImage(
+        CxtRef.LlamaInputs.begin(),
+        CxtRef.LlamaInputs.begin() + CxtRef.LlavaImagePosition);
+    std::vector<llama_token> EmbdInputAfterImage(CxtRef.LlamaInputs.begin() +
+                                                     CxtRef.LlavaImagePosition,
+                                                 CxtRef.LlamaInputs.end());
+    ReturnCode = details::EvaluateTokens(GraphRef, LlamaContext,
+                                         EmbdInputBeforeImage, NPast);
+    if (ReturnCode != ErrNo::Success) {
+      spdlog::error(
+          "[WASI-NN] GGML backend: failed to evaluate input tokens before image."sv);
+      return ReturnCode;
+    }
+    bool EvalImageStatus = llava_eval_image_embed(
+        LlamaContext, CxtRef.LlavaImageEmbd, GraphRef.BatchSize, &NPast);
+    if (!EvalImageStatus) {
+      spdlog::error(
+          "[WASI-NN] GGML backend: failed to evaluate embed image tokens."sv);
+      return ErrNo::RuntimeError;
+    }
+    ReturnCode = details::EvaluateTokens(GraphRef, LlamaContext,
+                                         EmbdInputAfterImage, NPast);
+    if (ReturnCode != ErrNo::Success) {
+      spdlog::error(
+          "[WASI-NN] GGML backend: failed to evaluate input tokens after image."sv);
+      return ReturnCode;
+    }
+  }
 
-    Embd.clear();
+  // Main predict loop.
+  if (GraphRef.EnableDebugLog) {
+    spdlog::info("[WASI-NN][Debug] GGML backend: enter main predict loop"sv);
+  }
+  while (NRemain > 0) {
+    const llama_token Id =
+        llama_sampling_sample(CtxSampling, LlamaContext, nullptr);
+    llama_sampling_accept(CtxSampling, LlamaContext, Id, true);
+    --NRemain;
 
-    if (static_cast<uint64_t>(CxtRef.LlamaInputs.size()) <= NConsumed) {
-      const llama_token Id =
-          llama_sampling_sample(CtxSampling, LlamaContext, nullptr);
-      llama_sampling_accept(CtxSampling, LlamaContext, Id, true);
-      Embd.emplace_back(Id);
-      --NRemain;
-      // Save the output token.
-      CxtRef.LlamaOutputTokens.emplace_back(Id);
-      CxtRef.LlamaOutputs += llama_token_to_piece(LlamaContext, Id);
-      // When setting StreamStdout, we print the output to stdout.
-      if (GraphRef.StreamStdout) {
-        std::cout << llama_token_to_piece(LlamaContext, Id) << std::flush;
+    // Save the output token.
+    CxtRef.LlamaOutputTokens.emplace_back(Id);
+    CxtRef.LlamaOutputs += llama_token_to_piece(LlamaContext, Id);
+    // When setting StreamStdout, we print the output to stdout.
+    if (GraphRef.StreamStdout) {
+      std::cout << llama_token_to_piece(LlamaContext, Id) << std::flush;
+    }
+    // Break if reverse prompt is found.
+    if (!GraphRef.ReversePrompt.empty() &&
+        CxtRef.LlamaOutputs.find(GraphRef.ReversePrompt) != std::string::npos) {
+      if (GraphRef.EnableLog) {
+        spdlog::info("[WASI-NN] GGML backend: reverse prompt found"sv);
       }
-      // Break if reverse prompt is found.
-      if (!GraphRef.ReversePrompt.empty() &&
-          CxtRef.LlamaOutputs.find(GraphRef.ReversePrompt) !=
-              std::string::npos) {
-        if (GraphRef.EnableLog) {
-          spdlog::info("[WASI-NN] GGML backend: reverse prompt found"sv);
-        }
-        break;
+      break;
+    }
+    // Deal with end of text token.
+    if (llama_sampling_last(CtxSampling) ==
+        llama_token_eos(GraphRef.LlamaModel)) {
+      if (GraphRef.EnableLog) {
+        spdlog::info("[WASI-NN] GGML backend: EOS token found"sv);
       }
-      // Deal with end of text token.
-      if (llama_sampling_last(CtxSampling) ==
-          llama_token_eos(GraphRef.LlamaModel)) {
-        if (GraphRef.EnableLog) {
-          spdlog::info("[WASI-NN] GGML backend: EOS token found"sv);
-        }
-        break;
-      }
-    } else {
-      while (static_cast<uint64_t>(CxtRef.LlamaInputs.size()) > NConsumed) {
-        Embd.push_back(CxtRef.LlamaInputs[NConsumed]);
-        // Push the prompt in the sampling context.
-        llama_sampling_accept(CtxSampling, LlamaContext,
-                              CxtRef.LlamaInputs[NConsumed], false);
-        ++NConsumed;
-        if (Embd.size() >= GraphRef.BatchSize) {
-          break;
-        }
-      }
+      break;
+    }
+    // Evaluate the output token.
+    ReturnCode = details::EvaluateTokens(GraphRef, LlamaContext, {Id}, NPast);
+    if (ReturnCode != ErrNo::Success) {
+      break;
     }
   }
   if (GraphRef.EnableDebugLog) {
     spdlog::info(
         "[WASI-NN][Debug] GGML backend: enter main predict loop...Done"sv);
   }
+  // End of main predict loop.
 
   if (GraphRef.EnableLog) {
     llama_print_timings(LlamaContext);
@@ -751,6 +877,10 @@ Expect<ErrNo> compute(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
   // Users could fully control the contexts by themselves via their prompt.
   llama_sampling_free(CtxSampling);
   llama_free(LlamaContext);
+  if (CxtRef.LlavaImageEmbd != nullptr) {
+    llava_image_embed_free(CxtRef.LlavaImageEmbd);
+    CxtRef.LlavaImageEmbd = nullptr;
+  }
 
   if (GraphRef.EnableDebugLog) {
     spdlog::info("[WASI-NN][Debug] GGML backend: compute...Done"sv);
@@ -813,133 +943,113 @@ Expect<ErrNo> computeSingle(WasiNNEnvironment &Env,
 
     // Initialize the llama context.
     gpt_params GPTParams;
-    GPTParams.sparams.temp = GraphRef.Temp;
-    GPTParams.sparams.top_p = GraphRef.TopP;
-    GPTParams.sparams.penalty_repeat = GraphRef.RepeatPenalty;
-    GPTParams.sparams.penalty_present = GraphRef.PresencePenalty;
-    GPTParams.sparams.penalty_freq = GraphRef.FrequencyPenalty;
-    CxtRef.LlamaSampling = llama_sampling_init(GPTParams.sparams);
     llama_context_params ContextParams = llama_context_default_params();
-    ContextParams.n_ctx = GraphRef.CtxSize;
-    ContextParams.n_batch = GraphRef.BatchSize;
-    ContextParams.n_threads = GraphRef.Threads;
-    ContextParams.n_threads_batch = GraphRef.Threads;
+    details::setupGPTParam(GraphRef, GPTParams);
+    details::setupContextParam(GraphRef, ContextParams);
     CxtRef.LlamaContext =
         llama_new_context_with_model(GraphRef.LlamaModel, ContextParams);
-    CxtRef.LlamaEmbd.clear();
+    CxtRef.LlamaSampling = llama_sampling_init(GPTParams.sparams);
     CxtRef.LlamaNPast = 0;
-    CxtRef.LlamaNConsumed = 0;
-  }
 
-  // Get the context size.
-  const uint64_t NCtx = llama_n_ctx(CxtRef.LlamaContext);
-  // Minus 4 for the special tokens. (Such as <BOS>, <EOS>, ... tokens.)
-  const uint64_t MaxTokensListSize = NCtx - 4;
-  // Use the const sequence id here.
-  const llama_seq_id SequenceId = 0;
+    // Get the context size.
+    const uint64_t NCtx = llama_n_ctx(CxtRef.LlamaContext);
+    // Minus 4 for the special tokens. (Such as <BOS>, <EOS>, ... tokens.)
+    const uint64_t MaxTokensListSize = NCtx - 4;
+    // Return value.
+    auto ReturnCode = ErrNo::Success;
 
-  // Check if the input is too long.
-  if (static_cast<uint64_t>(CxtRef.LlamaInputs.size()) > MaxTokensListSize) {
-    if (GraphRef.EnableLog) {
-      spdlog::info(
-          "[WASI-NN] GGML backend: the prompt is too long. Your input has {} tokens. Please reduce it to {} tokens."sv,
-          CxtRef.LlamaInputs.size(), MaxTokensListSize);
-    }
-    return ErrNo::PromptTooLong;
-  }
-
-  // Main predict loop.
-  while (true) {
-    if (!CxtRef.LlamaEmbd.empty()) {
-      // Input too long.
-      if (static_cast<uint64_t>(CxtRef.LlamaEmbd.size()) > MaxTokensListSize) {
-        if (GraphRef.EnableLog) {
-          spdlog::info(
-              "[WASI-NN] GGML backend: the prompt is too long. Your input has {} tokens. Please reduce it to {} tokens."sv,
-              CxtRef.LlamaEmbd.size(), MaxTokensListSize);
-        }
-        return ErrNo::PromptTooLong;
+    // Check if the input is too long.
+    if (static_cast<uint64_t>(CxtRef.LlamaInputs.size()) > MaxTokensListSize) {
+      if (GraphRef.EnableLog) {
+        spdlog::info(
+            "[WASI-NN] GGML backend: the prompt is too long. Your input has {} tokens. Please reduce it to {} tokens."sv,
+            CxtRef.LlamaInputs.size(), MaxTokensListSize);
       }
-
-      // We do not swap context here. End the inference if the context is full.
-      if (CxtRef.LlamaNPast + static_cast<uint64_t>(CxtRef.LlamaEmbd.size()) >
-          NCtx) {
-        if (GraphRef.EnableLog) {
-          spdlog::info(
-              "[WASI-NN] GGML backend: the context if full ({} / {} tokens). Please increase your ctx-size."sv,
-              CxtRef.LlamaNPast +
-                  static_cast<uint64_t>(CxtRef.LlamaEmbd.size()),
-              NCtx);
-        }
-        return ErrNo::ContextFull;
-      }
-
-      // Evaluate tokens in batches.
-      for (uint64_t I = 0; I < static_cast<uint64_t>(CxtRef.LlamaEmbd.size());
-           I += GraphRef.BatchSize) {
-        uint64_t NEval = static_cast<uint64_t>(CxtRef.LlamaEmbd.size()) - I;
-        if (NEval > static_cast<uint64_t>(GraphRef.BatchSize)) {
-          NEval = GraphRef.BatchSize;
-        }
-        // llama_batch_get_one(*token, n_tokens, position, sequence_id)
-        // This will return batch for single sequence of tokens starting at
-        // position.
-        auto Status =
-            llama_decode(CxtRef.LlamaContext,
-                         llama_batch_get_one(&CxtRef.LlamaEmbd[I], NEval,
-                                             CxtRef.LlamaNPast, SequenceId));
-        if (Status == 1) {
-          spdlog::error(
-              "[WASI-NN] GGML backend: failed to llama_decode: try reducing the size of the batch or increasing the size of context"sv);
-          return ErrNo::RuntimeError;
-        }
-        if (Status < 0) {
-          spdlog::error(
-              "[WASI-NN] GGML backend: failed to llama_decode: internal fatal error. Please open an issue on GitHub"sv);
-          return ErrNo::RuntimeError;
-        }
-
-        CxtRef.LlamaNPast += NEval;
-      }
+      return ErrNo::PromptTooLong;
     }
 
-    CxtRef.LlamaEmbd.clear();
-
-    if (static_cast<uint64_t>(CxtRef.LlamaInputs.size()) <=
-        CxtRef.LlamaNConsumed) {
-      const llama_token Id = llama_sampling_sample(
-          CxtRef.LlamaSampling, CxtRef.LlamaContext, nullptr);
-      llama_sampling_accept(CxtRef.LlamaSampling, CxtRef.LlamaContext, Id,
-                            true);
-      CxtRef.LlamaEmbd.emplace_back(Id);
-      // Save the output token.
-      CxtRef.LlamaOutputTokens.emplace_back(Id);
-      CxtRef.LlamaOutputs += llama_token_to_piece(CxtRef.LlamaContext, Id);
-      // Deal with end of text token.
-      if (llama_sampling_last(CxtRef.LlamaSampling) ==
-          llama_token_eos(GraphRef.LlamaModel)) {
-        if (GraphRef.EnableLog) {
-          spdlog::info("[WASI-NN] GGML backend: EOS token found"sv);
-        }
-        return ErrNo::EndOfSequence;
+    // Evaluate input tokens.
+    if (CxtRef.LlavaImageEmbd == nullptr) {
+      // Text only prompt.
+      ReturnCode = details::EvaluateTokens(
+          GraphRef, CxtRef.LlamaContext, CxtRef.LlamaInputs, CxtRef.LlamaNPast);
+      if (ReturnCode != ErrNo::Success) {
+        spdlog::error(
+            "[WASI-NN] GGML backend: failed to evaluate input tokens."sv);
+        return ReturnCode;
       }
-      return ErrNo::Success;
     } else {
-      while (static_cast<uint64_t>(CxtRef.LlamaInputs.size()) >
-             CxtRef.LlamaNConsumed) {
-        CxtRef.LlamaEmbd.push_back(CxtRef.LlamaInputs[CxtRef.LlamaNConsumed]);
-        // Push the prompt in the sampling context.
-        llama_sampling_accept(CxtRef.LlamaSampling, CxtRef.LlamaContext,
-                              CxtRef.LlamaInputs[CxtRef.LlamaNConsumed], false);
-        ++CxtRef.LlamaNConsumed;
-        if (CxtRef.LlamaEmbd.size() >= GraphRef.BatchSize) {
-          break;
-        }
+      // Llava format prompt with image data.
+      std::vector<llama_token> EmbdInputBeforeImage(
+          CxtRef.LlamaInputs.begin(),
+          CxtRef.LlamaInputs.begin() + CxtRef.LlavaImagePosition);
+      std::vector<llama_token> EmbdInputAfterImage(
+          CxtRef.LlamaInputs.begin() + CxtRef.LlavaImagePosition,
+          CxtRef.LlamaInputs.end());
+      ReturnCode =
+          details::EvaluateTokens(GraphRef, CxtRef.LlamaContext,
+                                  EmbdInputBeforeImage, CxtRef.LlamaNPast);
+      if (ReturnCode != ErrNo::Success) {
+        spdlog::error(
+            "[WASI-NN] GGML backend: failed to evaluate input tokens before image."sv);
+        return ReturnCode;
+      }
+      bool EvalImageStatus =
+          llava_eval_image_embed(CxtRef.LlamaContext, CxtRef.LlavaImageEmbd,
+                                 GraphRef.BatchSize, &CxtRef.LlamaNPast);
+      if (!EvalImageStatus) {
+        spdlog::error(
+            "[WASI-NN] GGML backend: failed to evaluate embed image tokens ."sv);
+        return ErrNo::RuntimeError;
+      }
+      ReturnCode =
+          details::EvaluateTokens(GraphRef, CxtRef.LlamaContext,
+                                  EmbdInputAfterImage, CxtRef.LlamaNPast);
+      if (ReturnCode != ErrNo::Success) {
+        spdlog::error(
+            "[WASI-NN] GGML backend: failed to evaluate input tokens after image."sv);
+        return ReturnCode;
       }
     }
   }
 
-  return ErrNo::Success;
+  // Main predict process.
+  if (GraphRef.EnableDebugLog) {
+    spdlog::info("[WASI-NN][Debug] GGML backend: enter main predict process"sv);
+  }
+  auto ReturnCode = ErrNo::Success;
+  const llama_token Id =
+      llama_sampling_sample(CxtRef.LlamaSampling, CxtRef.LlamaContext, nullptr);
+  llama_sampling_accept(CxtRef.LlamaSampling, CxtRef.LlamaContext, Id, true);
+
+  // Save the output token.
+  // In single token mode, we do not handle StreamStdout and ReversePrompt.
+  CxtRef.LlamaOutputTokens.emplace_back(Id);
+  CxtRef.LlamaOutputs += llama_token_to_piece(CxtRef.LlamaContext, Id);
+  // Deal with end of text token.
+  if (llama_sampling_last(CxtRef.LlamaSampling) ==
+      llama_token_eos(GraphRef.LlamaModel)) {
+    ReturnCode = ErrNo::EndOfSequence;
+    if (GraphRef.EnableLog) {
+      spdlog::info("[WASI-NN] GGML backend: EOS token found"sv);
+    }
+  }
+  // Evaluate the output token if not EOS.
+  if (ReturnCode != ErrNo::EndOfSequence) {
+    ReturnCode = details::EvaluateTokens(GraphRef, CxtRef.LlamaContext, {Id},
+                                         CxtRef.LlamaNPast);
+  }
+  if (GraphRef.EnableDebugLog) {
+    spdlog::info(
+        "[WASI-NN][Debug] GGML backend: enter main predict process...Done"sv);
+  }
+  // End of main predict process.
+
+  if (GraphRef.EnableDebugLog) {
+    spdlog::info("[WASI-NN][Debug] GGML backend: computeSingleToken...Done"sv);
+  }
+
+  return ReturnCode;
 }
 
 Expect<ErrNo> finiSingle(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
@@ -972,15 +1082,17 @@ Expect<ErrNo> finiSingle(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
   llama_free(CxtRef.LlamaContext);
   CxtRef.LlamaSampling = nullptr;
   CxtRef.LlamaContext = nullptr;
+  if (CxtRef.LlavaImageEmbd != nullptr) {
+    llava_image_embed_free(CxtRef.LlavaImageEmbd);
+    CxtRef.LlavaImageEmbd = nullptr;
+  }
   if (GraphRef.EnableDebugLog) {
     spdlog::info(
         "[WASI-NN][Debug] GGML backend: finiSingle: free the llama context...Done"sv);
   }
 
   // Reset the context variables.
-  CxtRef.LlamaEmbd.clear();
   CxtRef.LlamaNPast = 0;
-  CxtRef.LlamaNConsumed = 0;
 
   return ErrNo::Success;
 }

--- a/plugins/wasi_nn/ggml.h
+++ b/plugins/wasi_nn/ggml.h
@@ -9,6 +9,7 @@
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
 #include <common.h>
 #include <llama.h>
+#include <llava.h>
 #endif
 
 namespace WasmEdge::Host::WASINN {
@@ -28,6 +29,8 @@ struct Graph {
   bool Embedding = false;
   uint64_t NPredict;
   std::string ReversePrompt;
+  std::string MMProjModelPath;
+  std::string ImagePath;
   // Model parameters:
   int64_t NGPULayers = 0;
   // Context parameters:
@@ -47,15 +50,16 @@ public:
   Context(size_t GId, Graph &) noexcept : GraphId(GId) {}
   size_t GraphId;
   std::vector<llama_token> LlamaInputs;
+  uint64_t LlamaNInputs = 0;
   std::string LlamaOutputs;
   std::vector<llama_token> LlamaOutputTokens;
   // Preserve for computing single token
   llama_context *LlamaContext = nullptr;
   struct llama_sampling_context *LlamaSampling = nullptr;
-  std::vector<llama_token> LlamaEmbd;
-  uint64_t LlamaNInputs;
-  uint64_t LlamaNPast;
-  uint64_t LlamaNConsumed;
+  int32_t LlamaNPast = 0;
+  // Preserve for llava
+  struct llava_image_embed *LlavaImageEmbd = nullptr;
+  size_t LlavaImagePosition = 0;
 };
 #else
 struct Graph {};

--- a/thirdparty/ggml/ggml.patch
+++ b/thirdparty/ggml/ggml.patch
@@ -1,8 +1,8 @@
 diff --git a/examples/llava/clip.cpp b/examples/llava/clip.cpp
-index 9129052a..482a84e5 100644
+index ef9e4ba7..a1b49793 100644
 --- a/examples/llava/clip.cpp
 +++ b/examples/llava/clip.cpp
-@@ -768,6 +768,7 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
+@@ -859,6 +859,7 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
  
      // kv
      const int n_kv = gguf_get_n_kv(ctx);
@@ -10,15 +10,15 @@ index 9129052a..482a84e5 100644
      printf("%s: loaded meta data with %d key-value pairs and %d tensors from %s\n",
          __func__, n_kv, n_tensors, fname);
      {
-@@ -807,6 +808,7 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
+@@ -898,6 +899,7 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
              printf("%s: - type %4s: %4d tensors\n", __func__, ggml_type_name(kv.first), kv.second);
          }
      }
 +    }
  
      // data
-     size_t buffer_size = 0;
-@@ -848,18 +850,18 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
+     size_t model_size = 0;
+@@ -937,18 +939,18 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
  
  #ifdef GGML_USE_CUBLAS
      new_clip->backend = ggml_backend_cuda_init(0);
@@ -40,29 +40,35 @@ index 9129052a..482a84e5 100644
      }
  
      // model size and capabilities
-@@ -891,7 +893,7 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
+@@ -980,7 +982,7 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
          }
      }
  
--    printf("%s: params backend buffer size = % 6.2f MB (%i tensors)\n", __func__, buffer_size / (1024.0 * 1024.0), n_tensors);
-+    if (verbosity >= 1) printf("%s: params backend buffer size = % 6.2f MB (%i tensors)\n", __func__, buffer_size / (1024.0 * 1024.0), n_tensors);
+-    printf("%s: params backend buffer size = % 6.2f MB (%i tensors)\n", __func__, model_size / (1024.0 * 1024.0), n_tensors);
++    if (verbosity >= 1) printf("%s: params backend buffer size = % 6.2f MB (%i tensors)\n", __func__, model_size / (1024.0 * 1024.0), n_tensors);
  
      // load tensors
      {
-@@ -1086,7 +1088,7 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
-         new_clip->compute_buffer = ggml_backend_alloc_buffer(new_clip->backend, compute_memory_buffer_size);
-         new_clip->compute_alloc = ggml_allocr_new_from_buffer(new_clip->compute_buffer);
- 
+@@ -1216,7 +1218,7 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
+         ggml_cgraph * gf = clip_image_build_graph(new_clip, &batch);
+         ggml_gallocr_reserve(new_clip->compute_alloc, gf);
+         size_t compute_memory_buffer_size = ggml_gallocr_get_buffer_size(new_clip->compute_alloc, 0);
 -        printf("%s: compute allocated memory: %.2f MB\n", __func__, compute_memory_buffer_size /1024.0/1024.0);
 +        if (verbosity >= 1) printf("%s: compute allocated memory: %.2f MB\n", __func__, compute_memory_buffer_size /1024.0/1024.0);
      }
  
      return new_clip;
 diff --git a/examples/llava/llava.cpp b/examples/llava/llava.cpp
-index d42e7582..30833df0 100644
+index 1a1cf7c7..b84a9404 100644
 --- a/examples/llava/llava.cpp
 +++ b/examples/llava/llava.cpp
-@@ -31,7 +31,7 @@ static bool encode_image_with_clip(clip_ctx * ctx_clip, int n_threads, const cli
+@@ -290,12 +290,12 @@ static bool encode_image_with_clip(clip_ctx * ctx_clip, int n_threads, const cli
+         // clip_image_save_to_bmp(*tmp, "image_feature.bmp");
+     }
+ 
+-    printf("%s: image embedding created: %d tokens\n", __func__, *n_img_pos);
++    // printf("%s: image embedding created: %d tokens\n", __func__, *n_img_pos);
+ 
      const int64_t t_img_enc_end_us = ggml_time_us();
      float t_img_enc_ms = (t_img_enc_end_us - t_img_enc_start_us) / 1000.0;
  
@@ -71,11 +77,23 @@ index d42e7582..30833df0 100644
  
      return true;
  }
+diff --git a/examples/llava/llava.h b/examples/llava/llava.h
+index 2d40f3f1..8897b3d8 100644
+--- a/examples/llava/llava.h
++++ b/examples/llava/llava.h
+@@ -18,6 +18,7 @@
+ #endif
+ 
+ struct clip_ctx;
++struct clip_image_u8;
+ 
+ #ifdef __cplusplus
+ extern "C" {
 diff --git a/llama.cpp b/llama.cpp
-index 02b0a485..2088b5a9 100644
+index 4296eca3..5ac03032 100644
 --- a/llama.cpp
 +++ b/llama.cpp
-@@ -11516,7 +11516,9 @@ static void llama_log_internal(ggml_log_level level, const char * format, ...) {
+@@ -12757,7 +12757,9 @@ static void llama_log_internal(ggml_log_level level, const char * format, ...) {
  
  static void llama_log_callback_default(ggml_log_level level, const char * text, void * user_data) {
      (void) level;

--- a/thirdparty/ggml/ggml.patch
+++ b/thirdparty/ggml/ggml.patch
@@ -1,8 +1,81 @@
+diff --git a/examples/llava/clip.cpp b/examples/llava/clip.cpp
+index 9129052a..482a84e5 100644
+--- a/examples/llava/clip.cpp
++++ b/examples/llava/clip.cpp
+@@ -768,6 +768,7 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
+ 
+     // kv
+     const int n_kv = gguf_get_n_kv(ctx);
++    if (verbosity >= 1) {
+     printf("%s: loaded meta data with %d key-value pairs and %d tensors from %s\n",
+         __func__, n_kv, n_tensors, fname);
+     {
+@@ -807,6 +808,7 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
+             printf("%s: - type %4s: %4d tensors\n", __func__, ggml_type_name(kv.first), kv.second);
+         }
+     }
++    }
+ 
+     // data
+     size_t buffer_size = 0;
+@@ -848,18 +850,18 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
+ 
+ #ifdef GGML_USE_CUBLAS
+     new_clip->backend = ggml_backend_cuda_init(0);
+-    printf("%s: CLIP using CUDA backend\n", __func__);
++    if (verbosity >= 1) printf("%s: CLIP using CUDA backend\n", __func__);
+ #endif
+ 
+ #ifdef GGML_USE_METAL
+     new_clip->backend = ggml_backend_metal_init();
+-    printf("%s: CLIP using Metal backend\n", __func__);
++    if (verbosity >= 1) printf("%s: CLIP using Metal backend\n", __func__);
+ #endif
+ 
+ 
+     if (!new_clip->backend) {
+         new_clip->backend = ggml_backend_cpu_init();
+-        printf("%s: CLIP using CPU backend\n", __func__);
++        if (verbosity >= 1) printf("%s: CLIP using CPU backend\n", __func__);
+     }
+ 
+     // model size and capabilities
+@@ -891,7 +893,7 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
+         }
+     }
+ 
+-    printf("%s: params backend buffer size = % 6.2f MB (%i tensors)\n", __func__, buffer_size / (1024.0 * 1024.0), n_tensors);
++    if (verbosity >= 1) printf("%s: params backend buffer size = % 6.2f MB (%i tensors)\n", __func__, buffer_size / (1024.0 * 1024.0), n_tensors);
+ 
+     // load tensors
+     {
+@@ -1086,7 +1088,7 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
+         new_clip->compute_buffer = ggml_backend_alloc_buffer(new_clip->backend, compute_memory_buffer_size);
+         new_clip->compute_alloc = ggml_allocr_new_from_buffer(new_clip->compute_buffer);
+ 
+-        printf("%s: compute allocated memory: %.2f MB\n", __func__, compute_memory_buffer_size /1024.0/1024.0);
++        if (verbosity >= 1) printf("%s: compute allocated memory: %.2f MB\n", __func__, compute_memory_buffer_size /1024.0/1024.0);
+     }
+ 
+     return new_clip;
+diff --git a/examples/llava/llava.cpp b/examples/llava/llava.cpp
+index d42e7582..30833df0 100644
+--- a/examples/llava/llava.cpp
++++ b/examples/llava/llava.cpp
+@@ -31,7 +31,7 @@ static bool encode_image_with_clip(clip_ctx * ctx_clip, int n_threads, const cli
+     const int64_t t_img_enc_end_us = ggml_time_us();
+     float t_img_enc_ms = (t_img_enc_end_us - t_img_enc_start_us) / 1000.0;
+ 
+-    printf("\n%s: image encoded in %8.2f ms by CLIP (%8.2f ms per image patch)\n", __func__, t_img_enc_ms, t_img_enc_ms / *n_img_pos);
++    // printf("\n%s: image encoded in %8.2f ms by CLIP (%8.2f ms per image patch)\n", __func__, t_img_enc_ms, t_img_enc_ms / *n_img_pos);
+ 
+     return true;
+ }
 diff --git a/llama.cpp b/llama.cpp
-index 5329bd8..fa2b3d2 100644
+index 02b0a485..2088b5a9 100644
 --- a/llama.cpp
 +++ b/llama.cpp
-@@ -9625,7 +9625,9 @@ static void llama_log_internal(ggml_log_level level, const char * format, ...) {
+@@ -11516,7 +11516,9 @@ static void llama_log_internal(ggml_log_level level, const char * format, ...) {
  
  static void llama_log_callback_default(ggml_log_level level, const char * text, void * user_data) {
      (void) level;


### PR DESCRIPTION
- Add `mmproj` and `image` options.
- Refactor inference code, separate evaluation and prediction.
- Related example PR https://github.com/second-state/WasmEdge-WASINN-examples/pull/97