### PR TITLE
[WASI] fix special case in vinode path resolving

### DIFF
--- a/lib/host/wasi/vinode.cpp
+++ b/lib/host/wasi/vinode.cpp
@@ -106,7 +106,7 @@ WasiExpect<std::shared_ptr<VINode>> VINode::bind(__wasi_rights_t FRB,
 WasiExpect<void> VINode::pathCreateDirectory(std::shared_ptr<VINode> Fd,
                                              std::string_view Path) {
   std::vector<char> Buffer;
-  if (auto Res = resolvePath(Fd, Path); unlikely(!Res)) {
+  if (auto Res = resolvePath(Fd, Path, false); unlikely(!Res)) {
     return WasiUnexpect(Res);
   } else if (!Fd->can(__WASI_RIGHTS_PATH_CREATE_DIRECTORY)) {
     return WasiUnexpect(__WASI_ERRNO_NOTCAPABLE);


### PR DESCRIPTION
This patch attempt to fix #3231.

The resolvePath function uses fstatat for path resolution, which will return error when the relative path (foo) is not exist.