### PR TITLE
remove typo charctor '=' in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ WasmEdge and its contained wasm program can be started from the [CLI](https://wa
 * [Embed WasmEdge into a host application](https://wasmedge.org/docs/embed/overview)
 * [Orchestrate and manage WasmEdge instances using container tools](https://wasmedge.org/docs/category/deploy-wasmedge-apps-in-kubernetes)
 * [Run a WasmEdge app as a Dapr microservice](https://wasmedge.org/docs/develop/rust/dapr)
-=
+
 
 # Community
 


### PR DESCRIPTION
remove typo charctor '=' in readme file, English version, this typo error only exists in English version Readmefile

<img width="1095" alt="Screenshot 2024-03-08 at 22 30 58" src="https://github.com/WasmEdge/WasmEdge/assets/4081542/1b88047f-eb24-4dc0-8c8c-6366d82aaa48">
