### PR TITLE
[Installer] Allow users to install the specific build number of the ggml plugin

### DIFF
--- a/.github/workflows/test-python-install-script.yml
+++ b/.github/workflows/test-python-install-script.yml
@@ -197,6 +197,21 @@ jobs:
         ls ~/new_wasmedge/plugin/ | grep .so && echo "Pass: Plugins found" || (echo "Fail: Plugins not found" && exit 1)
         ${{ matrix.python3_ex }} utils/install.py -v 0.10.0-alpha.1 -p /usr
         ls /usr/lib/wasmedge/ | grep libwasmedgePluginWasmEdgeProcess.so && echo "Pass: Plugins found" || (echo "Fail: Plugins not found" && exit 1)
+    - name: Plugin install test - WasmEdge WASI-NN-GGML
+      run: |
+        # Without the build number
+        ${{ matrix.python2_ex }} utils/install.py -v 0.13.5 --plugins wasi_nn-ggml
+        ls ~/.wasmedge/plugin/ | grep libwasmedgePluginWasiNN.so && echo "Pass: Plugins found" || (echo "Fail: Wasmedge WASI-NN GGML Plugin not found" && exit 1)
+
+        ${{ matrix.python3_ex }} utils/install.py -v 0.13.5 --plugins wasi_nn-ggml
+        ls ~/.wasmedge/plugin/ | grep libwasmedgePluginWasiNN.so && echo "Pass: Plugins found" || (echo "Fail: Wasmedge WASI-NN GGML Plugin not found" && exit 1)
+
+        # With the build number
+        ${{ matrix.python2_ex }} utils/install.py -v 0.13.5 --plugins wasi_nn-ggml-b2334
+        ls ~/.wasmedge/plugin/ | grep libwasmedgePluginWasiNN.so && echo "Pass: Plugins found" || (echo "Fail: Wasmedge WASI-NN GGML Plugin not found" && exit 1)
+
+        ${{ matrix.python3_ex }} utils/install.py -v 0.13.5 --plugins wasi_nn-ggml-b2334
+        ls ~/.wasmedge/plugin/ | grep libwasmedgePluginWasiNN.so && echo "Pass: Plugins found" || (echo "Fail: Wasmedge WASI-NN GGML Plugin not found" && exit 1)
     - name: Plugin install test - WasmEdge rustls
       if: ${{ matrix.name != 'manylinux2014 aarch64' }}
       run: |

--- a/utils/install.py
+++ b/utils/install.py
@@ -1156,10 +1156,39 @@ def install_plugins(args, compat):
     if len(args.plugins) >= 1:
         for plugin_name in args.plugins:
             plugin_version_supplied = None
+            plugin_wasi_nn_ggml_bypass_check = False
             if plugin_name.find(":") != -1:
                 plugin_name, plugin_version_supplied = plugin_name.split(":")
 
-            if plugin_name not in PLUGINS_AVAILABLE:
+            # Split the WASI-NN-GGML plugin and the others
+            if plugin_name.startswith(WASI_NN_GGML):
+                # Re-write the plugin name if the build number is supplied
+                # E.g. wasi_nn-ggml-b2330, wasi_nn-ggml-cuda-b2330, wasi_nn-ggml-cuda-11-b2330
+                # "https://github.com/second-state/WASI-NN-GGML-PLUGIN-REGISTRY/raw/main/"
+                # "$VERSION$/"
+                # "$BUILD_NUMBER$/"
+                # "WasmEdge-plugin"
+                # "-$PLUGIN_NAME$"
+                # "-$VERSION$"
+                # "-$DIST$"
+                # "_$ARCH$" # ".tar.gz"
+                # If the build number is supplied, bypass the checks
+                plugin_wasi_nn_ggml_bypass_check = True
+                if plugin_name.startswith(WASI_NN_GGML) and "-b" in plugin_name:
+                    [plugin_name, plugin_build_number] = plugin_name.split("-b")
+                    url_root = "https://github.com/second-state/WASI-NN-GGML-PLUGIN-REGISTRY/raw/main/"
+                    url_root += "$VERSION$/b$BUILD_NUMBER$/WasmEdge-plugin-$PLUGIN_NAME$-$VERSION$-$DIST$_$ARCH$.tar.gz"
+                    url_root = url_root.replace("$BUILD_NUMBER$", plugin_build_number)
+
+                # Re-write the plugin name if CUDA is available
+                if plugin_name == WASI_NN_GGML and compat.cuda:
+                    plugin_name = WASI_NN_GGML_CUDA
+
+            # Normal plugin
+            if (
+                plugin_name not in PLUGINS_AVAILABLE
+                and not plugin_wasi_nn_ggml_bypass_check
+            ):
                 logging.error(
                     "%s plugin not found, available names - %s",
                     plugin_name,
@@ -1167,11 +1196,10 @@ def install_plugins(args, compat):
                 )
                 continue
 
-            # Re-write the plugin name if CUDA is available
-            if plugin_name == WASI_NN_GGML and compat.cuda:
-                plugin_name = WASI_NN_GGML_CUDA
-
-            if compat.dist + compat.machine + plugin_name not in SUPPORTTED_PLUGINS:
+            if (
+                compat.dist + compat.machine + plugin_name not in SUPPORTTED_PLUGINS
+                and not plugin_wasi_nn_ggml_bypass_check
+            ):
                 logging.error(
                     "Plugin not compatible: %s",
                     compat.dist + compat.machine + plugin_name,


### PR DESCRIPTION
This PR allows users to install the specific build number version of the ggml plugin.
This is a workaround because the AI/LLM is moving too fast. Applying this patch will bypass two checks, including PLUGINS_AVAILABLE and SUPPORTTED_PLUGINS when the plugin name starts with `wasi_nn-ggml`.

Usage:

```
# xxxx is the 4-digit build number
install.py --plugin wasi_nn-ggml-bxxxx
```