### PR TITLE
[WASI-NN] rpc: implement `load_by_name_with_config`

### DIFF
--- a/include/driver/wasi_nn_rpc/wasi_nn_rpcserver/wasi_nn_rpcserver.h
+++ b/include/driver/wasi_nn_rpc/wasi_nn_rpcserver/wasi_nn_rpcserver.h
@@ -131,6 +131,47 @@ public:
     return grpc::Status::OK;
   }
 
+  /*
+    Expect<WASINN::ErrNo>
+    WasiNNLoadByNameWithConfig::bodyImpl(
+      const Runtime::CallingFrame &Frame,
+      uint32_t NamePtr, uint32_t NameLen,
+      uint32_t ConfigPtr, uint32_t ConfigLen,
+      uint32_t GraphIdPtr
+    )
+  */
+  virtual grpc::Status LoadByNameWithConfig(
+      grpc::ServerContext * /*RPCContext*/,
+      const wasi_ephemeral_nn::LoadByNameWithConfigRequest *RPCRequest,
+      wasi_ephemeral_nn::LoadByNameWithConfigResult *RPCResult) {
+    std::string_view FuncName = "load_by_name_with_config"sv;
+    auto Name = RPCRequest->name();
+    auto Config = RPCRequest->config();
+    uint32_t NamePtr = UINT32_C(0);
+    uint32_t NameLen = Name.size(); // does not include the '\0' terminator
+    uint32_t ConfigPtr =
+        Name.size() + 1;                // 1 is for the '\0' terminator of Name
+    uint32_t ConfigLen = Config.size(); // does not include the '\0' terminator
+    uint32_t OutPtr =
+        NamePtr + NameLen + 1 + ConfigLen + 1; // 1 is for the '\0' terminator
+    uint32_t MemorySize = OutPtr + 4;          // 4 is for sizeof(OutPtr)
+
+    HostFuncCaller HostFuncCaller(NNMod, FuncName, MemorySize);
+    auto &MemInst = HostFuncCaller.getMemInst();
+    std::vector<char> NameVec(Name.begin(), Name.end());
+    std::vector<char> ConfigVec(Config.begin(), Config.end());
+    writeBinaries(MemInst, NameVec, NamePtr);
+    writeBinaries(MemInst, ConfigVec, ConfigPtr);
+    uint32_t Errno =
+        HostFuncCaller.call({NamePtr, NameLen, ConfigPtr, ConfigLen, OutPtr});
+    if (Errno != 0) {
+      return createRPCStatusFromErrno(FuncName, Errno);
+    }
+    uint32_t GraphHandle = *MemInst.getPointer<uint32_t *>(OutPtr);
+    RPCResult->set_graph_handle(GraphHandle);
+    return grpc::Status::OK;
+  }
+
 private:
   const Runtime::Instance::ModuleInstance &NNMod;
 };

--- a/lib/wasi_nn_rpc/wasi_ephemeral_nn.proto
+++ b/lib/wasi_nn_rpc/wasi_ephemeral_nn.proto
@@ -44,9 +44,19 @@ message LoadByNameResult {
   uint32 graph_handle = 1;
 }
 
+message LoadByNameWithConfigRequest {
+  string name = 1;
+  string config = 2;
+}
+
+message LoadByNameWithConfigResult {
+  uint32 graph_handle = 1;
+}
+
 service Graph {
   // No support for Load yet
   rpc LoadByName(LoadByNameRequest) returns (LoadByNameResult) {};
+  rpc LoadByNameWithConfig(LoadByNameWithConfigRequest) returns (LoadByNameWithConfigResult) {};
 }
 
 message SetInputRequest {

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -1525,6 +1525,13 @@ TEST(WasiNNTest, GGMLBackendWithRPC) {
   EXPECT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncLoadByName =
       dynamic_cast<WasmEdge::Host::WasiNNLoadByName &>(FuncInst->getHostFunc());
+  // Get the function "load_by_name_with_config".
+  FuncInst = NNMod->findFuncExports("load_by_name_with_config");
+  EXPECT_NE(FuncInst, nullptr);
+  EXPECT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncLoadByNameWithConfig =
+      dynamic_cast<WasmEdge::Host::WasiNNLoadByNameWithConfig &>(
+          FuncInst->getHostFunc());
   // Get the function "init_execution_context".
   FuncInst = NNMod->findFuncExports("init_execution_context");
   EXPECT_NE(FuncInst, nullptr);
@@ -1559,6 +1566,26 @@ TEST(WasiNNTest, GGMLBackendWithRPC) {
         CallFrame,
         std::initializer_list<WasmEdge::ValVariant>{
             LoadEntryPtr, static_cast<uint32_t>(NameVec.size()), BuilderPtr},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+    EXPECT_EQ(*MemInst.getPointer<uint32_t *>(BuilderPtr), 0);
+    BuilderPtr += 4;
+  }
+
+  // Test: load_by_name_with_config -- load successfully.
+  {
+    std::string Name = "default";
+    std::string Config = "{}";
+    std::vector<char> NameVec(Name.begin(), Name.end());
+    std::vector<char> ConfigVec(Config.begin(), Config.end());
+    uint32_t ConfigPtr = LoadEntryPtr + NameVec.size();
+    writeBinaries<char>(MemInst, NameVec, LoadEntryPtr);
+    writeBinaries<char>(MemInst, ConfigVec, ConfigPtr);
+    EXPECT_TRUE(HostFuncLoadByNameWithConfig.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            LoadEntryPtr, static_cast<uint32_t>(NameVec.size()), ConfigPtr,
+            static_cast<uint32_t>(ConfigVec.size()), BuilderPtr},
         Errno));
     EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
     EXPECT_EQ(*MemInst.getPointer<uint32_t *>(BuilderPtr), 0);


### PR DESCRIPTION
In this PR, I implement the `LoadByNameWithConfig` function in the `wasi_nn_rpcserver` tool and add the corresponding tests.