### PR TITLE
[WASI-NN] ggml: bump llama.cpp b2479 and fix embeddings

### DIFF
--- a/plugins/wasi_nn/CMakeLists.txt
+++ b/plugins/wasi_nn/CMakeLists.txt
@@ -49,7 +49,7 @@ if(BACKEND STREQUAL "ggml")
   FetchContent_Declare(
     llama
     GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-    GIT_TAG        b2334
+    GIT_TAG        b2479
     PATCH_COMMAND  test -f ggml.patched || git apply ${CMAKE_SOURCE_DIR}/thirdparty/ggml/ggml.patch && ${CMAKE_COMMAND} -E touch ggml.patched
     GIT_SHALLOW    FALSE
   )


### PR DESCRIPTION
- Update llama.cpp to the latest version.
- Fix the embedding generation to ensure that our result matches the output from [llama.cpp/examples/embedding](https://github.com/ggerganov/llama.cpp/tree/master/examples/embedding).