### PR TITLE
[WASI-NN] ggml: fix input size checking of computeSingle

### DIFF
--- a/plugins/wasi_nn/ggml.cpp
+++ b/plugins/wasi_nn/ggml.cpp
@@ -1151,13 +1151,15 @@ Expect<ErrNo> computeSingle(WasiNNEnvironment &Env,
   if (GraphRef.EnableDebugLog) {
     spdlog::info("[WASI-NN][Debug] GGML backend: computeSingleToken"sv);
   }
-  if (CxtRef.LlamaInputs.size() == 0) {
-    spdlog::error("[WASI-NN] GGML backend: Llama input is not set!"sv);
-    return ErrNo::InvalidArgument;
-  }
 
   // New compute single token context.
   if (CxtRef.LlamaContext == nullptr) {
+    // Check if the input is set before setting up the context.
+    if (CxtRef.LlamaInputs.size() == 0) {
+      spdlog::error("[WASI-NN] GGML backend: Llama input is not set!"sv);
+      return ErrNo::InvalidArgument;
+    }
+
     // Clear the outputs.
     if (GraphRef.EnableDebugLog) {
       spdlog::info(


### PR DESCRIPTION
- Fix the computeSingle error: https://github.com/second-state/WasmEdge-WASINN-examples/actions/runs/8685945654/job/23816444215
- Only check the input size when the context is not initialized. The input will be moved after init.