### PR TITLE
[CI] Add manylinux_2_28 (x86_64) to workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,16 +89,27 @@ jobs:
       matrix: "[{'name':'MacOS 12 (x86_64)','runner':'macos-12','darwin_version':21,'arch':'x86_64'},
                 {'name':'MacOS 13 (arm64)','runner':'macos-14','darwin_version':22,'arch':'arm64'}]"
 
-  build_on_manylinux_2014:
+  build_on_manylinux2014:
     permissions:
       contents: write
     needs: [get_version, lint]
-    name: Manylinux2014
+    name: Manylinux2014 (deprecated)
     uses: ./.github/workflows/reusable-build-on-manylinux.yml
     with:
       version: ${{ needs.get_version.outputs.version }}
-      matrix: "[{'name':'manylinux 2014 x86_64','runner':'ubuntu-latest','docker_tag':'manylinux2014_x86_64'},
-                {'name':'manylinux 2014 aarch64','runner':'linux-arm64-v2','docker_tag':'manylinux2014_aarch64'}]"
+      matrix: "[{'name':'manylinux2014 x86_64','runner':'ubuntu-latest','docker_tag':'manylinux2014_x86_64'},
+                {'name':'manylinux2014 aarch64','runner':'linux-arm64-v2','docker_tag':'manylinux2014_aarch64'}]"
+
+  # TODO: add aarch64
+  build_on_manylinux_2_28:
+    permissions:
+      contents: write
+    needs: [get_version, lint]
+    name: Manylinux_2_28
+    uses: ./.github/workflows/reusable-build-on-manylinux.yml
+    with:
+      version: ${{ needs.get_version.outputs.version }}
+      matrix: "[{'name':'manylinux_2_28 x86_64','runner':'ubuntu-latest','docker_tag':'manylinux_2_28_x86_64'}]"
 
   build_on_debian_static:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,19 @@ jobs:
     with:
       version: ${{ needs.create_release.outputs.version }}
       matrix:
-        "[{'name':'manylinux 2014 x86_64','runner':'ubuntu-latest','docker_tag':'manylinux2014_x86_64','asset_tag':'manylinux2014_x86_64'},
-        {'name':'manylinux 2014 aarch64','runner':'linux-arm64-v2','docker_tag':'manylinux2014_aarch64','asset_tag':'manylinux2014_aarch64'}]"
+        "[{'name':'manylinux2014 x86_64','runner':'ubuntu-latest','docker_tag':'manylinux2014_x86_64','asset_tag':'manylinux2014_x86_64'},
+        {'name':'manylinux2014 aarch64','runner':'linux-arm64-v2','docker_tag':'manylinux2014_aarch64','asset_tag':'manylinux2014_aarch64'}]"
+      release: true
+    secrets: inherit
+
+  # TODO: Add aarch64
+  build_on_manylinux_2_28:
+    needs: create_release
+    uses: ./.github/workflows/reusable-build-on-manylinux.yml
+    with:
+      version: ${{ needs.create_release.outputs.version }}
+      matrix:
+        "[{'name':'manylinux_2_28 x86_64','runner':'ubuntu-latest','docker_tag':'manylinux_2_28_x86_64','asset_tag':'manylinux_2_28_x86_64'}]"
       release: true
     secrets: inherit
 

--- a/.github/workflows/reusable-build-on-manylinux.yml
+++ b/.github/workflows/reusable-build-on-manylinux.yml
@@ -11,10 +11,10 @@ on:
         required: true
       release:
         type: boolean
-        
+
 permissions:
   contents: read
-  
+
 jobs:
   build_on_manylinux:
     permissions:


### PR DESCRIPTION
This PR only adds build & release on x86_64, aarch64 will be added after the docker image `manylinux_2_28_aarch64` is fixed; plugins will be added after the docker images `*-plugin-deps` are fixed.