### PR TITLE
[component model] Do despecialize when we load types

### DIFF
--- a/include/ast/component/type.h
+++ b/include/ast/component/type.h
@@ -165,9 +165,8 @@ private:
   TypeIndex Idx;
 };
 
-using DefValType = std::variant<PrimValType, Record, VariantTy, List, Tuple,
-                                Flags, Enum, Option, Result, Own, Borrow>;
-
+using DefValType =
+    std::variant<PrimValType, Record, VariantTy, List, Flags, Own, Borrow>;
 using ResultList = std::variant<ValueType, std::vector<LabelValType>>;
 class FuncType {
 public:


### PR DESCRIPTION
Do despecialize when we loading the type has a benefit that we can reduce the things have to do at the instantiate part.

Reference: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#despecialization