### PR TITLE
Supported WASI-NN streaming extension for NNRPC.

### DIFF
--- a/include/driver/wasi_nn_rpc/wasi_nn_rpcserver/wasi_nn_rpcserver.h
+++ b/include/driver/wasi_nn_rpc/wasi_nn_rpcserver/wasi_nn_rpcserver.h
@@ -286,12 +286,13 @@ public:
   }
 
   /*
-    Expect<ErrNo> computeSingle(WasiNNEnvironment &Env, uint32_t ContextId) noexcept
+    Expect<ErrNo> computeSingle(WasiNNEnvironment &Env, uint32_t ContextId)
+    noexcept
   */
   virtual grpc::Status
   ComputeSingle(grpc::ServerContext * /*RPCContext*/,
-          const wasi_ephemeral_nn::ComputeRequest *RPCRequest,
-          google::protobuf::Empty * /*RPCResult*/) {
+                const wasi_ephemeral_nn::ComputeRequest *RPCRequest,
+                google::protobuf::Empty * /*RPCResult*/) {
     std::string_view FuncName = "compute_single"sv;
     uint32_t ResourceHandle = RPCRequest->resource_handle();
     uint32_t MemorySize = UINT32_C(0);
@@ -338,15 +339,15 @@ public:
     return grpc::Status::OK;
   }
 
-/*
-    Expect<ErrNo> getOutputSingle(WasiNNEnvironment &Env, uint32_t ContextId,
-                            uint32_t Index, Span<uint8_t> OutBuffer,
-                            uint32_t &BytesWritten) noexcept
-  */
+  /*
+      Expect<ErrNo> getOutputSingle(WasiNNEnvironment &Env, uint32_t ContextId,
+                              uint32_t Index, Span<uint8_t> OutBuffer,
+                              uint32_t &BytesWritten) noexcept
+    */
   virtual grpc::Status
   GetOutputSingle(grpc::ServerContext * /*RPCContext*/,
-            const wasi_ephemeral_nn::GetOutputRequest *RPCRequest,
-            wasi_ephemeral_nn::GetOutputResult *RPCResult) {
+                  const wasi_ephemeral_nn::GetOutputRequest *RPCRequest,
+                  wasi_ephemeral_nn::GetOutputResult *RPCResult) {
     std::string_view FuncName = "get_output_single"sv;
     uint32_t ResourceHandle = RPCRequest->resource_handle();
     uint32_t Index = RPCRequest->index();
@@ -374,12 +375,13 @@ public:
   }
 
   /*
-    Expect<ErrNo> finiSingle(WasiNNEnvironment &Env, uint32_t ContextId) noexcept
+    Expect<ErrNo> finiSingle(WasiNNEnvironment &Env, uint32_t ContextId)
+    noexcept
   */
   virtual grpc::Status
   FiniSingle(grpc::ServerContext * /*RPCContext*/,
-          const wasi_ephemeral_nn::ComputeRequest *RPCRequest,
-          google::protobuf::Empty * /*RPCResult*/) {
+             const wasi_ephemeral_nn::ComputeRequest *RPCRequest,
+             google::protobuf::Empty * /*RPCResult*/) {
     std::string_view FuncName = "fini_single"sv;
     uint32_t ResourceHandle = RPCRequest->resource_handle();
     uint32_t MemorySize = UINT32_C(0);

--- a/include/driver/wasi_nn_rpc/wasi_nn_rpcserver/wasi_nn_rpcserver.h
+++ b/include/driver/wasi_nn_rpc/wasi_nn_rpcserver/wasi_nn_rpcserver.h
@@ -291,7 +291,7 @@ public:
   */
   virtual grpc::Status
   ComputeSingle(grpc::ServerContext * /*RPCContext*/,
-                const wasi_ephemeral_nn::ComputeRequest *RPCRequest,
+                const wasi_ephemeral_nn::ComputeSingleRequest *RPCRequest,
                 google::protobuf::Empty * /*RPCResult*/) {
     std::string_view FuncName = "compute_single"sv;
     uint32_t ResourceHandle = RPCRequest->resource_handle();
@@ -346,8 +346,8 @@ public:
     */
   virtual grpc::Status
   GetOutputSingle(grpc::ServerContext * /*RPCContext*/,
-                  const wasi_ephemeral_nn::GetOutputRequest *RPCRequest,
-                  wasi_ephemeral_nn::GetOutputResult *RPCResult) {
+                  const wasi_ephemeral_nn::GetOutputSingleRequest *RPCRequest,
+                  wasi_ephemeral_nn::GetOutputSingleResult *RPCResult) {
     std::string_view FuncName = "get_output_single"sv;
     uint32_t ResourceHandle = RPCRequest->resource_handle();
     uint32_t Index = RPCRequest->index();
@@ -380,7 +380,7 @@ public:
   */
   virtual grpc::Status
   FiniSingle(grpc::ServerContext * /*RPCContext*/,
-             const wasi_ephemeral_nn::ComputeRequest *RPCRequest,
+             const wasi_ephemeral_nn::FiniSingleRequest *RPCRequest,
              google::protobuf::Empty * /*RPCResult*/) {
     std::string_view FuncName = "fini_single"sv;
     uint32_t ResourceHandle = RPCRequest->resource_handle();

--- a/include/driver/wasi_nn_rpc/wasi_nn_rpcserver/wasi_nn_rpcserver.h
+++ b/include/driver/wasi_nn_rpc/wasi_nn_rpcserver/wasi_nn_rpcserver.h
@@ -373,6 +373,24 @@ public:
     return grpc::Status::OK;
   }
 
+  /*
+    Expect<ErrNo> finiSingle(WasiNNEnvironment &Env, uint32_t ContextId) noexcept
+  */
+  virtual grpc::Status
+  FiniSingle(grpc::ServerContext * /*RPCContext*/,
+          const wasi_ephemeral_nn::ComputeRequest *RPCRequest,
+          google::protobuf::Empty * /*RPCResult*/) {
+    std::string_view FuncName = "fini_single"sv;
+    uint32_t ResourceHandle = RPCRequest->resource_handle();
+    uint32_t MemorySize = UINT32_C(0);
+    HostFuncCaller HostFuncCaller(NNMod, FuncName, MemorySize);
+    uint32_t Errno = HostFuncCaller.call({ResourceHandle});
+    if (Errno != 0) {
+      return createRPCStatusFromErrno(FuncName, Errno);
+    }
+    return grpc::Status::OK;
+  }
+
 private:
   const Runtime::Instance::ModuleInstance &NNMod;
 };

--- a/include/driver/wasi_nn_rpc/wasi_nn_rpcserver/wasi_nn_rpcserver.h
+++ b/include/driver/wasi_nn_rpc/wasi_nn_rpcserver/wasi_nn_rpcserver.h
@@ -286,6 +286,24 @@ public:
   }
 
   /*
+    Expect<ErrNo> computeSingle(WasiNNEnvironment &Env, uint32_t ContextId) noexcept
+  */
+  virtual grpc::Status
+  ComputeSingle(grpc::ServerContext * /*RPCContext*/,
+          const wasi_ephemeral_nn::ComputeRequest *RPCRequest,
+          google::protobuf::Empty * /*RPCResult*/) {
+    std::string_view FuncName = "compute_single"sv;
+    uint32_t ResourceHandle = RPCRequest->resource_handle();
+    uint32_t MemorySize = UINT32_C(0);
+    HostFuncCaller HostFuncCaller(NNMod, FuncName, MemorySize);
+    uint32_t Errno = HostFuncCaller.call({ResourceHandle});
+    if (Errno != 0) {
+      return createRPCStatusFromErrno(FuncName, Errno);
+    }
+    return grpc::Status::OK;
+  }
+
+  /*
     Expect<ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
                             uint32_t Index, Span<uint8_t> OutBuffer,
                             uint32_t &BytesWritten) noexcept

--- a/lib/wasi_nn_rpc/wasi_ephemeral_nn.proto
+++ b/lib/wasi_nn_rpc/wasi_ephemeral_nn.proto
@@ -73,6 +73,10 @@ message ComputeSingleRequest{
   uint32 resource_handle = 1;
 }
 
+message FiniSingleRequest{
+  uint32 resource_handle = 1;
+}
+
 message GetOutputRequest {
   uint32 resource_handle = 1;
   uint32 index = 2; // defined as a string in wit
@@ -97,6 +101,7 @@ service GraphExecutionContextResource {
   rpc ComputeSingle(ComputeRequest) returns (google.protobuf.Empty) {};
   rpc GetOutput(GetOutputRequest) returns (GetOutputResult) {};
   rpc GetOutputSingle(GetOutputSingleRequest) returns (GetOutputSingleResult) {};
+  rpc FiniSingle(FiniSingleRequest) returns (google.protobuf.Empty) {};
 }
 
 // ref:

--- a/lib/wasi_nn_rpc/wasi_ephemeral_nn.proto
+++ b/lib/wasi_nn_rpc/wasi_ephemeral_nn.proto
@@ -69,6 +69,10 @@ message ComputeRequest{
   uint32 resource_handle = 1;
 }
 
+message ComputeSingleRequest{
+  uint32 resource_handle = 1;
+}
+
 message GetOutputRequest {
   uint32 resource_handle = 1;
   uint32 index = 2; // defined as a string in wit
@@ -90,6 +94,7 @@ message GetOutputSingleResult {
 service GraphExecutionContextResource {
   rpc SetInput(SetInputRequest) returns (google.protobuf.Empty) {};
   rpc Compute(ComputeRequest) returns (google.protobuf.Empty) {};
+  rpc ComputeSingle(ComputeRequest) returns (google.protobuf.Empty) {};
   rpc GetOutput(GetOutputRequest) returns (GetOutputResult) {};
   rpc GetOutputSingle(GetOutputSingleRequest) returns (GetOutputSingleResult) {};
 }

--- a/lib/wasi_nn_rpc/wasi_ephemeral_nn.proto
+++ b/lib/wasi_nn_rpc/wasi_ephemeral_nn.proto
@@ -98,7 +98,7 @@ message GetOutputSingleResult {
 service GraphExecutionContextResource {
   rpc SetInput(SetInputRequest) returns (google.protobuf.Empty) {};
   rpc Compute(ComputeRequest) returns (google.protobuf.Empty) {};
-  rpc ComputeSingle(ComputeRequest) returns (google.protobuf.Empty) {};
+  rpc ComputeSingle(ComputeSingleRequest) returns (google.protobuf.Empty) {};
   rpc GetOutput(GetOutputRequest) returns (GetOutputResult) {};
   rpc GetOutputSingle(GetOutputSingleRequest) returns (GetOutputSingleResult) {};
   rpc FiniSingle(FiniSingleRequest) returns (google.protobuf.Empty) {};

--- a/lib/wasi_nn_rpc/wasi_ephemeral_nn.proto
+++ b/lib/wasi_nn_rpc/wasi_ephemeral_nn.proto
@@ -78,10 +78,20 @@ message GetOutputResult {
   bytes data = 1; // defined as a tensor in wit
 }
 
+message GetOutputSingleRequest {
+  uint32 resource_handle = 1;
+  uint32 index = 2; // defined as a string in wit
+}
+
+message GetOutputSingleResult {
+  bytes data = 1; // defined as a tensor in wit
+}
+
 service GraphExecutionContextResource {
   rpc SetInput(SetInputRequest) returns (google.protobuf.Empty) {};
   rpc Compute(ComputeRequest) returns (google.protobuf.Empty) {};
   rpc GetOutput(GetOutputRequest) returns (GetOutputResult) {};
+  rpc GetOutputSingle(GetOutputSingleRequest) returns (GetOutputSingleResult) {};
 }
 
 // ref:

--- a/plugins/wasi_nn/wasinnfunc.cpp
+++ b/plugins/wasi_nn/wasinnfunc.cpp
@@ -454,7 +454,7 @@ Expect<WASINN::ErrNo> WasiNNGetOutputSingle::bodyImpl(
     return WASINN::ErrNo::InvalidArgument;
   }
 
-  #ifdef WASMEDGE_BUILD_WASI_NN_RPC
+#ifdef WASMEDGE_BUILD_WASI_NN_RPC
   if (Env.NNRPCChannel != nullptr) {
     auto Stub = wasi_ephemeral_nn::GraphExecutionContextResource::NewStub(
         Env.NNRPCChannel);
@@ -475,7 +475,7 @@ Expect<WASINN::ErrNo> WasiNNGetOutputSingle::bodyImpl(
     *BytesWritten = BytesWrittenVal;
     return WASINN::ErrNo::Success;
   }
-  #endif // ifdef WASMEDGE_BUILD_WASI_NN_RPC
+#endif // ifdef WASMEDGE_BUILD_WASI_NN_RPC
 
   switch (Env.NNContext[Context].getBackend()) {
   case WASINN::Backend::GGML:
@@ -534,19 +534,19 @@ WasiNNComputeSingle::bodyImpl(const Runtime::CallingFrame &Frame,
                               uint32_t Context) {
 #ifdef WASMEDGE_BUILD_WASI_NN_RPC
   if (Env.NNRPCChannel != nullptr) {
-      auto Stub = wasi_ephemeral_nn::GraphExecutionContextResource::NewStub(
-          Env.NNRPCChannel);
-      grpc::ClientContext ClientContext;
-      wasi_ephemeral_nn::ComputeRequest Req;
-      Req.set_resource_handle(Context);
-      google::protobuf::Empty Res;
-      auto Status = Stub->ComputeSingle(&ClientContext, Req, &Res);
-      if (!Status.ok()) {
-          spdlog::error("[WASI-NN] Failed when calling remote Compute: {}"sv,
-                          Status.error_message());
-          return WASINN::ErrNo::RuntimeError;
-      }
-      return WASINN::ErrNo::Success;
+    auto Stub = wasi_ephemeral_nn::GraphExecutionContextResource::NewStub(
+        Env.NNRPCChannel);
+    grpc::ClientContext ClientContext;
+    wasi_ephemeral_nn::ComputeRequest Req;
+    Req.set_resource_handle(Context);
+    google::protobuf::Empty Res;
+    auto Status = Stub->ComputeSingle(&ClientContext, Req, &Res);
+    if (!Status.ok()) {
+      spdlog::error("[WASI-NN] Failed when calling remote Compute: {}"sv,
+                    Status.error_message());
+      return WASINN::ErrNo::RuntimeError;
+    }
+    return WASINN::ErrNo::Success;
   }
 #endif // ifdef WASMEDGE_BUILD_WASI_NN_RPC
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -575,11 +575,21 @@ WasiNNFiniSingle::bodyImpl(const Runtime::CallingFrame &Frame,
                            uint32_t Context) {
 #ifdef WASMEDGE_BUILD_WASI_NN_RPC
   if (Env.NNRPCChannel != nullptr) {
-    // TODO: implement RPC for FiniSingle
-    spdlog::error("[WASI-NN] RPC client is not implemented for FiniSingle"sv);
-    return WASINN::ErrNo::UnsupportedOperation;
+    auto Stub = wasi_ephemeral_nn::GraphExecutionContextResource::NewStub(
+        Env.NNRPCChannel);
+    grpc::ClientContext ClientContext;
+    wasi_ephemeral_nn::ComputeRequest Req;
+    Req.set_resource_handle(Context);
+    google::protobuf::Empty Res;
+    auto Status = Stub->FiniSingle(&ClientContext, Req, &Res);
+    if (!Status.ok()) {
+      spdlog::error("[WASI-NN] Failed when calling remote Compute: {}"sv,
+                    Status.error_message());
+      return WASINN::ErrNo::RuntimeError;
+    }
+    return WASINN::ErrNo::Success;
   }
-#endif
+#endif // ifdef WASMEDGE_BUILD_WASI_NN_RPC
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
     return Unexpect(ErrCode::Value::HostFuncError);

--- a/plugins/wasi_nn/wasinnfunc.cpp
+++ b/plugins/wasi_nn/wasinnfunc.cpp
@@ -534,12 +534,21 @@ WasiNNComputeSingle::bodyImpl(const Runtime::CallingFrame &Frame,
                               uint32_t Context) {
 #ifdef WASMEDGE_BUILD_WASI_NN_RPC
   if (Env.NNRPCChannel != nullptr) {
-    // TODO: implement RPC for ComputeSingle
-    spdlog::error(
-        "[WASI-NN] RPC client is not implemented for ComputeSingle"sv);
-    return WASINN::ErrNo::UnsupportedOperation;
+      auto Stub = wasi_ephemeral_nn::GraphExecutionContextResource::NewStub(
+          Env.NNRPCChannel);
+      grpc::ClientContext ClientContext;
+      wasi_ephemeral_nn::ComputeRequest Req;
+      Req.set_resource_handle(Context);
+      google::protobuf::Empty Res;
+      auto Status = Stub->ComputeSingle(&ClientContext, Req, &Res);
+      if (!Status.ok()) {
+          spdlog::error("[WASI-NN] Failed when calling remote Compute: {}"sv,
+                          Status.error_message());
+          return WASINN::ErrNo::RuntimeError;
+      }
+      return WASINN::ErrNo::Success;
   }
-#endif
+#endif // ifdef WASMEDGE_BUILD_WASI_NN_RPC
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
     return Unexpect(ErrCode::Value::HostFuncError);


### PR DESCRIPTION
Addresses #3319. This PR did the following for the following functions: `ComputeSingle`, `GetOutputSingle`, and `FiniSingle`.
- Defined new RPCs and messages for the NNRPC server.
- Client Side: added RPC call code path for `ComputeSingle`, `GetOutputSingle`, `FiniSingle`
- Server Side: updated backend to call rust bindings for the given functions.
- Tests: Added corresponding tests for the given functions using the OpenVINO-backend.