### PR TITLE
[CI] Build aarch64 images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,9 +50,33 @@ jobs:
           echo "docker_image=$DOCKER_IMAGE" >> $GITHUB_OUTPUT
           echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
+  bake-base-images:
+    name: Bake `ci-image-base`
+    needs: [prep]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Bake and Push
+        uses: docker/bake-action@v4
+        with:
+          files: utils/docker/docker-bake.ci-image-base
+          push: ${{ github.event_name != 'pull_request' }}
+
   build-docker-images:
     name: build-docker-images
-    needs: [prep]
+    needs: [prep, bake-base-images]
     runs-on: ubuntu-latest
     container:
       image: wasmedge/wasmedge:ci-image-base
@@ -70,23 +94,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-
-      - name: "Rebuild wasmedge/wasmedge:ci-image-base"
-        uses: docker/build-push-action@v5
-        with:
-          context: ./utils/docker
-          file: utils/docker/Dockerfile.ci-image-base
-          platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ needs.prep.outputs.docker_image }}:ci-image-base
-          labels: |
-            org.opencontainers.image.title=${{ github.event.repository.name }}
-            org.opencontainers.image.description=${{ github.event.repository.description }}
-            org.opencontainers.image.url=${{ github.event.repository.html_url }}
-            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-            org.opencontainers.image.version=${{ needs.prep.outputs.version }}
-            org.opencontainers.image.created=${{ needs.prep.outputs.created }}
-            org.opencontainers.image.revision=${{ github.sha }}
 
       - name: "Rebuild wasmedge/wasmedge:ubuntu-base"
         uses: docker/build-push-action@v5
@@ -196,6 +203,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
   build-manylinux-docker-images:
+    needs: [prep, bake-base-images]
     strategy:
       fail-fast: false
       matrix:
@@ -216,7 +224,6 @@ jobs:
             host_container: wasmedge/wasmedge:ci-image-base
     name: build ${{ matrix.name }}
     runs-on: ${{ matrix.host_runner }}
-    needs: [prep]
     container:
       image: ${{ matrix.host_container }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -222,6 +222,20 @@ jobs:
             target_platforms: linux/amd64
             host_runner: ubuntu-latest
             host_container: wasmedge/wasmedge:ci-image-base
+          - name: manylinux2014 aarch64
+            docker_tag: manylinux2014_aarch64
+            dockerfile: utils/docker/Dockerfile.manylinux2014_aarch64
+            dockerfile_plugin: utils/docker/Dockerfile.manylinux2014-build-plugins-deps
+            target_platforms: linux/arm64
+            host_runner: linux-arm64-v2
+            host_container: wasmedge/wasmedge:ci-image-base_aarch64
+          - name: manylinux_2_28 aarch64
+            docker_tag: manylinux_2_28_aarch64
+            dockerfile: utils/docker/Dockerfile.manylinux_2_28_aarch64
+            dockerfile_plugin: utils/docker/Dockerfile.manylinux_2_28-build-plugins-deps
+            target_platforms: linux/arm64
+            host_runner: linux-arm64-v2
+            host_container: wasmedge/wasmedge:ci-image-base_aarch64
     name: build ${{ matrix.name }}
     runs-on: ${{ matrix.host_runner }}
     container:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -195,12 +195,30 @@ jobs:
             org.opencontainers.image.created=${{ needs.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
 
-  build-manylinux2014_x86_64:
-    name: build-manylinux2014_x86_64
-    runs-on: ubuntu-latest
+  build-manylinux-docker-images:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: manylinux2014 x86_64
+            docker_tag: manylinux2014_x86_64
+            dockerfile: utils/docker/Dockerfile.manylinux2014_x86_64
+            dockerfile_plugin: utils/docker/Dockerfile.manylinux2014-build-plugins-deps
+            target_platforms: linux/amd64
+            host_runner: ubuntu-latest
+            host_container: wasmedge/wasmedge:ci-image-base
+          - name: manylinux_2_28 x86_64
+            docker_tag: manylinux_2_28_x86_64
+            dockerfile: utils/docker/Dockerfile.manylinux_2_28_x86_64
+            dockerfile_plugin: utils/docker/Dockerfile.manylinux_2_28-build-plugins-deps
+            target_platforms: linux/amd64
+            host_runner: ubuntu-latest
+            host_container: wasmedge/wasmedge:ci-image-base
+    name: build ${{ matrix.name }}
+    runs-on: ${{ matrix.host_runner }}
     needs: [prep]
     container:
-      image: wasmedge/wasmedge:ci-image-base
+      image: ${{ matrix.host_container }}
 
     steps:
       - name: Checkout code
@@ -216,15 +234,15 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-      - name: "Rebuild wasmedge/wasmedge:manylinux2014_x86_64"
+      - name: "Rebuild wasmedge/wasmedge:${{ matrix.docker_tag }}"
         uses: docker/build-push-action@v5
         with:
-          build-args: BASE=quay.io/pypa/manylinux2014_x86_64
+          build-args: BASE=quay.io/pypa/${{ matrix.docker_tag }}
           context: ./utils/docker
-          file: utils/docker/Dockerfile.manylinux2014_x86_64
-          platforms: linux/amd64
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.target_platforms }}
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ needs.prep.outputs.docker_image }}:manylinux2014_x86_64
+          tags: ${{ needs.prep.outputs.docker_image }}:${{ matrix.docker_tag }}
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -234,72 +252,15 @@ jobs:
             org.opencontainers.image.created=${{ needs.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
 
-      - name: "Rebuild wasmedge/wasmedge:manylinux2014_x86_64-plugins-deps"
+      - name: "Rebuild wasmedge/wasmedge:${{ matrix.docker_tag }}-plugins-deps"
         uses: docker/build-push-action@v5
         with:
-          build-args: BASE=wasmedge/wasmedge:manylinux2014_x86_64
+          build-args: BASE=wasmedge/wasmedge:${{ matrix.docker_tag }}
           context: ./utils
-          file: utils/docker/Dockerfile.manylinux2014-build-plugins-deps
-          platforms: linux/amd64
+          file: ${{ matrix.dockerfile_plugin }}
+          platforms: ${{ matrix.target_platforms }}
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ needs.prep.outputs.docker_image }}:manylinux2014_x86_64-plugins-deps
-          labels: |
-            org.opencontainers.image.title=${{ github.event.repository.name }}
-            org.opencontainers.image.description=${{ github.event.repository.description }}
-            org.opencontainers.image.url=${{ github.event.repository.html_url }}
-            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-            org.opencontainers.image.version=${{ needs.prep.outputs.version }}
-            org.opencontainers.image.created=${{ needs.prep.outputs.created }}
-            org.opencontainers.image.revision=${{ github.sha }}
-
-  build-manylinux_2_28_x86_64:
-    name: build-manylinux_2_28_x86_64
-    runs-on: ubuntu-latest
-    needs: [prep]
-    container:
-      image: wasmedge/wasmedge:ci-image-base
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-
-      - name: "Rebuild wasmedge/wasmedge:manylinux_2_28_x86_64"
-        uses: docker/build-push-action@v5
-        with:
-          build-args: BASE=quay.io/pypa/manylinux_2_28_x86_64
-          context: ./utils/docker
-          file: utils/docker/Dockerfile.manylinux_2_28_x86_64
-          platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ needs.prep.outputs.docker_image }}:manylinux_2_28_x86_64
-          labels: |
-            org.opencontainers.image.title=${{ github.event.repository.name }}
-            org.opencontainers.image.description=${{ github.event.repository.description }}
-            org.opencontainers.image.url=${{ github.event.repository.html_url }}
-            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-            org.opencontainers.image.version=${{ needs.prep.outputs.version }}
-            org.opencontainers.image.created=${{ needs.prep.outputs.created }}
-            org.opencontainers.image.revision=${{ github.sha }}
-
-      - name: "Rebuild wasmedge/wasmedge:manylinux_2_28_x86_64-plugins-deps"
-        uses: docker/build-push-action@v5
-        with:
-          build-args: BASE=wasmedge/wasmedge:manylinux_2_28_x86_64
-          context: ./utils
-          file: utils/docker/Dockerfile.manylinux_2_28-build-plugins-deps
-          platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ needs.prep.outputs.docker_image }}:manylinux_2_28_x86_64-plugins-deps
+          tags: ${{ needs.prep.outputs.docker_image }}:${{ matrix.docker_tag }}-plugins-deps
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}

--- a/utils/docker/Dockerfile.ci-image-base
+++ b/utils/docker/Dockerfile.ci-image-base
@@ -13,7 +13,7 @@ RUN apt update && apt upgrade -y \
 
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 RUN add-apt-repository \
-		"deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+		"deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu \
 		$(lsb_release -cs) \
 		stable"
 

--- a/utils/docker/docker-bake.ci-image-base
+++ b/utils/docker/docker-bake.ci-image-base
@@ -1,0 +1,26 @@
+group "default" {
+  targets = [
+    "x86_64",
+    "aarch64"
+  ]
+}
+
+target "base" {
+  dockerfile = "./utils/docker/Dockerfile.ci-image-base"
+  context    = "."
+}
+
+target "x86_64" {
+  inherits  = ["base"]
+  platforms = ["linux/amd64"]
+  tags      = [
+    "wasmedge/wasmedge:ci-image-base",
+    "wasmedge/wasmedge:ci-image-base_x86_64"
+  ]
+}
+
+target "aarch64" {
+  inherits  = ["base"]
+  platforms = ["linux/arm64"]
+  tags      = ["wasmedge/wasmedge:ci-image-base_aarch64"]
+}


### PR DESCRIPTION
0. Add `:ci-image-base_aarch64`
0. Add CI workflows to build `:manylinux_2_28_aarch64*` images

NOTE: Please prevent from hitting the "Update branch" button unless necessary, since it would take hours for the CI checks to finish.