### PR TITLE
enables usage of parameter `--no-mmap` from llama.cpp

### DIFF
--- a/plugins/wasi_nn/ggml.h
+++ b/plugins/wasi_nn/ggml.h
@@ -35,6 +35,7 @@ struct Graph {
   int64_t MainGPU = 0; // Use GPU 0 by default
   int64_t NGPULayers = 0;
   std::vector<float> TensorSplit;
+  bool UseMMap = true;
   // Context parameters:
   uint64_t CtxSize;
   uint64_t BatchSize;


### PR DESCRIPTION
This pull request integrates simple support on mmap by adding the parameter to `Graph`, `load()`, `parseMetadata()` of GGML plugin.

`UseMMap` is set to true by default, and will be set to false if `--no-mmap` is presented to the program calling `wasi-nn` SDK.

In upcoming updates of this PR, I will attach changes made to example of LlamaEdge that support `--no-mmap` since it is only adjustable through parameter passed to the end program.

Is mmap in [lib/system/mmap.cpp](https://github.com/WasmEdge/WasmEdge/blob/master/lib/system/mmap.cpp) more preferred than simply passing into llama.cpp using model parameter?