### PR TITLE
[Docs] Remove module.wasm.image annotation when building wasm container images

### DIFF
--- a/docs/book/en/src/use_cases/kubernetes/demo/wasi.md
+++ b/docs/book/en/src/use_cases/kubernetes/demo/wasi.md
@@ -40,50 +40,12 @@ ADD wasi_example_main.wasm /
 CMD ["/wasi_example_main.wasm"]
 ```
 
-## Create container image with annotations
-
-> Please note that adding self-defined annotation is still a new feature in buildah.
-
-The `crun` container runtime can start the above WebAssembly-based container image. But it requires the `module.wasm.image/variant=compat-smart` annotation on the container image to indicate that it is a WebAssembly application without a guest OS. You can find the details in [Official crun repo](https://github.com/containers/crun/blob/main/docs/wasm-wasi-example.md).
-
-To add `module.wasm.image/variant=compat-smart` annotation in the container image, you will need the latest [buildah](https://buildah.io/). Currently, Docker does not support this feature. Please follow [the install instructions of buildah](https://github.com/containers/buildah/blob/main/install.md) to build the latest buildah binary.
-
-### Build and install the latest buildah on Ubuntu
-
-On Ubuntu zesty and xenial, use these commands to prepare for buildah.
-
-```bash
-sudo apt-get -y install software-properties-common
-
-export OS="xUbuntu_20.04"
-sudo bash -c "echo \"deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/ /\" > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-sudo bash -c "curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/Release.key | apt-key add -"
-
-sudo add-apt-repository -y ppa:alexlarsson/flatpak
-sudo apt-get -y -qq update
-sudo apt-get -y install bats git libapparmor-dev libdevmapper-dev libglib2.0-dev libgpgme-dev libseccomp-dev libselinux1-dev skopeo-containers go-md2man containers-common
-sudo apt-get -y install golang-1.16 make
-```
-
-Then, follow these steps to build and install buildah on Ubuntu.
-
-```bash
-mkdir -p ~/buildah
-cd ~/buildah
-export GOPATH=`pwd`
-git clone https://github.com/containers/buildah ./src/github.com/containers/buildah
-cd ./src/github.com/containers/buildah
-PATH=/usr/lib/go-1.16/bin:$PATH make
-cp bin/buildah /usr/bin/buildah
-buildah --help
-```
-
 ### Create and publish a container image with buildah
 
 In the `target/wasm32-wasi/release/` folder, do the following.
 
 ```bash
-$ sudo buildah build --annotation "module.wasm.image/variant=compat-smart" -t wasm-wasi-example .
+$ sudo buildah build -t wasm-wasi-example .
 # make sure docker is install and running
 # systemctl status docker
 # to make sure regular user can use docker


### PR DESCRIPTION
Fixes #2567 