### PR TITLE
[CI] Remove vswhere for windows-clang building

### DIFF
--- a/.github/workflows/reusable-build-on-windows-msvc.yml
+++ b/.github/workflows/reusable-build-on-windows-msvc.yml
@@ -31,7 +31,8 @@ jobs:
         uses: crazy-max/ghaction-chocolatey@v3
         with:
           args: install cmake ninja vswhere
-      - uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
+      - name: Install Windows SDK
+        uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
         with:
           sdk-version: 19041
       - name: Set environment variables for release
@@ -43,8 +44,9 @@ jobs:
           $vsPath = (vswhere -latest -property installationPath)
           Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
+          $uri = "https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-17.0.6/LLVM-17.0.6-win64-MultiThreadedDLL.zip"
           $llvm = "LLVM-17.0.6-win64-MultiThreadedDLL.zip"
-          curl -sLO https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-17.0.6/LLVM-17.0.6-win64-MultiThreadedDLL.zip -o $llvm
+          Invoke-WebRequest -Uri "$uri" -HttpVersion 2.0 -OutFile "$llvm"
           Expand-Archive -Path $llvm
           $llvm_dir = "$pwd\\LLVM-17.0.6-win64-MultiThreadedDLL\\LLVM-17.0.6-win64\\lib\\cmake\\llvm"
           $cmake_sys_version = "10.0.19041.0"
@@ -58,7 +60,7 @@ jobs:
           $Env:PATH += ";$pwd\\build\\lib\\api"
           cd build
           tools\wasmedge\wasmedge -v
-          ctest
+          ctest --output-on-failure
           cd -
       - name: Create WasmEdge package
         run: |

--- a/.github/workflows/reusable-build-on-windows.yml
+++ b/.github/workflows/reusable-build-on-windows.yml
@@ -27,8 +27,13 @@ jobs:
       - name: Install dependency
         uses: crazy-max/ghaction-chocolatey@v3
         with:
-          args: install cmake ninja vswhere
-      - uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
+          args: install cmake ninja
+      - name: Upgrade dependency
+        uses: crazy-max/ghaction-chocolatey@v3
+        with:
+          args: upgrade llvm
+      - name: Install Windows SDK
+        uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
         with:
           sdk-version: 19041
       - name: Set environment variables for release
@@ -37,33 +42,26 @@ jobs:
           echo "build_tests=OFF" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
       - name: Build WasmEdge
         run: |
-          $vsPath = (vswhere -latest -property installationPath)
-          Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
-          Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
+          $uri = "https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-17.0.6/LLVM-17.0.6-win64-MultiThreadedDLL.zip"
           $llvm = "LLVM-17.0.6-win64-MultiThreadedDLL.zip"
-          curl -sLO https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-17.0.6/LLVM-17.0.6-win64-MultiThreadedDLL.zip -o $llvm
+          Invoke-WebRequest -Uri "$uri" -HttpVersion 2.0 -OutFile "$llvm"
           Expand-Archive -Path $llvm
           $llvm_dir = "$pwd\\LLVM-17.0.6-win64-MultiThreadedDLL\\LLVM-17.0.6-win64\\lib\\cmake\\llvm"
-          $Env:CC = "clang-cl"
-          $Env:CXX = "clang-cl"
+          $Env:CC = "$pwd\\LLVM-17.0.6-win64-MultiThreadedDLL\\LLVM-17.0.6-win64\\bin\\clang-cl.exe"
+          $Env:CXX = "$pwd\\LLVM-17.0.6-win64-MultiThreadedDLL\\LLVM-17.0.6-win64\\bin\\clang-cl.exe"
+          $llvm_mt = "$Env:ProgramFiles\\LLVM\\bin\\llvm-mt.exe"
           $cmake_sys_version = "10.0.19041.0"
-          cmake -Bbuild -GNinja "-DCMAKE_SYSTEM_VERSION=$cmake_sys_version" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL "-DLLVM_DIR=$llvm_dir" "-DWASMEDGE_BUILD_TESTS=$Env:build_tests" -DWASMEDGE_BUILD_PACKAGE="ZIP" .
+          cmake -Bbuild -GNinja "-DCMAKE_SYSTEM_VERSION=$cmake_sys_version" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL -DCMAKE_MT="$llvm_mt" "-DLLVM_DIR=$llvm_dir" "-DWASMEDGE_BUILD_TESTS=$Env:build_tests" -DWASMEDGE_BUILD_PACKAGE="ZIP" .
           cmake --build build
       - name: Test WasmEdge
         run: |
-          $vsPath = (vswhere -latest -property installationPath)
-          Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
-          Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
           $Env:PATH += ";$pwd\\build\\lib\\api"
           cd build
           tools\wasmedge\wasmedge -v
-          ctest
+          ctest --output-on-failure
           cd -
       - name: Create WasmEdge package
         run: |
-          $vsPath = (vswhere -latest -property installationPath)
-          Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
-          Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.19041.0"
           cmake --build build --target package
           Get-ChildItem -Path "$pwd\\build"
       - name: Generate product version and package Windows installer

--- a/.github/workflows/wasi-testsuite.yml
+++ b/.github/workflows/wasi-testsuite.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -62,6 +62,38 @@ jobs:
           cmake -Bbuild -GNinja -DWASMEDGE_USE_LLVM=OFF .
           cmake --build build
           echo "$GITHUB_WORKSPACE/WasmEdge/build/tools/wasmedge" >> $GITHUB_PATH
+
+      - name: Install dependency on Windows
+        if: matrix.os == 'windows-2022'
+        uses: crazy-max/ghaction-chocolatey@v3
+        with:
+          args: install cmake ninja
+      - name: Upgrade dependency on Windows
+        if: matrix.os == 'windows-2022'
+        uses: crazy-max/ghaction-chocolatey@v3
+        with:
+          args: upgrade llvm
+      - name: Install Windows SDK
+        if: matrix.os == 'windows-2022'
+        uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
+        with:
+          sdk-version: 22621
+      - name: Build WasmEdge on Windows
+        if: matrix.os == 'windows-2022'
+        working-directory: WasmEdge
+        run: |
+          $uri = "https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-17.0.6/LLVM-17.0.6-win64-MultiThreadedDLL.zip"
+          $llvm = "LLVM-17.0.6-win64-MultiThreadedDLL.zip"
+          Invoke-WebRequest -Uri "$uri" -HttpVersion 2.0 -OutFile "$llvm"
+          Expand-Archive -Path $llvm
+          $Env:CC = "$pwd\\LLVM-17.0.6-win64-MultiThreadedDLL\\LLVM-17.0.6-win64\\bin\\clang-cl.exe"
+          $Env:CXX = "$pwd\\LLVM-17.0.6-win64-MultiThreadedDLL\\LLVM-17.0.6-win64\\bin\\clang-cl.exe"
+          $llvm_mt = "$Env:ProgramFiles\\LLVM\\bin\\llvm-mt.exe"
+          $cmake_sys_version = "10.0.22621.0"
+          cmake -Bbuild -GNinja "-DCMAKE_SYSTEM_VERSION=$cmake_sys_version" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL -DCMAKE_MT="$llvm_mt" -DWASMEDGE_USE_LLVM=OFF .
+          cmake --build build
+          echo "$Env:GITHUB_WORKSPACE\\WasmEdge\\build\\tools\\wasmedge" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
+          echo "$Env:GITHUB_WORKSPACE\\WasmEdge\\build\\lib\\api" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Checkout wasi-testsuite
         uses: actions/checkout@v4


### PR DESCRIPTION
* Use prebuilt clang
* Report ctest failure
* Add step name
* Use Invoke-WebRequest from powershell
* Add windows test on wasi-testsuite