### PR TITLE
[CI] Try to fix the build on fedora:rawhide with options

### DIFF
--- a/.github/workflows/reusable-build-on-fedora.yml
+++ b/.github/workflows/reusable-build-on-fedora.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.image }}
+      options: --privileged
     steps:
       - name: Install dependency
         run: |


### PR DESCRIPTION
Try to fix the CI build: `Test WasmEdge Core` when building on `fedora:latest` image.

I was able to reproduce it on my machine with `Unpack error: ...` and it should be resolved by adding the `--privileged` option when running the docker container.