### PR TITLE
[Community] nominate new committers

### DIFF
--- a/docs/OWNER.md
+++ b/docs/OWNER.md
@@ -11,23 +11,26 @@
 
 ## WasmEdge Committers
 
-| Committers      | GitHub ID  | Organization | Email                      |
-| --------------- | ---------  | -----------  | -----------                |
-| dm4             | @dm4       | Second State | <dm4@secondstate.io>       |
-| yi              | @0yi0      | Second State | <yi@secondstate.io>        |
-| Sam             | @apepkuss  | Second State | <sam@secondstate.io>       |
-| danny           | @dannypsnl | Second State | <dannypsnl@secondstate.io> |
-| Shreyas Atre    | @SAtacker  | SRA VJTI     | <shreyasatre16@gmail.com>  |
+| Committers      | GitHub ID  | Organization                  | Email                         |
+| --------------- | ---------  | -----------                   | -----------                   |
+| dm4             | @dm4       | Second State                  | <dm4@secondstate.io>          |
+| yi              | @0yi0      | Second State                  | <yi@secondstate.io>           |
+| Sam             | @apepkuss  | Second State                  | <sam@secondstate.io>          |
+| danny           | @dannypsnl | Second State                  | <dannypsnl@secondstate.io>    |
+| Shreyas Atre    | @SAtacker  | SRA VJTI                      | <shreyasatre16@gmail.com>     |
+| csh             | @L-jasmine | Second State                  | <458761603@qq.com>            |
+| Vivian Hu       | @alabulei1 | Second State                  | <vivian@secondstate.io>       |
+| Wang-Yang Li    | @LFsWang   | National Tsing Hua University | <s108062578@m108.nthu.edu.tw> |
+| HanWen Tsao     | @grorge123 | National Tsing Hua University | <chodehirgd157842@gmail.com>  |
 
 ## WasmEdge Reviewers
 
-| Reviewers       | GitHub ID     | Organization                                  | Email                        |
-| --------------- | ---------     | -----------                                   | -----------                  |
-| 叶坚白          | @gusye1234    | University of Science and Technology of China | <jianbaiye@outlook.com>      |
-| Tricster        | @MediosZ      | Southeast University                          | <mediosrity@gmail.com>       |
-| Wenshuo Yang    | @sonder-joker | Bytedance                                     | <highmagic@outlook.com>      |
-| csh             | @L-jasmine    | Second State                                  | <458761603@qq.com>           |
-| Amun            | @hangedfish   | Giant Network Group Co., Ltd.                 | <bravohangedman@outlook.com> |
-| yb              | @yanghaku     | Nanjing University                            | <bo.yang@smail.nju.edu.cn>   |
-| WenYuan Huang   | @michael1017  | Purdue University                             | <huan2086@purdue.edu>        |
-| 王纪开          | @am009        | Huazhong University of Science and Technology | <warrenwjk@qq.com>           |
+| Reviewers       | GitHub ID     | Organization                                  | Email                         |
+| --------------- | ---------     | -----------                                   | -----------                   |
+| 叶坚白          | @gusye1234    | University of Science and Technology of China | <jianbaiye@outlook.com>       |
+| Tricster        | @MediosZ      | Southeast University                          | <mediosrity@gmail.com>        |
+| Wenshuo Yang    | @sonder-joker | Bytedance                                     | <highmagic@outlook.com>       |
+| Amun            | @hangedfish   | Giant Network Group Co., Ltd.                 | <bravohangedman@outlook.com>  |
+| yb              | @yanghaku     | Nanjing University                            | <bo.yang@smail.nju.edu.cn>    |
+| WenYuan Huang   | @michael1017  | Purdue University                             | <huan2086@purdue.edu>         |
+| 王纪开          | @am009        | Huazhong University of Science and Technology | <warrenwjk@qq.com>            |


### PR DESCRIPTION
In this PR, I am pleased to nominate the following four individuals as new committers:

1. csh(@L-jasmine), the previous reviewer, works hard on reviewing the [WasmEdge Rust SDK](https://github.com/WasmEdge/wasmedge-rust-sdk), WasmEdge Rust Plugin SDK, and other rust-related projects.
2. Vivian Hu(@alabulei1), who applies herself to hosting the community meetings and maintaining the [docs repository](https://github.com/WasmEdge/docs).
3. Wang-Yang Li(@LFsWang), who contributed to the WasmEdge WASI socket in 2022, fixes several Windows bugs and implements the relaxed SIMD proposal(#3311).
4. HanWen Tsao(@grorge123), the mentee of our LFX mentorships program, implements the WASI-NN Neural Speed backend(#3303). After finishing his mentorship, he continued contributing to the Stable Diffusion.cpp plugin(#3444) to extend the ecosystem.

I kindly ask for approval from other maintainers. Please leave your comments and decision below.
/cc @WasmEdge/maintainers 