### PR TITLE
[CI] Allow node16 on manylinux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
     outputs:
       version: ${{ steps.prep.outputs.version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Ensure git safe directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -474,6 +474,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: wasmedge/wasmedge:manylinux2014_x86_64
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/reusable-build-extensions-on-manylinux.yml
+++ b/.github/workflows/reusable-build-extensions-on-manylinux.yml
@@ -55,6 +55,8 @@ jobs:
       # Required for mounting debugfs
       # Tests of wasm_bpf also require privileges
       options: --privileged
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - uses: actions/checkout@v3
         with:
@@ -101,6 +103,7 @@ jobs:
       # Tests of wasm_bpf also require privileges
       options: --privileged
     env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       bin_name: ${{ matrix.bin }}
       target: ${{ inputs.release && matrix.bin || matrix.testBin }}
       test_dir: build/test/plugins/${{ matrix.dir }}

--- a/.github/workflows/reusable-build-on-manylinux.yml
+++ b/.github/workflows/reusable-build-on-manylinux.yml
@@ -26,6 +26,8 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     container: wasmedge/wasmedge:${{ matrix.docker_tag }}
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/