### PR TITLE
[Installer] Deprecate manylinux2014 with manylinux_2_28

### DIFF
--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -63,10 +63,10 @@ jobs:
             python2_ex: python2.7
             python3_ex: python3.7
             extra_setup_command: apt update -y && apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget && wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz && tar xzf Python-3.7.4.tgz && cd Python-3.7.4 && ./configure && make -j && make install && cd ..
-          - name: manylinux2014 aarch64
+          - name: manylinux_2_28 aarch64
             host_runner: linux-arm64-v2
             package_manager: yum
-            docker_image: wasmedge/wasmedge:manylinux2014_aarch64
+            docker_image: wasmedge/wasmedge:manylinux_2_28_aarch64
             python_package: python2 python3
             python2_ex: python2
             python3_ex: python3

--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -31,10 +31,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: CentOS 7
+          - name: AlmaLinux 8
             host_runner: ubuntu-latest
             package_manager: yum
-            docker_image: centos:7.9.2009
+            docker_image: almalinux:8
             python_package: python3 python2
             python2_ex: python2
             python3_ex: python3

--- a/utils/install.py
+++ b/utils/install.py
@@ -335,9 +335,9 @@ PLUGINS_AVAILABLE = [
 
 SUPPORTTED_PLUGINS = {
     "ubuntu20.04" + "x86_64" + WASI_CRYPTO: VersionString("0.13.0"),
-    "manylinux2014" + "x86_64" + WASI_CRYPTO: VersionString("0.13.0"),
-    "manylinux2014" + "aarch64" + WASI_CRYPTO: VersionString("0.13.0"),
-    "manylinux2014" + "arm64" + WASI_CRYPTO: VersionString("0.13.0"),
+    "manylinux_2_28" + "x86_64" + WASI_CRYPTO: VersionString("0.13.0"),
+    "manylinux_2_28" + "aarch64" + WASI_CRYPTO: VersionString("0.13.0"),
+    "manylinux_2_28" + "arm64" + WASI_CRYPTO: VersionString("0.13.0"),
     "ubuntu20.04" + "x86_64" + WASI_NN_OPENVINO: VersionString("0.13.0"),
     "ubuntu20.04" + "x86_64" + WASI_NN_PYTORCH: VersionString("0.13.0"),
     "ubuntu20.04" + "x86_64" + WASI_NN_GGML: VersionString("0.13.4"),
@@ -345,47 +345,47 @@ SUPPORTTED_PLUGINS = {
     "ubuntu20.04" + "x86_64" + WASI_NN_GGML_NOAVX: VersionString("0.13.5"),
     "ubuntu20.04" + "x86_64" + WASI_NN_GGML_CUDA: VersionString("0.13.4"),
     "ubuntu20.04" + "aarch64" + WASI_NN_GGML_CUDA: VersionString("0.13.5"),
-    "manylinux2014" + "x86_64" + WASI_NN_PYTORCH: VersionString("0.13.0"),
-    "manylinux2014" + "x86_64" + WASI_NN_TENSORFLOW_LITE: VersionString("0.13.0"),
-    "manylinux2014" + "x86_64" + WASI_NN_GGML: VersionString("0.13.4"),
-    "manylinux2014" + "aarch64" + WASI_NN_TENSORFLOW_LITE: VersionString("0.13.0"),
-    "manylinux2014" + "aarch64" + WASI_NN_GGML: VersionString("0.13.4"),
+    "manylinux_2_28" + "x86_64" + WASI_NN_PYTORCH: VersionString("0.13.0"),
+    "manylinux_2_28" + "x86_64" + WASI_NN_TENSORFLOW_LITE: VersionString("0.13.0"),
+    "manylinux_2_28" + "x86_64" + WASI_NN_GGML: VersionString("0.13.4"),
+    "manylinux_2_28" + "aarch64" + WASI_NN_TENSORFLOW_LITE: VersionString("0.13.0"),
+    "manylinux_2_28" + "aarch64" + WASI_NN_GGML: VersionString("0.13.4"),
     "darwin" + "x86_64" + WASI_NN_GGML: VersionString("0.13.4"),
     "darwin" + "arm64" + WASI_NN_GGML: VersionString("0.13.4"),
     "ubuntu20.04" + "x86_64" + WASI_NN_TENSORFLOW_LITE: VersionString("0.13.0"),
     "darwin" + "x86_64" + WASMEDGE_TENSORFLOW_PLUGIN: VersionString("0.13.0"),
     "darwin" + "arm64" + WASMEDGE_TENSORFLOW_PLUGIN: VersionString("0.13.0"),
-    "manylinux2014" + "x86_64" + WASMEDGE_TENSORFLOW_PLUGIN: VersionString("0.13.0"),
-    "manylinux2014" + "aarch64" + WASMEDGE_TENSORFLOW_PLUGIN: VersionString("0.13.0"),
+    "manylinux_2_28" + "x86_64" + WASMEDGE_TENSORFLOW_PLUGIN: VersionString("0.13.0"),
+    "manylinux_2_28" + "aarch64" + WASMEDGE_TENSORFLOW_PLUGIN: VersionString("0.13.0"),
     "ubuntu20.04" + "x86_64" + WASMEDGE_TENSORFLOW_PLUGIN: VersionString("0.13.0"),
     "darwin" + "x86_64" + WASMEDGE_TENSORFLOW_LITE_PLUGIN: VersionString("0.13.0"),
     "darwin" + "arm64" + WASMEDGE_TENSORFLOW_LITE_PLUGIN: VersionString("0.13.0"),
-    "manylinux2014"
+    "manylinux_2_28"
     + "x86_64"
     + WASMEDGE_TENSORFLOW_LITE_PLUGIN: VersionString("0.13.0"),
-    "manylinux2014"
+    "manylinux_2_28"
     + "aarch64"
     + WASMEDGE_TENSORFLOW_LITE_PLUGIN: VersionString("0.13.0"),
     "ubuntu20.04" + "x86_64" + WASMEDGE_TENSORFLOW_LITE_PLUGIN: VersionString("0.13.0"),
     "darwin" + "x86_64" + WASMEDGE_IMAGE_PLUGIN: VersionString("0.13.0"),
     "darwin" + "arm64" + WASMEDGE_IMAGE_PLUGIN: VersionString("0.13.0"),
-    "manylinux2014" + "x86_64" + WASMEDGE_IMAGE_PLUGIN: VersionString("0.13.0"),
-    "manylinux2014" + "aarch64" + WASMEDGE_IMAGE_PLUGIN: VersionString("0.13.0"),
+    "manylinux_2_28" + "x86_64" + WASMEDGE_IMAGE_PLUGIN: VersionString("0.13.0"),
+    "manylinux_2_28" + "aarch64" + WASMEDGE_IMAGE_PLUGIN: VersionString("0.13.0"),
     "ubuntu20.04" + "x86_64" + WASMEDGE_IMAGE_PLUGIN: VersionString("0.13.0"),
     "darwin" + "x86_64" + WASI_LOGGING: VersionString("0.14.0"),
     "darwin" + "arm64" + WASI_LOGGING: VersionString("0.13.5"),
-    "manylinux2014" + "aarch64" + WASI_LOGGING: VersionString("0.13.5"),
-    "manylinux2014" + "x86_64" + WASI_LOGGING: VersionString("0.13.5"),
+    "manylinux_2_28" + "aarch64" + WASI_LOGGING: VersionString("0.13.5"),
+    "manylinux_2_28" + "x86_64" + WASI_LOGGING: VersionString("0.13.5"),
     "ubuntu20.04" + "x86_64" + WASI_LOGGING: VersionString("0.13.5"),
     "ubuntu20.04" + "aarch64" + WASI_LOGGING: VersionString("0.14.0"),
     "darwin" + "x86_64" + WASMEDGE_RUSTLS: VersionString("0.13.4"),
     "darwin" + "arm64" + WASMEDGE_RUSTLS: VersionString("0.13.4"),
-    "manylinux2014" + "aarch64" + WASMEDGE_RUSTLS: VersionString("0.13.5"),
-    "manylinux2014" + "x86_64" + WASMEDGE_RUSTLS: VersionString("0.13.4"),
+    "manylinux_2_28" + "aarch64" + WASMEDGE_RUSTLS: VersionString("0.13.5"),
+    "manylinux_2_28" + "x86_64" + WASMEDGE_RUSTLS: VersionString("0.13.4"),
     "ubuntu20.04" + "x86_64" + WASMEDGE_RUSTLS: VersionString("0.13.4"),
     "ubuntu20.04" + "aarch64" + WASMEDGE_RUSTLS: VersionString("0.13.5"),
     "ubuntu20.04" + "x86_64" + WASM_BPF: VersionString("0.13.2"),
-    "manylinux2014" + "x86_64" + WASM_BPF: VersionString("0.13.2"),
+    "manylinux_2_28" + "x86_64" + WASM_BPF: VersionString("0.13.2"),
 }
 
 HOME = expanduser("~")
@@ -1167,9 +1167,9 @@ class Compat:
             self.ld_library_path = "LD_LIBRARY_PATH"
 
             if self.machine in ["arm64", "armv8", "aarch64"]:
-                self.release_package = "manylinux2014_aarch64.tar.gz"
+                self.release_package = "manylinux_2_28_aarch64.tar.gz"
             elif self.machine in ["x86_64", "amd64"]:
-                self.release_package = "manylinux2014_x86_64.tar.gz"
+                self.release_package = "manylinux_2_28_x86_64.tar.gz"
             else:
                 reraise(Exception("Unsupported arch: {0}".format(self.machine)))
 
@@ -1194,9 +1194,9 @@ class Compat:
                         ):
                             self.dist = "ubuntu20.04"
                         else:
-                            self.dist = "manylinux2014"
+                            self.dist = "manylinux_2_28"
                     else:
-                        self.dist = "manylinux2014"
+                        self.dist = "manylinux_2_28"
                 elif sys.version_info[0] == 3:
                     __lsb_rel = run_shell_command(
                         "cat /etc/lsb-release 2>/dev/null | grep RELEASE"
@@ -1213,10 +1213,10 @@ class Compat:
                         ):
                             self.dist = "ubuntu20.04"
                         else:
-                            self.dist = "manylinux2014"
+                            self.dist = "manylinux_2_28"
                         self.dist = "ubuntu20.04"
                     else:
-                        self.dist = "manylinux2014"
+                        self.dist = "manylinux_2_28"
 
             # Below version 0.11.1 different distributions for wasmedge binary do not exist
             if self.version.compare("0.11.1") != -1:
@@ -1524,9 +1524,9 @@ if __name__ == "__main__":
         dest="dist",
         required=False,
         default=None,
-        choices=["ubuntu20.04", "manylinux2014"],
+        choices=["ubuntu20.04", "manylinux_2_28"],
         type=lambda s: s.lower(),
-        help="Dist ex- ubuntu20.04,manylinux2014",
+        help="Dist ex- ubuntu20.04,manylinux_2_28",
     )
     args = parser.parse_args()
 

--- a/utils/install.sh.old
+++ b/utils/install.sh.old
@@ -155,7 +155,7 @@ VERSION_TF_DEPS=$(get_latest_release second-state/WasmEdge-tensorflow-deps)
 VERSION_TF_TOOLS=$(get_latest_release second-state/WasmEdge-tensorflow-tools)
 
 check_os_arch() {
-    RELEASE_PKG="manylinux2014_x86_64.tar.gz"
+    RELEASE_PKG="manylinux_2_28_x86_64.tar.gz"
     IM_DEPS_RELEASE_PKG="manylinux1_x86_64.tar.gz"
     [ -z "$ARCH" ] && ARCH=$(uname -m)
     [ -z "$OS" ] && OS=$(uname)
@@ -168,8 +168,8 @@ check_os_arch() {
     'Linux')
         case $ARCH in
         'x86_64') ;;
-        'arm64' | 'armv8*' | "aarch64") RELEASE_PKG="manylinux2014_aarch64.tar.gz" ;;
-        "amd64") RELEASE_PKG="manylinux2014_amd64.tar.gz" ;;
+        'arm64' | 'armv8*' | "aarch64") RELEASE_PKG="manylinux_2_28_aarch64.tar.gz" ;;
+        "amd64") RELEASE_PKG="manylinux_2_28_amd64.tar.gz" ;;
         *)
             echo "${RED}Detected $OS-$ARCH${NC} - currently unsupported${NC}"
             exit 1

--- a/utils/install_v2.sh
+++ b/utils/install_v2.sh
@@ -162,7 +162,7 @@ check_os_arch() {
 					;;
 			esac
 			if [ "${LEGACY}" == 1 ]; then
-				RELEASE_PKG="manylinux2014_${ARCH}.tar.gz"
+				RELEASE_PKG="manylinux_2_28_${ARCH}.tar.gz"
 			else
 				RELEASE_PKG="ubuntu20.04_${ARCH}.tar.gz"
 			fi


### PR DESCRIPTION
This PR 
- `sed -i 's/manylinux2014/manylinux_2_28/g'` on the files:
```
.github/workflows/test-install-script.yml
utils/install.py
utils/install.sh.old
utils/install_v2.sh
```
- CentOS 7 -> AlmaLinux 8