### PR TITLE
[CI] Workaround for (the lack of) node20 on Ubuntu 16 & 18, and CentOS 7

### DIFF
--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -76,6 +76,10 @@ jobs:
     container:
       image: ${{ matrix.docker_image }}
 
+    # For older OS like Ubuntu 16 & 18.
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/test-python-install-script.yml
+++ b/.github/workflows/test-python-install-script.yml
@@ -90,6 +90,10 @@ jobs:
     container:
       image: ${{ matrix.docker_image }}
 
+    # For older OS like Ubuntu 16 & 18.
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

Note: This PR only fixes `actions/checkout`, CentOS 7 will still fail on `yum`