### PR TITLE
[WASI-NN] ggml: fix model path in nn-preload string on Windows

### DIFF
--- a/plugins/wasi_nn/wasinnenv.cpp
+++ b/plugins/wasi_nn/wasinnenv.cpp
@@ -100,14 +100,23 @@ WasiNNEnvironment::WasiNNEnvironment() noexcept {
     auto Backend = BackendMap.find(Encode);
     auto Device = DeviceMap.find(Target);
     if (Backend != BackendMap.end() && Device != DeviceMap.end()) {
-      for (const std::string &P : Paths) {
-        if (Backend->second == Backend::GGML) {
-          // We write model path to model data to avoid file IO in llama.cpp.
-          std::string ModelPath = "preload:" + P;
-          std::vector<uint8_t> ModelPathData(ModelPath.begin(),
-                                             ModelPath.end());
-          Models.push_back(std::move(ModelPathData));
-        } else {
+      if (Backend->second == Backend::GGML) {
+        // In GGML, we only support loading one model from nn-preload config.
+        // To handle paths on Windows that contains `:` in the path, we combine
+        // the Paths into a single string separated by `:`.
+        std::string P;
+        for (const std::string &PathSegment : Paths) {
+          P += PathSegment;
+          if (PathSegment != Paths.back()) {
+            P += ":";
+          }
+        }
+        // We write model path to model data to avoid file IO in llama.cpp.
+        std::string ModelPath = "preload:" + P;
+        std::vector<uint8_t> ModelPathData(ModelPath.begin(), ModelPath.end());
+        Models.push_back(std::move(ModelPathData));
+      } else {
+        for (const std::string &P : Paths) {
           std::vector<uint8_t> Model;
           if (load(std::filesystem::u8path(P), Model)) {
             Models.push_back(std::move(Model));


### PR DESCRIPTION
Fixes #3533 

As mentioned in issue #3533, this PR aims to fix the model path in the Windows environment.

The cause of this issue lies in the definition of nn-preload in wasi-nn, which allows multiple model paths for the same name, such as `<name>:<backend>:<device>:<model-path-1>:<model-path-2>`. However, in a Windows environment, using `:` as a delimiter will disrupt paths. 

Fortunately, because GGML currently only supports a single model path for the same name, and we will place `Builder[1]` as the location for the config parameter, this pull request modification mainly treats the string after `<name>:<backend>:<device>:` in the nn-preload as the model path for the GGML backend, thereby avoiding cutting off paths in the Windows environment.