### PR TITLE
build: resolve build failure with fmt-11

### DIFF
--- a/lib/common/errinfo.cpp
+++ b/lib/common/errinfo.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2019-2022 Second State INC
 
+#include <fmt/ranges.h>
 #include "common/errinfo.h"
 #include "common/errcode.h"
 #include "common/hexstr.h"


### PR DESCRIPTION
```
lib/common/errinfo.cpp:165:25: error: "join" is not a member of "fmt"
 165 |                    fmt::join(Info.ExpParams, " , "sv),
```