### PR TITLE
[CI] Sync build-extensions from Ubuntu to manylinux

### DIFF
--- a/.github/workflows/matrix-extensions.json
+++ b/.github/workflows/matrix-extensions.json
@@ -1,87 +1,59 @@
 {
     "list": {
         "manylinux2014_x86_64": [
-            "wasi_nn-tensorflowlite",
-            "wasi_nn-wasi_nn-ggml",
-            "wasi_nn-wasi_nn-pytorch",
-            "wasm_bpf",
             "wasi_crypto",
             "wasi_logging",
-            "wasmedge_process",
-            "wasmedge_tensorflow",
-            "wasmedge_tensorflowlite",
+            "wasi_nn-ggml",
+            "wasi_nn-pytorch",
+            "wasi_nn-tensorflowlite",
+            "wasm_bpf",
+            "wasmedge_ffmpeg",
             "wasmedge_image",
             "wasmedge_opencvmini",
-            "wasmedge_ffmpeg"
+            "wasmedge_process",
+            "wasmedge_tensorflow",
+            "wasmedge_tensorflowlite"
         ],
         "manylinux2014_aarch64": [
-            "wasi_nn-tensorflowlite",
-            "wasi_nn-wasi_nn-ggml",
             "wasi_crypto",
             "wasi_logging",
-            "wasmedge_process",
-            "wasmedge_tensorflow",
-            "wasmedge_tensorflowlite",
+            "wasi_nn-ggml",
+            "wasi_nn-tensorflowlite",
+            "wasmedge_ffmpeg",
             "wasmedge_image",
             "wasmedge_opencvmini",
-            "wasmedge_ffmpeg"
+            "wasmedge_process",
+            "wasmedge_tensorflow",
+            "wasmedge_tensorflowlite"
         ],
         "manylinux_2_28_x86_64": [
-            "wasi_nn-tensorflowlite",
-            "wasi_nn-wasi_nn-ggml",
-            "wasi_nn-wasi_nn-pytorch",
-            "wasm_bpf",
             "wasi_crypto",
             "wasi_logging",
-            "wasmedge_process",
-            "wasmedge_tensorflow",
-            "wasmedge_tensorflowlite",
+            "wasi_nn-ggml",
+            "wasi_nn-pytorch",
+            "wasi_nn-tensorflowlite",
+            "wasm_bpf",
+            "wasmedge_ffmpeg",
             "wasmedge_image",
             "wasmedge_opencvmini",
-            "wasmedge_ffmpeg"
+            "wasmedge_process",
+            "wasmedge_tensorflow",
+            "wasmedge_tensorflowlite"
         ],
         "manylinux_2_28_aarch64": [
-            "wasi_nn-tensorflowlite",
-            "wasi_nn-wasi_nn-ggml",
             "wasi_crypto",
             "wasi_logging",
-            "wasmedge_process",
-            "wasmedge_tensorflow",
-            "wasmedge_tensorflowlite",
+            "wasi_nn-ggml",
+            "wasi_nn-tensorflowlite",
+            "wasmedge_ffmpeg",
             "wasmedge_image",
             "wasmedge_opencvmini",
-            "wasmedge_ffmpeg"
+            "wasmedge_process",
+            "wasmedge_tensorflow",
+            "wasmedge_tensorflowlite"
         ]
     },
     "detail": {
-        "wasi_nn-tensorflowlite": {
-            "plugin": "wasi_nn-tensorflowlite",
-            "bin": "libwasmedgePluginWasiNN.so",
-            "dir": "wasi_nn",
-            "testBin": "wasiNNTests",
-            "options": "-DWASMEDGE_PLUGIN_WASI_NN_BACKEND=TensorFlowLite"
-        },
-        "wasi_nn-wasi_nn-ggml": {
-            "plugin": "wasi_nn-wasi_nn-ggml",
-            "bin": "libwasmedgePluginWasiNN.so",
-            "dir": "wasi_nn",
-            "testBin": "wasiNNTests",
-            "options": "-DWASMEDGE_PLUGIN_WASI_NN_BACKEND=GGML -DWASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_BLAS=OFF"
-        },
-        "wasi_nn-wasi_nn-pytorch": {
-            "plugin": "wasi_nn-wasi_nn-pytorch",
-            "bin": "libwasmedgePluginWasiNN.so",
-            "dir": "wasi_nn",
-            "testBin": "wasiNNTests",
-            "options": "-DWASMEDGE_PLUGIN_WASI_NN_BACKEND=PyTorch"
-        },
-        "wasm_bpf": {
-            "plugin": "wasm_bpf",
-            "bin": "libwasmedgePluginWasmBpf.so",
-            "dir": "wasm_bpf",
-            "testBin": "wasmBpfTests",
-            "options": "-DWASMEDGE_PLUGIN_WASM_BPF=ON -DWASMEDGE_PLUGIN_WASM_BPF_BUILD_LIBBPF_WITH_PKG_CONF=OFF"
-        },
         "wasi_crypto": {
             "plugin": "wasi_crypto",
             "bin": "libwasmedgePluginWasiCrypto.so",
@@ -95,6 +67,55 @@
             "dir": "wasi_logging",
             "testBin": "wasiLoggingTests",
             "options": "-DWASMEDGE_PLUGIN_WASI_LOGGING=ON"
+        },
+        "wasi_nn-ggml": {
+            "plugin": "wasi_nn-ggml",
+            "bin": "libwasmedgePluginWasiNN.so",
+            "dir": "wasi_nn",
+            "testBin": "wasiNNTests",
+            "options": "-DWASMEDGE_PLUGIN_WASI_NN_BACKEND=GGML -DWASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_BLAS=OFF"
+        },
+        "wasi_nn-pytorch": {
+            "plugin": "wasi_nn-pytorch",
+            "bin": "libwasmedgePluginWasiNN.so",
+            "dir": "wasi_nn",
+            "testBin": "wasiNNTests",
+            "options": "-DWASMEDGE_PLUGIN_WASI_NN_BACKEND=PyTorch"
+        },
+        "wasi_nn-tensorflowlite": {
+            "plugin": "wasi_nn-tensorflowlite",
+            "bin": "libwasmedgePluginWasiNN.so",
+            "dir": "wasi_nn",
+            "testBin": "wasiNNTests",
+            "options": "-DWASMEDGE_PLUGIN_WASI_NN_BACKEND=TensorFlowLite"
+        },
+        "wasm_bpf": {
+            "plugin": "wasm_bpf",
+            "bin": "libwasmedgePluginWasmBpf.so",
+            "dir": "wasm_bpf",
+            "testBin": "wasmBpfTests",
+            "options": "-DWASMEDGE_PLUGIN_WASM_BPF=ON -DWASMEDGE_PLUGIN_WASM_BPF_BUILD_LIBBPF_WITH_PKG_CONF=OFF"
+        },
+        "wasmedge_ffmpeg": {
+            "plugin": "wasmedge_ffmpeg",
+            "bin": "libwasmedgePluginWasmEdgeFFmpeg.so",
+            "dir": "wasmedge_ffmpeg",
+            "testBin": "wasmedgeFFmpegTests",
+            "options": "-DWASMEDGE_PLUGIN_FFMPEG=ON"
+        },
+        "wasmedge_image": {
+            "plugin": "wasmedge_image",
+            "bin": "libwasmedgePluginWasmEdgeImage.so",
+            "dir": "wasmedge_image",
+            "testBin": "wasmedgeImageTests",
+            "options": "-DWASMEDGE_PLUGIN_IMAGE=ON"
+        },
+        "wasmedge_opencvmini": {
+            "plugin": "wasmedge_opencvmini",
+            "bin": "libwasmedgePluginWasmEdgeOpenCVMini.so",
+            "dir": "wasmedge_opencvmini",
+            "testBin": "wasmedgeOpencvminiTests",
+            "options": "-DWASMEDGE_PLUGIN_OPENCVMINI=ON"
         },
         "wasmedge_process": {
             "plugin": "wasmedge_process",
@@ -116,27 +137,6 @@
             "dir": "wasmedge_tensorflowlite",
             "testBin": "wasmedgeTensorflowLiteTests",
             "options": "-DWASMEDGE_PLUGIN_TENSORFLOWLITE=ON"
-        },
-        "wasmedge_image": {
-            "plugin": "wasmedge_image",
-            "bin": "libwasmedgePluginWasmEdgeImage.so",
-            "dir": "wasmedge_image",
-            "testBin": "wasmedgeImageTests",
-            "options": "-DWASMEDGE_PLUGIN_IMAGE=ON"
-        },
-        "wasmedge_opencvmini": {
-            "plugin": "wasmedge_opencvmini",
-            "bin": "libwasmedgePluginWasmEdgeOpenCVMini.so",
-            "dir": "wasmedge_opencvmini",
-            "testBin": "wasmedgeOpencvminiTests",
-            "options": "-DWASMEDGE_PLUGIN_OPENCVMINI=ON"
-        },
-        "wasmedge_ffmpeg": {
-            "plugin": "wasmedge_ffmpeg",
-            "bin": "libwasmedgePluginWasmEdgeFFmpeg.so",
-            "dir": "wasmedge_ffmpeg",
-            "testBin": "wasmedgeFFmpegTests",
-            "options": "-DWASMEDGE_PLUGIN_FFMPEG=ON"
         }
     }
 }

--- a/.github/workflows/matrix-extensions.json
+++ b/.github/workflows/matrix-extensions.json
@@ -83,7 +83,7 @@
             "bin": "libwasmedgePluginWasiNN.so",
             "dir": "wasi_nn",
             "testBin": "wasiNNTests",
-            "options": "-DWASMEDGE_PLUGIN_WASI_NN_BACKEND=GGML -DWASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_BLAS=OFF"
+            "options": "-DWASMEDGE_PLUGIN_WASI_NN_BACKEND=GGML"
         },
         "wasi_nn-pytorch": {
             "plugin": "wasi_nn-pytorch",

--- a/.github/workflows/matrix-extensions.json
+++ b/.github/workflows/matrix-extensions.json
@@ -6,11 +6,13 @@
             "wasi_nn-ggml",
             "wasi_nn-pytorch",
             "wasi_nn-tensorflowlite",
+            "wasi_nn-whisper",
             "wasm_bpf",
             "wasmedge_ffmpeg",
             "wasmedge_image",
             "wasmedge_opencvmini",
             "wasmedge_process",
+            "wasmedge_stablediffusion",
             "wasmedge_tensorflow",
             "wasmedge_tensorflowlite"
         ],
@@ -19,10 +21,12 @@
             "wasi_logging",
             "wasi_nn-ggml",
             "wasi_nn-tensorflowlite",
+            "wasi_nn-whisper",
             "wasmedge_ffmpeg",
             "wasmedge_image",
             "wasmedge_opencvmini",
             "wasmedge_process",
+            "wasmedge_stablediffusion",
             "wasmedge_tensorflow",
             "wasmedge_tensorflowlite"
         ],
@@ -32,25 +36,31 @@
             "wasi_nn-ggml",
             "wasi_nn-pytorch",
             "wasi_nn-tensorflowlite",
+            "wasi_nn-whisper",
             "wasm_bpf",
             "wasmedge_ffmpeg",
             "wasmedge_image",
             "wasmedge_opencvmini",
             "wasmedge_process",
+            "wasmedge_stablediffusion",
             "wasmedge_tensorflow",
-            "wasmedge_tensorflowlite"
+            "wasmedge_tensorflowlite",
+            "wasmedge_zlib"
         ],
         "manylinux_2_28_aarch64": [
             "wasi_crypto",
             "wasi_logging",
             "wasi_nn-ggml",
             "wasi_nn-tensorflowlite",
+            "wasi_nn-whisper",
             "wasmedge_ffmpeg",
             "wasmedge_image",
             "wasmedge_opencvmini",
             "wasmedge_process",
+            "wasmedge_stablediffusion",
             "wasmedge_tensorflow",
-            "wasmedge_tensorflowlite"
+            "wasmedge_tensorflowlite",
+            "wasmedge_zlib"
         ]
     },
     "detail": {
@@ -89,6 +99,13 @@
             "testBin": "wasiNNTests",
             "options": "-DWASMEDGE_PLUGIN_WASI_NN_BACKEND=TensorFlowLite"
         },
+        "wasi_nn-whisper": {
+            "plugin": "wasi_nn-whisper",
+            "bin": "libwasmedgePluginWasiNN.so",
+            "dir": "wasi_nn",
+            "testBin": "wasiNNTests",
+            "options": "-DWASMEDGE_PLUGIN_WASI_NN_BACKEND=Whisper"
+        },
         "wasm_bpf": {
             "plugin": "wasm_bpf",
             "bin": "libwasmedgePluginWasmBpf.so",
@@ -124,6 +141,13 @@
             "testBin": "wasmedgeProcessTests",
             "options": "-DWASMEDGE_PLUGIN_PROCESS=ON"
         },
+        "wasmedge_stablediffusion": {
+            "plugin": "wasmedge_stablediffusion",
+            "bin": "libwasmedgePluginWasmEdgeStableDiffusion.so",
+            "dir": "wasmedge_stablediffusion",
+            "testBin": "wasmedgeStableDiffusionTests",
+            "options": "-DWASMEDGE_PLUGIN_STABLEDIFFUSION=ON"
+        },
         "wasmedge_tensorflow": {
             "plugin": "wasmedge_tensorflow",
             "bin": "libwasmedgePluginWasmEdgeTensorflow.so",
@@ -137,6 +161,13 @@
             "dir": "wasmedge_tensorflowlite",
             "testBin": "wasmedgeTensorflowLiteTests",
             "options": "-DWASMEDGE_PLUGIN_TENSORFLOWLITE=ON"
+        },
+        "wasmedge_zlib": {
+            "plugin": "wasmedge_zlib",
+            "bin": "libwasmedgePluginWasmEdgeZlib.so",
+            "dir": "wasmedge_zlib",
+            "testBin": "wasmedgeZlibTests",
+            "options": "-DWASMEDGE_PLUGIN_ZLIB=ON"
         }
     }
 }


### PR DESCRIPTION
This PR includes those marked with `o` in the table.

| | `manylinux2014` | `manylinux_2_28` |
| --- | --- | --- |
| Stable Diffusion | o | o |
| WASI-NN Neural Speed | x | #3574 |
| WASI-NN OpenVINO | x | #3575 |
| WASI-NN Piper | x | #3576 |
| Whisper | o | o |
| zlib | x | o |

#### Notes for `manylinux2014`
Those marked with `x` will not release on `manylinux2014`.
- (zlib) dependency: `zlib` is `1.2.7`
- (piper) dependency: `fatal error: ucd/ucd.h: No such file or directory`