### PR TITLE
[Runtime] Create limited page size of memory instance if configured.

### DIFF
--- a/include/runtime/instance/memory.h
+++ b/include/runtime/instance/memory.h
@@ -46,14 +46,14 @@ public:
                  uint32_t PageLim = UINT32_C(65536)) noexcept
       : MemType(MType), PageLimit(PageLim) {
     if (MemType.getLimit().getMin() > PageLimit) {
-      spdlog::error(
-          "Create memory instance failed -- exceeded limit page size: {}",
-          PageLimit);
-      return;
+      spdlog::error("Memory Instance: Limited {} page in configuration.",
+                    PageLimit);
+      MemType.getLimit().setMin(PageLimit);
     }
     DataPtr = Allocator::allocate(MemType.getLimit().getMin());
     if (DataPtr == nullptr) {
-      spdlog::error("Unable to find usable memory address");
+      spdlog::error("Memory Instance: Unable to find usable memory address.");
+      MemType.getLimit().setMin(0U);
       return;
     }
   }
@@ -105,7 +105,8 @@ public:
     }
     assuming(PageLimit >= Min);
     if (Count > PageLimit - Min) {
-      spdlog::error("Memory grow page failed -- exceeded limit page size: {}",
+      spdlog::error("Memory Instance: Memory grow page failed, exceeded "
+                    "limited {} page size in configuration.",
                     PageLimit);
       return false;
     }

--- a/test/memlimit/MemLimitTest.cpp
+++ b/test/memlimit/MemLimitTest.cpp
@@ -15,7 +15,8 @@ TEST(MemLimitTest, Limit__Pages) {
 
   MemInst Inst1(WasmEdge::AST::MemoryType(257),
                 Conf.getRuntimeConfigure().getMaxMemoryPage());
-  ASSERT_TRUE(Inst1.getDataPtr() == nullptr);
+  ASSERT_FALSE(Inst1.getDataPtr() == nullptr);
+  EXPECT_EQ(Inst1.getPageSize(), 256U);
 
   MemInst Inst2(WasmEdge::AST::MemoryType(257));
   ASSERT_FALSE(Inst2.getDataPtr() == nullptr);


### PR DESCRIPTION
If the page size limit is set in configuration, and the `min` in memory type is smaller than the limited page size value when creating the memory instance, modify the `min` in memory type and create with the limited size.