### PR TITLE
[WASI-NN] neural speed: Use Py_XDECREF in a safe way. Fix #3596

### DIFF
--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -89,8 +89,8 @@ jobs:
     env:
       output_dir: build/plugins/wasi_nn
       test_dir: build/test/plugins/wasi_nn
-      build_options: -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=PyTorch -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=OpenVINO -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=TensorFlowLite -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=GGML -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=NeuralSpeed -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=Piper -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=Whisper
-      tar_names: wasi_nn-pytorch wasi_nn-openvino wasi_nn-tensorflowlite wasi_nn-ggml wasi_nn-neuralspeed wasi_nn-piper wasi_nn-whisper
+      build_options: -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=NeuralSpeed -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=Piper -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=Whisper
+      tar_names: wasi_nn-neuralspeed wasi_nn-piper wasi_nn-whisper
       test_bin: wasiNNTests
       output_bin: libwasmedgePluginWasiNN.so
       OPENVINO_VERSION: "2024.2.0"

--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -112,9 +112,7 @@ jobs:
         shell: bash
         run: |
           apt update
-          apt install -y unzip libopenblas-dev pkg-config protobuf-compiler-grpc libgrpc-dev libgrpc++-dev
-          bash utils/wasi-nn/install-openvino.sh
-          bash utils/wasi-nn/install-pytorch.sh
+          apt install -y unzip pkg-config
           bash utils/wasi-nn/install-neuralspeed.sh
       - name: Build and test WASI-NN using ${{ matrix.compiler }} with ${{ matrix.build_type }} mode
         shell: bash

--- a/plugins/wasi_nn/neuralspeed.cpp
+++ b/plugins/wasi_nn/neuralspeed.cpp
@@ -321,7 +321,6 @@ Expect<WASINN::ErrNo> unload(WASINN::WasiNNEnvironment &Env,
     safeXDECREF(GraphRef.Model);
     safeXDECREF(GraphRef.ModelClass);
     safeXDECREF(GraphRef.NeuralSpeedModule);
-    Py_Finalize();
   }
   return WASINN::ErrNo::Success;
 }

--- a/plugins/wasi_nn/neuralspeed.h
+++ b/plugins/wasi_nn/neuralspeed.h
@@ -16,6 +16,7 @@ struct WasiNNEnvironment;
 
 namespace WasmEdge::Host::WASINN::NeuralSpeed {
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_NEURAL_SPEED
+void safeXDECREF(PyObject *&Obj) noexcept;
 struct Graph {
   bool EnableDebugLog = true;
   std::string model_type = "llama";
@@ -23,16 +24,16 @@ struct Graph {
   Graph() noexcept { Py_Initialize(); }
   ~Graph() noexcept {
     if (Py_IsInitialized()) {
-      Py_XDECREF(Model);
-      Py_XDECREF(ModelClass);
-      Py_XDECREF(NeuralSpeedModule);
+      safeXDECREF(Model);
+      safeXDECREF(ModelClass);
+      safeXDECREF(NeuralSpeedModule);
     }
   }
-  PyObject *Model;
-  PyObject *NeuralSpeedModule;
-  PyObject *ModelClass;
-  int64_t LoadTime;
-  int64_t ComputeTime;
+  PyObject *Model = nullptr;
+  PyObject *NeuralSpeedModule = nullptr;
+  PyObject *ModelClass = nullptr;
+  int64_t LoadTime = 0;
+  int64_t ComputeTime = 0;
 };
 struct Context {
   Context(size_t Gid, Graph &) noexcept : GraphId(Gid) {}

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -1837,6 +1837,8 @@ TEST(WasiNNTest, NeuralSpeedBackend) {
   FuncInst = NNMod->findFuncExports("unload");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncUnload =
+      dynamic_cast<WasmEdge::Host::WasiNNUnload &>(FuncInst->getHostFunc());
 
   // Neural Speed WASI-NN load tests.
   // Test: load -- meaningless binaries.
@@ -2018,6 +2020,15 @@ TEST(WasiNNTest, NeuralSpeedBackend) {
         Errno));
     EXPECT_EQ(Errno[0].get<int32_t>(),
               static_cast<uint32_t>(ErrNo::InvalidArgument));
+  }
+
+  // Neural Speed WASI-NN unload tests.
+  // Test: unload -- unload successfully.
+  {
+    EXPECT_TRUE(HostFuncUnload.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0)},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
   }
 
   delete NNMod;

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -2022,15 +2022,6 @@ TEST(WasiNNTest, NeuralSpeedBackend) {
               static_cast<uint32_t>(ErrNo::InvalidArgument));
   }
 
-  // Neural Speed WASI-NN unload tests.
-  // Test: unload -- unload successfully.
-  {
-    EXPECT_TRUE(HostFuncUnload.run(
-        CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0)},
-        Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
-  }
-
   delete NNMod;
 }
 #endif // WASMEDGE_PLUGIN_WASI_NN_BACKEND_NEURAL_SPEED

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -1837,8 +1837,6 @@ TEST(WasiNNTest, NeuralSpeedBackend) {
   FuncInst = NNMod->findFuncExports("unload");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncUnload =
-      dynamic_cast<WasmEdge::Host::WasiNNUnload &>(FuncInst->getHostFunc());
 
   // Neural Speed WASI-NN load tests.
   // Test: load -- meaningless binaries.

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -1987,6 +1987,19 @@ TEST(WasiNNTest, NeuralSpeedBackend) {
   }
 
   // Neural Speed WASI-NN get_output tests.
+  // Test: get_output -- get output successfully.
+  {
+    EXPECT_TRUE(HostFuncGetOutput.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            UINT32_C(0), UINT32_C(0), StorePtr, 65532, BuilderPtr},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+    // Should output more than 50 bytes.
+    auto BytesWritten = *MemInst.getPointer<uint32_t *>(BuilderPtr);
+    EXPECT_GE(BytesWritten, 50);
+  }
+
   // Test: get_output -- output bytes ptr out of bounds.
   {
     EXPECT_TRUE(HostFuncGetOutput.run(
@@ -2007,18 +2020,6 @@ TEST(WasiNNTest, NeuralSpeedBackend) {
         Errno));
     EXPECT_EQ(Errno[0].get<int32_t>(),
               static_cast<uint32_t>(ErrNo::InvalidArgument));
-  }
-  // Test: get_output -- get output successfully.
-  {
-    EXPECT_TRUE(HostFuncGetOutput.run(
-        CallFrame,
-        std::initializer_list<WasmEdge::ValVariant>{
-            UINT32_C(0), UINT32_C(0), StorePtr, 65532, BuilderPtr},
-        Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
-    // Should output more than 50 bytes.
-    auto BytesWritten = *MemInst.getPointer<uint32_t *>(BuilderPtr);
-    EXPECT_GE(BytesWritten, 50);
   }
 
   // Neural Speed WASI-NN unload tests.


### PR DESCRIPTION
Fix #3596