### PR TITLE
Fix fd_sync Error for Preopened Base Directory

### DIFF
--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -549,11 +549,15 @@ WasiExpect<void> INode::fdSeek(__wasi_filedelta_t Offset,
 }
 
 WasiExpect<void> INode::fdSync() const noexcept {
-  if (auto Res = ::fsync(Fd); unlikely(Res != 0)) {
-    return WasiUnexpect(fromErrNo(errno));
-  }
+    struct stat fdStat;
+    if (fstat(Fd, &fdStat) == 0 && S_ISDIR(fdStat.st_mode)) {
+        return {};
+    }
+    if (auto Res = ::fsync(Fd); unlikely(Res != 0)) {
+        return WasiUnexpect(fromErrNo(errno)); 
+    }
 
-  return {};
+    return {}; // Success
 }
 
 WasiExpect<void> INode::fdTell(__wasi_filesize_t &Size) const noexcept {

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -554,7 +554,7 @@ WasiExpect<void> INode::fdSync() const noexcept {
     return {};
   }
   if (auto Res = ::fsync(Fd); unlikely(Res != 0)) {
-    return WasiUnexpect(fromErrNo(errno)); 
+    return WasiUnexpect(fromErrNo(errno));
   }
 
   return {};

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -549,15 +549,15 @@ WasiExpect<void> INode::fdSeek(__wasi_filedelta_t Offset,
 }
 
 WasiExpect<void> INode::fdSync() const noexcept {
-    struct stat fdStat;
-    if (fstat(Fd, &fdStat) == 0 && S_ISDIR(fdStat.st_mode)) {
-        return {};
-    }
-    if (auto Res = ::fsync(Fd); unlikely(Res != 0)) {
-        return WasiUnexpect(fromErrNo(errno)); 
-    }
+  struct stat fdStat;
+  if (fstat(Fd, &fdStat) == 0 && S_ISDIR(fdStat.st_mode)) {
+    return {};
+  }
+  if (auto Res = ::fsync(Fd); unlikely(Res != 0)) {
+    return WasiUnexpect(fromErrNo(errno)); 
+  }
 
-    return {}; // Success
+  return {};
 }
 
 WasiExpect<void> INode::fdTell(__wasi_filesize_t &Size) const noexcept {


### PR DESCRIPTION
Fix `fdSync` to Handle Directories in Linux Implementation.
I have updated the `fdSync` function in `inode-linux.cpp` to correctly handle synchronization requests for directories. The function now checks if the file descriptor is a directory and treats it as syncable, in addition to performing the `fsync` operation for regular files. This change ensures compatibility with other runtimes and aligns the behavior with the WASI specification.
#3039 