### PR TITLE
[CI] Fix mirrors on manylinux2014(CentOS 7)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,8 @@ jobs:
     with:
       version: ${{ needs.create_release.outputs.version }}
       matrix:
-        "[{'name':'manylinux2014 x86_64','runner':'ubuntu-latest','docker_tag':'manylinux2014_x86_64','asset_tag':'manylinux2014_x86_64'},
-        {'name':'manylinux2014 aarch64','runner':'linux-arm64-v2','docker_tag':'manylinux2014_aarch64','asset_tag':'manylinux2014_aarch64'}]"
+        "[{'name':'manylinux2014 x86_64','runner':'ubuntu-latest','docker_tag':'manylinux2014_x86_64-plugins-deps','asset_tag':'manylinux2014_x86_64'},
+        {'name':'manylinux2014 aarch64','runner':'linux-arm64-v2','docker_tag':'manylinux2014_aarch64-plugins-deps','asset_tag':'manylinux2014_aarch64'}]"
       release: true
     secrets: inherit
 
@@ -485,7 +485,7 @@ jobs:
     needs: create_release
     runs-on: ubuntu-latest
     container:
-      image: wasmedge/wasmedge:manylinux2014_x86_64
+      image: wasmedge/wasmedge:manylinux2014_x86_64-plugins-deps
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
@@ -502,11 +502,6 @@ jobs:
         with:
           name: build_manylinux2014_runtime_only
           path: build/WasmEdge-${{ needs.create_release.outputs.version }}-Linux.tar.gz
-      - name: Install gh on manylinux
-        run: |
-          type -p yum-config-manager >/dev/null || yum install -y yum-utils
-          yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-          yum install -y gh
       - name: Upload ${{ matrix.name }} tar.gz package
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-build-extensions-on-manylinux.yml
+++ b/.github/workflows/reusable-build-extensions-on-manylinux.yml
@@ -150,8 +150,8 @@ jobs:
         with:
           name: ${{ steps.prep.outputs.artifact }}
           path: ${{ steps.prep.outputs.filename }}
-      - name: Install gh
-        if: ${{ inputs.release }}
+      - name: Install gh except for manylinux2014
+        if: ${{ inputs.release && !startsWith(matrix.docker_tag, 'manylinux2014') }}
         run: |
           type -p yum-config-manager >/dev/null || yum install -y yum-utils
           yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo

--- a/.github/workflows/reusable-build-on-manylinux.yml
+++ b/.github/workflows/reusable-build-on-manylinux.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           path: build/WasmEdge-${{ inputs.version }}-Linux.tar.gz
           name: WasmEdge-${{ inputs.version }}-${{ matrix.docker_tag }}.tar.gz
-      - name: Install gh on manylinux
-        if: ${{ inputs.release }}
+      - name: Install gh except for manylinux2014
+        if: ${{ inputs.release && !startsWith(matrix.docker_tag, 'manylinux2014') }}
         run: |
           type -p yum-config-manager >/dev/null || yum install -y yum-utils
           yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo

--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -39,6 +39,7 @@ jobs:
             python2_ex: python2
             python3_ex: python3
             extra_setup_command: yum install -y which
+            fix_mirror: "centos7"
           - name: Ubuntu 20.04
             host_runner: ubuntu-latest
             package_manager: apt
@@ -47,6 +48,7 @@ jobs:
             python2_ex: python2
             python3_ex: python3
             extra_setup_command: echo "No extra command"
+            fix_mirror: ""
           - name: Ubuntu 18.04
             host_runner: ubuntu-latest
             package_manager: apt
@@ -55,6 +57,7 @@ jobs:
             python2_ex: python2.7
             python3_ex: python3
             extra_setup_command: echo "No extra command"
+            fix_mirror: ""
           - name: Ubuntu 16.04
             host_runner: ubuntu-latest
             package_manager: apt
@@ -63,6 +66,7 @@ jobs:
             python2_ex: python2.7
             python3_ex: python3.7
             extra_setup_command: apt update -y && apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget && wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz && tar xzf Python-3.7.4.tgz && cd Python-3.7.4 && ./configure && make -j && make install && cd ..
+            fix_mirror: ""
           - name: manylinux2014 aarch64
             host_runner: linux-arm64-v2
             package_manager: yum
@@ -71,6 +75,7 @@ jobs:
             python2_ex: python2
             python3_ex: python3
             extra_setup_command: echo "No extra command"
+            fix_mirror: "centos7aarch64"
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.host_runner }}
     container:
@@ -85,6 +90,21 @@ jobs:
       with:
         fetch-depth: 0
 
+    - if: ${{ matrix.fix_mirror == 'centos7' }}
+      name: Fix mirrors on manylinux2014
+      # Reference: https://github.com/pypa/manylinux/pull/1628
+      run: |
+        sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf
+        sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/*.repo
+        sed -i 's;^.*baseurl=http://mirror;baseurl=https://vault;g' /etc/yum.repos.d/*.repo
+    - if: ${{ matrix.fix_mirror == 'centos7aarch64' }}
+      name: Fix mirrors on manylinux2014 for aarch64
+      # Reference: https://github.com/pypa/manylinux/pull/1628
+      run: |
+        sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf
+        sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/*.repo
+        sed -i 's;^.*baseurl=http://mirror;baseurl=https://vault;g' /etc/yum.repos.d/*.repo
+        sed -i 's;/centos/7/;/altarch/7/;g' /etc/yum.repos.d/*.repo
     - name: Install git and curl
       run: |
         ${{ matrix.extra_setup_command }}

--- a/.github/workflows/test-python-install-script.yml
+++ b/.github/workflows/test-python-install-script.yml
@@ -53,6 +53,7 @@ jobs:
             python2_ex: python2
             python3_ex: python3
             extra_setup_command: echo "No extra command"
+            fix_mirror: "centos7"
           - name: Ubuntu 20.04
             host_runner: ubuntu-latest
             package_manager: apt
@@ -61,6 +62,7 @@ jobs:
             python2_ex: python2
             python3_ex: python3
             extra_setup_command: apt update && apt install -y lsb-release
+            fix_mirror: ""
           - name: Ubuntu 18.04
             host_runner: ubuntu-latest
             package_manager: apt
@@ -69,6 +71,7 @@ jobs:
             python2_ex: python2.7
             python3_ex: python3
             extra_setup_command: echo "No extra command"
+            fix_mirror: ""
           - name: Ubuntu 16.04
             host_runner: ubuntu-latest
             package_manager: apt
@@ -77,6 +80,7 @@ jobs:
             python2_ex: python2.7
             python3_ex: python3.7
             extra_setup_command: apt update -y && apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget && wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz && tar xzf Python-3.7.4.tgz && cd Python-3.7.4 && ./configure && make -j && make install && cd ..
+            fix_mirror: ""
           - name: manylinux2014 aarch64
             host_runner: linux-arm64-v2
             package_manager: yum
@@ -85,6 +89,7 @@ jobs:
             python2_ex: python2
             python3_ex: python3
             extra_setup_command: echo "No extra command"
+            fix_mirror: "centos7aarch64"
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.host_runner }}
     container:
@@ -98,6 +103,22 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+
+    - if: ${{ matrix.fix_mirror == 'centos7' }}
+      name: Fix mirrors on manylinux2014
+      # Reference: https://github.com/pypa/manylinux/pull/1628
+      run: |
+        sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf
+        sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/*.repo
+        sed -i 's;^.*baseurl=http://mirror;baseurl=https://vault;g' /etc/yum.repos.d/*.repo
+    - if: ${{ matrix.fix_mirror == 'centos7aarch64' }}
+      name: Fix mirrors on manylinux2014 for aarch64
+      # Reference: https://github.com/pypa/manylinux/pull/1628
+      run: |
+        sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf
+        sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/*.repo
+        sed -i 's;^.*baseurl=http://mirror;baseurl=https://vault;g' /etc/yum.repos.d/*.repo
+        sed -i 's;/centos/7/;/altarch/7/;g' /etc/yum.repos.d/*.repo
 
     - name: Install git and curl
       run: |


### PR DESCRIPTION
* For the installer tests, we replace the mirrors.
* For manylinux2014, we use the pre-installed gh client inside the
  docker image instead.
* For non-EOL manylinux, it's fine to use the package manager to install
  the gh client.