### PR TITLE
[CMake] Fix the .git Detection Issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ set(WASMEDGE_WASI_NN_VERSION "0.1.0" CACHE STRING "WasmEdge WASI-NN library vers
 set(WASMEDGE_WASI_NN_SOVERSION "0" CACHE STRING "WasmEdge WASI-NN library soversion")
 
 find_program(GIT_CMD git)
+# Assuming the git command is not found and .git folder is not available.
+set(GIT_VERSION_NOT_FOUND 1)
 if(GIT_CMD AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
   execute_process(COMMAND
     ${GIT_CMD} describe --match "[0-9].[0-9]*" --tag


### PR DESCRIPTION
In #3626, .git detection was introduced to avoid the error triggered by the git describe command. However, the GIT_VERSION_NOT_FOUND variable is defined and set within the git describe command call. After applying #3626, GIT_VERSION_NOT_FOUND will never be defined and set if the git command exists but the .git folder does not.

In this PR, we define and initialize GIT_VERSION_NOT_FOUND to 1. This will ensure that CPACK_PACKAGE_VERSION is set to "0.0.0-unreleased" if `git describe` is not working or the .git folder does not exist.

@q82419 
We need to merge this PR into rc.2.