### PR TITLE
Fix: Correction of out of bounds error

### DIFF
--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -20,6 +20,7 @@ namespace {
 auto logOutOfRange(ErrCode Code, ErrInfo::IndexCategory Cate, uint32_t Idx,
                    uint32_t Bound) {
   spdlog::error(Code);
+  spdlog::error("YOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO");
   spdlog::error(ErrInfo::InfoForbidIndex(Cate, Idx, Bound));
   return Unexpect(Code);
 }
@@ -231,7 +232,7 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
                              &Instr](uint32_t N, Span<const ValType> Take,
                                      Span<const ValType> Put,
                                      bool CheckLane = false) -> Expect<void> {
-    if (Instr.getTargetIndex() >= Mems) {
+    if (Instr.getTargetIndex() + Instr.getMemoryOffset() + N/8>= Mems) {
       return logOutOfRange(ErrCode::Value::InvalidMemoryIdx,
                            ErrInfo::IndexCategory::Memory,
                            Instr.getTargetIndex(), Mems);


### PR DESCRIPTION
**Do not merge**

According to #2761,
We do not encounter error while in WasmEdge, I tried the below code, which will check if the loaded memory goes out of total memory. 

I need to write the test cases according to the changes done. 

I'll remove `spdlog::error("YOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO")` afterwards. 

I was thinking should I only check for i32, i64 ,f32, f64 load commands because it will be easier to do so. Otherwise it will take a lot of time to write new tests. 
 