### PR TITLE
[WASI-NN] ggml: bump llama.cpp b3567

### DIFF
--- a/plugins/wasi_nn/CMakeLists.txt
+++ b/plugins/wasi_nn/CMakeLists.txt
@@ -72,7 +72,7 @@ foreach(BACKEND ${WASMEDGE_PLUGIN_WASI_NN_BACKEND})
     FetchContent_Declare(
       llama
       GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-      GIT_TAG        b3499
+      GIT_TAG        b3567
       GIT_SHALLOW    FALSE
     )
     FetchContent_MakeAvailable(llama)
@@ -165,7 +165,7 @@ foreach(BACKEND ${WASMEDGE_PLUGIN_WASI_NN_BACKEND})
       target_link_libraries(wasmedgePluginWasiNN PRIVATE ${Python3_LIBRARIES})
       target_link_directories(wasmedgePluginWasiNN PRIVATE ${Python3_RUNTIME_LIBRARY_DIRS})
     else()
-      message(FATAL_ERROR "Can not find python3.") 
+      message(FATAL_ERROR "Can not find python3.")
     endif()
     target_link_libraries(wasmedgePluginWasiNN PRIVATE simdjson::simdjson)
   elseif(BACKEND STREQUAL "piper")


### PR DESCRIPTION
Some related updates between llama.cpp b3499 ~ b3567

```
- metal : fix uninitialized abort_callback (#8968)
- llama : default n_swa for phi-3 (#8931)
- llava : support MiniCPM-V-2.5 (#7599)
- CUDA: fix padding logic for FP16/FP32 (#8884)
- [Vulkan] Fix compilation of `vulkan-shaders-gen` on w64devkit after `e31a4f6` (#8880)
- Stop the generation when <|eom_id|> token is encountered - needed for Llama 3.1 tool call support (#8858)
- cmake: fix paths for vulkan shaders compilation on Windows (#8573)
- vulkan : fix Qantized Mat-Vec Mul on AMD GPUs for ncols < 64 (#8855)
- cuda : fix dmmv cols requirement to 2*GGML_CUDA_DMMV_X (#8800)
```