### PR TITLE
[WASI-NN] piper: make piper dependency use the same fmt and spdlog as the top-level project

### DIFF
--- a/cmake/Helper.cmake
+++ b/cmake/Helper.cmake
@@ -339,3 +339,44 @@ function(wasmedge_setup_simdjson)
     endif()
   endif()
 endfunction()
+
+function(wasmedge_setup_spdlog)
+  find_package(spdlog QUIET)
+  if(spdlog_FOUND)
+  else()
+    FetchContent_Declare(
+      fmt
+      GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+      GIT_TAG        11.0.2
+      GIT_SHALLOW    TRUE
+    )
+    set(FMT_INSTALL OFF CACHE BOOL "Generate the install target." FORCE)
+    FetchContent_MakeAvailable(fmt)
+    wasmedge_setup_target(fmt)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      target_compile_options(fmt
+        PUBLIC
+        -Wno-missing-noreturn
+        PRIVATE
+        -Wno-sign-conversion
+      )
+    endif()
+    if (WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      target_compile_options(fmt
+        PUBLIC
+        -Wno-duplicate-enum
+      )
+    endif()
+
+    FetchContent_Declare(
+      spdlog
+      GIT_REPOSITORY https://github.com/gabime/spdlog.git
+      GIT_TAG        v1.13.0
+      GIT_SHALLOW    TRUE
+    )
+    set(SPDLOG_BUILD_SHARED OFF CACHE BOOL "Build shared library" FORCE)
+    set(SPDLOG_FMT_EXTERNAL ON  CACHE BOOL "Use external fmt library instead of bundled" FORCE)
+    FetchContent_MakeAvailable(spdlog)
+    wasmedge_setup_target(spdlog)
+  endif()
+endfunction()

--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -234,6 +234,8 @@ function(wasmedge_setup_tflite_target target)
 endfunction()
 
 function(wasmedge_setup_piper)
+  include(Helper)
+  wasmedge_setup_spdlog()
   find_package(onnxruntime)
   if(NOT onnxruntime_FOUND)
     find_library(ONNXRUNTIME_LIBRARY onnxruntime)

--- a/lib/common/CMakeLists.txt
+++ b/lib/common/CMakeLists.txt
@@ -1,44 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2019-2024 Second State INC
 
-find_package(spdlog QUIET)
-if(spdlog_FOUND)
-else()
-  FetchContent_Declare(
-    fmt
-    GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-    GIT_TAG        11.0.2
-    GIT_SHALLOW    TRUE
-  )
-  set(FMT_INSTALL OFF CACHE BOOL "Generate the install target." FORCE)
-  FetchContent_MakeAvailable(fmt)
-  wasmedge_setup_target(fmt)
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    target_compile_options(fmt
-      PUBLIC
-      -Wno-missing-noreturn
-      PRIVATE
-      -Wno-sign-conversion
-    )
-  endif()
-  if (WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    target_compile_options(fmt
-      PUBLIC
-      -Wno-duplicate-enum
-    )
-  endif()
-
-  FetchContent_Declare(
-    spdlog
-    GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG        v1.13.0
-    GIT_SHALLOW    TRUE
-  )
-  set(SPDLOG_BUILD_SHARED OFF CACHE BOOL "Build shared library" FORCE)
-  set(SPDLOG_FMT_EXTERNAL ON  CACHE BOOL "Use external fmt library instead of bundled" FORCE)
-  FetchContent_MakeAvailable(spdlog)
-  wasmedge_setup_target(spdlog)
-endif()
+wasmedge_setup_spdlog()
 
 wasmedge_add_library(wasmedgeCommon
   hexstr.cpp

--- a/plugins/wasi_nn/piper.patch
+++ b/plugins/wasi_nn/piper.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f96ec44..ef67ff5 100644
+index f96ec44..1e84722 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.13)
@@ -27,8 +27,75 @@ index f96ec44..ef67ff5 100644
  add_executable(test_piper src/cpp/test.cpp src/cpp/piper.cpp)
  
  # NOTE: external project prefix are shortened because of path length restrictions on Windows
-@@ -58,59 +62,54 @@ endif()
+@@ -25,7 +29,21 @@ add_executable(test_piper src/cpp/test.cpp src/cpp/piper.cpp)
  
+ # ---- fmt ---
+ 
+-if(NOT DEFINED FMT_DIR)
++set(fmt_FOUND FALSE)
++
++if(NOT fmt_FOUND AND TARGET "fmt::fmt")
++  list(APPEND FMT_LINK_LIBRARIES "fmt::fmt")
++  set(fmt_FOUND TRUE)
++endif()
++
++if(NOT fmt_FOUND AND NOT DEFINED FMT_DIR)
++  find_package(fmt)
++  if(fmt_FOUND)
++    list(APPEND FMT_LINK_LIBRARIES "fmt::fmt")
++  endif()
++endif()
++
++if(NOT fmt_FOUND AND NOT DEFINED FMT_DIR)
+   set(FMT_VERSION "10.0.0")
+   set(FMT_DIR "${CMAKE_CURRENT_BINARY_DIR}/fi")
+ 
+@@ -41,11 +59,33 @@ if(NOT DEFINED FMT_DIR)
+   add_dependencies(test_piper fmt_external)
+ endif()
+ 
++if(NOT fmt_FOUND AND DEFINED FMT_DIR)
++  list(APPEND FMT_LINK_LIBRARIES "fmt")
++  list(APPEND FMT_LINK_DIRECTORIES "${FMT_DIR}/lib")
++  list(APPEND FMT_INCLUDE_DIRECTORIES "${FMT_DIR}/include")
++  set(fmt_FOUND TRUE)
++endif()
++
+ # ---- spdlog ---
+ 
+-if(NOT DEFINED SPDLOG_DIR)
++set(spdlog_FOUND FALSE)
++
++if(NOT spdlog_FOUND AND TARGET "spdlog::spdlog")
++  list(APPEND SPDLOG_LINK_LIBRARIES "spdlog::spdlog")
++  set(spdlog_FOUND TRUE)
++endif()
++
++if(NOT spdlog_FOUND AND NOT DEFINED SPDLOG_DIR)
++  find_package(spdlog)
++  if(spdlog_FOUND)
++    list(APPEND SPDLOG_LINK_LIBRARIES "spdlog::spdlog")
++  endif()
++endif()
++
++if(NOT spdlog_FOUND AND NOT DEFINED SPDLOG_DIR)
+   set(SPDLOG_DIR "${CMAKE_CURRENT_BINARY_DIR}/si")
+   set(SPDLOG_VERSION "1.12.0")
++  include(ExternalProject)
+   ExternalProject_Add(
+     spdlog_external
+     PREFIX "${CMAKE_CURRENT_BINARY_DIR}/s"
+@@ -56,81 +96,81 @@ if(NOT DEFINED SPDLOG_DIR)
+   add_dependencies(test_piper spdlog_external)
+ endif()
+ 
++if(NOT spdlog_FOUND AND DEFINED SPDLOG_DIR)
++  list(APPEND SPDLOG_LINK_LIBRARIES "spdlog")
++  list(APPEND SPDLOG_LINK_DIRECTORIES "${SPDLOG_DIR}/lib")
++  list(APPEND SPDLOG_INCLUDE_DIRECTORIES "${SPDLOG_DIR}/include")
++  set(spdlog_FOUND TRUE)
++endif()
++
  # ---- piper-phonemize ---
  
 -if(NOT DEFINED PIPER_PHONEMIZE_DIR)
@@ -69,9 +136,11 @@ index f96ec44..ef67ff5 100644
  endif()
  
 -target_link_libraries(piper
+-  fmt
+-  spdlog
 +target_link_libraries(piper PRIVATE
-   fmt
-   spdlog
++  "${FMT_LINK_LIBRARIES}"
++  "${SPDLOG_LINK_LIBRARIES}"
    espeak-ng
 -  piper_phonemize
    onnxruntime
@@ -80,52 +149,67 @@ index f96ec44..ef67ff5 100644
  )
  
 -target_link_directories(piper PUBLIC
-+target_link_directories(piper PRIVATE
-   ${FMT_DIR}/lib
-   ${SPDLOG_DIR}/lib
+-  ${FMT_DIR}/lib
+-  ${SPDLOG_DIR}/lib
 -  ${PIPER_PHONEMIZE_DIR}/lib
- )
- 
+-)
+-
 -target_include_directories(piper PUBLIC
-+set(PIPER_INTERFACE_INCLUDE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
-+file(COPY src/cpp/piper.hpp src/cpp/json.hpp DESTINATION "${PIPER_INTERFACE_INCLUDE_DIRECTORY}")
-+
-+target_include_directories(piper PRIVATE
-   ${FMT_DIR}/include
-   ${SPDLOG_DIR}/include
+-  ${FMT_DIR}/include
+-  ${SPDLOG_DIR}/include
 -  ${PIPER_PHONEMIZE_DIR}/include
-+  INTERFACE "${PIPER_INTERFACE_INCLUDE_DIRECTORY}"
++target_link_directories(piper PRIVATE
++  "${FMT_LINK_DIRECTORIES}"
++  "${SPDLOG_LINK_DIRECTORIES}"
  )
  
 -target_compile_definitions(piper PUBLIC _PIPER_VERSION=${piper_version})
--
++set(PIPER_INTERFACE_INCLUDE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
++file(COPY src/cpp/piper.hpp src/cpp/json.hpp DESTINATION "${PIPER_INTERFACE_INCLUDE_DIRECTORY}")
+ 
 -# ---- Declare test ----
 -include(CTest)
 -enable_testing()
 -add_test(
 -  NAME test_piper
 -  COMMAND test_piper "${CMAKE_SOURCE_DIR}/etc/test_voice.onnx" "${PIPER_PHONEMIZE_DIR}/share/espeak-ng-data" "${CMAKE_CURRENT_BINARY_DIR}/test.wav"
--)
-+target_compile_definitions(piper PRIVATE _PIPER_VERSION=${piper_version})
++target_include_directories(piper PRIVATE
++  "${FMT_INCLUDE_DIRECTORIES}"
++  "${SPDLOG_INCLUDE_DIRECTORIES}"
++  INTERFACE "${PIPER_INTERFACE_INCLUDE_DIRECTORY}"
+ )
  
++target_compile_definitions(piper PRIVATE _PIPER_VERSION=${piper_version})
++
  target_compile_features(test_piper PUBLIC cxx_std_17)
  
-@@ -118,14 +117,12 @@ target_include_directories(
+ target_include_directories(
    test_piper PUBLIC
-   ${FMT_DIR}/include
-   ${SPDLOG_DIR}/include
+-  ${FMT_DIR}/include
+-  ${SPDLOG_DIR}/include
 -  ${PIPER_PHONEMIZE_DIR}/include
++  "${FMT_INCLUDE_DIRECTORIES}"
++  "${SPDLOG_INCLUDE_DIRECTORIES}"
  )
  
  target_link_directories(
    test_piper PUBLIC
-   ${FMT_DIR}/lib
-   ${SPDLOG_DIR}/lib
+-  ${FMT_DIR}/lib
+-  ${SPDLOG_DIR}/lib
 -  ${PIPER_PHONEMIZE_DIR}/lib
++  "${FMT_LINK_DIRECTORIES}"
++  "${SPDLOG_LINK_DIRECTORIES}"
  )
  
  target_link_libraries(test_piper PUBLIC
-@@ -141,32 +138,3 @@ target_link_libraries(test_piper PUBLIC
+-  fmt
+-  spdlog
++  "${FMT_LINK_LIBRARIES}"
++  "${SPDLOG_LINK_LIBRARIES}"
+   espeak-ng
+   piper_phonemize
+   onnxruntime
+@@ -141,32 +181,3 @@ target_link_libraries(test_piper PUBLIC
  install(
    TARGETS piper
    DESTINATION ${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
### Background
WASI-NN Piper plug-in dependency: Piper also uses spdlog and fmt.
It uses `ExternalProject_Add` to download and install spdlog 1.12.0 and fmt 10.0.0.
It expects spdlog and fmt installations to have a directory containing include and lib directories (does not fit for `FetchContent` so a patch is required).
For includes, Piper uses its installed spdlog and fmt headers.
For linking (libwasmedgePluginWasiNN.so), it chooses to link with spdlog and fmt selected by the top-level project (wasmedge).
Before https://github.com/WasmEdge/WasmEdge/commit/bc1e277db997df63175556f7d90ffe0f0ac1f903, the ABI was the same so  it happened to worked.

https://github.com/WasmEdge/WasmEdge/commit/bc1e277db997df63175556f7d90ffe0f0ac1f903 bumped fmt from 10.2.1 to 11.0.2 and we got this error when running wasiNNTests:
```
./wasiNNTests: symbol lookup error: ../../../plugins/wasi_nn/libwasmedgePluginWasiNN.so: undefined symbol: _ZN6spdlog7details7log_msgC1ENS_10source_locEN3fmt3v1017basic_string_viewIcEENS_5level10level_enumES6_
```
The demangled symbol:
```
spdlog::details::log_msg::log_msg(spdlog::source_loc, fmt::v10::basic_string_view<char>, spdlog::level::level_enum, fmt::v10::basic_string_view<char>)
```
This symbol is from the headers installed by piper. It does not exist when spdlog uses fmt v11.

### Solution
Make piper dependency use the same fmt and spdlog as the top-level project.

This PR will:
- move the spdlog setup logic from lib/common/CMakeLists.txt to a new function `wasmedge_setup_spdlog` in cmake/Helper.cmake.
- patch piper to allow using existing fmt and spdlog library targets.
- call `wasmedge_setup_spdlog` before FetchContent for piper so it will use the same fmt and spdlog as the top-level project.