### PR TITLE
[Plugin] Stable Diffusion: enable CUBLAS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ option(WASMEDGE_PLUGIN_TENSORFLOWLITE "Enable WasmEdge TensorFlow-Lite plugin." 
 option(WASMEDGE_PLUGIN_ZLIB "Enable WasmEdge zlib plugin." OFF)
 option(WASMEDGE_PLUGIN_FFMPEG "Enable WasmEdge ffmpeg plugin." OFF)
 option(WASMEDGE_PLUGIN_STABLEDIFFUSION "Enable WasmEdge stable-diffusion plugin." OFF)
+option(WASMEDGE_PLUGIN_STABLEDIFFUSION_CUBLAS "Enable CUBLAS in the stable-diffusion plugin." OFF)
 
 if(WASMEDGE_BUILD_TOOLS AND WASMEDGE_BUILD_FUZZING)
   message(FATAL_ERROR "wasmedge tool and fuzzing tool are exclusive options.")

--- a/plugins/wasmedge_stablediffusion/CMakeLists.txt
+++ b/plugins/wasmedge_stablediffusion/CMakeLists.txt
@@ -1,6 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2019-2024 Second State INC
 
+
+if(WASMEDGE_PLUGIN_STABLEDIFFUSION_CUBLAS)
+  message(STATUS "Stable diffusion plugin: Enable SD_CUBLAS")
+  set(SD_CUBLAS ON)
+else()
+  message(STATUS "Stable diffusion plugin: Disable SD_CUBLAS")
+  set(SD_CUBLAS OFF)
+endif()
+
 # setup stable diffusion
 message(STATUS "Downloading stable diffusion source")
 FetchContent_Declare(
@@ -13,7 +22,7 @@ FetchContent_MakeAvailable(stable-diffusion)
 set_property(TARGET stable-diffusion PROPERTY POSITION_INDEPENDENT_CODE ON)
 if(APPLE AND CMAKE_SYSTEM_VERSION VERSION_LESS 23)
   # `cblas_sgemm()` introduced in macOS 13.3.
-  set(GGML_NO_ACCELERATE ON CACHE INTERNAL "Stable diffusion turn off accelerate")
+  set(GGML_NO_ACCELERATE ON CACHE INTERNAL "Stable diffusion plugin: Turn off accelerate")
 endif()
 get_target_property(SD_DEPS stable-diffusion LINK_LIBRARIES)
 foreach(dep ${SD_DEPS})


### PR DESCRIPTION
- Add option `WASMEDGE_PLUGIN_STABLEDIFFUSION_CUBLAS` to enable `SD_CUBLAS` if required.