### PR TITLE
[Plugin] stable diffusion: add Metal support

### DIFF
--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -676,3 +676,71 @@ jobs:
         with:
           name: WasmEdge-plugin-wasi_llm-${{ needs.get_version.outputs.version }}-${{ matrix.darwin_version }}_${{ matrix.arch }}.tar.gz
           path: plugin_wasi_llm.tar.gz
+
+  build_macos_metal:
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        include:
+          - system: MacOS 14 (arm64)
+            host_runner: macos-14
+            darwin_version: darwin_23
+            build_type: Release
+            arch: arm64
+    name: Plugins (Metal, ${{ matrix.system }}, clang++, ${{ matrix.build_type }})
+    runs-on: ${{ matrix.host_runner }}
+    env:
+      output_prefix: build/plugins
+      test_prefix: build/test/plugins
+      build_options: -DWASMEDGE_PLUGIN_STABLEDIFFUSION=ON -DWASMEDGE_PLUGIN_STABLEDIFFUSION_METAL=ON
+      tar_names: wasmedge_stablediffusion
+      test_bins: wasmedgeStableDiffusionTests
+      output_bins: libwasmedgePluginWasmEdgeStableDiffusion.dylib
+    needs: [ get_version ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build and install dependencies
+        run: |
+          eval $(/opt/homebrew/bin/brew shellenv)
+          brew install llvm@16 ninja cmake
+      - name: Build WasmEdge plugins using clang++ with ${{ matrix.build_type }} mode
+        shell: bash
+        run: |
+          eval $(/opt/homebrew/bin/brew shellenv)
+          testbin_array=(${test_bins})
+          export LLVM_DIR="$(brew --prefix)/opt/llvm@16/lib/cmake"
+          export CC=clang
+          export CXX=clang++
+          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_USE_LLVM=OFF -DWASMEDGE_BUILD_TOOLS=OFF ${build_options} -DOPENSSL_ROOT_DIR=$(brew --prefix)/opt/openssl
+          for (( i=0; i<${#testbin_array[@]}; i++ ));
+          do
+            echo "Building ${testbin_array[$i]} :"
+            cmake --build build --target ${testbin_array[$i]}
+          done
+      - name: Test WasmEdge plugins (skipped)
+        shell: bash
+        run: |
+          echo 'The GitHub Actions runner does not support some instructions for Metal GPU testing.'
+      - name: Prepare the WasmEdge plugins tar.gz package (with metal files)
+        shell: bash
+        run: |
+          eval $(/opt/homebrew/bin/brew shellenv)
+          plugin_array=(${tar_names})
+          outbin_array=(${output_bins})
+          for (( i=0; i<${#plugin_array[@]}; i++ ));
+          do
+            echo "Copying ${plugin_array[$i]} :"
+            for plugin_files in "${outbin_array[$i]}" "ggml-metal.metal" "ggml-common.h"
+            do
+              cp ${output_prefix}/${plugin_array[$i]}/$plugin_files .
+            done
+            tar -zcvf plugin_${plugin_array[$i]}.tar.gz "${outbin_array[$i]}" "ggml-metal.metal" "ggml-common.h"
+          done
+      - name: Upload artifact - wasmedge_stablediffusion
+        uses: actions/upload-artifact@v3
+        with:
+          name: WasmEdge-plugin-wasmedge_stablediffusion-metal-${{ needs.get_version.outputs.version }}-${{ matrix.darwin_version }}_${{ matrix.arch }}.tar.gz
+          path: plugin_wasmedge_stablediffusion.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -621,6 +621,71 @@ jobs:
           mv plugin_wasmedge_stablediffusion.tar.gz WasmEdge-plugin-wasmedge_stablediffusion-${{ needs.create_release.outputs.version }}-darwin_${{ matrix.arch }}.tar.gz
           gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_stablediffusion-${{ needs.create_release.outputs.version }}-darwin_${{ matrix.arch }}.tar.gz --clobber
 
+  build_and_upload_plugin_macos_metal:
+    strategy:
+      matrix:
+        include:
+          - system: MacOS 14 (arm64)
+            host_runner: macos-14
+            arch: arm64
+    name: Build and upload plugins on ${{ matrix.system }} with Metal
+    runs-on: ${{ matrix.host_runner }}
+    env:
+      output_prefix: build/plugins
+      build_options: -DWASMEDGE_PLUGIN_STABLEDIFFUSION=ON -DWASMEDGE_PLUGIN_STABLEDIFFUSION_METAL=ON
+      tar_names: wasmedge_stablediffusion
+      output_bins: libwasmedgePluginWasmEdgeStableDiffusion.dylib
+    needs: create_release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Grant the safe directory for git
+        run: |
+          git config --global --add safe.directory $(pwd)
+      - name: Install dependencies
+        run: |
+          eval $(/opt/homebrew/bin/brew shellenv)
+          brew install llvm@16 ninja cmake gh
+      - name: Build plugins
+        shell: bash
+        run: |
+          eval $(/opt/homebrew/bin/brew shellenv)
+          outbin_array=(${output_bins})
+          export LLVM_DIR="$(brew --prefix)/opt/llvm@16/lib/cmake"
+          export CC=clang
+          export CXX=clang++
+          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_USE_LLVM=OFF -DWASMEDGE_BUILD_TOOLS=OFF -DOPENSSL_ROOT_DIR=$(brew --prefix)/opt/openssl ${build_options}
+          for (( i=0; i<${#outbin_array[@]}; i++ ));
+          do
+            echo "Building ${outbin_array[$i]} :"
+            outtarget=${outbin_array[$i]}
+            outtarget=${outtarget%.*}
+            outtarget=${outtarget#lib}
+            cmake --build build --target ${outtarget}
+          done
+      - name: Prepare the WasmEdge plugins tar.gz package (with metal files)
+        shell: bash
+        run: |
+          plugin_array=(${tar_names})
+          outbin_array=(${output_bins})
+          for (( i=0; i<${#plugin_array[@]}; i++ ));
+          do
+            echo "Copying ${plugin_array[$i]} :"
+            for plugin_files in "${outbin_array[$i]}" "ggml-metal.metal" "ggml-common.h"
+            do
+              cp ${output_prefix}/${plugin_array[$i]}/$plugin_files .
+            done
+            tar -zcvf plugin_${plugin_array[$i]}.tar.gz "${outbin_array[$i]}" "ggml-metal.metal" "ggml-common.h"
+          done
+      - name: Upload wasmedge_stablediffusion plugin tar.gz package
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mv plugin_wasmedge_stablediffusion.tar.gz WasmEdge-plugin-wasmedge_stablediffusion-metal-${{ needs.create_release.outputs.version }}-darwin_${{ matrix.arch }}.tar.gz
+          gh release upload ${{ needs.create_release.outputs.version }} WasmEdge-plugin-wasmedge_stablediffusion-metal-${{ needs.create_release.outputs.version }}-darwin_${{ matrix.arch }}.tar.gz --clobber
+
   build_manylinux2014_runtime_only:
     name: Build runtime only on manylinux2014 platform
     needs: create_release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ option(WASMEDGE_PLUGIN_ZLIB "Enable WasmEdge zlib plugin." OFF)
 option(WASMEDGE_PLUGIN_FFMPEG "Enable WasmEdge ffmpeg plugin." OFF)
 option(WASMEDGE_PLUGIN_STABLEDIFFUSION "Enable WasmEdge stable-diffusion plugin." OFF)
 option(WASMEDGE_PLUGIN_STABLEDIFFUSION_CUBLAS "Enable CUBLAS in the stable-diffusion plugin." OFF)
+option(WASMEDGE_PLUGIN_STABLEDIFFUSION_METAL "Enable Metal in the stable-diffusion plugin." OFF)
 
 if(WASMEDGE_BUILD_TOOLS AND WASMEDGE_BUILD_FUZZING)
   message(FATAL_ERROR "wasmedge tool and fuzzing tool are exclusive options.")

--- a/plugins/wasmedge_stablediffusion/CMakeLists.txt
+++ b/plugins/wasmedge_stablediffusion/CMakeLists.txt
@@ -10,6 +10,15 @@ else()
   set(SD_CUBLAS OFF CACHE BOOL "Stable diffusion plugin: Disable SD_CUBLAS")
 endif()
 
+if(APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64" AND WASMEDGE_PLUGIN_STABLEDIFFUSION_METAL)
+  message(STATUS "Stable diffusion plugin: Enable SD_METAL")
+  set(SD_METAL ON CACHE BOOL "Stable diffusion plugin: Enable SD_METAL")
+  set(GGML_METAL_EMBED_LIBRARY ON)
+else()
+  message(STATUS "Stable diffusion plugin: Disable SD_METAL")
+  set(SD_METAL OFF CACHE BOOL "Stable diffusion plugin: Disable SD_METAL")
+endif()
+
 # setup stable diffusion
 message(STATUS "Downloading stable diffusion source")
 FetchContent_Declare(
@@ -84,6 +93,15 @@ else()
 		-Wno-missing-field-initializers
     -Wno-deprecated-declarations
 	)
+endif()
+
+if(WASMEDGE_PLUGIN_STABLEDIFFUSION_METAL)
+  add_custom_command(
+    TARGET wasmedgePluginWasmEdgeStableDiffusion
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ${stable-diffusion_SOURCE_DIR}/ggml/src/ggml-metal.metal ggml-metal.metal
+    COMMAND ${CMAKE_COMMAND} -E copy ${stable-diffusion_SOURCE_DIR}/ggml/ggml-common.h ggml-common.h
+  )
 endif()
 
 install(


### PR DESCRIPTION
- Add Metal support by `WASMEDGE_PLUGIN_STABLEDIFFUSION_METAL`
- Build and upload plugin with Metal support on CI. Pack with related files (`.metal`, `.h` files).