### PR TITLE
Added stdin, stdout, stderr to Environ::init

### DIFF
--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -56,7 +56,8 @@ public:
   ~Environ() noexcept;
 
   void init(Span<const std::string> Dirs, std::string ProgramName,
-            Span<const std::string> Args, Span<const std::string> Envs);
+            Span<const std::string> Args, Span<const std::string> Envs,
+            int StdinFd = 0, int StdoutFd = 1, int StderrFd = 2);
 
   void fini() noexcept;
 

--- a/lib/host/wasi/environ.cpp
+++ b/lib/host/wasi/environ.cpp
@@ -71,7 +71,8 @@ static inline constexpr const auto kReadOnly = "readonly"sv;
 } // namespace
 
 void Environ::init(Span<const std::string> Dirs, std::string ProgramName,
-                   Span<const std::string> Args, Span<const std::string> Envs) {
+                   Span<const std::string> Args, Span<const std::string> Envs,
+                   int StdinFd, int StdoutFd, int StderrFd) {
   {
     // Open dir for WASI environment.
     std::vector<std::shared_ptr<VINode>> PreopenedDirs;
@@ -111,12 +112,20 @@ void Environ::init(Span<const std::string> Dirs, std::string ProgramName,
 
     std::sort(PreopenedDirs.begin(), PreopenedDirs.end());
 
-    FdMap.emplace(0, VINode::stdIn(kStdInDefaultRights, kNoInheritingRights));
-    FdMap.emplace(1, VINode::stdOut(kStdOutDefaultRights, kNoInheritingRights));
-    FdMap.emplace(2, VINode::stdErr(kStdErrDefaultRights, kNoInheritingRights));
+    FdMap.emplace(StdinFd,
+                  VINode::stdIn(kStdInDefaultRights, kNoInheritingRights));
+    FdMap.emplace(StdoutFd,
+                  VINode::stdOut(kStdOutDefaultRights, kNoInheritingRights));
+    FdMap.emplace(StderrFd,
+                  VINode::stdErr(kStdErrDefaultRights, kNoInheritingRights));
 
-    int NewFd = 3;
+    int NewFd = 0;
     for (auto &PreopenedDir : PreopenedDirs) {
+      if (NewFd == StdinFd || NewFd == StdoutFd || NewFd == StderrFd) {
+        while (NewFd == StdinFd || NewFd == StdoutFd || NewFd == StderrFd) {
+          ++NewFd;
+        }
+      }
       FdMap.emplace(NewFd++, std::move(PreopenedDir));
     }
   }


### PR DESCRIPTION
1. Expands Environ::init() to take 3 more additional parameters StdinFd, StdoutFd, StderrFd.

Fixes #2936 