### PR TITLE
[CI] Docker: remove `on.push.tags`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,8 +6,6 @@ concurrency:
 
 on:
   push:
-    tags:
-      - '*.*.*'
     branches:
       - master
     paths:


### PR DESCRIPTION
This workflow does not have release-related jobs.