### PR TITLE
[CI] Workaround for jobs not cancellable

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -96,7 +96,6 @@ jobs:
     needs:
       - prep
       - paths-filter
-    if: ${{ needs.paths-filter.outputs.ci-image-base == 'true' }}
 
     name: CI image base
     runs-on: ubuntu-latest
@@ -115,7 +114,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-      - name: Bake and Push
+      # DO NOT skip the whole job to prevent descending jobs to be skipped
+      - if: ${{ needs.paths-filter.outputs.ci-image-base == 'true' }}
+        name: Bake and Push
         uses: docker/bake-action@v5
         with:
           files: utils/docker/docker-bake.ci-image-base.hcl
@@ -126,8 +127,7 @@ jobs:
       - prep
       - paths-filter
       - bake-base-images
-    # Allow dependent job to be skipped
-    if: ${{ !failure() && needs.paths-filter.outputs.ubuntu == 'true' }}
+    if: ${{ needs.paths-filter.outputs.ubuntu == 'true' }}
 
     strategy:
       fail-fast: false
@@ -175,8 +175,7 @@ jobs:
       - prep
       - paths-filter
       - bake-base-images
-    # Allow dependent job to be skipped
-    if: ${{ !failure() && needs.paths-filter.outputs.manylinux == 'true' }}
+    if: ${{ needs.paths-filter.outputs.manylinux == 'true' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -129,6 +129,13 @@ jobs:
     # Allow dependent job to be skipped
     if: ${{ !failure() && needs.paths-filter.outputs.ubuntu == 'true' }}
 
+    strategy:
+      fail-fast: false
+      matrix:
+        targets:
+          - default
+          - clang-ubuntu2004-aarch64
+
     name: Ubuntu
     runs-on: ubuntu-latest
     container:
@@ -152,21 +159,7 @@ jobs:
         uses: docker/bake-action@v5
         with:
           files: utils/docker/docker-bake.ubuntu.hcl
-          push: ${{ github.event_name != 'pull_request' }}
-          set: |
-            *.labels.org.opencontainers.image.title=${{ github.event.repository.name }}
-            *.labels.org.opencontainers.image.description=${{ github.event.repository.description }}
-            *.labels.org.opencontainers.image.url=${{ github.event.repository.html_url }}
-            *.labels.org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-            *.labels.org.opencontainers.image.revision=${{ github.sha }}
-            *.labels.org.opencontainers.image.version=${{ needs.prep.outputs.version }}
-            *.labels.org.opencontainers.image.created=${{ needs.prep.outputs.created }}
-
-      - name: Bake and Push (aarch64)
-        uses: docker/bake-action@v5
-        with:
-          files: utils/docker/docker-bake.ubuntu.hcl
-          targets: "clang-ubuntu2004-aarch64"
+          targets: ${{ matrix.targets }}
           push: ${{ github.event_name != 'pull_request' }}
           set: |
             *.labels.org.opencontainers.image.title=${{ github.event.repository.name }}


### PR DESCRIPTION
TLDR: `if: always()` cause jobs being non-cancellable. Seems like `if: !failure()` results in the same behavior here.

See https://github.com/actions/runner/issues/1846

> To cancel the workflow run, the server re-evaluates if conditions for all currently running jobs. If the condition evaluates to true, the job will not get canceled. For example, the condition if: always() would evaluate to true and the job continues to run. When there is no condition, that is the equivalent of the condition if: success(), which only runs if the previous step finished successfully.

Docs quoted from: https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/canceling-a-workflow#steps-github-takes-to-cancel-a-workflow-run

Force cancel: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#force-cancel-a-workflow-run
```sh
gh api \
  --method POST \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  /repos/WasmEdge/WasmEdge/actions/runs/RUN_ID/force-cancel
```