### PR TITLE
[Docker] Ubuntu: Refine structure for better caching

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -90,6 +90,7 @@ jobs:
               - '.github/workflows/docker.yml'
               - 'utils/docker/docker-bake.ubuntu.hcl'
               - 'utils/docker/Dockerfile.ubuntu-**'
+              - 'utils/ffmpeg/**'
               - 'utils/opencvmini/**'
 
   bake-base-images:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -135,7 +135,7 @@ jobs:
       matrix:
         targets:
           - default
-          - clang-ubuntu2004-aarch64
+          - base-2004-clang-aarch64
 
     name: Ubuntu
     runs-on: ubuntu-latest

--- a/utils/docker/Dockerfile.ubuntu-base
+++ b/utils/docker/Dockerfile.ubuntu-base
@@ -9,6 +9,8 @@ RUN apt-get update && \
         cmake \
         curl \
         dpkg-dev \
+        g++ \
+        gcc \
         git \
         ninja-build \
         software-properties-common \
@@ -20,14 +22,24 @@ FROM base AS deps-20
 
 RUN apt-get install -y \
         llvm-12-dev \
-        liblld-12-dev
+        liblld-12-dev \
+        clang-12
+
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 100 && \
+    update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-12 100
 
 ### deps for ubuntu 22.04 ###
 FROM base AS deps-22
 
 RUN apt-get install -y \
         llvm-15-dev \
-        liblld-15-dev
+        liblld-15-dev \
+        clang-15
+
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 100 && \
+    update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-15 100
 
 ### deps for clang / ubuntu 20.04 ###
 FROM deps-20 AS deps-20-clang
@@ -50,19 +62,11 @@ ENV CXX=/usr/bin/clang++-15
 ### deps for gcc / ubuntu 20.04 ###
 FROM deps-20 AS deps-20-gcc
 
-RUN apt-get install -y \
-        gcc \
-        g++
-
 ENV CC=gcc
 ENV CXX=g++
 
 ### deps for gcc / ubuntu 22.04 ###
 FROM deps-22 AS deps-22-gcc
-
-RUN apt-get install -y \
-        gcc \
-        g++
 
 ENV CC=gcc
 ENV CXX=g++

--- a/utils/docker/Dockerfile.ubuntu-base
+++ b/utils/docker/Dockerfile.ubuntu-base
@@ -1,5 +1,4 @@
 ARG UBUNTU_VER=22
-ARG TOOLCHAIN=clang
 FROM ubuntu:${UBUNTU_VER}.04 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -29,6 +28,9 @@ RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 100 && 
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 100 && \
     update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-12 100
 
+ENV CC=/usr/bin/clang-12
+ENV CXX=/usr/bin/clang++-12
+
 ### deps for ubuntu 22.04 ###
 FROM base AS deps-22
 
@@ -41,37 +43,10 @@ RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100 && 
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 100 && \
     update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-15 100
 
-### deps for clang / ubuntu 20.04 ###
-FROM deps-20 AS deps-20-clang
-
-RUN apt-get install -y \
-        clang-12
-
-ENV CC=/usr/bin/clang-12
-ENV CXX=/usr/bin/clang++-12
-
-### deps for clang / ubuntu 22.04 ###
-FROM deps-22 AS deps-22-clang
-
-RUN apt-get install -y \
-        clang-15
-
 ENV CC=/usr/bin/clang-15
 ENV CXX=/usr/bin/clang++-15
 
-### deps for gcc / ubuntu 20.04 ###
-FROM deps-20 AS deps-20-gcc
-
-ENV CC=gcc
-ENV CXX=g++
-
-### deps for gcc / ubuntu 22.04 ###
-FROM deps-22 AS deps-22-gcc
-
-ENV CC=gcc
-ENV CXX=g++
-
-### deps for all ###
-FROM deps-${UBUNTU_VER}-${TOOLCHAIN} AS final
+### cleanup
+FROM deps-${UBUNTU_VER} AS clean-apt
 
 RUN rm -rf /var/lib/apt/lists/*

--- a/utils/docker/Dockerfile.ubuntu-gcc
+++ b/utils/docker/Dockerfile.ubuntu-gcc
@@ -1,0 +1,5 @@
+ARG BASE_IMAGE=wasmedge/wasmedge:latest
+FROM ${BASE_IMAGE} AS base
+
+ENV CC=/usr/bin/gcc
+ENV CXX=/usr/bin/g++

--- a/utils/docker/Dockerfile.ubuntu-plugins-deps
+++ b/utils/docker/Dockerfile.ubuntu-plugins-deps
@@ -1,13 +1,28 @@
 ARG BASE_IMAGE=wasmedge/wasmedge:latest
 FROM ${BASE_IMAGE} AS base
 
+WORKDIR /root
+
 RUN apt-get update && \
     apt-get install -y \
+        cargo \
+        libelf-dev \
+        libomp-dev \
+        libssl-dev \
+        pkg-config \
         unzip \
-        wget
+        yasm
 
 COPY opencvmini/install-opencvmini.sh .
 ENV OPENCV_VERSION="4.8.0"
 RUN [ "/bin/bash", "install-opencvmini.sh" ]
+
+COPY ffmpeg/install-ffmpeg-v6.0.sh .
+RUN [ "/bin/bash", "install-ffmpeg-v6.0.sh" ]
+ENV PKG_CONFIG_PATH=/root/FFmpeg-n6.0/output/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}
+ENV LD_LIBRARY_PATH=/root/FFmpeg-n6.0/output/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+
+### cleanup
+FROM base AS clean-apt
 
 RUN rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Reduce docker-bake time for `docker-bake.ubuntu.hcl` (target: `default`) roughly from 2 hrs to 1 hr.

The main change for the base image `wasmedge/wasmedge:latest` (`wasmedge/wasmedge:ubuntu-build-clang`) is that both `gcc` (`g++`) and `clang` are installed, just the `ENV`s differs from `wasmedge/wasmedge:ubuntu-build-gcc`.