### PR TITLE
[CI] Prepare to upgrade Ubuntu latest from 22.04 to 24.04

### DIFF
--- a/.github/workflows/bindings-java.yml
+++ b/.github/workflows/bindings-java.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
     container:
-      image: wasmedge/wasmedge:ubuntu-build-clang
+      image: wasmedge/wasmedge:ubuntu-22.04-build-clang
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -75,10 +75,10 @@ jobs:
       matrix:
         include:
           - name: g++
-            docker_tag: ubuntu-build-gcc-plugins-deps
+            docker_tag: ubuntu-22.04-build-gcc-plugins-deps
             build_type: Release
           - name: clang++
-            docker_tag: ubuntu-build-clang-plugins-deps
+            docker_tag: ubuntu-22.04-build-clang-plugins-deps
             build_type: Release
     name: WASI-NN GGML RPC (${{ matrix.name }})
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,13 +127,13 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.get_version.outputs.version }}
-      matrix: "[{'name':'ubuntu-22.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'g++','build_type':'Debug','docker_tag':'ubuntu-build-gcc','tests':true},
-                {'name':'ubuntu-22.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'g++','build_type':'Release','docker_tag':'ubuntu-build-gcc','tests':true},
-                {'name':'ubuntu-22.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Debug','docker_tag':'ubuntu-build-clang','tests':true},
-                {'name':'ubuntu-22.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-build-clang','tests':true},
+      matrix: "[{'name':'ubuntu-22.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'g++','build_type':'Debug','docker_tag':'ubuntu-22.04-build-gcc','tests':true},
+                {'name':'ubuntu-22.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'g++','build_type':'Release','docker_tag':'ubuntu-22.04-build-gcc','tests':true},
+                {'name':'ubuntu-22.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Debug','docker_tag':'ubuntu-22.04-build-clang','tests':true},
+                {'name':'ubuntu-22.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-22.04-build-clang','tests':true},
                 {'name':'ubuntu-20.04','arch':'aarch64','runner':'linux-arm64-v2','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-20.04-build-clang-aarch64','tests':true},
-                {'name':'linux-static','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-build-clang','options':'-DWASMEDGE_BUILD_SHARED_LIB=Off -DWASMEDGE_BUILD_STATIC_LIB=On -DWASMEDGE_LINK_TOOLS_STATIC=On -DWASMEDGE_BUILD_PLUGINS=Off'},
-                {'name':'ubuntu-22.04-coverage','arch':'x86_64','runner':'ubuntu-latest','compiler':'g++','build_type':'Debug','docker_tag':'ubuntu-build-gcc','coverage':true,'tests':true}]"
+                {'name':'linux-static','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-22.04-build-clang','options':'-DWASMEDGE_BUILD_SHARED_LIB=Off -DWASMEDGE_BUILD_STATIC_LIB=On -DWASMEDGE_LINK_TOOLS_STATIC=On -DWASMEDGE_BUILD_PLUGINS=Off'},
+                {'name':'ubuntu-22.04-coverage','arch':'x86_64','runner':'ubuntu-latest','compiler':'g++','build_type':'Debug','docker_tag':'ubuntu-22.04-build-gcc','coverage':true,'tests':true}]"
 
   build_on_windows:
     permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -56,7 +56,7 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     container:
-      image: wasmedge/wasmedge:ubuntu-build-gcc
+      image: wasmedge/wasmedge:ubuntu-22.04-build-gcc
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/reusable-build-extensions.yml
+++ b/.github/workflows/reusable-build-extensions.yml
@@ -131,11 +131,11 @@ jobs:
       matrix:
         include:
           - runner: 'ubuntu-latest'
-            docker_tag: 'ubuntu-build-clang-plugins-deps'
+            docker_tag: 'ubuntu-22.04-build-clang-plugins-deps'
             asset_tag: 'ubuntu22.04-clang'
             plugins: ${{ needs.prepare.outputs.ubuntu_latest }}
           - runner: 'ubuntu-latest'
-            docker_tag: 'ubuntu-build-gcc-plugins-deps'
+            docker_tag: 'ubuntu-22.04-build-gcc-plugins-deps'
             asset_tag: 'ubuntu22.04-gcc'
             plugins: ${{ needs.prepare.outputs.ubuntu_latest }}
     name: ${{ matrix.asset_tag }}

--- a/cmake/Helper.cmake
+++ b/cmake/Helper.cmake
@@ -250,13 +250,15 @@ if((WASMEDGE_LINK_LLVM_STATIC OR WASMEDGE_BUILD_STATIC_LIB) AND WASMEDGE_USE_LLV
       ${LLVM_LIBRARY_DIR}/liblldWasm.a
     )
   endif()
-  if(APPLE AND LLVM_VERSION_MAJOR GREATER_EQUAL 15)
-    # For LLVM 15 or greater on MacOS
-    find_package(zstd REQUIRED)
-    get_filename_component(ZSTD_PATH "${zstd_LIBRARY}" DIRECTORY)
-    list(APPEND WASMEDGE_LLVM_LINK_STATIC_COMPONENTS
-      ${ZSTD_PATH}/libzstd.a
-    )
+  if(LLVM_VERSION_MAJOR GREATER_EQUAL 15)
+    # For LLVM 15 or greater on MacOS, or all LLVM 16+
+    if(APPLE OR LLVM_VERSION_MAJOR GREATER_EQUAL 16)
+      find_package(zstd REQUIRED)
+      get_filename_component(ZSTD_PATH "${zstd_LIBRARY}" DIRECTORY)
+      list(APPEND WASMEDGE_LLVM_LINK_STATIC_COMPONENTS
+        ${ZSTD_PATH}/libzstd.a
+      )
+    endif()
   endif()
 
   list(APPEND WASMEDGE_LLVM_LINK_SHARED_COMPONENTS

--- a/utils/docker/Dockerfile.ubuntu-base
+++ b/utils/docker/Dockerfile.ubuntu-base
@@ -50,6 +50,24 @@ RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100 && 
 ENV CC=/usr/bin/clang-15
 ENV CXX=/usr/bin/clang++-15
 
+### deps for ubuntu 24.04 ###
+FROM base AS deps-24
+
+RUN apt-get install -y cmake
+
+RUN apt-get install -y \
+        llvm-18-dev \
+        liblld-18-dev \
+        libpolly-18-dev \
+        clang-18
+
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100 && \
+    update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-18 100
+
+ENV CC=/usr/bin/clang-18
+ENV CXX=/usr/bin/clang++-18
+
 ### cleanup
 FROM deps-${UBUNTU_VER} AS clean-apt
 

--- a/utils/docker/docker-bake.ubuntu.hcl
+++ b/utils/docker/docker-bake.ubuntu.hcl
@@ -7,7 +7,34 @@ group "default" {
 
 group "latest" {
   targets = [
+    "base-2404-clang",
+  ]
+}
+
+group "focal" {
+  targets = [
+    "base-2004-clang",
+    "base-2004-gcc",
+    "plugins-2004-clang",
+    "plugins-2004-gcc",
+  ]
+}
+
+group "jammy" {
+  targets = [
     "base-2204-clang",
+    "base-2204-gcc",
+    "plugins-2204-clang",
+    "plugins-2204-gcc",
+  ]
+}
+
+group "noble" {
+  targets = [
+    "base-2404-clang",
+    "base-2404-gcc",
+    "plugins-2404-clang",
+    "plugins-2404-gcc",
   ]
 }
 
@@ -23,12 +50,12 @@ function "major" {
 
 function "tags-latest" {
   params = [target, ubuntu, toolchain]
-  result = target == "base" && ubuntu == "22.04" && toolchain == "clang" ? "latest" : ""
+  result = target == "base" && ubuntu == "24.04" && toolchain == "clang" ? "latest" : ""
 }
 
 function "tags-latest-backports" {
   params = [target, ubuntu, toolchain]
-  result = ubuntu == "22.04" ? join("-", compact([
+  result = ubuntu == "24.04" ? join("-", compact([
     "ubuntu",
     "build",
     toolchain,
@@ -67,7 +94,7 @@ target "base" {
   context    = "./utils/docker"
 
   matrix     = {
-    ubuntu = ["20.04", "22.04"]
+    ubuntu = ["20.04", "22.04", "24.04"]
   }
 
   name       = "base-${no-dot(ubuntu)}"
@@ -82,7 +109,7 @@ target "plugins" {
   context    = "./utils"
 
   matrix     = {
-    ubuntu = ["20.04", "22.04"]
+    ubuntu = ["20.04", "22.04", "24.04"]
   }
 
   name       = "plugins-${no-dot(ubuntu)}"
@@ -99,7 +126,7 @@ target "plugins" {
 target "final" {
   matrix     = {
     parent = ["base", "plugins"]
-    ubuntu = ["20.04", "22.04"]
+    ubuntu = ["20.04", "22.04", "24.04"]
     toolchain = ["clang", "gcc"]
   }
 


### PR DESCRIPTION
This PR added docker images for ubuntu 24.04:
- `wasmedge/wasmedge:ubuntu-24.04-build-clang`
- `wasmedge/wasmedge:ubuntu-24.04-build-clang-plugins-deps`
- `wasmedge/wasmedge:ubuntu-24.04-build-gcc`
- `wasmedge/wasmedge:ubuntu-24.04-build-gcc-plugins-deps`

Also changed all `latest`-related tags from ubuntu 22.04 to ubuntu 24.04:
- `wasmedge/wasmedge:latest`
- `wasmedge/wasmedge:ubuntu-build-clang`
- `wasmedge/wasmedge:ubuntu-build-clang-plugins-deps`
- `wasmedge/wasmedge:ubuntu-build-gcc`
- `wasmedge/wasmedge:ubuntu-build-gcc-plugins-deps`

Since workflows are not 100% ready for ubuntu 24.04, all jobs previously using `ubuntu-build-*` were changed to use `ubuntu-22.04-build-*`.