### PR TITLE
[WASI-NN] piper: use cmake -E tar x instead of file(ARCHIVE_EXTRACT) to extract testing data to meet the minimum cmake version required for the project

### DIFF
--- a/test/plugins/wasi_nn/CMakeLists.txt
+++ b/test/plugins/wasi_nn/CMakeLists.txt
@@ -89,11 +89,14 @@ foreach(BACKEND ${WASMEDGE_PLUGIN_WASI_NN_BACKEND})
       ${CMAKE_CURRENT_BINARY_DIR}/wasinn_piper_fixtures/piper_linux_x86_64.tar.gz
       SHA256=a50cb45f355b7af1f6d758c1b360717877ba0a398cc8cbe6d2a7a3a26e225992
     )
-    file(ARCHIVE_EXTRACT
-      INPUT ${CMAKE_CURRENT_BINARY_DIR}/wasinn_piper_fixtures/piper_linux_x86_64.tar.gz
-      DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/wasinn_piper_fixtures
-      PATTERNS piper/espeak-ng-data
+    execute_process(
+      COMMAND ${CMAKE_COMMAND} -E tar x ${CMAKE_CURRENT_BINARY_DIR}/wasinn_piper_fixtures/piper_linux_x86_64.tar.gz -- piper/espeak-ng-data
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/wasinn_piper_fixtures
+      RESULT_VARIABLE return_code
     )
+    if(NOT return_code EQUAL 0)
+      message(FATAL_ERROR "Failed to extract piper/espeak-ng-data from wasinn_piper_fixtures/piper_linux_x86_64.tar.gz")
+    endif()
   elseif(BACKEND STREQUAL "whisper")
     message( STATUS "Download ML artifacts to ${CMAKE_CURRENT_BINARY_DIR}/wasinn_whisper_fixtures")
     download(


### PR DESCRIPTION
Fixes #3787

The cause of #3787:

```
CMake Error at test/plugins/wasi_nn/CMakeLists.txt:92 (file):
  file does not recognize sub-command ARCHIVE_EXTRACT
```

[`file(ARCHIVE_EXTRACT)`](https://cmake.org/cmake/help/latest/command/file.html#archive-extract) is not available until cmake 3.18.

The minimum required version of cmake of this project is [3.15](https://github.com/WasmEdge/WasmEdge/blob/41fb955ed9d245ba9c34fd274744df861e68a8e6/CMakeLists.txt#L4).

The cmake version on `wasmedge/wasmedge:ubuntu-20.04-build-clang-plugins-deps` is 3.16.3.
The cmake version on `wasmedge/wasmedge:ubuntu-build-clang-plugins-deps` (Ubuntu 22.04) is 3.22.1.
Therefore, the workflows with Ubuntu 20.04 fails and those with Ubuntu 22.04 succeeds.

This PR uses [`cmake -E tar x`](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-E-arg-tar) instead of `file(ARCHIVE_EXTRACT)` to extract testing data.
`cmake -E tar x` is available in 3.15.
