### PR TITLE
[CMake] bump cmake to 3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2019-2024 Second State INC
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.18)
 cmake_policy(SET CMP0091 NEW)
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
   cmake_policy(SET CMP0135 NEW)

--- a/examples/embed_cxx/CMakeLists.txt
+++ b/examples/embed_cxx/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.18)
 
 project(embed_cxx CXX)
 

--- a/utils/docker/Dockerfile.ubuntu-base
+++ b/utils/docker/Dockerfile.ubuntu-base
@@ -5,7 +5,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
-        cmake \
         curl \
         dpkg-dev \
         g++ \
@@ -18,6 +17,9 @@ RUN apt-get update && \
 
 ### deps for ubuntu 20.04 ###
 FROM base AS deps-20
+
+RUN curl -sSf https://apt.kitware.com/kitware-archive.sh | sh
+RUN apt-get install -y cmake
 
 RUN apt-get install -y \
         llvm-12-dev \
@@ -33,6 +35,8 @@ ENV CXX=/usr/bin/clang++-12
 
 ### deps for ubuntu 22.04 ###
 FROM base AS deps-22
+
+RUN apt-get install -y cmake
 
 RUN apt-get install -y \
         llvm-15-dev \


### PR DESCRIPTION
Fixes #3787

This PR does:
1. update utils/docker/Dockerfile.ubuntu-base to install latest cmake from Kitware PPA for ubuntu 20.04
2. cmake_minimum_required(VERSION 3.18) for the root project and examples/embed_cxx

reference:
https://github.com/WasmEdge/WasmEdge/pull/3788