### PR TITLE
use winget-releaser to submit package to winget

### DIFF
--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -3,34 +3,15 @@ name: Submit WasmEdge MSI package to the Windows Package Manager Community Repos
 on:
   workflow_dispatch:
   release:
-    types: [published]
-
-permissions:
-  contents: read
+    types: [released]
 
 jobs:
-  winget:
-    permissions:
-      packages: write
-    name: Publish WinGet Package
+  publish:
     runs-on: windows-latest
     steps:
-      - name: Submit WasmEdge MSI package with WinGet Create
-        run: |
-
-          $packageId = "WasmEdge.WasmEdge"
-          $gitToken = "${{ secrets.GITHUB_TOKEN }}"
-
-          # Fetching latest release from GitHub
-          $github = Invoke-RestMethod -uri "https://api.github.com/repos/WasmEdge/WasmEdge/releases"
-          $targetRelease = $github | Where-Object -Property name -match 'WasmEdge'| Select-Object -First 1
-          $installerUrl = $targetRelease | Select-Object -ExpandProperty assets -First 1 | Where-Object -Property name -match 'WasmEdge.*.msi' | Select-Object -ExpandProperty browser_download_url
-          $packageVersion = $targetRelease.tag_name
-
-          # Install .NET Runtime
-          Invoke-WebRequest https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1
-          .\dotnet-install.ps1 -Runtime dotnet -Architecture x64 -Version 6.0.13 -InstallDir $env:ProgramFiles\dotnet
-
-          # Update package using wingetcreate
-          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          .\wingetcreate.exe update $packageId --version $packageVersion --urls "$installerUrl" --submit --token $gitToken
+      - name: Submit WasmEdge MSI package with Winget-Releaser
+        uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: WasmEdge.WasmEdge
+          installers-regex: 'windows\.msi$'
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Resolves https://github.com/WasmEdge/WasmEdge/issues/2673


## Changes made
1. Uses [WinGet Releaser](https://github.com/marketplace/actions/winget-releaser).
2. Will ONLY submit artifacts ending with `windows.msi` (NOT `windows-msvc.msi`), since Microsoft VCRedist is added as a dependency in the [manifest itself](https://github.com/microsoft/winget-pkgs/blob/master/manifests/w/WasmEdge/WasmEdge/0.14.0/WasmEdge.WasmEdge.installer.yaml).
3. Will only run on Stable releases (NOT on Pre-releases)
 

