### PR TITLE
[WASI] Windows overlapped transmission bytes matter

### DIFF
--- a/include/system/winapi.h
+++ b/include/system/winapi.h
@@ -536,6 +536,7 @@ using OBJECT_NAME_INFORMATION_ = struct _OBJECT_NAME_INFORMATION {
 
 #endif
 
+static inline constexpr const DWORD_ ERROR_SUCCESS_ = 0;
 static inline constexpr const DWORD_ ERROR_INVALID_FUNCTION_ = 1;
 static inline constexpr const DWORD_ ERROR_FILE_NOT_FOUND_ = 2;
 static inline constexpr const DWORD_ ERROR_ACCESS_DENIED_ = 5;

--- a/lib/host/wasi/inode-win.cpp
+++ b/lib/host/wasi/inode-win.cpp
@@ -976,19 +976,21 @@ WasiExpect<void> INode::fdPread(Span<Span<uint8_t>> IOVs,
   for (size_t I = 0; I < Queries.size(); ++I) {
     auto &Query = Queries[I];
     DWORD_ NumberOfBytesRead = 0;
-    if (unlikely(
-            !GetOverlappedResult(Handle, &Query, &NumberOfBytesRead, true))) {
+    auto OverlappedResult =
+        GetOverlappedResult(Handle, &Query, &NumberOfBytesRead, true);
+    NRead += NumberOfBytesRead;
+    if (unlikely(!OverlappedResult)) {
       if (const auto Error = GetLastError();
           unlikely(Error != ERROR_HANDLE_EOF_)) {
         Result = WasiUnexpect(detail::fromLastError(Error));
         CancelIo(Handle);
         for (size_t J = I + 1; J < Queries.size(); ++J) {
           GetOverlappedResult(Handle, &Queries[J], &NumberOfBytesRead, true);
+          NRead += NumberOfBytesRead;
         }
         break;
       }
     }
-    NRead += NumberOfBytesRead;
   }
 
   return Result;
@@ -1023,19 +1025,21 @@ WasiExpect<void> INode::fdPwrite(Span<Span<const uint8_t>> IOVs,
   for (size_t I = 0; I < Queries.size(); ++I) {
     auto &Query = Queries[I];
     DWORD_ NumberOfBytesWrite = 0;
-    if (unlikely(
-            !GetOverlappedResult(Handle, &Query, &NumberOfBytesWrite, true))) {
+    auto OverlappedResult =
+        GetOverlappedResult(Handle, &Query, &NumberOfBytesWrite, true);
+    NWritten += NumberOfBytesWrite;
+    if (unlikely(!OverlappedResult)) {
       if (const auto Error = GetLastError();
           unlikely(Error != ERROR_HANDLE_EOF_)) {
         Result = WasiUnexpect(detail::fromLastError(Error));
         CancelIo(Handle);
         for (size_t J = I + 1; J < Queries.size(); ++J) {
           GetOverlappedResult(Handle, &Queries[J], &NumberOfBytesWrite, true);
+          NWritten += NumberOfBytesWrite;
         }
         break;
       }
     }
-    NWritten += NumberOfBytesWrite;
   }
 
   return Result;
@@ -1073,19 +1077,21 @@ WasiExpect<void> INode::fdRead(Span<Span<uint8_t>> IOVs,
   for (size_t I = 0; I < Queries.size(); ++I) {
     auto &Query = Queries[I];
     DWORD_ NumberOfBytesRead = 0;
-    if (unlikely(
-            !GetOverlappedResult(Handle, &Query, &NumberOfBytesRead, true))) {
+    auto OverlappedResult =
+        GetOverlappedResult(Handle, &Query, &NumberOfBytesRead, true);
+    NRead += NumberOfBytesRead;
+    if (unlikely(!OverlappedResult)) {
       if (const auto Error = GetLastError();
           unlikely(Error != ERROR_HANDLE_EOF_)) {
         Result = WasiUnexpect(detail::fromLastError(Error));
         CancelIo(Handle);
         for (size_t J = I + 1; J < Queries.size(); ++J) {
           GetOverlappedResult(Handle, &Queries[J], &NumberOfBytesRead, true);
+          NRead += NumberOfBytesRead;
         }
         break;
       }
     }
-    NRead += NumberOfBytesRead;
   }
 
   OldOffset.QuadPart += NRead;
@@ -1211,19 +1217,21 @@ WasiExpect<void> INode::fdWrite(Span<Span<const uint8_t>> IOVs,
   for (size_t I = 0; I < Queries.size(); ++I) {
     auto &Query = Queries[I];
     DWORD_ NumberOfBytesWrite = 0;
-    if (unlikely(
-            !GetOverlappedResult(Handle, &Query, &NumberOfBytesWrite, true))) {
+    auto OverlappedResult =
+        GetOverlappedResult(Handle, &Query, &NumberOfBytesWrite, true);
+    NWritten += NumberOfBytesWrite;
+    if (unlikely(!OverlappedResult)) {
       if (const auto Error = GetLastError();
           unlikely(Error != ERROR_HANDLE_EOF_)) {
         Result = WasiUnexpect(detail::fromLastError(Error));
         CancelIo(Handle);
         for (size_t J = I + 1; J < Queries.size(); ++J) {
           GetOverlappedResult(Handle, &Queries[J], &NumberOfBytesWrite, true);
+          NWritten += NumberOfBytesWrite;
         }
         break;
       }
     }
-    NWritten += NumberOfBytesWrite;
   }
 
   if (!Append) {

--- a/lib/host/wasi/inode-win.cpp
+++ b/lib/host/wasi/inode-win.cpp
@@ -981,7 +981,7 @@ WasiExpect<void> INode::fdPread(Span<Span<uint8_t>> IOVs,
     NRead += NumberOfBytesRead;
     if (unlikely(!OverlappedResult)) {
       if (const auto Error = GetLastError();
-          unlikely(Error != ERROR_HANDLE_EOF_)) {
+          unlikely(Error != ERROR_HANDLE_EOF_ && Error != ERROR_SUCCESS_)) {
         Result = WasiUnexpect(detail::fromLastError(Error));
         CancelIo(Handle);
         for (size_t J = I + 1; J < Queries.size(); ++J) {
@@ -1030,7 +1030,7 @@ WasiExpect<void> INode::fdPwrite(Span<Span<const uint8_t>> IOVs,
     NWritten += NumberOfBytesWrite;
     if (unlikely(!OverlappedResult)) {
       if (const auto Error = GetLastError();
-          unlikely(Error != ERROR_HANDLE_EOF_)) {
+          unlikely(Error != ERROR_HANDLE_EOF_ && Error != ERROR_SUCCESS_)) {
         Result = WasiUnexpect(detail::fromLastError(Error));
         CancelIo(Handle);
         for (size_t J = I + 1; J < Queries.size(); ++J) {
@@ -1082,7 +1082,7 @@ WasiExpect<void> INode::fdRead(Span<Span<uint8_t>> IOVs,
     NRead += NumberOfBytesRead;
     if (unlikely(!OverlappedResult)) {
       if (const auto Error = GetLastError();
-          unlikely(Error != ERROR_HANDLE_EOF_)) {
+          unlikely(Error != ERROR_HANDLE_EOF_ && Error != ERROR_SUCCESS_)) {
         Result = WasiUnexpect(detail::fromLastError(Error));
         CancelIo(Handle);
         for (size_t J = I + 1; J < Queries.size(); ++J) {
@@ -1222,7 +1222,7 @@ WasiExpect<void> INode::fdWrite(Span<Span<const uint8_t>> IOVs,
     NWritten += NumberOfBytesWrite;
     if (unlikely(!OverlappedResult)) {
       if (const auto Error = GetLastError();
-          unlikely(Error != ERROR_HANDLE_EOF_)) {
+          unlikely(Error != ERROR_HANDLE_EOF_ && Error != ERROR_SUCCESS_)) {
         Result = WasiUnexpect(detail::fromLastError(Error));
         CancelIo(Handle);
         for (size_t J = I + 1; J < Queries.size(); ++J) {


### PR DESCRIPTION
DRAFT: I need to grab the build from CI and see if it resolved my test-case.

Closes: #3811

Two main changes in the Windows read/write support code:
* Whatever else happens, the total count of bytes transmitted includes all `GetOverlappedResult` calls.
* Treat `ERROR_SUCCESS` like `ERROR_HANDLE_EOF`: don't abort any other in-progress operations on this handle.