### PR TITLE
Fix build errors (ubuntu 24.04, clang)

### DIFF
--- a/plugins/wasm_bpf/CMakeLists.txt
+++ b/plugins/wasm_bpf/CMakeLists.txt
@@ -92,7 +92,7 @@ if(NOT ${LIBBPF_FOUND})
   FetchContent_Declare(
     libbpf
     GIT_REPOSITORY https://github.com/libbpf/libbpf
-    GIT_TAG cf46d44f0a06aa8b9400691ea3eb86ca4f066d5c
+    GIT_TAG 950cffc0366981d4e41b08f007b37bd6af931f25
   )
   FetchContent_GetProperties(libbpf)
 

--- a/test/plugins/wasmedge_zlib/wasmedge_zlib.cpp
+++ b/test/plugins/wasmedge_zlib/wasmedge_zlib.cpp
@@ -120,8 +120,8 @@ TEST(WasmEdgeZlibTest, DeflateInflateCycle) {
   std::array<WasmEdge::ValVariant, 1> RetVal;
 
   WasmZlibVersion = WasmHP;
-  std::snprintf(MemInst.getPointer<char *>(WasmHP), std::strlen(ZLIB_VERSION),
-                ZLIB_VERSION);
+  std::snprintf(MemInst.getPointer<char *>(WasmHP),
+                std::strlen(ZLIB_VERSION) + 1, ZLIB_VERSION);
   WasmHP += std::strlen(ZLIB_VERSION);
 
   WasmData = WasmHP;


### PR DESCRIPTION
### `libbpf`
- Error caused by https://github.com/libbpf/libbpf/commit/42d77b062c0e483bbc176b2d27f5ced02b19ecb3 (2023-01-26)
- Original tag`cf46d44f0a06aa8b9400691ea3eb86ca4f066d5c` (2023-03-07)
- New tag `950cffc0366981d4e41b08f007b37bd6af931f25` https://github.com/libbpf/libbpf/commit/950cffc0366981d4e41b08f007b37bd6af931f25 (2023-03-16)