### PR TITLE
[Voting Passed] ci(commitlint): introduce conventional commits

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+};

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       interval: "weekly"
     commit-message:
       # Prefix for PR title and commit messages
-      prefix: "[CI] dependabot"
+      prefix: "ci(dependabot):"
     groups:
       # Group updates, actions that match are grouped into a single PR;
       # dependabot should still raise a PR for each of the remaining actions

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,30 @@
+name: Commit Lint
+
+on: [pull_request]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install required dependencies
+        run: |
+          sudo apt update && sudo apt install -y git curl
+          curl -fsSL https://deb.nodesource.com/setup_18.x  | sudo -E bash -
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y nodejs
+      - name: Print versions
+        run: |
+          git --version
+          node --version
+          npm --version
+          npx commitlint --version
+      - name: Install commitlint
+        run: |
+          npm install conventional-changelog-conventionalcommits
+          npm install commitlint@latest @commitlint/config-conventional
+
+      - name: Validate PR commits with commitlint
+        if: github.event_name == 'pull_request'
+        run: npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose


### PR DESCRIPTION
Previously, WasmEdge maintainers manually checked the commit messages to see if their title meets the following format, `[Type] optionalScope: subject`. However, it's not possible to avoid fat finger merging some PR that doesn't meet this standard. So, I propose to use commitlint and the conventional commits spec for automatic detection.

If the commit message doesn't meet the standard, then the CI will fail to notify the contributors that their commit messages need to be fixed.

An example of failure will be like this:

![Google Chrome 2024-10-23 18 49 17](https://github.com/user-attachments/assets/515d4767-f43f-441e-bca0-cdf6a9d8849d)


Reference:
* Conventional commits: https://www.conventionalcommits.org/en/v1.0.0/