### PR TITLE
[WASI-NN] ggml: bump llama.cpp b4034

### DIFF
--- a/.github/workflows/IWYU_scan.yml
+++ b/.github/workflows/IWYU_scan.yml
@@ -67,9 +67,13 @@ jobs:
     - name: Install requirements
       run: |
         dnf update -y
-        dnf install -y cmake ninja-build llvm llvm-devel lld-devel clang git file rpm-build dpkg-dev clang-devel spdlog-devel
+        dnf install -y cmake ninja-build llvm18 llvm18-devel lld18-devel clang18 git file rpm-build dpkg-dev clang18-devel spdlog-devel
         curl -L -O https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/0.22.zip
         unzip 0.22.zip
+        export LLVM_DIR="/usr/lib64/llvm18/lib/cmake"
+        export Clang_DIR="/usr/lib64/llvm18/lib/cmake/clang"
+        export CC=clang-18
+        export CXX=clang++-18
         cmake -Bbuild-iwyu -GNinja -DCMAKE_BUILD_TYPE=Release include-what-you-use-0.22
         cmake --build build-iwyu --target install
 
@@ -82,6 +86,10 @@ jobs:
 
     - name: Build and scan WasmEdge with IWYU
       run: |
+        export LLVM_DIR="/usr/lib64/llvm18/lib/cmake"
+        export Clang_DIR="/usr/lib64/llvm18/lib/cmake/clang"
+        export CC=clang-18
+        export CXX=clang++-18
         cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug -DWASMEDGE_BUILD_TESTS=ON -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE=include-what-you-use .
         cmake --build build > iwyu_fedora.log
 

--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -325,7 +325,7 @@ function(wasmedge_setup_llama_target target)
     FetchContent_Declare(
       llama
       GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-      GIT_TAG        b3942
+      GIT_TAG        b4034
       GIT_SHALLOW    FALSE
     )
     FetchContent_MakeAvailable(llama)
@@ -365,6 +365,11 @@ function(wasmedge_setup_llama_target target)
         -Wno-unused-function
         -Wno-unused-variable
       )
+      # string_split<std::string> in common.h unused
+      target_compile_options(${target}
+        PRIVATE
+        -Wno-unused-function
+      )
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       target_compile_options(llava
         PRIVATE
@@ -386,6 +391,11 @@ function(wasmedge_setup_llama_target target)
         -Wno-format-nonliteral
         -Wno-documentation
         -Wno-unused-template
+      )
+      # string_split<std::string> in common.h unused
+      target_compile_options(${target}
+        PRIVATE
+        -Wno-unused-function
       )
     endif()
     target_link_libraries(llava PRIVATE ggml llama)

--- a/plugins/wasi_nn/wasinn_ggml.cpp
+++ b/plugins/wasi_nn/wasinn_ggml.cpp
@@ -402,13 +402,11 @@ ErrNo evaluateTokens(Graph &GraphRef, struct llama_context *LlamaContext,
     if (NEval > static_cast<int>(GraphRef.BatchSize)) {
       NEval = static_cast<int>(GraphRef.BatchSize);
     }
-    // llama_batch_get_one(*token, n_tokens, position, sequence_id)
-    // This will return batch for single sequence of tokens starting at
-    // position.
-    const llama_seq_id SequenceId = 0;
+    // llama_batch_get_one(*token, n_tokens)
+    // - Return batch for single sequence of tokens.
+    // - The sequence ID will be fixed to 0.
     auto Status =
-        llama_decode(LlamaContext,
-                     llama_batch_get_one(&Tokens[I], NEval, NPast, SequenceId));
+        llama_decode(LlamaContext, llama_batch_get_one(&Tokens[I], NEval));
     if (Status == 1) {
       spdlog::error(
           "[WASI-NN] GGML backend: failed to llama_decode: try reducing the size of the batch or increasing the size of context"sv);

--- a/test/plugins/wasi_nn/CMakeLists.txt
+++ b/test/plugins/wasi_nn/CMakeLists.txt
@@ -68,6 +68,12 @@ foreach(BACKEND ${WASMEDGE_PLUGIN_WASI_NN_BACKEND})
     if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
       target_compile_options(wasiNNTests PUBLIC
         /wd4067 # unexpected tokens following preprocessor directive - expected a newline
+        /wd4505 # unreferenced local function has been removed
+      )
+    else()
+      # string_split<std::string> in common.h unused
+      target_compile_options(wasiNNTests PUBLIC
+        -Wno-unused-function
       )
     endif()
   elseif(BACKEND STREQUAL "piper")


### PR DESCRIPTION
- Bump llama.cpp to b4034 for tool calling
- Use the new `llama_batch_get_one` API
- The `fedora:latest` is Fedora 41 and `llvm` in upgrade to 19 by default. Use `llvm18` to specify the llvm version.