### PR TITLE
[WASI] win: Use `ReadFile/WriteFile` instead of `ReadFileEx/WriteFileEx`

### DIFF
--- a/include/system/winapi.h
+++ b/include/system/winapi.h
@@ -386,10 +386,6 @@ using OVERLAPPED_ = struct _OVERLAPPED {
 };
 using LPOVERLAPPED_ = OVERLAPPED_ *;
 
-using LPOVERLAPPED_COMPLETION_ROUTINE_ = VOID_(WASMEDGE_WINAPI_WINAPI_CC *)(
-    DWORD_ dwErrorCode, DWORD_ dwNumberOfBytesTransfered,
-    LPOVERLAPPED_ lpOverlapped) noexcept;
-
 using REPARSE_DATA_BUFFER_ = struct _REPARSE_DATA_BUFFER {
   ULONG_ ReparseTag;
   USHORT_ ReparseDataLength;
@@ -798,11 +794,11 @@ WASMEDGE_WINAPI_SYMBOL_IMPORT WasmEdge::winapi::BOOL_ WASMEDGE_WINAPI_WINAPI_CC
 QueryPerformanceFrequency(WasmEdge::winapi::LARGE_INTEGER_ *lpFrequency);
 
 WASMEDGE_WINAPI_SYMBOL_IMPORT
-WasmEdge::winapi::BOOL_ WASMEDGE_WINAPI_WINAPI_CC ReadFileEx(
-    WasmEdge::winapi::HANDLE_ hFile, WasmEdge::winapi::LPVOID_ lpBuffer,
-    WasmEdge::winapi::DWORD_ nNumberOfBytesToRead,
-    WasmEdge::winapi::LPOVERLAPPED_ lpOverlapped,
-    WasmEdge::winapi::LPOVERLAPPED_COMPLETION_ROUTINE_ lpCompletionRoutine);
+WasmEdge::winapi::BOOL_ WASMEDGE_WINAPI_WINAPI_CC
+ReadFile(WasmEdge::winapi::HANDLE_ hFile, WasmEdge::winapi::LPVOID_ lpBuffer,
+         WasmEdge::winapi::DWORD_ nNumberOfBytesToRead,
+         WasmEdge::winapi::LPDWORD_ lpNumberOfBytesRead,
+         WasmEdge::winapi::LPOVERLAPPED_ lpOverlapped);
 
 WASMEDGE_WINAPI_SYMBOL_IMPORT
 WasmEdge::winapi::BOOL_ WASMEDGE_WINAPI_WINAPI_CC
@@ -845,11 +841,11 @@ int WASMEDGE_WINAPI_WINAPI_CC WideCharToMultiByte(
     WasmEdge::winapi::LPBOOL_ lpUsedDefaultChar);
 
 WASMEDGE_WINAPI_SYMBOL_IMPORT
-WasmEdge::winapi::BOOL_ WASMEDGE_WINAPI_WINAPI_CC WriteFileEx(
-    WasmEdge::winapi::HANDLE_ hFile, WasmEdge::winapi::LPCVOID_ lpBuffer,
-    WasmEdge::winapi::DWORD_ nNumberOfBytesToWrite,
-    WasmEdge::winapi::LPOVERLAPPED_ lpOverlapped,
-    WasmEdge::winapi::LPOVERLAPPED_COMPLETION_ROUTINE_ lpCompletionRoutine);
+WasmEdge::winapi::BOOL_ WASMEDGE_WINAPI_WINAPI_CC
+WriteFile(WasmEdge::winapi::HANDLE_ hFile, WasmEdge::winapi::LPCVOID_ lpBuffer,
+          WasmEdge::winapi::DWORD_ nNumberOfBytesToWrite,
+          WasmEdge::winapi::LPDWORD_ lpNumberOfBytesWritten,
+          WasmEdge::winapi::LPOVERLAPPED_ lpOverlapped);
 
 #if WINAPI_PARTITION_DESKTOP
 WASMEDGE_WINAPI_SYMBOL_IMPORT WasmEdge::winapi::HANDLE_
@@ -1051,7 +1047,7 @@ using ::GetSystemTimeAsFileTime;
 using ::MoveFileExW;
 using ::QueryPerformanceCounter;
 using ::QueryPerformanceFrequency;
-using ::ReadFileEx;
+using ::ReadFile;
 using ::RemoveDirectoryW;
 using ::SetEndOfFile;
 using ::SetFilePointerEx;
@@ -1060,7 +1056,7 @@ using ::SwitchToThread;
 using ::UnmapViewOfFile;
 using ::WaitForMultipleObjects;
 using ::WideCharToMultiByte;
-using ::WriteFileEx;
+using ::WriteFile;
 
 #if WINAPI_PARTITION_DESKTOP
 using ::CreateFileMappingW;

--- a/lib/host/wasi/inode-win.cpp
+++ b/lib/host/wasi/inode-win.cpp
@@ -25,9 +25,6 @@ namespace WASI {
 
 namespace {
 
-inline void WASMEDGE_WINAPI_WINAPI_CC
-EmptyOverlappedCompletionRoutine(DWORD_, DWORD_, LPOVERLAPPED_) noexcept {}
-
 #if WINAPI_PARTITION_DESKTOP
 inline constexpr uint64_t combineHighLow(uint32_t HighPart,
                                          uint32_t LowPart) noexcept {
@@ -961,8 +958,8 @@ WasiExpect<void> INode::fdPread(Span<Span<uint8_t>> IOVs,
     Query.Offset = LocalOffset.LowPart;
     Query.OffsetHigh = LocalOffset.HighPart;
     Query.hEvent = nullptr;
-    if (!ReadFileEx(Handle, IOV.data(), static_cast<uint32_t>(IOV.size()),
-                    &Query, &EmptyOverlappedCompletionRoutine)) {
+    if (!ReadFile(Handle, IOV.data(), static_cast<uint32_t>(IOV.size()),
+                  nullptr, &Query)) {
       if (unlikely(GetLastError() != ERROR_IO_PENDING_)) {
         Result = WasiUnexpect(detail::fromLastError(GetLastError()));
         Queries.resize(I);
@@ -1007,8 +1004,8 @@ WasiExpect<void> INode::fdPwrite(Span<Span<const uint8_t>> IOVs,
     Query.Offset = LocalOffset.LowPart;
     Query.OffsetHigh = LocalOffset.HighPart;
     Query.hEvent = nullptr;
-    if (!WriteFileEx(Handle, IOV.data(), static_cast<uint32_t>(IOV.size()),
-                     &Query, &EmptyOverlappedCompletionRoutine)) {
+    if (!WriteFile(Handle, IOV.data(), static_cast<uint32_t>(IOV.size()),
+                   nullptr, &Query)) {
       if (const auto Error = GetLastError();
           unlikely(Error != ERROR_IO_PENDING_ && Error != ERROR_HANDLE_EOF_)) {
         Result = WasiUnexpect(detail::fromLastError(Error));
@@ -1058,8 +1055,8 @@ WasiExpect<void> INode::fdRead(Span<Span<uint8_t>> IOVs,
     Query.Offset = LocalOffset.LowPart;
     Query.OffsetHigh = static_cast<DWORD_>(LocalOffset.HighPart);
     Query.hEvent = nullptr;
-    if (!ReadFileEx(Handle, IOV.data(), static_cast<uint32_t>(IOV.size()),
-                    &Query, &EmptyOverlappedCompletionRoutine)) {
+    if (!ReadFile(Handle, IOV.data(), static_cast<uint32_t>(IOV.size()),
+                  nullptr, &Query)) {
       if (unlikely(GetLastError() != ERROR_IO_PENDING_)) {
         Result = WasiUnexpect(detail::fromLastError(GetLastError()));
         Queries.resize(I);
@@ -1193,8 +1190,8 @@ WasiExpect<void> INode::fdWrite(Span<Span<const uint8_t>> IOVs,
       Query.OffsetHigh = 0xFFFFFFFF;
     }
     Query.hEvent = nullptr;
-    if (!WriteFileEx(Handle, IOV.data(), static_cast<uint32_t>(IOV.size()),
-                     &Query, &EmptyOverlappedCompletionRoutine)) {
+    if (!WriteFile(Handle, IOV.data(), static_cast<uint32_t>(IOV.size()),
+                   nullptr, &Query)) {
       if (const auto Error = GetLastError();
           unlikely(Error != ERROR_IO_PENDING_ && Error != ERROR_HANDLE_EOF_)) {
         Result = WasiUnexpect(detail::fromLastError(Error));


### PR DESCRIPTION
`GetOverlappedResult` occasionally succeeds but returns zero inlpNumberOfBytesTransferred`. After switching to
`ReadFile/WriteFile`, this issue no longer occurs.

* Fix #3811