### PR TITLE
[Component] fix: sizeof(ComponentSection)=uint64_t, but loadComponent takes uint32_t

### DIFF
--- a/include/loader/loader.h
+++ b/include/loader/loader.h
@@ -211,7 +211,7 @@ private:
   Expect<void> loadUniversalWASM(AST::Module &Mod);
   Expect<void> loadModuleAOT(AST::AOTSection &AOTSection);
   Expect<void> loadComponent(AST::Component::Component &Comp,
-                             std::optional<uint32_t> Bound = std::nullopt);
+                             std::optional<uint64_t> Bound = std::nullopt);
   /// @}
 
   /// \name Load AST section node helper functions

--- a/lib/loader/ast/component.cpp
+++ b/lib/loader/ast/component.cpp
@@ -101,7 +101,7 @@ Loader::loadUnit() {
 }
 
 Expect<void> Loader::loadComponent(AST::Component::Component &Comp,
-                                   std::optional<uint32_t> Bound) {
+                                   std::optional<uint64_t> Bound) {
   using namespace AST::Component;
 
   uint64_t StartOffset = FMgr.getOffset();


### PR DESCRIPTION
This fixed the Windows-MSVC build.