### PR TITLE
[DO NOT MERGE] tmp: show the IWYU errors on Fedora

### DIFF
--- a/.github/workflows/IWYU_scan.yml
+++ b/.github/workflows/IWYU_scan.yml
@@ -91,6 +91,8 @@ jobs:
         export CC=clang-18
         export CXX=clang++-18
         cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug -DWASMEDGE_BUILD_TESTS=ON -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE=include-what-you-use .
+        # Dump the output directly
+        cmake --build build
         cmake --build build > iwyu_fedora.log
 
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Figure out why the IWYU workflow on Fedora has failed.