### PR TITLE
[WASI-NN] Fix gaianet embeddings issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
 # WasmEdge CAPI and so versions.
 set(WASMEDGE_CAPI_VERSION "0.1.0" CACHE STRING "WasmEdge C API library version")
 set(WASMEDGE_CAPI_SOVERSION "0" CACHE STRING "WasmEdge C API library soversion")
-set(WASMEDGE_WASI_NN_VERSION "0.1.2" CACHE STRING "WasmEdge WASI-NN library version")
+set(WASMEDGE_WASI_NN_VERSION "0.1.3" CACHE STRING "WasmEdge WASI-NN library version")
 set(WASMEDGE_WASI_NN_SOVERSION "0" CACHE STRING "WasmEdge WASI-NN library soversion")
 
 # Set cpack package version.

--- a/plugins/wasi_nn/wasinn_ggml.h
+++ b/plugins/wasi_nn/wasinn_ggml.h
@@ -40,7 +40,7 @@ struct Graph {
   int64_t NGPULayers = 0;
   std::vector<float> TensorSplit;
   bool UseMMap = true;
-  bool WarmUp = true;
+  bool WarmUp = false;
   // Context parameters:
   uint64_t CtxSize;
   uint64_t BatchSize;


### PR DESCRIPTION
* [WASI-NN] ggml: disable warmup by default to match previous behavior
* [WASI-NN] ggml: reload llama context if embedding status changed
* [WASI-NN] bump to 0.1.3

After we changed the context initialization at commit https://github.com/WasmEdge/WasmEdge/commit/e80cdcd8d88b1a77960ec062eb9ddcf1212b648f, we should recreate the context when some parameters change (currently, only the ⁠embedding parameter). Additionally, I disabled warm-up by default to match the previous behavior.