### PR TITLE
[CMake] Link libfmt to the target in the static build

### DIFF
--- a/lib/api/CMakeLists.txt
+++ b/lib/api/CMakeLists.txt
@@ -138,6 +138,7 @@ if(WASMEDGE_BUILD_SHARED_LIB)
 endif()
 
 if(WASMEDGE_BUILD_STATIC_LIB)
+  wasmedge_add_static_lib_component_command(fmt::fmt)
   wasmedge_add_static_lib_component_command(spdlog::spdlog)
   wasmedge_add_static_lib_component_command(wasmedgeSystem)
   wasmedge_add_static_lib_component_command(wasmedgeCommon)


### PR DESCRIPTION
Fix undefined symbols related to fmt.

Based on the latest (0.14.1) release, libfmt.a is no longer included. Therefore, the previous method of actively linking libfmt.a at the FFI layer (build.rs) is no longer work.