### PR TITLE
[CI] Windows: use the preinstalled cmake as a workaround

### DIFF
--- a/.github/workflows/reusable-build-on-windows-msvc.yml
+++ b/.github/workflows/reusable-build-on-windows-msvc.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependency
         uses: crazy-max/ghaction-chocolatey@v3
         with:
-          args: install cmake ninja vswhere
+          args: install ninja vswhere
       - name: Install Windows SDK
         uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
         with:

--- a/.github/workflows/reusable-build-on-windows-msvc.yml
+++ b/.github/workflows/reusable-build-on-windows-msvc.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependency
         uses: crazy-max/ghaction-chocolatey@v3
         with:
-          args: install ninja vswhere
+          args: install --no-progress ninja vswhere
       - name: Install Windows SDK
         uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
         with:

--- a/.github/workflows/reusable-build-on-windows.yml
+++ b/.github/workflows/reusable-build-on-windows.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependency
         uses: crazy-max/ghaction-chocolatey@v3
         with:
-          args: install ninja
+          args: install --no-progress ninja
       - name: Upgrade dependency
         uses: crazy-max/ghaction-chocolatey@v3
         with:

--- a/.github/workflows/reusable-build-on-windows.yml
+++ b/.github/workflows/reusable-build-on-windows.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependency
         uses: crazy-max/ghaction-chocolatey@v3
         with:
-          args: install cmake ninja
+          args: install ninja
       - name: Upgrade dependency
         uses: crazy-max/ghaction-chocolatey@v3
         with:


### PR DESCRIPTION
See: https://github.com/actions/runner-images/issues/11174
It's not possible to install a specific version of cmake on the GitHub Windows Image currently.