### PR TITLE
Windows detection implemented inside check_os_arch() 

### DIFF
--- a/utils/install_v2.sh
+++ b/utils/install_v2.sh
@@ -195,6 +195,12 @@ check_os_arch() {
 			_LD_LIBRARY_PATH_="DYLD_LIBRARY_PATH"
 
 			;;
+		'Windows_NT' | MINGW*)
+			error "Detected ${OS} - currently unsupported"
+			eprintf "Please download WasmEdge manually from the release page:"
+			eprintf "https://github.com/WasmEdge/WasmEdge/releases/latest"
+			exit 1
+			;;
 		*)
 			error "Detected ${OS}-${ARCH} - currently unsupported"
 			eprintf "Use --os and --arch to specify the OS and ARCH"


### PR DESCRIPTION
Windows detection implemented inside check_os_arch() and removing empty lines
to resolve this issue (https://github.com/WasmEdge/WasmEdge/issues/3920)
Fixes #3920