### PR TITLE
Fix Typographical Errors

### DIFF
--- a/examples/capi/unix_domain_socket/README.md
+++ b/examples/capi/unix_domain_socket/README.md
@@ -17,7 +17,7 @@ Please follow the [installation step](https://emscripten.org/docs/getting_starte
 
 ### The Socket C++ Program to WASM
 
-A example signal thread server and a simple client are provided. The header file `wrapper.h` provided the `sock_*_v2` function signature let emcc to generate the api import.
+An example signal thread server and a simple client are provided. The header file `wrapper.h` provided the `sock_*_v2` function signature let emcc to generate the api import.
 
 The Unix Domain Socket use file path as input address, therefore the address format V2 are required. Unlike the address V1 has only 4 or 8 bytes. The address has fixed 128 bytes storage and make it large enough to store the unix path.
 

--- a/examples/capi/unix_domain_socket/README.md
+++ b/examples/capi/unix_domain_socket/README.md
@@ -38,7 +38,7 @@ emcc client.cpp -o client.wasm -sERROR_ON_UNDEFINED_SYMBOLS=0 -sSTANDALONE_WASM
 
 ## Results and Evaluation
 
-Try to input an string in client. The example server will return a reversed string to client.
+Try to input a string in client. The example server will return a reversed string to client.
 
 ### Client
 

--- a/examples/plugin/wasi-crypto-signature/README.md
+++ b/examples/plugin/wasi-crypto-signature/README.md
@@ -1,6 +1,6 @@
 # WasmEdge WASI-Crypto example
 
-This is a example for demonstrate how to use wasi-crypto plugin of WasmEdge in Rust which is adopted from wasi-crypto tests.
+This is an example for demonstrate how to use wasi-crypto plugin of WasmEdge in Rust which is adopted from wasi-crypto tests.
 
 ## Prerequisites
 


### PR DESCRIPTION
Specifically:  

1. Fixed improper use of articles ("a" vs. "an") in the following locations:  
   - **File**: `examples/capi/unix_domain_socket/README.md`  
     - Changed "A example" to "An example".  
     - Changed "an string" to "a string".  
   - **File**: `examples/plugin/wasi-crypto-signature/README.md`  
     - Changed "a example" to "an example".  

These changes improve the clarity and grammatical correctness of the documentation.  

## Checklist  
- [x] I have tested locally.  
- [x] I have performed a self-review of the changes.  
- [x] Documentation has been updated to reflect the changes.  

Allow edits by maintainers.  
