### PR TITLE
[WASI-NN] ChatTTS: modify compute function to be compatible with v0.2.1

### DIFF
--- a/.github/workflows/matrix-extensions.json
+++ b/.github/workflows/matrix-extensions.json
@@ -125,6 +125,17 @@
             ]
         },
         {
+            "plugin": "wasi_nn-chattts",
+            "bin": "libwasmedgePluginWasiNN",
+            "dir": "wasi_nn",
+            "target": "wasmedgePluginWasiNN",
+            "testBin": "wasiNNTests",
+            "options": "-DWASMEDGE_PLUGIN_WASI_NN_BACKEND=ChatTTS",
+            "platforms": [
+                "ubuntu_latest"
+            ]
+        },
+        {
             "plugin": "wasm_bpf",
             "bin": "libwasmedgePluginWasmBpf",
             "dir": "wasm_bpf",

--- a/plugins/wasi_nn/wasinn_chattts.cpp
+++ b/plugins/wasi_nn/wasinn_chattts.cpp
@@ -292,8 +292,11 @@ Expect<WASINN::ErrNo> compute(WasiNNEnvironment &Env,
     Py_XDECREF(Kwargs);
   }
   if (Result != nullptr) {
-    PyObject *Wav0 = PyList_GetItem(Result, 0);
+    PyObject *Index = PyLong_FromLong(0);
+    PyObject *Wav0 = PyObject_GetItem(Result, Index);
+    Py_XDECREF(Index);
     PyObject *BytesObj = PyObject_CallMethod(Wav0, "tobytes", nullptr);
+    Py_XDECREF(Wav0);
     char *Bytes = PyBytes_AsString(BytesObj);
     Py_ssize_t size = PyBytes_Size(BytesObj);
     CxtRef.Outputs = std::vector<uint8_t>(Bytes, Bytes + size);

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -20,6 +20,7 @@ using namespace std::literals;
 using WasmEdge::Host::WASINN::Backend;
 using WasmEdge::Host::WASINN::Device;
 using WasmEdge::Host::WASINN::ErrNo;
+using WasmEdge::Host::WASINN::TensorType;
 
 #if defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_OPENVINO) ||                       \
     defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_TORCH) ||                          \
@@ -2730,7 +2731,7 @@ TEST(WasiNNTest, ChatTTSBackend) {
   // ChatTTS WASI-NN set_input tests.
   SetInputEntryPtr = BuilderPtr;
   writeFatPointer(MemInst, StorePtr, TensorDim.size(), BuilderPtr);
-  writeUInt32(MemInst, UINT32_C(2), BuilderPtr);
+  writeUInt32(MemInst, static_cast<uint32_t>(TensorType::U8), BuilderPtr);
   writeFatPointer(MemInst, StorePtr + TensorDim.size() * 4, TensorData.size(),
                   BuilderPtr);
   writeBinaries<uint32_t>(MemInst, TensorDim, StorePtr);
@@ -2777,7 +2778,7 @@ TEST(WasiNNTest, ChatTTSBackend) {
   // Test: setInput -- set metadata successfully.
   SetInputEntryPtr = BuilderPtr;
   writeFatPointer(MemInst, StorePtr, TensorDim.size(), BuilderPtr);
-  writeUInt32(MemInst, UINT32_C(2), BuilderPtr);
+  writeUInt32(MemInst, static_cast<uint32_t>(TensorType::U8), BuilderPtr);
   writeFatPointer(MemInst, StorePtr + TensorDim.size() * 4, ConfigData.size(),
                   BuilderPtr);
   writeBinaries<uint32_t>(MemInst, TensorDim, StorePtr);


### PR DESCRIPTION
In chattts v0.1.1, ChatTTS.Chat.infer returns a Python list.
In chattts v0.2.1, ChatTTS.Chat.infer returns a numpy.ndarray.

Use PyObject_GetItem (the equivalent of the Python expression o[index]) instead of PyList_GetItem (works only for list).
