### PR TITLE
[WASI-NN] ggml: update options types and embeddings generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
 # WasmEdge CAPI and so versions.
 set(WASMEDGE_CAPI_VERSION "0.1.0" CACHE STRING "WasmEdge C API library version")
 set(WASMEDGE_CAPI_SOVERSION "0" CACHE STRING "WasmEdge C API library soversion")
-set(WASMEDGE_WASI_NN_VERSION "0.1.5" CACHE STRING "WasmEdge WASI-NN library version")
+set(WASMEDGE_WASI_NN_VERSION "0.1.6" CACHE STRING "WasmEdge WASI-NN library version")
 set(WASMEDGE_WASI_NN_SOVERSION "0" CACHE STRING "WasmEdge WASI-NN library soversion")
 
 # Set cpack package version.

--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -326,7 +326,7 @@ function(wasmedge_setup_llama_target target)
     FetchContent_Declare(
       llama
       GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-      GIT_TAG        b4381
+      GIT_TAG        b4400
       GIT_SHALLOW    FALSE
     )
     FetchContent_MakeAvailable(llama)

--- a/plugins/wasi_nn/wasinn_ggml.cpp
+++ b/plugins/wasi_nn/wasinn_ggml.cpp
@@ -604,7 +604,8 @@ Expect<ErrNo> getEmbedding(WasiNNEnvironment &Env,
 
   // Add SEP if not present.
   if (CxtRef.LlamaInputs.back() != llama_token_sep(GraphRef.LlamaModel)) {
-    CxtRef.LlamaInputs.push_back(llama_token_sep(GraphRef.LlamaModel));
+    spdlog::warn(
+        "[WASI-NN] GGML backend: last token in the prompt is not SEP, 'tokenizer.ggml.add_eos_token' should be set to 'true' in the GGUF header"sv);
   }
 
   // Check if the input is too long.

--- a/plugins/wasi_nn/wasinn_ggml.h
+++ b/plugins/wasi_nn/wasinn_ggml.h
@@ -49,7 +49,7 @@ struct Graph {
   bool Embedding = false;
   EmbdNormalizeType EmbdNormalize = EmbdNormalizeType::Euclidean;
   bool ComputeSingleStarted = false;
-  uint64_t NPredict;
+  int64_t NPredict;
   std::string ReversePrompt;
   std::string MMProjModelPath;
   std::string ImagePath;
@@ -61,10 +61,10 @@ struct Graph {
   bool UseMMap = true;
   bool WarmUp = false;
   // Context parameters:
-  uint64_t CtxSize;
-  uint64_t BatchSize;
-  uint64_t UBatchSize;
-  uint64_t Threads;
+  int64_t CtxSize;
+  int64_t BatchSize;
+  int64_t UBatchSize;
+  int64_t Threads;
   // Sampling parameters:
   double Temp = 0.80;
   double TopP = 0.95;


### PR DESCRIPTION
- Update option types according to llama.cpp
  - In llama.cpp, the types of context parameters and common parameters are actually different.
  - For instance, `cparams.n_ctx` is `uint32_t` while `params.n_ctx` is `int32_t`.
  - This is because some parameters are initially set in common params and are only assigned to context params after evaluation.
  - The ggml plugin mainly follows the types of common params.
  - Ref:
    - https://github.com/ggerganov/llama.cpp/blob/master/common/common.h
    - https://github.com/ggerganov/llama.cpp/blob/master/include/llama.h
- Do not append SEP when getting embeddings
  - Ref: https://github.com/ggerganov/llama.cpp/blob/7eee341/examples/embedding/embedding.cpp#L147-L154
- Bump llama.cpp version and WASI-NN plugin version
