### PR TITLE
[Docs] Rust 1.84 uses wasm32-wasip1 instead of wasm32-wasi

### DIFF
--- a/examples/capi/wasi-env/README.md
+++ b/examples/capi/wasi-env/README.md
@@ -67,14 +67,14 @@ clang set_wasi_env.c -o set_wasm_env -lwasmedge
 For building the WASM from the rust source, the following steps are required:
 
 * Install the [rust and cargo](https://www.rust-lang.org/tools/install).
-* Install the `wasm32-wasi` target: `$ rustup target add wasm32-wasi`
+* Install the `wasm32-wasip1` target: `$ rustup target add wasm32-wasip1`
 
 ```bash
 cd rust
-cargo build --release --target=wasm32-wasi
-# The output wasm will be at `target/wasm32-wasi/release/wasi_get_env.wasm`.
+cargo build --release --target=wasm32-wasip1
+# The output wasm will be at `target/wasm32-wasip1/release/wasi_get_env.wasm`.
 # Copy it to the same level of set_wasi_env.c
-cp ./target/wasm32-wasi/release/wasi_get_env.wasm ../
+cp ./target/wasm32-wasip1/release/wasi_get_env.wasm ../
 ```
 
 ## Run

--- a/examples/plugin/wasi-crypto-signature/README.md
+++ b/examples/plugin/wasi-crypto-signature/README.md
@@ -6,11 +6,11 @@ This is an example for demonstrate how to use wasi-crypto plugin of WasmEdge in 
 
 ### Install Rust
 
-Follow the instructions below to install rust and wasm32-wasi target.
+Follow the instructions below to install rust and wasm32-wasip1 target.
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 ### Install WasmEdge and WASI-crypto plugin
@@ -33,17 +33,17 @@ export WASMEDGE_PLUGIN_PATH=$PWD/plugins/wasi_crypto
 ## Build the example
 
 ```bash
-cargo b --target wasm32-wasi
+cargo b --target wasm32-wasip1
 ```
 
-Then we get `target/wasm32-wasi/debug/wasi-crypto-example.wasm`.
+Then we get `target/wasm32-wasip1/debug/wasi-crypto-example.wasm`.
 
 ## Run the example
 
 We can run this example with `wasmedge` like
 
 ```bash
-wasmedge target/wasm32-wasi/debug/wasi-crypto-example.wasm
+wasmedge target/wasm32-wasip1/debug/wasi-crypto-example.wasm
 ```
 
 This example should run successfully and print out the signatures as follows.

--- a/examples/plugin/wasi-logging/README.md
+++ b/examples/plugin/wasi-logging/README.md
@@ -6,11 +6,11 @@ This is an example of using the WASI-Logging plugin of WasmEdge in Rust.
 
 ### Install Rust
 
-Follow the instructions below to install Rust and wasm32-wasi target.
+Follow the instructions below to install Rust and wasm32-wasip1 target.
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 ### Install WasmEdge and WASI-Logging plugin
@@ -40,10 +40,10 @@ cp -r wit /path/to/wasmedge/examples/plugin/wasi-logging
 ## Build the example
 
 ```sh
-cargo build --target wasm32-wasi
+cargo build --target wasm32-wasip1
 ```
 
-Then we get `target/wasm32-wasi/debug/wasi-logging-example.wasm`.
+Then we get `target/wasm32-wasip1/debug/wasi-logging-example.wasm`.
 
 ## Logging context
 
@@ -54,7 +54,7 @@ For the logging context of the `log` function in Rust, developers can use the `"
 We can run this example with `wasmedge` like
 
 ```sh
-wasmedge target/wasm32-wasi/debug/wasi-logging-example.wasm
+wasmedge target/wasm32-wasip1/debug/wasi-logging-example.wasm
 ```
 
 This example should run successfully and print out the log as follow.

--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -48,8 +48,8 @@ The `hello.wasm` example is a WebAssembly which compiled from a Rust application
 If you want to compile it, please [install Rust toolchain](https://www.rust-lang.org/tools/install). And then use the following commands in the `hello` folder:
 
 ```bash
-cargo build --offline --release --target=wasm32-wasi
-# The hello.wasm will be located at `target/wasm32-wasi/release/hello.wasm`
+cargo build --offline --release --target=wasm32-wasip1
+# The hello.wasm will be located at `target/wasm32-wasip1/release/hello.wasm`
 ```
 
 ```bash


### PR DESCRIPTION
Well, Rust changed the wasm triple from wasm32-wasi to wasm32-wasip1 ◡ ヽ(`Д´)ﾉ ┻━┻
That's why we have to change the docs.