### PR TITLE
[CI] Fix failure after upgrading `docker/bake-action`, and remove unused `actions/checkout`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -104,9 +104,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -145,9 +142,6 @@ jobs:
       image: wasmedge/wasmedge:ci-image-base
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -201,9 +195,6 @@ jobs:
       image: ${{ matrix.host_container }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/reusable-build-on-alpine-static.yml
+++ b/.github/workflows/reusable-build-on-alpine-static.yml
@@ -8,10 +8,10 @@ on:
         required: true
       release:
         type: boolean
-        
+
 permissions:
       contents: read
-      
+
 jobs:
   build_on_alpine_static:
     permissions:
@@ -31,6 +31,7 @@ jobs:
       - name: Build WasmEdge
         uses: docker/bake-action@v6
         with:
+          source: .
           files: ./utils/docker/docker-bake.alpine-static.hcl
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/reusable-build-on-debian-static.yml
+++ b/.github/workflows/reusable-build-on-debian-static.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Build WasmEdge
         uses: docker/bake-action@v6
         with:
+          source: .
           files: ./utils/docker/docker-bake.debian-static.hcl
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- According to the new doc of `docker/bake-action`, we don't need to do checkout anymore.
- For alpine-static and debian-static, we need `git describe` to fetch current version.

See #3971