### PR TITLE
[CI] Add groups and prefix for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,15 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    commit-message:
+      # Prefix for PR title and commit messages
+      prefix: "[CI] dependabot"
+    groups:
+      # Group updates, actions that match are grouped into a single PR;
+      # dependabot should still raise a PR for each of the remaining actions
+      upload-and-download-artifact:
+        patterns:
+          - "*load-artifact"
+      docker:
+        patterns:
+          - "docker/*"


### PR DESCRIPTION
Expected PR should look like
```
[CI] dependabot: bump actions/checkout from 3 to 4
[CI] dependabot: bump the docker group with 2 updates
```

After #3850 merged, we should also update prefix from `[CI] dependabot` to `ci(dependabot)`.