### PR TITLE
[WASI-NN] ggml: tts writes wav to output buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
 # WasmEdge CAPI and so versions.
 set(WASMEDGE_CAPI_VERSION "0.1.0" CACHE STRING "WasmEdge C API library version")
 set(WASMEDGE_CAPI_SOVERSION "0" CACHE STRING "WasmEdge C API library soversion")
-set(WASMEDGE_WASI_NN_VERSION "0.1.11" CACHE STRING "WasmEdge WASI-NN library version")
+set(WASMEDGE_WASI_NN_VERSION "0.1.12" CACHE STRING "WasmEdge WASI-NN library version")
 set(WASMEDGE_WASI_NN_SOVERSION "0" CACHE STRING "WasmEdge WASI-NN library soversion")
 
 # Set cpack package version.

--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -326,7 +326,7 @@ function(wasmedge_setup_llama_target target)
     FetchContent_Declare(
       llama
       GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-      GIT_TAG        b4681
+      GIT_TAG        b4743
       GIT_SHALLOW    FALSE
     )
     FetchContent_MakeAvailable(llama)

--- a/plugins/wasi_nn/wasinn_ggml.h
+++ b/plugins/wasi_nn/wasinn_ggml.h
@@ -85,7 +85,7 @@ public:
   std::vector<llama_token> LlamaInputs;
   uint64_t LlamaNInputs = 0;
   // Llama outputs:
-  std::string LlamaOutputs;
+  std::vector<uint8_t> LlamaOutputs;
   std::vector<llama_token> LlamaOutputTokens;
   // Preserve for llava
   struct llava_image_embed *LlavaImageEmbd = nullptr;


### PR DESCRIPTION
- Change `LlamaOutputs` from `string` to `vector<uint8_t>`.
- Save the tts output audio to the output buffer.
- I think it's better to merge this PR after #3995 to avoid more conflict in that PR.
- Upgrade llama.cpp to b4743.