### PR TITLE
[CMake] Enable Metal for stable-diffusion by default

### DIFF
--- a/.github/extensions.paths-filter.yml
+++ b/.github/extensions.paths-filter.yml
@@ -1,5 +1,6 @@
 all:
   - '.github/**'
+  - 'CMakeLists.txt'
   - 'plugins/CMakeLists.txt'
   - 'test/plugins/CMakeLists.txt'
 wasi_crypto:

--- a/.github/workflows/matrix-extensions.json
+++ b/.github/workflows/matrix-extensions.json
@@ -240,16 +240,6 @@
             ]
         },
         {
-            "plugin": "wasmedge_stablediffusion-metal",
-            "bin": "libwasmedgePluginWasmEdgeStableDiffusion",
-            "dir": "wasmedge_stablediffusion",
-            "target": "wasmedgePluginWasmEdgeStableDiffusion",
-            "options": "-DWASMEDGE_PLUGIN_STABLEDIFFUSION=ON -DWASMEDGE_PLUGIN_STABLEDIFFUSION_METAL=ON",
-            "platforms": [
-                "macos_arm64"
-            ]
-        },
-        {
             "plugin": "wasmedge_tensorflow",
             "bin": "libwasmedgePluginWasmEdgeTensorflow",
             "dir": "wasmedge_tensorflow",

--- a/.github/workflows/reusable-build-extensions-on-macos.yml
+++ b/.github/workflows/reusable-build-extensions-on-macos.yml
@@ -36,9 +36,6 @@ jobs:
       test_dir: build/test/plugins/${{ matrix.dir }}
       output_dir: build/plugins/${{ matrix.dir }}
     steps:
-      - id: var
-        run: |
-          echo "artifact=WasmEdge-plugin-${{ matrix.plugin }}-${{ inputs.version }}-${{ inputs.asset_tag }}.tar.gz" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -55,6 +52,7 @@ jobs:
           export OpenSSL_DIR="$(brew --prefix)/opt/openssl"
           export CC=clang
           export CXX=clang++
+
           cmake -Bbuild -GNinja \
             -DCMAKE_BUILD_TYPE=Release \
             -DWASMEDGE_BUILD_TESTS=${{ inputs.release && 'OFF' || 'ON' }} \
@@ -63,19 +61,36 @@ jobs:
             -DOPENSSL_ROOT_DIR=${OpenSSL_DIR} \
             ${{ matrix.options }}
           cmake --build build --target ${target}
-      - if: ${{ !endsWith(matrix.plugin, 'metal') }}
-        name: Package ${{ matrix.plugin }}
+      - id: var
+        run: |
+          export prefix="WasmEdge-plugin-${{ matrix.plugin }}"
+          export postfix="${{ inputs.version }}-${{ inputs.asset_tag }}"
+
+          echo "artifact=${prefix}-${postfix}.tar.gz" >> $GITHUB_OUTPUT
+          echo "artifact_test=${prefix}-no-metal-${postfix}.tar.gz" >> $GITHUB_OUTPUT
+          echo "artifacts=${prefix}-*.tar.gz" >> $GITHUB_OUTPUT
+      - name: Package ${{ matrix.plugin }}
+        shell: bash
         run: |
           cp -f ${output_dir}/${bin_name} ${bin_name}
           tar -zcvf ${{ steps.var.outputs.artifact }} ${bin_name}
-      - if: ${{ endsWith(matrix.plugin, 'metal') }}
-        name: Package ${{ matrix.plugin }} with metal files
+      - if: ${{ !inputs.release && contains(matrix.plugin, 'stablediffusion') && contains(inputs.asset_tag, 'arm64') }}
+        name: Rebuild with METAL=OFF for testing
         run: |
-          export FILES="${bin_name} ggml-metal.metal ggml-common.h"
-          for file_name in $FILES; do
-            cp -f ${output_dir}/${file_name} .
-          done
-          tar -zcvf ${{ steps.var.outputs.artifact }} ${FILES}
+          rm -rf build/
+
+          cmake -Bbuild -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DWASMEDGE_BUILD_TESTS=ON \
+            -DWASMEDGE_BUILD_TOOLS=OFF \
+            -DWASMEDGE_USE_LLVM=OFF \
+            -DWASMEDGE_PLUGIN_STABLEDIFFUSION_METAL=OFF \
+            -DOPENSSL_ROOT_DIR=${OpenSSL_DIR} \
+            ${{ matrix.options }}
+          cmake --build build --target ${target}
+
+          cp -f ${output_dir}/${bin_name} ${bin_name}
+          tar -zcvf ${{ steps.var.outputs.artifact_test }} ${bin_name}
       - if: ${{ !inputs.release }}
         name: Test ${{ matrix.plugin }}
         run: |
@@ -92,7 +107,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.var.outputs.artifact }}
-          path: ${{ steps.var.outputs.artifact }}
+          path: ${{ steps.var.outputs.artifacts }}
       - if: ${{ inputs.release }}
         name: Install gh for release
         run: |

--- a/.github/workflows/reusable-build-extensions.yml
+++ b/.github/workflows/reusable-build-extensions.yml
@@ -17,14 +17,14 @@ jobs:
   #
   # 'paths-filter' example:
   #
-  #   wasmedge_stablediffusion:
-  #     - paths/to/wasmedge_stablediffusion
-  #     - other/paths/to/wasmedge_stablediffusion
+  #   wasi_nn:
+  #     - paths/to/wasi_nn
+  #     - other/paths/to/wasi_nn
   #
-  # plugin: 'wasmedge_stablediffusion-metal'
+  # plugin: 'wasi_nn-ggml'
   #
-  #   process.env['wasmedge_stablediffusion'] => true
-  #   process.env['wasmedge_stablediffusion-metal'] => undefined
+  #   process.env['wasi_nn'] => true
+  #   process.env['wasi_nn-ggml'] => undefined
   # ------------------------------------------------------------------#
   prepare:
     name: Prepare ${{ inputs.asset_tag }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ option(WASMEDGE_PLUGIN_PROCESS "Enable and build WasmEdge process plugin." OFF)
 #   WasmEdge plug-in: Stable-diffusion.
 option(WASMEDGE_PLUGIN_STABLEDIFFUSION "Enable and build WasmEdge stable-diffusion plugin." OFF)
 option(WASMEDGE_PLUGIN_STABLEDIFFUSION_CUDA "Enable CUDA in the stable-diffusion plugin." OFF)
-option(WASMEDGE_PLUGIN_STABLEDIFFUSION_METAL "Enable Metal in the stable-diffusion plugin." OFF)
+option(WASMEDGE_PLUGIN_STABLEDIFFUSION_METAL "Enable Metal in the stable-diffusion plugin." ON)
 option(WASMEDGE_PLUGIN_STABLEDIFFUSION_OPENMP "Enable OpenMP in the stable-diffusion plugin." OFF)
 #   WasmEdge plug-in: TensorFlow.
 option(WASMEDGE_PLUGIN_TENSORFLOW "Enable and build WasmEdge TensorFlow plugin." OFF)

--- a/plugins/wasmedge_stablediffusion/CMakeLists.txt
+++ b/plugins/wasmedge_stablediffusion/CMakeLists.txt
@@ -99,25 +99,16 @@ else()
   target_compile_options(
     stable-diffusion
     PRIVATE
-		-Wno-unused-function
-		-Wno-unused-variable
-		-Wno-unused-parameter
-		-Wno-missing-field-initializers
+    -Wno-unused-function
+    -Wno-unused-variable
+    -Wno-unused-parameter
+    -Wno-missing-field-initializers
     -Wno-deprecated-declarations
     -Wno-braced-scalar-init
     -Wno-unused-value
     -Wno-uninitialized
     -Wno-format
     -Wno-enum-compare
-	)
-endif()
-
-if(WASMEDGE_PLUGIN_STABLEDIFFUSION_METAL)
-  add_custom_command(
-    TARGET wasmedgePluginWasmEdgeStableDiffusion
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${stable-diffusion_SOURCE_DIR}/ggml/src/ggml-metal/ggml-metal.metal ggml-metal.metal
-    COMMAND ${CMAKE_COMMAND} -E copy ${stable-diffusion_SOURCE_DIR}/ggml/src/ggml-common.h ggml-common.h
   )
 endif()
 


### PR DESCRIPTION
The refactor of workflows caused #3757 happened again.

This PR changed the default value for `WASMEDGE_PLUGIN_STABLEDIFFUSION_METAL` to `ON` (also to be consistent with `WASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_METAL` and  `WASMEDGE_PLUGIN_WASI_NN_WHISPER_METAL`) and updated related workflows; also added `CMakeLists.txt` to paths-filter of all plugins.