### PR TITLE
[CI] Test WasmEdge (Core) on Ubuntu 20.04 (x86_64)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,7 +15,7 @@ This document has not yet covered all workflows.
 | Ubuntu 24.04 | x86_64 | clang | `ubuntu-24.04-build-clang` | o ||
 | Ubuntu 24.04 | x86_64 | gcc | `ubuntu-24.04-build-gcc` | o ||
 | Ubuntu 22.04 | x86_64 | gcc | `ubuntu-22.04-build-gcc` | coverage ||
-| Ubuntu 20.04 | x86_64 | clang | `ubuntu-20.04-build-clang` || o |
+| Ubuntu 20.04 | x86_64 | clang | `ubuntu-20.04-build-clang` | o | o |
 | Ubuntu 20.04 | aarch64 | clang | `ubuntu-20.04-build-clang-aarch64` | o | o |
 
 ### WasmEdge plugins

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,7 @@ jobs:
                 {'name':'ubuntu-24.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'g++','build_type':'Release','docker_tag':'ubuntu-24.04-build-gcc','tests':true},
                 {'name':'ubuntu-24.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Debug','docker_tag':'ubuntu-24.04-build-clang','tests':true},
                 {'name':'ubuntu-24.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-24.04-build-clang','tests':true},
+                {'name':'ubuntu-20.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-20.04-build-clang','tests':true},
                 {'name':'ubuntu-20.04','arch':'aarch64','runner':'linux-arm64-v2','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-20.04-build-clang-aarch64','tests':true},
                 {'name':'linux-static','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-24.04-build-clang','options':'-DWASMEDGE_BUILD_SHARED_LIB=Off -DWASMEDGE_BUILD_STATIC_LIB=On -DWASMEDGE_LINK_TOOLS_STATIC=On -DWASMEDGE_BUILD_PLUGINS=Off'},
                 {'name':'ubuntu-22.04-coverage','arch':'x86_64','runner':'ubuntu-latest','compiler':'g++','build_type':'Debug','docker_tag':'ubuntu-22.04-build-gcc','coverage':true,'tests':true}]"


### PR DESCRIPTION
WasmEdge release for Ubuntu is built on Ubuntu 20.04, but no tests were run for the exact same settings.