### PR TITLE
[System] allocator: clarify the condition of mmap checking

### DIFF
--- a/lib/system/allocator.cpp
+++ b/lib/system/allocator.cpp
@@ -9,8 +9,9 @@
 
 #if WASMEDGE_OS_WINDOWS
 #include "system/winapi.h"
-#elif defined(HAVE_MMAP) && defined(__x86_64__) || defined(__aarch64__) ||     \
-    defined(__arm__) || (defined(__riscv) && __riscv_xlen == 64)
+#elif defined(HAVE_MMAP) &&                                                    \
+    (defined(__x86_64__) || defined(__aarch64__) || defined(__arm__) ||        \
+     (defined(__riscv) && __riscv_xlen == 64))
 #include <sys/mman.h>
 #else
 #include <cctype>


### PR DESCRIPTION
According to the test, this could also fix the AOT issue.
See: https://github.com/hydai/debug_wasm_test/actions/runs/13699609921/job/38309919463

Maybe this can replace https://github.com/WasmEdge/WasmEdge/pull/4049

cc @q82419 