### PR TITLE
Update `0.14.1_plugin_lts` branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
 # WasmEdge CAPI and so versions.
 set(WASMEDGE_CAPI_VERSION "0.1.0" CACHE STRING "WasmEdge C API library version")
 set(WASMEDGE_CAPI_SOVERSION "0" CACHE STRING "WasmEdge C API library soversion")
-set(WASMEDGE_WASI_NN_VERSION "0.1.14" CACHE STRING "WasmEdge WASI-NN library version")
+set(WASMEDGE_WASI_NN_VERSION "0.1.15" CACHE STRING "WasmEdge WASI-NN library version")
 set(WASMEDGE_WASI_NN_SOVERSION "0" CACHE STRING "WasmEdge WASI-NN library soversion")
 
 # Set cpack package version.

--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -326,7 +326,7 @@ function(wasmedge_setup_llama_target target)
     FetchContent_Declare(
       llama
       GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-      GIT_TAG        b4818
+      GIT_TAG        b4875
       GIT_SHALLOW    FALSE
     )
     FetchContent_MakeAvailable(llama)

--- a/plugins/wasi_nn/wasinn_ggml.cpp
+++ b/plugins/wasi_nn/wasinn_ggml.cpp
@@ -1739,14 +1739,14 @@ ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
                 "Unable to retrieve the spm-infill option."sv)
     }
   }
-  if (Doc.at_key("lora-outfile").error() == simdjson::SUCCESS) {
-    std::string_view LoraOutfile;
-    auto Err = Doc["lora-outfile"].get<std::string_view>().get(LoraOutfile);
+  if (Doc.at_key("out-file").error() == simdjson::SUCCESS) {
+    std::string_view Outfile;
+    auto Err = Doc["out-file"].get<std::string_view>().get(Outfile);
     if (Err) {
       RET_ERROR(ErrNo::InvalidArgument,
-                "Unable to retrieve the lora-outfile option."sv)
+                "Unable to retrieve the outfile option."sv)
     }
-    GraphRef.Params.lora_outfile = LoraOutfile;
+    GraphRef.Params.out_file = Outfile;
   }
   if (Doc.at_key("batched-bench-output-jsonl").error() == simdjson::SUCCESS) {
     auto Err = Doc["batched-bench-output-jsonl"].get<bool>().get(


### PR DESCRIPTION
* Starts from b4875: support gemma-3 text-only model
* Rename lora_outfile to out_file