### PR TITLE
Update `0.14.1_plugin_lts` branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
 # WasmEdge CAPI and so versions.
 set(WASMEDGE_CAPI_VERSION "0.1.0" CACHE STRING "WasmEdge C API library version")
 set(WASMEDGE_CAPI_SOVERSION "0" CACHE STRING "WasmEdge C API library soversion")
-set(WASMEDGE_WASI_NN_VERSION "0.1.15" CACHE STRING "WasmEdge WASI-NN library version")
+set(WASMEDGE_WASI_NN_VERSION "0.1.16" CACHE STRING "WasmEdge WASI-NN library version")
 set(WASMEDGE_WASI_NN_SOVERSION "0" CACHE STRING "WasmEdge WASI-NN library soversion")
 
 # Set cpack package version.

--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -326,7 +326,7 @@ function(wasmedge_setup_llama_target target)
     FetchContent_Declare(
       llama
       GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-      GIT_TAG        b4875
+      GIT_TAG        b4897
       GIT_SHALLOW    FALSE
     )
     FetchContent_MakeAvailable(llama)

--- a/plugins/wasi_nn/wasinn_ggml.cpp
+++ b/plugins/wasi_nn/wasinn_ggml.cpp
@@ -2294,7 +2294,7 @@ ErrNo evaluateInput(Graph &GraphRef, Context &CxtRef,
             "{}: clear the previous output and tokens...Done"sv, LogPrefix)
 
   // Clear the llama context.
-  llama_kv_cache_clear(GraphRef.LlamaContext.get());
+  llama_kv_self_clear(GraphRef.LlamaContext.get());
 
   // Prepare variables;
   CxtRef.NPos = 0;
@@ -3068,7 +3068,7 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
 
   // Clear the llama context.
   LOG_DEBUG(GraphRef.EnableDebugLog, "setInput: clear llama context"sv)
-  llama_kv_cache_clear(GraphRef.LlamaContext.get());
+  llama_kv_self_clear(GraphRef.LlamaContext.get());
   LOG_DEBUG(GraphRef.EnableDebugLog, "setInput: clear llama context...Done"sv)
 
   // Set the input.


### PR DESCRIPTION
[WASI-NN] ggml: bump to b4897; bump wasi-nn plugin to 0.1.16 (#4058)
Replace llama_kv_cache_clear with llama_kv_self_clear. The API is changed by llama.cpp upstream.