### PR TITLE
[Component Validation] Validate instantiate imports and arguments

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1074,6 +1074,14 @@ E(UnknownCanonicalOption, 0x050A, "unknown canonical option")
 E(MalformedName, 0x050B, "malformed name")
 // @}
 
+// Component model validation phase
+// @{
+// Unknown Argument
+E(UnknownArgument, 0x050C, "unknown argument")
+// Argument Type Mismatch with Import Type
+E(ArgTypeMismatch, 0x050D, "type mismatch")
+// @}
+
 // Component model instantiation phase
 // @{
 E(CoreInvalidExport, 0x0600, "invalid export in core module")

--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1076,10 +1076,14 @@ E(MalformedName, 0x050B, "malformed name")
 
 // Component model validation phase
 // @{
-// Unknown Argument
-E(UnknownArgument, 0x050C, "unknown argument")
+// Missing Argument
+E(MissingArgument, 0x050C, "missing argument")
 // Argument Type Mismatch with Import Type
 E(ArgTypeMismatch, 0x050D, "type mismatch")
+// Extra Import(s)
+E(UnexpectedImport, 0x050E, "unexpected import")
+// Extra Argument(s)
+E(UnexpectedArgument, 0x050F, "unexpected argument")
 // @}
 
 // Component model instantiation phase

--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1080,10 +1080,6 @@ E(MalformedName, 0x050B, "malformed name")
 E(MissingArgument, 0x050C, "missing argument")
 // Argument Type Mismatch with Import Type
 E(ArgTypeMismatch, 0x050D, "type mismatch")
-// Extra Import(s)
-E(UnexpectedImport, 0x050E, "unexpected import")
-// Extra Argument(s)
-E(UnexpectedArgument, 0x050F, "unexpected argument")
 // @}
 
 // Component model instantiation phase

--- a/include/validator/validator_component.h
+++ b/include/validator/validator_component.h
@@ -77,19 +77,21 @@ struct InstanceExprVisitor {
     auto Args = Inst.getArgs();
     auto ImportMap = getImports(Inst.getComponentIdx());
 
-    for (const auto &[ImportName, ImportDesc] : ImportMap) {
-      auto it = std::find_if(Args.begin(), Args.end(), [&](const auto &Arg) {
+    for (auto it = ImportMap.begin(); it != ImportMap.end(); ++it) {
+      const auto &ImportName = it->first;
+      const auto &ImportDesc = it->second;
+      auto argIt = std::find_if(Args.begin(), Args.end(), [&](const auto &Arg) {
         return Arg.getName() == ImportName;
       });
 
-      if (it == Args.end()) {
+      if (argIt == Args.end()) {
         spdlog::error(ErrCode::Value::MissingArgument);
         spdlog::error("Component[{}]: Missing argument for import '{}'",
                       Inst.getComponentIdx(), ImportName);
         return Unexpect(ErrCode::Value::MissingArgument);
       }
 
-      if (!matchImportAndArgTypes(ImportDesc, it->getIndex().getSort())) {
+      if (!matchImportAndArgTypes(ImportDesc, argIt->getIndex().getSort())) {
         spdlog::error(ErrCode::Value::ArgTypeMismatch);
         spdlog::error("Component[{}]: Argument '{}' type mismatch",
                       Inst.getComponentIdx(), ImportName);
@@ -120,7 +122,7 @@ private:
       spdlog::error("Unreachable State: Index {} exceeds Component Count {}",
                     Index, Ctx.getComponentCount());
       spdlog::error(
-          WasmEdge::ErrInfo::InfoBoundary(Index, 0, Ctx.getComponentCount()));
+          WasmEdge::ErrInfo::InfoBoundary(Index, 0, static_cast<uint32_t>(Ctx.getComponentCount())));
 
       return ImportMap;
     }

--- a/include/validator/validator_component.h
+++ b/include/validator/validator_component.h
@@ -121,8 +121,8 @@ private:
     if (Index >= Ctx.getComponentCount()) {
       spdlog::error("Unreachable State: Index {} exceeds Component Count {}",
                     Index, Ctx.getComponentCount());
-      spdlog::error(
-          WasmEdge::ErrInfo::InfoBoundary(Index, 0, static_cast<uint32_t>(Ctx.getComponentCount())));
+      spdlog::error(WasmEdge::ErrInfo::InfoBoundary(
+          Index, 0, static_cast<uint32_t>(Ctx.getComponentCount())));
 
       return ImportMap;
     }

--- a/lib/validator/validator_component.cpp
+++ b/lib/validator/validator_component.cpp
@@ -14,8 +14,10 @@ using namespace AST::Component;
 Expect<void> Validator::validate(const AST::Component::Component &Comp) {
   spdlog::warn("component validation is not done yet."sv);
 
+  Context Ctx;
+
   for (auto &Sec : Comp.getSections()) {
-    EXPECTED_TRY(std::visit(SectionVisitor{*this}, Sec));
+    EXPECTED_TRY(std::visit(SectionVisitor{*this, Ctx}, Sec));
   }
 
   return {};


### PR DESCRIPTION
Validates each <importname> in `c` must match a name in `a` with an argument, compared as strings. Types must match for the validation to pass.

Maintaining the Context class, will be extended in future to store the index spaces for further validation.

ref: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Binary.md