### PR TITLE
[Component Model Validator] Fix InstanceExpr Validation, Add tests

### DIFF
--- a/include/ast/component/type.h
+++ b/include/ast/component/type.h
@@ -186,7 +186,7 @@ private:
 
 enum class IndexKind : Byte {
   CoreType = 0x00,
-  FuncType = 0x02,
+  FuncType = 0x01,
   ComponentType = 0x04,
   InstanceType = 0x05,
 };

--- a/include/validator/validator_component.h
+++ b/include/validator/validator_component.h
@@ -182,9 +182,7 @@ private:
                       WasmEdge::Validator::toString(ArgCoreSort));
 
         return false;
-      }
-
-      else if (std::holds_alternative<ValueType>(ImportType)) {
+      } else if (std::holds_alternative<ValueType>(ImportType)) {
         if (ArgCoreSort == CoreSort::Func || ArgCoreSort == CoreSort::Table ||
             ArgCoreSort == CoreSort::Memory ||
             ArgCoreSort == CoreSort::Global) {
@@ -195,9 +193,7 @@ private:
             "'Global' but got '{}'",
             WasmEdge::Validator::toString(ArgCoreSort));
         return false;
-      }
-
-      else if (std::holds_alternative<TypeBound>(ImportType)) {
+      } else if (std::holds_alternative<TypeBound>(ImportType)) {
         if (ArgCoreSort == CoreSort::Module ||
             ArgCoreSort == CoreSort::Instance) {
           return true;
@@ -207,9 +203,7 @@ private:
                       WasmEdge::Validator::toString(ArgCoreSort));
         return false;
       }
-    }
-
-    else if (std::holds_alternative<SortCase>(ArgSort)) {
+    } else if (std::holds_alternative<SortCase>(ArgSort)) {
       SortCase ArgSortCase = std::get<SortCase>(ArgSort);
 
       if (std::holds_alternative<TypeBound>(ImportType)) {
@@ -219,9 +213,7 @@ private:
         spdlog::error("[Sort Case] Type mismatch: Expected 'Type' but got '{}'",
                       WasmEdge::Validator::toString(ArgSortCase));
         return false;
-      }
-
-      else if (std::holds_alternative<ValueType>(ImportType)) {
+      } else if (std::holds_alternative<ValueType>(ImportType)) {
         if (ArgSortCase == SortCase::Value) {
           return true;
         }
@@ -229,9 +221,7 @@ private:
             "[Sort Case] Type mismatch: Expected 'Value' but got '{}'",
             WasmEdge::Validator::toString(ArgSortCase));
         return false;
-      }
-
-      else if (std::holds_alternative<DescTypeIndex>(ImportType)) {
+      } else if (std::holds_alternative<DescTypeIndex>(ImportType)) {
         const auto &Desc = std::get<DescTypeIndex>(ImportType);
         IndexKind Kind = Desc.getKind();
 

--- a/include/validator/validator_component.h
+++ b/include/validator/validator_component.h
@@ -184,7 +184,7 @@ private:
         return false;
       }
 
-      if (std::holds_alternative<ValueType>(ImportType)) {
+      else if (std::holds_alternative<ValueType>(ImportType)) {
         if (ArgCoreSort == CoreSort::Func || ArgCoreSort == CoreSort::Table ||
             ArgCoreSort == CoreSort::Memory ||
             ArgCoreSort == CoreSort::Global) {
@@ -197,7 +197,7 @@ private:
         return false;
       }
 
-      if (std::holds_alternative<TypeBound>(ImportType)) {
+      else if (std::holds_alternative<TypeBound>(ImportType)) {
         if (ArgCoreSort == CoreSort::Module ||
             ArgCoreSort == CoreSort::Instance) {
           return true;
@@ -209,7 +209,7 @@ private:
       }
     }
 
-    if (std::holds_alternative<SortCase>(ArgSort)) {
+    else if (std::holds_alternative<SortCase>(ArgSort)) {
       SortCase ArgSortCase = std::get<SortCase>(ArgSort);
 
       if (std::holds_alternative<TypeBound>(ImportType)) {
@@ -221,7 +221,7 @@ private:
         return false;
       }
 
-      if (std::holds_alternative<ValueType>(ImportType)) {
+      else if (std::holds_alternative<ValueType>(ImportType)) {
         if (ArgSortCase == SortCase::Value) {
           return true;
         }
@@ -231,7 +231,7 @@ private:
         return false;
       }
 
-      if (std::holds_alternative<DescTypeIndex>(ImportType)) {
+      else if (std::holds_alternative<DescTypeIndex>(ImportType)) {
         const auto &Desc = std::get<DescTypeIndex>(ImportType);
         IndexKind Kind = Desc.getKind();
 

--- a/include/validator/validator_component.h
+++ b/include/validator/validator_component.h
@@ -190,9 +190,10 @@ private:
             ArgCoreSort == CoreSort::Global) {
           return true;
         }
-        spdlog::error("[Core Sort] Type mismatch: Expected 'Func', 'Table', 'Memory', or "
-                      "'Global' but got '{}'",
-                      WasmEdge::Validator::toString(ArgCoreSort));
+        spdlog::error(
+            "[Core Sort] Type mismatch: Expected 'Func', 'Table', 'Memory', or "
+            "'Global' but got '{}'",
+            WasmEdge::Validator::toString(ArgCoreSort));
         return false;
       }
 
@@ -201,9 +202,9 @@ private:
             ArgCoreSort == CoreSort::Instance) {
           return true;
         }
-        spdlog::error(
-            "[Core Sort] Type mismatch: Expected 'Module' or 'Instance' but got '{}'",
-            WasmEdge::Validator::toString(ArgCoreSort));
+        spdlog::error("[Core Sort] Type mismatch: Expected 'Module' or "
+                      "'Instance' but got '{}'",
+                      WasmEdge::Validator::toString(ArgCoreSort));
         return false;
       }
     }
@@ -224,8 +225,9 @@ private:
         if (ArgSortCase == SortCase::Value) {
           return true;
         }
-        spdlog::error("[Sort Case] Type mismatch: Expected 'Value' but got '{}'",
-                      WasmEdge::Validator::toString(ArgSortCase));
+        spdlog::error(
+            "[Sort Case] Type mismatch: Expected 'Value' but got '{}'",
+            WasmEdge::Validator::toString(ArgSortCase));
         return false;
       }
 
@@ -241,7 +243,6 @@ private:
             (Kind == IndexKind::CoreType && ArgSortCase == SortCase::Type)) {
           return true;
         }
-
 
         spdlog::error("[Sort Case] Type mismatch: Expected '{}' but got '{}'",
                       WasmEdge::Validator::toString(Kind),

--- a/test/component/CMakeLists.txt
+++ b/test/component/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 wasmedge_add_executable(componentTests
   spectest.cpp
+  componentvalidatortest.cpp
 )
 
 add_test(componentTests componentTests)

--- a/test/component/componentvalidatortest.cpp
+++ b/test/component/componentvalidatortest.cpp
@@ -1,0 +1,194 @@
+#include "common/errinfo.h"
+#include "validator/validator_component.h"
+#include <gtest/gtest.h>
+
+namespace WasmEdge {
+namespace Validator {
+
+template <typename T> void assertOk(Expect<T> Res, const char *Message) {
+  if (!Res) {
+    EXPECT_TRUE(false) << Message;
+  }
+}
+
+template <typename T> void assertFail(Expect<T> Res, const char *Message) {
+  if (Res) {
+    FAIL() << Message;
+  }
+}
+
+AST::Component::ImportSection
+createImportSection(const std::vector<AST::Component::Import> &imports) {
+  AST::Component::ImportSection ImportSec;
+  ImportSec.getContent().insert(ImportSec.getContent().end(), imports.begin(),
+                                imports.end());
+  return ImportSec;
+}
+
+std::shared_ptr<AST::Component::Component>
+createComponent(const AST::Component::ComponentSection &CompSec) {
+  return std::make_shared<AST::Component::Component>(CompSec.getContent());
+}
+
+TEST(ComponentValidatorTest, CorrectMatching) {
+  AST::Component::DescTypeIndex Desc;
+  Desc.getIndex() = 0;
+  Desc.getKind() = AST::Component::IndexKind::FuncType;
+
+  AST::Component::Import ImportF;
+  ImportF.getName() = "f";
+  ImportF.getDesc() = Desc;
+
+  auto ImportSec = createImportSection({ImportF});
+
+  AST::Component::ComponentSection CompSec;
+  CompSec.getContent() = std::make_shared<AST::Component::Component>();
+  CompSec.getContent()->getSections().push_back(ImportSec);
+
+  auto C1 = createComponent(CompSec);
+
+  AST::Component::SortIndex<AST::Component::Sort> SortIdx;
+  SortIdx.getSort() = AST::Component::SortCase::Func;
+  SortIdx.getSortIdx() = 0;
+
+  AST::Component::InstantiateArg<
+      AST::Component::SortIndex<AST::Component::Sort>>
+      InstArg;
+  InstArg.getName() = "f";
+  InstArg.getIndex() = SortIdx;
+
+  std::vector<AST::Component::InstantiateArg<
+      AST::Component::SortIndex<AST::Component::Sort>>>
+      Args = {InstArg};
+  AST::Component::Instantiate Inst(0, std::move(Args));
+
+  AST::Component::InstanceSection InstSec;
+  InstSec.getContent().push_back(Inst);
+
+  AST::Component::ComponentSection OuterCompSec;
+  OuterCompSec.getContent() = std::make_shared<AST::Component::Component>();
+  OuterCompSec.getContent()->getSections().push_back(CompSec);
+  OuterCompSec.getContent()->getSections().push_back(InstSec);
+
+  auto C0 = createComponent(OuterCompSec);
+
+  WasmEdge::Validator::Context Ctx;
+  WasmEdge::Configure Conf;
+  WasmEdge::Validator::Validator Validator(Conf);
+
+  Ctx.addComponent(*C1);
+
+  WasmEdge::Validator::SectionVisitor Visitor(Validator, Ctx);
+  auto Result = Visitor(InstSec);
+  assertOk(Result, "Validation should pass for correct matching");
+}
+
+TEST(ComponentValidatorTest, MissingArgument) {
+  AST::Component::DescTypeIndex Desc;
+  Desc.getIndex() = 0;
+  Desc.getKind() = AST::Component::IndexKind::FuncType;
+
+  AST::Component::Import ImportF;
+  ImportF.getName() = "f";
+  ImportF.getDesc() = Desc;
+
+  auto ImportSec = createImportSection({ImportF});
+
+  AST::Component::ComponentSection CompSec;
+  CompSec.getContent() = std::make_shared<AST::Component::Component>();
+  CompSec.getContent()->getSections().push_back(ImportSec);
+
+  auto C1 = createComponent(CompSec);
+
+  AST::Component::SortIndex<AST::Component::Sort> SortIdx;
+  SortIdx.getSort() = AST::Component::SortCase::Func;
+  SortIdx.getSortIdx() = 0;
+
+  AST::Component::InstantiateArg<
+      AST::Component::SortIndex<AST::Component::Sort>>
+      InstArg;
+  InstArg.getName() = "g";
+  InstArg.getIndex() = SortIdx;
+
+  std::vector<AST::Component::InstantiateArg<
+      AST::Component::SortIndex<AST::Component::Sort>>>
+      Args = {InstArg};
+  AST::Component::Instantiate Inst(0, std::move(Args));
+
+  AST::Component::InstanceSection InstSec;
+  InstSec.getContent().push_back(Inst);
+
+  AST::Component::ComponentSection OuterCompSec;
+  OuterCompSec.getContent() = std::make_shared<AST::Component::Component>();
+  OuterCompSec.getContent()->getSections().push_back(CompSec);
+  OuterCompSec.getContent()->getSections().push_back(InstSec);
+
+  auto C0 = createComponent(OuterCompSec);
+
+  WasmEdge::Validator::Context Ctx;
+  WasmEdge::Configure Conf;
+  WasmEdge::Validator::Validator Validator(Conf);
+
+  Ctx.addComponent(*C1);
+
+  WasmEdge::Validator::SectionVisitor Visitor(Validator, Ctx);
+  auto Result = Visitor(InstSec);
+  assertFail(Result,
+             "Validation should fail due to missing argument 'f' but got 'g'");
+}
+
+TEST(ComponentValidatorTest, TypeMismatch) {
+  AST::Component::DescTypeIndex Desc;
+  Desc.getIndex() = 0;
+  Desc.getKind() = AST::Component::IndexKind::FuncType;
+
+  AST::Component::Import ImportF;
+  ImportF.getName() = "f";
+  ImportF.getDesc() = Desc;
+
+  auto ImportSec = createImportSection({ImportF});
+
+  AST::Component::ComponentSection CompSec;
+  CompSec.getContent() = std::make_shared<AST::Component::Component>();
+  CompSec.getContent()->getSections().push_back(ImportSec);
+
+  auto C1 = createComponent(CompSec);
+
+  AST::Component::SortIndex<AST::Component::Sort> SortIdx;
+  SortIdx.getSort() = AST::Component::SortCase::Component;
+  SortIdx.getSortIdx() = 0;
+
+  AST::Component::InstantiateArg<
+      AST::Component::SortIndex<AST::Component::Sort>>
+      InstArg;
+  InstArg.getName() = "f";
+  InstArg.getIndex() = SortIdx;
+
+  std::vector<AST::Component::InstantiateArg<
+      AST::Component::SortIndex<AST::Component::Sort>>>
+      Args = {InstArg};
+  AST::Component::Instantiate Inst(0, std::move(Args));
+
+  AST::Component::InstanceSection InstSec;
+  InstSec.getContent().push_back(Inst);
+
+  AST::Component::ComponentSection OuterCompSec;
+  OuterCompSec.getContent() = std::make_shared<AST::Component::Component>();
+  OuterCompSec.getContent()->getSections().push_back(CompSec);
+  OuterCompSec.getContent()->getSections().push_back(InstSec);
+
+  auto C0 = createComponent(OuterCompSec);
+
+  WasmEdge::Validator::Context Ctx;
+  WasmEdge::Configure Conf;
+  WasmEdge::Validator::Validator Validator(Conf);
+
+  Ctx.addComponent(*C1);
+
+  WasmEdge::Validator::SectionVisitor Visitor(Validator, Ctx);
+  auto Result = Visitor(InstSec);
+  assertFail(Result, "Validation should fail due to type mismatch");
+}
+
+} // namespace Validator
+} // namespace WasmEdge

--- a/test/component/componentvalidatortest.cpp
+++ b/test/component/componentvalidatortest.cpp
@@ -5,6 +5,12 @@
 namespace WasmEdge {
 namespace Validator {
 
+static AST::Component::ImportSection
+createImportSection(const std::vector<AST::Component::Import> &imports);
+
+static std::shared_ptr<AST::Component::Component>
+createComponent(const AST::Component::ComponentSection &CompSec);
+
 template <typename T> void assertOk(Expect<T> Res, const char *Message) {
   if (!Res) {
     EXPECT_TRUE(false) << Message;
@@ -17,7 +23,7 @@ template <typename T> void assertFail(Expect<T> Res, const char *Message) {
   }
 }
 
-AST::Component::ImportSection
+static AST::Component::ImportSection
 createImportSection(const std::vector<AST::Component::Import> &imports) {
   AST::Component::ImportSection ImportSec;
   ImportSec.getContent().insert(ImportSec.getContent().end(), imports.begin(),
@@ -25,7 +31,7 @@ createImportSection(const std::vector<AST::Component::Import> &imports) {
   return ImportSec;
 }
 
-std::shared_ptr<AST::Component::Component>
+static std::shared_ptr<AST::Component::Component>
 createComponent(const AST::Component::ComponentSection &CompSec) {
   return std::make_shared<AST::Component::Component>(CompSec.getContent());
 }


### PR DESCRIPTION
- Validation failed due to a typo in [IndexKind](https://github.com/WasmEdge/WasmEdge/blob/master/include/ast/component/type.h#L189)
FuncType should have the byte identifier `0x01`. See https://github.com/WebAssembly/component-model/blob/main/design/mvp/Binary.md#type-definitions
- tested with `hello_wasi_http.wasm` (ref: https://github.com/sunfishcode/hello-wasi-http/tree/29205a0749835bd65be65841640af913be9be794)
```
[2025-03-31 05:34:18.273] [warning] component model is enabled, this is experimental.
[2025-03-31 05:34:18.273] [warning] component model is an experimental proposal
[2025-03-31 05:34:18.277] [warning] component validation is not done yet.
[2025-03-31 05:34:18.277] [warning] component validation is not done yet.
[2025-03-31 05:34:18.277] [error] instantiation failed: unknown import, Code: 0x302
[2025-03-31 05:34:18.277] [error] component name: wasi:io/error@0.2.3
[2025-03-31 05:34:18.277] [error]     At AST node: component import section
```
Validation Passes, but has some issue in the instantiation phase. 
- constructed tests for correct validation, missing argument and type mismatch (will cover more cases)
```
[==========] Running 5 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 3 tests from ComponentValidatorTest
[ RUN      ] ComponentValidatorTest.CorrectMatching
[       OK ] ComponentValidatorTest.CorrectMatching (0 ms)
[ RUN      ] ComponentValidatorTest.MissingArgument
[2025-03-31 05:39:14.231] [error] user defined failed: missing argument, Code: 0x50c
[2025-03-31 05:39:14.231] [error] Component[0]: Missing argument for import 'f'
[       OK ] ComponentValidatorTest.MissingArgument (0 ms)
[ RUN      ] ComponentValidatorTest.TypeMismatch
[2025-03-31 05:39:14.231] [error] [Sort Case] Type mismatch: Expected 'FuncType' but got 'Component'
[2025-03-31 05:39:14.231] [error] user defined failed: type mismatch, Code: 0x50d
[2025-03-31 05:39:14.231] [error] Component[0]: Argument 'f' type mismatch
[       OK ] ComponentValidatorTest.TypeMismatch (0 ms)
[----------] 3 tests from ComponentValidatorTest (0 ms total)
// spectest.cpp
[----------] 2 tests from Component
[ RUN      ] Component.LoadAndRun_SimpleBinary
[2025-03-31 05:39:14.231] [warning] component model is an experimental proposal
[2025-03-31 05:39:14.232] [warning] component validation is not done yet.
[2025-03-31 05:39:14.232] [info] lifted: [ i64 ] -> [ i64 ]
[       OK ] Component.LoadAndRun_SimpleBinary (0 ms)
[ RUN      ] Component.Load_HttpBinary
[2025-03-31 05:39:14.232] [warning] component model is an experimental proposal
[2025-03-31 05:39:14.232] [warning] component validation is not done yet.
[       OK ] Component.Load_HttpBinary (0 ms)
[----------] 2 tests from Component (0 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 5 tests.
```


cc: @dannypsnl 