### PR TITLE
Validate CoreInstance Section, Improve Context, Add Tests for nested components

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1080,6 +1080,8 @@ E(MalformedName, 0x050B, "malformed name")
 E(MissingArgument, 0x050C, "missing argument")
 // Argument Type Mismatch with Import Type
 E(ArgTypeMismatch, 0x050D, "type mismatch")
+// Invalid Index
+E(InvalidIndex, 0x050E, "invalid index")
 // @}
 
 // Component model instantiation phase

--- a/include/validator/context.h
+++ b/include/validator/context.h
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+#include "ast/module.h"
+#include "common/errinfo.h"
+
+#include <optional>
+#include <vector>
+
+namespace WasmEdge {
+namespace Validator {
+
+class Context {
+public:
+  struct ComponentContext {
+    const AST::Component::Component *Component;
+    std::vector<AST::Module> CoreModules;
+    std::vector<AST::Component::Component> ChildComponents;
+    std::optional<const ComponentContext *> Parent;
+
+    ComponentContext(const AST::Component::Component *C,
+                     std::optional<const ComponentContext *> P = std::nullopt)
+        : Component(C), CoreModules(), ChildComponents(), Parent(P) {}
+  };
+
+  void enterComponent(const AST::Component::Component &C) {
+    if (!ComponentContexts.empty()) {
+      ComponentContexts.back().ChildComponents.emplace_back(C);
+    }
+    std::optional<const ComponentContext *> Parent =
+        ComponentContexts.empty() ? std::nullopt
+                                  : std::optional{&ComponentContexts.back()};
+    ComponentContexts.emplace_back(&C, Parent);
+  }
+
+  void exitComponent() {
+    if (!ComponentContexts.empty()) {
+      ComponentContexts.pop_back();
+    } else {
+      assumingUnreachable();
+    }
+  }
+
+  ComponentContext &getCurrentContext() { return ComponentContexts.back(); }
+
+  const ComponentContext &getCurrentContext() const {
+    return ComponentContexts.back();
+  }
+
+  void addCoreModule(const AST::Module &M) {
+    getCurrentContext().CoreModules.emplace_back(M);
+  }
+
+  const AST::Module &getCoreModule(uint32_t Index) const {
+    return getCurrentContext().CoreModules.at(Index);
+  }
+
+  size_t getCoreModuleCount() const {
+    return getCurrentContext().CoreModules.size();
+  }
+
+  const AST::Component::Component &getComponent(uint32_t Index) const {
+    return getCurrentContext().ChildComponents.at(Index);
+  }
+
+  size_t getComponentCount() const {
+    return getCurrentContext().ChildComponents.size();
+  }
+
+  std::optional<const ComponentContext *> getParentContext() const {
+    return ComponentContexts.empty() ? std::nullopt
+                                     : ComponentContexts.back().Parent;
+  }
+
+private:
+  std::vector<ComponentContext> ComponentContexts;
+};
+
+class ComponentContextGuard {
+public:
+  ComponentContextGuard(const AST::Component::Component &C, Context &Ctx)
+      : Ctx(Ctx) {
+    Ctx.enterComponent(C);
+  }
+
+  ~ComponentContextGuard() { Ctx.exitComponent(); }
+
+private:
+  Context &Ctx;
+};
+
+} // namespace Validator
+} // namespace WasmEdge

--- a/lib/validator/validator_component.cpp
+++ b/lib/validator/validator_component.cpp
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2019-2024 Second State INC
 #include "validator/validator_component.h"
+#include "common/spdlog.h"
 
 #include <variant>
-
-using namespace std::literals;
 
 namespace WasmEdge {
 namespace Validator {
 
+using namespace std::literals;
 using namespace AST::Component;
 
 Expect<void> Validator::validate(const AST::Component::Component &Comp) {
-  spdlog::warn("component validation is not done yet."sv);
+  spdlog::warn("Component Model Validation is in active development."sv);
 
   Context Ctx;
-
+  ComponentContextGuard guard(Comp, Ctx);
   for (auto &Sec : Comp.getSections()) {
     EXPECTED_TRY(std::visit(SectionVisitor{*this, Ctx}, Sec));
   }


### PR DESCRIPTION
Changes:
- Used stack based approach to store the Component and its context. Now it will be easy to maintain the index spaces for each component separately, also parent component be accessed to validate the `Alias section`.
- Updated old flaky test

Tests:
```
Running main() from /home/sridamul/Desktop/open-source/WasmEdge/build/_deps/gtest-src/googletest/src/gtest_main.cc
[==========] Running 6 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 4 tests from ComponentValidatorTest
[ RUN      ] ComponentValidatorTest.CorrectMatchingMultipleComponents
[2025-04-07 03:44:55.590] [info] Started Component Model Validation.
[2025-04-07 03:44:55.590] [info] Started Component Model Validation.
[2025-04-07 03:44:55.590] [info] Started Component Model Validation.
[       OK ] ComponentValidatorTest.CorrectMatchingMultipleComponents (0 ms)
[ RUN      ] ComponentValidatorTest.NestedCorrectMatching
[2025-04-07 03:44:55.590] [info] Started Component Model Validation.
[2025-04-07 03:44:55.590] [info] Started Component Model Validation.
[       OK ] ComponentValidatorTest.NestedCorrectMatching (0 ms)
[ RUN      ] ComponentValidatorTest.MissingArgument
[2025-04-07 03:44:55.590] [info] Started Component Model Validation.
[2025-04-07 03:44:55.590] [info] Started Component Model Validation.
[2025-04-07 03:44:55.590] [error] user defined failed: missing argument, Code: 0x50c
[2025-04-07 03:44:55.590] [error] Component[0]: Missing argument for import 'f'
[       OK ] ComponentValidatorTest.MissingArgument (0 ms)
[ RUN      ] ComponentValidatorTest.TypeMismatch
[2025-04-07 03:44:55.590] [info] Started Component Model Validation.
[2025-04-07 03:44:55.590] [info] Started Component Model Validation.
[2025-04-07 03:44:55.590] [error] [Sort Case] Type mismatch: Expected 'FuncType' but got 'Component'
[2025-04-07 03:44:55.590] [error] user defined failed: type mismatch, Code: 0x50d
[2025-04-07 03:44:55.590] [error] Component[0]: Argument 'f' type mismatch
[       OK ] ComponentValidatorTest.TypeMismatch (0 ms)
[----------] 4 tests from ComponentValidatorTest (0 ms total)

[----------] 2 tests from Component
[ RUN      ] Component.LoadAndRun_SimpleBinary
[2025-04-07 03:44:55.590] [warning] component model is an experimental proposal
[2025-04-07 03:44:55.590] [info] Started Component Model Validation.
[2025-04-07 03:44:55.590] [info] lifted: [ i64 ] -> [ i64 ]
[       OK ] Component.LoadAndRun_SimpleBinary (0 ms)
[ RUN      ] Component.Load_HttpBinary
[2025-04-07 03:44:55.590] [warning] component model is an experimental proposal
[2025-04-07 03:44:55.590] [info] Started Component Model Validation.
[       OK ] Component.Load_HttpBinary (0 ms)
[----------] 2 tests from Component (0 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 6 tests.
```
hello-wasi-http:
```
tools/wasmedge/wasmedge --enable-component /home/sridamul/Desktop/open-source/hello-wasi-http/target/wasm32-wasip1/debug/hello_wasi_http.wasm
[2025-04-07 03:46:13.105] [warning] component model is enabled, this is experimental.
[2025-04-07 03:46:13.106] [warning] component model is an experimental proposal
[2025-04-07 03:46:13.113] [info] Started Component Model Validation.
[2025-04-07 03:46:13.119] [info] Started Component Model Validation.
[2025-04-07 03:46:13.119] [error] instantiation failed: unknown import, Code: 0x302
[2025-04-07 03:46:13.119] [error] component name: wasi:io/error@0.2.3
[2025-04-07 03:46:13.119] [error]     At AST node: component import section
```

~[WIP]
I am not sure, that we add index of the Outermost Component to the `CompList` or not.~

~[wat.txt](https://github.com/user-attachments/files/19612944/wat.txt)
This is the WAT format of [hello-wasi-http](https://github.com/sunfishcode/hello-wasi-http/tree/29205a0749835bd65be65841640af913be9be794)
Here, the outermost component holds the core modules, core instance and so on.
Also has the inner component (;0;)
I am not sure about how we index the components (applies to index spaces too)~