### PR TITLE
[WASI-NN] ggml: bump to b5074; bump wasi-nn plugin to 0.1.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
 # WasmEdge CAPI and so versions.
 set(WASMEDGE_CAPI_VERSION "0.1.0" CACHE STRING "WasmEdge C API library version")
 set(WASMEDGE_CAPI_SOVERSION "0" CACHE STRING "WasmEdge C API library soversion")
-set(WASMEDGE_WASI_NN_VERSION "0.1.17" CACHE STRING "WasmEdge WASI-NN library version")
+set(WASMEDGE_WASI_NN_VERSION "0.1.18" CACHE STRING "WasmEdge WASI-NN library version")
 set(WASMEDGE_WASI_NN_SOVERSION "0" CACHE STRING "WasmEdge WASI-NN library soversion")
 
 # Set cpack package version.

--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -294,6 +294,8 @@ function(wasmedge_setup_llama_target target)
     # llama.cpp options
     # Disable warnings and debug messages
     set(LLAMA_ALL_WARNINGS OFF)
+    # Disable curl dependency
+    set(LLAMA_CURL OFF)
     set(LLAMA_METAL_NDEBUG ON)
     set(LLAMA_BUILD_COMMON ON)
     set(GGML_ACCELERATE OFF)
@@ -338,8 +340,8 @@ function(wasmedge_setup_llama_target target)
     include(FetchContent)
     FetchContent_Declare(
       llama
-      GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-      GIT_TAG        b4915
+      GIT_REPOSITORY https://github.com/ggml-org/llama.cpp.git
+      GIT_TAG        b5074
       GIT_SHALLOW    FALSE
     )
     FetchContent_MakeAvailable(llama)


### PR DESCRIPTION
* There is no model, model_url, hf_repo, and hf_file. Instead, all these options are now inside the common_params_model structure.
* Support llama4-text only