### PR TITLE
Update `0.14.1_plugin_lts` branch

### DIFF
--- a/.github/workflows/matrix-extensions.json
+++ b/.github/workflows/matrix-extensions.json
@@ -86,6 +86,17 @@
             ]
         },
         {
+            "plugin": "wasi_nn-chattts",
+            "bin": "libwasmedgePluginWasiNN",
+            "dir": "wasi_nn",
+            "target": "wasmedgePluginWasiNN",
+            "testBin": "wasiNNTests",
+            "options": "-DWASMEDGE_PLUGIN_WASI_NN_BACKEND=ChatTTS",
+            "platforms": [
+                "ubuntu_latest"
+            ]
+        },
+        {
             "plugin": "wasm_bpf",
             "bin": "libwasmedgePluginWasmBpf.so",
             "dir": "wasm_bpf",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
 # WasmEdge CAPI and so versions.
 set(WASMEDGE_CAPI_VERSION "0.1.0" CACHE STRING "WasmEdge C API library version")
 set(WASMEDGE_CAPI_SOVERSION "0" CACHE STRING "WasmEdge C API library soversion")
-set(WASMEDGE_WASI_NN_VERSION "0.1.19" CACHE STRING "WasmEdge WASI-NN library version")
+set(WASMEDGE_WASI_NN_VERSION "0.1.20" CACHE STRING "WasmEdge WASI-NN library version")
 set(WASMEDGE_WASI_NN_SOVERSION "0" CACHE STRING "WasmEdge WASI-NN library soversion")
 
 # Set cpack package version.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
 # WasmEdge CAPI and so versions.
 set(WASMEDGE_CAPI_VERSION "0.1.0" CACHE STRING "WasmEdge C API library version")
 set(WASMEDGE_CAPI_SOVERSION "0" CACHE STRING "WasmEdge C API library soversion")
-set(WASMEDGE_WASI_NN_VERSION "0.1.18" CACHE STRING "WasmEdge WASI-NN library version")
+set(WASMEDGE_WASI_NN_VERSION "0.1.19" CACHE STRING "WasmEdge WASI-NN library version")
 set(WASMEDGE_WASI_NN_SOVERSION "0" CACHE STRING "WasmEdge WASI-NN library soversion")
 
 # Set cpack package version.

--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -328,7 +328,7 @@ function(wasmedge_setup_llama_target target)
     FetchContent_Declare(
       llama
       GIT_REPOSITORY https://github.com/ggml-org/llama.cpp.git
-      GIT_TAG        b5166
+      GIT_TAG        b5201
       GIT_SHALLOW    FALSE
     )
     FetchContent_MakeAvailable(llama)
@@ -357,6 +357,7 @@ function(wasmedge_setup_llama_target target)
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4189> # 'identifier' : local variable is initialized but not referenced
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4244> # 'argument' : conversion from 'type1' to 'type2', possible loss of data
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4267> # 'var' : conversion from 'size_t' to 'type', possible loss of data
+        $<$<COMPILE_LANGUAGE:C,CXX>:/wd4305> # 'initializing' : truncation from 'double' to 'float'
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4297> # 'function' : function assumed not to throw an exception but does
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4456> # declaration of 'identifier' hides previous local declaration
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4505> # 'function' : unreferenced local function has been removed

--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -328,7 +328,7 @@ function(wasmedge_setup_llama_target target)
     FetchContent_Declare(
       llama
       GIT_REPOSITORY https://github.com/ggml-org/llama.cpp.git
-      GIT_TAG        b5074
+      GIT_TAG        b5166
       GIT_SHALLOW    FALSE
     )
     FetchContent_MakeAvailable(llama)
@@ -360,6 +360,7 @@ function(wasmedge_setup_llama_target target)
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4297> # 'function' : function assumed not to throw an exception but does
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4456> # declaration of 'identifier' hides previous local declaration
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4505> # 'function' : unreferenced local function has been removed
+        $<$<COMPILE_LANGUAGE:C,CXX>:/wd4701> # potentially uninitialized local variable used
       )
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
       target_compile_options(llava

--- a/plugins/wasi_nn/wasinn_chattts.cpp
+++ b/plugins/wasi_nn/wasinn_chattts.cpp
@@ -292,8 +292,11 @@ Expect<WASINN::ErrNo> compute(WasiNNEnvironment &Env,
     Py_XDECREF(Kwargs);
   }
   if (Result != nullptr) {
-    PyObject *Wav0 = PyList_GetItem(Result, 0);
+    PyObject *Index = PyLong_FromLong(0);
+    PyObject *Wav0 = PyObject_GetItem(Result, Index);
+    Py_XDECREF(Index);
     PyObject *BytesObj = PyObject_CallMethod(Wav0, "tobytes", nullptr);
+    Py_XDECREF(Wav0);
     char *Bytes = PyBytes_AsString(BytesObj);
     Py_ssize_t size = PyBytes_Size(BytesObj);
     CxtRef.Outputs = std::vector<uint8_t>(Bytes, Bytes + size);

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -19,6 +19,7 @@
 using WasmEdge::Host::WASINN::Backend;
 using WasmEdge::Host::WASINN::Device;
 using WasmEdge::Host::WASINN::ErrNo;
+using WasmEdge::Host::WASINN::TensorType;
 
 #if defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_OPENVINO) ||                       \
     defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_TORCH) ||                          \
@@ -2729,7 +2730,7 @@ TEST(WasiNNTest, ChatTTSBackend) {
   // ChatTTS WASI-NN set_input tests.
   SetInputEntryPtr = BuilderPtr;
   writeFatPointer(MemInst, StorePtr, TensorDim.size(), BuilderPtr);
-  writeUInt32(MemInst, UINT32_C(2), BuilderPtr);
+  writeUInt32(MemInst, static_cast<uint32_t>(TensorType::U8), BuilderPtr);
   writeFatPointer(MemInst, StorePtr + TensorDim.size() * 4, TensorData.size(),
                   BuilderPtr);
   writeBinaries<uint32_t>(MemInst, TensorDim, StorePtr);
@@ -2776,7 +2777,7 @@ TEST(WasiNNTest, ChatTTSBackend) {
   // Test: setInput -- set metadata successfully.
   SetInputEntryPtr = BuilderPtr;
   writeFatPointer(MemInst, StorePtr, TensorDim.size(), BuilderPtr);
-  writeUInt32(MemInst, UINT32_C(2), BuilderPtr);
+  writeUInt32(MemInst, static_cast<uint32_t>(TensorType::U8), BuilderPtr);
   writeFatPointer(MemInst, StorePtr + TensorDim.size() * 4, ConfigData.size(),
                   BuilderPtr);
   writeBinaries<uint32_t>(MemInst, TensorDim, StorePtr);


### PR DESCRIPTION
commits:
* 934a3a4a feat(wasi-nn): bump ggml to b5201; bump wasi-nn plugin to 0.1.20
* 113c9ca1 feat(wasi-nn): bump ggml to b5166; bump wasi-nn plugin to 0.1.19 (#4088)
* bc8fdc56 ci(wasi-nn/ChatTTS): add ubuntu_latest (24.04) workflow
* 749ba0e9 test(wasi-nn/ChatTTS): update for TensorType change
* 4f2e7a30 fix(wasi-nn/ChatTTS): update compute function to be compatible with v0.2.1