### PR TITLE
[Component Model] Validation of Alias section

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1084,6 +1084,8 @@ E(ArgTypeMismatch, 0x050D, "type mismatch")
 E(InvalidIndex, 0x050E, "invalid index")
 // Invalid Type Reference
 E(InvalidTypeReference, 0x050F, "invalid type reference")
+// Export Not Found
+E(ExportNotFound, 0x0510, "export not found")
 // @}
 
 // Component model instantiation phase

--- a/include/validator/context.h
+++ b/include/validator/context.h
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2019-2024 Second State INC
+#pragma once
+
 #include "ast/module.h"
 #include "common/errinfo.h"
 
+#include <deque>
 #include <optional>
 #include <unordered_map>
 #include <vector>
@@ -21,18 +24,52 @@ public:
     std::unordered_map<AST::Component::CoreSort, size_t> CoreIndexSizes;
     std::unordered_map<std::string, uint32_t> TypeSubstitutions;
 
+    std::unordered_map<uint32_t, std::unordered_map<std::string_view,
+                                                    AST::Component::ExternDesc>>
+        ComponentInstanceExports;
+    std::unordered_map<uint32_t,
+                       std::unordered_map<std::string_view, ExternalType>>
+        CoreInstanceExports;
+    std::unordered_map<uint32_t, AST::Component::InstanceType>
+        ComponentInstanceTypes;
+    std::unordered_map<uint32_t, AST::Component::ResourceType>
+        ComponentResourceTypes;
+
     ComponentContext(const AST::Component::Component *C,
                      std::optional<const ComponentContext *> P = std::nullopt)
         : Component(C), CoreModules(), ChildComponents(), Parent(P) {}
+
+    size_t getComponentIndexSize(AST::Component::SortCase SC) const noexcept {
+      auto It = ComponentIndexSizes.find(SC);
+      if (It != ComponentIndexSizes.end()) {
+        return It->second;
+      } else {
+        return 0;
+      }
+    }
+
+    size_t getCoreIndexSize(AST::Component::CoreSort CS) const noexcept {
+      auto It = CoreIndexSizes.find(CS);
+      if (It != CoreIndexSizes.end()) {
+        return It->second;
+      } else {
+        return 0;
+      }
+    }
   };
 
   void enterComponent(const AST::Component::Component &C) {
     if (!ComponentContexts.empty()) {
       ComponentContexts.back().ChildComponents.emplace_back(C);
     }
-    std::optional<const ComponentContext *> Parent =
-        ComponentContexts.empty() ? std::nullopt
-                                  : std::optional{&ComponentContexts.back()};
+
+    std::optional<const ComponentContext *> Parent;
+    if (ComponentContexts.empty()) {
+      Parent = std::nullopt;
+    } else {
+      Parent = std::optional{&ComponentContexts.back()};
+    }
+
     ComponentContexts.emplace_back(&C, Parent);
   }
 
@@ -71,19 +108,30 @@ public:
   }
 
   std::optional<const ComponentContext *> getParentContext() const {
-    return ComponentContexts.empty() ? std::nullopt
-                                     : ComponentContexts.back().Parent;
+    if (ComponentContexts.empty()) {
+      return std::nullopt;
+    }
+    return ComponentContexts.back().Parent;
   }
 
   size_t getComponentIndexSize(AST::Component::SortCase SC) const noexcept {
-    auto It = getCurrentContext().ComponentIndexSizes.find(SC);
-    return (It != getCurrentContext().ComponentIndexSizes.end()) ? It->second
-                                                                 : 0;
+    const auto &Ctx = getCurrentContext();
+    auto It = Ctx.ComponentIndexSizes.find(SC);
+    if (It != Ctx.ComponentIndexSizes.end()) {
+      return It->second;
+    } else {
+      return 0;
+    }
   }
 
   size_t getCoreIndexSize(AST::Component::CoreSort CS) const noexcept {
-    auto It = getCurrentContext().CoreIndexSizes.find(CS);
-    return (It != getCurrentContext().CoreIndexSizes.end()) ? It->second : 0;
+    const auto &Ctx = getCurrentContext();
+    auto It = Ctx.CoreIndexSizes.find(CS);
+    if (It != Ctx.CoreIndexSizes.end()) {
+      return It->second;
+    } else {
+      return 0;
+    }
   }
 
   void incComponentIndexSize(AST::Component::SortCase SC) noexcept {
@@ -100,15 +148,115 @@ public:
 
   std::optional<uint32_t>
   getSubstitutedType(const std::string &ImportName) const {
-    auto It = getCurrentContext().TypeSubstitutions.find(ImportName);
-    if (It != getCurrentContext().TypeSubstitutions.end()) {
+    const auto &Ctx = getCurrentContext();
+    auto It = Ctx.TypeSubstitutions.find(ImportName);
+    if (It != Ctx.TypeSubstitutions.end()) {
       return It->second;
     }
     return std::nullopt;
   }
 
+  void addComponentInstanceExport(uint32_t InstanceIdx,
+                                  const std::string_view &ExportName,
+                                  const AST::Component::ExternDesc &ED) {
+    auto &Ctx = getCurrentContext();
+    Ctx.ComponentInstanceExports[InstanceIdx][ExportName] = ED;
+  }
+
+  std::unordered_map<std::string_view, AST::Component::ExternDesc>
+  getComponentInstanceExports(uint32_t InstanceIdx) const {
+    const auto &Ctx = getCurrentContext();
+    auto It = Ctx.ComponentInstanceExports.find(InstanceIdx);
+    if (It != Ctx.ComponentInstanceExports.end()) {
+      return It->second;
+    }
+    return {};
+  }
+
+  size_t getComponentInstanceExportsSize() const {
+    const auto &Exports = getCurrentContext().ComponentInstanceExports;
+    if (Exports.empty()) {
+      return 0;
+    }
+
+    uint32_t MaxIdx = 0;
+    for (const auto &Pair : Exports) {
+      if (Pair.first > MaxIdx) {
+        MaxIdx = Pair.first;
+      }
+    }
+    return static_cast<size_t>(MaxIdx) + 1;
+  }
+
+  void addCoreInstanceExport(uint32_t InstanceIdx,
+                             const std::string_view &ExportName,
+                             const ExternalType &ET) {
+    auto &Ctx = getCurrentContext();
+    Ctx.CoreInstanceExports[InstanceIdx][ExportName] = ET;
+  }
+
+  std::unordered_map<std::string_view, ExternalType>
+  getCoreInstanceExports(uint32_t InstanceIdx) const {
+    const auto &Ctx = getCurrentContext();
+    auto It = Ctx.CoreInstanceExports.find(InstanceIdx);
+    if (It != Ctx.CoreInstanceExports.end()) {
+      return It->second;
+    }
+    return {};
+  }
+
+  size_t getCoreInstanceExportsSize() const {
+    const auto &Exports = getCurrentContext().CoreInstanceExports;
+    if (Exports.empty()) {
+      return 0;
+    }
+
+    uint32_t MaxIdx = 0;
+    for (const auto &Pair : Exports) {
+      if (Pair.first > MaxIdx) {
+        MaxIdx = Pair.first;
+      }
+    }
+    return static_cast<size_t>(MaxIdx) + 1;
+  }
+
+  void addComponentInstanceType(uint32_t Idx,
+                                const AST::Component::InstanceType &IT) {
+    auto &Ctx = getCurrentContext();
+    Ctx.ComponentInstanceTypes[Idx] = IT;
+  }
+
+  const AST::Component::InstanceType *
+  getComponentInstanceType(uint32_t Idx) const {
+    const auto &Ctx = getCurrentContext();
+    auto It = Ctx.ComponentInstanceTypes.find(Idx);
+    if (It != Ctx.ComponentInstanceTypes.end()) {
+      return &It->second;
+    } else {
+      return nullptr;
+    }
+  }
+
+  void addComponentResourceType(uint32_t Idx,
+                                const AST::Component::ResourceType &IT) {
+    auto &Ctx = getCurrentContext();
+    Ctx.ComponentResourceTypes[Idx] = IT;
+  }
+
+  const AST::Component::ResourceType *
+  getComponentResourceType(uint32_t Idx) const {
+    const auto &Ctx = getCurrentContext();
+    auto It = Ctx.ComponentResourceTypes.find(Idx);
+
+    if (It != Ctx.ComponentResourceTypes.end()) {
+      return &It->second;
+    } else {
+      return nullptr;
+    }
+  }
+
 private:
-  std::vector<ComponentContext> ComponentContexts;
+  std::deque<ComponentContext> ComponentContexts;
 };
 
 class ComponentContextGuard {

--- a/include/validator/validator.h
+++ b/include/validator/validator.h
@@ -16,6 +16,7 @@
 
 #include "ast/module.h"
 #include "common/configure.h"
+#include "validator/context.h"
 #include "validator/formchecker.h"
 
 #include <cstdint>
@@ -78,6 +79,8 @@ private:
   const Configure Conf;
   /// Formal checker
   FormChecker Checker;
+  /// Context for Component validation
+  Context Ctx;
 };
 
 } // namespace Validator

--- a/lib/loader/ast/component/component_type.cpp
+++ b/lib/loader/ast/component/component_type.cpp
@@ -284,7 +284,7 @@ Expect<void> Loader::loadType(FuncType &Ty) {
 Expect<void> Loader::loadType(InstanceType &Ty) {
   // instancetype  ::= 0x42 id*:vec(<instancedecl>)
   // => (instance id*)
-  return loadVec<TypeSection>(Ty.getContent(), [this](InstanceDecl Decl) {
+  return loadVec<TypeSection>(Ty.getContent(), [this](InstanceDecl &Decl) {
     return loadInstanceDecl(Decl);
   });
 }

--- a/lib/validator/validator_component.cpp
+++ b/lib/validator/validator_component.cpp
@@ -14,7 +14,6 @@ using namespace AST::Component;
 Expect<void> Validator::validate(const AST::Component::Component &Comp) {
   spdlog::warn("Component Model Validation is in active development."sv);
 
-  Context Ctx;
   ComponentContextGuard guard(Comp, Ctx);
   for (auto &Sec : Comp.getSections()) {
     EXPECTED_TRY(std::visit(SectionVisitor{*this, Ctx}, Sec));


### PR DESCRIPTION
~- SortCase (`alias export`) needs to be validated, the [InstanceDecl] (https://github.com/WasmEdge/WasmEdge/blob/master/include/ast/component/type.h#L253) always returning the CoreType for different cases !?~
~- Need to manage the shared context that persist between components~

Tests:
```
test/component/componentTests 
Running main() from /home/sridamul/Desktop/open-source/WasmEdge/build/_deps/gtest-src/googletest/src/gtest_main.cc
[==========] Running 5 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 3 tests from Component
[ RUN      ] Component.LoadAndValidate_TestWasm
[2025-05-02 00:58:18.589] [warning] component model is an experimental proposal
[2025-05-02 00:58:18.589] [warning] Component Model Validation is in active development.
[       OK ] Component.LoadAndValidate_TestWasm (1 ms)
[ RUN      ] Component.LoadAndRun_SimpleBinary
[2025-05-02 00:58:18.590] [warning] component model is an experimental proposal
[2025-05-02 00:58:18.590] [warning] Component Model Validation is in active development.
[2025-05-02 00:58:18.590] [info] lifted: [ i64 ] -> [ i64 ]
[       OK ] Component.LoadAndRun_SimpleBinary (0 ms)
[ RUN      ] Component.Load_HttpBinary
[2025-05-02 00:58:18.591] [warning] component model is an experimental proposal
[2025-05-02 00:58:18.591] [warning] Component Model Validation is in active development.
[       OK ] Component.Load_HttpBinary (1 ms)
[----------] 3 tests from Component (2 ms total)

[----------] 2 tests from ComponentValidatorTest
[ RUN      ] ComponentValidatorTest.MissingArgument
[2025-05-02 00:58:18.591] [warning] Component Model Validation is in active development.
[2025-05-02 00:58:18.591] [warning] Component Model Validation is in active development.
[2025-05-02 00:58:18.591] [error] user defined failed: missing argument, Code: 0x50c
[2025-05-02 00:58:18.591] [error] Component[0]: Missing argument for import 'f'
[       OK ] ComponentValidatorTest.MissingArgument (0 ms)
[ RUN      ] ComponentValidatorTest.TypeMismatch
[2025-05-02 00:58:18.591] [warning] Component Model Validation is in active development.
[2025-05-02 00:58:18.591] [warning] Component Model Validation is in active development.
[2025-05-02 00:58:18.591] [error] [Sort Case] Type mismatch: Expected 'FuncType' but got 'Component'
[2025-05-02 00:58:18.591] [error] user defined failed: type mismatch, Code: 0x50d
[2025-05-02 00:58:18.591] [error] Component[0]: Argument 'f' type mismatch
[       OK ] ComponentValidatorTest.TypeMismatch (0 ms)
[----------] 2 tests from ComponentValidatorTest (0 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 5 tests.
```

hello-http-wasi:
```
 tools/wasmedge/wasmedge --enable-component /home/sridamul/Desktop/open-source/hello-wasi-http/target/wasm32-wasip1/debug/hello_wasi_http.wasm
[2025-05-02 00:58:54.022] [warning] component model is enabled, this is experimental.
[2025-05-02 00:58:54.023] [warning] component model is an experimental proposal
[2025-05-02 00:58:54.054] [warning] Component Model Validation is in active development.
[2025-05-02 00:58:54.073] [warning] Component Model Validation is in active development.
[2025-05-02 00:58:54.073] [error] instantiation failed: unknown import, Code: 0x302
[2025-05-02 00:58:54.073] [error] component name: wasi:io/error@0.2.3
[2025-05-02 00:58:54.073] [error]     At AST node: component import section
```

WAT used to test the Outer aliases:
```
(component
  (type (;0;)
    (instance
      (type (;0;) (func))
      (export (;0;) "hello" (func (type 0)))
    )
  )

  (import "my:demo/host" (instance (;0;) (type 0)))

  (core module (;0;)
    (type (;0;) (func))
    (import "my:demo/host" "hello" (func (type 0)))
    (@producers (processed-by "wit-component" "0.227.1"))
  )

  (alias export 0 "hello" (func (;0;)))

  (component
    (alias outer 1 0 (type (;0;)
    (instance
      (type (;0;) (func))
      (export (;0;) "hello" (func (type 0)))
    )
  ))
  )

  (instance (;1;) (instantiate 0))

  (@producers (processed-by "wit-component" "0.227.1"))
)
```