### PR TITLE
fix(cli): allow --enable-jit to work without 'run' subcommand

### DIFF
--- a/lib/driver/uniTool.cpp
+++ b/lib/driver/uniTool.cpp
@@ -28,6 +28,7 @@ int UniTool(int Argc, const char *Argv[], const ToolType ToolSelect) noexcept {
   struct DriverCompilerOptions CompilerOptions;
 
   // Construct Parser Subcommands and Options
+  ToolOptions.add_option(Parser);
   if (ToolSelect == ToolType::All) {
     ToolOptions.add_option(Parser);
 


### PR DESCRIPTION
Fixes #4090

This pull request addresses a CLI parsing issue where the --enable-jit flag was only recognized when used with the run subcommand. As a result, running
wasmedge --enable-jit add.wasm 5 6

did not enable JIT mode, even though the flag was passed, because the configuration check returned false.

The change moves the call to ToolOptions.add_option(Parser) outside the run subcommand scope in lib/driver/uniTool.cpp. This ensures that all flags defined in DriverToolOptions, including --enable-jit, are parsed regardless of subcommand.

The existing logic in runtimeTool.cpp already applies the flag by checking if Opt.ConfEnableJIT.value() and then setting EnableJIT to true; this fix simply makes sure the flag reaches that check in all CLI modes.

This was tested by comparing behavior before and after the fix. Before the fix,
wasmedge --enable-jit add.wasm 5 6
silently ignored the flag and ran the interpreter. After the fix, the same command triggers JIT compilation, as indicated by compile start, optimize done, and the correct result printed. Other commands such as run, compile, and --version remain unaffected.

This is my first open-source contribution to WasmEdge. I appreciate your review and am happy to iterate. Thanks — koliangyu99