### PR TITLE
fix: deterministic NaN propagation in f64.max (prefer first NaN)

### DIFF
--- a/include/executor/engine/binary_numeric.ipp
+++ b/include/executor/engine/binary_numeric.ipp
@@ -188,10 +188,14 @@ TypeF<T> Executor::runMaxOp(ValVariant &Val1, const ValVariant &Val2) const {
   T &Z1 = Val1.get<T>();
   const T &Z2 = Val2.get<T>();
   const T kZero = 0.0;
+  if (std::isnan(Z1) && std::isnan(Z2)) {
+  } else if (std::isnan(Z1)) {
+    Z1 = Z2;
+    return {};
+  } else if (std::isnan(Z2)) {
+    return {};
+  }
   if (std::isnan(Z1) || std::isnan(Z2)) {
-    if (std::isnan(Z2)) {
-      Z1 = Z2;
-    }
     // Set the most significant bit of the payload to 1.
     if constexpr (sizeof(T) == sizeof(uint32_t)) {
       uint32_t I32;

--- a/include/executor/engine/binary_numeric.ipp
+++ b/include/executor/engine/binary_numeric.ipp
@@ -188,14 +188,10 @@ TypeF<T> Executor::runMaxOp(ValVariant &Val1, const ValVariant &Val2) const {
   T &Z1 = Val1.get<T>();
   const T &Z2 = Val2.get<T>();
   const T kZero = 0.0;
-  if (std::isnan(Z1) && std::isnan(Z2)) {
-  } else if (std::isnan(Z1)) {
-    Z1 = Z2;
-    return {};
-  } else if (std::isnan(Z2)) {
-    return {};
-  }
   if (std::isnan(Z1) || std::isnan(Z2)) {
+    if (!std::isnan(Z2)) {
+      Z1 = Z2;
+    }
     // Set the most significant bit of the payload to 1.
     if constexpr (sizeof(T) == sizeof(uint32_t)) {
       uint32_t I32;


### PR DESCRIPTION
fix: deterministic NaN propagation in f64.max (prefer first NaN)
Closes #4057

### Summary
This PR makes WasmEdge’s f64.max deterministic for NaN inputs by aligning interpreter behavior with AOT and Wasmtime:

- Both operands NaN → return the first NaN

- One operand NaN → return the non‑NaN value

### Background
Different runtimes pick different NaN payloads when f64.max sees NaNs. Wasmtime chooses the first NaN; Wasmer and AOT mode in WasmEdge chose the second. Interpreter mode in WasmEdge also picked the second, causing inconsistency.

### Changes
In include/executor/engine/binary_numeric.ipp (line 191):
### From:
```
  if (std::isnan(Z1) || std::isnan(Z2)) {
    if (std::isnan(Z2)) {
      Z1 = Z2;
    }
    // Set the most significant bit of the payload to 1.
    if constexpr (sizeof(T) == sizeof(uint32_t)) {
```

### To:
```
  if (std::isnan(Z1) && std::isnan(Z2)) {
  } else if (std::isnan(Z1)) {
    Z1 = Z2;
    return {};
  } else if (std::isnan(Z2)) {
    return {};
  }
  if (std::isnan(Z1) || std::isnan(Z2)) {
    // Set the most significant bit of the payload to 1.
    if constexpr (sizeof(T) == sizeof(uint32_t)) {
```

### Reproduction / Testing

### 1. Both‑NaN case (nan_max.wat)

```
(module
  (func (export "main") (result i64)
    ;; first NaN
    f64.const -nan:0xffff000000000
    ;; second NaN
    f64.const -nan:0xf800000000000
    f64.max
    ;; reinterpret the f64 result bits as i64
    i64.reinterpret_f64
  )
)
```
### Outout (nan_max.wat):
```
wat2wasm local_test/nan_max.wat -o nan_max.wasm
./tools/wasmedge/wasmedge --reactor ../local_test/nan_max.wasm main \ | xargs printf '0x%016x\n'# => 0xfffffff000000000
```

### 2. One‑NaN case (one_nan.wat)
```
(module
  (func (export "main") (result i64)
    ;; First: NaN, Second: 2.0
    f64.const -nan:0xffff000000000
    f64.const 2.0
    f64.max
    ;; reinterpret the result bits to i64
    i64.reinterpret_f64
  )
)
```
### Outout (one_nan.wat):
```
wat2wasm local_test/one_nan.wat -o one_nan.wasm
./tools/wasmedge/wasmedge --reactor ../local_test/one_nan.wasm main \ | xargs printf '0x%016x\n'
# => 0x4000000000000000
```
### Follow‑Up:
I’ll add the new spec tests (float/nan_max.wat and float/one_nan.wat) in a follow‑up PR once this lands.

