### PR TITLE
[EXAMPLE] wasi-cryptography-signature: add proper error handling

### DIFF
--- a/examples/plugin/wasi-crypto-signature/src/signatures.rs
+++ b/examples/plugin/wasi-crypto-signature/src/signatures.rs
@@ -1,3 +1,12 @@
+#[derive(Debug)]
+pub enum Error {
+    // i32 is the error code from the WASI-Crypto-Signature plugin
+    SignatureImport(i32),
+    SignatureExport(i32),
+    ArrayOutputLen(i32),
+    ArrayOutputPull(i32),
+}
+
 mod ffi {
 
     #[link(wasm_import_module = "wasi_ephemeral_crypto_signatures")]
@@ -33,7 +42,7 @@ pub fn signature_import<S: AsRef<[u8]>>(
     alg: String,
     encoded: S,
     encoding: u16,
-) -> Result<u32, i32> {
+) -> Result<u32, Error> {
     let alg_size = alg.len() as u32;
     let encoded_size = encoded.as_ref().len() as u32;
     let mut sig_handle: u32 = 0;
@@ -49,43 +58,43 @@ pub fn signature_import<S: AsRef<[u8]>>(
         if res == 0 {
             Ok(sig_handle)
         } else {
-            Err(res)
+            Err(Error::SignatureImport(res))
         }
     }
 }
 
-pub fn signature_export(sig_handle: u32, encoding: u16) -> Result<u32, i32> {
+pub fn signature_export(sig_handle: u32, encoding: u16) -> Result<u32, Error> {
     let mut output_handle: u32 = 0;
     unsafe {
         let res = ffi::signature_export(sig_handle, encoding as u32, &mut output_handle);
         if res == 0 {
             Ok(output_handle)
         } else {
-            Err(res)
+            Err(Error::SignatureExport(res))
         }
     }
 }
 
-pub fn array_output_len(output_handle: u32) -> Result<u32, i32> {
+pub fn array_output_len(output_handle: u32) -> Result<u32, Error> {
     let mut length: u32 = 0;
     unsafe {
         let res = ffi::array_output_len(output_handle, &mut length);
         if res == 0 {
             Ok(length)
         } else {
-            Err(res)
+            Err(Error::ArrayOutputLen(res))
         }
     }
 }
 
-pub fn array_output_pull(output_handle: u32, buf: &mut Vec<u8>) -> Result<u32, i32> {
+pub fn array_output_pull(output_handle: u32, buf: &mut Vec<u8>) -> Result<u32, Error> {
     let mut length: u32 = 0;
     unsafe {
         let res = ffi::array_output_pull(output_handle, buf.as_mut_ptr(), 64, &mut length);
         if res == 0 {
             Ok(length)
         } else {
-            Err(res)
+            Err(Error::ArrayOutputPull(res))
         }
     }
 }


### PR DESCRIPTION
The current WASI-Crypto-Signature example in [`examples/plugin/wasi-crypto-signature/src/signatures.rs`](https://github.com/WasmEdge/WasmEdge/blob/d2e412a66e87720e840f4122e05b4f5f18c340bf/examples/plugin/wasi-crypto-signature/src/signatures.rs) uses basic error handling with simple `Result<u32, i32>` return types, where the error is just a numeric code returned from the wasi-crypto-signature plugin. This makes the example less user-friendly and harder to understand.
My contribution features an Error Enum that maps the numeric errors to meaningful error names.
```rust
pub enum Error {
    // i32 is the error code from the WASI-Crypto-Signature plugin
    SignatureImport(i32),
    SignatureExport(i32),
    ArrayOutputLen(i32),
    ArrayOutputPull(i32),
}
```