### PR TITLE
feat(wasi-nn): bump ggml to b5463; bump wasi-nn plugin to 0.1.22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
 # WasmEdge CAPI and so versions.
 set(WASMEDGE_CAPI_VERSION "0.1.0" CACHE STRING "WasmEdge C API library version")
 set(WASMEDGE_CAPI_SOVERSION "0" CACHE STRING "WasmEdge C API library soversion")
-set(WASMEDGE_WASI_NN_VERSION "0.1.21" CACHE STRING "WasmEdge WASI-NN library version")
+set(WASMEDGE_WASI_NN_VERSION "0.1.22" CACHE STRING "WasmEdge WASI-NN library version")
 set(WASMEDGE_WASI_NN_SOVERSION "0" CACHE STRING "WasmEdge WASI-NN library soversion")
 
 # Set cpack package version.

--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -343,7 +343,7 @@ function(wasmedge_setup_llama_target target)
     FetchContent_Declare(
       llama
       GIT_REPOSITORY https://github.com/ggml-org/llama.cpp.git
-      GIT_TAG        b5361
+      GIT_TAG        b5463
       GIT_SHALLOW    FALSE
     )
     FetchContent_MakeAvailable(llama)
@@ -354,6 +354,7 @@ function(wasmedge_setup_llama_target target)
     set_property(TARGET ggml-cpu PROPERTY POSITION_INDEPENDENT_CODE ON)
     set_property(TARGET llama PROPERTY POSITION_INDEPENDENT_CODE ON)
     set_property(TARGET mtmd PROPERTY POSITION_INDEPENDENT_CODE ON)
+    set_property(TARGET mtmd_audio PROPERTY POSITION_INDEPENDENT_CODE ON)
     if(WASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_CUBLAS)
       set_property(TARGET ggml-cuda PROPERTY POSITION_INDEPENDENT_CODE ON)
     endif()

--- a/plugins/wasi_nn/wasinn_ggml.h
+++ b/plugins/wasi_nn/wasinn_ggml.h
@@ -11,7 +11,6 @@
 #include <common.h>
 #include <llama-cpp.h>
 #include <llama.h>
-#include <llava.h>
 #include <mtmd.h>
 #include <sampling.h>
 #endif


### PR DESCRIPTION
- Bump ggml to b5463
- Bump wasi-nn plugin to 0.1.22
- Remove deprecated `dump-kv-cache`
- Use the new `media_marker` in mtmd