### PR TITLE
Fix install.sh failure for Mac M4 with wasi_nn-tensorflowlite plugin

### DIFF
--- a/utils/install.py
+++ b/utils/install.py
@@ -352,6 +352,7 @@ SUPPORTTED_PLUGINS = {
     "manylinux2014" + "aarch64" + WASI_NN_GGML: VersionString("0.13.4"),
     "darwin" + "x86_64" + WASI_NN_GGML: VersionString("0.13.4"),
     "darwin" + "arm64" + WASI_NN_GGML: VersionString("0.13.4"),
+    "darwin" + "arm64" + WASI_NN_TENSORFLOW_LITE: VersionString("0.14.1"),
     "ubuntu20.04" + "x86_64" + WASI_NN_TENSORFLOW_LITE: VersionString("0.13.0"),
     "darwin" + "x86_64" + WASMEDGE_TENSORFLOW_PLUGIN: VersionString("0.13.0"),
     "darwin" + "arm64" + WASMEDGE_TENSORFLOW_PLUGIN: VersionString("0.13.0"),


### PR DESCRIPTION
The command

```bash
curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- --plugins wasi_nn-tensorflowlite
```

fails on Apple Silicon machines (darwin/arm64) with the following error:

```
ERROR - Plugin not compatible: darwinarm64wasi_nn-tensorflowlite
```

**Change:**
Added the following line to the plugin compatibility map in the install script:

```python
"darwin" + "arm64" + WASI_NN_TENSORFLOW_LITE: VersionString("0.13.0"),
```

This enables successful installation of the plugin on Apple Silicon machines (M1/M2/M3/M4) using the install script.