### PR TITLE
chore(docker): bump the llvm from 12 to 18 on ubuntu 20.04

### DIFF
--- a/utils/docker/Dockerfile.ubuntu-base
+++ b/utils/docker/Dockerfile.ubuntu-base
@@ -21,17 +21,21 @@ FROM base AS deps-20
 RUN curl -sSf https://apt.kitware.com/kitware-archive.sh | sh
 RUN apt-get install -y cmake
 
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+        && echo "deb http://apt.llvm.org/focal llvm-toolchain-focal-18 main" | tee /etc/apt/sources.list.d/llvm.list
+
 RUN apt-get install -y \
-        llvm-12-dev \
-        liblld-12-dev \
-        clang-12
+        llvm-18-dev \
+        liblld-18-dev \
+        libpolly-18-dev \
+        clang-18
 
-RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 100 && \
-    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 100 && \
-    update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-12 100
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100 && \
+    update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-18 100
 
-ENV CC=/usr/bin/clang-12
-ENV CXX=/usr/bin/clang++-12
+ENV CC=/usr/bin/clang-18
+ENV CXX=/usr/bin/clang++-18
 
 ### deps for ubuntu 22.04 ###
 FROM base AS deps-22


### PR DESCRIPTION
The mac is using llvm@18. I think we should use the same version of the llvm for all assets.