### PR TITLE
fix: add Python 3.9 setup for OpenWRT build dependencies

### DIFF
--- a/.github/workflows/build_for_openwrt.yml
+++ b/.github/workflows/build_for_openwrt.yml
@@ -50,6 +50,10 @@ jobs:
     - name: Ensure git safe directory
       run: |
         git config --global --add safe.directory $(pwd)
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
     - name: Restore OpenWrt
       id: restore-openwrt
       uses: actions/cache/restore@v4


### PR DESCRIPTION
Fixes #4138

## Description
The OpenWRT build was failing due to missing Python 3.9+ and distutils dependencies in the GitHub Actions workflow.

## Changes
- Added Python 3.9 setup step before the OpenWRT build process
- Uses the official `actions/setup-python@v4` action

## Testing
- Workflow runs successfully in my fork
- The OpenWRT build should now proceed past the dependency check