### PR TITLE
fix(wasi-nn): clear the context before mtmd evaluation

### DIFF
--- a/plugins/wasi_nn/CMakeLists.txt
+++ b/plugins/wasi_nn/CMakeLists.txt
@@ -23,7 +23,7 @@ wasmedge_add_library(wasmedgePluginWasiNN
 include(WASINNDeps)
 wasmedge_setup_wasinn_target(wasmedgePluginWasiNN PLUGINLIB)
 
-set(WASMEDGE_WASI_NN_VERSION "0.1.23" CACHE STRING "WasmEdge WASI-NN library version")
+set(WASMEDGE_WASI_NN_VERSION "0.1.24" CACHE STRING "WasmEdge WASI-NN library version")
 set(WASMEDGE_WASI_NN_SOVERSION "0" CACHE STRING "WasmEdge WASI-NN library soversion")
 
 # Handle the version of the WASI-NN plugin


### PR DESCRIPTION
- Clear the context before mtmd evaluation.
- Add `clearContext()`.