### PR TITLE
ci(runner): Use github hosted arm runner instead of ours

### DIFF
--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -1,4 +1,4 @@
-name: Test WasmEdge extensions
+name: Extensions
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -189,7 +189,7 @@ jobs:
   build_plugins:
     permissions:
       contents: write
-    name: Build and Test
+    name: Plugins
     needs: get_version
     uses: ./.github/workflows/reusable-build-extensions.yml
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
     with:
       version: ${{ needs.get_version.outputs.version }}
       matrix: "[{'name':'manylinux_2_28 x86_64','runner':'ubuntu-latest','docker_tag':'manylinux_2_28_x86_64','asset_tag':'manylinux_2_28_x86_64'},
-                {'name':'manylinux_2_28 aarch64','runner':'linux-arm64-v2','docker_tag':'manylinux_2_28_aarch64','asset_tag':'manylinux_2_28_aarch64'}]"
+                {'name':'manylinux_2_28 aarch64','runner':'ubuntu-24.04-arm','docker_tag':'manylinux_2_28_aarch64','asset_tag':'manylinux_2_28_aarch64'}]"
 
   build_on_debian_static:
     permissions:
@@ -132,7 +132,7 @@ jobs:
                 {'name':'ubuntu-24.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Debug','docker_tag':'ubuntu-24.04-build-clang','tests':true},
                 {'name':'ubuntu-24.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-24.04-build-clang','tests':true},
                 {'name':'ubuntu-20.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-20.04-build-clang','tests':true},
-                {'name':'ubuntu-20.04','arch':'aarch64','runner':'linux-arm64-v2','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-20.04-build-clang-aarch64','tests':true},
+                {'name':'ubuntu-20.04','arch':'aarch64','runner':'ubuntu-24.04-arm','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-20.04-build-clang-aarch64','tests':true},
                 {'name':'linux-static','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-24.04-build-clang','options':'-DWASMEDGE_BUILD_SHARED_LIB=Off -DWASMEDGE_BUILD_STATIC_LIB=On -DWASMEDGE_LINK_TOOLS_STATIC=On -DWASMEDGE_BUILD_PLUGINS=Off'},
                 {'name':'ubuntu-22.04-coverage','arch':'x86_64','runner':'ubuntu-latest','compiler':'g++','build_type':'Debug','docker_tag':'ubuntu-22.04-build-gcc','coverage':true,'tests':true}]"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Test WasmEdge Core
+name: Core
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -186,7 +186,7 @@ jobs:
           - name: manylinux_2_28 aarch64
             docker_tag: manylinux_2_28_aarch64
             targets: aarch64,aarch64-plugins
-            host_runner: linux-arm64-v2
+            host_runner: ubuntu-24.04-arm
             host_container: wasmedge/wasmedge:ci-image-base_aarch64
 
     name: ${{ matrix.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
     with:
       version: ${{ needs.create_release.outputs.version }}
       matrix: "[{'name':'ubuntu-20.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-20.04-build-clang'},
-                {'name':'ubuntu-20.04','arch':'aarch64','runner':'linux-arm64-v2','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-20.04-build-clang-aarch64'}]"
+                {'name':'ubuntu-20.04','arch':'aarch64','runner':'ubuntu-24.04-arm','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-20.04-build-clang-aarch64'}]"
       release: true
     secrets: inherit
 
@@ -75,7 +75,7 @@ jobs:
       version: ${{ needs.create_release.outputs.version }}
       matrix:
         "[{'name':'manylinux_2_28 x86_64','runner':'ubuntu-latest','docker_tag':'manylinux_2_28_x86_64','asset_tag':'manylinux_2_28_x86_64'},
-          {'name':'manylinux_2_28 aarch64','runner':'linux-arm64-v2','docker_tag':'manylinux_2_28_aarch64','asset_tag':'manylinux_2_28_aarch64'}]"
+          {'name':'manylinux_2_28 aarch64','runner':'ubuntu-24.04-arm','docker_tag':'manylinux_2_28_aarch64','asset_tag':'manylinux_2_28_aarch64'}]"
       release: true
     secrets: inherit
 

--- a/.github/workflows/reusable-build-extensions.yml
+++ b/.github/workflows/reusable-build-extensions.yml
@@ -181,7 +181,7 @@ jobs:
             docker_tag: 'manylinux_2_28_x86_64-plugins-deps'
             asset_tag: 'manylinux_2_28_x86_64'
             plugins: ${{ needs.prepare.outputs.manylinux_2_28_x86_64 }}
-          - runner: 'linux-arm64-v2'
+          - runner: 'ubuntu-24.04-arm'
             docker_tag: 'manylinux_2_28_aarch64-plugins-deps'
             asset_tag: 'manylinux_2_28_aarch64'
             plugins: ${{ needs.prepare.outputs.manylinux_2_28_aarch64 }}

--- a/.github/workflows/reusable-build-on-ubuntu.yml
+++ b/.github/workflows/reusable-build-on-ubuntu.yml
@@ -88,7 +88,7 @@ jobs:
         if: ${{ !inputs.release && !matrix.coverage }}
         uses: actions/upload-artifact@v4
         with:
-          name: WasmEdge-${{ inputs.version }}-${{ matrix.name }}-${{ matrix.compiler }}-${{ matrix.build_type }}.tar.gz
+          name: WasmEdge-${{ inputs.version }}-${{ matrix.name }}-${{ matrix.compiler }}-${{ matrix.build_type }}-${{ matrix.arch }}.tar.gz
           path: build/WasmEdge-${{ inputs.version }}-Linux.tar.gz
       - name: Upload package tarball
         if: ${{ inputs.release }}

--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -40,7 +40,7 @@ jobs:
             python3_ex: python3
             extra_setup_command: echo "No extra command"
           - name: manylinux_2_28 aarch64
-            host_runner: linux-arm64-v2
+            host_runner: ubuntu-24.04-arm
             package_manager: yum
             docker_image: wasmedge/wasmedge:manylinux_2_28_aarch64
             python_package: python2 python3

--- a/.github/workflows/test-python-install-script.yml
+++ b/.github/workflows/test-python-install-script.yml
@@ -54,7 +54,7 @@ jobs:
             python3_ex: python3
             extra_setup_command: apt update && apt install -y lsb-release
           - name: manylinux_2_28 aarch64
-            host_runner: linux-arm64-v2
+            host_runner: ubuntu-24.04-arm
             package_manager: yum
             docker_image: wasmedge/wasmedge:manylinux_2_28_aarch64
             python_package: python2 python3


### PR DESCRIPTION
Fixes #3712 