### PR TITLE
feat(wasi-nn): bump ggml to b5640 and wasi-nn plugin to 0.1.26

### DIFF
--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -343,7 +343,7 @@ function(wasmedge_setup_llama_target target)
     FetchContent_Declare(
       llama
       GIT_REPOSITORY https://github.com/ggml-org/llama.cpp.git
-      GIT_TAG        b5593
+      GIT_TAG        b5640
       GIT_SHALLOW    FALSE
     )
     FetchContent_MakeAvailable(llama)

--- a/plugins/wasi_nn/CMakeLists.txt
+++ b/plugins/wasi_nn/CMakeLists.txt
@@ -23,7 +23,7 @@ wasmedge_add_library(wasmedgePluginWasiNN
 include(WASINNDeps)
 wasmedge_setup_wasinn_target(wasmedgePluginWasiNN PLUGINLIB)
 
-set(WASMEDGE_WASI_NN_VERSION "0.1.25" CACHE STRING "WasmEdge WASI-NN library version")
+set(WASMEDGE_WASI_NN_VERSION "0.1.26" CACHE STRING "WasmEdge WASI-NN library version")
 set(WASMEDGE_WASI_NN_SOVERSION "0" CACHE STRING "WasmEdge WASI-NN library soversion")
 
 # Handle the version of the WASI-NN plugin

--- a/plugins/wasi_nn/wasinn_ggml.cpp
+++ b/plugins/wasi_nn/wasinn_ggml.cpp
@@ -2184,7 +2184,7 @@ ErrNo evaluateTokens(Span<const llama_token> Tokens, Graph &GraphRef,
 // Clear the context and reset the sampler.
 void clearContext(Graph &GraphRef, Context &CxtRef) noexcept {
   LOG_DEBUG(GraphRef.EnableDebugLog, "{}: clearContext"sv)
-  llama_kv_self_clear(GraphRef.LlamaContext.get());
+  llama_memory_clear(llama_get_memory(GraphRef.LlamaContext.get()), true);
   common_sampler_reset(CxtRef.LlamaSampler);
   CxtRef.NPos = 0;
   CxtRef.LlamaOutputs.clear();
@@ -2913,7 +2913,7 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
 
   // Clear the llama context.
   LOG_DEBUG(GraphRef.EnableDebugLog, "setInput: clear llama context"sv)
-  llama_kv_self_clear(GraphRef.LlamaContext.get());
+  llama_memory_clear(llama_get_memory(GraphRef.LlamaContext.get()), true);
   LOG_DEBUG(GraphRef.EnableDebugLog, "setInput: clear llama context...Done"sv)
 
   // Set the input.


### PR DESCRIPTION
- Upgrade ggml to b5640
- Update depreated `llama_kv_self_clear` to `llama_memory_claer`.