### PR TITLE
feat(plugin): update the `0.14.1_plugin_lts` branch

### DIFF
--- a/cmake/Helper.cmake
+++ b/cmake/Helper.cmake
@@ -413,7 +413,7 @@ function(wasmedge_setup_stb_image)
     stb
     GIT_REPOSITORY https://github.com/nothings/stb.git
     GIT_TAG        2dfbe86bef853be33cbbda07abcb4db58c7f817d
-    GIT_SHALLOW    TRUE
+    GIT_SHALLOW    FALSE
   )
   FetchContent_MakeAvailable(stb)
   message(STATUS "Downloading stb_image source -- done")

--- a/cmake/Helper.cmake
+++ b/cmake/Helper.cmake
@@ -412,7 +412,7 @@ function(wasmedge_setup_stb_image)
   FetchContent_Declare(
     stb
     GIT_REPOSITORY https://github.com/nothings/stb.git
-    GIT_TAG        5c205738c191bcb0abc65c4febfa9bd25ff35234
+    GIT_TAG        2dfbe86bef853be33cbbda07abcb4db58c7f817d
     GIT_SHALLOW    TRUE
   )
   FetchContent_MakeAvailable(stb)

--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -330,7 +330,7 @@ function(wasmedge_setup_llama_target target)
     FetchContent_Declare(
       llama
       GIT_REPOSITORY https://github.com/ggml-org/llama.cpp.git
-      GIT_TAG        b5593
+      GIT_TAG        b5640
       GIT_SHALLOW    FALSE
     )
     FetchContent_MakeAvailable(llama)

--- a/plugins/wasi_nn/CMakeLists.txt
+++ b/plugins/wasi_nn/CMakeLists.txt
@@ -22,7 +22,7 @@ wasmedge_add_library(wasmedgePluginWasiNN
 include(WASINNDeps)
 wasmedge_setup_wasinn_target(wasmedgePluginWasiNN PLUGINLIB)
 
-set(WASMEDGE_WASI_NN_VERSION "0.1.25" CACHE STRING "WasmEdge WASI-NN library version")
+set(WASMEDGE_WASI_NN_VERSION "0.1.26" CACHE STRING "WasmEdge WASI-NN library version")
 set(WASMEDGE_WASI_NN_SOVERSION "0" CACHE STRING "WasmEdge WASI-NN library soversion")
 
 # Handle the version of the WASI-NN plugin

--- a/plugins/wasi_nn/wasinn_ggml.cpp
+++ b/plugins/wasi_nn/wasinn_ggml.cpp
@@ -2184,7 +2184,7 @@ ErrNo evaluateTokens(Span<const llama_token> Tokens, Graph &GraphRef,
 // Clear the context and reset the sampler.
 void clearContext(Graph &GraphRef, Context &CxtRef) noexcept {
   LOG_DEBUG(GraphRef.EnableDebugLog, "{}: clearContext"sv)
-  llama_kv_self_clear(GraphRef.LlamaContext.get());
+  llama_memory_clear(llama_get_memory(GraphRef.LlamaContext.get()), true);
   common_sampler_reset(CxtRef.LlamaSampler);
   CxtRef.NPos = 0;
   CxtRef.LlamaOutputs.clear();
@@ -2913,7 +2913,7 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
 
   // Clear the llama context.
   LOG_DEBUG(GraphRef.EnableDebugLog, "setInput: clear llama context"sv)
-  llama_kv_self_clear(GraphRef.LlamaContext.get());
+  llama_memory_clear(llama_get_memory(GraphRef.LlamaContext.get()), true);
   LOG_DEBUG(GraphRef.EnableDebugLog, "setInput: clear llama context...Done"sv)
 
   // Set the input.

--- a/plugins/wasi_nn/wasinn_ggml.cpp
+++ b/plugins/wasi_nn/wasinn_ggml.cpp
@@ -273,7 +273,7 @@ ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
       RET_ERROR(ErrNo::InvalidArgument,
                 "Unable to retrieve the ubatch-size option."sv)
     }
-    GraphRef.Params.n_batch = static_cast<int32_t>(UBatchSize);
+    GraphRef.Params.n_ubatch = static_cast<int32_t>(UBatchSize);
   }
   if (Doc.at_key("n-keep").error() == simdjson::SUCCESS) {
     int64_t NKeep;


### PR DESCRIPTION
Update the `0.14.1_plugin_lts` branch with the following commits:

* 9e297009 feat(wasi-nn): bump ggml to b5640 and wasi-nn plugin to 0.1.26 (#4164)
* cc6ac2fd fix(wasi-nn): fix n_ubatch assignment (#4163)
* 1ee910e7 chore(cmake): false the shallow mode for stb_image (#4153)
* 61e42c5a chore(plugin): wasmedge-images: bump to stb_image_resize2 2.14 (#4141)
