### PR TITLE
ci(commitlint): fix the permission to allow adding labels and comments under a PR

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -2,8 +2,13 @@ name: Commit Lint
 
 on: [pull_request]
 
+permissions:
+  contents: read
 jobs:
   commitlint:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -59,6 +64,7 @@ jobs:
         if: ${{ !cancelled() && steps.commitlint.outcome == 'success' }}
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             // Add label
             await github.rest.issues.addLabels({
@@ -106,6 +112,7 @@ jobs:
         if: ${{ !cancelled() && steps.commitlint.outcome == 'failure' }}
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             // Add label
             await github.rest.issues.addLabels({


### PR DESCRIPTION
It seems like the external contributors don't have enough permission to execute the commitlint workflow.

https://github.com/WasmEdge/WasmEdge/actions/runs/15607262843/job/43962494219?pr=4134