### PR TITLE
ci(commitlint): add missing permissions and github tokens

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,6 +1,11 @@
-name: Commit Lint
+name: "Commit Lint"
 
-on: [pull_request]
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 permissions:
   contents: read
@@ -9,6 +14,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +44,7 @@ jobs:
         if: ${{ !cancelled() && github.event_name == 'pull_request' }}
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             try {
               await github.rest.issues.removeLabel({


### PR DESCRIPTION
Still failed, check https://github.com/WasmEdge/WasmEdge/actions/runs/15611065731/job/43972967501?pr=4134

I changed how this workflow is triggered. It should have the same permissions as the issue labeler workflow.