### PR TITLE
Add conditional check for stdbool.h before C23 

### DIFF
--- a/include/api/wasmedge/wasmedge.h
+++ b/include/api/wasmedge/wasmedge.h
@@ -46,8 +46,8 @@
 #include "wasmedge/int128.h"
 #include "wasmedge/version.h"
 
-    /// WasmEdge WASM value type struct.
-    typedef struct WasmEdge_ValType {
+/// WasmEdge WASM value type struct.
+typedef struct WasmEdge_ValType {
   // This struct contains the raw data which describes the value type in WASM.
   // Developers should use the corresponding `WasmEdge_ValueTypeGen` functions
   // to generate this struct.


### PR DESCRIPTION
## Summary
Adds conditional inclusion of `stdbool.h` to prevent deprecation issues in C23.

## Changes
- Replace `#include <stdbool.h>` with conditional check
- Only include `stdbool.h` for C standards before C23 (`__STDC_VERSION__ < 202311L`)

Fixes #4147 