### PR TITLE
[CI] Add job to verify static library build configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,6 +139,7 @@ jobs:
                 {'name':'ubuntu-20.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-20.04-build-clang','tests':true},
                 {'name':'ubuntu-20.04','arch':'aarch64','runner':'ubuntu-24.04-arm','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-20.04-build-clang-aarch64','tests':true},
                 {'name':'linux-static','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-24.04-build-clang','options':'-DWASMEDGE_BUILD_SHARED_LIB=Off -DWASMEDGE_BUILD_STATIC_LIB=On -DWASMEDGE_LINK_TOOLS_STATIC=On -DWASMEDGE_BUILD_PLUGINS=Off'},
+                {'name':'ubuntu-24.04-static-lib','arch':'x86_64','runner':'ubuntu-latest','compiler':'g++','build_type':'Release','docker_tag':'ubuntu-24.04-build-gcc','options':'-DWASMEDGE_BUILD_STATIC_LIB=On','tests':true},
                 {'name':'ubuntu-22.04-coverage','arch':'x86_64','runner':'ubuntu-latest','compiler':'g++','build_type':'Debug','docker_tag':'ubuntu-22.04-build-gcc','coverage':true,'tests':true}]"
 
   build_on_windows:


### PR DESCRIPTION
## Description

This PR adds a new CI job in the Ubuntu build matrix to verify builds with `-DWASMEDGE_BUILD_STATIC_LIB=ON`. This addresses issue #3608, which requested a dedicated CI configuration to catch name conflicts in static library builds.

The new job builds on Ubuntu 24.04 with g++ in Release mode, enables tests, and specifically sets the `-DWASMEDGE_BUILD_STATIC_LIB=On` option without disabling other features (shared libraries, plugins, etc.).

## Motivation

As discussed in PR #3607, name conflicts can cause failures when building WasmEdge with static libraries enabled. This new CI job will help catch these issues earlier in the development process, ensuring that static library builds continue to work correctly.

Unlike the existing `linux-static` job which builds with shared libraries disabled and static linking enabled for tools, this new job specifically tests that static libraries can be built alongside shared libraries and plugins, which is a common use case.

## Related issues

Fixes #3608

References:
- #3607 (original PR where the need for this CI job was identified)
- #3600 (the original issue with name conflicts in static library builds)