### PR TITLE
chore(bpf): reorder the dual licenses to avoid the false positive license issue

### DIFF
--- a/test/plugins/wasm_bpf/assets/bpf-sources/simple_map.bpf.c
+++ b/test/plugins/wasm_bpf/assets/bpf-sources/simple_map.bpf.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
+// SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
 // SPDX-FileCopyrightText: 2019-2024 Second State INC
 
 #define SEC(name) __attribute__((section(name), used))

--- a/test/plugins/wasm_bpf/assets/bpf-sources/simple_ringbuf.bpf.c
+++ b/test/plugins/wasm_bpf/assets/bpf-sources/simple_ringbuf.bpf.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
+// SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
 // SPDX-FileCopyrightText: 2019-2024 Second State INC
 
 #define SEC(name) __attribute__((section(name), used))


### PR DESCRIPTION
Not sure why the dual license triggers the license failure. If reordering doesn't help, maybe we should separate these BPF tests into a standalone repo or remove them.