### PR TITLE
fix(CAPI): no longer include stdbool.h after C23

### DIFF
--- a/include/api/wasmedge/wasmedge.h
+++ b/include/api/wasmedge/wasmedge.h
@@ -32,7 +32,10 @@
 #define WASMEDGE_CAPI_PLUGIN_EXPORT __attribute__((visibility("default")))
 #endif // _WIN32
 
+#if !defined(__cplusplus) &&                                                   \
+    (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 202311L)
 #include <stdbool.h>
+#endif
 #include <stdint.h>
 #include <time.h>
 


### PR DESCRIPTION
Fixes #4147

Replace #4188 due to inactivity.