### PR TITLE
feat(c-api): add method to delete registered modules from VM

### DIFF
--- a/include/api/wasmedge/wasmedge.h
+++ b/include/api/wasmedge/wasmedge.h
@@ -3788,7 +3788,7 @@ WASMEDGE_CAPI_EXPORT extern uint32_t WasmEdge_VMGetFunctionList(
     const WasmEdge_VMContext *Cxt, WasmEdge_String *Names,
     const WasmEdge_FunctionTypeContext **FuncTypes, const uint32_t Len);
 
-/// Unsafely delete a registered module from the VM context.
+/// Forcibly delete a registered module from the VM context.
 ///
 /// \warning This function does not check whether other modules depend on the
 /// target. Deleting a module that is still in use may cause undefined behavior
@@ -3800,8 +3800,8 @@ WASMEDGE_CAPI_EXPORT extern uint32_t WasmEdge_VMGetFunctionList(
 /// \param Cxt the WasmEdge_VMContext to delete the module from.
 /// \param ModuleName the name of the module to delete.
 WASMEDGE_CAPI_EXPORT extern void
-WasmEdge_VMUnsafeDeleteRegisteredModule(const WasmEdge_VMContext *Cxt,
-                                        const WasmEdge_String ModuleName);
+WasmEdge_VMForceDeleteRegisteredModule(const WasmEdge_VMContext *Cxt,
+                                       const WasmEdge_String ModuleName);
 
 /// Get the module instance corresponding to the WasmEdge_HostRegistration
 /// settings.

--- a/include/api/wasmedge/wasmedge.h
+++ b/include/api/wasmedge/wasmedge.h
@@ -3788,6 +3788,18 @@ WASMEDGE_CAPI_EXPORT extern uint32_t WasmEdge_VMGetFunctionList(
     const WasmEdge_VMContext *Cxt, WasmEdge_String *Names,
     const WasmEdge_FunctionTypeContext **FuncTypes, const uint32_t Len);
 
+/// Delete a registered module from the VM context.
+///
+/// \warning Developers must ensure the module is not depended by other modules.
+/// Deleting a module that is still in use may cause undefined behavior or
+/// segmentation faults.
+///
+/// \param Cxt the WasmEdge_VMContext to delete the module from.
+/// \param ModuleName the name of the module to delete.
+WASMEDGE_CAPI_EXPORT extern void
+WasmEdge_VMDeleteRegisteredModule(const WasmEdge_VMContext *Cxt,
+                                  const WasmEdge_String ModuleName);
+
 /// Get the module instance corresponding to the WasmEdge_HostRegistration
 /// settings.
 ///

--- a/include/api/wasmedge/wasmedge.h
+++ b/include/api/wasmedge/wasmedge.h
@@ -3788,17 +3788,20 @@ WASMEDGE_CAPI_EXPORT extern uint32_t WasmEdge_VMGetFunctionList(
     const WasmEdge_VMContext *Cxt, WasmEdge_String *Names,
     const WasmEdge_FunctionTypeContext **FuncTypes, const uint32_t Len);
 
-/// Delete a registered module from the VM context.
+/// Unsafely delete a registered module from the VM context.
 ///
-/// \warning Developers must ensure the module is not depended by other modules.
-/// Deleting a module that is still in use may cause undefined behavior or
-/// segmentation faults.
+/// \warning This function does not check whether other modules depend on the
+/// target. Deleting a module that is still in use may cause undefined behavior
+/// or crashes.
+///
+/// A safer deletion API may be introduced in the future once module dependency
+/// management is implemented.
 ///
 /// \param Cxt the WasmEdge_VMContext to delete the module from.
 /// \param ModuleName the name of the module to delete.
 WASMEDGE_CAPI_EXPORT extern void
-WasmEdge_VMDeleteRegisteredModule(const WasmEdge_VMContext *Cxt,
-                                  const WasmEdge_String ModuleName);
+WasmEdge_VMUnsafeDeleteRegisteredModule(const WasmEdge_VMContext *Cxt,
+                                        const WasmEdge_String ModuleName);
 
 /// Get the module instance corresponding to the WasmEdge_HostRegistration
 /// settings.

--- a/include/runtime/storemgr.h
+++ b/include/runtime/storemgr.h
@@ -98,6 +98,18 @@ public:
     return {};
   }
 
+  /// Unregister a named module from this store.
+  Expect<void> unregisterModule(std::string_view Name) {
+    std::unique_lock Lock(Mutex);
+    auto Iter = NamedMod.find(Name);
+    if (Iter == NamedMod.cend()) {
+      return Unexpect(ErrCode::Value::UnknownImport);
+    }
+    (const_cast<Instance::ModuleInstance *>(Iter->second))->unlinkStore(this);
+    NamedMod.erase(Iter);
+    return {};
+  }
+
   void addNamedModule(std::string_view Name,
                       const Instance::ModuleInstance *Inst) {
     std::unique_lock Lock(Mutex);

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -3104,22 +3104,23 @@ WASMEDGE_CAPI_EXPORT void WasmEdge_VMCleanup(WasmEdge_VMContext *Cxt) {
   }
 }
 
-void WasmEdge_VMDeleteRegisteredModule(const WasmEdge_VMContext *Cxt,
-                                       const WasmEdge_String ModuleName) {
+void WasmEdge_VMUnsafeDeleteRegisteredModule(const WasmEdge_VMContext *Cxt,
+                                             const WasmEdge_String ModuleName) {
   if (!Cxt || !ModuleName.Buf) {
     return; // Invalid input
   }
+
   // Cast away const to match WasmEdge_VMGetStoreContext signature
   WasmEdge_StoreContext *StoreCxt =
       WasmEdge_VMGetStoreContext(const_cast<WasmEdge_VMContext *>(Cxt));
   if (!StoreCxt) {
     return; // Invalid store context
   }
+
   const WasmEdge_ModuleInstanceContext *ModInst =
       WasmEdge_StoreFindModule(StoreCxt, ModuleName);
   if (ModInst) {
     fromStoreCxt(StoreCxt)->unregisterModule(genStrView(ModuleName));
-    // Cast away const for WasmEdge_ModuleInstanceDelete
     WasmEdge_ModuleInstanceDelete(
         const_cast<WasmEdge_ModuleInstanceContext *>(ModInst));
   }

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -3104,8 +3104,8 @@ WASMEDGE_CAPI_EXPORT void WasmEdge_VMCleanup(WasmEdge_VMContext *Cxt) {
   }
 }
 
-void WasmEdge_VMUnsafeDeleteRegisteredModule(const WasmEdge_VMContext *Cxt,
-                                             const WasmEdge_String ModuleName) {
+void WasmEdge_VMForceDeleteRegisteredModule(const WasmEdge_VMContext *Cxt,
+                                            const WasmEdge_String ModuleName) {
   if (!Cxt || !ModuleName.Buf) {
     return; // Invalid input
   }

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -3104,6 +3104,27 @@ WASMEDGE_CAPI_EXPORT void WasmEdge_VMCleanup(WasmEdge_VMContext *Cxt) {
   }
 }
 
+void WasmEdge_VMDeleteRegisteredModule(const WasmEdge_VMContext *Cxt,
+                                       const WasmEdge_String ModuleName) {
+  if (!Cxt || !ModuleName.Buf) {
+    return; // Invalid input
+  }
+  // Cast away const to match WasmEdge_VMGetStoreContext signature
+  WasmEdge_StoreContext *StoreCxt =
+      WasmEdge_VMGetStoreContext(const_cast<WasmEdge_VMContext *>(Cxt));
+  if (!StoreCxt) {
+    return; // Invalid store context
+  }
+  const WasmEdge_ModuleInstanceContext *ModInst =
+      WasmEdge_StoreFindModule(StoreCxt, ModuleName);
+  if (ModInst) {
+    fromStoreCxt(StoreCxt)->unregisterModule(genStrView(ModuleName));
+    // Cast away const for WasmEdge_ModuleInstanceDelete
+    WasmEdge_ModuleInstanceDelete(
+        const_cast<WasmEdge_ModuleInstanceContext *>(ModInst));
+  }
+}
+
 WASMEDGE_CAPI_EXPORT uint32_t
 WasmEdge_VMGetFunctionListLength(const WasmEdge_VMContext *Cxt) {
   if (Cxt) {

--- a/test/api/APIVMCoreTest.cpp
+++ b/test/api/APIVMCoreTest.cpp
@@ -243,6 +243,12 @@ TEST(WasmEdgeVM, UnsafeDeleteRegisteredModule) {
   WasmEdge_VMUnsafeDeleteRegisteredModule(VMCxt, ModuleName);
   EXPECT_EQ(WasmEdge_VMListRegisteredModuleLength(VMCxt), originalCount);
 
+  // Added check to ensure module is no longer accessible
+  WasmEdge_StoreContext *StoreCxt = WasmEdge_VMGetStoreContext(VMCxt);
+  const WasmEdge_ModuleInstanceContext *FindResult =
+      WasmEdge_StoreFindModule(StoreCxt, ModuleName);
+  EXPECT_EQ(FindResult, nullptr);
+  
   // Cleanup
   WasmEdge_StringDelete(ModuleName);
   WasmEdge_VMDelete(VMCxt);
@@ -273,14 +279,14 @@ TEST(WasmEdgeVM, UnsafeDeleteInvalidInput) {
   WasmEdge_String ModuleName = WasmEdge_StringCreateByCString("test_module");
   WasmEdge_String EmptyName = WasmEdge_StringCreateByCString("");
 
-  // Test null VM context — should not crash
+  // Test null VM context, should not crash
   WasmEdge_VMUnsafeDeleteRegisteredModule(nullptr, ModuleName);
 
-  // Test empty module name — should not crash
+  // Test empty module name, should not crash
   WasmEdge_VMUnsafeDeleteRegisteredModule(VMCxt, EmptyName);
   uint32_t originalCount = WasmEdge_VMListRegisteredModuleLength(VMCxt);
   EXPECT_EQ(WasmEdge_VMListRegisteredModuleLength(VMCxt),
-            originalCount); // No change
+            originalCount); 
 
   // Cleanup
   WasmEdge_StringDelete(ModuleName);

--- a/test/api/APIVMCoreTest.cpp
+++ b/test/api/APIVMCoreTest.cpp
@@ -225,7 +225,7 @@ TEST(AsyncExecute, InterruptTest) {
   WasmEdge_VMDelete(VM);
 }
 
-TEST(WasmEdgeVM, UnsafeDeleteRegisteredModule) {
+TEST(WasmEdgeVM, ForceDeleteRegisteredModule) {
   WasmEdge_ConfigureContext *Conf = WasmEdge_ConfigureCreate();
   WasmEdge_VMContext *VMCxt = WasmEdge_VMCreate(Conf, nullptr);
 
@@ -239,8 +239,8 @@ TEST(WasmEdgeVM, UnsafeDeleteRegisteredModule) {
   EXPECT_TRUE(WasmEdge_ResultOK(Res));
   EXPECT_EQ(WasmEdge_VMListRegisteredModuleLength(VMCxt), originalCount + 1);
 
-  // Unsafe delete
-  WasmEdge_VMUnsafeDeleteRegisteredModule(VMCxt, ModuleName);
+  // Force delete
+  WasmEdge_VMForceDeleteRegisteredModule(VMCxt, ModuleName);
   EXPECT_EQ(WasmEdge_VMListRegisteredModuleLength(VMCxt), originalCount);
 
   // Added check to ensure module is no longer accessible
@@ -248,14 +248,14 @@ TEST(WasmEdgeVM, UnsafeDeleteRegisteredModule) {
   const WasmEdge_ModuleInstanceContext *FindResult =
       WasmEdge_StoreFindModule(StoreCxt, ModuleName);
   EXPECT_EQ(FindResult, nullptr);
-  
+
   // Cleanup
   WasmEdge_StringDelete(ModuleName);
   WasmEdge_VMDelete(VMCxt);
   WasmEdge_ConfigureDelete(Conf);
 }
 
-TEST(WasmEdgeVM, UnsafeDeleteNonExistentModule) {
+TEST(WasmEdgeVM, ForceDeleteNonExistentModule) {
   WasmEdge_ConfigureContext *Conf = WasmEdge_ConfigureCreate();
   WasmEdge_VMContext *VMCxt = WasmEdge_VMCreate(Conf, nullptr);
   uint32_t originalCount = WasmEdge_VMListRegisteredModuleLength(VMCxt);
@@ -263,7 +263,7 @@ TEST(WasmEdgeVM, UnsafeDeleteNonExistentModule) {
       WasmEdge_StringCreateByCString("nonexistent_module");
 
   // Try deleting a module that doesn’t exist — should not crash
-  WasmEdge_VMUnsafeDeleteRegisteredModule(VMCxt, ModuleName);
+  WasmEdge_VMForceDeleteRegisteredModule(VMCxt, ModuleName);
   EXPECT_EQ(WasmEdge_VMListRegisteredModuleLength(VMCxt),
             originalCount); // No change
 
@@ -273,20 +273,18 @@ TEST(WasmEdgeVM, UnsafeDeleteNonExistentModule) {
   WasmEdge_ConfigureDelete(Conf);
 }
 
-TEST(WasmEdgeVM, UnsafeDeleteInvalidInput) {
+TEST(WasmEdgeVM, ForceDeleteInvalidInput) {
   WasmEdge_ConfigureContext *Conf = WasmEdge_ConfigureCreate();
   WasmEdge_VMContext *VMCxt = WasmEdge_VMCreate(Conf, nullptr);
   WasmEdge_String ModuleName = WasmEdge_StringCreateByCString("test_module");
   WasmEdge_String EmptyName = WasmEdge_StringCreateByCString("");
 
   // Test null VM context, should not crash
-  WasmEdge_VMUnsafeDeleteRegisteredModule(nullptr, ModuleName);
-
+  WasmEdge_VMForceDeleteRegisteredModule(nullptr, ModuleName);
   // Test empty module name, should not crash
-  WasmEdge_VMUnsafeDeleteRegisteredModule(VMCxt, EmptyName);
+  WasmEdge_VMForceDeleteRegisteredModule(VMCxt, EmptyName);
   uint32_t originalCount = WasmEdge_VMListRegisteredModuleLength(VMCxt);
-  EXPECT_EQ(WasmEdge_VMListRegisteredModuleLength(VMCxt),
-            originalCount); 
+  EXPECT_EQ(WasmEdge_VMListRegisteredModuleLength(VMCxt), originalCount);
 
   // Cleanup
   WasmEdge_StringDelete(ModuleName);
@@ -295,14 +293,14 @@ TEST(WasmEdgeVM, UnsafeDeleteInvalidInput) {
   WasmEdge_ConfigureDelete(Conf);
 }
 
-TEST(WasmEdgeVM, UnsafeDeleteInvalidStoreContext) {
+TEST(WasmEdgeVM, ForceDeleteInvalidStoreContext) {
   WasmEdge_ConfigureContext *Conf = WasmEdge_ConfigureCreate();
   WasmEdge_VMContext *VMCxt = WasmEdge_VMCreate(Conf, nullptr);
   WasmEdge_String ModuleName = WasmEdge_StringCreateByCString("test_module");
 
   // Simulate an invalid store context by deleting the VM
   WasmEdge_VMDelete(VMCxt);
-  WasmEdge_VMUnsafeDeleteRegisteredModule(VMCxt, ModuleName); // Should not crash
+  WasmEdge_VMForceDeleteRegisteredModule(VMCxt, ModuleName); // Should not crash
 
   // Cleanup
   WasmEdge_StringDelete(ModuleName);

--- a/test/api/APIVMCoreTest.cpp
+++ b/test/api/APIVMCoreTest.cpp
@@ -293,20 +293,6 @@ TEST(WasmEdgeVM, ForceDeleteInvalidInput) {
   WasmEdge_ConfigureDelete(Conf);
 }
 
-TEST(WasmEdgeVM, ForceDeleteInvalidStoreContext) {
-  WasmEdge_ConfigureContext *Conf = WasmEdge_ConfigureCreate();
-  WasmEdge_VMContext *VMCxt = WasmEdge_VMCreate(Conf, nullptr);
-  WasmEdge_String ModuleName = WasmEdge_StringCreateByCString("test_module");
-
-  // Simulate an invalid store context by deleting the VM
-  WasmEdge_VMDelete(VMCxt);
-  WasmEdge_VMForceDeleteRegisteredModule(VMCxt, ModuleName); // Should not crash
-
-  // Cleanup
-  WasmEdge_StringDelete(ModuleName);
-  WasmEdge_ConfigureDelete(Conf);
-}
-
 } // namespace
 
 GTEST_API_ int main(int argc, char **argv) {


### PR DESCRIPTION
Closes: #2481 

Currently, the WasmEdge C API does not provide a way to delete or unregister a module that has been registered to a `WasmEdge_VMContext`. This can lead to inefficient memory/resource usage in long-running applications or when modules are dynamically managed.

This PR introduces a new API function:

```c
WASMEDGE_CAPI_EXPORT extern void
WasmEdge_VMDeleteRegisteredModule(const WasmEdge_VMContext *Cxt,
                                  const WasmEdge_String ModuleName);
```

This allows users to explicitly delete a named module registered in a VM, enabling better control over module lifecycle and resource management.

#### What’s Done

* **API Definition**
  Added the `WasmEdge_VMDeleteRegisteredModule` function declaration to the public C API header (`include/api/wasmedge/wasmedge.h`).

* **Core Implementation**
  Implemented the function in `lib/api/wasmedge.cpp` to:

  * Validate input parameters.
  * Retrieve the store context from the VM.
  * Locate and unregister the named module from the store.
  * Delete the module instance to release resources.

* **Store Manager Enhancements**
  Extended the `StoreManager` class (`include/runtime/storemgr.h`) with an `unregisterModule` method that safely removes a named module from internal storage with proper synchronization.

* **Unit Tests**
  Added new test cases in `test/api/APIVMCoreTest.cpp` to verify:

  * Successful registration and subsequent deletion of a module updates the registered module count correctly.
  * Attempting to delete a non-existent module does not affect the registered modules or cause errors.
 

#### Build Success & Test Coverage

* **Build System**
  The project was successfully built using **CMake + Ninja** on a Windows environment (`MSVC`). A clean build was performed to ensure no stale artifacts affected the result.

* **Test Execution**
  Focused test case `wasmedgeAPIVMCoreTests` (Test #14), which contains the new module deletion test cases, was run independently to validate the functionality.

  ```bash
  PS D:\Programs\wasmedge\WasmEdge\build> ctest -R wasmedgeAPIVMCoreTests --output-on-failure
  Test project D:/Programs/wasmedge/WasmEdge/build
      Start 14: wasmedgeAPIVMCoreTests
  1/1 Test #14: wasmedgeAPIVMCoreTests ...........   Passed  362.60 sec

  100% tests passed, 0 tests failed out of 1
  ```

* **Conclusion**
  The new API function behaves as expected:

  * Registered modules are correctly removed.
  * Non-existent module deletion does not cause crashes or memory faults.

  All assertions passed, confirming the correctness and stability of the feature under test.