### PR TITLE
docker(ubuntu): simplify image names for plugins

### DIFF
--- a/utils/docker/docker-bake.ubuntu.hcl
+++ b/utils/docker/docker-bake.ubuntu.hcl
@@ -76,7 +76,11 @@ function "tags-backports" {
 
 function "tags-simplified" {
   params = [target, ubuntu, toolchain]
-  result = target == "base" && toolchain == "clang" ? "ubuntu-${ubuntu}" : ""
+  result = toolchain == "clang" ? join("-", compact([
+    "ubuntu",
+    ubuntu,
+    target == "plugins" ? "plugins" : "",
+  ])) : ""
 }
 
 function "tags" {


### PR DESCRIPTION
Update `"tags-simplified"` so that images for both base and plugins have a default one.

Before this PR:
- `ubuntu-24.04-build-clang` -> `ubuntu-24.04` 

After this PR:
- `ubuntu-24.04-build-clang` -> `ubuntu-24.04` 
- `ubuntu-20.04-build-clang-plugins-deps` -> `ubuntu-20.04-plugins`