### PR TITLE
ci(release): fixed the incorrect GitHub permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,8 @@ jobs:
 
   create_source_tarball:
     needs: create_release
+    permissions:
+      contents: write
     uses: ./.github/workflows/reusable-create-source-tarball.yml
     with:
       version: ${{ needs.create_release.outputs.version }}
@@ -60,6 +62,8 @@ jobs:
   build_on_macos:
     needs: create_release
     uses: ./.github/workflows/reusable-build-on-macos.yml
+    permissions:
+      contents: write
     with:
       version: ${{ needs.create_release.outputs.version }}
       matrix:
@@ -71,6 +75,8 @@ jobs:
   build_on_ubuntu_20_04:
     needs: create_release
     uses: ./.github/workflows/reusable-build-on-ubuntu.yml
+    permissions:
+      contents: write
     with:
       version: ${{ needs.create_release.outputs.version }}
       matrix: "[{'name':'ubuntu-20.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-20.04-build-clang'},
@@ -81,6 +87,8 @@ jobs:
   build_on_manylinux_2_28:
     needs: create_release
     uses: ./.github/workflows/reusable-build-on-manylinux.yml
+    permissions:
+      contents: write
     with:
       version: ${{ needs.create_release.outputs.version }}
       matrix:
@@ -92,6 +100,8 @@ jobs:
   build_on_debian_static:
     needs: create_release
     uses: ./.github/workflows/reusable-build-on-debian-static.yml
+    permissions:
+      contents: write
     with:
       version: ${{ needs.create_release.outputs.version }}
       release: true
@@ -100,6 +110,8 @@ jobs:
   build_on_alpine_static:
     needs: create_release
     uses: ./.github/workflows/reusable-build-on-alpine-static.yml
+    permissions:
+      contents: write
     with:
       version: ${{ needs.create_release.outputs.version }}
       release: true
@@ -108,6 +120,8 @@ jobs:
   build_on_windows:
     needs: create_release
     uses: ./.github/workflows/reusable-build-on-windows.yml
+    permissions:
+      contents: write
     with:
       version: ${{ needs.create_release.outputs.version }}
       release: true
@@ -116,6 +130,8 @@ jobs:
   build_on_windows_msvc:
     needs: create_release
     uses: ./.github/workflows/reusable-build-on-windows-msvc.yml
+    permissions:
+      contents: write
     with:
       version: ${{ needs.create_release.outputs.version }}
       release: true
@@ -124,6 +140,8 @@ jobs:
   build_on_android:
     needs: create_release
     uses: ./.github/workflows/reusable-build-on-android.yml
+    permissions:
+      contents: write
     with:
       version: ${{ needs.create_release.outputs.version }}
       release: true
@@ -133,6 +151,8 @@ jobs:
     name: Build and Upload
     needs: create_release
     uses: ./.github/workflows/reusable-build-extensions.yml
+    permissions:
+      contents: write
     with:
       version: ${{ needs.create_release.outputs.version }}
       release: true


### PR DESCRIPTION
Unfortunately, we introduce a regression for the release process.

![CleanShot 2025-07-10 at 15 03 21](https://github.com/user-attachments/assets/c878e758-009c-43f3-974e-a2f20212c167)
