### PR TITLE
fix(executor): add checks before dumpStackTrace

### DIFF
--- a/lib/executor/executor.cpp
+++ b/lib/executor/executor.cpp
@@ -144,7 +144,9 @@ Executor::invoke(const Runtime::Instance::FunctionInstance *FuncInst,
 
   // Call runFunction.
   EXPECTED_TRY(runFunction(StackMgr, *FuncInst, Params).map_error([](auto E) {
-    dumpStackTrace(Span<const uint32_t>{StackTrace}.first(StackTraceSize));
+    if (E != ErrCode::Value::Terminated) {
+      dumpStackTrace(Span<const uint32_t>{StackTrace}.first(StackTraceSize));
+    }
     return E;
   }));
 


### PR DESCRIPTION
## Summary

Fixes #4273

This PR prevents **extra `[error]` output after normal execution** of wasm files built with `emcc` on Linux.

---

## Bug Report

### Background

* Issue only occurs with **`emcc`-generated wasm**, not `rustc`.
* Reproducible on **Linux**, not on macOS.
* Present since `0.15.0-alpha.1`, not in `0.14`.

* likely introduced with pr https://github.com/WasmEdge/WasmEdge/pull/3967
The cause was `dumpStackTrace` being called even on `ErrCode::Terminated`, resulting in unnecessary `[error]` logs despite normal termination.

---

### Changes

* Add guard before `dumpStackTrace`:
  * Check that error is **not `ErrCode::Terminated`**.
  * Check that **`StackTraceSize > 0`**.

---

### Testing(on linux)

* `emcc` wasm files (previously showed extra error)
* `rustc` wasm files (never showed extra error)

Confirmed:

* Normal executions no longer output `[error]`.
* Real errors continue to display stack traces as intended.

---

#### Notes

* Thanks @gaaraw for the clear report and reproduction files.
* Root cause identified as introduced in #3967.