### PR TITLE
ci(commitlint): set header-max-length to warning level due to Dependabot will create long commit header

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   rules: {
     // Set to warning level since Dependabot creates long commit message lines
     // that we have no control.
+    "header-max-length": [1, "always", 100],
     "body-max-line-length": [1, "always", 100],
   },
 };


### PR DESCRIPTION
See:
* https://github.com/WasmEdge/WasmEdge/actions/runs/16891220877/job/47851216236?pr=4313
* https://github.com/WasmEdge/WasmEdge/actions/runs/16891048853/job/47850646700?pr=4312
