### PR TITLE
feat(installer,v2): support WasmEdge 0.15.0 tarball structure

### DIFF
--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -218,8 +218,8 @@ jobs:
         for file in "$HOME/.zshrc" "$HOME/.bash_profile"; do
         [ -f "$file" ] || continue
         if grep -q ". \"$IPATH/env\"" "$file"; then
-          echo "✗ Found WasmEdge source line in: $file"
-          echo "✗ Uninstallation failed"
+          echo "[FAIL] Found WasmEdge source line in: $file"
+          echo "[FAIL] Uninstallation failed"
           exit 1
         fi
         done
@@ -275,9 +275,9 @@ jobs:
         # Note: install_v2.sh currently defaults to ${TEST_VERSION}, not the latest version
         INSTALLED_VERSION=$(wasmedge -v | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
         if [[ "${INSTALLED_VERSION}" == "${TEST_VERSION}" ]]; then
-          echo "✓ Version: ${TEST_VERSION} (install_v2.sh default)"
+          echo "[PASS] Version: ${TEST_VERSION} (install_v2.sh default)"
         else
-          echo "✗ Version mismatch: expected ${TEST_VERSION}, got ${INSTALLED_VERSION}"
+          echo "[FAIL] Version mismatch: expected ${TEST_VERSION}, got ${INSTALLED_VERSION}"
           exit 1
         fi
 
@@ -289,6 +289,19 @@ jobs:
         # Test specific version with custom GGML build
         printf "\n=== Test 3: Custom GGML build ===\n"
         bash utils/install_v2.sh -V --version=${TEST_VERSION} --ggmlbn=b5640
+        verify_plugin "libwasmedgePluginWasiNN.so"
+
+        # Test version 0.15.0 with new tarball structure
+        printf "\n=== Test 4: Version ${TEST_228_VERSION} (new tarball structure) ===\n"
+        bash utils/install_v2.sh -V --version=${TEST_228_VERSION}
+        source ~/.wasmedge/env
+        INSTALLED_VERSION=$(wasmedge -v | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+        if [[ "${INSTALLED_VERSION}" == "${TEST_228_VERSION}" ]]; then
+          echo "[PASS] Version ${TEST_228_VERSION} installed successfully"
+        else
+          echo "[FAIL] Version mismatch: expected ${TEST_228_VERSION}, got ${INSTALLED_VERSION}"
+          exit 1
+        fi
         verify_plugin "libwasmedgePluginWasiNN.so"
 
         # Test uninstallation
@@ -361,20 +374,38 @@ jobs:
         echo "Installed version: ${INSTALLED_VERSION}"
 
         if [ "${INSTALLED_VERSION}" = "${TEST_VERSION}" ]; then
-          echo "✓ Version: ${TEST_VERSION} (install_v2.sh default)"
+          echo "[PASS] Version: ${TEST_VERSION} (install_v2.sh default)"
         else
-          echo "✗ Version mismatch: expected ${TEST_VERSION}, got ${INSTALLED_VERSION}"
+          echo "[FAIL] Version mismatch: expected ${TEST_VERSION}, got ${INSTALLED_VERSION}"
           exit 1
         fi
 
+        bash utils/uninstall.sh -q -V
+
+        # Test version 0.15.0 with new tarball structure
+        echo "=== Test: Version ${TEST_228_VERSION} (new tarball structure) ==="
+        bash utils/install_v2.sh -V --version=${TEST_228_VERSION}
+        source ~/.wasmedge/env 2>/dev/null || source ~/.bashrc 2>/dev/null || true
+        
+        INSTALLED_VERSION=$(~/.wasmedge/bin/wasmedge --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+        echo "Installed version: ${INSTALLED_VERSION}"
+        
+        if [ "${INSTALLED_VERSION}" = "${TEST_228_VERSION}" ]; then
+          echo "[PASS] Version ${TEST_228_VERSION} installed successfully"
+        else
+          echo "[FAIL] Version mismatch: expected ${TEST_228_VERSION}, got ${INSTALLED_VERSION}"
+          exit 1
+        fi
+        verify_plugin "libwasmedgePluginWasiNN.dylib"
+        
         bash utils/uninstall.sh -q -V
         # Test if the environment variable was removed
         IPATH="$HOME/.wasmedge"
         for file in "$HOME/.zshrc" "$HOME/.bash_profile"; do
           [ -f "$file" ] || continue
           if grep -q ". \"$IPATH/env\"" "$file"; then
-            echo "✗ Found WasmEdge source line in: $file"
-            echo "✗ Uninstallation failed"
+            echo "[FAIL] Found WasmEdge source line in: $file"
+            echo "[FAIL] Uninstallation failed"
             exit 1
           fi
         done
@@ -448,7 +479,7 @@ jobs:
           # Test deprecated version handling
           echo "Test 3: Deprecated version handling"
           ${python_cmd} utils/install.py -v ${DEPRECATED_TEST_VERSION} -D 2>&1 | grep -q "Version not supported. Min Version: 0.13.0" && \
-            echo "✓ Version validation works" || (echo "✗ Version validation failed" && exit 1)
+            echo "[PASS] Version validation works" || (echo "[FAIL] Version validation failed" && exit 1)
         done
 
     - name: Test Plugin Installations
@@ -534,7 +565,7 @@ jobs:
         # Test deprecated version handling
         printf "\n=== Test 3: Deprecated version handling ===\n"
         python3 utils/install.py -v ${DEPRECATED_TEST_VERSION} -D 2>&1 | grep -q "Version not supported. Min Version: 0.13.0" && \
-          echo "✓ Version validation works" || (echo "✗ Version validation failed" && exit 1)
+          echo "[PASS] Version validation works" || (echo "[FAIL] Version validation failed" && exit 1)
 
     - name: Test Plugin Installations
       shell: zsh {0}

--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -386,10 +386,10 @@ jobs:
         echo "=== Test: Version ${TEST_228_VERSION} (new tarball structure) ==="
         bash utils/install_v2.sh -V --version=${TEST_228_VERSION}
         source ~/.wasmedge/env 2>/dev/null || source ~/.bashrc 2>/dev/null || true
-        
+
         INSTALLED_VERSION=$(~/.wasmedge/bin/wasmedge --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
         echo "Installed version: ${INSTALLED_VERSION}"
-        
+
         if [ "${INSTALLED_VERSION}" = "${TEST_228_VERSION}" ]; then
           echo "[PASS] Version ${TEST_228_VERSION} installed successfully"
         else
@@ -397,7 +397,7 @@ jobs:
           exit 1
         fi
         verify_plugin "libwasmedgePluginWasiNN.dylib"
-        
+
         bash utils/uninstall.sh -q -V
         # Test if the environment variable was removed
         IPATH="$HOME/.wasmedge"

--- a/utils/install_v2.sh
+++ b/utils/install_v2.sh
@@ -157,14 +157,14 @@ get_latest_release() {
 version_ge() {
 	local version1=$1
 	local version2=$2
-	
+
 	# Convert versions to comparable format (major*10000 + minor*100 + patch)
 	local v1_parts=(${version1//./ })
 	local v2_parts=(${version2//./ })
-	
+
 	local v1_num=$((${v1_parts[0]:-0} * 10000 + ${v1_parts[1]:-0} * 100 + ${v1_parts[2]:-0}))
 	local v2_num=$((${v2_parts[0]:-0} * 10000 + ${v2_parts[1]:-0} * 100 + ${v2_parts[2]:-0}))
-	
+
 	if [ $v1_num -ge $v2_num ]; then
 		return 0
 	else
@@ -403,7 +403,7 @@ install() {
 		src_dir="$TMP_DIR"
 		info "Detected new tarball structure (0.15.0+)"
 	fi
-	
+
 	for var in "$@"; do
 		if [ "$var" = "lib" ]; then
 			if [ -d "$src_dir"/lib64 ]; then
@@ -420,7 +420,7 @@ install() {
 				# Plugin was extracted to the old structure location
 				plugin_src="$TMP_DIR/$dir/plugin"
 			fi
-			
+
 			if [ -n "$plugin_src" ] && [ -d "$plugin_src" ]; then
 				if [[ ! $IPATH =~ ^"/usr" ]]; then
 					cp -rf "$plugin_src"/* "$IPATH/plugin"
@@ -429,7 +429,7 @@ install() {
 					cp -rf "$plugin_src"/* "$IPATH/lib"
 					local plugin_dest="$IPATH/lib"
 				fi
-				
+
 				for _file_ in "$plugin_dest"/*; do
 					if [[ "$_file_" =~ "Plugin" ]] || [[ "$_file_" =~ "plugin" ]] || [[ "$_file_" =~ "ggml" ]]; then
 						local _plugin_name_=${_file_##*/}
@@ -496,13 +496,7 @@ get_wasmedge_ggml_plugin() {
 		_downloader "https://github.com/WasmEdge/WasmEdge/releases/download/$VERSION/WasmEdge-plugin-wasi_nn-ggml${CUDA_EXT}${NOAVX_EXT}-$VERSION-$RELEASE_PKG"
 	else
 		info "Use ${GGML_BUILD_NUMBER} GGML plugin"
-		if [[ "${VERSION}" =~ ^"0.14.1" ]]; then
-			# Due to the cuda assets are too large to be inside the repo tree
-			# We are using the release assets instead of the repo tree from 0.14.1
-			_downloader "https://github.com/second-state/WASI-NN-GGML-PLUGIN-REGISTRY/releases/download/${GGML_BUILD_NUMBER}/WasmEdge-plugin-wasi_nn-ggml${CUDA_EXT}${NOAVX_EXT}-${VERSION}-${RELEASE_PKG}"
-		else
-			_downloader "https://github.com/second-state/WASI-NN-GGML-PLUGIN-REGISTRY/raw/main/${VERSION}/${GGML_BUILD_NUMBER}/WasmEdge-plugin-wasi_nn-ggml${CUDA_EXT}${NOAVX_EXT}-$VERSION-$RELEASE_PKG"
-		fi
+		_downloader "https://github.com/second-state/WASI-NN-GGML-PLUGIN-REGISTRY/releases/download/${GGML_BUILD_NUMBER}/WasmEdge-plugin-wasi_nn-ggml${CUDA_EXT}${NOAVX_EXT}-${VERSION}-${RELEASE_PKG}"
 	fi
 
 	local TMP_PLUGIN_DIR="${TMP_DIR}/${IPKG}/plugin"

--- a/utils/install_v2.sh
+++ b/utils/install_v2.sh
@@ -152,6 +152,26 @@ get_latest_release() {
 	echo "0.14.1"
 }
 
+# Compare semantic versions
+# Returns 0 if version1 >= version2, 1 otherwise
+version_ge() {
+	local version1=$1
+	local version2=$2
+	
+	# Convert versions to comparable format (major*10000 + minor*100 + patch)
+	local v1_parts=(${version1//./ })
+	local v2_parts=(${version2//./ })
+	
+	local v1_num=$((${v1_parts[0]:-0} * 10000 + ${v1_parts[1]:-0} * 100 + ${v1_parts[2]:-0}))
+	local v2_num=$((${v2_parts[0]:-0} * 10000 + ${v2_parts[1]:-0} * 100 + ${v2_parts[2]:-0}))
+	
+	if [ $v1_num -ge $v2_num ]; then
+		return 0
+	else
+		return 1
+	fi
+}
+
 VERSION=$(get_latest_release)
 
 check_os_arch() {
@@ -174,7 +194,11 @@ check_os_arch() {
 					;;
 			esac
 			if [ "${LEGACY}" == 1 ]; then
-				RELEASE_PKG="manylinux2014_${ARCH}.tar.gz"
+				if version_ge "${VERSION}" "0.15.0"; then
+					RELEASE_PKG="manylinux_2_28_${ARCH}.tar.gz"
+				else
+					RELEASE_PKG="manylinux2014_${ARCH}.tar.gz"
+				fi
 			else
 				RELEASE_PKG="ubuntu20.04_${ARCH}.tar.gz"
 			fi


### PR DESCRIPTION
- Handle new directory structure for v0.15.0+
- Remove obsolete wasi-logging plugin logic
- Add tests for tarball structure detection
- Fix non-ASCII characters in CI output