### PR TITLE
fix: added alignment for WASI host functions

### DIFF
--- a/test/host/wasi/wasi.cpp
+++ b/test/host/wasi/wasi.cpp
@@ -5429,4 +5429,3 @@ TEST(WasiTest, PointerAlignment) {
     }
   }
 }
-


### PR DESCRIPTION
#4362

Added alignment checks for `WasiArgsGet, WasiArgsSizesGet, WasiEnvironGet, and WasiEnvironSizesGet`
For this, I introduced a new error code: `__WASI_ERRNO_NOTALIGNED` : 88

Also added basic tests to verify that the alignment code works correctly and traps when needed.

@q82419 Could you please review the PR and share your feedback on these changes?

Thank you