### PR TITLE
ci(runner): update macOS 13 runner to 14-large, due to deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
     uses: ./.github/workflows/reusable-build-on-macos.yml
     with:
       version: ${{ needs.get_version.outputs.version }}
-      matrix: "[{'name':'MacOS 13 (x86_64)','runner':'macos-13','darwin_version':22,'arch':'x86_64'},
+      matrix: "[{'name':'MacOS 14 (x86_64)','runner':'macos-14-large','darwin_version':23,'arch':'x86_64'},
                 {'name':'MacOS 14 (arm64)','runner':'macos-14','darwin_version':23,'arch':'arm64'}]"
 
   build_on_manylinux_2_28:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
     with:
       version: ${{ needs.create_release.outputs.version }}
       matrix:
-        "[{'name':'MacOS 13 (x86_64)','runner':'macos-13','darwin_version':22,'arch':'x86_64'},
+        "[{'name':'MacOS 14 (x86_64)','runner':'macos-14-large','darwin_version':23,'arch':'x86_64'},
         {'name':'MacOS 14 (arm64)','runner':'macos-14','darwin_version':23,'arch':'arm64'}]"
       release: true
     secrets: inherit

--- a/.github/workflows/reusable-build-extensions-on-macos.yml
+++ b/.github/workflows/reusable-build-extensions-on-macos.yml
@@ -52,13 +52,11 @@ jobs:
       - name: Build and install dependencies
         shell: bash
         run: |
-          eval $(/opt/homebrew/bin/brew shellenv)
           brew install ninja opencv rust ffmpeg@7
           brew unlink ffmpeg
       - name: Build ${{ matrix.plugin }}
         shell: bash
         run: |
-          eval $(/opt/homebrew/bin/brew shellenv)
           export PKG_CONFIG_PATH="$(brew --prefix)/opt/ffmpeg@7/lib/pkgconfig:$PKG_CONFIG_PATH"
           export OpenSSL_DIR="$(brew --prefix)/opt/openssl"
           export CC=clang
@@ -129,7 +127,6 @@ jobs:
       - if: ${{ inputs.release }}
         name: Install gh for release
         run: |
-          eval $(/opt/homebrew/bin/brew shellenv)
           brew install gh
       - if: ${{ inputs.release }}
         name: Upload release ${{ steps.var.outputs.artifact }}

--- a/.github/workflows/reusable-build-extensions.yml
+++ b/.github/workflows/reusable-build-extensions.yml
@@ -169,8 +169,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: 'macos-13'
-            asset_tag: 'darwin_22-x86_64'
+          - runner: 'macos-14-large'
+            asset_tag: 'darwin_23-x86_64'
             plugins: ${{ needs.prepare.outputs.macos_x86_64 }}
           - runner: 'macos-14'
             asset_tag: 'darwin_23-arm64'

--- a/.github/workflows/reusable-build-on-macos.yml
+++ b/.github/workflows/reusable-build-on-macos.yml
@@ -75,17 +75,14 @@ jobs:
           cmake --build build
       - name: Test WasmEdge
         run: |
-          eval $(/opt/homebrew/bin/brew shellenv)
           export DYLD_LIBRARY_PATH="$(pwd)/build/lib/api:$DYLD_LIBRARY_PATH"
           cd build
           ctest
       - name: Create package tarball
         run: |
-          eval $(/opt/homebrew/bin/brew shellenv)
           cmake --build build --target package
       - name: Test Standalone WasmEdge without LLVM
         run: |
-          eval $(/opt/homebrew/bin/brew shellenv)
           export DYLD_LIBRARY_PATH="$(pwd)/build/lib/api:$DYLD_LIBRARY_PATH"
           echo "otool -L ./build/tools/wasmedge/wasmedge:"
           otool -L ./build/tools/wasmedge/wasmedge

--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -165,7 +165,7 @@ jobs:
       matrix:
         include:
           - name: macOS x86_64
-            runner: macos-13
+            runner: macos-14-large
           - name: macOS arm64
             runner: macos-15
 
@@ -326,7 +326,7 @@ jobs:
       matrix:
         include:
           - name: macOS Intel
-            runner: macos-13
+            runner: macos-14-large
           - name: macOS Apple Silicon
             runner: macos-15
 
@@ -514,7 +514,7 @@ jobs:
       matrix:
         include:
           - name: macOS Intel
-            runner: macos-13
+            runner: macos-14-large
           - name: macOS Apple Silicon
             runner: macos-15
 

--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -185,7 +185,6 @@ jobs:
 
     - name: Install Zsh
       run: |
-        eval $(/opt/homebrew/bin/brew shellenv) 2>/dev/null || true
         brew install zsh
 
     - name: Test install.sh Functionality
@@ -346,7 +345,6 @@ jobs:
 
     - name: Install Zsh
       run: |
-        eval $(/opt/homebrew/bin/brew shellenv) 2>/dev/null || true
         brew install zsh
 
     - name: Test install_v2.sh Functionality
@@ -535,7 +533,6 @@ jobs:
     - name: Install Python and Zsh
       shell: zsh {0}
       run: |
-        eval $(/opt/homebrew/bin/brew shellenv) 2>/dev/null || true
         brew upgrade
         brew install python zsh
 


### PR DESCRIPTION
See: https://github.com/actions/runner-images/issues/13046

The macOS 13 Ventura based runner images will begin deprecation on September 22nd and will be fully unsupported by December 4th.