### PR TITLE
fix(WASI-NN,ggml): moving the function definitions to prevent macos linker issue

### DIFF
--- a/plugins/wasi_nn/GGML/tts/tts_core.cpp
+++ b/plugins/wasi_nn/GGML/tts/tts_core.cpp
@@ -303,6 +303,8 @@ std::string replaceNumbersWithWords(const std::string &InputText) {
   return Result;
 }
 
+} // namespace
+
 std::vector<llama_token> processTTSPrompt(WasiNNEnvironment &Env,
                                           Graph &GraphRef,
                                           std::string &Prompt) noexcept {
@@ -475,6 +477,5 @@ ErrNo codesToSpeech(WasiNNEnvironment &Env, Graph &GraphRef,
   return ErrNo::Success;
 }
 
-} // namespace
 #endif
 } // namespace WasmEdge::Host::WASINN::GGML

--- a/plugins/wasi_nn/GGML/tts/tts_core.h
+++ b/plugins/wasi_nn/GGML/tts/tts_core.h
@@ -32,15 +32,16 @@ const std::map<int, std::string> Tens = {
     {2, "twenty"}, {3, "thirty"},  {4, "forty"},  {5, "fifty"},
     {6, "sixty"},  {7, "seventy"}, {8, "eighty"}, {9, "ninety"}};
 
-std::string processTTSPromptText(const std::string &Text);
-std::optional<TTSSpeakerProfile>
-getSpeakerProfileFromFile(const std::string &FilePath, WasiNNEnvironment &Env);
-
 std::vector<float> embdToAudio(const float *Embd, const int NCodes,
                                const int NEmbd, const int NThread);
 std::vector<uint8_t> audioDataToWav(const std::vector<float> &Data,
                                     int SampleRate);
 } // namespace
+
+std::string processTTSPromptText(const std::string &Text);
+std::optional<TTSSpeakerProfile>
+getSpeakerProfileFromFile(const std::string &FilePath, WasiNNEnvironment &Env);
+
 std::vector<llama_token> processTTSPrompt(WasiNNEnvironment &Env,
                                           Graph &GraphRef,
                                           std::string &Prompt) noexcept;


### PR DESCRIPTION
Fixes:

```
plugins/wasi_nn/CMakeFiles/wasmedgePluginWasiNN.dir/GGML/tts/tts_core.cpp.o plugins/wasi_nn/CMakeFiles/wasmedgePluginWasiNN.dir/GGML/utils.cpp.o  -Wl,-rpath,/Users/runner/work/wasi-nn-ggml-plugin/wasi-nn-ggml-plugin/build/lib/api  _deps/llama-build/common/libcommon.a  _deps/simdjson-build/libsimdjson.a  _deps/llama-build/tools/mtmd/libmtmd.a  lib/api/libwasmedge.0.1.0.tbd  _deps/llama-build/vendor/cpp-httplib/libcpp-httplib.a  _deps/llama-build/src/libllama.a  _deps/llama-build/ggml/src/libggml.a  _deps/llama-build/ggml/src/libggml-cpu.a  _deps/llama-build/ggml/src/ggml-metal/libggml-metal.a  _deps/llama-build/ggml/src/libggml-base.a  -lm  -framework Foundation  -framework Metal  -framework MetalKit  lib/driver/libwasmedgeDriver.a  lib/vm/libwasmedgeVM.a  lib/plugin/libwasmedgePlugin.a  lib/plugin/wasi_logging/libwasmedgePluginWasiLogging.a  lib/po/libwasmedgePO.a  lib/loader/libwasmedgeLoader.a  lib/loader/libwasmedgeLoaderFileMgr.a  -ldl  lib/validator/libwasmedgeValidator.a  lib/executor/libwasmedgeExecutor.a  lib/host/wasi/libwasmedgeHostModuleWasi.a  lib/system/libwasmedgeSystem.a  lib/common/libwasmedgeCommon.a  _deps/spdlog-build/libspdlog.a  _deps/fmt-build/libfmt.a && :
Undefined symbols for architecture arm64:
  "WasmEdge::Host::WASINN::GGML::codesToSpeech(WasmEdge::Host::WASINN::WasiNNEnvironment&, WasmEdge::Host::WASINN::GGML::Graph&, WasmEdge::Host::WASINN::GGML::Context&)", referenced from:
      WasmEdge::Host::WASINN::GGML::compute(WasmEdge::Host::WASINN::WasiNNEnvironment&, unsigned int) in 
  "WasmEdge::Host::WASINN::GGML::processTTSPrompt(WasmEdge::Host::WASINN::WasiNNEnvironment&, WasmEdge::Host::WASINN::GGML::Graph&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&)", referenced from:
      WasmEdge::Host::WASINN::GGML::setInput(WasmEdge::Host::WASINN::WasiNNEnvironment&, unsigned int, unsigned int, WasmEdge::Host::WASINN::TensorData const&) in 
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
[361/363] Building CXX object _deps/llama-build/tools/tts/CMakeFiles/llama-tts.dir/tts.cpp.o
```