### PR TITLE
ci: use macos-15-intel as the ci runner, instead of macos-14-large

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
     uses: ./.github/workflows/reusable-build-on-macos.yml
     with:
       version: ${{ needs.get_version.outputs.version }}
-      matrix: "[{'name':'MacOS 14 (x86_64)','runner':'macos-14-large','darwin_version':23,'arch':'x86_64'},
+      matrix: "[{'name':'MacOS 15 (x86_64)','runner':'macos-15-intel','darwin_version':24,'arch':'x86_64'},
                 {'name':'MacOS 14 (arm64)','runner':'macos-14','darwin_version':23,'arch':'arm64'}]"
 
   build_on_manylinux_2_28:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
     with:
       version: ${{ needs.create_release.outputs.version }}
       matrix:
-        "[{'name':'MacOS 14 (x86_64)','runner':'macos-14-large','darwin_version':23,'arch':'x86_64'},
+        "[{'name':'MacOS 15 (x86_64)','runner':'macos-15-intel','darwin_version':24,'arch':'x86_64'},
         {'name':'MacOS 14 (arm64)','runner':'macos-14','darwin_version':23,'arch':'arm64'}]"
       release: true
     secrets: inherit

--- a/.github/workflows/reusable-build-extensions.yml
+++ b/.github/workflows/reusable-build-extensions.yml
@@ -169,8 +169,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: 'macos-14-large'
-            asset_tag: 'darwin_23-x86_64'
+          - runner: 'macos-15-intel'
+            asset_tag: 'darwin_24-x86_64'
             plugins: ${{ needs.prepare.outputs.macos_x86_64 }}
           - runner: 'macos-14'
             asset_tag: 'darwin_23-arm64'

--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -165,7 +165,7 @@ jobs:
       matrix:
         include:
           - name: macOS x86_64
-            runner: macos-14-large
+            runner: macos-15-intel
           - name: macOS arm64
             runner: macos-15
 
@@ -325,7 +325,7 @@ jobs:
       matrix:
         include:
           - name: macOS Intel
-            runner: macos-14-large
+            runner: macos-15-intel
           - name: macOS Apple Silicon
             runner: macos-15
 
@@ -512,7 +512,7 @@ jobs:
       matrix:
         include:
           - name: macOS Intel
-            runner: macos-14-large
+            runner: macos-15-intel
           - name: macOS Apple Silicon
             runner: macos-15
 


### PR DESCRIPTION
Reference: https://github.com/actions/runner-images/issues/13045