### PR TITLE
feat(docker): add libpiper to plugin-deps image

### DIFF
--- a/utils/docker/Dockerfile.manylinux_2_28-plugins-deps
+++ b/utils/docker/Dockerfile.manylinux_2_28-plugins-deps
@@ -41,4 +41,7 @@ ENV OPENVINO_YEAR="2025"
 COPY wasi-nn/install-onnxruntime.sh .
 RUN [ "/bin/bash", "install-onnxruntime.sh" ]
 
+COPY wasi-nn/install-libpiper.sh .
+RUN [ "/bin/bash", "install-libpiper.sh" ]
+
 RUN yum clean all

--- a/utils/docker/Dockerfile.ubuntu-base
+++ b/utils/docker/Dockerfile.ubuntu-base
@@ -40,6 +40,7 @@ ENV CXX=/usr/bin/clang++-18
 ### deps for ubuntu 22.04 ###
 FROM base AS deps-22
 
+RUN curl -sSf https://apt.kitware.com/kitware-archive.sh | sh
 RUN apt-get install -y cmake
 
 RUN apt-get install -y \

--- a/utils/docker/Dockerfile.ubuntu-plugins-deps
+++ b/utils/docker/Dockerfile.ubuntu-plugins-deps
@@ -75,6 +75,9 @@ RUN [ "/bin/bash", "-c", "echo \"source ./openvino_genai/setupvars.sh\" >> .bash
 COPY wasi-nn/install-onnxruntime.sh .
 RUN [ "/bin/bash", "install-onnxruntime.sh" ]
 
+COPY wasi-nn/install-libpiper.sh .
+RUN [ "/bin/bash", "install-libpiper.sh" ]
+
 COPY wasi-nn/install-chattts.sh .
 RUN [ "/bin/bash", "install-chattts.sh" ]
 
@@ -88,6 +91,7 @@ RUN rm -f \
     install-openvino.sh \
     install-onnxruntime.sh \
     install-openvino-genai.sh \
-    install-chattts.sh
+    install-chattts.sh \
+    install-libpiper.sh
 
 RUN rm -rf /var/lib/apt/lists/*

--- a/utils/wasi-nn/install-libpiper.sh
+++ b/utils/wasi-nn/install-libpiper.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2019-2026 Second State INC
+
+set -e
+
+PIPER_REPO="https://github.com/OHF-Voice/piper1-gpl.git"
+PIPER_COMMIT="32b95f8c1f0dc0ce27a6acd1143de331f61af777"
+PIPER_INSTALL_TO="/usr/local"
+
+case "$(uname -m)" in
+  'x86_64') ;;
+  'aarch64') ;;
+  *)
+    echo "Unsupported architecture for libpiper: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+git clone --depth 1 "${PIPER_REPO}" piper-source
+cd piper-source
+git fetch --depth 1 origin "${PIPER_COMMIT}"
+git checkout FETCH_HEAD
+
+cd libpiper
+
+cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${PIPER_INSTALL_TO}"
+cmake --build build
+cmake --install build
+
+cd ../..
+rm -rf piper-source
+
+ldconfig


### PR DESCRIPTION

**Description:**
This PR adds the `libpiper` dependency to the `manylinux` and `ubuntu` plugin-deps Docker images.

**Changes:**

* Added `utils/wasi-nn/install-libpiper.sh` to build `libpiper` from source.
* Updated `Dockerfile.manylinux_2_28-plugins-deps` and `Dockerfile.ubuntu-plugins-deps` to execute the install script during image build.

**Reason:**
Pre-building `libpiper` in the dependency images prevents redundant compilation during CI runs and improves build efficiency for the Piper plugin.