### PR TITLE
chore: add missing gitvote update from previous maintainer onboarding

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -64,6 +64,7 @@ profiles:
         - ibmibmibm
         - q82419
         - juntao
+        - grorge123
 
     # Periodic status check
     #


### PR DESCRIPTION
Add missing gitvote update from previous maintainer onboarding.
See: https://github.com/WasmEdge/WasmEdge/pull/4402