### PR TITLE
docs: add WasmEdge mentorship policy

### DIFF
--- a/docs/mentorship-policy.md
+++ b/docs/mentorship-policy.md
@@ -1,0 +1,29 @@
+# WasmEdge Mentorship Program Policy
+
+Welcome to the WasmEdge community! This document outlines the basic policies and guidelines for applicants and participants of mentorship programs such as LFX Mentorship and Google Summer of Code (GSoC).
+
+## Application Phase
+
+To ensure fairness, the following actions are **strictly prohibited** before the application period concludes:
+
+1. **No Private Contact:** Applicants must not privately contact mentors via email, Discord DM, or CNCF Slack DM during the application period to seek assistance or reviews beyond what is available in public channels.
+2. **No AI Spam:** Applicants must not submit AI-generated spam ("AI slop") to the repository. This includes, but is not limited to, meaningless or fabricated Issues, Pull Requests, and Discussions.
+3. **No Plagiarism:** Applicants must not plagiarize others' work or public proposals and implementations.
+
+### Communication and Discussion
+
+If communication or discussion regarding relevant topics is needed, please observe the following:
+
+1. **General Topics:** Broad questions should be asked in GitHub Discussions, the Discord mentoring channel, or the Slack CNCF `#wasmedge` channel.
+2. **Project Ideas:** Questions related to specific project ideas should be discussed directly under the relevant GitHub Issue.
+3. **Program/Administrative Inquiries:** Issues related to specific programs (e.g., LFX Mentorship or GSoC) or financial matters should be directed to the corresponding organizing body.
+
+## During the Mentorship Program
+
+Once accepted, mentees have the following obligations:
+
+1. **Initialization:** At the start of the program, create an issue using the appropriate LFX/GSoC issue template. This issue must detail the task's timeline and milestones.
+2. **Weekly Updates:** Provide progress updates in the designated issue every week.
+3. **Timely Communication:** If you encounter difficulties or require assistance, communicate with your mentor immediately within the issue.
+4. **Schedule Management:** If you anticipate events that will significantly impact your progress (such as midterm or final exams), you must inform your mentor in the issue **in advance** and update/communicate the new timeline.
+5. **Evaluations:** Please be mindful of the midterm and final evaluation schedules. Current programs have strict time limits. If your progress or Pull Requests do not meet the standards by the deadline, you will receive a failing ("reject") evaluation. No extensions will be granted.


### PR DESCRIPTION
I am requesting all maintainers to vote on this proposal.  
Since we will have the 2026 mentorship program soon, it is better to establish some rules to avoid the issues encountered previously and to provide applicants and mentees with a basic policy to follow.

/vote