### PR TITLE
feat: add module dependency tracking for safe deletion

### DIFF
--- a/include/runtime/instance/module.h
+++ b/include/runtime/instance/module.h
@@ -87,9 +87,28 @@ public:
     }
   }
 
+
   std::string_view getModuleName() const noexcept {
     std::shared_lock Lock(Mutex);
     return ModName;
+  }
+
+  /// Module dependency tracking.
+  void addDependent(const ModuleInstance *Mod) noexcept {
+    std::unique_lock Lock(Mutex);
+    Dependents.insert(Mod);
+  }
+  void removeDependent(const ModuleInstance *Mod) noexcept {
+    std::unique_lock Lock(Mutex);
+    Dependents.erase(Mod);
+  }
+  bool hasDependents() const noexcept {
+    std::shared_lock Lock(Mutex);
+    return !Dependents.empty();
+  }
+  uint32_t getDependentCount() const noexcept {
+    std::shared_lock Lock(Mutex);
+    return static_cast<uint32_t>(Dependents.size());
   }
 
   void *getHostData() const noexcept { return HostData; }
@@ -577,6 +596,9 @@ protected:
   /// Linked store.
   std::map<StoreManager *, std::function<BeforeModuleDestroyCallback>>
       LinkedStore;
+
+  /// Dependent modules.
+  std::set<const ModuleInstance *> Dependents;
 
   /// External data and its finalizer function pointer.
   void *HostData;


### PR DESCRIPTION
## What this PR does

Adds `Dependents` set and methods to `ModuleInstance` for tracking which modules import from this module. This enables checking if a module can be safely deleted without causing use-after-free.

## Changes

- Added `addDependent()` / `removeDependent()` methods
- Added `hasDependents()` / `getDependentCount()` methods  
- Added `Dependents` set as private member

## Next Steps

This is scaffolding for #4514. My follow-up PRs will:
1. Wire up dependency tracking during module instantiation
2. Add safe deletion check in `unregisterModule`

Related-to: #4514