### PR TITLE
fix(WASI-NN/bitnet): out-of-bounds array access in unload() function

### DIFF
--- a/plugins/wasi_nn/wasinn_bitnet.cpp
+++ b/plugins/wasi_nn/wasinn_bitnet.cpp
@@ -2356,8 +2356,11 @@ Expect<ErrNo> finiSingle(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
 
 Expect<ErrNo> unload(WasiNNEnvironment &Env, uint32_t GraphId) noexcept {
 
+  if (GraphId >= Env.NNGraph.size()) {
+    return ErrNo::Success;
+  }
   auto &GraphRef = Env.NNGraph[GraphId].get<Graph>();
-  if (GraphId >= Env.NNGraph.size() || GraphRef.LlamaModel == nullptr) {
+  if (GraphRef.LlamaModel == nullptr) {
     return ErrNo::Success;
   }
 


### PR DESCRIPTION
### Issue:
During reviewing the code, i noticed a out-of-bounds access in `plugins/wasi_nn/wasinn_bitnet.cpp`. The `unload()` function can access `Env.NNGraph[GraphId]` before checking if `GraphId` is within bounds. If `GraphId >= Env.NNGraph.size()`, this may cause an undefined behavior.

### Fix:
Moved the bounds check before accessing the array element. This prevents undefined behavior when an invalid `GraphId` is passed to the function.