### PR TITLE
feat(statistics): add VM lifecycle timing for module load and instantiation

### DIFF
--- a/include/common/statistics.h
+++ b/include/common/statistics.h
@@ -139,12 +139,38 @@ public:
     TimeRecorder.stopRecord(Timer::TimerTag::HostFunc);
   }
 
+  /// Start recording module load time.
+  void startRecordModuleLoad() noexcept {
+    TimeRecorder.startRecord(Timer::TimerTag::ModuleLoad);
+  }
+
+  /// Stop recording module load time.
+  void stopRecordModuleLoad() noexcept {
+    TimeRecorder.stopRecord(Timer::TimerTag::ModuleLoad);
+  }
+
+  /// Start recording instantiation time.
+  void startRecordInstantiation() noexcept {
+    TimeRecorder.startRecord(Timer::TimerTag::Instantiation);
+  }
+
+  /// Stop recording instantiation time.
+  void stopRecordInstantiation() noexcept {
+    TimeRecorder.stopRecord(Timer::TimerTag::Instantiation);
+  }
+
   /// Getter of execution time.
   Timer::Timer::Clock::duration getWasmExecTime() const noexcept {
     return TimeRecorder.getRecord(Timer::TimerTag::Wasm);
   }
   Timer::Timer::Clock::duration getHostFuncExecTime() const noexcept {
     return TimeRecorder.getRecord(Timer::TimerTag::HostFunc);
+  }
+  Timer::Timer::Clock::duration getModuleLoadTime() const noexcept {
+    return TimeRecorder.getRecord(Timer::TimerTag::ModuleLoad);
+  }
+  Timer::Timer::Clock::duration getInstantiationTime() const noexcept {
+    return TimeRecorder.getRecord(Timer::TimerTag::Instantiation);
   }
   Timer::Timer::Clock::duration getTotalExecTime() const noexcept {
     return TimeRecorder.getRecord(Timer::TimerTag::Wasm) +
@@ -167,6 +193,9 @@ public:
                    Nano(getWasmExecTime()));
       spdlog::info(" Host functions execution time: {} ns"sv,
                    Nano(getHostFuncExecTime()));
+      spdlog::info(" Module load time: {} ns"sv, Nano(getModuleLoadTime()));
+      spdlog::info(" Module instantiation time: {} ns"sv,
+                   Nano(getInstantiationTime()));
     }
     if (StatConf.isInstructionCounting()) {
       spdlog::info(" Executed wasm instructions count: {}"sv, getInstrCount());

--- a/include/common/timer.h
+++ b/include/common/timer.h
@@ -25,7 +25,13 @@
 namespace WasmEdge {
 namespace Timer {
 
-enum class TimerTag : uint32_t { Wasm, HostFunc, Max };
+enum class TimerTag : uint32_t {
+  Wasm,
+  HostFunc,
+  ModuleLoad,
+  Instantiation,
+  Max
+};
 
 class Timer {
 public:


### PR DESCRIPTION
### Fixes: #4076 

### Summary

This PR extends the existing statistics infrastructure to record and report VM lifecycle timing for module load and module instantiation when `--enable-all-statistics` is enabled.

### What changed

- Added new internal timing tags for module load and instantiation
- Instrumented VM load and instantiation paths to record timing
- Ensured timers are correctly stopped on both success and error paths
- Extended statistics output to include the new timing metrics

### Motivation

Startup and cold-start performance are important for benchmarking WasmEdge-based workloads. Measuring module load and instantiation time provides useful insight while reusing the existing statistics mechanism.

## Testing

- Built WasmEdge from a clean build directory
- Ran the WasmEdge CLI locally with `--enable-all-statistics`
- Verified that existing statistics remain unchanged
- Verified that the following new statistics are reported with non-zero values:
  - Module load time
  - Module instantiation time

All statistics are displayed correctly and the runtime behavior remains unchanged.

<img width="1283" height="613" alt="Screenshot 2026-01-19 105516" src="https://github.com/user-attachments/assets/994aa8b7-3b22-4a1f-979b-a004d2944b9c" />

