### PR TITLE
fix(docker): build libpiper statically in install script

### DIFF
--- a/utils/wasi-nn/install-libpiper.sh
+++ b/utils/wasi-nn/install-libpiper.sh
@@ -24,7 +24,11 @@ git checkout FETCH_HEAD
 
 cd libpiper
 
-cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${PIPER_INSTALL_TO}"
+cmake -Bbuild \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${PIPER_INSTALL_TO}" \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 cmake --build build
 cmake --install build
 


### PR DESCRIPTION
### Changes
- In #4481 we missed adding flags for building libpiper statically. This PR fixes that.

CI jobs: https://github.com/Divyansh200102/WasmEdge/pull/14/checks