### PR TITLE
fix(WASI-NN/whisper): implement resource cleanup in finalizeExecCtx

### DIFF
--- a/plugins/wasi_nn/wasinn_whisper.cpp
+++ b/plugins/wasi_nn/wasinn_whisper.cpp
@@ -1113,7 +1113,11 @@ Expect<ErrNo> finalizeExecCtx(WasiNNEnvironment &Env,
     spdlog::info(
         "[WASI-NN][Debug] Whisper backend: finalize_execution_context"sv);
   }
-  // TODO: Free resources
+  // Free resources
+  CxtRef.InputPCM.clear();
+  CxtRef.InputPCMs.clear();
+  CxtRef.Outputs.clear();
+  
   Env.deleteContext(ContextId);
   if (IsDebugLog) {
     spdlog::info(


### PR DESCRIPTION
### Summary
While reading the code, I noticed a TODO comment regarding missing resource cleanup. So, in this PR I implemented that TODO.

### Tests
<img width="317" height="54" alt="Screenshot 2026-01-21 074030" src="https://github.com/user-attachments/assets/8b8bd7b4-2a87-4c76-b0ce-88682241c8c1" />