### PR TITLE
feat(wasi-crypto): implement stubbed common functions

### DIFF
--- a/plugins/wasi_crypto/CMakeLists.txt
+++ b/plugins/wasi_crypto/CMakeLists.txt
@@ -25,6 +25,7 @@ wasmedge_add_library(wasmedgePluginWasiCrypto
   kx/kx.cpp
   kx/module.cpp
   kx/options.cpp
+  secrets_manager/options.cpp
   signatures/ctx.cpp
   signatures/ecdsa.cpp
   signatures/eddsa.cpp

--- a/plugins/wasi_crypto/CMakeLists.txt
+++ b/plugins/wasi_crypto/CMakeLists.txt
@@ -25,6 +25,7 @@ wasmedge_add_library(wasmedgePluginWasiCrypto
   kx/kx.cpp
   kx/module.cpp
   kx/options.cpp
+  secrets_manager/secrets_manager.cpp
   secrets_manager/options.cpp
   signatures/ctx.cpp
   signatures/ecdsa.cpp

--- a/plugins/wasi_crypto/common/options.cpp
+++ b/plugins/wasi_crypto/common/options.cpp
@@ -19,6 +19,9 @@ Options optionsOpen(__wasi_algorithm_type_e_t Alg) noexcept {
   case __WASI_ALGORITHM_TYPE_KEY_EXCHANGE:
     return Options{std::in_place_type<Kx::Options>};
   default:
+    if (static_cast<uint16_t>(Alg) == SecretsManager::AlgorithmType) {
+      return Options{std::in_place_type<SecretsManager::Options>};
+    }
     assumingUnreachable();
   }
 }

--- a/plugins/wasi_crypto/common/options.h
+++ b/plugins/wasi_crypto/common/options.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "kx/options.h"
+#include "secrets_manager/options.h"
 #include "signatures/options.h"
 #include "symmetric/options.h"
 #include "wasi_crypto/api.hpp"
@@ -39,8 +40,8 @@ namespace Common {
 ///
 /// More detail:
 /// https://github.com/WebAssembly/wasi-crypto/blob/main/docs/wasi-crypto.md#options
-using Options =
-    std::variant<Symmetric::Options, Kx::Options, Signatures::Options>;
+using Options = std::variant<Symmetric::Options, Kx::Options,
+                             Signatures::Options, SecretsManager::Options>;
 
 Options optionsOpen(__wasi_algorithm_type_e_t Alg) noexcept;
 

--- a/plugins/wasi_crypto/secrets_manager/options.cpp
+++ b/plugins/wasi_crypto/secrets_manager/options.cpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+#include "secrets_manager/options.h"
+
+namespace WasmEdge {
+namespace Host {
+namespace WasiCrypto {
+namespace SecretsManager {
+using namespace std::literals;
+
+namespace {
+constexpr std::array<std::string_view, 1> ValidNames{"password"sv};
+
+std::string toLower(std::string_view Name) noexcept {
+  std::string Ret{Name};
+  std::transform(Ret.begin(), Ret.end(), Ret.begin(),
+                 [](char C) { return static_cast<char>(std::tolower(C)); });
+  return Ret;
+}
+
+bool isValidName(std::string_view Name) noexcept {
+  return std::find(ValidNames.begin(), ValidNames.end(), Name) !=
+         ValidNames.end();
+}
+
+constexpr std::array<std::string_view, 1> ValidU64Names{"auto_lock"sv};
+
+bool isValidU64Name(std::string_view Name) noexcept {
+  return std::find(ValidU64Names.begin(), ValidU64Names.end(), Name) !=
+         ValidU64Names.end();
+}
+
+} // namespace
+
+WasiCryptoExpect<void> Options::set(std::string_view Name,
+                                    Span<const uint8_t> Value) noexcept {
+  std::string ActuallyName = toLower(Name);
+
+  ensureOrReturn(isValidName(ActuallyName),
+                 __WASI_CRYPTO_ERRNO_UNSUPPORTED_OPTION);
+
+  {
+    std::unique_lock<std::shared_mutex> Lock{Inner->Mutex};
+    Inner->ValueMap.insert_or_assign(ActuallyName,
+                                     std::vector(Value.begin(), Value.end()));
+  }
+  return {};
+}
+
+WasiCryptoExpect<void> Options::setU64(std::string_view Name,
+                                       uint64_t Value) noexcept {
+  std::string ActuallyName = toLower(Name);
+  ensureOrReturn(isValidU64Name(ActuallyName),
+                 __WASI_CRYPTO_ERRNO_UNSUPPORTED_OPTION);
+  {
+    std::unique_lock<std::shared_mutex> Lock{Inner->Mutex};
+    Inner->U64ValueMap.insert_or_assign(ActuallyName, Value);
+  }
+  return {};
+}
+
+WasiCryptoExpect<void> Options::setGuestBuffer(std::string_view,
+                                               Span<uint8_t>) noexcept {
+  return WasiCryptoUnexpect(__WASI_CRYPTO_ERRNO_UNSUPPORTED_OPTION);
+}
+
+WasiCryptoExpect<size_t> Options::get(std::string_view Name,
+                                      Span<uint8_t> Value) const noexcept {
+  std::string ActuallyName = toLower(Name);
+  ensureOrReturn(isValidName(ActuallyName),
+                 __WASI_CRYPTO_ERRNO_UNSUPPORTED_OPTION);
+  {
+    std::shared_lock<std::shared_mutex> Lock{Inner->Mutex};
+    if (auto It = Inner->ValueMap.find(ActuallyName);
+        It != Inner->ValueMap.end()) {
+      ensureOrReturn(It->second.size() <= Value.size(),
+                     __WASI_CRYPTO_ERRNO_OVERFLOW);
+      std::copy(It->second.begin(), It->second.end(), Value.begin());
+      return It->second.size();
+    }
+  }
+  return WasiCryptoUnexpect(__WASI_CRYPTO_ERRNO_OPTION_NOT_SET);
+}
+
+WasiCryptoExpect<uint64_t>
+Options::getU64(std::string_view Name) const noexcept {
+  std::string ActuallyName = toLower(Name);
+  ensureOrReturn(isValidU64Name(ActuallyName),
+                 __WASI_CRYPTO_ERRNO_UNSUPPORTED_OPTION);
+  {
+    std::shared_lock<std::shared_mutex> Lock{Inner->Mutex};
+    if (auto It = Inner->U64ValueMap.find(ActuallyName);
+        It != Inner->U64ValueMap.end()) {
+      return It->second;
+    }
+  }
+  return WasiCryptoUnexpect(__WASI_CRYPTO_ERRNO_OPTION_NOT_SET);
+}
+
+} // namespace SecretsManager
+} // namespace WasiCrypto
+} // namespace Host
+} // namespace WasmEdge

--- a/plugins/wasi_crypto/secrets_manager/options.h
+++ b/plugins/wasi_crypto/secrets_manager/options.h
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+//===-- wasmedge/plugins/wasi_crypto/secrets_manager/options.h -
+// Options--------===//
+//
+// Part of the WasmEdge Project.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the Secrets Manager Options class definition.
+///
+//===----------------------------------------------------------------------===//
+#pragma once
+
+#include "utils/error.h"
+
+#include <algorithm>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace WasmEdge {
+namespace Host {
+namespace WasiCrypto {
+namespace SecretsManager {
+
+// WasmEdge extension defined - not part of WASI Crypto specification
+constexpr uint16_t AlgorithmType = 0x100;
+
+// Options for secrets manager
+// More detail:
+// TODO: Add the link to the docs when it's ready.
+class Options {
+public:
+  WasiCryptoExpect<void> set(std::string_view Name,
+                             Span<const uint8_t> Value) noexcept;
+
+  WasiCryptoExpect<void> setU64(std::string_view Name, uint64_t Value) noexcept;
+
+  WasiCryptoExpect<void> setGuestBuffer(std::string_view Name,
+                                        Span<uint8_t> Buffer) noexcept;
+
+  WasiCryptoExpect<size_t> get(std::string_view Name,
+                               Span<uint8_t> Value) const noexcept;
+
+  WasiCryptoExpect<uint64_t> getU64(std::string_view Name) const noexcept;
+
+private:
+  struct DataType {
+    std::unordered_map<std::string, std::vector<uint8_t>> ValueMap;
+    std::unordered_map<std::string, uint64_t> U64ValueMap;
+    mutable std::shared_mutex Mutex;
+  };
+  std::shared_ptr<DataType> Inner = std::make_shared<DataType>();
+};
+
+} // namespace SecretsManager
+} // namespace WasiCrypto
+} // namespace Host
+} // namespace WasmEdge

--- a/plugins/wasi_crypto/secrets_manager/secrets_manager.cpp
+++ b/plugins/wasi_crypto/secrets_manager/secrets_manager.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2019-2024 Second State INC
 
-#include "common/secrets_manager.h"
+#include "secrets_manager/secrets_manager.h"
 
 // TODO: Implement secrets manager

--- a/plugins/wasi_crypto/secrets_manager/secrets_manager.cpp
+++ b/plugins/wasi_crypto/secrets_manager/secrets_manager.cpp
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+#include "common/secrets_manager.h"
+
+// TODO: Implement secrets manager

--- a/plugins/wasi_crypto/secrets_manager/secrets_manager.h
+++ b/plugins/wasi_crypto/secrets_manager/secrets_manager.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+//===-- wasmedge/plugins/wasi_crypto/common/secrets_manager.h - SecretsManager --===//
+//
+// Part of the WasmEdge Project.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the SecretsManager class definitions.
+///
+//===----------------------------------------------------------------------===//
+
+// TODO: Declare secrets manager definitions

--- a/plugins/wasi_crypto/secrets_manager/secrets_manager.h
+++ b/plugins/wasi_crypto/secrets_manager/secrets_manager.h
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2019-2024 Second State INC
 
-//===-- wasmedge/plugins/wasi_crypto/common/secrets_manager.h - SecretsManager --===//
+//===-- wasmedge/plugins/wasi_crypto/common/secrets_manager.h -
+// SecretsManager--===//
 //
 // Part of the WasmEdge Project.
 //

--- a/plugins/wasi_crypto/utils/hostfunction.h
+++ b/plugins/wasi_crypto/utils/hostfunction.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "ctx.h"
+#include "secrets_manager/options.h"
 #include "symmetric/registered.h"
 #include "utils/error.h"
 
@@ -64,6 +65,7 @@ cast(uint64_t AlgType) noexcept {
   case __WASI_ALGORITHM_TYPE_SIGNATURES:
   case __WASI_ALGORITHM_TYPE_SYMMETRIC:
   case __WASI_ALGORITHM_TYPE_KEY_EXCHANGE:
+  case SecretsManager::AlgorithmType:
     return static_cast<__wasi_algorithm_type_e_t>(AlgType);
   default:
     return WasiCryptoUnexpect(__WASI_CRYPTO_ERRNO_UNSUPPORTED_ALGORITHM);

--- a/test/plugins/wasi_crypto/CMakeLists.txt
+++ b/test/plugins/wasi_crypto/CMakeLists.txt
@@ -11,6 +11,7 @@ wasmedge_add_executable(wasiCryptoTests
   kx.cpp
   mac.cpp
   notimplement.cpp
+  secrets_manager.cpp
   signatures.cpp
 )
 

--- a/test/plugins/wasi_crypto/notimplement.cpp
+++ b/test/plugins/wasi_crypto/notimplement.cpp
@@ -33,6 +33,8 @@ TEST_F(WasiCryptoTest, NotImplement) {
                              __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
   WASI_CRYPTO_EXPECT_FAILURE(keypairFromId(1, {}, 1),
                              __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
+  WASI_CRYPTO_EXPECT_FAILURE(secretsManagerInvalidate(InvaildHandle, {}, 0),
+                             __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
 }
 
 } // namespace WasiCrypto

--- a/test/plugins/wasi_crypto/notimplement.cpp
+++ b/test/plugins/wasi_crypto/notimplement.cpp
@@ -33,13 +33,6 @@ TEST_F(WasiCryptoTest, NotImplement) {
                              __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
   WASI_CRYPTO_EXPECT_FAILURE(keypairFromId(1, {}, 1),
                              __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
-
-  WASI_CRYPTO_EXPECT_FAILURE(secretsManagerOpen(std::nullopt),
-                             __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
-  WASI_CRYPTO_EXPECT_FAILURE(secretsManagerClose(InvaildHandle),
-                             __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
-  WASI_CRYPTO_EXPECT_FAILURE(secretsManagerInvalidate(InvaildHandle, {}, 0),
-                             __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
 }
 
 } // namespace WasiCrypto

--- a/test/plugins/wasi_crypto/secrets_manager.cpp
+++ b/test/plugins/wasi_crypto/secrets_manager.cpp
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+#include "helper.h"
+
+namespace WasmEdge {
+namespace Host {
+namespace WasiCrypto {
+using namespace std::literals;
+
+TEST_F(WasiCryptoTest, SecretsManager) {
+  // Test cover for opening and closing.
+  // Basic lifecycle.
+  {
+    // Open without options.
+    WASI_CRYPTO_EXPECT_SUCCESS(SecretsManagerHandleDefault,
+                               secretsManagerOpen(std::nullopt));
+    ASSERT_NE(SecretsManagerHandleDefault, 0u);
+
+    // Reopen already opened manager without closing.
+    WASI_CRYPTO_EXPECT_FAILURE(secretsManagerOpen(std::nullopt),
+                               __WASI_CRYPTO_ERRNO_PROHIBITED_OPERATION);
+
+    // Open with empty options.
+    WASI_CRYPTO_EXPECT_SUCCESS(
+        OptOptionalHandleEmptyOptions,
+        optionsOpen(static_cast<__wasi_algorithm_type_e_t>(
+            SecretsManager::AlgorithmType)));
+    WASI_CRYPTO_EXPECT_SUCCESS(
+        SecretsManagerHandleEmptyOptions,
+        secretsManagerOpen(
+            OptOptionalHandleEmptyOptions)); // Gets default manager.
+    WASI_CRYPTO_EXPECT_TRUE(
+        secretsManagerClose(SecretsManagerHandleEmptyOptions));
+    WASI_CRYPTO_EXPECT_TRUE(optionsClose(OptOptionalHandleEmptyOptions));
+
+    // Open with options.
+    WASI_CRYPTO_EXPECT_SUCCESS(
+        OptOptionalHandle, optionsOpen(static_cast<__wasi_algorithm_type_e_t>(
+                               SecretsManager::AlgorithmType)));
+    WASI_CRYPTO_EXPECT_TRUE(
+        optionsSet(OptOptionalHandle, "password"sv, "very strong password"_u8));
+    WASI_CRYPTO_EXPECT_TRUE(
+        optionsSetU64(OptOptionalHandle, "auto_lock"sv, 5000));
+
+    WASI_CRYPTO_EXPECT_SUCCESS(SecretsManagerHandleWithOptions,
+                               secretsManagerOpen(OptOptionalHandle));
+    ASSERT_NE(SecretsManagerHandleWithOptions, 0u);
+    ASSERT_NE(SecretsManagerHandleDefault, SecretsManagerHandleWithOptions);
+
+    // Reopen already opened manager.
+    WASI_CRYPTO_EXPECT_FAILURE(secretsManagerOpen(OptOptionalHandle),
+                               __WASI_CRYPTO_ERRNO_PROHIBITED_OPERATION);
+
+    // Cleanup managers.
+    WASI_CRYPTO_EXPECT_TRUE(secretsManagerClose(SecretsManagerHandleDefault));
+    WASI_CRYPTO_EXPECT_TRUE(
+        secretsManagerClose(SecretsManagerHandleWithOptions));
+
+    // Reopen after close.
+    WASI_CRYPTO_EXPECT_SUCCESS(
+        SecretsManagerHandleDefaultAfterClose,
+        secretsManagerOpen(std::nullopt)); // Same manager as HandleDefault.
+    ASSERT_NE(SecretsManagerHandleDefaultAfterClose,
+              SecretsManagerHandleDefault);
+
+    WASI_CRYPTO_EXPECT_SUCCESS(
+        SecretsManagerHandleWithOptionsAfterClose,
+        secretsManagerOpen(
+            OptOptionalHandle)); // Same manager as HandleWithOptions.
+    ASSERT_NE(SecretsManagerHandleWithOptionsAfterClose,
+              SecretsManagerHandleWithOptions);
+
+    // Cleanup.
+    WASI_CRYPTO_EXPECT_TRUE(optionsClose(OptOptionalHandle));
+    WASI_CRYPTO_EXPECT_TRUE(
+        secretsManagerClose(SecretsManagerHandleDefaultAfterClose));
+    WASI_CRYPTO_EXPECT_TRUE(
+        secretsManagerClose(SecretsManagerHandleWithOptionsAfterClose));
+
+    // Double close already closed manager.
+    WASI_CRYPTO_EXPECT_FAILURE(
+        secretsManagerClose(SecretsManagerHandleWithOptionsAfterClose),
+        __WASI_CRYPTO_ERRNO_INVALID_HANDLE);
+  }
+
+  // Password boundary.
+  {
+    // Correct password.
+    WASI_CRYPTO_EXPECT_SUCCESS(
+        OptOptionsHandleVariantPassword,
+        optionsOpen(static_cast<__wasi_algorithm_type_e_t>(
+            SecretsManager::AlgorithmType)));
+    WASI_CRYPTO_EXPECT_TRUE(
+        optionsSet(OptOptionsHandleVariantPassword, "password"sv,
+                   "very strong password"_u8)); // should be actual strong.
+    WASI_CRYPTO_EXPECT_SUCCESS(
+        SecretsManagerHandleCorrectPassword,
+        secretsManagerOpen(OptOptionsHandleVariantPassword));
+    WASI_CRYPTO_EXPECT_TRUE(
+        secretsManagerClose(SecretsManagerHandleCorrectPassword));
+
+    // Wrong password.
+    WASI_CRYPTO_EXPECT_TRUE(
+        optionsSet(OptOptionsHandleVariantPassword, "password"sv,
+                   "strong but wrong password"_u8)); // should be actual strong.
+    WASI_CRYPTO_EXPECT_FAILURE(
+        secretsManagerOpen(OptOptionsHandleVariantPassword),
+        __WASI_CRYPTO_ERRNO_VERIFICATION_FAILED);
+    WASI_CRYPTO_EXPECT_TRUE(optionsClose(OptOptionsHandleVariantPassword));
+
+    // empty password string.
+    WASI_CRYPTO_EXPECT_SUCCESS(
+        OptOptionsHandlePasswordEdgeCase,
+        optionsOpen(static_cast<__wasi_algorithm_type_e_t>(
+            SecretsManager::AlgorithmType)));
+    WASI_CRYPTO_EXPECT_TRUE(
+        optionsSet(OptOptionsHandlePasswordEdgeCase, "password"sv, ""_u8));
+    WASI_CRYPTO_EXPECT_FAILURE(
+        secretsManagerOpen(OptOptionsHandlePasswordEdgeCase),
+        __WASI_CRYPTO_ERRNO_PROHIBITED_OPERATION);
+
+    // Null bytes in password.
+    WASI_CRYPTO_EXPECT_TRUE(optionsSet(OptOptionsHandlePasswordEdgeCase,
+                                       "password"sv, "p@$$w0rd!\n\t\x00"_u8));
+    WASI_CRYPTO_EXPECT_FAILURE(
+        secretsManagerOpen(OptOptionsHandlePasswordEdgeCase),
+        __WASI_CRYPTO_ERRNO_PROHIBITED_OPERATION);
+
+    // Very long password.
+    std::vector<uint8_t> LongPassword(10'000, 'A');
+    WASI_CRYPTO_EXPECT_TRUE(optionsSet(OptOptionsHandlePasswordEdgeCase,
+                                       "password"sv, LongPassword));
+    WASI_CRYPTO_EXPECT_FAILURE(
+        secretsManagerOpen(OptOptionsHandlePasswordEdgeCase),
+        __WASI_CRYPTO_ERRNO_OVERFLOW);
+
+    WASI_CRYPTO_EXPECT_TRUE(optionsClose(OptOptionsHandlePasswordEdgeCase));
+  }
+
+  // Auto_lock boundary
+  {
+    // Auto_lock = 0 -> manager never lock.
+    WASI_CRYPTO_EXPECT_SUCCESS(
+        OptOptionsHandleAutoLockDisabled,
+        optionsOpen(static_cast<__wasi_algorithm_type_e_t>(
+            SecretsManager::AlgorithmType)));
+    WASI_CRYPTO_EXPECT_TRUE(
+        optionsSetU64(OptOptionsHandleAutoLockDisabled, "auto_lock"sv, 0));
+    WASI_CRYPTO_EXPECT_SUCCESS(
+        SecretsManagerHandleAutoLockDisabled,
+        secretsManagerOpen(OptOptionsHandleAutoLockDisabled));
+    WASI_CRYPTO_EXPECT_TRUE(
+        secretsManagerClose(SecretsManagerHandleAutoLockDisabled));
+    WASI_CRYPTO_EXPECT_TRUE(optionsClose(OptOptionsHandleAutoLockDisabled));
+
+    // TODO: add test cover access after lock.
+  }
+
+  // Test cover for invalidate.
+  // TODO: add tests cover for invalidate.
+}
+
+} // namespace WasiCrypto
+} // namespace Host
+} // namespace WasmEdge


### PR DESCRIPTION
## Summary
This pr implements the stubbed `secretsManager` operations following WASI_Crypto specs.

## Details

- [x] Implement and integrate new test cases into the existing test suite.
- [x] Briefly explain design trade-offs and why those fit existing plugin, broader system.
- [ ] Implement the missing functionality with careful attention to security.
- [ ] Ensure all tests pass and CI succeeds.

## Design Trade-offs
This secrets management design is inspired by portability nature of `WasmEdge`.

**options:** 
* added the groundwork layer that integrates with existing options management  
* added minimal (future extendable) options with only `password` and `auto_lock`

**error_codes:**
 mapped existing specs defined error_codes to handle different life-cycle scenarios.

ex:
* manager already open -> prohibited_operation 
* wrong password -> verification_failed

**storage:**
* guests can create ONLY one of each manager type. 
* Manager type defined by the uniqueness of guest selected options. making opening a manager with certain option set is one way permanent move.
* default secret storage is under `~/.wasmedge/.secrets` (could be customized if `secrets_path` option introduced in the future).

**encryption:**
* machine-bound key that blends a `machine-id`  with runtime secret. This locks the .secrets folder to the specific machine WasmEdge runs on. if the folder is stolen, it won't open on another machine (strongly implies [this part of specs](https://github.com/WebAssembly/wasi-crypto/blob/main/docs/wasi-crypto.md#secrets-management)).

* Wasm Fingerprinting Identifies each guest by the SHA-256 hash of its actual code(combining it with set of uniquely selected options). creating  a unique, encrypted sub-folder that serves as our secrets storage for that guest of that secret manager type that can only get called with same set of options again! that also ensure that Guest A can never "spoof" its way into Guest B’s data.

* note: that also mean that each new build is entirely different identity with NO WAY to get previously generated key unless `export` option is Introduced.

* keys are represented by a file for each, integrity checks uses `AES-256-GCM` to encrypt files. It stores a unique Salt and Nonce in the header so the manager can instantly detect if a secret has been tampered with or corrupted.

## Related Issues
Closes  #4527 

## Appendix

[WASI-Crypto](https://github.com/WebAssembly/wasi-crypto)

Parent issue: #2669 