### PR TITLE
feat: Limit the range of randomly generated fd in the WASI component

### DIFF
--- a/include/common/configure.h
+++ b/include/common/configure.h
@@ -169,7 +169,7 @@ public:
     return AllowAFUNIX.load(std::memory_order_relaxed);
   }
 
-  void setMaxWasiFd(uint32_t Fd) noexcept { MaxWasiFd = Fd; }
+  void setMaxWasiFd(uint32_t MaxFd) noexcept { MaxWasiFd = MaxFd; }
 
   uint32_t getMaxWasiFd() const noexcept { return MaxWasiFd; }
 
@@ -180,7 +180,7 @@ private:
   std::atomic<bool> CoredumpWasmgdb = false;
   std::atomic<bool> ForceInterpreter = false;
   std::atomic<bool> AllowAFUNIX = false;
-  uint32_t MaxWasiFd = 0x7FFFFFFF;
+  std::atomic<uint32_t> MaxWasiFd = 0x7FFFFFFF;
 };
 
 class StatisticsConfigure {

--- a/include/common/configure.h
+++ b/include/common/configure.h
@@ -169,6 +169,10 @@ public:
     return AllowAFUNIX.load(std::memory_order_relaxed);
   }
 
+  void setMaxWasiFd(uint32_t Fd) noexcept { MaxWasiFd = Fd; }
+
+  uint32_t getMaxWasiFd() const noexcept { return MaxWasiFd; }
+
 private:
   std::atomic<uint32_t> MaxMemPage = 65536;
   std::atomic<bool> EnableJIT = false;
@@ -176,6 +180,7 @@ private:
   std::atomic<bool> CoredumpWasmgdb = false;
   std::atomic<bool> ForceInterpreter = false;
   std::atomic<bool> AllowAFUNIX = false;
+  uint32_t MaxWasiFd = 0x7FFFFFFF;
 };
 
 class StatisticsConfigure {

--- a/include/driver/tool.h
+++ b/include/driver/tool.h
@@ -117,13 +117,13 @@ struct DriverToolOptions {
                 "Limitation of maximum time(in milliseconds) for execution, "
                 "default value is 0 for no limitations"sv),
             PO::MetaVar("TIMEOUT"sv), PO::DefaultValue<uint64_t>(0)),
-        MaxWasiFd(PO::Description(
-                      "Limitation of max range for randomly generated file "
-                      "descriptors. The value will be clamped to the range [3, "
-                      "2**31-1]. "
-                      "Default value is 2**31-1."sv),
-                  PO::MetaVar("MAX_FD"sv),
-                  PO::DefaultValue<uint32_t>(0x7FFFFFFF)),
+        MaxWasiFd(
+            PO::Description(
+                "Limitation of max range for randomly generated file "
+                "descriptors. The value will be clamped to the range [1024, "
+                "2**31-1]. "
+                "Default value is 2**31-1."sv),
+            PO::MetaVar("MAX_FD"sv), PO::DefaultValue<uint32_t>(0x7FFFFFFF)),
         GasLim(
             PO::Description(
                 "Limitation of execution gas. Upper bound can be specified as "

--- a/include/driver/tool.h
+++ b/include/driver/tool.h
@@ -117,9 +117,11 @@ struct DriverToolOptions {
                 "Limitation of maximum time(in milliseconds) for execution, "
                 "default value is 0 for no limitations"sv),
             PO::MetaVar("TIMEOUT"sv), PO::DefaultValue<uint64_t>(0)),
-        MaxWasiFd(PO::Description("Limitation of max range of randomly "
-                                  "generated file descriptors. "
-                                  "Default value is 2**31-1."sv),
+        MaxWasiFd(PO::Description(
+                      "Limitation of max range for randomly generated file "
+                      "descriptors. The value will be clamped to the range [3, "
+                      "2**31-1]. "
+                      "Default value is 2**31-1."sv),
                   PO::MetaVar("MAX_FD"sv),
                   PO::DefaultValue<uint32_t>(0x7FFFFFFF)),
         GasLim(

--- a/include/driver/tool.h
+++ b/include/driver/tool.h
@@ -117,6 +117,11 @@ struct DriverToolOptions {
                 "Limitation of maximum time(in milliseconds) for execution, "
                 "default value is 0 for no limitations"sv),
             PO::MetaVar("TIMEOUT"sv), PO::DefaultValue<uint64_t>(0)),
+        MaxWasiFd(PO::Description("Limitation of max range of randomly "
+                                  "generated file descriptors. "
+                                  "Default value is 2**31-1."sv),
+                  PO::MetaVar("MAX_FD"sv),
+                  PO::DefaultValue<uint32_t>(0x7FFFFFFF)),
         GasLim(
             PO::Description(
                 "Limitation of execution gas. Upper bound can be specified as "
@@ -175,6 +180,7 @@ struct DriverToolOptions {
   PO::Option<PO::Toggle> ConfForceInterpreter;
   PO::Option<PO::Toggle> ConfAFUNIX;
   PO::Option<uint64_t> TimeLim;
+  PO::Option<uint32_t> MaxWasiFd;
   PO::List<int> GasLim;
   PO::List<int> MemLim;
   PO::List<std::string> ForbiddenPlugins;
@@ -227,6 +233,7 @@ struct DriverToolOptions {
         .add_option("enable-component"sv, PropComponent)
         .add_option("enable-all"sv, PropAll)
         .add_option("time-limit"sv, TimeLim)
+        .add_option("max-fd"sv, MaxWasiFd)
         .add_option("gas-limit"sv, GasLim)
         .add_option("memory-page-limit"sv, MemLim)
         .add_option("forbidden-plugin"sv, ForbiddenPlugins);

--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -1200,6 +1200,10 @@ public:
     return std::string(Buffer.data(), Buffer.size());
   }
 
+  void setMaxWasiFd(uint32_t Limit) noexcept {
+    MaxFd = std::clamp(Limit, 3U, 0x7FFFFFFFU);
+  }
+
 private:
   std::vector<std::string> Arguments;
   std::vector<std::string> EnvironVariables;
@@ -1211,6 +1215,7 @@ private:
 
   mutable std::shared_mutex FdMutex; ///< Protect FdMap
   std::unordered_map<__wasi_fd_t, std::shared_ptr<VINode>> FdMap;
+  uint32_t MaxFd = 0x7FFFFFFF;
 
   std::shared_ptr<VINode> getNodeOrNull(__wasi_fd_t Fd) const {
     std::shared_lock Lock(FdMutex);
@@ -1221,7 +1226,8 @@ private:
   }
 
   WasiExpect<__wasi_fd_t> generateRandomFdToNode(std::shared_ptr<VINode> Node) {
-    std::uniform_int_distribution<__wasi_fd_t> Distribution(0, 0x7FFFFFFF);
+    std::uniform_int_distribution<__wasi_fd_t> Distribution(
+        0, static_cast<__wasi_fd_t>(MaxFd));
     bool Success = false;
     __wasi_fd_t NewFd;
     while (!Success) {

--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -1200,8 +1200,8 @@ public:
     return std::string(Buffer.data(), Buffer.size());
   }
 
-  void setMaxWasiFd(uint32_t Limit) noexcept {
-    MaxFd = std::clamp(Limit, 3U, 0x7FFFFFFFU);
+  void setMaxWasiFd(uint32_t MaxFd) noexcept {
+    MaxFd = std::clamp(MaxFd, 3U, 0x7FFFFFFFU);
   }
 
 private:

--- a/include/host/wasi/wasimodule.h
+++ b/include/host/wasi/wasimodule.h
@@ -33,7 +33,7 @@ public:
                            StdErrFd);
   }
 
-  void setMaxWasiFd(uint32_t Limit) noexcept { Env.setMaxWasiFd(Limit); }
+  void setMaxWasiFd(uint32_t MaxFd) noexcept { Env.setMaxWasiFd(MaxFd); }
 
   const WASI::Environ *getEnv() const noexcept { return &Env; }
 

--- a/include/host/wasi/wasimodule.h
+++ b/include/host/wasi/wasimodule.h
@@ -33,6 +33,8 @@ public:
                            StdErrFd);
   }
 
+  void setMaxWasiFd(uint32_t Limit) noexcept { Env.setMaxWasiFd(Limit); }
+
   const WASI::Environ *getEnv() const noexcept { return &Env; }
 
 private:

--- a/lib/driver/runtimeTool.cpp
+++ b/lib/driver/runtimeTool.cpp
@@ -354,6 +354,9 @@ int Tool(struct DriverToolOptions &Opt) noexcept {
     Conf.getStatisticsConfigure().setCostLimit(
         static_cast<uint32_t>(Opt.GasLim.value().back()));
   }
+  if (Opt.MaxWasiFd.value() > 0) {
+    Conf.getRuntimeConfigure().setMaxWasiFd(Opt.MaxWasiFd.value());
+  }
   if (Opt.MemLim.value().size() > 0) {
     Conf.getRuntimeConfigure().setMaxMemoryPage(
         static_cast<uint32_t>(Opt.MemLim.value().back()));


### PR DESCRIPTION
## Motivation
 
Due to some applications using the old select API, our current implementation follows the standard of WASI which means we will have a map to handle the randomly generated fd number (`<= 2**31`) to the actual fd number. However, in some cases, the application only accepts the fd number which is less than `FD_SETSIZE (usually 1024)`.
 
 It would be nice to have an API to set the range of the randomly generated fd numbers.
 ## Details
 * [x]  Implement an internal function to control the range
 * [x]  Export this function as a configuration option in C API
 * [x] Export a CLI option to control this flag
 * [ ] Write a section in the document
 
 solves issue #2102 