### PR TITLE
fix(compiler): enforce 32-bit memory boundary for x86_64 AOT

### DIFF
--- a/lib/llvm/compiler.cpp
+++ b/lib/llvm/compiler.cpp
@@ -4615,6 +4615,10 @@ private:
       Off = Builder.createAdd(Off, LLContext.getInt64(Offset));
     }
 
+#if defined(__x86_64__) // Enforce 32-bit WASM memory boundary for x86_64 to
+                        // prevent SIGSEGV
+    Off = Builder.createAnd(Off, LLContext.getInt64(0xFFFFFFFFULL));
+#endif
     auto VPtr = Builder.createInBoundsGEP1(
         Context.Int8Ty, Context.getMemory(Builder, ExecCtx, MemoryIndex), Off);
     auto Ptr = Builder.createBitCast(VPtr, LoadTy.getPointerTo());
@@ -4675,6 +4679,10 @@ private:
       Off = Builder.createAdd(Off, LLContext.getInt64(Offset));
     }
 
+#if defined(__x86_64__) // Enforce 32-bit WASM memory boundary for x86_64 to
+                        // prevent SIGSEGV
+    Off = Builder.createAnd(Off, LLContext.getInt64(0xFFFFFFFFULL));
+#endif
     if (Trunc) {
       V = Builder.createTrunc(V, LoadTy);
     }


### PR DESCRIPTION
WebAssembly linear memory is restricted to 32-bit address spaces. On x86_64 LTS environments, AOT compilation allowed out-of-bounds pointer arithmetic to exceed the 4GB limit, accessing WasmEdge guard pages and causing SIGSEGV.

This commit adds a 32-bit bitwise mask (0xFFFFFFFF) to the LLVM IR generation for load and store operations. It is strictly guarded by __x86_64__ to enforce this boundary on Linux architecture.

Verification via objdump confirms LLVM optimizes this mask via Address Mode Folding. By utilizing a 32-bit index register (e.g., %ecx) for the memory operand, the x86_64 hardware automatically zero-extends the pointer, correctly wrapping the memory address.

Fixes #3063