### PR TITLE
fix(compiler): replace createInBoundsGEP1 with createGEP1 to prevent UB

### DIFF
--- a/lib/llvm/compiler.cpp
+++ b/lib/llvm/compiler.cpp
@@ -4615,7 +4615,8 @@ private:
       Off = Builder.createAdd(Off, LLContext.getInt64(Offset));
     }
 
-    auto VPtr = Builder.createInBoundsGEP1(
+    // Use GEP without inbounds to allow trapping on Guard Page access.
+    auto VPtr = Builder.createGEP1(
         Context.Int8Ty, Context.getMemory(Builder, ExecCtx, MemoryIndex), Off);
     auto Ptr = Builder.createBitCast(VPtr, LoadTy.getPointerTo());
     auto LoadInst = Builder.createLoad(LoadTy, Ptr, true);
@@ -4682,7 +4683,9 @@ private:
       V = Builder.createBitCast(V, LoadTy);
     }
     V = switchEndian(V);
-    auto VPtr = Builder.createInBoundsGEP1(
+    
+    // Use GEP without inbounds to allow trapping on Guard Page access.
+    auto VPtr = Builder.createGEP1(
         Context.Int8Ty, Context.getMemory(Builder, ExecCtx, MemoryIndex), Off);
     auto Ptr = Builder.createBitCast(VPtr, LoadTy.getPointerTo());
     auto StoreInst = Builder.createStore(V, Ptr, true);

--- a/lib/llvm/llvm.h
+++ b/lib/llvm/llvm.h
@@ -1282,6 +1282,12 @@ public:
     return LLVMBuildInBoundsGEP2(Ref, Ty.unwrap(), Pointer.unwrap(), Data,
                                  static_cast<unsigned>(std::size(Data)), Name);
   }
+  Value createGEP1(Type Ty, Value Pointer, Value Idx0,
+                   const char *Name = "") noexcept {
+    LLVMValueRef Data[1] = {Idx0.unwrap()};
+    return LLVMBuildGEP2(Ref, Ty.unwrap(), Pointer.unwrap(), Data,
+                         static_cast<unsigned>(std::size(Data)), Name);
+  }
   Value createInBoundsGEP2(Type Ty, Value Pointer, Value Idx0, Value Idx1,
                            const char *Name = "") noexcept {
     LLVMValueRef Data[2] = {Idx0.unwrap(), Idx1.unwrap()};


### PR DESCRIPTION
Summary:
Replaces 'createInBoundsGEP1' with 'createGEP1' for memory access operations in the AOT compiler. This fixes a raw Segmentation Fault issue where the WasmEdge signal handler failed to trap out-of-bounds accesses.

Root Cause:
WasmEdge's zero-cost bounds checking relies on pointers legally hitting the OS Guard Page to trigger a SIGSEGV.
The LLVM 'inbounds' keyword contract states that pointers must stay within allocated objects. When a pointer hits the Guard Page, this contract is violated, resulting in Undefined Behavior (Poison). This UB allowed LLVM to optimize away the necessary trap mechanics.

Fix:
Using standard 'createGEP1' (without 'inbounds') forces the compiler to generate the exact pointer arithmetic required to hit the Guard Page and trigger the trap deterministically.

Verification:
- Checked LLVM IR: Verified 'inbounds' keyword is removed from generated 'getelementptr' instructions.
- Runtime: Confirmed raw Segfault is replaced by graceful '[error] execution failed: out of bounds memory access'.

Fixes #3063