### PR TITLE
fix(examples): avoid unbounded strcpy in unix domain socket examples

### DIFF
--- a/examples/capi/unix_domain_socket/client.cpp
+++ b/examples/capi/unix_domain_socket/client.cpp
@@ -22,7 +22,13 @@ int main() {
   }
 
   ClientAddr.sun_family = AF_UNIX;
-  strcpy(ClientAddr.sun_path, ClientSockPath);
+  if (std::strlen(ClientSockPath) >= sizeof(ClientAddr.sun_path)) {
+    std::fprintf(stderr, "Socket path is too long\n");
+    return -1;
+  }
+  std::strncpy(ClientAddr.sun_path, ClientSockPath,
+               sizeof(ClientAddr.sun_path) - 1);
+  ClientAddr.sun_path[sizeof(ClientAddr.sun_path) - 1] = '\0';
   Size = offsetof(sockaddr_un, sun_path) + strlen(ClientAddr.sun_path);
 
   // unlink(ClientSockPath);
@@ -33,7 +39,13 @@ int main() {
   }
 
   ServerAddr.sun_family = AF_UNIX;
-  strcpy(ServerAddr.sun_path, ServerSockPath);
+  if (std::strlen(ServerSockPath) >= sizeof(ServerAddr.sun_path)) {
+    std::fprintf(stderr, "Socket path is too long\n");
+    return -1;
+  }
+  std::strncpy(ServerAddr.sun_path, ServerSockPath,
+               sizeof(ServerAddr.sun_path) - 1);
+  ServerAddr.sun_path[sizeof(ServerAddr.sun_path) - 1] = '\0';
   Size = offsetof(sockaddr_un, sun_path) + strlen(ServerAddr.sun_path);
 
   if (WasmedgeConnect(SockFd, reinterpret_cast<sockaddr *>(&ServerAddr), Size) <

--- a/examples/capi/unix_domain_socket/server.cpp
+++ b/examples/capi/unix_domain_socket/server.cpp
@@ -22,7 +22,12 @@ int main() {
   }
 
   Addr.sun_family = AF_UNIX;
-  strcpy(Addr.sun_path, SockPath);
+  if (std::strlen(SockPath) >= sizeof(Addr.sun_path)) {
+    std::fprintf(stderr, "Socket path is too long\n");
+    return -1;
+  }
+  std::strncpy(Addr.sun_path, SockPath, sizeof(Addr.sun_path) - 1);
+  Addr.sun_path[sizeof(Addr.sun_path) - 1] = '\0';
   Size = offsetof(sockaddr_un, sun_path) + strlen(Addr.sun_path);
 
   // unlink(SockPath);


### PR DESCRIPTION
### Summary

This PR fixes unsafe usage of `strcpy` in the Unix domain socket C API examples.

The affected examples copy user-provided socket paths into `sockaddr_un::sun_path` without any bounds checking. Since `sun_path` has a fixed size (typically 108 bytes on Linux), this can lead to buffer overflow or  undefined behavior if a longer path is provided. 
This PR replaces strcpy with a bounded copy to ensure the buffer is not overrun and is always NUL-terminated.

Although these are example files, they are often used as reference code, so it’s important that they demonstrate safe patterns.

### Real-world references

- Python / mod_wsgi hardening against long sun_path
https://github.com/GrahamDumpleton/mod_wsgi/issues/35

- Linux man-pages explicitly document the size limit of sun_path
https://man7.org/linux/man-pages/man7/unix.7.html

- Discussion on Unix socket path length limits
https://unix.stackexchange.com/questions/367008/why-is-socket-path-length-limited-to-a-hundred-chars

### Testing

- Build verified locally
- No functional changes