### PR TITLE
fix: correct memory.init error log logic

### DIFF
--- a/include/runtime/instance/memory.h
+++ b/include/runtime/instance/memory.h
@@ -149,7 +149,8 @@ public:
     if (unlikely(static_cast<uint64_t>(Start) + static_cast<uint64_t>(Length) >
                  Slice.size())) {
       spdlog::error(ErrCode::Value::MemoryOutOfBounds);
-      spdlog::error(ErrInfo::InfoBoundary(Offset, Length, getBoundIdx()));
+      spdlog::error(ErrInfo::InfoBoundary(Start, Length,
+                                          static_cast<uint32_t>(Slice.size())));
       return Unexpect(ErrCode::Value::MemoryOutOfBounds);
     }
 


### PR DESCRIPTION
The memory.init instruction was incorrectly logging the Memory limit when the Data Segment (Slice) was out of bounds.
This change updates the log to print Slice.size() to clarify the error (addresses #3159).

Also adds static_cast<uint32_t> to prevent MSVC warning C4267 on Windows (Since WasmEdge uses /WX (Treat Warnings as Errors)).
In linux it worked even without static_cast<uint32_t> but had to add this for warning C4267.