### PR TITLE
Fix: AddressSanitizer SEGV on unknown address 0x000000000000 with JIT

### DIFF
--- a/include/llvm/jit.h
+++ b/include/llvm/jit.h
@@ -24,6 +24,7 @@ class OrcLLJIT;
 
 class JITLibrary : public Executable {
 public:
+  JITLibrary() noexcept;
   JITLibrary(OrcLLJIT JIT) noexcept;
   ~JITLibrary() noexcept override;
 

--- a/test/llvm/LLVMcoreTest.cpp
+++ b/test/llvm/LLVMcoreTest.cpp
@@ -19,6 +19,7 @@
 #include "vm/vm.h"
 #include "llvm/codegen.h"
 #include "llvm/compiler.h"
+#include "llvm/jit.h"
 
 #include "../spec/hostfunc.h"
 #include "../spec/spectest.h"
@@ -668,6 +669,31 @@ TEST(SIMDNaN, F32x4MaxNaNHandling) {
 
   VM.cleanup();
   EXPECT_NO_THROW(std::filesystem::remove(Path));
+}
+
+TEST(JITLibrary, NullPointerTest) {
+  WasmEdge::LLVM::JITLibrary JITLib;
+
+  {
+    auto Result = JITLib.getIntrinsics();
+    EXPECT_FALSE(static_cast<bool>(Result));
+  }
+
+  {
+    auto Result = JITLib.getTypes(3);
+    EXPECT_EQ(Result.size(), 3);
+    for (const auto &Symbol : Result) {
+      EXPECT_FALSE(static_cast<bool>(Symbol));
+    }
+  }
+
+  {
+    auto Result = JITLib.getCodes(0, 2);
+    EXPECT_EQ(Result.size(), 2);
+    for (const auto &Symbol : Result) {
+      EXPECT_FALSE(static_cast<bool>(Symbol));
+    }
+  }
 }
 
 } // namespace


### PR DESCRIPTION
This PR resolves a segmentation fault that occurred when running WasmEdge with JIT enabled (`wasmedge run --enable-jit ...`). The root cause was a null pointer dereference in the JITLibrary when the JIT engine failed to initialize.

#### Changes:
- Added null pointer checks and error logging in all JITLibrary methods (`getIntrinsics`, `getTypes`, `getCodes`).
- Now, if the JIT engine is not properly initialized, a clear error is logged and the process exits gracefully, preventing a SEGV.

#### How to test:
```bash
# Configure with LLVM support
cmake -S . -B build -DWASMEDGE_USE_LLVM=ON -DWASMEDGE_BUILD_TESTS=ON -DLLD_DIR=/usr/lib/llvm-18/lib/cmake/lld

# Build the LLVM tests (which now include the JIT null pointer test)
cmake --build build --target wasmedgeLLVMCoreTests

# Run the JIT null pointer test
cd build/test/llvm && ./wasmedgeLLVMCoreTests --gtest_filter="JITLibrary.*"
```

Fixes #4422.