### PR TITLE
fix: canonicalize NaN in SIMD floating-point operations

### DIFF
--- a/include/executor/engine/binary_numeric_vector.ipp
+++ b/include/executor/engine/binary_numeric_vector.ipp
@@ -166,6 +166,15 @@ Expect<void> Executor::runVectorAddOp(ValVariant &Val1,
   VT &V1 = Val1.get<VT>();
   V1 += Val2.get<VT>();
 
+  if constexpr (std::is_floating_point_v<T>) {
+    constexpr size_t NumElements = 16 / sizeof(T);
+    for (size_t I = 0; I < NumElements; ++I) {
+      if (std::isnan(V1[I])) {
+        V1[I] = std::numeric_limits<T>::quiet_NaN();
+      }
+    }
+  }
+
   return {};
 }
 
@@ -196,6 +205,14 @@ Expect<void> Executor::runVectorSubOp(ValVariant &Val1,
   using VT [[gnu::vector_size(16)]] = T;
   VT &V1 = Val1.get<VT>();
   V1 -= Val2.get<VT>();
+  if constexpr (std::is_floating_point_v<T>) {
+    constexpr size_t NumElements = 16 / sizeof(T);
+    for (size_t I = 0; I < NumElements; ++I) {
+      if (std::isnan(V1[I])) {
+        V1[I] = std::numeric_limits<T>::quiet_NaN();
+      }
+    }
+  }
 
   return {};
 }
@@ -228,6 +245,15 @@ Expect<void> Executor::runVectorMulOp(ValVariant &Val1,
   VT &V1 = Val1.get<VT>();
   V1 *= Val2.get<VT>();
 
+  if constexpr (std::is_floating_point_v<T>) {
+    constexpr size_t NumElements = 16 / sizeof(T);
+    for (size_t I = 0; I < NumElements; ++I) {
+      if (std::isnan(V1[I])) {
+        V1[I] = std::numeric_limits<T>::quiet_NaN();
+      }
+    }
+  }
+
   return {};
 }
 
@@ -237,6 +263,15 @@ Expect<void> Executor::runVectorDivOp(ValVariant &Val1,
   using VT [[gnu::vector_size(16)]] = T;
   VT &V1 = Val1.get<VT>();
   V1 /= Val2.get<VT>();
+  
+  if constexpr (std::is_floating_point_v<T>) {
+    constexpr size_t NumElements = 16 / sizeof(T);
+    for (size_t I = 0; I < NumElements; ++I) {
+      if (std::isnan(V1[I])) {
+        V1[I] = std::numeric_limits<T>::quiet_NaN();
+      }
+    }
+  }
 
   return {};
 }

--- a/include/executor/engine/binary_numeric_vector_msvc.ipp
+++ b/include/executor/engine/binary_numeric_vector_msvc.ipp
@@ -245,6 +245,14 @@ Expect<void> Executor::runVectorAddOp(ValVariant &Val1,
     V1[I] += V2[I];
   }
 
+  if constexpr (std::is_floating_point_v<T>) {
+    for (size_t I = 0; I < V1.size(); ++I) {
+      if (std::isnan(V1[I])) {
+        V1[I] = std::numeric_limits<T>::quiet_NaN();
+      }
+    }
+  }
+
   return {};
 }
 
@@ -283,6 +291,14 @@ Expect<void> Executor::runVectorSubOp(ValVariant &Val1,
   const VT &V2 = Val2.get<VT>();
   for (size_t I = 0; I < V1.size(); ++I) {
     V1[I] -= V2[I];
+  }
+
+  if constexpr (std::is_floating_point_v<T>) {
+    for (size_t I = 0; I < V1.size(); ++I) {
+      if (std::isnan(V1[I])) {
+        V1[I] = std::numeric_limits<T>::quiet_NaN();
+      }
+    }
   }
 
   return {};
@@ -324,6 +340,14 @@ Expect<void> Executor::runVectorMulOp(ValVariant &Val1,
     V1[I] *= V2[I];
   }
 
+  if constexpr (std::is_floating_point_v<T>) {
+    for (size_t I = 0; I < V1.size(); ++I) {
+      if (std::isnan(V1[I])) {
+        V1[I] = std::numeric_limits<T>::quiet_NaN();
+      }
+    }
+  }
+
   return {};
 }
 
@@ -335,6 +359,14 @@ Expect<void> Executor::runVectorDivOp(ValVariant &Val1,
   const VT &V2 = Val2.get<VT>();
   for (size_t I = 0; I < V1.size(); ++I) {
     V1[I] /= V2[I];
+  }
+
+  if constexpr (std::is_floating_point_v<T>) {
+    for (size_t I = 0; I < V1.size(); ++I) {
+      if (std::isnan(V1[I])) {
+        V1[I] = std::numeric_limits<T>::quiet_NaN();
+      }
+    }
   }
 
   return {};


### PR DESCRIPTION
## Description
Fixes #4259 - Inconsistent f64x2.add output between interpreter and JIT modes

This PR adds NaN canonicalization to floating-point SIMD operations in the interpreter, ensuring consistent behavior across all execution modes.

## Changes
- Implemented NaN checks in runVectorAddOp, runVectorSubOp, runVectorMulOp, and runVectorDivOp.
- Modified `include/executor/engine/binary_numeric_vector.ipp` (GCC/Clang)
- Modified `include/executor/engine/binary_numeric_vector_msvc.ipp` (MSVC)

## Problem
The interpreter used native C++ operators that preserve NaN bit patterns, while JIT/AOT modes use LLVM instructions that canonicalize NaN. This caused different outputs for the same WASM code.

## Solution
After each floating-point arithmetic operation, check if result is NaN and replace with `std::numeric_limits<T>::quiet_NaN()`.

## Testing
- Tested with the exact test case from issue #4259
- All existing tests in wasmedgeExecutorCoreTests passed successfully.

## Checklist
- [x] Follows Conventional Commit format
- [x] DCO sign-off included
- [x] Code follows CNCF Code of Conduct
- [x] Minimal, focused changes
- [x] Fixes reported issue