### PR TITLE
feat(plugin): add hot-reloading support for plugins

### DIFF
--- a/examples/plugin/hot_reload/CMakeLists.txt
+++ b/examples/plugin/hot_reload/CMakeLists.txt
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+cmake_minimum_required(VERSION 3.16)
+project(WasmEdgeHotReloadExample)
+
+find_package(wasmedge CONFIG REQUIRED)
+
+add_executable(hot_reload_example
+  hot_reload_example.cpp
+)
+
+target_link_libraries(hot_reload_example
+  PRIVATE
+  wasmedge
+)
+
+target_compile_features(hot_reload_example PRIVATE cxx_std_17)

--- a/examples/plugin/hot_reload/hot_reload_example.cpp
+++ b/examples/plugin/hot_reload/hot_reload_example.cpp
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+//===-- hot_reload_example.cpp - Plugin Hot-Reload Example ----------------===//
+//
+// Part of the WasmEdge Project.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file demonstrates the plugin hot-reloading feature of WasmEdge.
+/// It shows how to:
+/// - Configure hot-reload settings
+/// - Start/stop file watching for plugin changes
+/// - Register callbacks for plugin lifecycle events
+/// - Manually reload plugins
+/// - Check plugin states and statistics
+///
+//===----------------------------------------------------------------------===//
+
+#include <wasmedge/wasmedge.h>
+#include <wasmedge/wasmedge_hot_reload.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+
+void OnPluginEvent(const char *PluginName, const char *Path, void *UserData) {
+  const char *EventName = static_cast<const char *>(UserData);
+  printf("[%s] Plugin: %s, Path: %s\n", EventName, 
+         PluginName ? PluginName : "(none)",
+         Path ? Path : "(none)");
+}
+
+void PrintUsage(const char *ProgramName) {
+  printf("WasmEdge Plugin Hot-Reload Example\n");
+  printf("===================================\n\n");
+  printf("Usage: %s [OPTIONS] [PLUGIN_PATH]\n\n", ProgramName);
+  printf("Options:\n");
+  printf("  --watch           Start watching plugin directory for changes\n");
+  printf("  --list            List all loaded plugins\n");
+  printf("  --reload <name>   Reload a specific plugin by name\n");
+  printf("  --unload <name>   Unload a specific plugin by name\n");
+  printf("  --stats           Show hot-reload statistics\n");
+  printf("  --help            Show this help message\n\n");
+  printf("Example:\n");
+  printf("  %s --watch /path/to/plugins\n", ProgramName);
+  printf("  %s --reload wasi_nn\n", ProgramName);
+}
+
+void PrintStatistics() {
+  WasmEdge_HotReloadStatistics Stats;
+  WasmEdge_HotReloadGetStatistics(&Stats);
+  
+  printf("\nHot-Reload Statistics:\n");
+  printf("  Total Loads:       %lu\n", Stats.TotalLoads);
+  printf("  Total Unloads:     %lu\n", Stats.TotalUnloads);
+  printf("  Total Reloads:     %lu\n", Stats.TotalReloads);
+  printf("  Failed Loads:      %lu\n", Stats.FailedLoads);
+  printf("  Failed Unloads:    %lu\n", Stats.FailedUnloads);
+  printf("  Failed Reloads:    %lu\n", Stats.FailedReloads);
+  printf("  File Change Events:%lu\n", Stats.FileChangeEvents);
+}
+
+void ListPlugins() {
+  uint32_t PluginCount = WasmEdge_PluginListPluginsLength();
+  printf("\nLoaded Plugins (%u):\n", PluginCount);
+  
+  if (PluginCount == 0) {
+    printf("  (none)\n");
+    return;
+  }
+  
+  WasmEdge_String *Names = 
+      static_cast<WasmEdge_String *>(malloc(PluginCount * sizeof(WasmEdge_String)));
+  
+  WasmEdge_PluginListPlugins(Names, PluginCount);
+  
+  for (uint32_t I = 0; I < PluginCount; ++I) {
+    char PathBuf[1024] = {0};
+    WasmEdge_PluginGetPath(Names[I], PathBuf, sizeof(PathBuf));
+    
+    WasmEdge_PluginState State = WasmEdge_PluginGetState(Names[I]);
+    const char *StateStr = "Unknown";
+    switch (State) {
+    case WasmEdge_PluginState_Loaded:
+      StateStr = "Loaded";
+      break;
+    case WasmEdge_PluginState_Unloaded:
+      StateStr = "Unloaded";
+      break;
+    case WasmEdge_PluginState_Loading:
+      StateStr = "Loading";
+      break;
+    case WasmEdge_PluginState_Unloading:
+      StateStr = "Unloading";
+      break;
+    case WasmEdge_PluginState_Reloading:
+      StateStr = "Reloading";
+      break;
+    case WasmEdge_PluginState_Error:
+      StateStr = "Error";
+      break;
+    default:
+      break;
+    }
+    
+    bool Changed = WasmEdge_PluginHasChanged(Names[I]);
+    
+    printf("  %u. %.*s\n", I + 1, Names[I].Length, Names[I].Buf);
+    printf("     Path: %s\n", PathBuf[0] ? PathBuf : "(built-in)");
+    printf("     State: %s%s\n", StateStr, Changed ? " (changed)" : "");
+  }
+  
+  free(Names);
+}
+
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    PrintUsage(argv[0]);
+    return 0;
+  }
+  
+  WasmEdge_LogSetDebugLevel();
+  
+  WasmEdge_PluginLoadWithDefaultPaths();
+  
+  WasmEdge_HotReloadConfig Config = WasmEdge_HotReloadConfigCreate();
+  Config.EnableFileWatching = true;
+  Config.WatchIntervalMs = 1000;
+  Config.DebounceDelayMs = 500;
+  Config.AutoReloadOnChange = true;
+  WasmEdge_HotReloadConfigure(&Config);
+  
+  WasmEdge_HotReloadRegisterCallback(
+      WasmEdge_PluginEvent_BeforeLoad, OnPluginEvent, 
+      const_cast<char *>("BeforeLoad"));
+  WasmEdge_HotReloadRegisterCallback(
+      WasmEdge_PluginEvent_AfterLoad, OnPluginEvent, 
+      const_cast<char *>("AfterLoad"));
+  WasmEdge_HotReloadRegisterCallback(
+      WasmEdge_PluginEvent_BeforeUnload, OnPluginEvent, 
+      const_cast<char *>("BeforeUnload"));
+  WasmEdge_HotReloadRegisterCallback(
+      WasmEdge_PluginEvent_AfterUnload, OnPluginEvent, 
+      const_cast<char *>("AfterUnload"));
+  WasmEdge_HotReloadRegisterCallback(
+      WasmEdge_PluginEvent_BeforeReload, OnPluginEvent, 
+      const_cast<char *>("BeforeReload"));
+  WasmEdge_HotReloadRegisterCallback(
+      WasmEdge_PluginEvent_AfterReload, OnPluginEvent, 
+      const_cast<char *>("AfterReload"));
+  WasmEdge_HotReloadRegisterCallback(
+      WasmEdge_PluginEvent_FileChanged, OnPluginEvent, 
+      const_cast<char *>("FileChanged"));
+  WasmEdge_HotReloadRegisterCallback(
+      WasmEdge_PluginEvent_LoadFailed, OnPluginEvent, 
+      const_cast<char *>("LoadFailed"));
+  
+  for (int I = 1; I < argc; ++I) {
+    if (strcmp(argv[I], "--help") == 0 || strcmp(argv[I], "-h") == 0) {
+      PrintUsage(argv[0]);
+      return 0;
+    }
+    
+    if (strcmp(argv[I], "--list") == 0) {
+      ListPlugins();
+      continue;
+    }
+    
+    if (strcmp(argv[I], "--stats") == 0) {
+      PrintStatistics();
+      continue;
+    }
+    
+    if (strcmp(argv[I], "--reload") == 0 && I + 1 < argc) {
+      ++I;
+      WasmEdge_String Name = WasmEdge_StringCreateByCString(argv[I]);
+      printf("Reloading plugin: %s\n", argv[I]);
+      if (WasmEdge_PluginReload(Name)) {
+        printf("Plugin reloaded successfully.\n");
+      } else {
+        printf("Failed to reload plugin.\n");
+      }
+      WasmEdge_StringDelete(Name);
+      continue;
+    }
+    
+    if (strcmp(argv[I], "--unload") == 0 && I + 1 < argc) {
+      ++I;
+      WasmEdge_String Name = WasmEdge_StringCreateByCString(argv[I]);
+      printf("Unloading plugin: %s\n", argv[I]);
+      if (WasmEdge_PluginUnload(Name)) {
+        printf("Plugin unloaded successfully.\n");
+      } else {
+        printf("Failed to unload plugin.\n");
+      }
+      WasmEdge_StringDelete(Name);
+      continue;
+    }
+    
+    if (strcmp(argv[I], "--watch") == 0) {
+      const char *WatchPath = ".";
+      if (I + 1 < argc && argv[I + 1][0] != '-') {
+        WatchPath = argv[++I];
+      }
+      
+      printf("Starting file watcher for: %s\n", WatchPath);
+      if (WasmEdge_HotReloadStartWatchingPath(WatchPath)) {
+        printf("File watcher started. Press Ctrl+C to stop.\n");
+        printf("Modify plugin files to trigger automatic reload.\n\n");
+        
+        while (WasmEdge_HotReloadIsWatching()) {
+          std::this_thread::sleep_for(std::chrono::seconds(1));
+          
+          uint32_t ReloadedCount = WasmEdge_PluginReloadChanged();
+          if (ReloadedCount > 0) {
+            printf("Reloaded %u plugins.\n", ReloadedCount);
+            ListPlugins();
+          }
+        }
+      } else {
+        printf("Failed to start file watcher.\n");
+        return 1;
+      }
+      continue;
+    }
+    
+    printf("Loading plugin from: %s\n", argv[I]);
+    WasmEdge_PluginLoadFromPath(argv[I]);
+  }
+  
+  PrintStatistics();
+  ListPlugins();
+  
+  WasmEdge_HotReloadStopWatching();
+  WasmEdge_HotReloadClearAllCallbacks();
+  
+  return 0;
+}

--- a/include/api/wasmedge/wasmedge.h
+++ b/include/api/wasmedge/wasmedge.h
@@ -23,6 +23,7 @@
 #include "wasmedge/wasmedge_execution.h"
 #include "wasmedge/wasmedge_instance.h"
 #include "wasmedge/wasmedge_plugin.h"
+#include "wasmedge/wasmedge_hot_reload.h"
 #include "wasmedge/wasmedge_tools.h"
 #include "wasmedge/wasmedge_value.h"
 #include "wasmedge/wasmedge_vm.h"

--- a/include/api/wasmedge/wasmedge_hot_reload.h
+++ b/include/api/wasmedge/wasmedge_hot_reload.h
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+//===-- wasmedge/wasmedge_hot_reload.h - WasmEdge Hot-Reload C API --------===//
+//
+// Part of the WasmEdge Project.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the C API functions for plugin hot-reloading support
+/// in WasmEdge. These functions allow dynamic loading, unloading, and
+/// reloading of plugins at runtime without restarting the host process.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef WASMEDGE_C_API_HOT_RELOAD_H
+#define WASMEDGE_C_API_HOT_RELOAD_H
+
+#include "wasmedge/wasmedge_basic.h"
+
+typedef enum WasmEdge_PluginState {
+  WasmEdge_PluginState_Unknown = 0,
+  WasmEdge_PluginState_Loaded = 1,
+  WasmEdge_PluginState_Unloaded = 2,
+  WasmEdge_PluginState_Loading = 3,
+  WasmEdge_PluginState_Unloading = 4,
+  WasmEdge_PluginState_Reloading = 5,
+  WasmEdge_PluginState_Error = 6,
+} WasmEdge_PluginState;
+
+typedef enum WasmEdge_PluginEvent {
+  WasmEdge_PluginEvent_BeforeUnload = 0,
+  WasmEdge_PluginEvent_AfterUnload = 1,
+  WasmEdge_PluginEvent_BeforeLoad = 2,
+  WasmEdge_PluginEvent_AfterLoad = 3,
+  WasmEdge_PluginEvent_BeforeReload = 4,
+  WasmEdge_PluginEvent_AfterReload = 5,
+  WasmEdge_PluginEvent_LoadFailed = 6,
+  WasmEdge_PluginEvent_UnloadFailed = 7,
+  WasmEdge_PluginEvent_WatchStarted = 8,
+  WasmEdge_PluginEvent_WatchStopped = 9,
+  WasmEdge_PluginEvent_FileChanged = 10,
+} WasmEdge_PluginEvent;
+
+typedef struct WasmEdge_HotReloadConfig {
+  bool EnableFileWatching;
+  uint32_t WatchIntervalMs;
+  uint32_t DebounceDelayMs;
+  uint32_t MaxRetryCount;
+  uint32_t RetryDelayMs;
+  bool AutoReloadOnChange;
+} WasmEdge_HotReloadConfig;
+
+typedef struct WasmEdge_HotReloadStatistics {
+  uint64_t TotalLoads;
+  uint64_t TotalUnloads;
+  uint64_t TotalReloads;
+  uint64_t FailedLoads;
+  uint64_t FailedUnloads;
+  uint64_t FailedReloads;
+  uint64_t FileChangeEvents;
+} WasmEdge_HotReloadStatistics;
+
+/// Plugin event callback function type.
+/// \param PluginName the name of the plugin (may be empty for some events).
+/// \param Path the path to the plugin file.
+/// \param UserData user-provided data pointer.
+typedef void (*WasmEdge_PluginEventCallback)(const char *PluginName,
+                                              const char *Path, void *UserData);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Get the default hot-reload configuration.
+///
+/// \returns the default configuration with sensible defaults.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_HotReloadConfig
+WasmEdge_HotReloadConfigCreate(void);
+
+/// Configure the hot-reload manager.
+///
+/// \param Config the configuration to apply.
+WASMEDGE_CAPI_EXPORT extern void
+WasmEdge_HotReloadConfigure(const WasmEdge_HotReloadConfig *Config);
+
+/// Start watching plugin paths for changes.
+///
+/// This will monitor the specified paths for file changes and automatically
+/// reload plugins when changes are detected (if AutoReloadOnChange is enabled).
+///
+/// \param Paths array of paths to watch (files or directories).
+/// \param PathCount number of paths in the array.
+///
+/// \returns true if watching started successfully.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_HotReloadStartWatching(const char *const *Paths, uint32_t PathCount);
+
+/// Start watching a single path for changes.
+///
+/// \param Path the path to watch (file or directory).
+///
+/// \returns true if watching started successfully.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_HotReloadStartWatchingPath(const char *Path);
+
+/// Stop watching all paths for changes.
+WASMEDGE_CAPI_EXPORT extern void WasmEdge_HotReloadStopWatching(void);
+
+/// Check if file watching is currently active.
+///
+/// \returns true if watching is active.
+WASMEDGE_CAPI_EXPORT extern bool WasmEdge_HotReloadIsWatching(void);
+
+/// Unload a plugin by name.
+///
+/// This will unload the plugin and free its resources. After unloading,
+/// the plugin can no longer be used until it is loaded again.
+///
+/// \param Name the name of the plugin to unload.
+///
+/// \returns true if the plugin was found and unloaded successfully.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_PluginUnload(const WasmEdge_String Name);
+
+/// Unload a plugin by file path.
+///
+/// \param Path the path to the plugin file.
+///
+/// \returns true if the plugin was found and unloaded successfully.
+WASMEDGE_CAPI_EXPORT extern bool WasmEdge_PluginUnloadByPath(const char *Path);
+
+/// Reload a plugin by name.
+///
+/// This will unload the current version of the plugin and load the new
+/// version from the same file path. Any existing references to module
+/// instances from this plugin will become invalid.
+///
+/// \param Name the name of the plugin to reload.
+///
+/// \returns true if the plugin was reloaded successfully.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_PluginReload(const WasmEdge_String Name);
+
+/// Reload a plugin by file path.
+///
+/// \param Path the path to the plugin file.
+///
+/// \returns true if the plugin was reloaded successfully.
+WASMEDGE_CAPI_EXPORT extern bool WasmEdge_PluginReloadByPath(const char *Path);
+
+/// Reload all plugins that have changed on disk.
+///
+/// This function checks all loaded plugins for file modifications and
+/// reloads any that have changed.
+///
+/// \returns the number of plugins that were reloaded.
+WASMEDGE_CAPI_EXPORT extern uint32_t WasmEdge_PluginReloadChanged(void);
+
+/// Unload all plugins.
+///
+/// This will unload all loaded plugins (except built-in plugins).
+///
+/// \returns the number of plugins that were unloaded.
+WASMEDGE_CAPI_EXPORT extern uint32_t WasmEdge_PluginUnloadAll(void);
+
+/// Check if a plugin is currently loaded.
+///
+/// \param Name the name of the plugin to check.
+///
+/// \returns true if the plugin is loaded.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_PluginIsLoaded(const WasmEdge_String Name);
+
+/// Get the state of a plugin.
+///
+/// \param Name the name of the plugin.
+///
+/// \returns the current state of the plugin.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_PluginState
+WasmEdge_PluginGetState(const WasmEdge_String Name);
+
+/// Check if a plugin file has been modified since it was loaded.
+///
+/// \param Name the name of the plugin to check.
+///
+/// \returns true if the plugin file has been modified.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_PluginHasChanged(const WasmEdge_String Name);
+
+/// Get the path of a loaded plugin.
+///
+/// \param Name the name of the plugin.
+/// \param PathBuf buffer to store the path.
+/// \param BufLen length of the buffer.
+///
+/// \returns the length of the path, or 0 if the plugin is not found.
+WASMEDGE_CAPI_EXPORT extern uint32_t
+WasmEdge_PluginGetPath(const WasmEdge_String Name, char *PathBuf,
+                       uint32_t BufLen);
+
+/// Register a callback for plugin lifecycle events.
+///
+/// The callback will be invoked when the specified event occurs. The callback
+/// receives the plugin name, file path, and user data.
+///
+/// \param Event the event type to listen for.
+/// \param Callback the callback function.
+/// \param UserData user-provided data to pass to the callback.
+///
+/// \returns a callback ID that can be used to unregister the callback.
+WASMEDGE_CAPI_EXPORT extern uint64_t WasmEdge_HotReloadRegisterCallback(
+    WasmEdge_PluginEvent Event, WasmEdge_PluginEventCallback Callback,
+    void *UserData);
+
+/// Unregister a callback by ID.
+///
+/// \param CallbackId the ID returned from WasmEdge_HotReloadRegisterCallback.
+///
+/// \returns true if the callback was found and removed.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_HotReloadUnregisterCallback(uint64_t CallbackId);
+
+/// Clear all registered callbacks for an event type.
+///
+/// \param Event the event type.
+WASMEDGE_CAPI_EXPORT extern void
+WasmEdge_HotReloadClearCallbacks(WasmEdge_PluginEvent Event);
+
+/// Clear all registered callbacks.
+WASMEDGE_CAPI_EXPORT extern void WasmEdge_HotReloadClearAllCallbacks(void);
+
+/// Get current hot-reload statistics.
+///
+/// \param Stats pointer to a statistics structure to fill.
+WASMEDGE_CAPI_EXPORT extern void
+WasmEdge_HotReloadGetStatistics(WasmEdge_HotReloadStatistics *Stats);
+
+/// Reset hot-reload statistics counters.
+WASMEDGE_CAPI_EXPORT extern void WasmEdge_HotReloadResetStatistics(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/plugin/hot_reload.h
+++ b/include/plugin/hot_reload.h
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+//===-- wasmedge/plugin/hot_reload.h - Plugin Hot-Reload Manager ----------===//
+//
+// Part of the WasmEdge Project.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the HotReloadManager class for
+/// dynamically loading, unloading, and reloading plugins at runtime without
+/// restarting the WasmEdge host process.
+///
+//===----------------------------------------------------------------------===//
+#pragma once
+
+#include "common/defines.h"
+#include "common/filesystem.h"
+#include "plugin/plugin.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+namespace WasmEdge {
+namespace Plugin {
+
+using PluginEventCallback =
+    std::function<void(const std::string &PluginName,
+                       const std::filesystem::path &Path)>;
+
+enum class PluginEvent {
+  BeforeUnload,    ///< Called before a plugin is unloaded.
+  AfterUnload,     ///< Called after a plugin is unloaded.
+  BeforeLoad,      ///< Called before a plugin is loaded.
+  AfterLoad,       ///< Called after a plugin is loaded.
+  BeforeReload,    ///< Called before a plugin is reloaded.
+  AfterReload,     ///< Called after a plugin is reloaded.
+  LoadFailed,      ///< Called when plugin loading fails.
+  UnloadFailed,    ///< Called when plugin unloading fails.
+  WatchStarted,    ///< Called when file watching starts.
+  WatchStopped,    ///< Called when file watching stops.
+  FileChanged,     ///< Called when a watched file changes.
+};
+
+enum class PluginState {
+  Unknown,    ///< Unknown state.
+  Loaded,     ///< Plugin is loaded and ready.
+  Unloaded,   ///< Plugin has been unloaded.
+  Loading,    ///< Plugin is being loaded.
+  Unloading,  ///< Plugin is being unloaded.
+  Reloading,  ///< Plugin is being reloaded.
+  Error,      ///< Plugin is in an error state.
+};
+
+struct WatchedPluginInfo {
+  std::filesystem::path Path;
+  std::filesystem::file_time_type LastModified;
+  PluginState State;
+  uint64_t LoadCount;        ///< Number of times the plugin has been loaded.
+  uint64_t ReloadCount;      ///< Number of times the plugin has been reloaded.
+  std::string LastError;     ///< Last error message if any.
+  bool AutoReload;           ///< Whether to automatically reload on changes.
+};
+
+/// Configuration for hot-reload behavior.
+struct HotReloadConfig {
+  /// Enable file watching for automatic reload.
+  bool EnableFileWatching = true;
+  
+  /// Interval for polling file changes (milliseconds).
+  std::chrono::milliseconds WatchInterval{1000};
+  
+  /// Debounce delay to prevent multiple rapid reloads (milliseconds).
+  std::chrono::milliseconds DebounceDelay{500};
+  
+  /// Maximum retry count for failed reloads.
+  uint32_t MaxRetryCount = 3;
+  
+  /// Delay between retry attempts (milliseconds).
+  std::chrono::milliseconds RetryDelay{1000};
+  
+  /// Whether to enable automatic reload on file changes.
+  bool AutoReloadOnChange = true;
+  
+  /// Whether to backup the old plugin before reload.
+  bool BackupBeforeReload = false;
+  
+  /// Directory for plugin backups (if BackupBeforeReload is true).
+  std::filesystem::path BackupDirectory;
+};
+
+/// Hot-Reload Manager for WasmEdge plugins.
+///
+/// This class provides functionality to dynamically load, unload, and reload
+/// plugins at runtime. It supports file watching for automatic reloading
+/// when plugin files change on disk.
+///
+/// Example usage:
+/// @code
+/// auto& manager = HotReloadManager::getInstance();
+/// 
+/// // Register callbacks for lifecycle events
+/// manager.registerCallback(PluginEvent::BeforeReload, 
+///     [](const std::string& name, const auto& path) {
+///         std::cout << "Reloading plugin: " << name << std::endl;
+///     });
+///
+/// // Start watching a plugin directory
+/// manager.startWatching("/path/to/plugins");
+///
+/// // Manually reload a specific plugin
+/// if (manager.reloadPlugin("my_plugin")) {
+///     std::cout << "Plugin reloaded successfully" << std::endl;
+/// }
+///
+/// // Unload a plugin
+/// manager.unloadPlugin("my_plugin");
+///
+/// // Stop watching
+/// manager.stopWatching();
+/// @endcode
+class HotReloadManager {
+public:
+  HotReloadManager(const HotReloadManager &) = delete;
+  HotReloadManager &operator=(const HotReloadManager &) = delete;
+  HotReloadManager(HotReloadManager &&) = delete;
+  HotReloadManager &operator=(HotReloadManager &&) = delete;
+
+  /// Get the singleton instance of the HotReloadManager.
+  WASMEDGE_EXPORT static HotReloadManager &getInstance() noexcept;
+
+  /// Configure the hot-reload manager.
+  /// \param Config the configuration to apply.
+  WASMEDGE_EXPORT void configure(const HotReloadConfig &Config) noexcept;
+
+  /// Get the current configuration.
+  /// \returns the current configuration.
+  WASMEDGE_EXPORT const HotReloadConfig &getConfig() const noexcept;
+
+  /// Start watching plugin paths for changes.
+  /// This will monitor files and directories for changes and automatically
+  /// reload plugins when changes are detected.
+  /// \param Paths the paths to watch (files or directories).
+  /// \returns true if watching started successfully.
+  WASMEDGE_EXPORT bool
+  startWatching(const std::vector<std::filesystem::path> &Paths) noexcept;
+
+  /// Start watching a single path for changes.
+  /// \param Path the path to watch (file or directory).
+  /// \returns true if watching started successfully.
+  WASMEDGE_EXPORT bool startWatching(const std::filesystem::path &Path) noexcept;
+
+  /// Stop watching all paths.
+  WASMEDGE_EXPORT void stopWatching() noexcept;
+
+  /// Check if currently watching any paths.
+  /// \returns true if file watching is active.
+  WASMEDGE_EXPORT bool isWatching() const noexcept;
+
+  /// Get list of currently watched paths.
+  /// \returns vector of watched paths.
+  WASMEDGE_EXPORT std::vector<std::filesystem::path> getWatchedPaths() const noexcept;
+
+  /// Load a plugin from the given path.
+  /// \param Path the path to the plugin file.
+  /// \returns true if the plugin was loaded successfully.
+  WASMEDGE_EXPORT bool loadPlugin(const std::filesystem::path &Path) noexcept;
+
+  /// Unload a plugin by name.
+  /// This will unload the plugin and free its resources.
+  /// \param Name the name of the plugin to unload.
+  /// \returns true if the plugin was unloaded successfully.
+  WASMEDGE_EXPORT bool unloadPlugin(std::string_view Name) noexcept;
+
+  /// Unload a plugin by path.
+  /// \param Path the path of the plugin to unload.
+  /// \returns true if the plugin was unloaded successfully.
+  WASMEDGE_EXPORT bool unloadPluginByPath(const std::filesystem::path &Path) noexcept;
+
+  /// Reload a plugin by name.
+  /// This will unload the current version and load the new version.
+  /// \param Name the name of the plugin to reload.
+  /// \returns true if the plugin was reloaded successfully.
+  WASMEDGE_EXPORT bool reloadPlugin(std::string_view Name) noexcept;
+
+  /// Reload a plugin by path.
+  /// \param Path the path of the plugin to reload.
+  /// \returns true if the plugin was reloaded successfully.
+  WASMEDGE_EXPORT bool reloadPluginByPath(const std::filesystem::path &Path) noexcept;
+
+  /// Reload all plugins that have changed on disk.
+  /// \returns number of plugins reloaded.
+  WASMEDGE_EXPORT uint32_t reloadChangedPlugins() noexcept;
+
+  /// Unload all plugins.
+  /// \returns number of plugins unloaded.
+  WASMEDGE_EXPORT uint32_t unloadAllPlugins() noexcept;
+
+  /// Get the state of a plugin by name.
+  /// \param Name the name of the plugin.
+  /// \returns the state of the plugin.
+  WASMEDGE_EXPORT PluginState getPluginState(std::string_view Name) const noexcept;
+
+  /// Get information about a watched plugin.
+  /// \param Name the name of the plugin.
+  /// \returns optional containing plugin info if found.
+  WASMEDGE_EXPORT std::optional<WatchedPluginInfo>
+  getPluginInfo(std::string_view Name) const noexcept;
+
+  /// Get list of all plugin names currently managed.
+  /// \returns vector of plugin names.
+  WASMEDGE_EXPORT std::vector<std::string> getManagedPluginNames() const noexcept;
+
+  /// Register a callback for plugin lifecycle events.
+  /// \param Event the event type to listen for.
+  /// \param Callback the callback function.
+  /// \returns callback ID for later removal.
+  WASMEDGE_EXPORT uint64_t registerCallback(PluginEvent Event,
+                                             PluginEventCallback Callback) noexcept;
+
+  /// Unregister a callback by ID.
+  /// \param CallbackId the ID returned from registerCallback.
+  /// \returns true if the callback was found and removed.
+  WASMEDGE_EXPORT bool unregisterCallback(uint64_t CallbackId) noexcept;
+
+  /// Clear all registered callbacks for an event type.
+  /// \param Event the event type.
+  WASMEDGE_EXPORT void clearCallbacks(PluginEvent Event) noexcept;
+
+  /// Clear all registered callbacks.
+  WASMEDGE_EXPORT void clearAllCallbacks() noexcept;
+
+  /// Check if a plugin file has been modified since last load.
+  /// \param Name the name of the plugin.
+  /// \returns true if the plugin file has been modified.
+  WASMEDGE_EXPORT bool hasPluginChanged(std::string_view Name) const noexcept;
+
+  /// Get statistics about hot-reload operations.
+  struct Statistics {
+    uint64_t TotalLoads = 0;
+    uint64_t TotalUnloads = 0;
+    uint64_t TotalReloads = 0;
+    uint64_t FailedLoads = 0;
+    uint64_t FailedUnloads = 0;
+    uint64_t FailedReloads = 0;
+    uint64_t FileChangeEvents = 0;
+  };
+
+  /// Get current statistics.
+  /// \returns current statistics.
+  WASMEDGE_EXPORT Statistics getStatistics() const noexcept;
+
+  /// Reset statistics counters.
+  WASMEDGE_EXPORT void resetStatistics() noexcept;
+
+private:
+  HotReloadManager() noexcept;
+  ~HotReloadManager() noexcept;
+
+  /// Internal implementation details.
+  struct Impl;
+  std::unique_ptr<Impl> PImpl;
+};
+
+} // namespace Plugin
+} // namespace WasmEdge

--- a/include/plugin/plugin.h
+++ b/include/plugin/plugin.h
@@ -160,8 +160,37 @@ public:
   // Static function to find loaded plugin by name.
   WASMEDGE_EXPORT static const Plugin *find(std::string_view Name) noexcept;
 
+  // Static function to find loaded plugin by path.
+  WASMEDGE_EXPORT static const Plugin *
+  findByPath(const std::filesystem::path &Path) noexcept;
+
   // Static function to list loaded plugins.
   static Span<const Plugin> plugins() noexcept;
+
+  // Static function to unload a plugin by name.
+  // Returns true if the plugin was found and unloaded successfully.
+  WASMEDGE_EXPORT static bool unload(std::string_view Name) noexcept;
+
+  // Static function to unload a plugin by path.
+  // Returns true if the plugin was found and unloaded successfully.
+  WASMEDGE_EXPORT static bool
+  unloadByPath(const std::filesystem::path &Path) noexcept;
+
+  // Static function to reload a plugin by name.
+  // This will unload the current version and load the new version from the
+  // same path. Returns true if the plugin was reloaded successfully.
+  WASMEDGE_EXPORT static bool reload(std::string_view Name) noexcept;
+
+  // Static function to reload a plugin by path.
+  // Returns true if the plugin was reloaded successfully.
+  WASMEDGE_EXPORT static bool
+  reloadByPath(const std::filesystem::path &Path) noexcept;
+
+  // Static function to check if a plugin is loaded.
+  WASMEDGE_EXPORT static bool isLoaded(std::string_view Name) noexcept;
+
+  // Static function to get the number of loaded plugins.
+  static size_t count() noexcept;
 
   Plugin(const Plugin &) = delete;
   Plugin &operator=(const Plugin &) = delete;
@@ -210,6 +239,17 @@ public:
 
   std::filesystem::path path() const noexcept { return Path; }
 
+  // Get the last modification time of the plugin file.
+  std::filesystem::file_time_type lastModified() const noexcept {
+    return LastModified;
+  }
+
+  // Get the number of times this plugin has been loaded.
+  uint64_t loadCount() const noexcept { return LoadCount; }
+
+  // Check if the plugin file has been modified since it was loaded.
+  bool hasChanged() const noexcept;
+
 private:
   static std::mutex Mutex;
   static std::vector<Plugin> PluginRegistry;
@@ -224,6 +264,8 @@ private:
 
   // Plugin contents.
   std::filesystem::path Path;
+  std::filesystem::file_time_type LastModified;
+  uint64_t LoadCount = 0;
   const PluginDescriptor *Desc = nullptr;
   std::shared_ptr<Loader::SharedLibrary> Lib;
   std::vector<PluginModule> ModuleRegistry;

--- a/lib/api/CMakeLists.txt
+++ b/lib/api/CMakeLists.txt
@@ -73,6 +73,7 @@ set(WASMEDGE_CAPI_HEADERS
   ${CMAKE_CURRENT_SOURCE_DIR}/../../include/api/wasmedge/wasmedge_experimental.h
   ${CMAKE_CURRENT_SOURCE_DIR}/../../include/api/wasmedge/wasmedge_instance.h
   ${CMAKE_CURRENT_SOURCE_DIR}/../../include/api/wasmedge/wasmedge_plugin.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../include/api/wasmedge/wasmedge_hot_reload.h
   ${CMAKE_CURRENT_SOURCE_DIR}/../../include/api/wasmedge/wasmedge_tools.h
   ${CMAKE_CURRENT_SOURCE_DIR}/../../include/api/wasmedge/wasmedge_value.h
   ${CMAKE_CURRENT_SOURCE_DIR}/../../include/api/wasmedge/wasmedge_vm.h
@@ -87,6 +88,7 @@ set(WASMEDGE_CAPI_HEADERS
 # Object library of the C API wrapper.
 wasmedge_add_library(wasmedgeCAPI OBJECT
   wasmedge.cpp
+  wasmedge_hot_reload.cpp
 )
 
 target_link_libraries(wasmedgeCAPI

--- a/lib/api/wasmedge_hot_reload.cpp
+++ b/lib/api/wasmedge_hot_reload.cpp
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+#include "wasmedge/wasmedge_hot_reload.h"
+#include "plugin/hot_reload.h"
+#include "plugin/plugin.h"
+
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+using namespace WasmEdge;
+
+inline std::string_view genStrView(const WasmEdge_String S) noexcept {
+  return std::string_view(S.Buf, S.Length);
+}
+
+inline WasmEdge_PluginState
+toPluginState(Plugin::PluginState State) noexcept {
+  switch (State) {
+  case Plugin::PluginState::Unknown:
+    return WasmEdge_PluginState_Unknown;
+  case Plugin::PluginState::Loaded:
+    return WasmEdge_PluginState_Loaded;
+  case Plugin::PluginState::Unloaded:
+    return WasmEdge_PluginState_Unloaded;
+  case Plugin::PluginState::Loading:
+    return WasmEdge_PluginState_Loading;
+  case Plugin::PluginState::Unloading:
+    return WasmEdge_PluginState_Unloading;
+  case Plugin::PluginState::Reloading:
+    return WasmEdge_PluginState_Reloading;
+  case Plugin::PluginState::Error:
+    return WasmEdge_PluginState_Error;
+  default:
+    return WasmEdge_PluginState_Unknown;
+  }
+}
+
+inline Plugin::PluginEvent toPluginEvent(WasmEdge_PluginEvent Event) noexcept {
+  switch (Event) {
+  case WasmEdge_PluginEvent_BeforeUnload:
+    return Plugin::PluginEvent::BeforeUnload;
+  case WasmEdge_PluginEvent_AfterUnload:
+    return Plugin::PluginEvent::AfterUnload;
+  case WasmEdge_PluginEvent_BeforeLoad:
+    return Plugin::PluginEvent::BeforeLoad;
+  case WasmEdge_PluginEvent_AfterLoad:
+    return Plugin::PluginEvent::AfterLoad;
+  case WasmEdge_PluginEvent_BeforeReload:
+    return Plugin::PluginEvent::BeforeReload;
+  case WasmEdge_PluginEvent_AfterReload:
+    return Plugin::PluginEvent::AfterReload;
+  case WasmEdge_PluginEvent_LoadFailed:
+    return Plugin::PluginEvent::LoadFailed;
+  case WasmEdge_PluginEvent_UnloadFailed:
+    return Plugin::PluginEvent::UnloadFailed;
+  case WasmEdge_PluginEvent_WatchStarted:
+    return Plugin::PluginEvent::WatchStarted;
+  case WasmEdge_PluginEvent_WatchStopped:
+    return Plugin::PluginEvent::WatchStopped;
+  case WasmEdge_PluginEvent_FileChanged:
+    return Plugin::PluginEvent::FileChanged;
+  default:
+    return Plugin::PluginEvent::AfterLoad;
+  }
+}
+
+struct CallbackWrapper {
+  WasmEdge_PluginEventCallback Callback;
+  void *UserData;
+};
+
+std::mutex CallbackWrapperMutex;
+std::unordered_map<uint64_t, std::unique_ptr<CallbackWrapper>>
+    CallbackWrappers;
+
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+WASMEDGE_CAPI_EXPORT WasmEdge_HotReloadConfig
+WasmEdge_HotReloadConfigCreate(void) {
+  WasmEdge_HotReloadConfig Config;
+  Config.EnableFileWatching = true;
+  Config.WatchIntervalMs = 1000;
+  Config.DebounceDelayMs = 500;
+  Config.MaxRetryCount = 3;
+  Config.RetryDelayMs = 1000;
+  Config.AutoReloadOnChange = true;
+  return Config;
+}
+
+WASMEDGE_CAPI_EXPORT void
+WasmEdge_HotReloadConfigure(const WasmEdge_HotReloadConfig *Config) {
+  if (!Config) {
+    return;
+  }
+
+  WasmEdge::Plugin::HotReloadConfig CppConfig;
+  CppConfig.EnableFileWatching = Config->EnableFileWatching;
+  CppConfig.WatchInterval =
+      std::chrono::milliseconds(Config->WatchIntervalMs);
+  CppConfig.DebounceDelay =
+      std::chrono::milliseconds(Config->DebounceDelayMs);
+  CppConfig.MaxRetryCount = Config->MaxRetryCount;
+  CppConfig.RetryDelay = std::chrono::milliseconds(Config->RetryDelayMs);
+  CppConfig.AutoReloadOnChange = Config->AutoReloadOnChange;
+
+  WasmEdge::Plugin::HotReloadManager::getInstance().configure(CppConfig);
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_HotReloadStartWatching(const char *const *Paths, uint32_t PathCount) {
+  if (!Paths || PathCount == 0) {
+    return false;
+  }
+
+  std::vector<std::filesystem::path> PathVec;
+  PathVec.reserve(PathCount);
+  for (uint32_t I = 0; I < PathCount; ++I) {
+    if (Paths[I]) {
+      PathVec.emplace_back(Paths[I]);
+    }
+  }
+
+  return WasmEdge::Plugin::HotReloadManager::getInstance().startWatching(
+      PathVec);
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_HotReloadStartWatchingPath(const char *Path) {
+  if (!Path) {
+    return false;
+  }
+  return WasmEdge::Plugin::HotReloadManager::getInstance().startWatching(
+      std::filesystem::path(Path));
+}
+
+WASMEDGE_CAPI_EXPORT void WasmEdge_HotReloadStopWatching(void) {
+  WasmEdge::Plugin::HotReloadManager::getInstance().stopWatching();
+}
+
+WASMEDGE_CAPI_EXPORT bool WasmEdge_HotReloadIsWatching(void) {
+  return WasmEdge::Plugin::HotReloadManager::getInstance().isWatching();
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_PluginUnload(const WasmEdge_String Name) {
+  return WasmEdge::Plugin::Plugin::unload(genStrView(Name));
+}
+
+WASMEDGE_CAPI_EXPORT bool WasmEdge_PluginUnloadByPath(const char *Path) {
+  if (!Path) {
+    return false;
+  }
+  return WasmEdge::Plugin::Plugin::unloadByPath(std::filesystem::path(Path));
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_PluginReload(const WasmEdge_String Name) {
+  return WasmEdge::Plugin::Plugin::reload(genStrView(Name));
+}
+
+WASMEDGE_CAPI_EXPORT bool WasmEdge_PluginReloadByPath(const char *Path) {
+  if (!Path) {
+    return false;
+  }
+  return WasmEdge::Plugin::Plugin::reloadByPath(std::filesystem::path(Path));
+}
+
+WASMEDGE_CAPI_EXPORT uint32_t WasmEdge_PluginReloadChanged(void) {
+  return WasmEdge::Plugin::HotReloadManager::getInstance()
+      .reloadChangedPlugins();
+}
+
+WASMEDGE_CAPI_EXPORT uint32_t WasmEdge_PluginUnloadAll(void) {
+  return WasmEdge::Plugin::HotReloadManager::getInstance().unloadAllPlugins();
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_PluginIsLoaded(const WasmEdge_String Name) {
+  return WasmEdge::Plugin::Plugin::isLoaded(genStrView(Name));
+}
+
+WASMEDGE_CAPI_EXPORT WasmEdge_PluginState
+WasmEdge_PluginGetState(const WasmEdge_String Name) {
+  return toPluginState(
+      WasmEdge::Plugin::HotReloadManager::getInstance().getPluginState(
+          genStrView(Name)));
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_PluginHasChanged(const WasmEdge_String Name) {
+  const auto *Plugin = WasmEdge::Plugin::Plugin::find(genStrView(Name));
+  if (Plugin) {
+    return Plugin->hasChanged();
+  }
+  return false;
+}
+
+WASMEDGE_CAPI_EXPORT uint32_t
+WasmEdge_PluginGetPath(const WasmEdge_String Name, char *PathBuf,
+                       uint32_t BufLen) {
+  const auto *Plugin = WasmEdge::Plugin::Plugin::find(genStrView(Name));
+  if (!Plugin) {
+    return 0;
+  }
+
+  std::string PathStr = Plugin->path().string();
+  uint32_t PathLen = static_cast<uint32_t>(PathStr.size());
+
+  if (PathBuf && BufLen > 0) {
+    uint32_t CopyLen = std::min(PathLen, BufLen - 1);
+    std::memcpy(PathBuf, PathStr.data(), CopyLen);
+    PathBuf[CopyLen] = '\0';
+  }
+
+  return PathLen;
+}
+
+WASMEDGE_CAPI_EXPORT uint64_t WasmEdge_HotReloadRegisterCallback(
+    WasmEdge_PluginEvent Event, WasmEdge_PluginEventCallback Callback,
+    void *UserData) {
+  if (!Callback) {
+    return 0;
+  }
+
+  auto Wrapper = std::make_unique<CallbackWrapper>();
+  Wrapper->Callback = Callback;
+  Wrapper->UserData = UserData;
+  CallbackWrapper *WrapperPtr = Wrapper.get();
+
+  uint64_t Id = WasmEdge::Plugin::HotReloadManager::getInstance()
+      .registerCallback(
+          toPluginEvent(Event),
+          [WrapperPtr](const std::string &PluginName,
+                       const std::filesystem::path &Path) {
+            WrapperPtr->Callback(PluginName.c_str(), Path.string().c_str(),
+                                 WrapperPtr->UserData);
+          });
+
+  {
+    std::lock_guard<std::mutex> Lock(CallbackWrapperMutex);
+    CallbackWrappers[Id] = std::move(Wrapper);
+  }
+
+  return Id;
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_HotReloadUnregisterCallback(uint64_t CallbackId) {
+  bool Result =
+      WasmEdge::Plugin::HotReloadManager::getInstance().unregisterCallback(
+          CallbackId);
+
+  if (Result) {
+    std::lock_guard<std::mutex> Lock(CallbackWrapperMutex);
+    CallbackWrappers.erase(CallbackId);
+  }
+
+  return Result;
+}
+
+WASMEDGE_CAPI_EXPORT void
+WasmEdge_HotReloadClearCallbacks(WasmEdge_PluginEvent Event) {
+  WasmEdge::Plugin::HotReloadManager::getInstance().clearCallbacks(
+      toPluginEvent(Event));
+}
+
+WASMEDGE_CAPI_EXPORT void WasmEdge_HotReloadClearAllCallbacks(void) {
+  WasmEdge::Plugin::HotReloadManager::getInstance().clearAllCallbacks();
+
+  std::lock_guard<std::mutex> Lock(CallbackWrapperMutex);
+  CallbackWrappers.clear();
+}
+
+WASMEDGE_CAPI_EXPORT void
+WasmEdge_HotReloadGetStatistics(WasmEdge_HotReloadStatistics *Stats) {
+  if (!Stats) {
+    return;
+  }
+
+  auto CppStats =
+      WasmEdge::Plugin::HotReloadManager::getInstance().getStatistics();
+  Stats->TotalLoads = CppStats.TotalLoads;
+  Stats->TotalUnloads = CppStats.TotalUnloads;
+  Stats->TotalReloads = CppStats.TotalReloads;
+  Stats->FailedLoads = CppStats.FailedLoads;
+  Stats->FailedUnloads = CppStats.FailedUnloads;
+  Stats->FailedReloads = CppStats.FailedReloads;
+  Stats->FileChangeEvents = CppStats.FileChangeEvents;
+}
+
+WASMEDGE_CAPI_EXPORT void WasmEdge_HotReloadResetStatistics(void) {
+  WasmEdge::Plugin::HotReloadManager::getInstance().resetStatistics();
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/plugin/CMakeLists.txt
+++ b/lib/plugin/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(wasi_logging)
 
 wasmedge_add_library(wasmedgePlugin
   plugin.cpp
+  hot_reload.cpp
 )
 
 target_include_directories(wasmedgePlugin

--- a/lib/plugin/hot_reload.cpp
+++ b/lib/plugin/hot_reload.cpp
@@ -1,0 +1,574 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+#include "plugin/hot_reload.h"
+#include "common/defines.h"
+#include "common/spdlog.h"
+
+#include <algorithm>
+#include <chrono>
+#include <map>
+#include <optional>
+
+#if WASMEDGE_OS_LINUX || WASMEDGE_OS_MACOS
+#include <sys/stat.h>
+#include <unistd.h>
+#elif WASMEDGE_OS_WINDOWS
+#include "system/winapi.h"
+#endif
+
+using namespace std::literals;
+
+namespace WasmEdge {
+namespace Plugin {
+
+struct HotReloadManager::Impl {
+  Impl() noexcept = default;
+  ~Impl() noexcept { stopWatching(); }
+
+  HotReloadConfig Config;
+
+  mutable std::mutex Mutex;
+
+  std::thread WatcherThread;
+  std::atomic<bool> WatcherRunning{false};
+  std::condition_variable WatcherCV;
+  std::mutex WatcherMutex;
+
+  std::vector<std::filesystem::path> WatchedPaths;
+  std::unordered_map<std::string, WatchedPluginInfo> PluginInfoMap;
+  std::unordered_map<std::string, std::filesystem::path> PathToNameMap;
+
+  std::mutex CallbackMutex;
+  uint64_t NextCallbackId = 1;
+  std::map<uint64_t, std::pair<PluginEvent, PluginEventCallback>> Callbacks;
+
+  std::atomic<uint64_t> TotalLoads{0};
+  std::atomic<uint64_t> TotalUnloads{0};
+  std::atomic<uint64_t> TotalReloads{0};
+  std::atomic<uint64_t> FailedLoads{0};
+  std::atomic<uint64_t> FailedUnloads{0};
+  std::atomic<uint64_t> FailedReloads{0};
+  std::atomic<uint64_t> FileChangeEvents{0};
+
+  std::unordered_map<std::string, std::chrono::steady_clock::time_point>
+      LastChangeTime;
+
+  void fireCallbacks(PluginEvent Event, const std::string &PluginName,
+                     const std::filesystem::path &Path) noexcept {
+    std::lock_guard<std::mutex> Lock(CallbackMutex);
+    for (const auto &[Id, CallbackPair] : Callbacks) {
+      if (CallbackPair.first == Event) {
+        try {
+          CallbackPair.second(PluginName, Path);
+        } catch (const std::exception &E) {
+          spdlog::error("Plugin callback exception: {}"sv, E.what());
+        } catch (...) {
+          spdlog::error("Plugin callback unknown exception"sv);
+        }
+      }
+    }
+  }
+
+  std::optional<std::filesystem::file_time_type>
+  getFileModTime(const std::filesystem::path &Path) const noexcept {
+    std::error_code EC;
+    auto ModTime = std::filesystem::last_write_time(Path, EC);
+    if (EC) {
+      return std::nullopt;
+    }
+    return ModTime;
+  }
+
+  bool shouldProcessChange(const std::string &PathStr) noexcept {
+    auto Now = std::chrono::steady_clock::now();
+    std::lock_guard<std::mutex> Lock(Mutex);
+    
+    auto It = LastChangeTime.find(PathStr);
+    if (It != LastChangeTime.end()) {
+      auto Elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+          Now - It->second);
+      if (Elapsed < Config.DebounceDelay) {
+        return false;
+      }
+    }
+    LastChangeTime[PathStr] = Now;
+    return true;
+  }
+
+  void watcherLoop() noexcept {
+    spdlog::info("Plugin file watcher started"sv);
+    fireCallbacks(PluginEvent::WatchStarted, "", "");
+
+    while (WatcherRunning.load()) {
+      {
+        std::unique_lock<std::mutex> Lock(WatcherMutex);
+        WatcherCV.wait_for(Lock, Config.WatchInterval,
+                           [this] { return !WatcherRunning.load(); });
+      }
+
+      if (!WatcherRunning.load()) {
+        break;
+      }
+
+      checkForChanges();
+    }
+
+    spdlog::info("Plugin file watcher stopped"sv);
+    fireCallbacks(PluginEvent::WatchStopped, "", "");
+  }
+
+  void checkForChanges() noexcept {
+    std::lock_guard<std::mutex> Lock(Mutex);
+
+    for (const auto &WatchPath : WatchedPaths) {
+      std::error_code EC;
+      
+      if (std::filesystem::is_directory(WatchPath, EC)) {
+        for (const auto &Entry :
+             std::filesystem::directory_iterator(WatchPath, EC)) {
+          if (EC) continue;
+          
+          const auto &FilePath = Entry.path();
+          if (FilePath.extension().u8string() == WASMEDGE_LIB_EXTENSION) {
+            checkFileChange(FilePath);
+          }
+        }
+      } else if (std::filesystem::is_regular_file(WatchPath, EC)) {
+        checkFileChange(WatchPath);
+      }
+    }
+  }
+
+  void checkFileChange(const std::filesystem::path &FilePath) noexcept {
+    auto ModTimeOpt = getFileModTime(FilePath);
+    if (!ModTimeOpt) {
+      return;
+    }
+
+    std::string PathStr = FilePath.string();
+    
+    for (auto &[Name, Info] : PluginInfoMap) {
+      if (Info.Path == FilePath) {
+        if (*ModTimeOpt != Info.LastModified) {
+          FileChangeEvents.fetch_add(1);
+          fireCallbacks(PluginEvent::FileChanged, Name, FilePath);
+          
+          if (Config.AutoReloadOnChange && Info.AutoReload) {
+            if (shouldProcessChange(PathStr)) {
+              spdlog::info("Plugin file changed, reloading: {}"sv, Name);
+              Info.State = PluginState::Reloading;
+            }
+          }
+          
+          Info.LastModified = *ModTimeOpt;
+        }
+        break;
+      }
+    }
+  }
+
+  bool startWatching() noexcept {
+    if (WatcherRunning.load()) {
+      return true;
+    }
+
+    WatcherRunning.store(true);
+    WatcherThread = std::thread(&Impl::watcherLoop, this);
+    return true;
+  }
+
+  void stopWatching() noexcept {
+    if (!WatcherRunning.load()) {
+      return;
+    }
+
+    WatcherRunning.store(false);
+    WatcherCV.notify_all();
+    
+    if (WatcherThread.joinable()) {
+      WatcherThread.join();
+    }
+  }
+};
+
+HotReloadManager &HotReloadManager::getInstance() noexcept {
+  static HotReloadManager Instance;
+  return Instance;
+}
+
+HotReloadManager::HotReloadManager() noexcept
+    : PImpl(std::make_unique<Impl>()) {}
+
+HotReloadManager::~HotReloadManager() noexcept = default;
+
+void HotReloadManager::configure(const HotReloadConfig &Config) noexcept {
+  std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+  PImpl->Config = Config;
+}
+
+const HotReloadConfig &HotReloadManager::getConfig() const noexcept {
+  std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+  return PImpl->Config;
+}
+
+bool HotReloadManager::startWatching(
+    const std::vector<std::filesystem::path> &Paths) noexcept {
+  {
+    std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+    for (const auto &Path : Paths) {
+      if (std::find(PImpl->WatchedPaths.begin(), PImpl->WatchedPaths.end(),
+                    Path) == PImpl->WatchedPaths.end()) {
+        PImpl->WatchedPaths.push_back(Path);
+      }
+    }
+  }
+  return PImpl->startWatching();
+}
+
+bool HotReloadManager::startWatching(
+    const std::filesystem::path &Path) noexcept {
+  return startWatching(std::vector<std::filesystem::path>{Path});
+}
+
+void HotReloadManager::stopWatching() noexcept { PImpl->stopWatching(); }
+
+bool HotReloadManager::isWatching() const noexcept {
+  return PImpl->WatcherRunning.load();
+}
+
+std::vector<std::filesystem::path>
+HotReloadManager::getWatchedPaths() const noexcept {
+  std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+  return PImpl->WatchedPaths;
+}
+
+bool HotReloadManager::loadPlugin(const std::filesystem::path &Path) noexcept {
+  PImpl->fireCallbacks(PluginEvent::BeforeLoad, "", Path);
+
+  bool Result = Plugin::load(Path);
+
+  if (Result) {
+    PImpl->TotalLoads.fetch_add(1);
+    
+    auto Plugins = Plugin::plugins();
+    for (const auto &P : Plugins) {
+      if (P.path() == Path) {
+        std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+        WatchedPluginInfo Info;
+        Info.Path = Path;
+        Info.State = PluginState::Loaded;
+        Info.LoadCount = 1;
+        Info.ReloadCount = 0;
+        Info.AutoReload = PImpl->Config.AutoReloadOnChange;
+        
+        auto ModTimeOpt = PImpl->getFileModTime(Path);
+        if (ModTimeOpt) {
+          Info.LastModified = *ModTimeOpt;
+        }
+        
+        std::string Name = P.name();
+        PImpl->PluginInfoMap[Name] = std::move(Info);
+        PImpl->PathToNameMap[Path.string()] = Name;
+        
+        PImpl->fireCallbacks(PluginEvent::AfterLoad, Name, Path);
+        break;
+      }
+    }
+  } else {
+    PImpl->FailedLoads.fetch_add(1);
+    PImpl->fireCallbacks(PluginEvent::LoadFailed, "", Path);
+  }
+
+  return Result;
+}
+
+bool HotReloadManager::unloadPlugin(std::string_view Name) noexcept {
+  std::filesystem::path PluginPath;
+  
+  {
+    std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+    auto It = PImpl->PluginInfoMap.find(std::string(Name));
+    if (It != PImpl->PluginInfoMap.end()) {
+      PluginPath = It->second.Path;
+      It->second.State = PluginState::Unloading;
+    }
+  }
+
+  std::string NameStr(Name);
+  PImpl->fireCallbacks(PluginEvent::BeforeUnload, NameStr, PluginPath);
+
+  bool Result = Plugin::unload(Name);
+
+  if (Result) {
+    PImpl->TotalUnloads.fetch_add(1);
+    
+    {
+      std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+      auto It = PImpl->PluginInfoMap.find(NameStr);
+      if (It != PImpl->PluginInfoMap.end()) {
+        It->second.State = PluginState::Unloaded;
+      }
+      PImpl->PathToNameMap.erase(PluginPath.string());
+    }
+    
+    PImpl->fireCallbacks(PluginEvent::AfterUnload, NameStr, PluginPath);
+  } else {
+    PImpl->FailedUnloads.fetch_add(1);
+    
+    {
+      std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+      auto It = PImpl->PluginInfoMap.find(NameStr);
+      if (It != PImpl->PluginInfoMap.end()) {
+        It->second.State = PluginState::Error;
+        It->second.LastError = "Failed to unload plugin";
+      }
+    }
+    
+    PImpl->fireCallbacks(PluginEvent::UnloadFailed, NameStr, PluginPath);
+  }
+
+  return Result;
+}
+
+bool HotReloadManager::unloadPluginByPath(
+    const std::filesystem::path &Path) noexcept {
+  std::string Name;
+  {
+    std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+    auto It = PImpl->PathToNameMap.find(Path.string());
+    if (It != PImpl->PathToNameMap.end()) {
+      Name = It->second;
+    }
+  }
+  
+  if (!Name.empty()) {
+    return unloadPlugin(Name);
+  }
+  
+  return Plugin::unloadByPath(Path);
+}
+
+bool HotReloadManager::reloadPlugin(std::string_view Name) noexcept {
+  std::filesystem::path PluginPath;
+  
+  {
+    std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+    auto It = PImpl->PluginInfoMap.find(std::string(Name));
+    if (It != PImpl->PluginInfoMap.end()) {
+      PluginPath = It->second.Path;
+      It->second.State = PluginState::Reloading;
+    } else {
+      const Plugin *P = Plugin::find(Name);
+      if (P) {
+        PluginPath = P->path();
+      } else {
+        spdlog::error("Plugin not found for reload: {}"sv, Name);
+        return false;
+      }
+    }
+  }
+
+  std::string NameStr(Name);
+  PImpl->fireCallbacks(PluginEvent::BeforeReload, NameStr, PluginPath);
+
+  bool Result = Plugin::reload(Name);
+
+  if (Result) {
+    PImpl->TotalReloads.fetch_add(1);
+    
+    {
+      std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+      auto It = PImpl->PluginInfoMap.find(NameStr);
+      if (It != PImpl->PluginInfoMap.end()) {
+        It->second.State = PluginState::Loaded;
+        It->second.ReloadCount++;
+        It->second.LoadCount++;
+        
+        auto ModTimeOpt = PImpl->getFileModTime(PluginPath);
+        if (ModTimeOpt) {
+          It->second.LastModified = *ModTimeOpt;
+        }
+      }
+    }
+    
+    PImpl->fireCallbacks(PluginEvent::AfterReload, NameStr, PluginPath);
+  } else {
+    PImpl->FailedReloads.fetch_add(1);
+    
+    {
+      std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+      auto It = PImpl->PluginInfoMap.find(NameStr);
+      if (It != PImpl->PluginInfoMap.end()) {
+        It->second.State = PluginState::Error;
+        It->second.LastError = "Failed to reload plugin";
+      }
+    }
+    
+    spdlog::error("Failed to reload plugin: {}"sv, Name);
+  }
+
+  return Result;
+}
+
+bool HotReloadManager::reloadPluginByPath(
+    const std::filesystem::path &Path) noexcept {
+  std::string Name;
+  {
+    std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+    auto It = PImpl->PathToNameMap.find(Path.string());
+    if (It != PImpl->PathToNameMap.end()) {
+      Name = It->second;
+    }
+  }
+  
+  if (!Name.empty()) {
+    return reloadPlugin(Name);
+  }
+  
+  return Plugin::reloadByPath(Path);
+}
+
+uint32_t HotReloadManager::reloadChangedPlugins() noexcept {
+  uint32_t ReloadCount = 0;
+  std::vector<std::string> PluginsToReload;
+  
+  {
+    std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+    for (const auto &[Name, Info] : PImpl->PluginInfoMap) {
+      if (Info.State == PluginState::Loaded) {
+        auto ModTimeOpt = PImpl->getFileModTime(Info.Path);
+        if (ModTimeOpt && *ModTimeOpt != Info.LastModified) {
+          PluginsToReload.push_back(Name);
+        }
+      }
+    }
+  }
+  
+  for (const auto &Name : PluginsToReload) {
+    if (reloadPlugin(Name)) {
+      ++ReloadCount;
+    }
+  }
+  
+  return ReloadCount;
+}
+
+uint32_t HotReloadManager::unloadAllPlugins() noexcept {
+  uint32_t UnloadCount = 0;
+  std::vector<std::string> PluginsToUnload;
+  
+  {
+    std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+    for (const auto &[Name, Info] : PImpl->PluginInfoMap) {
+      if (Info.State == PluginState::Loaded) {
+        PluginsToUnload.push_back(Name);
+      }
+    }
+  }
+  
+  for (const auto &Name : PluginsToUnload) {
+    if (unloadPlugin(Name)) {
+      ++UnloadCount;
+    }
+  }
+  
+  return UnloadCount;
+}
+
+PluginState
+HotReloadManager::getPluginState(std::string_view Name) const noexcept {
+  std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+  auto It = PImpl->PluginInfoMap.find(std::string(Name));
+  if (It != PImpl->PluginInfoMap.end()) {
+    return It->second.State;
+  }
+  return PluginState::Unknown;
+}
+
+std::optional<WatchedPluginInfo>
+HotReloadManager::getPluginInfo(std::string_view Name) const noexcept {
+  std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+  auto It = PImpl->PluginInfoMap.find(std::string(Name));
+  if (It != PImpl->PluginInfoMap.end()) {
+    return It->second;
+  }
+  return std::nullopt;
+}
+
+std::vector<std::string>
+HotReloadManager::getManagedPluginNames() const noexcept {
+  std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+  std::vector<std::string> Names;
+  Names.reserve(PImpl->PluginInfoMap.size());
+  for (const auto &[Name, Info] : PImpl->PluginInfoMap) {
+    Names.push_back(Name);
+  }
+  return Names;
+}
+
+uint64_t HotReloadManager::registerCallback(
+    PluginEvent Event, PluginEventCallback Callback) noexcept {
+  std::lock_guard<std::mutex> Lock(PImpl->CallbackMutex);
+  uint64_t Id = PImpl->NextCallbackId++;
+  PImpl->Callbacks[Id] = {Event, std::move(Callback)};
+  return Id;
+}
+
+bool HotReloadManager::unregisterCallback(uint64_t CallbackId) noexcept {
+  std::lock_guard<std::mutex> Lock(PImpl->CallbackMutex);
+  return PImpl->Callbacks.erase(CallbackId) > 0;
+}
+
+void HotReloadManager::clearCallbacks(PluginEvent Event) noexcept {
+  std::lock_guard<std::mutex> Lock(PImpl->CallbackMutex);
+  for (auto It = PImpl->Callbacks.begin(); It != PImpl->Callbacks.end();) {
+    if (It->second.first == Event) {
+      It = PImpl->Callbacks.erase(It);
+    } else {
+      ++It;
+    }
+  }
+}
+
+void HotReloadManager::clearAllCallbacks() noexcept {
+  std::lock_guard<std::mutex> Lock(PImpl->CallbackMutex);
+  PImpl->Callbacks.clear();
+}
+
+bool HotReloadManager::hasPluginChanged(std::string_view Name) const noexcept {
+  std::lock_guard<std::mutex> Lock(PImpl->Mutex);
+  auto It = PImpl->PluginInfoMap.find(std::string(Name));
+  if (It != PImpl->PluginInfoMap.end()) {
+    auto ModTimeOpt = PImpl->getFileModTime(It->second.Path);
+    if (ModTimeOpt) {
+      return *ModTimeOpt != It->second.LastModified;
+    }
+  }
+  return false;
+}
+
+HotReloadManager::Statistics HotReloadManager::getStatistics() const noexcept {
+  Statistics Stats;
+  Stats.TotalLoads = PImpl->TotalLoads.load();
+  Stats.TotalUnloads = PImpl->TotalUnloads.load();
+  Stats.TotalReloads = PImpl->TotalReloads.load();
+  Stats.FailedLoads = PImpl->FailedLoads.load();
+  Stats.FailedUnloads = PImpl->FailedUnloads.load();
+  Stats.FailedReloads = PImpl->FailedReloads.load();
+  Stats.FileChangeEvents = PImpl->FileChangeEvents.load();
+  return Stats;
+}
+
+void HotReloadManager::resetStatistics() noexcept {
+  PImpl->TotalLoads.store(0);
+  PImpl->TotalUnloads.store(0);
+  PImpl->TotalReloads.store(0);
+  PImpl->FailedLoads.store(0);
+  PImpl->FailedUnloads.store(0);
+  PImpl->FailedReloads.store(0);
+  PImpl->FileChangeEvents.store(0);
+}
+
+} // namespace Plugin
+} // namespace WasmEdge

--- a/test/plugins/unittest/CMakeLists.txt
+++ b/test/plugins/unittest/CMakeLists.txt
@@ -72,6 +72,22 @@ target_link_libraries(wasmedgePluginUnittestsCPP
   ${GTEST_BOTH_LIBRARIES}
 )
 
+wasmedge_add_executable(wasmedgePluginUnittestsHotReload
+  unittest_hot_reload.cpp
+)
+
+target_include_directories(wasmedgePluginUnittestsHotReload
+  PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  $<TARGET_PROPERTY:wasmedgePlugin,INCLUDE_DIRECTORIES>
+)
+
+target_link_libraries(wasmedgePluginUnittestsHotReload
+  PRIVATE
+  ${GTEST_BOTH_LIBRARIES}
+  wasmedgePlugin
+)
+
 # Link to the WasmEdge library
 if(WASMEDGE_LINK_PLUGINS_STATIC)
   target_link_libraries(wasmedgePluginTestModuleC
@@ -111,3 +127,4 @@ endif()
 
 add_test(wasmedgePluginUnittestsC wasmedgePluginUnittestsC)
 add_test(wasmedgePluginUnittestsCPP wasmedgePluginUnittestsCPP)
+add_test(wasmedgePluginUnittestsHotReload wasmedgePluginUnittestsHotReload)

--- a/test/plugins/unittest/unittest_hot_reload.cpp
+++ b/test/plugins/unittest/unittest_hot_reload.cpp
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+//===-- unittest_hot_reload.cpp - Hot-Reload Unit Tests -------------------===//
+//
+// Part of the WasmEdge Project.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains unit tests for the plugin hot-reloading feature.
+///
+//===----------------------------------------------------------------------===//
+
+#include "plugin/hot_reload.h"
+#include "plugin/plugin.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using namespace WasmEdge::Plugin;
+
+class HotReloadTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    auto &Manager = HotReloadManager::getInstance();
+    Manager.stopWatching();
+    Manager.clearAllCallbacks();
+    Manager.resetStatistics();
+  }
+
+  void TearDown() override {
+    auto &Manager = HotReloadManager::getInstance();
+    Manager.stopWatching();
+    Manager.clearAllCallbacks();
+  }
+};
+
+TEST_F(HotReloadTest, GetInstance) {
+  auto &Instance1 = HotReloadManager::getInstance();
+  auto &Instance2 = HotReloadManager::getInstance();
+  EXPECT_EQ(&Instance1, &Instance2);
+}
+
+TEST_F(HotReloadTest, Configuration) {
+  auto &Manager = HotReloadManager::getInstance();
+
+  HotReloadConfig Config;
+  Config.EnableFileWatching = true;
+  Config.WatchInterval = std::chrono::milliseconds(500);
+  Config.DebounceDelay = std::chrono::milliseconds(250);
+  Config.MaxRetryCount = 5;
+  Config.RetryDelay = std::chrono::milliseconds(2000);
+  Config.AutoReloadOnChange = false;
+
+  Manager.configure(Config);
+
+  const auto &CurrentConfig = Manager.getConfig();
+  EXPECT_EQ(CurrentConfig.EnableFileWatching, true);
+  EXPECT_EQ(CurrentConfig.WatchInterval, std::chrono::milliseconds(500));
+  EXPECT_EQ(CurrentConfig.DebounceDelay, std::chrono::milliseconds(250));
+  EXPECT_EQ(CurrentConfig.MaxRetryCount, 5u);
+  EXPECT_EQ(CurrentConfig.RetryDelay, std::chrono::milliseconds(2000));
+  EXPECT_EQ(CurrentConfig.AutoReloadOnChange, false);
+}
+
+TEST_F(HotReloadTest, FileWatchingStartStop) {
+  auto &Manager = HotReloadManager::getInstance();
+
+  EXPECT_FALSE(Manager.isWatching());
+
+  EXPECT_TRUE(Manager.startWatching(std::filesystem::current_path()));
+  EXPECT_TRUE(Manager.isWatching());
+
+  auto Paths = Manager.getWatchedPaths();
+  EXPECT_EQ(Paths.size(), 1u);
+
+  Manager.stopWatching();
+  EXPECT_FALSE(Manager.isWatching());
+}
+
+TEST_F(HotReloadTest, CallbackRegistration) {
+  auto &Manager = HotReloadManager::getInstance();
+
+  int CallbackCount = 0;
+
+  uint64_t Id = Manager.registerCallback(
+      PluginEvent::AfterLoad,
+      [&CallbackCount](const std::string &, const std::filesystem::path &) {
+        ++CallbackCount;
+      });
+
+  EXPECT_GT(Id, 0u);
+
+  EXPECT_TRUE(Manager.unregisterCallback(Id));
+
+  EXPECT_FALSE(Manager.unregisterCallback(Id));
+}
+
+TEST_F(HotReloadTest, MultipleCallbacks) {
+  auto &Manager = HotReloadManager::getInstance();
+
+  int Count1 = 0, Count2 = 0, Count3 = 0;
+
+  auto Id1 = Manager.registerCallback(
+      PluginEvent::BeforeLoad,
+      [&Count1](const std::string &, const std::filesystem::path &) {
+        ++Count1;
+      });
+
+  auto Id2 = Manager.registerCallback(
+      PluginEvent::BeforeLoad,
+      [&Count2](const std::string &, const std::filesystem::path &) {
+        ++Count2;
+      });
+
+  auto Id3 = Manager.registerCallback(
+      PluginEvent::AfterLoad,
+      [&Count3](const std::string &, const std::filesystem::path &) {
+        ++Count3;
+      });
+
+  EXPECT_NE(Id1, Id2);
+  EXPECT_NE(Id2, Id3);
+
+  Manager.clearCallbacks(PluginEvent::BeforeLoad);
+
+  EXPECT_FALSE(Manager.unregisterCallback(Id1));
+  EXPECT_FALSE(Manager.unregisterCallback(Id2));
+
+  EXPECT_TRUE(Manager.unregisterCallback(Id3));
+}
+
+TEST_F(HotReloadTest, StatisticsInitialState) {
+  auto &Manager = HotReloadManager::getInstance();
+
+  auto Stats = Manager.getStatistics();
+
+  EXPECT_EQ(Stats.TotalLoads, 0u);
+  EXPECT_EQ(Stats.TotalUnloads, 0u);
+  EXPECT_EQ(Stats.TotalReloads, 0u);
+  EXPECT_EQ(Stats.FailedLoads, 0u);
+  EXPECT_EQ(Stats.FailedUnloads, 0u);
+  EXPECT_EQ(Stats.FailedReloads, 0u);
+  EXPECT_EQ(Stats.FileChangeEvents, 0u);
+}
+
+TEST_F(HotReloadTest, PluginStateUnknown) {
+  auto &Manager = HotReloadManager::getInstance();
+
+  EXPECT_EQ(Manager.getPluginState("non_existent_plugin"),
+            PluginState::Unknown);
+}
+
+TEST_F(HotReloadTest, PluginInfoNotFound) {
+  auto &Manager = HotReloadManager::getInstance();
+
+  auto Info = Manager.getPluginInfo("non_existent_plugin");
+  EXPECT_FALSE(Info.has_value());
+}
+
+TEST_F(HotReloadTest, ManagedPluginNames) {
+  auto &Manager = HotReloadManager::getInstance();
+
+  auto Names = Manager.getManagedPluginNames();
+  EXPECT_GE(Names.size(), 0u);
+}
+
+TEST_F(HotReloadTest, HasPluginChangedNonExistent) {
+  auto &Manager = HotReloadManager::getInstance();
+
+  EXPECT_FALSE(Manager.hasPluginChanged("non_existent_plugin"));
+}
+
+TEST_F(HotReloadTest, UnloadNonExistent) {
+  auto &Manager = HotReloadManager::getInstance();
+
+  EXPECT_FALSE(Manager.unloadPlugin("non_existent_plugin"));
+}
+
+TEST_F(HotReloadTest, ReloadNonExistent) {
+  auto &Manager = HotReloadManager::getInstance();
+
+  EXPECT_FALSE(Manager.reloadPlugin("non_existent_plugin"));
+}
+
+TEST_F(HotReloadTest, PluginIsLoaded) {
+  EXPECT_FALSE(Plugin::isLoaded("non_existent_plugin"));
+}
+
+TEST_F(HotReloadTest, PluginCount) {
+  size_t Count = Plugin::count();
+  EXPECT_GE(Count, 0u);
+}
+
+TEST_F(HotReloadTest, PluginUnloadBuiltIn) {
+  EXPECT_FALSE(Plugin::unload("wasi:logging/logging"));
+}
+
+TEST_F(HotReloadTest, PluginFindByPathNonExistent) {
+  auto *P = Plugin::findByPath("/non/existent/path.so");
+  EXPECT_EQ(P, nullptr);
+}
+
+TEST_F(HotReloadTest, PluginReloadByPathNonExistent) {
+  EXPECT_FALSE(Plugin::reloadByPath("/non/existent/path.so"));
+}
+
+TEST_F(HotReloadTest, PluginUnloadByPathNonExistent) {
+  EXPECT_FALSE(Plugin::unloadByPath("/non/existent/path.so"));
+}
+
+TEST_F(HotReloadTest, MultipleWatchPaths) {
+  auto &Manager = HotReloadManager::getInstance();
+
+  std::vector<std::filesystem::path> Paths = {
+      std::filesystem::current_path(),
+      std::filesystem::temp_directory_path()
+  };
+
+  EXPECT_TRUE(Manager.startWatching(Paths));
+  EXPECT_TRUE(Manager.isWatching());
+
+  auto WatchedPaths = Manager.getWatchedPaths();
+  EXPECT_EQ(WatchedPaths.size(), 2u);
+
+  Manager.stopWatching();
+}
+
+TEST_F(HotReloadTest, ClearAllCallbacks) {
+  auto &Manager = HotReloadManager::getInstance();
+
+  Manager.registerCallback(
+      PluginEvent::BeforeLoad,
+      [](const std::string &, const std::filesystem::path &) {});
+  Manager.registerCallback(
+      PluginEvent::AfterLoad,
+      [](const std::string &, const std::filesystem::path &) {});
+  Manager.registerCallback(
+      PluginEvent::BeforeReload,
+      [](const std::string &, const std::filesystem::path &) {});
+
+  Manager.clearAllCallbacks();
+}
+
+} // namespace


### PR DESCRIPTION
This PR adds support for hot-reloading (live reloading) of plugins in WasmEdge. This feature allows users to dynamically load, unload, or update plugins at runtime without restarting the WasmEdge host process.

As discussed in #4581, while WASI-NN plugins can dynamically change models, updating the plugin's inference logic, preprocessing code, or swapping backends still requires restarting the host process. This PR addresses that limitation by enabling full plugin hot-reloading.