### PR TITLE
ci: cache homebrew deps

### DIFF
--- a/.github/workflows/reusable-build-on-macos.yml
+++ b/.github/workflows/reusable-build-on-macos.yml
@@ -43,17 +43,75 @@ jobs:
       - name: Setup build environment - non-release
         if: ${{ !inputs.release }}
         run: |
+          echo "BREW_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
           brew uninstall cmake # conflict with the one used by WasmEdge/llvm/lld
           brew tap WasmEdge/llvm
+      - name: Install Homebrew tools - non-release
+        if: ${{ !inputs.release }}
+        run: |
           brew install llvm ninja wabt grpc
-          brew install --build-from-source WasmEdge/llvm/lld
+      - name: Get lld version
+        if: ${{ !inputs.release }}
+        id: lld-version-non-release
+        run: |
+          VERSION=$(brew info --json WasmEdge/llvm/lld | jq -r '.[0].versions.stable')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+      - name: Cache lld and cmake - non-release
+        if: ${{ !inputs.release }}
+        id: cache-lld-non-release
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            ${{ env.BREW_PREFIX }}/Cellar/lld
+            ${{ env.BREW_PREFIX }}/Cellar/cmake
+          key: homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-${{ steps.lld-version-non-release.outputs.version }}-${{ hashFiles('.github/workflows/reusable-build-on-macos.yml') }}
+          restore-keys: |
+            homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-${{ steps.lld-version-non-release.outputs.version }}-
+            homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-
+      - name: Install or link lld and cmake - non-release
+        if: ${{ !inputs.release }}
+        run: |
+          if [ "${{ steps.cache-lld-non-release.outputs.cache-hit }}" != "true" ]; then
+            brew install --build-from-source WasmEdge/llvm/lld
+          fi
+          brew link lld || true
+          brew link cmake || true
       - name: Setup build environment - release
         if: ${{ inputs.release }}
         run: |
+          echo "BREW_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
           brew uninstall cmake # conflict with the one used by WasmEdge/llvm/lld
           brew tap WasmEdge/llvm
+      - name: Install Homebrew tools - release
+        if: ${{ inputs.release }}
+        run: |
           brew install llvm ninja wabt
-          brew install --build-from-source WasmEdge/llvm/lld
+      - name: Get lld version
+        if: ${{ inputs.release }}
+        id: lld-version-release
+        run: |
+          VERSION=$(brew info --json WasmEdge/llvm/lld | jq -r '.[0].versions.stable')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+      - name: Cache lld and cmake - release
+        if: ${{ inputs.release }}
+        id: cache-lld-release
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            ${{ env.BREW_PREFIX }}/Cellar/lld
+            ${{ env.BREW_PREFIX }}/Cellar/cmake
+          key: homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-${{ steps.lld-version-release.outputs.version }}-${{ hashFiles('.github/workflows/reusable-build-on-macos.yml') }}
+          restore-keys: |
+            homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-${{ steps.lld-version-release.outputs.version }}-
+            homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-
+      - name: Install or link lld and cmake - release
+        if: ${{ inputs.release }}
+        run: |
+          if [ "${{ steps.cache-lld-release.outputs.cache-hit }}" != "true" ]; then
+            brew install --build-from-source WasmEdge/llvm/lld
+          fi
+          brew link lld || true
+          brew link cmake || true
       - name: Set environment variables for release
         if: ${{ inputs.release }}
         run: |


### PR DESCRIPTION
**Before (recent CI run)**
[https://github.com/WasmEdge/WasmEdge/actions/runs/21559718073/job/62130271902?pr=4594](https://github.com/WasmEdge/WasmEdge/actions/runs/21559718073/job/62130271902?pr=4594)

**After (CI run for this PR on fork)**
[https://github.com/PhantomInTheWire/WasmEdge/actions/runs/21569964185/job/62147471372?pr=4](https://github.com/PhantomInTheWire/WasmEdge/actions/runs/21569964185/job/62147471372?pr=4)

On Intel macOS 15 runners, the core workflow consistently took the longest, around 30 minutes, making it the primary bottleneck. The main reason was that several Homebrew dependencies were being installed and `lld` was built from source on every run.

By caching `lld` and other heavy dependencies like LLVM, Ninja, WABT, and gRPC, the Intel macOS 15 job time was reduced by approximately 5 to 7 minutes. Since this job is the bottleneck, the overall core workflow time is also reduced by roughly the same amount.

At this point, the second slowest job is the Windows MSVC build, which completes in about 17 to 18 minutes. This implies that further optimizations in non macOS workflows will not meaningfully reduce the total core CI duration unless the Intel macOS 15 runtime can be brought down by an additional 5 to 7 minutes.(which I think is non trivial since most of the remaining time is build and test, so unless we can change the process itself it would be difficult, although I think if we build wasmedge in release mode the tests should complete much faster but I am not sure if we want that since the workflow has a special non release section for normal ci runs, would love some thoughts on this part)

cc: @0yi0 