### PR TITLE
docs: clarify Rust SDK migration and versioning status

### DIFF
--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -1,11 +1,16 @@
 # WasmEdge Rust Bindings
 
-** Rust Binding and related projects are moved to [wasmedge-rust-sdk](https://github.com/WasmEdge/wasmedge-rust-sdk) **
-** Please refer to the new repository for the further updates **
+> **Note**
+> Rust bindings and related projects have moved to
+> [wasmedge-rust-sdk](https://github.com/WasmEdge/wasmedge-rust-sdk).
+> Please refer to the new repository for further updates.
 
 WasmEdge Rust bindings consist of the following crates. They together provide different levels of APIs for Rust developers to use WasmEdge runtime. For example, `wasmedge-sdk` defines the high-level APIs for application development.
 
 ## Versioning Table
+
+> [!IMPORTANT]
+> The WasmEdge Rust SDK has moved to a separate repository: [wasmedge-rust-sdk](https://github.com/WasmEdge/wasmedge-rust-sdk). The table below is preserved for historical reference and may be outdated. Please refer to the new repository for up-to-date versioning and documentation.
 
 The following table provides the versioning information about each crate of WasmEdge Rust bindings.
 


### PR DESCRIPTION
### What this PR does
Clarifies that the WasmEdge Rust SDK has moved to a separate repository and that the versioning table in this document is preserved for historical reference.

### Why this change is needed
The current README can be confusing for new contributors, as the Rust SDK source and up-to-date versioning are no longer maintained in this repository.

### Scope of change
- Documentation only
- No code or logic changes