### PR TITLE
fix(loader): validate reserved bits in memory instruction flags

### DIFF
--- a/lib/loader/ast/instruction.cpp
+++ b/lib/loader/ast/instruction.cpp
@@ -253,10 +253,15 @@ Expect<void> Loader::loadInstruction(AST::Instruction &Instr) {
 
   auto readMemImmediate = [this, readU32, readU64, &Instr]() -> Expect<void> {
     Instr.getTargetIndex() = 0;
-    EXPECTED_TRY(readU32(Instr.getMemoryAlign()));
-    if (Conf.hasProposal(Proposal::MultiMemories) &&
-        Instr.getMemoryAlign() >= 64) {
-      Instr.getMemoryAlign() -= 64;
+    uint32_t Flags = 0;
+    EXPECTED_TRY(readU32(Flags));
+    Instr.getMemoryAlign() = Flags & 0x3FU;
+    if (unlikely(Flags & ~0x7FU)) {
+      return logLoadError(ErrCode::Value::MalformedMemoryOpFlags,
+                          FMgr.getLastOffset(), ASTNodeAttr::Instruction);
+    }
+    // Bit 6 indicates if memory index follows
+    if (Conf.hasProposal(Proposal::MultiMemories) && (Flags & 0x40U)) {
       EXPECTED_TRY(readU32(Instr.getTargetIndex()));
     }
     uint32_t MaxAlign = Conf.hasProposal(Proposal::Memory64) ? 64U : 32U;


### PR DESCRIPTION


## Changes
The WebAssembly spec requires only bits 0-6 to be used in memory instruction flags (bits 0-5 for alignment, bit 6 for memory index). This fix rejects malformed bytecode during the loading phase with MalformedMemoryOpFlags error, preventing runtime crashes.

## Testing
Tested with malformed wasm file that sets bit 7+, correctly rejected during loading with error code 0x11c.

