### PR TITLE
perf: optimise call_indirect insn

### DIFF
--- a/lib/executor/engine/proxy.cpp
+++ b/lib/executor/engine/proxy.cpp
@@ -164,7 +164,7 @@ Expect<void> Executor::proxyCallIndirect(Runtime::StackManager &StackMgr,
 
   const auto *ModInst = StackMgr.getModule();
   assuming(ModInst);
-  const auto &ExpDefType = **ModInst->getType(FuncTypeIdx);
+  const auto &ExpDefType = *ModInst->unsafeGetType(FuncTypeIdx);
   const auto *FuncInst = retrieveFuncRef(*Ref);
   assuming(FuncInst);
   bool IsMatch = false;
@@ -600,7 +600,7 @@ Expect<void *> Executor::proxyTableGetFuncSymbol(
 
   const auto *ModInst = StackMgr.getModule();
   assuming(ModInst);
-  const auto &ExpDefType = **ModInst->getType(FuncTypeIdx);
+  const auto &ExpDefType = *ModInst->unsafeGetType(FuncTypeIdx);
   const auto *FuncInst = retrieveFuncRef(*Ref);
   assuming(FuncInst);
   bool IsMatch = false;

--- a/test/thread/CMakeLists.txt
+++ b/test/thread/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 wasmedge_add_executable(wasmedgeThreadTests
   ThreadTest.cpp
+  TypeRaceTest.cpp
 )
 
 add_test(wasmedgeThreadTests wasmedgeThreadTests)

--- a/test/thread/TypeRaceTest.cpp
+++ b/test/thread/TypeRaceTest.cpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+#include "common/spdlog.h"
+#include "runtime/hostfunc.h"
+#include "runtime/instance/module.h"
+#include "gtest/gtest.h"
+
+#include <atomic>
+#include <cstdlib>
+#include <thread>
+#include <vector>
+
+namespace {
+
+class HostFunc : public WasmEdge::Runtime::HostFunctionBase {
+public:
+  HostFunc() : WasmEdge::Runtime::HostFunctionBase(0) {}
+  WasmEdge::Expect<void> run(const WasmEdge::Runtime::CallingFrame &,
+                             WasmEdge::Span<const WasmEdge::ValVariant>,
+                             WasmEdge::Span<WasmEdge::ValVariant>) override {
+    return {};
+  }
+};
+
+class TestModuleInstance : public WasmEdge::Runtime::Instance::ModuleInstance {
+public:
+  TestModuleInstance(std::string_view Name)
+      : WasmEdge::Runtime::Instance::ModuleInstance(Name) {}
+
+  const WasmEdge::AST::SubType *
+  publicUnsafeGetType(uint32_t Idx) const noexcept {
+    return unsafeGetType(Idx);
+  }
+
+  WasmEdge::Span<const WasmEdge::AST::SubType *const>
+  publicGetTypeList() const noexcept {
+    return getTypeList();
+  }
+};
+
+TEST(TypeRaceTest, ConcurrentReadWrite) {
+  WasmEdge::Log::setErrorLoggingLevel();
+  auto ModStub = std::make_unique<TestModuleInstance>("test_mod");
+
+  std::atomic<bool> Running = true;
+  std::vector<std::thread> Readers;
+  std::vector<std::thread> Writers;
+
+  // reader threads: Constantly read types
+  for (int I = 0; I < 4; ++I) {
+    Readers.emplace_back([&]() {
+      while (Running) {
+        uint32_t Size = ModStub->publicGetTypeList().size();
+        if (Size > 0) {
+          const auto *Type = ModStub->publicUnsafeGetType(rand() % Size);
+          assuming(Type != nullptr);
+        }
+      }
+    });
+  }
+
+  // writer Thread: Constantly add new types (via addHostFunc)
+  Writers.emplace_back([&]() {
+    int Count = 0;
+    while (Running) {
+      auto Func = std::make_unique<HostFunc>();
+      ModStub->addHostFunc("func" + std::to_string(Count++), std::move(Func));
+
+      // limiting growth to avoid OOM in test
+      if (Count > 10000) {
+        Running = false;
+      }
+
+      if (Count % 100 == 0) {
+        std::this_thread::yield();
+      }
+    }
+  });
+
+  for (auto &T : Writers)
+    T.join();
+  Running = false;
+  for (auto &T : Readers)
+    T.join();
+
+  // If we reached here without crashing, the RCU pattern works for avoiding
+  // use after free crash.
+  ASSERT_GT(ModStub->getFuncExportNum(), 1000);
+}
+
+} // namespace


### PR DESCRIPTION
Fixes #4369.

Results on running 
` $ sudo perf stat -r 10 -e 'task-clock' /path/to/wasmedge --enable-jit ~/wasmedge/test_case.wasm` 

on Ubuntu 24.04, Intel(R) Core(TM) i9-14900HX, x86_64, 32 logical CPU(s).

Old code - 
```
 Performance counter stats for '/home/surya/wasmedge/build/tools/wasmedge/wasmedge --enable-jit /home/surya/wasmedge/test_case.wasm' (10 runs):

         90,054.12 msec task-clock                       #    1.000 CPUs utilized               ( +-  0.01% )

          90.07134 +- 0.00860 seconds time elapsed  ( +-  0.01% )
```

New code -
```
 Performance counter stats for '/home/surya/wasmedge/build/tools/wasmedge/wasmedge --enable-jit /home/surya/wasmedge/test_case.wasm' (10 runs):

         29,796.19 msec task-clock                       #    1.000 CPUs utilized               ( +-  0.04% )

           29.8036 +- 0.0121 seconds time elapsed  ( +-  0.04% )
```


The optimisation was based on the following flamegraph for the old code:
![trace_old](https://github.com/user-attachments/assets/75aae68b-663c-43db-ada1-b114fafee2fb)
Most of the time was being spent while locking and unlocking the shared lock. The new flamegraph after updating the code to use the unsafe methods is:
![trace_new](https://github.com/user-attachments/assets/9c4edaa1-54ed-4431-8b75-c68b84b20704)

In my analysis, I found that removing locks is safe and does not cause any race condition because during runtime the shared variable being protected is immutable and is mutable only during the module instantiation phase but not during the execution phase. The lock seemed to protect against the rare case where a host application might try to dynamically add new functions/types to a module while it is running. And my optimisation was based on considering this as a rare case for webassembly. But I'd love to hear your opinion on this. 

_As a side note, if my above reasoning is correct we can make sure that all the intrinsics use the unsafe methods to improve performance._

Also there are other optimisation which can be performed from the second flamegraph, one of which is implemented in https://github.com/WasmEdge/WasmEdge/pull/4613, however these do not improve performance greatly since 66% of performance is being lost at the locks.
