### PR TITLE
fix(docker): manually link espeak-ng and ucd static libs for Piper backend

### DIFF
--- a/utils/wasi-nn/install-libpiper.sh
+++ b/utils/wasi-nn/install-libpiper.sh
@@ -43,6 +43,26 @@ cmake -Bbuild \
 cmake --build build --parallel $(nproc)
 cmake --install build
 
+echo "Copying espeak-ng static libraries to ${PIPER_INSTALL_TO}/lib..."
+
+if [ -f "build/espeak_ng-install/lib/libespeak-ng.a" ]; then
+    cp "build/espeak_ng-install/lib/libespeak-ng.a" "${PIPER_INSTALL_TO}/lib/"
+else
+    find build -name "libespeak-ng.a" -exec cp {} "${PIPER_INSTALL_TO}/lib/" \; -quit
+fi
+
+find build -name "libucd.a" -exec cp {} "${PIPER_INSTALL_TO}/lib/" \; -quit
+
+if [ ! -f "${PIPER_INSTALL_TO}/lib/libespeak-ng.a" ]; then
+    echo "Error: Failed to install libespeak-ng.a"
+    exit 1
+fi
+
+if [ ! -f "${PIPER_INSTALL_TO}/lib/libucd.a" ]; then
+    echo "Error: Failed to install libucd.a"
+    exit 1
+fi
+
 cd ../..
 rm -rf piper-source
 


### PR DESCRIPTION
### PR Description

**Summary**
Fixes static Piper build failures by manually installing missing `espeak-ng` and `ucd` static libraries.

**Problem**
The static Piper build compiles `espeak-ng` and `ucd` as internal dependencies but does not install them. This causes CI/Docker build failures (e.g., `cannot find -lespeak-ng`) because the WasmEdge CMake config expects these libraries in `PIPER_ROOT`.

**Changes**

* Updated `utils/wasi-nn/install-libpiper.sh` to copy `libespeak-ng.a` and `libucd.a` into `${PIPER_INSTALL_TO}/lib/`.
* Added verification checks to confirm file existence.

**Verification**

* Validated locally: libraries are correctly placed in `/usr/local/lib`.
* Verified CMake successfully locates both libraries.
* CI Checks: [https://github.com/Divyansh200102/WasmEdge/pull/23/checks](https://github.com/Divyansh200102/WasmEdge/pull/23/checks)

**Note**
This is a prerequisite for https://github.com/WasmEdge/WasmEdge/pull/4443, which enables full support for both static CI builds and local source builds.
