### PR TITLE
feat: support parameterized error messages

### DIFF
--- a/lib/validator/validator.cpp
+++ b/lib/validator/validator.cpp
@@ -479,7 +479,8 @@ Expect<void> Validator::validate(const AST::ImportDesc &ImpDesc) {
     if (!Checker.getTypes()[TId]->getCompositeType().isFunc()) {
       spdlog::error(ErrCode::Value::InvalidFuncTypeIdx);
       spdlog::error("    Defined type index {} is not a function type."sv, TId);
-      return Unexpect(ErrCode::Value::InvalidFuncTypeIdx);
+      return UnexpectMsg(ErrCode::Value::InvalidFuncTypeIdx,
+                         "type index {} is not a function type", TId);
     }
     Checker.addRef(static_cast<uint32_t>(Checker.getFunctions().size()));
     Checker.addFunc(TId, true);
@@ -522,7 +523,8 @@ Expect<void> Validator::validate(const AST::ImportDesc &ImpDesc) {
       spdlog::error(ErrCode::Value::InvalidTagIdx);
       spdlog::error("    Defined type index {} is not a function type."sv,
                     TagTypeIdx);
-      return Unexpect(ErrCode::Value::InvalidTagIdx);
+      return UnexpectMsg(ErrCode::Value::InvalidTagIdx,
+                         "type index {} is not a function type", TagTypeIdx);
     }
     if (!CompType.getFuncType().getReturnTypes().empty()) {
       spdlog::error(ErrCode::Value::InvalidTagResultType);
@@ -666,7 +668,8 @@ Expect<void> Validator::validate(const AST::FunctionSection &FuncSec) {
       spdlog::error(ErrCode::Value::InvalidFuncTypeIdx);
       spdlog::error("    Defined type index {} is not a function type."sv, TId);
       spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Type_Function));
-      return Unexpect(ErrCode::Value::InvalidFuncTypeIdx);
+      return UnexpectMsg(ErrCode::Value::InvalidFuncTypeIdx,
+                         "type index {} is not a function type", TId);
     }
     Checker.addFunc(TId);
   }
@@ -773,7 +776,8 @@ Expect<void> Validator::validate(const AST::StartSection &StartSec) {
     if (!Checker.getTypes()[TId]->getCompositeType().isFunc()) {
       spdlog::error(ErrCode::Value::InvalidStartFunc);
       spdlog::error("    Defined type index {} is not a function type."sv, TId);
-      return Unexpect(ErrCode::Value::InvalidStartFunc);
+      return UnexpectMsg(ErrCode::Value::InvalidStartFunc,
+                         "type index {} is not a function type", TId);
     }
     auto &Type = Checker.getTypes()[TId]->getCompositeType().getFuncType();
     if (Type.getParamTypes().size() != 0 || Type.getReturnTypes().size() != 0) {
@@ -826,7 +830,8 @@ Expect<void> Validator::validate(const AST::TagSection &TagSec) {
       spdlog::error(ErrCode::Value::InvalidTagIdx);
       spdlog::error("    Defined type index {} is not a function type."sv,
                     TagTypeIdx);
-      return Unexpect(ErrCode::Value::InvalidTagIdx);
+      return UnexpectMsg(ErrCode::Value::InvalidTagIdx,
+                         "type index {} is not a function type", TagTypeIdx);
     }
     if (!CompType.getFuncType().getReturnTypes().empty()) {
       spdlog::error(ErrCode::Value::InvalidTagResultType);

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -734,8 +734,7 @@ void SpecTest::run(std::string_view Proposal, std::string_view UnitName) {
     } else {
       EXPECT_TRUE(Res.error().getErrCodePhase() ==
                   WasmEdge::WasmPhase::Loading);
-      EXPECT_TRUE(
-          stringContains(Text, WasmEdge::ErrCodeStr[Res.error().getEnum()]));
+      EXPECT_TRUE(stringContains(Text, Res.error().getErrString()));
     }
   };
 
@@ -747,8 +746,7 @@ void SpecTest::run(std::string_view Proposal, std::string_view UnitName) {
     } else {
       EXPECT_TRUE(Res.error().getErrCodePhase() ==
                   WasmEdge::WasmPhase::Validation);
-      EXPECT_TRUE(
-          stringContains(Text, WasmEdge::ErrCodeStr[Res.error().getEnum()]));
+      EXPECT_TRUE(stringContains(Text, Res.error().getErrString()));
     }
   };
 
@@ -761,8 +759,7 @@ void SpecTest::run(std::string_view Proposal, std::string_view UnitName) {
       EXPECT_TRUE(
           Res.error().getErrCodePhase() == WasmEdge::WasmPhase::Instantiation ||
           Res.error().getErrCodePhase() == WasmEdge::WasmPhase::Execution);
-      EXPECT_TRUE(
-          stringContains(Text, WasmEdge::ErrCodeStr[Res.error().getEnum()]));
+      EXPECT_TRUE(stringContains(Text, Res.error().getErrString()));
     }
   };
 
@@ -780,8 +777,7 @@ void SpecTest::run(std::string_view Proposal, std::string_view UnitName) {
     } else {
       EXPECT_TRUE(Res.error().getErrCodePhase() ==
                   WasmEdge::WasmPhase::Execution);
-      EXPECT_TRUE(
-          stringContains(Text, WasmEdge::ErrCodeStr[Res.error().getEnum()]));
+      EXPECT_TRUE(stringContains(Text, Res.error().getErrString()));
     }
   };
 


### PR DESCRIPTION
 Implements support for dynamic error strings in ErrCode (e.g., "type index 5 is not...") to fix spec test failures, while maintaining backward compatibility with existing static constexpr strings.

## Key Changes

  -  Extended ErrCode: Added optional std::string member and getErrString() accessor to return dynamic messages when present.

   - New Helper: Added UnexpectMsg for one-line construction of formatted errors.

   - Test Infrastructure: Updated spectest.cpp trap helpers to verify dynamic error strings.

   - Validator: Migrated 5 priority call sites (Import, Function, Start, Tag sections) to use UnexpectMsg.
   

   * closes #4444 *