### PR TITLE
fix(wasinn):fix CI failure by updating BitNet git tag

### DIFF
--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -639,7 +639,7 @@ function(wasmedge_setup_bitnet_target target)
     FetchContent_Declare(
       bitnet
       GIT_REPOSITORY https://github.com/microsoft/BitNet.git
-      GIT_TAG        404980e
+      GIT_TAG        8fd3412
       GIT_SHALLOW    TRUE
       ${BITNET_PATCH_ARGS}
     )


### PR DESCRIPTION
**Fixes:** #4635

**Changes**

* **`cmake/WASINNDeps.cmake`**: Updated `GIT_TAG` to `8fd3412` (latest valid commit on `main`).

Reference: https://github.com/microsoft/BitNet/commits/main/

CI checks: https://github.com/Divyansh200102/WasmEdge/pull/26/checks