### PR TITLE
ci: fix BitNet FetchContent checkout failure

### DIFF
--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -639,7 +639,7 @@ function(wasmedge_setup_bitnet_target target)
     FetchContent_Declare(
       bitnet
       GIT_REPOSITORY https://github.com/microsoft/BitNet.git
-      GIT_TAG        404980e
+      GIT_TAG        8fd3412fbc9319f0764f82da6e9406c0323140f3
       GIT_SHALLOW    TRUE
       ${BITNET_PATCH_ARGS}
     )


### PR DESCRIPTION
### Fixes: #4635 

### Summary

This PR Fixes CI failure in the WASI-NN BitNet backend by updating the pinned BitNet.cpp commit. The previously used commit (`404980e`) no longer exists upstream, causing FetchContent checkout to fail. This change updates the `GIT_TAG` to a valid commit from the BitNet `main` branch, unblocking CI.

### Changes
- Updated BitNet.cpp `GIT_TAG` in `cmake/WASINNDeps.cmake` to a valid upstream commit

Reference: https://github.com/microsoft/BitNet/commits/main/