### PR TITLE
fix(executor): add explicit assuming for getType in toBottomType

### DIFF
--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -421,9 +421,9 @@ TypeCode Executor::toBottomType(Runtime::StackManager &StackMgr,
         assumingUnreachable();
       }
     } else {
-      const auto &CompType =
-          (*StackMgr.getModule()->getType(Type.getTypeIndex()))
-              ->getCompositeType();
+      auto TypeResult = StackMgr.getModule()->getType(Type.getTypeIndex());
+      assuming(TypeResult);
+      const auto &CompType = (*TypeResult)->getCompositeType();
       if (CompType.isFunc()) {
         return TypeCode::NullFuncRef;
       } else {

--- a/test/executor/CMakeLists.txt
+++ b/test/executor/CMakeLists.txt
@@ -12,3 +12,15 @@ target_link_libraries(wasmedgeExecutorCoreTests
   wasmedgeTestSpec
   wasmedgeVM
 )
+
+wasmedge_add_executable(wasmedgeExecutorNullDerefTests
+  executorNullDerefTest.cpp
+)
+
+add_test(wasmedgeExecutorNullDerefTests wasmedgeExecutorNullDerefTests)
+
+target_link_libraries(wasmedgeExecutorNullDerefTests
+  PRIVATE
+  ${GTEST_BOTH_LIBRARIES}
+  wasmedgeVM
+)

--- a/test/executor/executorNullDerefTest.cpp
+++ b/test/executor/executorNullDerefTest.cpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+//===-- wasmedge/test/executor/executorNullDerefTest.cpp -------------------===//
+//
+// Part of the WasmEdge Project.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Tests for unchecked Expect<> dereference in toBottomType.
+///
+//===----------------------------------------------------------------------===//
+
+#include "common/configure.h"
+#include "common/spdlog.h"
+#include "common/types.h"
+#include "executor/executor.h"
+#include "loader/loader.h"
+#include "runtime/instance/module.h"
+#include "runtime/storemgr.h"
+#include "validator/validator.h"
+
+#include <array>
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace WasmEdge;
+
+// (module
+//   (type $s (struct (field i32)))
+//   (func (export "test") (result i32)
+//     i32.const 7  struct.new $s  struct.get $s 0))
+std::array<Byte, 48> StructNewWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x09, 0x02,
+    0x5f, 0x01, 0x7f, 0x00, 0x60, 0x00, 0x01, 0x7f, 0x03, 0x02, 0x01,
+    0x01, 0x07, 0x08, 0x01, 0x04, 0x74, 0x65, 0x73, 0x74, 0x00, 0x00,
+    0x0a, 0x0d, 0x01, 0x0b, 0x00, 0x41, 0x07, 0xfb, 0x00, 0x00, 0xfb,
+    0x02, 0x00, 0x00, 0x0b,
+};
+
+// Module with struct having ref field pointing to non-existent type 99.
+// (module
+//   (type $s (struct (field (ref null 99))))
+//   (type $fn (func (result (ref null struct))))
+//   (func (export "test") (result (ref null struct))
+//     struct.new_default $s))
+std::array<Byte, 48> StructBadRefTypeWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0b, 0x02,
+    0x5f, 0x01, 0x63, 0x63, 0x00, 0x60, 0x00, 0x01, 0x63, 0x6b, 0x03,
+    0x02, 0x01, 0x01, 0x07, 0x08, 0x01, 0x04, 0x74, 0x65, 0x73, 0x74,
+    0x00, 0x00, 0x0a, 0x07, 0x01, 0x05, 0x00, 0xfb, 0x01, 0x00, 0x0b,
+};
+
+TEST(ExecutorToBottomType, ValidStructNew) {
+  Configure Conf;
+  Loader::Loader Ldr(Conf);
+  Validator::Validator Valid(Conf);
+  Executor::Executor Exec(Conf);
+  Runtime::StoreManager Store;
+
+  auto ASTMod = Ldr.parseModule(StructNewWasm);
+  ASSERT_TRUE(ASTMod) << ASTMod.error();
+  ASSERT_TRUE(Valid.validate(**ASTMod));
+  auto ModInst = Exec.instantiateModule(Store, **ASTMod);
+  ASSERT_TRUE(ModInst) << ModInst.error();
+  auto *FuncInst = (*ModInst)->findFuncExports("test");
+  ASSERT_NE(FuncInst, nullptr);
+  auto Res = Exec.invoke(FuncInst, {}, {});
+  ASSERT_TRUE(Res) << Res.error();
+  ASSERT_EQ(Res->size(), 1U);
+  EXPECT_EQ((*Res)[0].first.get<uint32_t>(), 7U);
+}
+
+TEST(ExecutorToBottomType, LoaderRejectsBadRefType) {
+  // The loader rejects struct fields referencing non-existent types,
+  // providing defense-in-depth for the toBottomType code path.
+  Configure Conf;
+  Loader::Loader Ldr(Conf);
+
+  auto ASTMod = Ldr.parseModule(StructBadRefTypeWasm);
+  EXPECT_FALSE(ASTMod);
+}
+
+} // namespace
+
+GTEST_API_ int main(int argc, char **argv) {
+  WasmEdge::Log::setErrorLoggingLevel();
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

- `StackMgr.getModule()->getType()` in `toBottomType` (`helper.cpp:425`) returns `Expect<>` which was dereferenced without checking, causing silent undefined behavior on error
- Since `toBottomType` returns `TypeCode` (not `Expect<>`), it cannot propagate errors via `EXPECTED_TRY`
- Add an explicit `assuming()` to make the postcondition contract clear and provide a debug assertion instead of silent UB
- The loader already provides defense-in-depth by rejecting modules with invalid type references before this code path is reached

## Test plan

- [x] Added `test/executor/executorNullDerefTest.cpp` with 2 tests:
  - Valid `struct.new` with GC types works correctly
  - Loader rejects module with struct field referencing non-existent type
- [x] All tests pass locally