### PR TITLE
fix(fault): handle stack overflow via sigaltstack & harden fault logic

### DIFF
--- a/include/system/winapi.h
+++ b/include/system/winapi.h
@@ -1372,7 +1372,8 @@ static inline constexpr const DWORD_ EXCEPTION_INT_DIVIDE_BY_ZERO_ =
 static inline constexpr const DWORD_ EXCEPTION_INT_OVERFLOW_ = 0xC0000095L;
 static inline constexpr const LONG_ EXCEPTION_CONTINUE_EXECUTION_ =
     static_cast<LONG_>(0xffffffff);
-
+static inline constexpr const LONG_ EXCEPTION_CONTINUE_SEARCH_ = 0L;
+static inline constexpr const DWORD_ EXCEPTION_STACK_OVERFLOW_ = 0xC00000FDL;
 using EXCEPTION_RECORD_ = struct _EXCEPTION_RECORD {
   DWORD_ ExceptionCode;
   DWORD_ ExceptionFlags;

--- a/lib/executor/engine/proxy.cpp
+++ b/lib/executor/engine/proxy.cpp
@@ -21,6 +21,9 @@ struct Executor::ProxyHelper<Expect<RetT> (Executor::*)(Runtime::StackManager &,
   template <Expect<RetT> (Executor::*Func)(Runtime::StackManager &,
                                            ArgsT...) noexcept>
   static auto proxy(ArgsT... Args) {
+    if (unlikely(!This || !CurrentStack)) {
+      Fault::emitFault(ErrCode::Value::AOTNotImpl);
+    }
 #if defined(__s390x__)
     // Required on s390x: materializing args prevents runtime failures in
     // release builds.

--- a/lib/system/fault.cpp
+++ b/lib/system/fault.cpp
@@ -11,6 +11,7 @@
 #include <atomic>
 #include <csetjmp>
 #include <csignal>
+#include <cstdlib>
 #include <cstdint>
 #include <utility>
 
@@ -26,7 +27,26 @@ std::atomic_uint handlerCount = 0;
 thread_local Fault *localHandler = nullptr;
 
 #if defined(SA_SIGINFO)
+static constexpr std::size_t AltStackSize = 65536;
+thread_local char AltStackMem[AltStackSize];
+thread_local bool AltStackInstalled = false;
+
+void ensureAltStack() noexcept {
+  if (!AltStackInstalled) {
+    stack_t SS;
+    SS.ss_sp = AltStackMem;
+    SS.ss_size = AltStackSize;
+    SS.ss_flags = 0;
+    sigaltstack(&SS, nullptr);
+    AltStackInstalled = true;
+  }
+}
 void signalHandler(int Signal, siginfo_t *Siginfo, void *) {
+  if (localHandler == nullptr) {
+    std::signal(Signal, SIG_DFL);
+    raise(Signal);
+    std::_Exit(128 + Signal);
+  }
   {
     // Unblock current signal
     sigset_t Set;
@@ -49,7 +69,7 @@ void signalHandler(int Signal, siginfo_t *Siginfo, void *) {
 void enableHandler() noexcept {
   struct sigaction Action {};
   Action.sa_sigaction = &signalHandler;
-  Action.sa_flags = SA_SIGINFO;
+  Action.sa_flags = SA_SIGINFO | SA_ONSTACK;
   sigaction(SIGFPE, &Action, nullptr);
   sigaction(SIGBUS, &Action, nullptr);
   sigaction(SIGSEGV, &Action, nullptr);
@@ -65,6 +85,9 @@ void disableHandler() noexcept {
 
 winapi::LONG_ WASMEDGE_WINAPI_WINAPI_CC
 vectoredExceptionHandler(winapi::PEXCEPTION_POINTERS_ ExceptionInfo) {
+  if (localHandler == nullptr) {
+    return winapi::EXCEPTION_CONTINUE_SEARCH_;
+  }
   const winapi::DWORD_ Code = ExceptionInfo->ExceptionRecord->ExceptionCode;
   switch (Code) {
   case winapi::EXCEPTION_INT_DIVIDE_BY_ZERO_:
@@ -72,6 +95,7 @@ vectoredExceptionHandler(winapi::PEXCEPTION_POINTERS_ ExceptionInfo) {
   case winapi::EXCEPTION_INT_OVERFLOW_:
     Fault::emitFault(ErrCode::Value::IntegerOverflow);
   case winapi::EXCEPTION_ACCESS_VIOLATION_:
+  case winapi::EXCEPTION_STACK_OVERFLOW_:
     Fault::emitFault(ErrCode::Value::MemoryOutOfBounds);
   }
   return winapi::EXCEPTION_CONTINUE_EXECUTION_;
@@ -105,6 +129,9 @@ void decreaseHandler() noexcept {
 } // namespace
 
 Fault::Fault() {
+#if defined(SA_SIGINFO)
+  ensureAltStack();
+#endif
   Prev = std::exchange(localHandler, this);
   increaseHandler();
 }
@@ -115,7 +142,10 @@ Fault::~Fault() noexcept {
 }
 
 [[noreturn]] void Fault::emitFault(ErrCode Error) {
-  assuming(localHandler != nullptr);
+  if (localHandler == nullptr) {
+    std::signal(SIGABRT, SIG_DFL);
+    std::abort();
+  }
   auto Buffer = stackTrace(localHandler->StackTraceBuffer);
   localHandler->StackTraceSize = Buffer.size();
   longjmp(localHandler->Buffer, static_cast<int>(Error.operator uint32_t()));


### PR DESCRIPTION
### Summary
This PR fixes a SIGSEGV crash triggered when JIT-compiled code exhausts the thread stack (e.g., infinite recursion). It introduces alternate signal stack support so the handler can execute safely even when the main stack is full. It also hardens Fault::emitFault and global handlers against undefined behavior when no local handler is installed.
### Changes:
  Alternate Signal Stack (Unix):
-    Implemented a per-thread 64KB alternate stack using sigaltstack and SA_ONSTACK.
-    Ensures handlers run safely even when the main thread stack is full.

  Fault Handler Hardening:
 -    emitFault: Replaced unsafe assuming(localHandler) with a runtime check that aborts cleanly if null.
  - Unix Handler: Fallback to SIG_DFL + raise() + std::Exit() if no local handler exists.
   - Windows Handler: Returns EXCEPTION_CONTINUE_SEARCH if no handler exists; maps EXCEPTION_STACK_OVERFLOW to MemoryOutOfBounds.

 Windows Support:
   -  Added EXCEPTION_CONTINUE_SEARCH_ and EXCEPTION_STACK_OVERFLOW_ constants to winapi.h.  
### verification
- Built WasmEdge with LLVM/JIT in the official wasmedge/wasmedge:latest Docker image.
- Ran:
`wasmedge run --enable-jit test_repro.wasm main`
- Before: Process crashed with SIGSEGV.
- After: Process exits with a clean error:
`execution failed: out of bounds memory access, Code: 0x408
and a calling-stack message, with no SIGSEGV.`
<img width="898" height="584" alt="Screenshot 2026-02-12 002121" src="https://github.com/user-attachments/assets/c41415c5-664f-46fa-bd3f-c4b9e9fc4975" />

#### **closes #4636**