### PR TITLE
ci: construct build matrices dynamically and skip empty matrix jobs

### DIFF
--- a/.github/workflows/reusable-build-extensions.yml
+++ b/.github/workflows/reusable-build-extensions.yml
@@ -58,7 +58,6 @@ jobs:
             const fs = require("fs")
             const s = fs.readFileSync(".github/workflows/matrix-extensions.json")
             let plugins = JSON.parse(s).plugins
-
             if (!${{ inputs.release || fromJSON(steps.filter.outputs.all) }}) {
               plugins = plugins.filter(
                 (plugin) => !(
@@ -106,7 +105,6 @@ jobs:
                 plugins: platformPlugins.ubuntu2004_cuda12,
               },
             ]
-
 
             const ubuntuLatestVariants = [
               {
@@ -183,7 +181,8 @@ jobs:
       contents: write # Required by reusable-build-extensions-on-linux.yml
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.prepare.outputs.ubuntu_matrix) }}
+      matrix:
+        include: ${{ fromJson(needs.prepare.outputs.ubuntu_matrix) }}
     name: ${{ matrix.asset_tag }}
     uses: ./.github/workflows/reusable-build-extensions-on-linux.yml
     with:
@@ -202,7 +201,8 @@ jobs:
       contents: write # Required by reusable-build-extensions-on-linux.yml
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.prepare.outputs.ubuntu_latest_matrix) }}
+      matrix:
+        include: ${{ fromJson(needs.prepare.outputs.ubuntu_latest_matrix) }}
     name: ${{ matrix.asset_tag }}
     uses: ./.github/workflows/reusable-build-extensions-on-linux.yml
     with:
@@ -221,7 +221,8 @@ jobs:
       contents: write # Required by reusable-build-extensions-on-macos.yml
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.prepare.outputs.macos_matrix) }}
+      matrix:
+        include: ${{ fromJson(needs.prepare.outputs.macos_matrix) }}
     name: ${{ matrix.asset_tag }}
     uses: ./.github/workflows/reusable-build-extensions-on-macos.yml
     with:
@@ -239,7 +240,8 @@ jobs:
       contents: write # Required by reusable-build-extensions-on-linux.yml
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.prepare.outputs.manylinux_matrix) }}
+      matrix:
+        include: ${{ fromJson(needs.prepare.outputs.manylinux_matrix) }}
     name: ${{ matrix.asset_tag }}
     uses: ./.github/workflows/reusable-build-extensions-on-linux.yml
     with:

--- a/.github/workflows/reusable-build-extensions.yml
+++ b/.github/workflows/reusable-build-extensions.yml
@@ -189,7 +189,7 @@ jobs:
       runner: ${{ matrix.runner }}
       docker_tag: ${{ matrix.docker_tag }}
       asset_tag: ${{ matrix.asset_tag }}
-      plugins: ${{ toJson(matrix.plugins) }}  
+      plugins: ${{ toJson(matrix.plugins) }}
       version: ${{ inputs.version }}
       release: ${{ inputs.release }}
     secrets: inherit
@@ -209,7 +209,7 @@ jobs:
       runner: ${{ matrix.runner }}
       docker_tag: ${{ matrix.docker_tag }}
       asset_tag: ${{ matrix.asset_tag }}
-      plugins: ${{ toJson(matrix.plugins) }}  
+      plugins: ${{ toJson(matrix.plugins) }}
       version: ${{ inputs.version }}
       release: false
     secrets: inherit
@@ -228,7 +228,7 @@ jobs:
     with:
       runner: ${{ matrix.runner }}
       asset_tag: ${{ matrix.asset_tag }}
-      plugins: ${{ toJson(matrix.plugins) }}  
+      plugins: ${{ toJson(matrix.plugins) }}
       version: ${{ inputs.version }}
       release: ${{ inputs.release }}
     secrets: inherit
@@ -248,7 +248,7 @@ jobs:
       runner: ${{ matrix.runner }}
       docker_tag: ${{ matrix.docker_tag }}
       asset_tag: ${{ matrix.asset_tag }}
-      plugins: ${{ toJson(matrix.plugins) }}  
+      plugins: ${{ toJson(matrix.plugins) }}
       version: ${{ inputs.version }}
       release: ${{ inputs.release }}
     secrets: inherit

--- a/.github/workflows/reusable-build-extensions.yml
+++ b/.github/workflows/reusable-build-extensions.yml
@@ -33,14 +33,10 @@ jobs:
     name: Prepare ${{ inputs.asset_tag }}
     runs-on: ubuntu-latest
     outputs:
-      macos_x86_64: ${{ steps.readfile.outputs.macos_x86_64 }}
-      macos_arm64: ${{ steps.readfile.outputs.macos_arm64 }}
-      manylinux_2_28_x86_64: ${{ steps.readfile.outputs.manylinux_2_28_x86_64 }}
-      manylinux_2_28_aarch64: ${{ steps.readfile.outputs.manylinux_2_28_aarch64 }}
-      ubuntu2004_x86_64: ${{ steps.readfile.outputs.ubuntu2004_x86_64 }}
-      ubuntu2004_cuda11: ${{ steps.readfile.outputs.ubuntu2004_cuda11 }}
-      ubuntu2004_cuda12: ${{ steps.readfile.outputs.ubuntu2004_cuda12 }}
-      ubuntu_latest: ${{ steps.readfile.outputs.ubuntu_latest }}
+      ubuntu_matrix: ${{ steps.prepare.outputs.ubuntu_matrix }}
+      ubuntu_latest_matrix: ${{ steps.prepare.outputs.ubuntu_latest_matrix }}
+      macos_matrix: ${{ steps.prepare.outputs.macos_matrix }}
+      manylinux_matrix: ${{ steps.prepare.outputs.manylinux_matrix }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
@@ -79,15 +75,137 @@ jobs:
               "ubuntu2004_cuda12",
               "ubuntu_latest",
             ]
-            for (const tag of asset_tags) {
-              core.setOutput(tag, plugins.filter(
-                (plugin) => plugin.platforms.includes(tag)
-              ).map((plugin) => {
-                let copy = { ...plugin }
+
+            const pluginsForPlatform = (platform) =>
+            plugins.filter(p => p.platforms.includes(platform))
+              .map(p => {
+                const copy = { ...p }
                 delete copy.platforms
                 return copy
-              }))
+              })
+            # for (const tag of asset_tags) {
+            #   core.setOutput(tag, plugins.filter(
+            #     (plugin) => plugin.platforms.includes(tag)
+            #   ).map((plugin) => {
+            #     let copy = { ...plugin }
+            #     delete copy.platforms
+            #     return copy
+            #   }))
+            # }
+
+            const platformPlugins = {
+            ubuntu2004_x86_64:  pluginsForPlatform("ubuntu2004_x86_64"),
+            ubuntu2004_cuda11:  pluginsForPlatform("ubuntu2004_cuda11"),
+            ubuntu2004_cuda12:  pluginsForPlatform("ubuntu2004_cuda12"),
+            ubuntu_latest:      pluginsForPlatform("ubuntu_latest"),
+            macos_x86_64:       pluginsForPlatform("macos_x86_64"),
+            macos_arm64:        pluginsForPlatform("macos_arm64"),
+            manylinux_x86_64:   pluginsForPlatform("manylinux_2_28_x86_64"),
+            manylinux_aarch64: pluginsForPlatform("manylinux_2_28_aarch64"),
             }
+
+            const buildMatrix = (variants) =>
+            variants
+              .filter(v => v.plugins.length > 0)
+              .map(v => ({
+                runner: v.runner,
+                docker_tag: v.docker_tag,
+                asset_tag: v.asset_tag,
+                plugins: v.plugins,
+              }))
+
+              // --------------------------------------------------
+             // Ubuntu 20.04 variants
+            // --------------------------------------------------
+           const ubuntuVariants = [
+            {
+              runner: "ubuntu-latest",
+              docker_tag: "ubuntu-20.04-build-clang-plugins-deps",
+              asset_tag: "ubuntu20.04_x86_64",
+              plugins: platformPlugins.ubuntu2004_x86_64,
+            },
+            {
+              runner: "ubuntu-latest",
+              docker_tag: "ubuntu-20.04-build-gcc-cuda11",
+              asset_tag: "ubuntu20.04_x86_64",
+              plugins: platformPlugins.ubuntu2004_cuda11,
+            },
+            {
+              runner: "ubuntu-latest",
+              docker_tag: "ubuntu-20.04-build-gcc-cuda12",
+              asset_tag: "ubuntu20.04_x86_64",
+              plugins: platformPlugins.ubuntu2004_cuda12,
+            },
+            ]
+
+            // --------------------------------------------------
+            // Ubuntu latest variants
+            // --------------------------------------------------
+            const ubuntuLatestVariants = [
+            {
+              runner: "ubuntu-latest",
+              docker_tag: "ubuntu-24.04-build-clang-plugins-deps",
+              asset_tag: "ubuntu24.04-clang",
+              plugins: platformPlugins.ubuntu_latest,
+            },
+            {
+              runner: "ubuntu-latest",
+              docker_tag: "ubuntu-24.04-build-gcc-plugins-deps",
+              asset_tag: "ubuntu24.04-gcc",
+              plugins: platformPlugins.ubuntu_latest,
+            },
+            ]
+
+            // --------------------------------------------------
+            // macOS variants
+            // --------------------------------------------------
+            const macosVariants = [
+            {
+              runner: "macos-15-intel",
+              asset_tag: "darwin_24-x86_64",
+              plugins: platformPlugins.macos_x86_64,
+            },
+            {
+              runner: "macos-14",
+              asset_tag: "darwin_23-arm64",
+              plugins: platformPlugins.macos_arm64,
+            },
+            ]
+
+            // --------------------------------------------------
+            // manylinux variants
+            // --------------------------------------------------
+            const manylinuxVariants = [
+            {
+              runner: "ubuntu-latest",
+              docker_tag: "manylinux_2_28_x86_64-plugins-deps",
+              asset_tag: "manylinux_2_28_x86_64",
+              plugins: platformPlugins.manylinux_x86_64,
+            },
+            {
+              runner: "ubuntu-24.04-arm",
+              docker_tag: "manylinux_2_28_aarch64-plugins-deps",
+              asset_tag: "manylinux_2_28_aarch64",
+              plugins: platformPlugins.manylinux_aarch64,
+            },
+            ]
+
+            // --------------------------------------------------
+            // Build matrices
+            // --------------------------------------------------
+            const ubuntuMatrix       = buildMatrix(ubuntuVariants)
+            const ubuntuLatestMatrix = buildMatrix(ubuntuLatestVariants)
+            const macosMatrix        = buildMatrix(macosVariants)
+            const manylinuxMatrix    = buildMatrix(manylinuxVariants)
+
+            // --------------------------------------------------
+            // Outputs
+            // --------------------------------------------------
+            core.setOutput("ubuntu_matrix", JSON.stringify(ubuntuMatrix))
+            core.setOutput("ubuntu_latest_matrix", JSON.stringify(ubuntuLatestMatrix))
+            core.setOutput("macos_matrix", JSON.stringify(macosMatrix))
+            core.setOutput("manylinux_matrix", JSON.stringify(manylinuxMatrix))
+
         env:
           wasi_crypto: ${{ steps.filter.outputs.wasi_crypto }}
           wasi_nn: ${{ steps.filter.outputs.wasi_nn }}

--- a/.github/workflows/reusable-build-extensions.yml
+++ b/.github/workflows/reusable-build-extensions.yml
@@ -189,7 +189,7 @@ jobs:
       runner: ${{ matrix.runner }}
       docker_tag: ${{ matrix.docker_tag }}
       asset_tag: ${{ matrix.asset_tag }}
-      plugins: ${{ matrix.plugins }}
+      plugins: ${{ toJson(matrix.plugins) }}  
       version: ${{ inputs.version }}
       release: ${{ inputs.release }}
     secrets: inherit
@@ -209,7 +209,7 @@ jobs:
       runner: ${{ matrix.runner }}
       docker_tag: ${{ matrix.docker_tag }}
       asset_tag: ${{ matrix.asset_tag }}
-      plugins: ${{ matrix.plugins }}
+      plugins: ${{ toJson(matrix.plugins) }}  
       version: ${{ inputs.version }}
       release: false
     secrets: inherit
@@ -228,7 +228,7 @@ jobs:
     with:
       runner: ${{ matrix.runner }}
       asset_tag: ${{ matrix.asset_tag }}
-      plugins: ${{ matrix.plugins }}
+      plugins: ${{ toJson(matrix.plugins) }}  
       version: ${{ inputs.version }}
       release: ${{ inputs.release }}
     secrets: inherit
@@ -248,7 +248,7 @@ jobs:
       runner: ${{ matrix.runner }}
       docker_tag: ${{ matrix.docker_tag }}
       asset_tag: ${{ matrix.asset_tag }}
-      plugins: ${{ matrix.plugins }}
+      plugins: ${{ toJson(matrix.plugins) }}  
       version: ${{ inputs.version }}
       release: ${{ inputs.release }}
     secrets: inherit

--- a/.github/workflows/reusable-build-extensions.yml
+++ b/.github/workflows/reusable-build-extensions.yml
@@ -65,7 +65,7 @@ jobs:
                   process.env[plugin.plugin] != 'true' &&
                   process.env[plugin.plugin.split('-')[0]] != 'true')
               )
-            }           
+            }
 
             const pluginsForPlatform = (platform) =>
               plugins.filter(p => p.platforms.includes(platform))
@@ -74,7 +74,7 @@ jobs:
                   delete copy.platforms
                   return copy
                 })
-           
+
             const platformPlugins = {
               macos_x86_64: pluginsForPlatform("macos_x86_64"),
               macos_arm64:  pluginsForPlatform("macos_arm64"),
@@ -85,7 +85,7 @@ jobs:
               ubuntu2004_cuda12:  pluginsForPlatform("ubuntu2004_cuda12"),
               ubuntu_latest:  pluginsForPlatform("ubuntu_latest"),
             }
- 
+
             const ubuntuVariants = [
               {
                 runner: "ubuntu-latest",

--- a/.github/workflows/reusable-build-extensions.yml
+++ b/.github/workflows/reusable-build-extensions.yml
@@ -33,10 +33,10 @@ jobs:
     name: Prepare ${{ inputs.asset_tag }}
     runs-on: ubuntu-latest
     outputs:
-      ubuntu_matrix: ${{ steps.prepare.outputs.ubuntu_matrix }}
-      ubuntu_latest_matrix: ${{ steps.prepare.outputs.ubuntu_latest_matrix }}
-      macos_matrix: ${{ steps.prepare.outputs.macos_matrix }}
-      manylinux_matrix: ${{ steps.prepare.outputs.manylinux_matrix }}
+      ubuntu_matrix: ${{ steps.readfile.outputs.ubuntu_matrix }}
+      ubuntu_latest_matrix: ${{ steps.readfile.outputs.ubuntu_latest_matrix }}
+      macos_matrix: ${{ steps.readfile.outputs.macos_matrix }}
+      manylinux_matrix: ${{ steps.readfile.outputs.manylinux_matrix }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
@@ -58,154 +58,110 @@ jobs:
             const fs = require("fs")
             const s = fs.readFileSync(".github/workflows/matrix-extensions.json")
             let plugins = JSON.parse(s).plugins
+
             if (!${{ inputs.release || fromJSON(steps.filter.outputs.all) }}) {
               plugins = plugins.filter(
                 (plugin) => !(
                   process.env[plugin.plugin] != 'true' &&
                   process.env[plugin.plugin.split('-')[0]] != 'true')
               )
-            }
-            let asset_tags = [
-              "macos_x86_64",
-              "macos_arm64",
-              "manylinux_2_28_x86_64",
-              "manylinux_2_28_aarch64",
-              "ubuntu2004_x86_64",
-              "ubuntu2004_cuda11",
-              "ubuntu2004_cuda12",
-              "ubuntu_latest",
-            ]
+            }           
 
             const pluginsForPlatform = (platform) =>
-            plugins.filter(p => p.platforms.includes(platform))
-              .map(p => {
-                const copy = { ...p }
-                delete copy.platforms
-                return copy
-              })
-            # for (const tag of asset_tags) {
-            #   core.setOutput(tag, plugins.filter(
-            #     (plugin) => plugin.platforms.includes(tag)
-            #   ).map((plugin) => {
-            #     let copy = { ...plugin }
-            #     delete copy.platforms
-            #     return copy
-            #   }))
-            # }
-
+              plugins.filter(p => p.platforms.includes(platform))
+                .map(p => {
+                  const copy = { ...p }
+                  delete copy.platforms
+                  return copy
+                })
+           
             const platformPlugins = {
-            ubuntu2004_x86_64:  pluginsForPlatform("ubuntu2004_x86_64"),
-            ubuntu2004_cuda11:  pluginsForPlatform("ubuntu2004_cuda11"),
-            ubuntu2004_cuda12:  pluginsForPlatform("ubuntu2004_cuda12"),
-            ubuntu_latest:      pluginsForPlatform("ubuntu_latest"),
-            macos_x86_64:       pluginsForPlatform("macos_x86_64"),
-            macos_arm64:        pluginsForPlatform("macos_arm64"),
-            manylinux_x86_64:   pluginsForPlatform("manylinux_2_28_x86_64"),
-            manylinux_aarch64: pluginsForPlatform("manylinux_2_28_aarch64"),
+              macos_x86_64: pluginsForPlatform("macos_x86_64"),
+              macos_arm64:  pluginsForPlatform("macos_arm64"),
+              manylinux_2_28_x86_64:  pluginsForPlatform("manylinux_2_28_x86_64"),
+              manylinux_2_28_aarch64: pluginsForPlatform("manylinux_2_28_aarch64"),
+              ubuntu2004_x86_64:  pluginsForPlatform("ubuntu2004_x86_64"),
+              ubuntu2004_cuda11:  pluginsForPlatform("ubuntu2004_cuda11"),
+              ubuntu2004_cuda12:  pluginsForPlatform("ubuntu2004_cuda12"),
+              ubuntu_latest:  pluginsForPlatform("ubuntu_latest"),
             }
-
-            const buildMatrix = (variants) =>
-            variants
-              .filter(v => v.plugins.length > 0)
-              .map(v => ({
-                runner: v.runner,
-                docker_tag: v.docker_tag,
-                asset_tag: v.asset_tag,
-                plugins: v.plugins,
-              }))
-
-              // --------------------------------------------------
-             // Ubuntu 20.04 variants
-            // --------------------------------------------------
-           const ubuntuVariants = [
-            {
-              runner: "ubuntu-latest",
-              docker_tag: "ubuntu-20.04-build-clang-plugins-deps",
-              asset_tag: "ubuntu20.04_x86_64",
-              plugins: platformPlugins.ubuntu2004_x86_64,
-            },
-            {
-              runner: "ubuntu-latest",
-              docker_tag: "ubuntu-20.04-build-gcc-cuda11",
-              asset_tag: "ubuntu20.04_x86_64",
-              plugins: platformPlugins.ubuntu2004_cuda11,
-            },
-            {
-              runner: "ubuntu-latest",
-              docker_tag: "ubuntu-20.04-build-gcc-cuda12",
-              asset_tag: "ubuntu20.04_x86_64",
-              plugins: platformPlugins.ubuntu2004_cuda12,
-            },
+ 
+            const ubuntuVariants = [
+              {
+                runner: "ubuntu-latest",
+                docker_tag: "ubuntu-20.04-build-clang-plugins-deps",
+                asset_tag: "ubuntu20.04_x86_64",
+                plugins: platformPlugins.ubuntu2004_x86_64,
+              },
+              {
+                runner: "ubuntu-latest",
+                docker_tag: "ubuntu-20.04-build-gcc-cuda11",
+                asset_tag: "ubuntu20.04_x86_64",
+                plugins: platformPlugins.ubuntu2004_cuda11,
+              },
+              {
+                runner: "ubuntu-latest",
+                docker_tag: "ubuntu-20.04-build-gcc-cuda12",
+                asset_tag: "ubuntu20.04_x86_64",
+                plugins: platformPlugins.ubuntu2004_cuda12,
+              },
             ]
 
-            // --------------------------------------------------
-            // Ubuntu latest variants
-            // --------------------------------------------------
+
             const ubuntuLatestVariants = [
-            {
-              runner: "ubuntu-latest",
-              docker_tag: "ubuntu-24.04-build-clang-plugins-deps",
-              asset_tag: "ubuntu24.04-clang",
-              plugins: platformPlugins.ubuntu_latest,
-            },
-            {
-              runner: "ubuntu-latest",
-              docker_tag: "ubuntu-24.04-build-gcc-plugins-deps",
-              asset_tag: "ubuntu24.04-gcc",
-              plugins: platformPlugins.ubuntu_latest,
-            },
+              {
+                runner: "ubuntu-latest",
+                docker_tag: "ubuntu-24.04-build-clang-plugins-deps",
+                asset_tag: "ubuntu24.04-clang",
+                plugins: platformPlugins.ubuntu_latest,
+              },
+              {
+                runner: "ubuntu-latest",
+                docker_tag: "ubuntu-24.04-build-gcc-plugins-deps",
+                asset_tag: "ubuntu24.04-gcc",
+                plugins: platformPlugins.ubuntu_latest,
+              },
             ]
 
-            // --------------------------------------------------
-            // macOS variants
-            // --------------------------------------------------
             const macosVariants = [
-            {
-              runner: "macos-15-intel",
-              asset_tag: "darwin_24-x86_64",
-              plugins: platformPlugins.macos_x86_64,
-            },
-            {
-              runner: "macos-14",
-              asset_tag: "darwin_23-arm64",
-              plugins: platformPlugins.macos_arm64,
-            },
+              {
+                runner: "macos-15-intel",
+                asset_tag: "darwin_24-x86_64",
+                plugins: platformPlugins.macos_x86_64,
+              },
+              {
+                runner: "macos-14",
+                asset_tag: "darwin_23-arm64",
+                plugins: platformPlugins.macos_arm64,
+              },
             ]
 
-            // --------------------------------------------------
-            // manylinux variants
-            // --------------------------------------------------
             const manylinuxVariants = [
-            {
-              runner: "ubuntu-latest",
-              docker_tag: "manylinux_2_28_x86_64-plugins-deps",
-              asset_tag: "manylinux_2_28_x86_64",
-              plugins: platformPlugins.manylinux_x86_64,
-            },
-            {
-              runner: "ubuntu-24.04-arm",
-              docker_tag: "manylinux_2_28_aarch64-plugins-deps",
-              asset_tag: "manylinux_2_28_aarch64",
-              plugins: platformPlugins.manylinux_aarch64,
-            },
+              {
+                runner: "ubuntu-latest",
+                docker_tag: "manylinux_2_28_x86_64-plugins-deps",
+                asset_tag: "manylinux_2_28_x86_64",
+                plugins: platformPlugins.manylinux_2_28_x86_64,
+              },
+              {
+                runner: "ubuntu-24.04-arm",
+                docker_tag: "manylinux_2_28_aarch64-plugins-deps",
+                asset_tag: "manylinux_2_28_aarch64",
+                plugins: platformPlugins.manylinux_2_28_aarch64,
+              },
             ]
 
-            // --------------------------------------------------
-            // Build matrices
-            // --------------------------------------------------
+            const buildMatrix = (variants) => variants.filter(v => v.plugins.length > 0);
+
             const ubuntuMatrix       = buildMatrix(ubuntuVariants)
             const ubuntuLatestMatrix = buildMatrix(ubuntuLatestVariants)
             const macosMatrix        = buildMatrix(macosVariants)
             const manylinuxMatrix    = buildMatrix(manylinuxVariants)
 
-            // --------------------------------------------------
-            // Outputs
-            // --------------------------------------------------
             core.setOutput("ubuntu_matrix", JSON.stringify(ubuntuMatrix))
             core.setOutput("ubuntu_latest_matrix", JSON.stringify(ubuntuLatestMatrix))
             core.setOutput("macos_matrix", JSON.stringify(macosMatrix))
             core.setOutput("manylinux_matrix", JSON.stringify(manylinuxMatrix))
-
         env:
           wasi_crypto: ${{ steps.filter.outputs.wasi_crypto }}
           wasi_nn: ${{ steps.filter.outputs.wasi_nn }}
@@ -222,24 +178,12 @@ jobs:
 
   build_on_ubuntu:
     needs: prepare
+    if: ${{ needs.prepare.outputs.ubuntu_matrix != '[]' }}
     permissions:
       contents: write # Required by reusable-build-extensions-on-linux.yml
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - runner: 'ubuntu-latest'
-            docker_tag: 'ubuntu-20.04-build-clang-plugins-deps'
-            asset_tag: 'ubuntu20.04_x86_64'
-            plugins: ${{ needs.prepare.outputs.ubuntu2004_x86_64 }}
-          - runner: 'ubuntu-latest'
-            docker_tag: 'ubuntu-20.04-build-gcc-cuda11'
-            asset_tag: 'ubuntu20.04_x86_64'
-            plugins: ${{ needs.prepare.outputs.ubuntu2004_cuda11 }}
-          - runner: 'ubuntu-latest'
-            docker_tag: 'ubuntu-20.04-build-gcc-cuda12'
-            asset_tag: 'ubuntu20.04_x86_64'
-            plugins: ${{ needs.prepare.outputs.ubuntu2004_cuda12 }}
+      matrix: ${{ fromJson(needs.prepare.outputs.ubuntu_matrix) }}
     name: ${{ matrix.asset_tag }}
     uses: ./.github/workflows/reusable-build-extensions-on-linux.yml
     with:
@@ -252,22 +196,13 @@ jobs:
     secrets: inherit
 
   build_on_ubuntu_latest:
-    if: ${{ !inputs.release }}
     needs: prepare
+    if: ${{ !inputs.release && needs.prepare.outputs.ubuntu_latest_matrix != '[]' }}
     permissions:
       contents: write # Required by reusable-build-extensions-on-linux.yml
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - runner: 'ubuntu-latest'
-            docker_tag: 'ubuntu-24.04-build-clang-plugins-deps'
-            asset_tag: 'ubuntu24.04-clang'
-            plugins: ${{ needs.prepare.outputs.ubuntu_latest }}
-          - runner: 'ubuntu-latest'
-            docker_tag: 'ubuntu-24.04-build-gcc-plugins-deps'
-            asset_tag: 'ubuntu24.04-gcc'
-            plugins: ${{ needs.prepare.outputs.ubuntu_latest }}
+      matrix: ${{ fromJson(needs.prepare.outputs.ubuntu_latest_matrix) }}
     name: ${{ matrix.asset_tag }}
     uses: ./.github/workflows/reusable-build-extensions-on-linux.yml
     with:
@@ -281,18 +216,12 @@ jobs:
 
   build_on_macos:
     needs: prepare
+    if: ${{ needs.prepare.outputs.macos_matrix != '[]' }}
     permissions:
       contents: write # Required by reusable-build-extensions-on-macos.yml
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - runner: 'macos-15-intel'
-            asset_tag: 'darwin_24-x86_64'
-            plugins: ${{ needs.prepare.outputs.macos_x86_64 }}
-          - runner: 'macos-14'
-            asset_tag: 'darwin_23-arm64'
-            plugins: ${{ needs.prepare.outputs.macos_arm64 }}
+      matrix: ${{ fromJson(needs.prepare.outputs.macos_matrix) }}
     name: ${{ matrix.asset_tag }}
     uses: ./.github/workflows/reusable-build-extensions-on-macos.yml
     with:
@@ -305,20 +234,12 @@ jobs:
 
   build_on_manylinux:
     needs: prepare
+    if: ${{ needs.prepare.outputs.manylinux_matrix != '[]' }}
     permissions:
       contents: write # Required by reusable-build-extensions-on-linux.yml
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - runner: 'ubuntu-latest'
-            docker_tag: 'manylinux_2_28_x86_64-plugins-deps'
-            asset_tag: 'manylinux_2_28_x86_64'
-            plugins: ${{ needs.prepare.outputs.manylinux_2_28_x86_64 }}
-          - runner: 'ubuntu-24.04-arm'
-            docker_tag: 'manylinux_2_28_aarch64-plugins-deps'
-            asset_tag: 'manylinux_2_28_aarch64'
-            plugins: ${{ needs.prepare.outputs.manylinux_2_28_aarch64 }}
+      matrix: ${{ fromJson(needs.prepare.outputs.manylinux_matrix) }}
     name: ${{ matrix.asset_tag }}
     uses: ./.github/workflows/reusable-build-extensions-on-linux.yml
     with:


### PR DESCRIPTION
Refactors the extension workflow to construct build matrices dynamically in the prepare job.
The matrices are wrapped with include and jobs are skipped when the matrix is empty to prevent the “Matrix must define at least one vector” error.

Fix issue: https://github.com/WasmEdge/WasmEdge/issues/3736