### PR TITLE
fix: catch std::bad_alloc in WasmEdge_StringCreateByBuffer

### DIFF
--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -734,9 +734,13 @@ WasmEdge_StringCreateByCString(const char *Str) {
 WASMEDGE_CAPI_EXPORT WasmEdge_String
 WasmEdge_StringCreateByBuffer(const char *Buf, const uint32_t Len) {
   if (Buf && Len) {
-    char *Str = new char[Len];
-    std::copy_n(Buf, Len, Str);
-    return WasmEdge_String{/* Length */ Len, /* Buf */ Str};
+    try {
+      char *Str = new char[Len];
+      std::copy_n(Buf, Len, Str);
+      return WasmEdge_String{/* Length */ Len, /* Buf */ Str};
+    } catch (const std::bad_alloc &) {
+      return WasmEdge_String{/* Length */ 0, /* Buf */ nullptr};
+    }
   }
   return WasmEdge_String{/* Length */ 0, /* Buf */ nullptr};
 }


### PR DESCRIPTION
Description:
Wraps the raw `new char[Len]` allocation in `WasmEdge_StringCreateByBuffer` with a `try-catch` block. This prevents `std::bad_alloc` from escaping across the FFI boundary, which previously caused undefined behavior/abort.

Returns an empty `WasmEdge_String (Length 0, Buf nullptr)` on failure.

Related Issue

Fixes #4651 

Verification

I verified this locally using fault injection (manually throwing `std::bad_alloc` inside the function) and confirmed that the C API returns an empty `WasmEdge_String` instead of crashing.

Why no test case is included:

I attempted to add a unit test using `UINT32_MAX` to force an allocation failure. However, on high-RAM machines (for me it's Apple M4 with 16GB RAM), the 4GB allocation actually succeeds instead of throwing `std::bad_alloc`. This causes the subsequent `std::copy_n` to segfault due to buffer over-read, rather than testing the OOM handling logic.

Since reliable OOM testing is highly dependent on available hardware and OS limits, I have omitted the test case.