### PR TITLE
fix(c-api): ensure default logger initialization before plugin loading

### DIFF
--- a/include/common/spdlog.h
+++ b/include/common/spdlog.h
@@ -38,6 +38,8 @@ void setCriticalLoggingLevel();
 void setLoggingCallback(
     std::function<void(const spdlog::details::log_msg &)> Callback);
 
+void ensureInitialized();
+
 } // namespace Log
 } // namespace WasmEdge
 

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -3408,6 +3408,7 @@ WASMEDGE_CAPI_EXPORT void WasmEdge_PluginLoadWithDefaultPaths(void) {
 }
 
 WASMEDGE_CAPI_EXPORT void WasmEdge_PluginLoadFromPath(const char *Path) {
+  WasmEdge::Log::ensureInitialized();
   WasmEdge::Plugin::Plugin::load(Path);
 }
 

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -3403,6 +3403,7 @@ WASMEDGE_CAPI_EXPORT extern "C" int WasmEdge_Driver_FuzzPO(const uint8_t *Data,
 // >>>>>>>> WasmEdge Plugin functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 WASMEDGE_CAPI_EXPORT void WasmEdge_PluginLoadWithDefaultPaths(void) {
+  WasmEdge::Log::ensureInitialized();
   WasmEdge::Plugin::Plugin::loadFromDefaultPaths();
 }
 

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -4,6 +4,7 @@
 #include "wasmedge/wasmedge.h"
 
 #include "common/defines.h"
+#include "common/spdlog.h"
 #include "driver/compiler.h"
 #include "driver/tool.h"
 #include "driver/unitool.h"
@@ -855,6 +856,7 @@ WASMEDGE_CAPI_EXPORT bool WasmEdge_LimitIsEqual(const WasmEdge_Limit Lim1,
 // >>>>>>>> WasmEdge configure functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 WASMEDGE_CAPI_EXPORT WasmEdge_ConfigureContext *WasmEdge_ConfigureCreate(void) {
+  WasmEdge::Log::ensureInitialized();
   return new WasmEdge_ConfigureContext;
 }
 

--- a/lib/common/spdlog.cpp
+++ b/lib/common/spdlog.cpp
@@ -33,11 +33,9 @@ std::once_flag InitOnce;
 
 void ensureInitialized() {
   std::call_once(InitOnce, []() {
-    if (spdlog::default_logger() == nullptr) {
-      spdlog::set_default_logger(std::make_shared<spdlog::logger>(
-          "WasmEdge"s, std::make_shared<color_sink_t>()));
-      spdlog::set_level(spdlog::level::err);
-    }
+    spdlog::set_default_logger(std::make_shared<spdlog::logger>(
+        "WasmEdge"s, std::make_shared<color_sink_t>()));
+    spdlog::set_level(spdlog::level::err);
   });
 }
 
@@ -57,6 +55,7 @@ void setCriticalLoggingLevel() { spdlog::set_level(spdlog::level::critical); }
 
 void setLoggingCallback(
     std::function<void(const spdlog::details::log_msg &)> Callback) {
+  std::call_once(InitOnce, []() {});
   if (Callback) {
     auto Callback_sink =
         std::make_shared<spdlog::sinks::callback_sink_mt>(Callback);

--- a/lib/common/spdlog.cpp
+++ b/lib/common/spdlog.cpp
@@ -64,7 +64,7 @@ void setLoggingCallback(
         std::make_shared<spdlog::logger>("WasmEdge"s, Callback_sink));
   } else {
     spdlog::set_default_logger(std::make_shared<spdlog::logger>(
-        ""s, std::make_shared<color_sink_t>()));
+        "WasmEdge"s, std::make_shared<color_sink_t>()));
   }
 }
 

--- a/lib/common/spdlog.cpp
+++ b/lib/common/spdlog.cpp
@@ -3,6 +3,7 @@
 
 #include "common/spdlog.h"
 
+#include <mutex>
 #if defined(__clang_major__) && __clang_major__ >= 10
 #pragma clang diagnostic push
 // Suppression can be removed after spdlog with fix is released
@@ -25,6 +26,20 @@ using namespace std::literals;
 
 namespace WasmEdge {
 namespace Log {
+
+namespace {
+std::once_flag InitOnce;
+}
+
+void ensureInitialized() {
+  std::call_once(InitOnce, []() {
+    if (spdlog::default_logger() == nullptr) {
+      spdlog::set_default_logger(std::make_shared<spdlog::logger>(
+          "WasmEdge"s, std::make_shared<color_sink_t>()));
+      spdlog::set_level(spdlog::level::err);
+    }
+  });
+}
 
 void setLogOff() { spdlog::set_level(spdlog::level::off); }
 


### PR DESCRIPTION
This PR fixes a null `spdlog::default_logger()` dereference that can occur when using the C API (and Rust SDK) during plugin auto-detection.
### **fixes #4003** 


When `auto_detect_plugin() `is called from the Rust SDK, it triggers `WasmEdge_PluginLoadWithDefaultPaths()`, which may call `spdlog::error()` before any logging initialization has occurred.
In shared library contexts, this can result in `spdlog::default_logger()` being null, leading to a segmentation fault.

The C++ CLI does not exhibit this issue because it initializes logging early via UniTool before plugin loading.

### **Root Cause**

The C API does not guarantee that a default logger is initialized before runtime operations that may emit logs (e.g., plugin loading).
Although the documentation states:
_**“By default, the error level is set, and the debug info is hidden.”**_
there is currently no guarantee that a valid default logger exists before the first logging call occurs in the C API path.
This leads to undefined behavior in shared library usage scenarios (e.g., Rust SDK).

### **Proposed Fix**

This PR introduces a thread-safe `WasmEdge::Log::ensureInitialized()` function that:
Uses `std::call_once` to guarantee one-time initialization
Creates a default logger if none exists
Sets the default log level to error (matching documented behavior)
Does not override an existing user-defined logger
`ensureInitialized()` is invoked at the beginning of:
`WasmEdge_ConfigureCreate()`


**This ensures that:**

Logging is initialized early in the runtime lifecycle
Rust SDK usage becomes safe
C API behavior aligns with documented guarantees
No duplicate logger initialization occurs