### PR TITLE
Fixed Critical Bug in Github Workflows

### DIFF
--- a/.github/workflows/reusable-build-extensions.yml
+++ b/.github/workflows/reusable-build-extensions.yml
@@ -30,7 +30,7 @@ jobs:
   #   process.env['wasi_nn-ggml'] => undefined
   # ------------------------------------------------------------------#
   prepare:
-    name: Prepare ${{ inputs.asset_tag }}
+    name: Prepare
     runs-on: ubuntu-latest
     outputs:
       macos_x86_64: ${{ steps.readfile.outputs.macos_x86_64 }}


### PR DESCRIPTION
fix:  `assert_tag` was not defined in `${{ inputs.asset_tag }}` ref: **.github/workflows/reusable-build-extensions.yml**

I found this critical bug when I ran actionlint on the workflows.
---
```
[.github/workflows/reusable-build-extensions.yml:33:23: property "asset_tag" is not defined in object type {release: bool; version: string} [expression]
   |                                                                                                                                                                   
33 |     name: Prepare ${{ inputs.asset_tag }}  ](url)
```
---
The **asset_tag** was not defined in the inputs so I set a static name "Prepare" which is safe.

You can **reproduce** this bug by using the command:
---
`actionlint .github/workflows/reusable-build-extensions.yml` 
---

**Additional Information:**
https://github.com/rhysd/actionlint

Signed-off-by: Mrinal Chaturvedi <mrinal.chaturvedi27@gmail.com>