### PR TITLE
docs: sync README-zh.md with latest english updates

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -21,10 +21,12 @@ WasmEdge (之前名为 SSVM) 是为边缘计算优化的轻量级、高性能、
 # 快速开始指引
 
 🚀 [安装](https://wasmedge.org/docs/zh/start/install) WasmEdge\
-🤖 [Build](https://wasmedge.org/docs/zh/category/build-wasmedge-from-source) 并[贡献](https://wasmedge.org/docs/zh/contribute/)给 WasmEdge\
-⌨️  [从 CLI 跑](https://wasmedge.org/docs/zh/category/running-with-wasmedge)一个独立的 Wasm 程序或 [JavaScript 程序](https://wasmedge.org/docs/zh/category/develop-wasm-apps-in-javascript) \
-🔌 [嵌入一个 Wasm 函数](https://www.secondstate.io/articles/getting-started-with-rust-function/)在你的[Node.js](https://github.com/second-state/wasm-learning/tree/master/ssvm/file-example)， [Go语言](https://wasmedge.org/docs/zh/category/go-sdk-for-embedding-wasmedge)或 Rust 应用里 \
-🛠 使用 [Docker 工具](https://www.secondstate.io/articles/manage-webassembly-apps-in-wasmedge-using-docker-tools/)、[数据流框架](https://www.secondstate.io/articles/yomo-wasmedge-real-time-data-streams/), 和 [区块链](https://medium.com/ethereum-on-steroids/running-ethereum-smart-contracts-in-a-substrate-blockchain-56fbc27fc95a) 管理和编排 Wasm runtimes
+👷🏻‍♂️ [Build](https://wasmedge.org/docs/zh/category/build-wasmedge-from-source) 并[贡献](https://wasmedge.org/docs/zh/contribute/)给 WasmEdge\
+⌨️ [从 CLI 跑](https://wasmedge.org/docs/zh/category/running-with-wasmedge)一个独立的 Wasm 程序或 [JavaScript 程序](https://wasmedge.org/docs/zh/category/develop-wasm-apps-in-javascript) \
+🤖 通过 [LlamaEdge](https://github.com/LlamaEdge/LlamaEdge) 与开源 LLM [聊天](https://llamaedge.com/docs/intro) \
+🔌 嵌入一个 Wasm 函数在你的 [Go语言](https://wasmedge.org/docs/zh/category/go-sdk-for-embedding-wasmedge)、[Rust](https://wasmedge.org/docs/zh/category/rust-sdk-for-embedding-wasmedge) 或 [C](https://wasmedge.org/docs/zh/category/c-sdk-for-embedding-wasmedge) 应用里 \
+🛠 使用 [Kubernetes](https://wasmedge.org/docs/zh/category/deploy-wasmedge-apps-in-kubernetes)、[数据流框架](https://wasmedge.org/docs/embed/use-case/yomo), 和 [区块链](https://medium.com/ethereum-on-steroids/running-ethereum-smart-contracts-in-a-substrate-blockchain-56fbc27fc95a) 管理和编排 Wasm runtimes \
+📚 **[查看我们的官方文档](https://wasmedge.org/docs/)**
 
 # 介绍
 
@@ -58,19 +60,41 @@ WasmEdge 及其包含的 wasm 程序可以作为新进程或从现有进程从 C
 * [使用容器工具管理和编排 Wasm 实例](https://wasmedge.org/docs/zh/category/deploy-wasmedge-apps-in-kubernetes)
 * [从 WasmEdge 调用原生 host 程序](docs/integrations.md#call-native-host-functions-from-wasmedge)
 
-## 社区
+# 社区
 
-### 贡献
+## 贡献
 
-如果您想为 WasmEdge 项目做出贡献，请参阅我们的 [CONTRIBUTING](https://wasmedge.org/docs/zh-tw/contribute/overview) 文档了解详情。 想要获得灵感，可查看[需求清单](https://github.com/WasmEdge/WasmEdge/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)!
+我们欢迎社区的贡献！请查看我们的：
+- [贡献指南](./docs/CONTRIBUTING.md) 了解如何开始
+- [治理文档](./docs/GOVERNANCE.md) 了解项目决策流程
+- [行为准则](./docs/CODE_OF_CONDUCT.md) 了解社区标准
 
-### 联系
+想成为维护者吗？请查看我们的 [贡献者阶梯](./docs/CONTRIBUTOR_LADDER.md)。
+
+## 路线图
+
+查看我们的 [项目路线图](https://github.com/WasmEdge/WasmEdge/blob/master/docs/ROADMAP.md) 以了解 WasmEdge 即将推出的功能和计划。
+
+## 联系
 
 如有任何疑问，请随时在相关项目上提 GitHub issue，或加入下列频道：
 
 * 邮件清单：发送邮件至 [WasmEdge@googlegroups.com](https://groups.google.com/g/wasmedge/)
+* Discord: 加入 [WasmEdge Discord 服务器](https://discord.gg/h4KDyB8XTt)!
 * Slack: 加入 #WasmEdge 组群： [CNCF Slack](https://slack.cncf.io/)
-* 推特：在[Twitter](https://twitter.com/realwasmedge)关注 @realwasmedge
+* 推特 (X)：在 [X](https://x.com/realwasmedge) 关注 @realwasmedge
+
+## 采用者
+
+查看我们在项目中使用了 WasmEdge 的 [采用者列表](https://wasmedge.org/docs/zh/contribute/users/)。
+
+## 社区会议
+
+我们每月举行一次社区会议，展示新功能、演示新用例并进行问答。欢迎所有人参加！
+
+时间：每月第一个星期二，香港时间晚上 11 点 / 太平洋标准时间早上 7 点。
+
+[公开会议议程/笔记](https://docs.google.com/document/d/1iFlVl7R97Lze4RDykzElJGDjjWYDlkI8Rhf8g4dQ5Rk/edit#) | [Zoom 链接](https://us06web.zoom.us/j/82221747919?pwd=3MORhaxDk15rACk7mNDvyz9KtaEbWy.1)
 
 ## License
 


### PR DESCRIPTION
Fixes #4228 

### Description
The `README-zh.md` file had fallen out of sync with the primary `README.md`. This PR updates the Simplified Chinese translation to match the current English version.

**Key Additions:**
- Added the `LlamaEdge` LLM bullet point to the Quick Start guide.
- Updated the "Contributing" section to include links to Governance, Code of Conduct, and the Contributor Ladder.
- Added the missing "Roadmap", "Adopters", and "Community Meeting" sections.
- Updated X (Twitter) links.