### PR TITLE
fix(compiler): error on LLVM-22

### DIFF
--- a/.github/workflows/reusable-build-on-macos.yml
+++ b/.github/workflows/reusable-build-on-macos.yml
@@ -67,7 +67,6 @@ jobs:
           key: homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-${{ steps.lld-version-non-release.outputs.version }}-${{ hashFiles('.github/workflows/reusable-build-on-macos.yml') }}
           restore-keys: |
             homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-${{ steps.lld-version-non-release.outputs.version }}-
-            homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-
       - name: Install or link lld and cmake - non-release
         if: ${{ !inputs.release }}
         run: |
@@ -103,7 +102,6 @@ jobs:
           key: homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-${{ steps.lld-version-release.outputs.version }}-${{ hashFiles('.github/workflows/reusable-build-on-macos.yml') }}
           restore-keys: |
             homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-${{ steps.lld-version-release.outputs.version }}-
-            homebrew-cellar-lld-${{ runner.os }}-${{ matrix.arch }}-
       - name: Install or link lld and cmake - release
         if: ${{ inputs.release }}
         run: |

--- a/lib/llvm/compiler.cpp
+++ b/lib/llvm/compiler.cpp
@@ -5887,10 +5887,9 @@ Expect<Data> Compiler::compile(const AST::Module &Module) noexcept {
   std::unique_lock Lock(Mutex);
   spdlog::info("compile start"sv);
 
-  LLVM::Core::init();
-
   LLVM::Data D;
   auto LLContext = D.extract().getLLContext();
+  LLVM::Core::init(LLContext.unwrap());
   auto &LLModule = D.extract().LLModule;
   LLModule.setTarget(LLVM::getDefaultTargetTriple().unwrap());
   LLModule.addFlag(LLVMModuleFlagBehaviorError, "PIC Level"sv, 2);

--- a/lib/llvm/llvm.h
+++ b/lib/llvm/llvm.h
@@ -75,7 +75,9 @@ namespace WasmEdge::LLVM {
 
 class Core {
 public:
-  static inline void init() noexcept { std::call_once(Once, initOnce); }
+  static inline void init(LLVMContextRef C) noexcept {
+    std::call_once(Once, initOnce, C);
+  }
 
   static inline const unsigned int NotIntrinsic = 0;
   static inline unsigned int Ceil = 0;
@@ -150,7 +152,7 @@ public:
 
 private:
   static inline std::once_flag Once;
-  static inline void initOnce() noexcept {
+  static inline void initOnce(LLVMContextRef C) noexcept {
     using namespace std::literals;
 #if LLVM_VERSION_MAJOR < 17
     LLVMInitializeCore(LLVMGetGlobalPassRegistry());
@@ -228,7 +230,7 @@ private:
     StrictFP = getEnumAttributeKind("strictfp"sv);
     UWTable = getEnumAttributeKind("uwtable"sv);
 
-    InvariantGroup = getMetadataKind("invariant.group"sv);
+    InvariantGroup = getMetadataKind(C, "invariant.group"sv);
   }
 
   template <typename... ArgsT>
@@ -246,8 +248,10 @@ private:
   static unsigned int getEnumAttributeKind(std::string_view Name) noexcept {
     return LLVMGetEnumAttributeKindForName(Name.data(), Name.size());
   }
-  static unsigned int getMetadataKind(std::string_view Name) noexcept {
-    return LLVMGetMDKindID(Name.data(), static_cast<unsigned int>(Name.size()));
+  static unsigned int getMetadataKind(LLVMContextRef C,
+                                      std::string_view Name) noexcept {
+    return LLVMGetMDKindIDInContext(C, Name.data(),
+                                    static_cast<unsigned int>(Name.size()));
   }
 };
 

--- a/thirdparty/blake3/CMakeLists.txt
+++ b/thirdparty/blake3/CMakeLists.txt
@@ -122,7 +122,6 @@ if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     -Wno-cast-align
     -Wno-cast-qual
     -Wno-implicit-int-conversion
-    -Wno-implicit-int-enum-cast
     -Wno-language-extension-token
     -Wno-missing-prototypes
     -Wno-pointer-sign
@@ -130,6 +129,12 @@ if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     -Wno-sign-conversion
     -Wno-unused-function
   )
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "21")
+    target_compile_options(utilBlake3
+      PRIVATE
+      -Wno-implicit-int-enum-cast
+    )
+  endif()
 endif()
 
 target_include_directories(utilBlake3


### PR DESCRIPTION
## Description

Fix for supporting building withLLVM-22

- [x] Fix error on AOT to remove using of deprecated function
- [x] Update for [WasmEdge homebrew llvm formula](https://github.com/WasmEdge/homebrew-llvm/blob/main/Formula/lld.rb) https://github.com/WasmEdge/homebrew-llvm/pull/1


## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.
