### PR TITLE
feat(hash): replace rapidhash with a5hash v5.25

### DIFF
--- a/include/common/hash.h
+++ b/include/common/hash.h
@@ -9,7 +9,7 @@
 ///
 /// \file
 /// This file contains the functions about hashing data.
-/// Currently using rapidhash.
+/// Currently using a5hash.
 ///
 //===----------------------------------------------------------------------===//
 #pragma once
@@ -19,24 +19,19 @@
 #include "common/errcode.h"
 #include "common/int128.h"
 #include "common/span.h"
-#include "common/variant.h"
 
-#include <array>
 #include <cstdint>
 #include <random>
 #include <string_view>
 #include <type_traits>
 
 namespace WasmEdge::Hash {
-inline constexpr void rapidMum(uint64_t &A, uint64_t &B) noexcept {
+inline constexpr void a5hashMul128(uint64_t A, uint64_t B, uint64_t &RL,
+                                   uint64_t &RH) noexcept {
   uint128_t R = A;
   R *= B;
-  A = static_cast<uint64_t>(R);
-  B = static_cast<uint64_t>(R >> 64);
-}
-inline constexpr uint64_t rapidMix(uint64_t A, uint64_t B) noexcept {
-  rapidMum(A, B);
-  return A ^ B;
+  RL = static_cast<uint64_t>(R);
+  RH = static_cast<uint64_t>(R >> 64);
 }
 
 struct RandomEngine {
@@ -44,41 +39,42 @@ struct RandomEngine {
   RandomEngine() noexcept {
     std::random_device RD;
     std::uniform_int_distribution<uint64_t> Dist(0, UINT64_MAX);
-    Seed = Dist(RD);
+    Seed1 = Seed2 = Dist(RD);
   }
-  RandomEngine(result_type S) noexcept : Seed(S) {}
+  RandomEngine(result_type S) noexcept : Seed1(S), Seed2(S) {}
   static inline constexpr result_type min() noexcept { return 0; }
   static inline constexpr result_type max() noexcept { return UINT64_MAX; }
   result_type operator()() noexcept {
-    Seed += 0x2d358dccaa6c78a5ull;
-    return rapidMix(Seed, Seed ^ 0x8bb84b93962eacc9ull);
+    a5hashMul128(Seed1 + UINT64_C(0x5555555555555555),
+                 Seed2 + UINT64_C(0xAAAAAAAAAAAAAAAA), Seed1, Seed2);
+    return Seed1 ^ Seed2;
   }
-  result_type Seed;
+  result_type Seed1;
+  result_type Seed2;
 };
 
 static inline thread_local RandomEngine RandEngine;
 
 struct Hash {
-  WASMEDGE_EXPORT static uint64_t
-  rapidHash(Span<const std::byte> Data) noexcept;
+  WASMEDGE_EXPORT static uint64_t a5Hash(Span<const std::byte> Data) noexcept;
 
   template <typename CharT>
   inline uint64_t operator()(const CharT *Str) const noexcept {
     std::basic_string_view<CharT> View(Str);
     Span<const CharT> S(View.data(), View.size());
-    return rapidHash(cxx20::as_bytes(S));
+    return a5Hash(cxx20::as_bytes(S));
   }
   template <typename CharT>
   inline uint64_t
   operator()(const std::basic_string<CharT> &Str) const noexcept {
     Span<const CharT> S(Str.data(), Str.size());
-    return rapidHash(cxx20::as_bytes(S));
+    return a5Hash(cxx20::as_bytes(S));
   }
   template <typename CharT>
   inline uint64_t
   operator()(const std::basic_string_view<CharT> &Str) const noexcept {
     Span<const CharT> S(Str.data(), Str.size());
-    return rapidHash(cxx20::as_bytes(S));
+    return a5Hash(cxx20::as_bytes(S));
   }
   template <typename T, std::enable_if_t<std::is_integral_v<std::remove_cv_t<
                             std::remove_reference_t<T>>>> * = nullptr>

--- a/lib/common/hash.cpp
+++ b/lib/common/hash.cpp
@@ -1,193 +1,11 @@
 #include "common/hash.h"
 #include "common/endian.h"
 
+#include <cstdint>
+#include <cstring>
+
 namespace {
 
-inline uint64_t mulMod(uint64_t A, uint64_t B, uint64_t M) noexcept {
-  uint64_t R = 0;
-  while (B) {
-    if (B & 1) {
-      uint64_t R2 = R + A;
-      if (R2 < R) {
-        R2 -= M;
-      }
-      R = R2 % M;
-    }
-    B >>= 1;
-    if (B) {
-      uint64_t A2 = A + A;
-      if (A2 < A) {
-        A2 -= M;
-      }
-      A = A2 % M;
-    }
-  }
-  return R;
-}
-
-inline uint64_t powMod(uint64_t A, uint64_t B, uint64_t M) noexcept {
-  uint64_t R = 1;
-  while (B) {
-    if (B & 1) {
-      R = mulMod(R, A, M);
-    }
-    B >>= 1;
-    if (B) {
-      A = mulMod(A, A, M);
-    }
-  }
-  return R;
-}
-
-inline bool sprp(uint64_t N, uint64_t A) noexcept {
-  uint64_t D = N - 1;
-  uint8_t S = 0;
-  while (!(D & 0xff)) {
-    D >>= 8;
-    S += 8;
-  }
-  if (!(D & 0xf)) {
-    D >>= 4;
-    S += 4;
-  }
-  if (!(D & 0x3)) {
-    D >>= 2;
-    S += 2;
-  }
-  if (!(D & 0x1)) {
-    D >>= 1;
-    S += 1;
-  }
-  uint64_t B = powMod(A, D, N);
-  if ((B == 1) || (B == (N - 1))) {
-    return true;
-  }
-  uint8_t R;
-  for (R = 1; R < S; R++) {
-    B = mulMod(B, B, N);
-    if (B <= 1) {
-      return false;
-    }
-    if (B == (N - 1)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-inline bool isPrime(uint64_t N) noexcept {
-  if (N < 2 || !(N & 1)) {
-    return false;
-  }
-  if (N < 4) {
-    return true;
-  }
-  if (!sprp(N, 2)) {
-    return false;
-  }
-  if (N < 2047) {
-    return true;
-  }
-  if (!sprp(N, 3)) {
-    return false;
-  }
-  if (!sprp(N, 5)) {
-    return false;
-  }
-  if (!sprp(N, 7)) {
-    return false;
-  }
-  if (!sprp(N, 11)) {
-    return false;
-  }
-  if (!sprp(N, 13)) {
-    return false;
-  }
-  if (!sprp(N, 17)) {
-    return false;
-  }
-  if (!sprp(N, 19)) {
-    return false;
-  }
-  if (!sprp(N, 23)) {
-    return false;
-  }
-  if (!sprp(N, 29)) {
-    return false;
-  }
-  if (!sprp(N, 31)) {
-    return false;
-  }
-  if (!sprp(N, 37)) {
-    return false;
-  }
-  return true;
-}
-
-inline int popcount(uint64_t X) noexcept {
-#if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
-  return __builtin_popcountll(X);
-#elif defined(_MSC_VER) && defined(_WIN64)
-#if defined(_M_X64)
-  return static_cast<int>(_mm_popcnt_u64(X));
-#else
-  return static_cast<int>(_CountOneBits64(X));
-#endif
-#else
-  X -= (X >> 1) & 0x5555555555555555;
-  X = (X & 0x3333333333333333) + ((X >> 2) & 0x3333333333333333);
-  X = (X + (X >> 4)) & 0x0f0f0f0f0f0f0f0f;
-  X = (X * 0x0101010101010101) >> 56;
-  return static_cast<int>(X);
-#endif
-}
-
-std::array<uint64_t, 4> generate() noexcept {
-  std::array<uint64_t, 4> Secret;
-  const std::array<uint8_t, 70> C = {
-      0x0f, 0x17, 0x1b, 0x1d, 0x1e, 0x27, 0x2b, 0x2d, 0x2e, 0x33, 0x35, 0x36,
-      0x39, 0x3a, 0x3c, 0x47, 0x4b, 0x4d, 0x4e, 0x53, 0x55, 0x56, 0x59, 0x5a,
-      0x5c, 0x63, 0x65, 0x66, 0x69, 0x6a, 0x6c, 0x71, 0x72, 0x74, 0x78, 0x87,
-      0x8b, 0x8d, 0x8e, 0x93, 0x95, 0x96, 0x99, 0x9a, 0x9c, 0xa3, 0xa5, 0xa6,
-      0xa9, 0xaa, 0xac, 0xb1, 0xb2, 0xb4, 0xb8, 0xc3, 0xc5, 0xc6, 0xc9, 0xca,
-      0xcc, 0xd1, 0xd2, 0xd4, 0xd8, 0xe1, 0xe2, 0xe4, 0xe8, 0xf0};
-  std::uniform_int_distribution<uint64_t> Dist(
-      UINT64_C(0), static_cast<uint64_t>(C.size() - 1));
-  for (size_t I = 0; I < 4; I++) {
-    bool Ok;
-    do {
-      Ok = true;
-      Secret[I] = 0;
-      for (size_t J = 0; J < 64; J += 8) {
-        Secret[I] |= static_cast<uint64_t>(C[Dist(WasmEdge::Hash::RandEngine)])
-                     << J;
-      }
-      if (Secret[I] % 2 == 0) {
-        Ok = false;
-        continue;
-      }
-      for (size_t J = 0; J < I; J++) {
-        if (popcount(Secret[J] ^ Secret[I]) != 32) {
-          Ok = false;
-          break;
-        }
-      }
-      if (Ok && !isPrime(Secret[I]))
-        Ok = false;
-    } while (!Ok);
-  }
-  return Secret;
-}
-
-inline uint64_t read(WasmEdge::Span<const std::byte, 8> Data) noexcept {
-  uint64_t V;
-  std::memcpy(&V, Data.data(), 8);
-  if constexpr (WasmEdge::Endian::native == WasmEdge::Endian::little) {
-    return V;
-  } else {
-    return WasmEdge::byteswap(V);
-  }
-}
 inline uint64_t read(WasmEdge::Span<const std::byte, 4> Data) noexcept {
   uint32_t V;
   std::memcpy(&V, Data.data(), 4);
@@ -198,79 +16,62 @@ inline uint64_t read(WasmEdge::Span<const std::byte, 4> Data) noexcept {
   }
 }
 
-inline uint64_t read_small(WasmEdge::Span<const std::byte> Data) noexcept {
-  return (static_cast<uint64_t>(Data[0]) << 56) |
-         (static_cast<uint64_t>(Data[Data.size() >> 1]) << 32) |
-         static_cast<uint64_t>(Data[Data.size() - 1]);
-}
-
-static const std::array<uint64_t, 4> Secret = generate();
+static const uint64_t UseSeed = WasmEdge::Hash::RandEngine();
 
 } // namespace
 
 namespace WasmEdge::Hash {
 
-WASMEDGE_EXPORT uint64_t Hash::rapidHash(Span<const std::byte> Data) noexcept {
-  const auto Size = Data.size();
-  uint64_t Seed = Secret[3];
-  Seed ^= rapidMix(Seed ^ Secret[0], Secret[1]) ^ Size;
-  uint64_t A, B;
-  if (likely(Data.size() <= 16)) {
-    if (likely(Data.size() >= 4)) {
-      A = (read(Data.first<4>()) << 32) | read(Data.last<4>());
-      const uint64_t delta = ((Data.size() & 24) >> (Data.size() >> 3));
-      B = (read(Data.subspan(delta).first<4>()) << 32) |
-          read(Data.last(4 + delta).first<4>());
-    } else if (likely(Data.size() > 0)) {
-      A = read_small(Data);
-      B = 0;
-    } else {
-      A = B = 0;
-    }
-  } else {
-    if (unlikely(Data.size() > 48)) {
-      uint64_t See1 = Seed, See2 = Seed;
-      while (likely(Data.size() >= 96)) {
-        Seed = rapidMix(read(Data.first<8>()) ^ Secret[0],
-                        read(Data.subspan<8>().first<8>()) ^ Seed);
-        See1 = rapidMix(read(Data.subspan<16>().first<8>()) ^ Secret[1],
-                        read(Data.subspan<24>().first<8>()) ^ See1);
-        See2 = rapidMix(read(Data.subspan<32>().first<8>()) ^ Secret[2],
-                        read(Data.subspan<40>().first<8>()) ^ See2);
-        Seed = rapidMix(read(Data.subspan<48>().first<8>()) ^ Secret[0],
-                        read(Data.subspan<56>().first<8>()) ^ Seed);
-        See1 = rapidMix(read(Data.subspan<64>().first<8>()) ^ Secret[1],
-                        read(Data.subspan<72>().first<8>()) ^ See1);
-        See2 = rapidMix(read(Data.subspan<80>().first<8>()) ^ Secret[2],
-                        read(Data.subspan<88>().first<8>()) ^ See2);
-        Data = Data.subspan<96>();
-      }
-      if (unlikely(Data.size() >= 48)) {
-        Seed = rapidMix(read(Data.first<8>()) ^ Secret[0],
-                        read(Data.subspan<8>().first<8>()) ^ Seed);
-        See1 = rapidMix(read(Data.subspan<16>().first<8>()) ^ Secret[1],
-                        read(Data.subspan<24>().first<8>()) ^ See1);
-        See2 = rapidMix(read(Data.subspan<32>().first<8>()) ^ Secret[2],
-                        read(Data.subspan<40>().first<8>()) ^ See2);
-        Data = Data.subspan<48>();
-      }
+WASMEDGE_EXPORT uint64_t Hash::a5Hash(Span<const std::byte> Data) noexcept {
+  uint64_t Val01 = UINT64_C(0x5555555555555555);
+  uint64_t Val10 = UINT64_C(0xAAAAAAAAAAAAAAAA);
 
-      Seed ^= See1 ^ See2;
-    }
-    if (Data.size() > 16) {
-      Seed = rapidMix(read(Data.first<8>()) ^ Secret[2],
-                      read(Data.subspan<8>().first<8>()) ^ Seed ^ Secret[1]);
-      if (Data.size() > 32)
-        Seed = rapidMix(read(Data.subspan<16>().first<8>()) ^ Secret[2],
-                        read(Data.subspan<24>().first<8>()) ^ Seed);
-    }
-    A = read(Data.last<16>().first<8>());
-    B = read(Data.last<8>());
+  // PI-mantissa seeds XORed with message length.
+  uint64_t Seed1 = UINT64_C(0x243F6A8885A308D3) ^ Data.size();
+  uint64_t Seed2 = UINT64_C(0x452821E638D01377) ^ Data.size();
+
+  // Mix in the per-process seed.
+  a5hashMul128(Seed2 ^ (UseSeed & Val10), Seed1 ^ (UseSeed & Val01), Seed1,
+               Seed2);
+
+  if (Data.size() > 16) {
+    Val01 ^= Seed1;
+    Val10 ^= Seed2;
+
+    do {
+      a5hashMul128(read(Data.first<4>()) << 32 ^
+                       read(Data.subspan<4>().first<4>()) ^ Seed1,
+                   read(Data.subspan<8>().first<4>()) << 32 ^
+                       read(Data.subspan<12>().first<4>()) ^ Seed2,
+                   Seed1, Seed2);
+
+      Data = Data.subspan<16>();
+
+      Seed1 += Val01;
+      Seed2 += Val10;
+    } while (Data.size() > 16);
   }
-  A ^= Secret[1];
-  B ^= Seed;
-  rapidMum(A, B);
-  return rapidMix(A ^ Secret[0] ^ Size, B ^ Secret[1]);
+
+  if (unlikely(Data.size() > 3)) {
+    size_t Mo = Data.size() >> 3;
+
+    Seed1 ^= read(Data.first<4>()) << 32 | read(Data.last<4>());
+    Seed2 ^= read(Data.subspan(Mo * 4).first<4>()) << 32 |
+             read(Data.last(4 + Mo * 4).first<4>());
+  } else if (unlikely(Data.size() != 0)) {
+    // 1-3 bytes.
+    Seed1 ^= static_cast<uint64_t>(Data[0]);
+    if (Data.size() > 1) {
+      Seed1 ^= static_cast<uint64_t>(Data[1]) << 8;
+      if (Data.size() > 2) {
+        Seed1 ^= static_cast<uint64_t>(Data[2]) << 16;
+      }
+    }
+  }
+
+  a5hashMul128(Seed1, Seed2, Seed1, Seed2);
+  a5hashMul128(Val01 ^ Seed1, Seed2, Seed1, Seed2);
+  return Seed1 ^ Seed2;
 }
 
 } // namespace WasmEdge::Hash


### PR DESCRIPTION
Replace rapidhash with a5hash for improved small-key hashing performance (~11.5 vs ~18 cycles for 0-64 byte keys).

Changes:
- Replace rapidMum/rapidMix with a5hashMul128 (128-bit multiply)
- Replace RandomEngine with a5rand two-seed PRNG
- Remove Miller-Rabin secret generation (~200 lines)
- Use fixed PI-mantissa seed constants with per-process randomization
- Rename Hash::rapidHash to Hash::a5Hash