### PR TITLE
fix: use unique_lock in StoreManager::reset() to prevent data race

### DIFF
--- a/include/runtime/storemgr.h
+++ b/include/runtime/storemgr.h
@@ -70,7 +70,7 @@ public:
 
   /// Reset this store manager and unlink all the registered module instances.
   void reset() noexcept {
-    std::shared_lock Lock(Mutex);
+    std::unique_lock Lock(Mutex);
     for (auto &&[Name, ModInst] : NamedMod) {
       (const_cast<Instance::ModuleInstance *>(ModInst))
           ->unlinkStore(this, Name);


### PR DESCRIPTION
## Summary

- `reset()` in `storemgr.h` uses `std::shared_lock` but performs write operations (`unlinkStore` + `NamedMod.clear()`), causing a data race with concurrent readers like `findModule()`
- Changed to `std::unique_lock` to match all other mutating methods (`registerModule`, `unregisterModule`, `registerComponent`)

## Root Cause

`shared_lock` allows concurrent readers while `reset()` is clearing the map. This is undefined behavior — TSAN confirms the race between `clear()` and concurrent `find()` calls.

## Test Plan

- [x] Verified all other write methods in `StoreManager` use `unique_lock`
- [x] Verified `findModule()` (read path) correctly uses `shared_lock`
- [ ] Existing CI tests should pass — this only tightens locking

Fixes #4770