### PR TITLE
feat(wasi_crypto): implement managed keypair generation for EDDSA

### DIFF
--- a/plugins/wasi_crypto/asymmetric_common/ctx.cpp
+++ b/plugins/wasi_crypto/asymmetric_common/ctx.cpp
@@ -164,8 +164,11 @@ Context::secretkeyImport(AsymmetricCommon::Algorithm Alg,
 
 WasiCryptoExpect<__wasi_keypair_t>
 Context::keypairGenerateManaged(__wasi_secrets_manager_t,
-                                AsymmetricCommon::Algorithm,
-                                __wasi_opt_options_t) noexcept {
+                                AsymmetricCommon::Algorithm Alg,
+                                __wasi_opt_options_t OptOptionsHandle) noexcept {
+  if (std::holds_alternative<Signatures::Eddsa>(Alg)) {
+    return keypairGenerate(Alg, OptOptionsHandle);
+  }
   return WasiCryptoUnexpect(__WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
 }
 

--- a/plugins/wasi_crypto/asymmetric_common/ctx.cpp
+++ b/plugins/wasi_crypto/asymmetric_common/ctx.cpp
@@ -162,10 +162,9 @@ Context::secretkeyImport(AsymmetricCommon::Algorithm Alg,
       });
 }
 
-WasiCryptoExpect<__wasi_keypair_t>
-Context::keypairGenerateManaged(__wasi_secrets_manager_t,
-                                AsymmetricCommon::Algorithm Alg,
-                                __wasi_opt_options_t OptOptionsHandle) noexcept {
+WasiCryptoExpect<__wasi_keypair_t> Context::keypairGenerateManaged(
+    __wasi_secrets_manager_t, AsymmetricCommon::Algorithm Alg,
+    __wasi_opt_options_t OptOptionsHandle) noexcept {
   if (std::holds_alternative<Signatures::Eddsa>(Alg)) {
     return keypairGenerate(Alg, OptOptionsHandle);
   }

--- a/test/plugins/wasi_crypto/asymmetric.cpp
+++ b/test/plugins/wasi_crypto/asymmetric.cpp
@@ -646,12 +646,9 @@ TEST_F(WasiCryptoTest, AsymmetricManagedNegative) {
       __WASI_CRYPTO_ERRNO_UNSUPPORTED_ALGORITHM);
 
   // Test with invalid options handle
-  __wasi_opt_options_t InvalidOptionsHandle;
-  InvalidOptionsHandle.tag = __WASI_OPT_OPTIONS_U_SOME;
-  InvalidOptionsHandle.u.some = InvaildHandle;
   WASI_CRYPTO_EXPECT_FAILURE(
       keypairGenerateManaged(1, __WASI_ALGORITHM_TYPE_SIGNATURES, "Ed25519"sv,
-                             InvalidOptionsHandle),
+                             static_cast<__wasi_options_t>(InvaildHandle)),
       __WASI_CRYPTO_ERRNO_INVALID_HANDLE);
 }
 

--- a/test/plugins/wasi_crypto/asymmetric.cpp
+++ b/test/plugins/wasi_crypto/asymmetric.cpp
@@ -28,6 +28,21 @@ TEST_F(WasiCryptoTest, Asymmetric) {
           WASI_CRYPTO_EXPECT_TRUE(keypairClose(KpHandle));
           WASI_CRYPTO_EXPECT_TRUE(publickeyClose(PkHandle));
           WASI_CRYPTO_EXPECT_TRUE(secretkeyClose(SkHandle));
+
+          if (Alg == "Ed25519"sv) {
+            WASI_CRYPTO_EXPECT_SUCCESS(
+                KpMHandle,
+                keypairGenerateManaged(1, AlgType, Alg, std::nullopt));
+            WASI_CRYPTO_EXPECT_SUCCESS(PkMHandle, keypairPublickey(KpMHandle));
+            WASI_CRYPTO_EXPECT_SUCCESS(SkMHandle, keypairSecretkey(KpMHandle));
+            WASI_CRYPTO_EXPECT_TRUE(keypairClose(KpMHandle));
+            WASI_CRYPTO_EXPECT_TRUE(publickeyClose(PkMHandle));
+            WASI_CRYPTO_EXPECT_TRUE(secretkeyClose(SkMHandle));
+          } else {
+            WASI_CRYPTO_EXPECT_FAILURE(
+                keypairGenerateManaged(1, AlgType, Alg, std::nullopt),
+                __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
+          }
         }
 
         // Encoding checking.
@@ -600,6 +615,44 @@ TEST_F(WasiCryptoTest, Asymmetric) {
         "3e28cd3c23ecbe66098bd0a029a8792ae5259282c116b32a28908aaa1bcf"
         "ef61d9529f"_u8v}},
       {});
+}
+
+TEST_F(WasiCryptoTest, AsymmetricManagedNegative) {
+  // Test with unsupported algorithm case for managed keypair generation
+  // ECDSA_P256_SHA256 is supported by the plugin but not by
+  // keypair_generate_managed
+  WASI_CRYPTO_EXPECT_FAILURE(
+      keypairGenerateManaged(1, __WASI_ALGORITHM_TYPE_SIGNATURES,
+                             "ECDSA_P256_SHA256"sv, std::nullopt),
+      __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
+
+  // Test with invalid handle / secrets manager misuse
+  // Secrets manager is not implemented, so any handle results in
+  // NOT_IMPLEMENTED for now
+  WASI_CRYPTO_EXPECT_FAILURE(keypairStoreManaged(InvaildHandle, 1, {}),
+                             __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
+
+  // Test with invalid algorithm type
+  // SYMMETRIC algorithm type is not allowed for asymmetric keypair generation
+  WASI_CRYPTO_EXPECT_FAILURE(
+      keypairGenerateManaged(1, __WASI_ALGORITHM_TYPE_SYMMETRIC, "Ed25519"sv,
+                             std::nullopt),
+      __WASI_CRYPTO_ERRNO_INVALID_OPERATION);
+
+  // Test with unsupported algorithm string
+  WASI_CRYPTO_EXPECT_FAILURE(
+      keypairGenerateManaged(1, __WASI_ALGORITHM_TYPE_SIGNATURES, "FooBar"sv,
+                             std::nullopt),
+      __WASI_CRYPTO_ERRNO_UNSUPPORTED_ALGORITHM);
+
+  // Test with invalid options handle
+  __wasi_opt_options_t InvalidOptionsHandle;
+  InvalidOptionsHandle.tag = __WASI_OPT_OPTIONS_U_SOME;
+  InvalidOptionsHandle.u.some = InvaildHandle;
+  WASI_CRYPTO_EXPECT_FAILURE(
+      keypairGenerateManaged(1, __WASI_ALGORITHM_TYPE_SIGNATURES, "Ed25519"sv,
+                             InvalidOptionsHandle),
+      __WASI_CRYPTO_ERRNO_INVALID_HANDLE);
 }
 
 } // namespace WasiCrypto

--- a/test/plugins/wasi_crypto/asymmetric.cpp
+++ b/test/plugins/wasi_crypto/asymmetric.cpp
@@ -215,6 +215,18 @@ TEST_F(WasiCryptoTest, Asymmetric) {
         }
       };
 
+  auto ManagedNegativeCheck = [this](
+                                  __wasi_secrets_manager_t SmHandle,
+                                  __wasi_algorithm_type_e_t AlgType,
+                                  std::string_view Alg,
+                                  std::optional<__wasi_options_t> OptOptions,
+                                  __wasi_crypto_errno_e_t ExpectedError) {
+    SCOPED_TRACE(Alg);
+    WASI_CRYPTO_EXPECT_FAILURE(
+        keypairGenerateManaged(SmHandle, AlgType, Alg, OptOptions),
+        ExpectedError);
+  };
+
   RsaCheck(
       "2048"sv,
       {{__WASI_PUBLICKEY_ENCODING_PEM,
@@ -615,41 +627,14 @@ TEST_F(WasiCryptoTest, Asymmetric) {
         "3e28cd3c23ecbe66098bd0a029a8792ae5259282c116b32a28908aaa1bcf"
         "ef61d9529f"_u8v}},
       {});
-}
 
-TEST_F(WasiCryptoTest, AsymmetricManagedNegative) {
-  // Test with unsupported algorithm case for managed keypair generation
-  // ECDSA_P256_SHA256 is supported by the plugin but not by
-  // keypair_generate_managed
-  WASI_CRYPTO_EXPECT_FAILURE(
-      keypairGenerateManaged(1, __WASI_ALGORITHM_TYPE_SIGNATURES,
-                             "ECDSA_P256_SHA256"sv, std::nullopt),
-      __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
-
-  // Test with invalid handle / secrets manager misuse
-  // Secrets manager is not implemented, so any handle results in
-  // NOT_IMPLEMENTED for now
-  WASI_CRYPTO_EXPECT_FAILURE(keypairStoreManaged(InvaildHandle, 1, {}),
-                             __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
-
-  // Test with invalid algorithm type
-  // SYMMETRIC algorithm type is not allowed for asymmetric keypair generation
-  WASI_CRYPTO_EXPECT_FAILURE(
-      keypairGenerateManaged(1, __WASI_ALGORITHM_TYPE_SYMMETRIC, "Ed25519"sv,
-                             std::nullopt),
-      __WASI_CRYPTO_ERRNO_INVALID_OPERATION);
-
-  // Test with unsupported algorithm string
-  WASI_CRYPTO_EXPECT_FAILURE(
-      keypairGenerateManaged(1, __WASI_ALGORITHM_TYPE_SIGNATURES, "FooBar"sv,
-                             std::nullopt),
-      __WASI_CRYPTO_ERRNO_UNSUPPORTED_ALGORITHM);
-
-  // Test with invalid options handle
-  WASI_CRYPTO_EXPECT_FAILURE(
-      keypairGenerateManaged(1, __WASI_ALGORITHM_TYPE_SIGNATURES, "Ed25519"sv,
-                             static_cast<__wasi_options_t>(InvaildHandle)),
-      __WASI_CRYPTO_ERRNO_INVALID_HANDLE);
+  ManagedNegativeCheck(1, __WASI_ALGORITHM_TYPE_SYMMETRIC, "Ed25519"sv,
+                       std::nullopt, __WASI_CRYPTO_ERRNO_INVALID_OPERATION);
+  ManagedNegativeCheck(1, __WASI_ALGORITHM_TYPE_SIGNATURES, "FooBar"sv,
+                       std::nullopt, __WASI_CRYPTO_ERRNO_UNSUPPORTED_ALGORITHM);
+  ManagedNegativeCheck(1, __WASI_ALGORITHM_TYPE_SIGNATURES, "Ed25519"sv,
+                       static_cast<__wasi_options_t>(InvaildHandle),
+                       __WASI_CRYPTO_ERRNO_INVALID_HANDLE);
 }
 
 } // namespace WasiCrypto

--- a/test/plugins/wasi_crypto/notimplement.cpp
+++ b/test/plugins/wasi_crypto/notimplement.cpp
@@ -22,7 +22,7 @@ TEST_F(WasiCryptoTest, NotImplement) {
                              __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
 
   EXPECT_EQ(keypairGenerateManaged(1, __WASI_ALGORITHM_TYPE_SIGNATURES,
-                                   "Ed25519"sv, std::nullopt)
+                                   "ECDSA_P256_SHA256"sv, std::nullopt)
                 .error(),
             __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
   WASI_CRYPTO_EXPECT_FAILURE(keypairStoreManaged(1, 1, {}),

--- a/test/plugins/wasi_crypto/notimplement.cpp
+++ b/test/plugins/wasi_crypto/notimplement.cpp
@@ -21,10 +21,10 @@ TEST_F(WasiCryptoTest, NotImplement) {
   WASI_CRYPTO_EXPECT_FAILURE(symmetricKeyFromId(1, {}, 1),
                              __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
 
-  EXPECT_EQ(keypairGenerateManaged(1, __WASI_ALGORITHM_TYPE_SIGNATURES,
-                                   "ECDSA_P256_SHA256"sv, std::nullopt)
-                .error(),
-            __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
+  WASI_CRYPTO_EXPECT_FAILURE(
+      keypairGenerateManaged(1, __WASI_ALGORITHM_TYPE_SIGNATURES,
+                             "ECDSA_P256_SHA256"sv, std::nullopt),
+      __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
   WASI_CRYPTO_EXPECT_FAILURE(keypairStoreManaged(1, 1, {}),
                              __WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
   WASI_CRYPTO_EXPECT_FAILURE(keypairReplaceManaged(1, 1, 1),


### PR DESCRIPTION
Closes #4775 

Implement keypairGenerateManaged specifically for the Signatures::Eddsa algorithm in asymmetric_common/ctx.cpp by delegating to the existing keypairGenerate logic.

Update tests in asymmetric.cpp to verify EDDSA managed keypair generation. In notimplement.cpp, replace the Ed25519 test case with ECDSA_P256_SHA256 to maintain a valid test for unimplemented managed keypair generation.

## Description
<!-- Describe your changes here -->

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally. Tested on CI: [link](https://github.com/ShigrafS/WasmEdge/actions/runs/24252920214)

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
