### PR TITLE
fix(api): fix parameter order of VM RegisterModuleFromImportWithAlias

### DIFF
--- a/include/api/wasmedge/wasmedge_vm.h
+++ b/include/api/wasmedge/wasmedge_vm.h
@@ -132,15 +132,15 @@ WASMEDGE_CAPI_EXPORT extern WasmEdge_Result WasmEdge_VMRegisterModuleFromImport(
 /// under the provided ModuleName instead of the module's own name.
 ///
 /// \param Cxt the WasmEdge_VMContext.
-/// \param ImportCxt the WasmEdge_ModuleInstanceContext to register.
 /// \param ModuleName the WasmEdge_String of module name to register as.
+/// \param ImportCxt the WasmEdge_ModuleInstanceContext to register.
 ///
 /// \returns WasmEdge_Result. Call `WasmEdge_ResultGetMessage` for the error
 /// message.
 WASMEDGE_CAPI_EXPORT extern WasmEdge_Result
 WasmEdge_VMRegisterModuleFromImportWithAlias(
-    WasmEdge_VMContext *Cxt, const WasmEdge_ModuleInstanceContext *ImportCxt,
-    const WasmEdge_String ModuleName) WASMEDGE_CAPI_NOEXCEPT;
+    WasmEdge_VMContext *Cxt, const WasmEdge_String ModuleName,
+    const WasmEdge_ModuleInstanceContext *ImportCxt) WASMEDGE_CAPI_NOEXCEPT;
 
 /// Instantiate the WASM module from a WASM file and invoke a function by name.
 ///

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -64,13 +64,13 @@ public:
   }
   Expect<void>
   registerModule(const Runtime::Instance::ModuleInstance &ModInst) {
-    std::unique_lock Lock(Mutex);
-    return unsafeRegisterModule(ModInst);
+    return registerModule(ModInst.getModuleName(), ModInst);
   }
-  Expect<void> registerModule(const Runtime::Instance::ModuleInstance &ModInst,
-                              std::string_view Name) {
+  Expect<void>
+  registerModule(std::string_view Name,
+                 const Runtime::Instance::ModuleInstance &ModInst) {
     std::unique_lock Lock(Mutex);
-    return unsafeRegisterModule(ModInst, Name);
+    return unsafeRegisterModule(Name, ModInst);
   }
 
   /// Rapidly load, validate, instantiate, and run wasm function.
@@ -287,10 +287,8 @@ private:
   Expect<void> unsafeRegisterModule(std::string_view Name,
                                     const AST::Module &Module);
   Expect<void>
-  unsafeRegisterModule(const Runtime::Instance::ModuleInstance &ModInst);
-  Expect<void>
-  unsafeRegisterModule(const Runtime::Instance::ModuleInstance &ModInst,
-                       std::string_view Name);
+  unsafeRegisterModule(std::string_view Name,
+                       const Runtime::Instance::ModuleInstance &ModInst);
 
   Expect<std::vector<std::pair<ValVariant, ValType>>>
   unsafeRunWasmFile(const std::filesystem::path &Path, std::string_view Func,

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -3223,12 +3223,12 @@ WASMEDGE_CAPI_EXPORT WasmEdge_Result WasmEdge_VMRegisterModuleFromImport(
 
 WASMEDGE_CAPI_EXPORT WasmEdge_Result
 WasmEdge_VMRegisterModuleFromImportWithAlias(
-    WasmEdge_VMContext *Cxt, const WasmEdge_ModuleInstanceContext *ImportCxt,
-    const WasmEdge_String ModuleName) noexcept {
+    WasmEdge_VMContext *Cxt, const WasmEdge_String ModuleName,
+    const WasmEdge_ModuleInstanceContext *ImportCxt) noexcept {
   return wrap(
       [&]() {
-        return Cxt->VM.registerModule(*fromModCxt(ImportCxt),
-                                      genStrView(ModuleName));
+        return Cxt->VM.registerModule(genStrView(ModuleName),
+                                      *fromModCxt(ImportCxt));
       },
       EmptyThen, Cxt, ImportCxt);
 }

--- a/lib/vm/vm.cpp
+++ b/lib/vm/vm.cpp
@@ -215,18 +215,8 @@ Expect<void> VM::unsafeRegisterModule(std::string_view Name,
 }
 
 Expect<void>
-VM::unsafeRegisterModule(const Runtime::Instance::ModuleInstance &ModInst) {
-  if (Stage == VMStage::Instantiated) {
-    // When registering module, instantiated module in store will be reset.
-    // Therefore the instantiation should restart.
-    Stage = VMStage::Validated;
-  }
-  return ExecutorEngine.registerModule(StoreRef, ModInst);
-}
-
-Expect<void>
-VM::unsafeRegisterModule(const Runtime::Instance::ModuleInstance &ModInst,
-                         std::string_view Name) {
+VM::unsafeRegisterModule(std::string_view Name,
+                         const Runtime::Instance::ModuleInstance &ModInst) {
   if (Stage == VMStage::Instantiated) {
     // When registering module, instantiated module in store will be reset.
     // Therefore the instantiation should restart.

--- a/test/api/APIAOTCoreTest.cpp
+++ b/test/api/APIAOTCoreTest.cpp
@@ -96,8 +96,8 @@ TEST_P(CoreCompileTest, TestSuites) {
         if (ModInst != nullptr) {
           WasmEdge_String AliasNameStr =
               WasmEdge_StringCreateByCString(AliasName.c_str());
-          WasmEdge_VMRegisterModuleFromImportWithAlias(Ctx->VM, ModInst,
-                                                       AliasNameStr);
+          WasmEdge_VMRegisterModuleFromImportWithAlias(Ctx->VM, AliasNameStr,
+                                                       ModInst);
           WasmEdge_StringDelete(AliasNameStr);
         }
       }

--- a/test/api/APIUnitTest.cpp
+++ b/test/api/APIUnitTest.cpp
@@ -3225,12 +3225,12 @@ TEST(APICoreTest, VM) {
   WasmEdge_String AliasName = WasmEdge_StringCreateByCString("vm-alias-name");
   EXPECT_TRUE(isErrMatch(WasmEdge_ErrCode_WrongVMWorkflow,
                          WasmEdge_VMRegisterModuleFromImportWithAlias(
-                             nullptr, HostModAlias, AliasName)));
+                             nullptr, AliasName, HostModAlias)));
   EXPECT_TRUE(isErrMatch(
       WasmEdge_ErrCode_WrongVMWorkflow,
-      WasmEdge_VMRegisterModuleFromImportWithAlias(VM, nullptr, AliasName)));
+      WasmEdge_VMRegisterModuleFromImportWithAlias(VM, AliasName, nullptr)));
   EXPECT_TRUE(WasmEdge_ResultOK(WasmEdge_VMRegisterModuleFromImportWithAlias(
-      VM, HostModAlias, AliasName)));
+      VM, AliasName, HostModAlias)));
   // The module should be findable by alias name
   WasmEdge_StoreContext *VMStore = WasmEdge_VMGetStoreContext(VM);
   EXPECT_NE(WasmEdge_StoreFindModule(VMStore, AliasName), nullptr);
@@ -3239,7 +3239,7 @@ TEST(APICoreTest, VM) {
       createExternModule("vm-alias-src2");
   EXPECT_TRUE(isErrMatch(WasmEdge_ErrCode_ModuleNameConflict,
                          WasmEdge_VMRegisterModuleFromImportWithAlias(
-                             VM, HostModAlias2, AliasName)));
+                             VM, AliasName, HostModAlias2)));
   WasmEdge_StringDelete(AliasName);
 
   // VM register module from file

--- a/test/api/APIVMCoreTest.cpp
+++ b/test/api/APIVMCoreTest.cpp
@@ -75,8 +75,8 @@ TEST_P(CoreTest, TestSuites) {
         if (ModInst != nullptr) {
           WasmEdge_String AliasNameStr =
               WasmEdge_StringCreateByCString(AliasName.c_str());
-          WasmEdge_VMRegisterModuleFromImportWithAlias(Ctx->VM, ModInst,
-                                                       AliasNameStr);
+          WasmEdge_VMRegisterModuleFromImportWithAlias(Ctx->VM, AliasNameStr,
+                                                       ModInst);
           WasmEdge_StringDelete(AliasNameStr);
         }
       }

--- a/test/executor/ExecutorTest.cpp
+++ b/test/executor/ExecutorTest.cpp
@@ -69,7 +69,7 @@ TEST_P(CoreTest, TestSuites) {
         if (ModInst != nullptr) {
           // Register the shared module under the alias name so that
           // the thread's wasm modules can import it by the expected name.
-          Ctx->VM.registerModule(*ModInst, AliasName);
+          Ctx->VM.registerModule(AliasName, *ModInst);
         }
       }
     }

--- a/test/llvm/LLVMcoreTest.cpp
+++ b/test/llvm/LLVMcoreTest.cpp
@@ -102,7 +102,7 @@ TEST_P(NativeCoreTest, TestSuites) {
       for (const auto &[ParentName, AliasName] : SharedModules) {
         const auto *ModInst = P->VM.getStoreManager().findModule(ParentName);
         if (ModInst != nullptr) {
-          Ctx->VM.registerModule(*ModInst, AliasName);
+          Ctx->VM.registerModule(AliasName, *ModInst);
         }
       }
     }
@@ -272,7 +272,7 @@ TEST_P(CustomWasmCoreTest, TestSuites) {
       for (const auto &[ParentName, AliasName] : SharedModules) {
         const auto *ModInst = P->VM.getStoreManager().findModule(ParentName);
         if (ModInst != nullptr) {
-          Ctx->VM.registerModule(*ModInst, AliasName);
+          Ctx->VM.registerModule(AliasName, *ModInst);
         }
       }
     }
@@ -417,7 +417,7 @@ TEST_P(JITCoreTest, TestSuites) {
       for (const auto &[ParentName, AliasName] : SharedModules) {
         const auto *ModInst = P->VM.getStoreManager().findModule(ParentName);
         if (ModInst != nullptr) {
-          Ctx->VM.registerModule(*ModInst, AliasName);
+          Ctx->VM.registerModule(AliasName, *ModInst);
         }
       }
     }


### PR DESCRIPTION
Reorder ModuleName before ImportCxt in WasmEdge_VMRegisterModuleFromImportWithAlias to be consistent with other VM RegisterModule variants (FromFile, FromBytes, FromASTModule) which all place ModuleName as the second parameter.

Internally, consolidate VM::registerModule by removing the separate unsafeRegisterModule(ModInst) overload and having the single-arg registerModule(ModInst) delegate to registerModule(Name, ModInst).

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Description
<!-- Describe your changes here -->

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
