### PR TITLE
fix(executor): return error when Inst is null

### DIFF
--- a/lib/executor/executor.cpp
+++ b/lib/executor/executor.cpp
@@ -178,7 +178,10 @@ Executor::invoke(const Runtime::Instance::FunctionInstance *FuncInst,
         // already dynamic typed into the top abstract heap type.
         auto *Inst =
             Val.get<RefVariant>().getPtr<Runtime::Instance::CompositeBase>();
-        assuming(Inst);
+        if (unlikely(!Inst)) {
+          return Unexpect(ErrCode::Value::WrongInstanceAddress);
+        }
+
         // The ModInst may be nullptr only in the independent host function
         // instance. Therefore the module instance here must not be nullptr
         // because the independent host function instance cannot be imported and


### PR DESCRIPTION
## Description
Replace `assuming(Inst)` with `Unexpect(..)` return in `executor.cpp.`
https://github.com/WasmEdge/WasmEdge/blob/5cb30cf81f8179650144f73914ae59c5b13eed8c/lib/executor/executor.cpp#L179-L188

In release builds , `assuming(...)` expands to `__builtin_unreachable()`. 
https://github.com/WasmEdge/WasmEdge/blob/5cb30cf81f8179650144f73914ae59c5b13eed8c/include/common/errcode.h#L29-L36
If `Inst` is unexpectedly null, that can lead to undefined behavior instead of a safe error. This change makes the executor return an explicit error in that case.

## Checklist
- [x]  Local Tests Passed: Local tests were run successfully.

## Test
<img width="679" height="810" alt="Screenshot 2026-04-15 at 3 40 16 PM" src="https://github.com/user-attachments/assets/34210599-d1b1-43e2-9a9a-bb16d8cc0747" />