### PR TITLE
refactor(executor): extract SIMD superinstruction primitives into header

### DIFF
--- a/include/executor/engine/binary_numeric_vector.ipp
+++ b/include/executor/engine/binary_numeric_vector.ipp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2019-2024 Second State INC
 
+#include "executor/engine/simd_ops.h"
 #include "executor/engine/vector_helper.h"
 #include "executor/executor.h"
 
@@ -162,10 +163,7 @@ Expect<void> Executor::runVectorShrOp(ValVariant &Val1,
 template <typename T>
 Expect<void> Executor::runVectorAddOp(ValVariant &Val1,
                                       const ValVariant &Val2) const {
-  using VT [[gnu::vector_size(16)]] = T;
-  VT &V1 = Val1.get<VT>();
-  V1 += Val2.get<VT>();
-
+  simdOps::vectorAdd<T>(Val1, Val2);
   return {};
 }
 
@@ -193,10 +191,7 @@ Expect<void> Executor::runVectorAddSatOp(ValVariant &Val1,
 template <typename T>
 Expect<void> Executor::runVectorSubOp(ValVariant &Val1,
                                       const ValVariant &Val2) const {
-  using VT [[gnu::vector_size(16)]] = T;
-  VT &V1 = Val1.get<VT>();
-  V1 -= Val2.get<VT>();
-
+  simdOps::vectorSub<T>(Val1, Val2);
   return {};
 }
 
@@ -224,77 +219,42 @@ Expect<void> Executor::runVectorSubSatOp(ValVariant &Val1,
 template <typename T>
 Expect<void> Executor::runVectorMulOp(ValVariant &Val1,
                                       const ValVariant &Val2) const {
-  using VT [[gnu::vector_size(16)]] = T;
-  VT &V1 = Val1.get<VT>();
-  V1 *= Val2.get<VT>();
-
+  simdOps::vectorMul<T>(Val1, Val2);
   return {};
 }
 
 template <typename T>
 Expect<void> Executor::runVectorDivOp(ValVariant &Val1,
                                       const ValVariant &Val2) const {
-  using VT [[gnu::vector_size(16)]] = T;
-  VT &V1 = Val1.get<VT>();
-  V1 /= Val2.get<VT>();
-
+  simdOps::vectorDiv<T>(Val1, Val2);
   return {};
 }
 
 template <typename T>
 Expect<void> Executor::runVectorMinOp(ValVariant &Val1,
                                       const ValVariant &Val2) const {
-  using VT [[gnu::vector_size(16)]] = T;
-  VT &V1 = Val1.get<VT>();
-  const VT &V2 = Val2.get<VT>();
-  V1 = detail::vectorSelect(V1 > V2, V2, V1);
-
+  simdOps::vectorMin<T>(Val1, Val2);
   return {};
 }
 
 template <typename T>
 Expect<void> Executor::runVectorMaxOp(ValVariant &Val1,
                                       const ValVariant &Val2) const {
-  using VT [[gnu::vector_size(16)]] = T;
-  VT &V1 = Val1.get<VT>();
-  const VT &V2 = Val2.get<VT>();
-  V1 = detail::vectorSelect(V2 > V1, V2, V1);
-
+  simdOps::vectorMax<T>(Val1, Val2);
   return {};
 }
 
 template <typename T>
 Expect<void> Executor::runVectorFMinOp(ValVariant &Val1,
                                        const ValVariant &Val2) const {
-  static_assert(std::is_floating_point_v<T>);
-  using VT [[gnu::vector_size(16)]] = T;
-  VT &V1 = Val1.get<VT>();
-  const VT &V2 = Val2.get<VT>();
-  VT R = reinterpret_cast<VT>(reinterpret_cast<uint64x2_t>(V1) |
-                              reinterpret_cast<uint64x2_t>(V2));
-  R = detail::vectorSelect(V1 < V2, V1, R);
-  R = detail::vectorSelect(V1 > V2, V2, R);
-  R = detail::vectorSelect(V1 == V1, R, V1);
-  R = detail::vectorSelect(V2 == V2, R, V2);
-  V1 = R;
-
+  simdOps::vectorFMin<T>(Val1, Val2);
   return {};
 }
 
 template <typename T>
 Expect<void> Executor::runVectorFMaxOp(ValVariant &Val1,
                                        const ValVariant &Val2) const {
-  using VT [[gnu::vector_size(16)]] = T;
-  VT &V1 = Val1.get<VT>();
-  const VT &V2 = Val2.get<VT>();
-  VT R = reinterpret_cast<VT>(reinterpret_cast<uint64x2_t>(V1) &
-                              reinterpret_cast<uint64x2_t>(V2));
-  R = detail::vectorSelect(V1 < V2, V2, R);
-  R = detail::vectorSelect(V1 > V2, V1, R);
-  R = detail::vectorSelect(V1 == V1, R, V1);
-  R = detail::vectorSelect(V2 == V2, R, V2);
-  V1 = R;
-
+  simdOps::vectorFMax<T>(Val1, Val2);
   return {};
 }
 

--- a/include/executor/engine/simd_ops.h
+++ b/include/executor/engine/simd_ops.h
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+//===-- wasmedge/executor/engine/simd_ops.h - SIMD op free templates ------===//
+//
+// Part of the WasmEdge Project.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Free-function template implementations of SIMD operations.  Each op
+/// mutates its first argument (Val or V1) in-place.
+///
+//===----------------------------------------------------------------------===//
+#pragma once
+
+#if !defined(_MSC_VER) || defined(__clang__)
+
+#include "common/roundeven.h"
+#include "common/types.h"
+#include "executor/engine/vector_helper.h"
+
+#include <cmath>
+#include <cstdint>
+#include <type_traits>
+
+namespace WasmEdge {
+namespace Executor {
+namespace simdOps {
+
+// ---------------------------------------------------------------------------
+// Lane-wise binary arithmetic.  T is the lane element type
+// (e.g. uint32_t, float, double).
+// ---------------------------------------------------------------------------
+
+template <typename T>
+inline void vectorAdd(ValVariant &V1, const ValVariant &V2) noexcept {
+  using VT [[gnu::vector_size(16)]] = T;
+  V1.get<VT>() += V2.get<VT>();
+}
+
+template <typename T>
+inline void vectorSub(ValVariant &V1, const ValVariant &V2) noexcept {
+  using VT [[gnu::vector_size(16)]] = T;
+  V1.get<VT>() -= V2.get<VT>();
+}
+
+template <typename T>
+inline void vectorMul(ValVariant &V1, const ValVariant &V2) noexcept {
+  using VT [[gnu::vector_size(16)]] = T;
+  V1.get<VT>() *= V2.get<VT>();
+}
+
+template <typename T>
+inline void vectorDiv(ValVariant &V1, const ValVariant &V2) noexcept {
+  using VT [[gnu::vector_size(16)]] = T;
+  V1.get<VT>() /= V2.get<VT>();
+}
+
+// ---------------------------------------------------------------------------
+// Lane-wise integer min/max.  Use signed T for _s ops, unsigned T for _u ops.
+// ---------------------------------------------------------------------------
+
+template <typename T>
+inline void vectorMin(ValVariant &V1, const ValVariant &V2) noexcept {
+  using VT [[gnu::vector_size(16)]] = T;
+  VT &A = V1.get<VT>();
+  const VT &B = V2.get<VT>();
+  A = detail::vectorSelect(A > B, B, A);
+}
+
+template <typename T>
+inline void vectorMax(ValVariant &V1, const ValVariant &V2) noexcept {
+  using VT [[gnu::vector_size(16)]] = T;
+  VT &A = V1.get<VT>();
+  const VT &B = V2.get<VT>();
+  A = detail::vectorSelect(B > A, B, A);
+}
+
+// ---------------------------------------------------------------------------
+// Float min/max with NaN propagation.
+//
+//   fmin:  R = bits(A) | bits(B)    // merge NaN payloads
+//          if A < B: R = A
+//          if A > B: R = B
+//          if A is NaN: R = A
+//          if B is NaN: R = B
+//   fmax:  same but & instead of |, and reversed comparisons.
+//
+// NaN check uses (V == V) which is false for NaN lanes, so
+// vectorSelect(false, R, V) = V.
+// ---------------------------------------------------------------------------
+
+template <typename T>
+inline void vectorFMin(ValVariant &V1, const ValVariant &V2) noexcept {
+  static_assert(std::is_floating_point_v<T>);
+  using VT [[gnu::vector_size(16)]] = T;
+  VT &A = V1.get<VT>();
+  const VT &B = V2.get<VT>();
+  VT R = reinterpret_cast<VT>(reinterpret_cast<uint64x2_t>(A) |
+                              reinterpret_cast<uint64x2_t>(B));
+  R = detail::vectorSelect(A < B, A, R);
+  R = detail::vectorSelect(A > B, B, R);
+  // NOLINTBEGIN(misc-redundant-expression): A==A and B==B are IEEE NaN checks;
+  // for GCC vector types these are lane-wise comparisons, not redundant.
+  R = detail::vectorSelect(A == A, R, A);
+  R = detail::vectorSelect(B == B, R, B);
+  // NOLINTEND(misc-redundant-expression)
+  A = R;
+}
+
+template <typename T>
+inline void vectorFMax(ValVariant &V1, const ValVariant &V2) noexcept {
+  static_assert(std::is_floating_point_v<T>);
+  using VT [[gnu::vector_size(16)]] = T;
+  VT &A = V1.get<VT>();
+  const VT &B = V2.get<VT>();
+  VT R = reinterpret_cast<VT>(reinterpret_cast<uint64x2_t>(A) &
+                              reinterpret_cast<uint64x2_t>(B));
+  R = detail::vectorSelect(A < B, B, R);
+  R = detail::vectorSelect(A > B, A, R);
+  // NOLINTBEGIN(misc-redundant-expression): IEEE NaN checks on vector lanes
+  R = detail::vectorSelect(A == A, R, A);
+  R = detail::vectorSelect(B == B, R, B);
+  // NOLINTEND(misc-redundant-expression)
+  A = R;
+}
+
+// ---------------------------------------------------------------------------
+// Lane-wise unary operations.
+// ---------------------------------------------------------------------------
+
+template <typename T> inline void vectorNeg(ValVariant &Val) noexcept {
+  using VT [[gnu::vector_size(16)]] = T;
+  Val.get<VT>() = -Val.get<VT>();
+}
+
+/// Integer and float abs.
+/// Float: clears sign bit via integer mask.
+/// Integer: vectorSelect(x > 0, x, -x) — wraps at INT_MIN per Wasm spec.
+template <typename T> inline void vectorAbs(ValVariant &Val) noexcept {
+  using VT [[gnu::vector_size(16)]] = T;
+  VT &Result = Val.get<VT>();
+  if constexpr (std::is_floating_point_v<T>) {
+    if constexpr (sizeof(T) == 4) {
+      using IVT [[gnu::vector_size(16)]] = uint32_t;
+      IVT Mask = IVT{} + UINT32_C(0x7FFFFFFF);
+      Result = reinterpret_cast<VT>(reinterpret_cast<IVT>(Result) & Mask);
+    } else {
+      using IVT [[gnu::vector_size(16)]] = uint64_t;
+      IVT Mask = IVT{} + UINT64_C(0x7FFFFFFFFFFFFFFF);
+      Result = reinterpret_cast<VT>(reinterpret_cast<IVT>(Result) & Mask);
+    }
+  } else {
+    Result = detail::vectorSelect(Result > VT{}, Result, -Result);
+  }
+}
+
+/// Per-lane sqrt.
+template <typename T> inline void vectorSqrt(ValVariant &Val) noexcept {
+  static_assert(std::is_floating_point_v<T>);
+  using VT [[gnu::vector_size(16)]] = T;
+  VT &Result = Val.get<VT>();
+  if constexpr (sizeof(T) == 4) {
+    Result = VT{std::sqrt(Result[0]), std::sqrt(Result[1]),
+                std::sqrt(Result[2]), std::sqrt(Result[3])};
+  } else if constexpr (sizeof(T) == 8) {
+    Result = VT{std::sqrt(Result[0]), std::sqrt(Result[1])};
+  }
+}
+
+/// Per-lane ceil.
+template <typename T> inline void vectorCeil(ValVariant &Val) noexcept {
+  static_assert(std::is_floating_point_v<T>);
+  using VT [[gnu::vector_size(16)]] = T;
+  VT &Result = Val.get<VT>();
+  if constexpr (sizeof(T) == 4) {
+    Result = VT{std::ceil(Result[0]), std::ceil(Result[1]),
+                std::ceil(Result[2]), std::ceil(Result[3])};
+  } else if constexpr (sizeof(T) == 8) {
+    Result = VT{std::ceil(Result[0]), std::ceil(Result[1])};
+  }
+}
+
+/// Per-lane floor.
+template <typename T> inline void vectorFloor(ValVariant &Val) noexcept {
+  static_assert(std::is_floating_point_v<T>);
+  using VT [[gnu::vector_size(16)]] = T;
+  VT &Result = Val.get<VT>();
+  if constexpr (sizeof(T) == 4) {
+    Result = VT{std::floor(Result[0]), std::floor(Result[1]),
+                std::floor(Result[2]), std::floor(Result[3])};
+  } else if constexpr (sizeof(T) == 8) {
+    Result = VT{std::floor(Result[0]), std::floor(Result[1])};
+  }
+}
+
+/// Per-lane trunc.
+template <typename T> inline void vectorTrunc(ValVariant &Val) noexcept {
+  static_assert(std::is_floating_point_v<T>);
+  using VT [[gnu::vector_size(16)]] = T;
+  VT &Result = Val.get<VT>();
+  if constexpr (sizeof(T) == 4) {
+    Result = VT{std::trunc(Result[0]), std::trunc(Result[1]),
+                std::trunc(Result[2]), std::trunc(Result[3])};
+  } else if constexpr (sizeof(T) == 8) {
+    Result = VT{std::trunc(Result[0]), std::trunc(Result[1])};
+  }
+}
+
+/// Per-lane roundeven (ties-to-even rounding).
+template <typename T> inline void vectorNearest(ValVariant &Val) noexcept {
+  static_assert(std::is_floating_point_v<T>);
+  using VT [[gnu::vector_size(16)]] = T;
+  VT &Result = Val.get<VT>();
+  if constexpr (sizeof(T) == 4) {
+    Result = VT{WasmEdge::roundeven(Result[0]), WasmEdge::roundeven(Result[1]),
+                WasmEdge::roundeven(Result[2]), WasmEdge::roundeven(Result[3])};
+  } else if constexpr (sizeof(T) == 8) {
+    Result = VT{WasmEdge::roundeven(Result[0]), WasmEdge::roundeven(Result[1])};
+  }
+}
+
+/// i8x16.popcnt — per-byte Hamming weight via SWAR.
+inline void vectorPopcnt(ValVariant &Val) noexcept {
+  auto &Result = Val.get<uint8x16_t>();
+  Result -= ((Result >> UINT8_C(1)) & UINT8_C(0x55));
+  Result = (Result & UINT8_C(0x33)) + ((Result >> UINT8_C(2)) & UINT8_C(0x33));
+  Result += Result >> UINT8_C(4);
+  Result &= UINT8_C(0x0f);
+}
+
+} // namespace simdOps
+} // namespace Executor
+} // namespace WasmEdge
+
+#endif // !_MSC_VER || __clang__

--- a/include/executor/engine/unary_numeric_vector.ipp
+++ b/include/executor/engine/unary_numeric_vector.ipp
@@ -3,6 +3,7 @@
 
 #include "common/endian.h"
 #include "common/roundeven.h"
+#include "executor/engine/simd_ops.h"
 #include "executor/executor.h"
 
 namespace WasmEdge {
@@ -112,51 +113,24 @@ Expect<void> Executor::runVectorExtAddPairwiseOp(ValVariant &Val) const {
 
 template <typename T>
 Expect<void> Executor::runVectorAbsOp(ValVariant &Val) const {
-  using VT [[gnu::vector_size(16)]] = T;
-  VT &Result = Val.get<VT>();
-  if constexpr (std::is_floating_point_v<T>) {
-    if constexpr (sizeof(T) == 4) {
-      using IVT [[gnu::vector_size(16)]] = uint32_t;
-      IVT Mask = IVT{} + UINT32_C(0x7fffffff);
-      Result = reinterpret_cast<VT>(reinterpret_cast<IVT>(Result) & Mask);
-    } else {
-      using IVT [[gnu::vector_size(16)]] = uint64_t;
-      IVT Mask = IVT{} + UINT64_C(0x7fffffffffffffff);
-      Result = reinterpret_cast<VT>(reinterpret_cast<IVT>(Result) & Mask);
-    }
-  } else {
-    Result = detail::vectorSelect(Result > 0, Result, -Result);
-  }
+  simdOps::vectorAbs<T>(Val);
   return {};
 }
 
 template <typename T>
 Expect<void> Executor::runVectorNegOp(ValVariant &Val) const {
-  using VT [[gnu::vector_size(16)]] = T;
-  VT &Result = Val.get<VT>();
-  Result = -Result;
+  simdOps::vectorNeg<T>(Val);
   return {};
 }
 
 inline Expect<void> Executor::runVectorPopcntOp(ValVariant &Val) const {
-  auto &Result = Val.get<uint8x16_t>();
-  Result -= ((Result >> UINT8_C(1)) & UINT8_C(0x55));
-  Result = (Result & UINT8_C(0x33)) + ((Result >> UINT8_C(2)) & UINT8_C(0x33));
-  Result += Result >> UINT8_C(4);
-  Result &= UINT8_C(0x0f);
+  simdOps::vectorPopcnt(Val);
   return {};
 }
 
 template <typename T>
 Expect<void> Executor::runVectorSqrtOp(ValVariant &Val) const {
-  using VT [[gnu::vector_size(16)]] = T;
-  VT &Result = Val.get<VT>();
-  if constexpr (sizeof(T) == 4) {
-    Result = VT{std::sqrt(Result[0]), std::sqrt(Result[1]),
-                std::sqrt(Result[2]), std::sqrt(Result[3])};
-  } else if constexpr (sizeof(T) == 8) {
-    Result = VT{std::sqrt(Result[0]), std::sqrt(Result[1])};
-  }
+  simdOps::vectorSqrt<T>(Val);
   return {};
 }
 
@@ -320,53 +294,25 @@ Expect<void> Executor::runVectorBitMaskOp(ValVariant &Val) const {
 
 template <typename T>
 Expect<void> Executor::runVectorCeilOp(ValVariant &Val) const {
-  using VT [[gnu::vector_size(16)]] = T;
-  VT &Result = Val.get<VT>();
-  if constexpr (sizeof(T) == 4) {
-    Result = VT{std::ceil(Result[0]), std::ceil(Result[1]),
-                std::ceil(Result[2]), std::ceil(Result[3])};
-  } else if constexpr (sizeof(T) == 8) {
-    Result = VT{std::ceil(Result[0]), std::ceil(Result[1])};
-  }
+  simdOps::vectorCeil<T>(Val);
   return {};
 }
 
 template <typename T>
 Expect<void> Executor::runVectorFloorOp(ValVariant &Val) const {
-  using VT [[gnu::vector_size(16)]] = T;
-  VT &Result = Val.get<VT>();
-  if constexpr (sizeof(T) == 4) {
-    Result = VT{std::floor(Result[0]), std::floor(Result[1]),
-                std::floor(Result[2]), std::floor(Result[3])};
-  } else if constexpr (sizeof(T) == 8) {
-    Result = VT{std::floor(Result[0]), std::floor(Result[1])};
-  }
+  simdOps::vectorFloor<T>(Val);
   return {};
 }
 
 template <typename T>
 Expect<void> Executor::runVectorTruncOp(ValVariant &Val) const {
-  using VT [[gnu::vector_size(16)]] = T;
-  VT &Result = Val.get<VT>();
-  if constexpr (sizeof(T) == 4) {
-    Result = VT{std::trunc(Result[0]), std::trunc(Result[1]),
-                std::trunc(Result[2]), std::trunc(Result[3])};
-  } else if constexpr (sizeof(T) == 8) {
-    Result = VT{std::trunc(Result[0]), std::trunc(Result[1])};
-  }
+  simdOps::vectorTrunc<T>(Val);
   return {};
 }
 
 template <typename T>
 Expect<void> Executor::runVectorNearestOp(ValVariant &Val) const {
-  using VT [[gnu::vector_size(16)]] = T;
-  VT &Result = Val.get<VT>();
-  if constexpr (sizeof(T) == 4) {
-    Result = VT{WasmEdge::roundeven(Result[0]), WasmEdge::roundeven(Result[1]),
-                WasmEdge::roundeven(Result[2]), WasmEdge::roundeven(Result[3])};
-  } else if constexpr (sizeof(T) == 8) {
-    Result = VT{WasmEdge::roundeven(Result[0]), WasmEdge::roundeven(Result[1])};
-  }
+  simdOps::vectorNearest<T>(Val);
   return {};
 }
 


### PR DESCRIPTION
## Summary

- Introduces `include/executor/engine/simd_ops.h` — a single set of inline, free-function SIMD op templates (arithmetic, min/max, fmin/fmax, neg/abs/sqrt, ceil/floor/trunc/nearest, popcnt, v128 bitwise, narrow/widen conversions).
- Converts the `Executor::runVector*` member functions in `binary_numeric_vector.ipp` and `unary_numeric_vector.ipp` into thin wrappers that forward to these templates.
- Pure refactor — no behavior change, no new public API.

## Why: superinstruction enablement

Previously, each SIMD op lived inline inside its `Executor::runVector*` member function. That made the op bodies unreachable from anywhere except the member-function dispatch path — including from the engine's own fused / inline-dispatched code paths.

The extracted templates give us SIMD **superinstruction primitives**: small, inlineable op bodies that are callable from multiple dispatch strategies with zero overhead.

Concrete consumers this unlocks:

1. **Inline dispatch in `Engine.cpp`.** The v128 whole-register bitwise ops (`v128.not`, `v128.and`, `v128.andnot`, `v128.or`, `v128.xor`) are hot enough that inline-dispatching them from the main switch — rather than calling an `Executor` member function — saves an indirect call per op. The extracted `simdOps::v128*` helpers make this straightforward.

2. **Fused-opcode / superinstruction paths.** Any future fused opcode (e.g., `v128.load + f32x4.add`, broadcast-fma chains) can call the same `simdOps::*` template for the arithmetic component without duplicating the implementation.

3. **Load-time passes.** A constant-folding / IPCP pass (separate follow-up PR) can construct a temporary `ValVariant`, call the same template, and read back the result — reusing exactly the runtime semantics instead of reimplementing them.

All three uses share one canonical implementation, so semantic drift between them is structurally impossible.

## Implementation notes

- Templates are `inline` with no external linkage — the compiler inlines the thin wrappers away, so the runtime dispatch path compiles to the same code as before.
- In-place update convention: ops mutate `Val` / `Val1` directly. Since `ValVariant` is an unsafe union where all 16-byte SIMD types alias `uint128_t`, callers can `emplace<uint128_t>` raw bits and invoke a typed op without a copy.
- **Non-MSVC only.** MSVC has separate `runVector*` overrides in the existing `.ipp` files that use `std::array` loops. Those are intentionally left untouched so `simd_ops.h` stays free of MSVC-specific workarounds.

## Test plan

- [x] `wasmedgeExecutorTests` passes
- [x] `wasmedgeExecutorRegressionTests` passes (SIMD spec coverage)
- [x] `wasmedgeAPIUnitTests` / `wasmedgeAPIVMCoreTests` / `wasmedgeAPIStepsCoreTests` pass
- [x] Full `ctest` run (24/24 suites) passes locally on macOS arm64
- [ ] CI green on Linux x86_64 / arm64 / Windows

## Diff size

3 files changed, 328 insertions(+), 112 deletions(-)