### PR TITLE
fix(wasi): split fcntl calls to prevent android FORTIFY crash

### DIFF
--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -1511,6 +1511,25 @@ static void sigevCallback(union sigval Value) noexcept {
   const uint64_t One = 1;
   ::write(Value.sival_int, &One, sizeof(One));
 }
+
+WasiExpect<void> setTimerPipeFlags(int Fd) noexcept {
+  const int FdFlags = ::fcntl(Fd, F_GETFD);
+  if (unlikely(FdFlags < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  const int StatusFlags = ::fcntl(Fd, F_GETFL);
+  if (unlikely(StatusFlags < 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  if (unlikely(::fcntl(Fd, F_SETFD, FdFlags | FD_CLOEXEC) != 0 ||
+               ::fcntl(Fd, F_SETFL, StatusFlags | O_NONBLOCK) != 0)) {
+    return WasiUnexpect(fromErrNo(errno));
+  }
+
+  return {};
+}
 } // namespace
 
 WasiExpect<void> Poller::Timer::create() noexcept {
@@ -1532,11 +1551,10 @@ WasiExpect<void> Poller::Timer::create() noexcept {
     Event.sigev_value.sival_int = Notify.Fd;
     Event.sigev_notify_attributes = nullptr;
 
-    if (unlikely(::fcntl(Fd, F_SETFD, FD_CLOEXEC) != 0 ||
-                 ::fcntl(Fd, F_SETFL, O_NONBLOCK) != 0 ||
-                 ::fcntl(Notify.Fd, F_SETFD, FD_CLOEXEC) != 0 ||
-                 ::fcntl(Notify.Fd, F_SETFL, O_NONBLOCK) != 0 ||
-                 ::timer_create(toClockId(Clock), &Event, &TId) < 0)) {
+    EXPECTED_TRY(setTimerPipeFlags(Fd));
+    EXPECTED_TRY(setTimerPipeFlags(Notify.Fd));
+
+    if (unlikely(::timer_create(toClockId(Clock), &Event, &TId) < 0)) {
       return WasiUnexpect(fromErrNo(errno));
     }
   }

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -1532,8 +1532,10 @@ WasiExpect<void> Poller::Timer::create() noexcept {
     Event.sigev_value.sival_int = Notify.Fd;
     Event.sigev_notify_attributes = nullptr;
 
-    if (unlikely(::fcntl(Fd, F_SETFD, O_NONBLOCK | FD_CLOEXEC) != 0 ||
-                 ::fcntl(Notify.Fd, F_SETFD, O_NONBLOCK | FD_CLOEXEC) != 0 ||
+    if (unlikely(::fcntl(Fd, F_SETFD, FD_CLOEXEC) != 0 ||
+                 ::fcntl(Fd, F_SETFL, O_NONBLOCK) != 0 ||
+                 ::fcntl(Notify.Fd, F_SETFD, FD_CLOEXEC) != 0 ||
+                 ::fcntl(Notify.Fd, F_SETFL, O_NONBLOCK) != 0 ||
                  ::timer_create(toClockId(Clock), &Event, &TId) < 0)) {
       return WasiUnexpect(fromErrNo(errno));
     }

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -1513,17 +1513,12 @@ static void sigevCallback(union sigval Value) noexcept {
 }
 
 WasiExpect<void> setTimerPipeFlags(int Fd) noexcept {
-  const int FdFlags = ::fcntl(Fd, F_GETFD);
-  if (unlikely(FdFlags < 0)) {
-    return WasiUnexpect(fromErrNo(errno));
-  }
-
   const int StatusFlags = ::fcntl(Fd, F_GETFL);
   if (unlikely(StatusFlags < 0)) {
     return WasiUnexpect(fromErrNo(errno));
   }
 
-  if (unlikely(::fcntl(Fd, F_SETFD, FdFlags | FD_CLOEXEC) != 0 ||
+  if (unlikely(::fcntl(Fd, F_SETFD, FD_CLOEXEC) != 0 ||
                ::fcntl(Fd, F_SETFL, StatusFlags | O_NONBLOCK) != 0)) {
     return WasiUnexpect(fromErrNo(errno));
   }


### PR DESCRIPTION
## Description

This change fixes a fatal crash encountered on Android when using WASI timers. I found that the runtime was aborting with a libc FORTIFY error in inode-linux.cpp because we were trying to set the O_NONBLOCK status flag using the F_SETFD command. While this sometimes passes on glibc, Android’s Bionic libc is stricter and requires status flags to be set specifically via F_SETFL. I've split these into two separate fcntl calls to follow the POSIX standard correctly, which stops the crash while keeping the intended non-blocking and close-on-exec behavior.

Fixes: #4426 

## Checklist

[x] -  DCO Signed-off: All commits are signed-off (git commit -s).
[x] - Commit Messages: Verified that the message meets Conventional Commit standards.
[x] - Local Tests Passed: Successfully completed a full build and verified core tests locally.

## Test Evidence

I performed a clean local build and verified that the core runtime and WASI host tests passed without issues:

```
[ 91%] Built target wasmedge
[ 95%] Built target wasmedgeAPITestHelpers
[ 98%] Built target wasmedgeAPIUnitTests
[100%] Built target wasmedgeAPIPerformanceTests
Build and local verification completed with exit code: 0 
