### PR TITLE
test(component): fix GCC -Wdangling-reference and gate Clang-only flags

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,14 +20,23 @@ else()
   else()
     add_compile_options(
       ${WASMEDGE_CFLAGS}
-      -Wno-language-extension-token
       -Wno-missing-noreturn
-      -Wno-shift-sign-overflow
       -Wno-undef
-      -Wno-unused-member-function
       $<$<COMPILE_LANGUAGE:CXX>:-Wno-zero-as-null-pointer-constant>
       -Wno-deprecated
     )
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      add_compile_options(
+        -Wno-language-extension-token
+        -Wno-shift-sign-overflow
+        -Wno-unused-member-function
+      )
+      if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+        add_compile_options(
+          -Wno-suggest-destructor-override
+        )
+      endif()
+    endif()
     if(WIN32)
       add_compile_options(
         -Wno-padded
@@ -38,7 +47,6 @@ else()
     endif()
     if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
       add_compile_options(
-        -Wno-suggest-destructor-override
         $<$<COMPILE_LANGUAGE:CXX>:-Wno-suggest-override>
       )
     endif()

--- a/test/component/ComponentLoaderTest.cpp
+++ b/test/component/ComponentLoaderTest.cpp
@@ -502,9 +502,10 @@ TEST(ComponentLoaderTest, AsyncI64ResourceRepWithMemory64) {
   ASSERT_EQ((*Comp)->getSections().size(), 1U);
   const auto &Sec = std::get<WasmEdge::AST::Component::TypeSection>(
       (*Comp)->getSections()[0]);
-  ASSERT_EQ(Sec.getContent().size(), 1U);
-  ASSERT_TRUE(Sec.getContent()[0].isResourceType());
-  const auto &RT = Sec.getContent()[0].getResourceType();
+  const auto Content = Sec.getContent();
+  ASSERT_EQ(Content.size(), 1U);
+  ASSERT_TRUE(Content[0].isResourceType());
+  const auto &RT = Content[0].getResourceType();
   EXPECT_TRUE(RT.isAddrI64());
   // For async dtor, the destructor funcidx is mandatory.
   ASSERT_TRUE(RT.getDestructor().has_value());


### PR DESCRIPTION
## Description

Bind the `Span<const DefType>` returned by `TypeSection::getContent()` to a named local before indexing so that the reference chain no longer runs through a temporary, silencing GCC 14's `-Wdangling-reference` false positive seen on manylinux_2_28.

Also gate `-Wno-language-extension-token`, `-Wno-shift-sign-overflow`, `-Wno-unused-member-function`, and `-Wno-suggest-destructor-override` behind a Clang check, since GCC has no such diagnostics and only lists them via the noisy "unrecognized command-line option" note.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
