### PR TITLE
fix(loader): reject non-canonical multi-byte SLEB128 blocktype

### DIFF
--- a/lib/loader/ast/instruction.cpp
+++ b/lib/loader/ast/instruction.cpp
@@ -290,6 +290,14 @@ Expect<void> Loader::loadInstruction(AST::Instruction &Instr) {
     // Read the block return type.
     EXPECTED_TRY(int64_t Code, FMgr.readS33().map_error(ReportError));
     if (Code < 0) {
+      // The empty and valtype cases are encoded as a single-byte SLEB128,
+      // i.e. the decoded value must be in [-64, -1]. Any negative value
+      // smaller than -64 means a non-canonical multi-byte SLEB128 encoding,
+      // which is not a valid blocktype.
+      if (Code < -64) {
+        return logLoadError(ErrCode::Value::MalformedValType,
+                            FMgr.getLastOffset(), ASTNodeAttr::Instruction);
+      }
       TypeCode TypeByte = static_cast<TypeCode>(Code & INT64_C(0x7F));
       if (TypeByte == TypeCode::Epsilon) {
         // Empty case.

--- a/test/loader/instructionTest.cpp
+++ b/test/loader/instructionTest.cpp
@@ -47,6 +47,7 @@ TEST(InstructionTest, LoadBlockControlInstruction) {
   //   4.  Load loop with invalid operations.
   //   5.  Load block with instructions.
   //   6.  Load loop with instructions.
+  //   7.  Load invalid loop with non-canonical multi-byte SLEB128 blocktype.
 
   Vec = {
       0x0AU, // Code section
@@ -131,6 +132,19 @@ TEST(InstructionTest, LoadBlockControlInstruction) {
       0x0BU                // Expression End.
   };
   EXPECT_TRUE(Ldr.parseModule(prefixedVec(Vec)));
+
+  Vec = {
+      0x0AU,        // Code section
+      0x09U,        // Content size = 9
+      0x01U,        // Vector length = 1
+      0x07U,        // Code segment size = 7
+      0x00U,        // Local vec(0)
+      0x03U,        // OpCode Loop.
+      0xC0U, 0x40U, // Non-canonical SLEB128 blocktype.
+      0x0BU,        // OpCode End.
+      0x0BU         // Expression End.
+  };
+  EXPECT_FALSE(Ldr.parseModule(prefixedVec(Vec)));
 }
 
 TEST(InstructionTest, LoadIfElseControlInstruction) {


### PR DESCRIPTION

## Description

The block / loop / if blocktype field is required to be one of:
  * the single byte 0x40 (empty),
  * a single-byte valtype encoding (i32, i64, ...), or
  * a non-negative S33 referring to a function type index.

`readBlockType` only checked `(Code & 0x7F) == 0x40` to detect the empty case after reading the SLEB128. This bit-mask matches every negative value whose low 7 bits happen to be 0x40, so a non-canonical multi-byte encoding such as `0xC0 0x40` (S33 = -8128) was silently accepted as empty even though it is an invalid blocktype.

Mirror the canonical-encoding guard already used in `loadHeapType`: when the decoded S33 is negative it must fit in one byte, i.e. be in [-64, -1]. Anything smaller is reported as MalformedValType.

Also add a regression test covering the `0xC0 0x40` loop blocktype.

close #3480


## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
