### PR TITLE
fix(executor): pin SIMD float add/mul operand order to preserve NaN payload

### DIFF
--- a/include/executor/engine/binary_numeric_vector.ipp
+++ b/include/executor/engine/binary_numeric_vector.ipp
@@ -164,7 +164,28 @@ Expect<void> Executor::runVectorAddOp(ValVariant &Val1,
                                       const ValVariant &Val2) const {
   using VT [[gnu::vector_size(16)]] = T;
   VT &V1 = Val1.get<VT>();
-  V1 += Val2.get<VT>();
+  const VT &V2 = Val2.get<VT>();
+  if constexpr (std::is_floating_point_v<T>) {
+    // LLVM models fadd as commutative at the IR level, so after
+    // inlining/LTO it can swap the operands and emit the equivalent
+    // of `fadd dst, V2, V1`. On ARM64 / SSE2 the first NaN operand's
+    // payload propagates, so a swap silently changes which NaN is
+    // observed -- diverging from other engines (e.g. Wasmtime) for
+    // `f32x4.add` / `f64x2.add` over NaN inputs.
+    //
+    // Pin the operand order by adding lane-by-lane through a
+    // general-register barrier: the empty asm clobbers prevent the
+    // optimizer from re-vectorising or re-ordering the scalar adds.
+    constexpr size_t Lanes = sizeof(VT) / sizeof(T);
+    for (size_t I = 0; I < Lanes; ++I) {
+      T Lhs = V1[I];
+      T Rhs = V2[I];
+      asm volatile("" : "+r"(Lhs), "+r"(Rhs));
+      V1[I] = Lhs + Rhs;
+    }
+  } else {
+    V1 += V2;
+  }
 
   return {};
 }
@@ -226,7 +247,22 @@ Expect<void> Executor::runVectorMulOp(ValVariant &Val1,
                                       const ValVariant &Val2) const {
   using VT [[gnu::vector_size(16)]] = T;
   VT &V1 = Val1.get<VT>();
-  V1 *= Val2.get<VT>();
+  const VT &V2 = Val2.get<VT>();
+  if constexpr (std::is_floating_point_v<T>) {
+    // See the comment in runVectorAddOp: pin operand order via a
+    // lane-by-lane scalar multiply with a register barrier so the
+    // optimizer cannot swap operands and change the NaN payload
+    // propagated by fmul.
+    constexpr size_t Lanes = sizeof(VT) / sizeof(T);
+    for (size_t I = 0; I < Lanes; ++I) {
+      T Lhs = V1[I];
+      T Rhs = V2[I];
+      asm volatile("" : "+r"(Lhs), "+r"(Rhs));
+      V1[I] = Lhs * Rhs;
+    }
+  } else {
+    V1 *= V2;
+  }
 
   return {};
 }


### PR DESCRIPTION
## Description

`f32x4.add` / `f64x2.add` (and the corresponding multiplies) were implemented with the gnu-vector compound-assignment forms

    V1 += Val2.get<VT>();
    V1 *= Val2.get<VT>();

LLVM models `fadd` and `fmul` as commutative at the IR level, so after inlining and LTO clang is free to swap the operands and emit the equivalent of `fadd dst, V2, V1`. On platforms whose hardware add picks the first NaN operand's payload (ARM64 FADD, x86 ADDPD), this swap silently changes which NaN payload propagates -- causing NaN results to differ from other engines such as Wasmtime even though the inputs were `lhs op rhs`.

For example, the module

    (func (result v128)
      v128.const i32x4 0xffffffff 0xffffffff 0xffffffff 0xffffffff
      v128.const i32x4 0xffffffff 0xffffffff 0xffffffff 0xffff60ff
      f64x2.add)

returned the rhs's NaN bits (0xffff60ffffffffff in the high lane) instead of the lhs's bits (0xffffffffffffffff) that Wasmtime and the WAT-level operand order suggest.

Pin the operand order for the floating-point specialisations by adding lane by lane through a general-register asm barrier. The empty `asm volatile("" : "+r"(...))` clobbers prevent the optimiser from re-vectorising the loop or treating the add/mul as commutative, so the lhs's NaN payload is preserved consistently. Integer vector adds/muls keep the original vector form since NaN payload semantics do not apply.


Assisted-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


## Checklist

Before submitting this PR, please ensure the following:

- [ ] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [ ] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
