### PR TITLE
fix(ci): bump Fedora IWYU toolchain to llvm19 + IWYU 0.23

### DIFF
--- a/.github/workflows/IWYU_scan.yml
+++ b/.github/workflows/IWYU_scan.yml
@@ -79,14 +79,14 @@ jobs:
     - name: Install requirements
       run: |
         dnf update -y
-        dnf install -y cmake ninja-build llvm18 llvm18-devel lld18-devel clang18 git file rpm-build dpkg-dev clang18-devel spdlog-devel
-        curl -L -O https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/0.22.zip
-        unzip 0.22.zip
-        patch -p1 -d include-what-you-use-0.22 <<EOF
+        dnf install -y cmake ninja-build llvm19 llvm19-devel lld19-devel clang19 git file rpm-build dpkg-dev clang19-devel spdlog-devel
+        curl -L -O https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/0.23.zip
+        unzip 0.23.zip
+        patch -p1 -d include-what-you-use-0.23 <<EOF
         diff --git a/iwyu.cc b/iwyu.cc
         --- a/iwyu.cc
         +++ b/iwyu.cc
-        @@ -1889,8 +1889,9 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
+        @@ -1911,8 +1911,9 @@ class IwyuBaseAstVisitor : public BaseAstVisitor<Derived> {
                case clang::CK_CPointerToObjCPointerCast:
                case clang::CK_ObjCObjectLValueCast:
                case clang::CK_VectorSplat:
@@ -99,11 +99,11 @@ jobs:
 
                // Kinds for reinterpret_cast and const_cast, which need no full types.
         EOF
-        export LLVM_DIR="/usr/lib64/llvm18/lib/cmake"
-        export Clang_DIR="/usr/lib64/llvm18/lib/cmake/clang"
-        export CC=clang-18
-        export CXX=clang++-18
-        cmake -Bbuild-iwyu -GNinja -DCMAKE_BUILD_TYPE=Release include-what-you-use-0.22
+        export LLVM_DIR="/usr/lib64/llvm19/lib/cmake"
+        export Clang_DIR="/usr/lib64/llvm19/lib/cmake/clang"
+        export CC=clang-19
+        export CXX=clang++-19
+        cmake -Bbuild-iwyu -GNinja -DCMAKE_BUILD_TYPE=Release include-what-you-use-0.23
         cmake --build build-iwyu --target install
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -115,10 +115,10 @@ jobs:
 
     - name: Build and scan WasmEdge with IWYU
       run: |
-        export LLVM_DIR="/usr/lib64/llvm18/lib/cmake"
-        export Clang_DIR="/usr/lib64/llvm18/lib/cmake/clang"
-        export CC=clang-18
-        export CXX=clang++-18
+        export LLVM_DIR="/usr/lib64/llvm19/lib/cmake"
+        export Clang_DIR="/usr/lib64/llvm19/lib/cmake/clang"
+        export CC=clang-19
+        export CXX=clang++-19
         cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug -DWASMEDGE_BUILD_TESTS=ON -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE=include-what-you-use .
         cmake --build build > iwyu_fedora.log
 

--- a/.github/workflows/IWYU_scan.yml
+++ b/.github/workflows/IWYU_scan.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Install requirements
       run: |
         dnf update -y
-        dnf install -y cmake ninja-build llvm19 llvm19-devel lld19-devel clang19 git file rpm-build dpkg-dev clang19-devel spdlog-devel
+        dnf install -y cmake ninja-build llvm19 llvm19-devel lld19 lld19-devel clang19 git file rpm-build dpkg-dev clang19-devel spdlog-devel
         curl -L -O https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/0.23.zip
         unzip 0.23.zip
         patch -p1 -d include-what-you-use-0.23 <<EOF


### PR DESCRIPTION
## Description

Fedora's `latest` tag rolled to Fedora 44, which ships GCC 16's libstdc++. Its <bits/stl_iterator.h> declares an in-class friend operator- whose trailing decltype dereferences the still-incomplete __normal_iterator class; clang <= 18 rejects this construct (fixed in clang 19, llvm/llvm-project#93512). The previous llvm18/clang18 + IWYU 0.22 stack therefore stopped building against the new host headers, breaking every IWYU CI run since 2026-04-29.

Bump the toolchain to llvm19/clang19 + IWYU 0.23 (the IWYU release paired with clang 19 per IWYU's compatibility table). The existing CK_VectorSplat CHECK_UNREACHABLE_ patch is preserved with its hunk header relocated to line 1911 to match the 0.23 source layout.

Verified locally: IWYU 0.23 builds and links cleanly inside fedora:latest with clang-19 after the patch is applied.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
