### PR TITLE
feat(wasi-nn): register async host functions for GGML backend

### DIFF
--- a/plugins/wasi_nn/wasinnfunc.cpp
+++ b/plugins/wasi_nn/wasinnfunc.cpp
@@ -9,6 +9,8 @@
 #include <string>
 #include <string_view>
 
+#include <chrono>
+
 #ifdef WASMEDGE_BUILD_WASI_NN_RPC
 #include "wasi_ephemeral_nn.grpc.pb.h"
 
@@ -748,5 +750,190 @@ WasiNNFinalizeExecCtx::bodyImpl(const Runtime::CallingFrame &Frame,
   }
 }
 
+// --- Async compute extensions (PR #3) ---
+
+Expect<WASINN::ErrNo>
+WasiNNComputeAsync::bodyImpl(const Runtime::CallingFrame &Frame,
+                             uint32_t ContextId) {
+  Env.setEnviron(&Frame);
+#ifdef WASMEDGE_BUILD_WASI_NN_RPC
+  if (Env.NNRPCChannel != nullptr) {
+    spdlog::error(
+        "[WASI-NN] RPC client is not implemented for compute_async"sv);
+    return WASINN::ErrNo::UnsupportedOperation;
+  }
+#endif
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (MemInst == nullptr) {
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
+
+  if (Env.NNContext.size() <= ContextId ||
+      !Env.NNContext[ContextId].isReady()) {
+    spdlog::error("[WASI-NN] compute_async: Context ID {} does not exist."sv,
+                  ContextId);
+    return WASINN::ErrNo::InvalidArgument;
+  }
+
+  auto GraphId = Env.NNContext[ContextId].getGraphId();
+  assuming(Env.NNGraph.size() > GraphId);
+  if (!Env.NNGraph[GraphId].isReady()) {
+    spdlog::error(
+        "[WASI-NN] compute_async: Graph ID {} for context ID {} does not "sv
+        "exist or has released."sv,
+        GraphId, ContextId);
+    return WASINN::ErrNo::InvalidArgument;
+  }
+
+  if (Env.NNContext[ContextId].getBackend() != WASINN::Backend::GGML) {
+    spdlog::error(
+        "[WASI-NN] compute_async: Only GGML backend supports "sv
+        "async compute."sv);
+    return WASINN::ErrNo::UnsupportedOperation;
+  }
+
+#ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
+  // Host-level re-entrancy guard. The backend has its own guard in
+  // compute_engine.cpp, but we reject early here to avoid unnecessary
+  // dispatch overhead.
+  auto &CxtRef = Env.NNContext[ContextId].get<WASINN::GGML::Context>();
+  auto Phase = CxtRef.Async.poll();
+  if (Phase == WASINN::GGML::AsyncContext::Phase::PromptEval ||
+      Phase == WASINN::GGML::AsyncContext::Phase::Generating) {
+    spdlog::error(
+        "[WASI-NN] compute_async: Context ID {} already has an active "sv
+        "computation."sv,
+        ContextId);
+    return WASINN::ErrNo::Busy;
+  }
+
+  // Dispatch to the GGML backend. After PR #2, compute() calls
+  // Async.launch() and returns ErrNo::Success immediately.
+  return WASINN::GGML::compute(Env, ContextId);
+#else
+  return WASINN::ErrNo::UnsupportedOperation;
+#endif
+}
+
+Expect<uint32_t>
+WasiNNComputePoll::bodyImpl(const Runtime::CallingFrame &Frame,
+                            uint32_t ContextId) {
+  Env.setEnviron(&Frame);
+#ifdef WASMEDGE_BUILD_WASI_NN_RPC
+  if (Env.NNRPCChannel != nullptr) {
+    spdlog::error(
+        "[WASI-NN] RPC client is not implemented for compute_poll"sv);
+    return static_cast<uint32_t>(WASINN::ErrNo::UnsupportedOperation);
+  }
+#endif
+
+  if (Env.NNContext.size() <= ContextId ||
+      !Env.NNContext[ContextId].isReady()) {
+    spdlog::error("[WASI-NN] compute_poll: Context ID {} does not exist."sv,
+                  ContextId);
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
+
+  if (Env.NNContext[ContextId].getBackend() != WASINN::Backend::GGML) {
+    spdlog::error(
+        "[WASI-NN] compute_poll: Only GGML backend supports "sv
+        "async compute."sv);
+    return static_cast<uint32_t>(WASINN::ErrNo::UnsupportedOperation);
+  }
+
+#ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
+  auto &CxtRef = Env.NNContext[ContextId].get<WASINN::GGML::Context>();
+  return static_cast<uint32_t>(CxtRef.Async.poll());
+#else
+  return static_cast<uint32_t>(WASINN::ErrNo::UnsupportedOperation);
+#endif
+}
+
+Expect<WASINN::ErrNo>
+WasiNNComputeCancel::bodyImpl(const Runtime::CallingFrame &Frame,
+                              uint32_t ContextId) {
+  Env.setEnviron(&Frame);
+#ifdef WASMEDGE_BUILD_WASI_NN_RPC
+  if (Env.NNRPCChannel != nullptr) {
+    spdlog::error(
+        "[WASI-NN] RPC client is not implemented for compute_cancel"sv);
+    return WASINN::ErrNo::UnsupportedOperation;
+  }
+#endif
+
+  if (Env.NNContext.size() <= ContextId ||
+      !Env.NNContext[ContextId].isReady()) {
+    spdlog::error("[WASI-NN] compute_cancel: Context ID {} does not exist."sv,
+                  ContextId);
+    return WASINN::ErrNo::InvalidArgument;
+  }
+
+  if (Env.NNContext[ContextId].getBackend() != WASINN::Backend::GGML) {
+    spdlog::error(
+        "[WASI-NN] compute_cancel: Only GGML backend supports "sv
+        "async compute."sv);
+    return WASINN::ErrNo::UnsupportedOperation;
+  }
+
+#ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
+  auto &CxtRef = Env.NNContext[ContextId].get<WASINN::GGML::Context>();
+  CxtRef.Async.cancel();
+  return WASINN::ErrNo::Success;
+#else
+  return WASINN::ErrNo::UnsupportedOperation;
+#endif
+}
+
+Expect<WASINN::ErrNo>
+WasiNNComputeWait::bodyImpl(const Runtime::CallingFrame &Frame,
+                            uint32_t ContextId, uint32_t TimeoutMs) {
+  Env.setEnviron(&Frame);
+#ifdef WASMEDGE_BUILD_WASI_NN_RPC
+  if (Env.NNRPCChannel != nullptr) {
+    spdlog::error(
+        "[WASI-NN] RPC client is not implemented for compute_wait"sv);
+    return WASINN::ErrNo::UnsupportedOperation;
+  }
+#endif
+
+  if (Env.NNContext.size() <= ContextId ||
+      !Env.NNContext[ContextId].isReady()) {
+    spdlog::error("[WASI-NN] compute_wait: Context ID {} does not exist."sv,
+                  ContextId);
+    return WASINN::ErrNo::InvalidArgument;
+  }
+
+  if (Env.NNContext[ContextId].getBackend() != WASINN::Backend::GGML) {
+    spdlog::error(
+        "[WASI-NN] compute_wait: Only GGML backend supports "sv
+        "async compute."sv);
+    return WASINN::ErrNo::UnsupportedOperation;
+  }
+
+#ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
+  auto &CxtRef = Env.NNContext[ContextId].get<WASINN::GGML::Context>();
+
+  // No active computation — nothing to wait on.
+  if (!CxtRef.Async.ComputeFuture.valid()) {
+    return WASINN::ErrNo::Success;
+  }
+
+  if (TimeoutMs == 0) {
+    // TimeoutMs == 0: block indefinitely until computation completes.
+    CxtRef.Async.ComputeFuture.wait();
+  } else {
+    if (!CxtRef.Async.waitFor(std::chrono::milliseconds(TimeoutMs))) {
+      return WASINN::ErrNo::Busy;
+    }
+  }
+
+  // Computation finished — propagate the result ErrNo.
+  return CxtRef.Async.ComputeFuture.get();
+#else
+  return WASINN::ErrNo::UnsupportedOperation;
+#endif
+}
+
 } // namespace Host
 } // namespace WasmEdge
+

--- a/plugins/wasi_nn/wasinnfunc.h
+++ b/plugins/wasi_nn/wasinnfunc.h
@@ -186,5 +186,56 @@ private:
                                  uint32_t Context);
 };
 
+// --- Async compute extensions (PR #3) ---
+
+class WasiNNComputeAsync : public WasiNN<WasiNNComputeAsync> {
+public:
+  WasiNNComputeAsync(WASINN::WasiNNEnvironment &HostEnv) : WasiNN(HostEnv) {}
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t Context) {
+    return bodyImpl(Frame, Context).map(castErrNo);
+  }
+
+private:
+  Expect<WASINN::ErrNo> bodyImpl(const Runtime::CallingFrame &Frame,
+                                 uint32_t Context);
+};
+
+class WasiNNComputePoll : public WasiNN<WasiNNComputePoll> {
+public:
+  WasiNNComputePoll(WASINN::WasiNNEnvironment &HostEnv) : WasiNN(HostEnv) {}
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t Context) {
+    return bodyImpl(Frame, Context);
+  }
+
+private:
+  Expect<uint32_t> bodyImpl(const Runtime::CallingFrame &Frame,
+                            uint32_t Context);
+};
+
+class WasiNNComputeCancel : public WasiNN<WasiNNComputeCancel> {
+public:
+  WasiNNComputeCancel(WASINN::WasiNNEnvironment &HostEnv) : WasiNN(HostEnv) {}
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t Context) {
+    return bodyImpl(Frame, Context).map(castErrNo);
+  }
+
+private:
+  Expect<WASINN::ErrNo> bodyImpl(const Runtime::CallingFrame &Frame,
+                                 uint32_t Context);
+};
+
+class WasiNNComputeWait : public WasiNN<WasiNNComputeWait> {
+public:
+  WasiNNComputeWait(WASINN::WasiNNEnvironment &HostEnv) : WasiNN(HostEnv) {}
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t Context,
+                        uint32_t TimeoutMs) {
+    return bodyImpl(Frame, Context, TimeoutMs).map(castErrNo);
+  }
+
+private:
+  Expect<WASINN::ErrNo> bodyImpl(const Runtime::CallingFrame &Frame,
+                                 uint32_t Context, uint32_t TimeoutMs);
+};
+
 } // namespace Host
 } // namespace WasmEdge

--- a/plugins/wasi_nn/wasinnmodule.cpp
+++ b/plugins/wasi_nn/wasinnmodule.cpp
@@ -24,6 +24,11 @@ WasiNNModule::WasiNNModule() : ModuleInstance("wasi_ephemeral_nn") {
   addHostFunc("unload", std::make_unique<WasiNNUnload>(Env));
   addHostFunc("finalize_execution_context",
               std::make_unique<WasiNNFinalizeExecCtx>(Env));
+  // Async compute extensions (PR #3).
+  addHostFunc("compute_async", std::make_unique<WasiNNComputeAsync>(Env));
+  addHostFunc("compute_poll", std::make_unique<WasiNNComputePoll>(Env));
+  addHostFunc("compute_cancel", std::make_unique<WasiNNComputeCancel>(Env));
+  addHostFunc("compute_wait", std::make_unique<WasiNNComputeWait>(Env));
 }
 
 } // namespace Host


### PR DESCRIPTION
# Description

### **Project Title: Asynchronous WASI-NN Execution Bridge (GGML Backend)**

This is the third PR in the 4-part series to implement non-blocking inference for WasmEdge. This PR establishes the ABI (Application Binary Interface) surface, allowing WebAssembly guests to invoke and manage background inference tasks through the host runtime.

**Changes in this PR:**
* **Host Function Registration**: Added 4 new host functions to the `wasi_ephemeral_nn` module in `wasinnmodule.cpp`.
* **Async Dispatch Bridge**: 
    * `compute_async`: A non-blocking trigger that launches the GGML inference pipeline on a background thread and returns immediately.
    * `compute_poll`: A zero-copy function that returns the current `Phase` (Idle, PromptEval, Generating, etc.) as a `u32` to the guest.
    * `compute_cancel`: Triggers the cooperative cancellation flag implemented in PR #2.
    * `compute_wait`: A blocking wait function supporting both timeout-based exits and a "Wait Forever" (0ms) mode.
* **RPC Parity**: Included `#ifdef WASMEDGE_BUILD_WASI_NN_RPC` blocks for all new functions to maintain build consistency across configurations.
* **Backend Safety**: Integrated backend-specific guards to ensure async capabilities are only exposed when the GGML backend is active.


## Checklist

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`).
- [x] **Commit Messages**: Meets [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards (`feat(wasi-nn): register async host functions for GGML backend`).
- [x] **Local Tests Passed**: Verified via `ninja` build on Pop!_OS. Symbols verified via `nm` and `strings`.

## Test Evidence
```bash
# Symbol verification in compiled shared library
strings build/plugins/wasi_nn/libwasmedgePluginWasiNN.so | grep -E "compute_async|compute_poll|compute_cancel|compute_wait"

# Output:
# compute_async
# compute_poll
# compute_cancel
# compute_wait
# [WASI-NN] compute_async: Only GGML backend supports async compute.