### PR TITLE
fix: null funcref crash in proxyCallRef

### DIFF
--- a/lib/executor/engine/proxy.cpp
+++ b/lib/executor/engine/proxy.cpp
@@ -208,6 +208,9 @@ Expect<void> Executor::proxyCallRef(Runtime::StackManager &StackMgr,
                                     const ValVariant *Args,
                                     ValVariant *Rets) noexcept {
   const auto *FuncInst = retrieveFuncRef(Ref);
+  if (unlikely(FuncInst == nullptr)) {
+    return Unexpect(ErrCode::Value::AccessNullFunc);
+  }
   const auto &FuncType = FuncInst->getFuncType();
   const uint32_t ParamsSize =
       static_cast<uint32_t>(FuncType.getParamTypes().size());


### PR DESCRIPTION
### **SUMMARY**

This PR fixes a null dereference in the AOT execution path of `Executor::proxyCallRef()` by adding a missing null check for function references. It aligns AOT behavior with the interpreter, ensuring proper WebAssembly trap handling instead of a host crash.

Primary changes are in `lib/executor/engine/proxy.cpp`.

---

### **FIX**


```cpp
// Before
const auto *FuncInst = retrieveFuncRef(Ref);
const auto &FuncType = FuncInst->getFuncType();  // potential null deref

// After
const auto *FuncInst = retrieveFuncRef(Ref);
if (unlikely(FuncInst == nullptr)) {
  return Unexpect(ErrCode::Value::AccessNullFunc);
}
const auto &FuncType = FuncInst->getFuncType();
```
