### PR TITLE
fix(cli): reject mismatched argument count

### DIFF
--- a/lib/driver/runtimeTool.cpp
+++ b/lib/driver/runtimeTool.cpp
@@ -72,6 +72,14 @@ ToolOnModule(WasmEdge::VM::VM &VM, const std::string &FuncName,
   std::vector<ValVariant> FuncArgs;
   std::vector<ValType> FuncArgTypes;
 
+  const size_t Expected = FuncType.getParamTypes().size();
+  const size_t Got = Opt.Args.value().size() - 1;
+  if (Got < Expected) {
+    spdlog::error("function `{}` expects {} argument(s), got {}"sv, FuncName,
+                  Expected, Got);
+    return EXIT_FAILURE;
+  }
+
   for (size_t I = 0;
        I < FuncType.getParamTypes().size() && I + 1 < Opt.Args.value().size();
        ++I) {
@@ -201,6 +209,14 @@ ToolOnComponent(WasmEdge::VM::VM &VM, const std::string &FuncName,
                 const AST::Component::FuncType &FuncType) noexcept {
   std::vector<ComponentValVariant> FuncArgs;
   std::vector<ComponentValType> FuncArgTypes;
+
+  const size_t Expected = FuncType.getParamList().size();
+  const size_t Got = Opt.Args.value().size() - 1;
+  if (Got < Expected) {
+    spdlog::error("function `{}` expects {} argument(s), got {}"sv, FuncName,
+                  Expected, Got);
+    return EXIT_FAILURE;
+  }
 
   for (size_t I = 0;
        I < FuncType.getParamList().size() && I + 1 < Opt.Args.value().size();

--- a/lib/executor/executor.cpp
+++ b/lib/executor/executor.cpp
@@ -230,6 +230,14 @@ Executor::invoke(const Runtime::Instance::Component::FunctionInstance *FuncInst,
   // TODO: COMPONENT - type matching.
   // const auto &FuncType = FuncInst->getFuncType();
   // const auto PTypes = FuncType.getParamList();
+  const auto &ExpectedFuncType = FuncInst->getFuncType();
+  const size_t ExpectedArity = ExpectedFuncType.getParamList().size();
+  if (Params.size() != ParamTypes.size() || ParamTypes.size() < ExpectedArity) {
+    spdlog::error(ErrCode::Value::FuncSigMismatch);
+    spdlog::error("    expected {} argument(s), got {}"sv, ExpectedArity,
+                  ParamTypes.size());
+    return Unexpect(ErrCode::Value::FuncSigMismatch);
+  }
 
   // Convert the component params into core WASM params.
   auto *ReallocFuncInst = FuncInst->getAllocFunction();


### PR DESCRIPTION
## Description

`wasmedge` accepts mismatched CLI arg counts for the invoked function.
Component lifted calls in release builds **silently return wrong answers with exit 0**.

### Minimal repro

```wat
;; add.wat
(component
  (core module $M
    (func (export "add") (param i32 i32) (result i32)
      (i32.add (local.get 0) (local.get 1))))
  (core instance $m (instantiate $M))
  (alias core export $m "add" (core func $add))
  (type $t (func (param "a" s32) (param "b" s32) (result s32)))
  (func (export "add") (type $t) (canon lift (core func $add))))
```

```bash
wasm-tools parse add.wat -o add.wasm
wasmedge --enable-component add.wasm add 5    # prints "5",  exit 0  ← silent
wasmedge --enable-component add.wasm add      # prints "0",  exit 0  ← silent
wasmedge --enable-component add.wasm add 5 7  # prints "12", exit 0  (correct)
```

Debug build hits `stackmgr.h:68` assertion. 
Release build: `assuming(...)` becomes `__builtin_unreachable()`, optimizer silently produces a wrong answer. `wasmtime`/`wasmer` reject the same input with a clear error and non-zero exit.

### `assuming(...)` is not a release-build guard

under NDEBUG `assuming(R)` reduces to `__builtin_unreachable()` — a debug-only assertion **and** an optimization hint, not a runtime check. 
Treating `assuming` as an input-validation barrier (as this code path implicitly did) means a caller that violates the precondition can produce silently wrong results in release.

### Question

Commit 3 removes a fallback present since at least 2021-10-03  (`14d6d553`): extra argv beyond declared params were silently appended to `FuncArgs` as `u64`. No tests, docs, or CLI flags reference it.

Strict `!=` in commit 2 makes it unreachable, so commit 3 is pure dead-code removal — but if anyone downstream relied on the lenient behavior (e.g. shoving raw stack values for ad-hoc testing), this is a CLI breaking change. 

## Checklist

Before submitting this PR, please ensure the following:

- [ ] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [ ] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
