### PR TITLE
feat(component,validator): validate canonical built-ins

### DIFF
--- a/include/validator/component_context.h
+++ b/include/validator/component_context.h
@@ -36,7 +36,7 @@ public:
     std::vector<std::unordered_map<std::string, ExternalType>>
         CoreInstances;                                 // core:instance
     std::vector<const AST::SubType *> CoreTypes;       // core:type
-    uint32_t CoreFuncCount = 0;                        // core:func
+    std::vector<const AST::SubType *> CoreFuncs;       // core:func
     std::vector<const AST::TableType *> CoreTables;    // core:table
     std::vector<const AST::MemoryType *> CoreMemories; // core:memory
     std::vector<const AST::GlobalType *> CoreGlobals;  // core:global
@@ -55,14 +55,20 @@ public:
     std::vector<std::unordered_map<std::string, InstanceExport>>
         Instances;                                      // instance
     std::vector<const AST::Component::DefType *> Types; // type
-    uint32_t FuncCount = 0;                             // func
-    uint32_t ValueCount = 0;                            // value
+    std::vector<const AST::Component::FuncType *>
+        Funcs;               // func (element i = FuncType* or nullptr)
+    uint32_t ValueCount = 0; // value
 
     // --- Type annotations (keyed by type index) ---
     std::unordered_map<uint32_t, const AST::Component::InstanceType *>
         InstanceTypes;
     std::unordered_map<uint32_t, const AST::Component::ResourceType *>
         ResourceTypes;
+
+    // Type indices that refer to locally-defined resources (not imported / not
+    // aliased from an outer scope). Required by canon resource.new /
+    // resource.rep, which are only valid for locally-defined resources.
+    std::unordered_set<uint32_t> DefinedResources;
 
     // --- Validation state ---
     std::unordered_map<std::string, uint32_t> TypeSubstitutions;
@@ -188,8 +194,15 @@ public:
     V.push_back(ST);
     return Idx;
   }
-  uint32_t addCoreFunc() noexcept {
-    return getCurrentContext().CoreFuncCount++;
+  uint32_t addCoreFunc(const AST::SubType *ST = nullptr) noexcept {
+    auto &V = getCurrentContext().CoreFuncs;
+    uint32_t Idx = static_cast<uint32_t>(V.size());
+    V.push_back(ST);
+    return Idx;
+  }
+  const AST::SubType *getCoreFunc(uint32_t Idx) const noexcept {
+    const auto &V = getCurrentContext().CoreFuncs;
+    return Idx < V.size() ? V[Idx] : nullptr;
   }
 
   uint32_t addCoreTable(const AST::TableType *TT = nullptr) noexcept {
@@ -266,18 +279,13 @@ public:
   // ==========================================================================
 
   uint32_t addType(const AST::Component::DefType *DT = nullptr) noexcept {
-    auto &Ctx = getCurrentContext();
-    uint32_t Idx = static_cast<uint32_t>(Ctx.Types.size());
-    Ctx.Types.push_back(DT);
-    if (DT != nullptr) {
-      if (DT->isInstanceType()) {
-        Ctx.InstanceTypes[Idx] = &DT->getInstanceType();
-      }
-      if (DT->isResourceType()) {
-        Ctx.ResourceTypes[Idx] = &DT->getResourceType();
-      }
-    }
-    return Idx;
+    return addTypeImpl(DT, /*IsLocal=*/true);
+  }
+
+  /// Like addType but marks the resource as imported rather than locally
+  /// defined. Used for resource type imports and outer-alias resources.
+  uint32_t addTypeImported(const AST::Component::DefType *DT) noexcept {
+    return addTypeImpl(DT, /*IsLocal=*/false);
   }
 
   const AST::Component::DefType *getDefType(uint32_t Idx) const noexcept {
@@ -291,6 +299,14 @@ public:
   bool isResourceType(uint32_t Idx) const noexcept {
     const auto &Ctx = getCurrentContext();
     return Ctx.ResourceTypes.find(Idx) != Ctx.ResourceTypes.end();
+  }
+
+  /// Returns true iff the type index is a resource defined in the current
+  /// scope (not imported, not an outer-alias). Required for canon
+  /// resource.new and resource.rep validation.
+  bool isLocalResource(uint32_t Idx) const noexcept {
+    const auto &Ctx = getCurrentContext();
+    return Ctx.DefinedResources.find(Idx) != Ctx.DefinedResources.end();
   }
 
   const AST::Component::InstanceType *
@@ -311,7 +327,16 @@ public:
   // func / value
   // ==========================================================================
 
-  uint32_t addFunc() noexcept { return getCurrentContext().FuncCount++; }
+  uint32_t addFunc(const AST::Component::FuncType *FT = nullptr) noexcept {
+    auto &V = getCurrentContext().Funcs;
+    uint32_t Idx = static_cast<uint32_t>(V.size());
+    V.push_back(FT);
+    return Idx;
+  }
+  const AST::Component::FuncType *getFunc(uint32_t Idx) const noexcept {
+    const auto &V = getCurrentContext().Funcs;
+    return Idx < V.size() ? V[Idx] : nullptr;
+  }
   uint32_t addValue() noexcept { return getCurrentContext().ValueCount++; }
 
   // ==========================================================================
@@ -343,6 +368,24 @@ public:
   }
 
 private:
+  uint32_t addTypeImpl(const AST::Component::DefType *DT,
+                       bool IsLocal) noexcept {
+    auto &Ctx = getCurrentContext();
+    uint32_t Idx = static_cast<uint32_t>(Ctx.Types.size());
+    Ctx.Types.push_back(DT);
+    if (DT != nullptr) {
+      if (DT->isInstanceType()) {
+        Ctx.InstanceTypes[Idx] = &DT->getInstanceType();
+      } else if (DT->isResourceType()) {
+        Ctx.ResourceTypes[Idx] = &DT->getResourceType();
+        if (IsLocal) {
+          Ctx.DefinedResources.insert(Idx);
+        }
+      }
+    }
+    return Idx;
+  }
+
   std::deque<Context> CompCtxs;
 };
 

--- a/include/validator/validator.h
+++ b/include/validator/validator.h
@@ -105,6 +105,20 @@ private:
   Expect<void> validate(const AST::Component::DefType &DType) noexcept;
   // Validate component canonical
   Expect<void> validate(const AST::Component::Canonical &Canon) noexcept;
+  Expect<void>
+  validateCanonOptions(AST::Component::Canonical::OpCode Code,
+                       Span<const AST::Component::CanonOpt> Opts) noexcept;
+  // Per-opcode canonical built-in validators.
+  Expect<void>
+  validateCanonLift(const AST::Component::Canonical &Canon) noexcept;
+  Expect<void>
+  validateCanonLower(const AST::Component::Canonical &Canon) noexcept;
+  Expect<void>
+  validateCanonResourceNew(const AST::Component::Canonical &Canon) noexcept;
+  Expect<void>
+  validateCanonResourceRep(const AST::Component::Canonical &Canon) noexcept;
+  Expect<void>
+  validateCanonResourceDrop(const AST::Component::Canonical &Canon) noexcept;
   // Validate component import
   Expect<void> validate(const AST::Component::Import &Im) noexcept;
   // Validate component export

--- a/lib/validator/component_context.cpp
+++ b/lib/validator/component_context.cpp
@@ -9,7 +9,7 @@ uint32_t
 ComponentContext::Context::getSortIndexSize(Sort::SortType ST) const noexcept {
   switch (ST) {
   case Sort::SortType::Func:
-    return FuncCount;
+    return static_cast<uint32_t>(Funcs.size());
   case Sort::SortType::Value:
     return ValueCount;
   case Sort::SortType::Type:
@@ -27,7 +27,7 @@ uint32_t ComponentContext::Context::getCoreSortIndexSize(
     Sort::CoreSortType ST) const noexcept {
   switch (ST) {
   case Sort::CoreSortType::Func:
-    return CoreFuncCount;
+    return static_cast<uint32_t>(CoreFuncs.size());
   case Sort::CoreSortType::Table:
     return static_cast<uint32_t>(CoreTables.size());
   case Sort::CoreSortType::Memory:

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -1053,40 +1053,390 @@ Validator::validate(const AST::Component::DefType &DType) noexcept {
 
 Expect<void>
 Validator::validate(const AST::Component::Canonical &Canon) noexcept {
-  // Canonical definitions are only validated structurally here — we just
-  // update the appropriate index space. A conformant implementation also
-  // needs to check, per opcode:
-  //
-  //   * canon lift:   `type` indexes a func type; `f` indexes a core func
-  //                   whose signature is the Canonical-ABI flattening of
-  //                   that func type under the supplied options;
-  //                   options are well-formed (at most one string-encoding,
-  //                   memory/realloc required when the ABI needs them,
-  //                   post-return forbidden under async, callback only
-  //                   under async, etc.).
-  //   * canon lower:  `f` indexes a component func; produces a core func
-  //                   whose signature is the Canonical-ABI flattening of
-  //                   `f`'s type under the supplied options.
-  //   * resource.new/drop/rep: `T` indexes a resource type defined in the
-  //                   current component; synthesizes a core func with the
-  //                   appropriate `T.rep` signature.
-  //
-  // None of that is wired up yet; only the index-space bookkeeping is.
   switch (Canon.getOpCode()) {
   case AST::Component::Canonical::OpCode::Lift:
-    CompCtx.addFunc();
-    return {};
+    return validateCanonLift(Canon);
   case AST::Component::Canonical::OpCode::Lower:
+    return validateCanonLower(Canon);
   case AST::Component::Canonical::OpCode::Resource__new:
-  case AST::Component::Canonical::OpCode::Resource__drop:
+    return validateCanonResourceNew(Canon);
   case AST::Component::Canonical::OpCode::Resource__rep:
-    CompCtx.addCoreFunc();
-    return {};
+    return validateCanonResourceRep(Canon);
+  case AST::Component::Canonical::OpCode::Resource__drop:
+  case AST::Component::Canonical::OpCode::Resource__drop_async:
+    return validateCanonResourceDrop(Canon);
   default:
     spdlog::error(ErrCode::Value::ComponentNotImplValidator);
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
     return Unexpect(ErrCode::Value::ComponentNotImplValidator);
   }
+}
+
+Expect<void> Validator::validateCanonOptions(
+    AST::Component::Canonical::OpCode Code,
+    Span<const AST::Component::CanonOpt> Opts) noexcept {
+  using OptCode = AST::Component::CanonOpt::OptCode;
+  using CanonOp = AST::Component::Canonical::OpCode;
+
+  // Only canon lift/lower accept canonical options. Any other built-in
+  // (resource.new/rep/drop, drop_async, ...) must be invoked without options.
+  if (Code != CanonOp::Lift && Code != CanonOp::Lower && !Opts.empty()) {
+    spdlog::error(ErrCode::Value::InvalidCanonOption);
+    spdlog::error(
+        "    canonical options are not allowed for this canon built-in"sv);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidCanonOption);
+  }
+
+  bool HasEncoding = false;
+  bool HasMemory = false;
+  bool HasRealloc = false;
+  bool HasPostReturn = false;
+  bool HasAsync = false;
+  bool HasCallback = false;
+  bool HasAlwaysTaskReturn = false;
+  uint32_t ReallocIdx = 0;
+  uint32_t CallbackIdx = 0;
+  uint32_t PostReturnIdx = 0;
+  uint32_t MemoryIdx = 0;
+
+  auto RejectDup = [&](const char *Name) -> Expect<void> {
+    spdlog::error(ErrCode::Value::InvalidCanonOption);
+    spdlog::error("    canonical option '{}' appears more than once"sv, Name);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidCanonOption);
+  };
+  auto RejectSite = [&](const char *Name) -> Expect<void> {
+    spdlog::error(ErrCode::Value::InvalidCanonOption);
+    spdlog::error(
+        "    canonical option '{}' is not allowed in this canon built-in"sv,
+        Name);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidCanonOption);
+  };
+
+  for (const auto &Opt : Opts) {
+    switch (Opt.getCode()) {
+    case OptCode::Encode_UTF8:
+    case OptCode::Encode_UTF16:
+    case OptCode::Encode_Latin1:
+      if (HasEncoding) {
+        return RejectDup("string-encoding");
+      }
+      HasEncoding = true;
+      break;
+    case OptCode::Memory:
+      if (HasMemory) {
+        return RejectDup("memory");
+      }
+      HasMemory = true;
+      MemoryIdx = Opt.getIndex();
+      break;
+    case OptCode::Realloc:
+      if (HasRealloc) {
+        return RejectDup("realloc");
+      }
+      HasRealloc = true;
+      ReallocIdx = Opt.getIndex();
+      break;
+    case OptCode::PostReturn:
+      if (Code != CanonOp::Lift) {
+        return RejectSite("post-return");
+      }
+      if (HasPostReturn) {
+        return RejectDup("post-return");
+      }
+      HasPostReturn = true;
+      PostReturnIdx = Opt.getIndex();
+      break;
+    case OptCode::Async:
+      if (HasAsync) {
+        return RejectDup("async");
+      }
+      HasAsync = true;
+      break;
+    case OptCode::Callback:
+      if (Code != CanonOp::Lift) {
+        return RejectSite("callback");
+      }
+      if (HasCallback) {
+        return RejectDup("callback");
+      }
+      HasCallback = true;
+      CallbackIdx = Opt.getIndex();
+      break;
+    case OptCode::AlwaysTaskReturn:
+      if (Code != CanonOp::Lift) {
+        return RejectSite("always-task-return");
+      }
+      if (HasAlwaysTaskReturn) {
+        return RejectDup("always-task-return");
+      }
+      HasAlwaysTaskReturn = true;
+      break;
+    default:
+      spdlog::error(ErrCode::Value::UnknownCanonicalOption);
+      spdlog::error("    unknown canonical option code 0x{:02x}"sv,
+                    static_cast<unsigned>(Opt.getCode()));
+      spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+      return Unexpect(ErrCode::Value::UnknownCanonicalOption);
+    }
+  }
+
+  // Structural rules.
+  if (HasPostReturn && HasAsync) {
+    spdlog::error(ErrCode::Value::InvalidCanonOption);
+    spdlog::error(
+        "    canonical options 'post-return' and 'async' are mutually exclusive"sv);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidCanonOption);
+  }
+  if (HasCallback && !HasAsync) {
+    spdlog::error(ErrCode::Value::InvalidCanonOption);
+    spdlog::error("    canonical option 'callback' requires 'async'"sv);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidCanonOption);
+  }
+  if (HasAlwaysTaskReturn && !HasAsync) {
+    spdlog::error(ErrCode::Value::InvalidCanonOption);
+    spdlog::error(
+        "    canonical option 'always-task-return' requires 'async'"sv);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidCanonOption);
+  }
+  if (HasRealloc && !HasMemory) {
+    spdlog::error(ErrCode::Value::InvalidCanonOption);
+    spdlog::error(
+        "    canonical option 'realloc' requires 'memory' to also be specified"sv);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidCanonOption);
+  }
+
+  // Index bounds checks. Core func signature body checks (realloc/callback)
+  // deferred as GAP-C-5b once getCoreFunc signatures are populated.
+  if (HasMemory &&
+      MemoryIdx >= CompCtx.getCoreSortIndexSize(
+                       AST::Component::Sort::CoreSortType::Memory)) {
+    spdlog::error(ErrCode::Value::InvalidIndex);
+    spdlog::error(
+        "    canonical option 'memory': core memory index {} out of bounds"sv,
+        MemoryIdx);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidIndex);
+  }
+  const uint32_t CoreFuncSpaceSize =
+      CompCtx.getCoreSortIndexSize(AST::Component::Sort::CoreSortType::Func);
+  if (HasRealloc && ReallocIdx >= CoreFuncSpaceSize) {
+    spdlog::error(ErrCode::Value::InvalidIndex);
+    spdlog::error(
+        "    canonical option 'realloc': core func index {} out of bounds"sv,
+        ReallocIdx);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidIndex);
+  }
+  if (HasCallback && CallbackIdx >= CoreFuncSpaceSize) {
+    spdlog::error(ErrCode::Value::InvalidIndex);
+    spdlog::error(
+        "    canonical option 'callback': core func index {} out of bounds"sv,
+        CallbackIdx);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidIndex);
+  }
+  if (HasPostReturn && PostReturnIdx >= CoreFuncSpaceSize) {
+    spdlog::error(ErrCode::Value::InvalidIndex);
+    spdlog::error(
+        "    canonical option 'post-return': core func index {} out of bounds"sv,
+        PostReturnIdx);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidIndex);
+  }
+  return {};
+}
+
+Expect<void>
+Validator::validateCanonLift(const AST::Component::Canonical &Canon) noexcept {
+  const uint32_t CoreFuncIdx = Canon.getIndex();
+  const uint32_t CoreFuncSpaceSize =
+      CompCtx.getCoreSortIndexSize(AST::Component::Sort::CoreSortType::Func);
+  // 1. Core func index bounds.
+  if (CoreFuncIdx >= CoreFuncSpaceSize) {
+    spdlog::error(ErrCode::Value::InvalidIndex);
+    spdlog::error(
+        "    canon lift: core func index {} exceeds core func index space size {}"sv,
+        CoreFuncIdx, CoreFuncSpaceSize);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidIndex);
+  }
+  const uint32_t TypeIdx = Canon.getTargetIndex();
+  const uint32_t TypeSpaceSize =
+      CompCtx.getSortIndexSize(AST::Component::Sort::SortType::Type);
+  // 2. Target type index bounds.
+  if (TypeIdx >= TypeSpaceSize) {
+    spdlog::error(ErrCode::Value::InvalidIndex);
+    spdlog::error(
+        "    canon lift: type index {} exceeds type index space size {}"sv,
+        TypeIdx, TypeSpaceSize);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidIndex);
+  }
+  // 3. Target type must be a component FuncType.
+  const auto *DT = CompCtx.getDefType(TypeIdx);
+  if (DT == nullptr) {
+    // Unresolved slot: the index was registered by an import or outer alias
+    // but the concrete definition has not been filled in yet.
+    spdlog::error(ErrCode::Value::InvalidTypeReference);
+    spdlog::error(
+        "    canon lift: target type index {} is an unresolved type slot"sv,
+        TypeIdx);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidTypeReference);
+  }
+  if (!DT->isFuncType()) {
+    spdlog::error(ErrCode::Value::InvalidTypeReference);
+    spdlog::error(
+        "    canon lift: target type index {} does not reference a component func type"sv,
+        TypeIdx);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidTypeReference);
+  }
+  // 4. Validate canonical options (Lift site allows all).
+  EXPECTED_TRY(validateCanonOptions(Canon.getOpCode(), Canon.getOptions()));
+  // 5. Allocate component func, binding the resolved FuncType. Full ABI
+  // signature match (flat_lifted) deferred as GAP-C-1b.
+  CompCtx.addFunc(&DT->getFuncType());
+  return {};
+}
+
+Expect<void>
+Validator::validateCanonLower(const AST::Component::Canonical &Canon) noexcept {
+  const uint32_t FuncIdx = Canon.getIndex();
+  const uint32_t FuncSpaceSize =
+      CompCtx.getSortIndexSize(AST::Component::Sort::SortType::Func);
+  // 1. Component func index bounds.
+  if (FuncIdx >= FuncSpaceSize) {
+    spdlog::error(ErrCode::Value::InvalidIndex);
+    spdlog::error(
+        "    canon lower: component func index {} exceeds func index space size {}"sv,
+        FuncIdx, FuncSpaceSize);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidIndex);
+  }
+  // 2. Validate canonical options (per-site rules for Lower).
+  EXPECTED_TRY(validateCanonOptions(Canon.getOpCode(), Canon.getOptions()));
+  // 3. Allocate the resulting core func. Full ABI signature synthesis
+  // (flatten_functype for lower) deferred as GAP-C-2b.
+  CompCtx.addCoreFunc();
+  return {};
+}
+
+Expect<void> Validator::validateCanonResourceNew(
+    const AST::Component::Canonical &Canon) noexcept {
+  const uint32_t Idx = Canon.getIndex();
+  const uint32_t TypeSpaceSize =
+      CompCtx.getSortIndexSize(AST::Component::Sort::SortType::Type);
+  // 1. Type index bounds.
+  if (Idx >= TypeSpaceSize) {
+    spdlog::error(ErrCode::Value::InvalidIndex);
+    spdlog::error(
+        "    canon resource.new: type index {} exceeds type index space size {}"sv,
+        Idx, TypeSpaceSize);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidIndex);
+  }
+  // 2. Type must be a resource type.
+  if (!CompCtx.isResourceType(Idx)) {
+    spdlog::error(ErrCode::Value::InvalidTypeReference);
+    spdlog::error(
+        "    canon resource.new: type index {} does not reference a resource"sv,
+        Idx);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidTypeReference);
+  }
+  // 3. Resource must be locally defined.
+  if (!CompCtx.isLocalResource(Idx)) {
+    spdlog::error(ErrCode::Value::InvalidTypeReference);
+    spdlog::error(
+        "    canon resource.new: type index {} is not locally defined (imported or outer-aliased resources are not allowed)"sv,
+        Idx);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidTypeReference);
+  }
+  // 4. Validate canonical options.
+  EXPECTED_TRY(validateCanonOptions(Canon.getOpCode(), Canon.getOptions()));
+  // 5. Allocate the resulting core func. Full signature tracking deferred.
+  CompCtx.addCoreFunc();
+  return {};
+}
+
+Expect<void> Validator::validateCanonResourceRep(
+    const AST::Component::Canonical &Canon) noexcept {
+  const uint32_t Idx = Canon.getIndex();
+  const uint32_t TypeSpaceSize =
+      CompCtx.getSortIndexSize(AST::Component::Sort::SortType::Type);
+  // 1. Type index bounds.
+  if (Idx >= TypeSpaceSize) {
+    spdlog::error(ErrCode::Value::InvalidIndex);
+    spdlog::error(
+        "    canon resource.rep: type index {} exceeds type index space size {}"sv,
+        Idx, TypeSpaceSize);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidIndex);
+  }
+  // 2. Type must be a resource type.
+  if (!CompCtx.isResourceType(Idx)) {
+    spdlog::error(ErrCode::Value::InvalidTypeReference);
+    spdlog::error(
+        "    canon resource.rep: type index {} does not reference a resource"sv,
+        Idx);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidTypeReference);
+  }
+  // 3. Resource must be locally defined.
+  if (!CompCtx.isLocalResource(Idx)) {
+    spdlog::error(ErrCode::Value::InvalidTypeReference);
+    spdlog::error(
+        "    canon resource.rep: type index {} is not locally defined (imported or outer-aliased resources are not allowed)"sv,
+        Idx);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidTypeReference);
+  }
+  // 4. Validate canonical options.
+  EXPECTED_TRY(validateCanonOptions(Canon.getOpCode(), Canon.getOptions()));
+  // 5. Allocate the resulting core func. Full signature tracking deferred.
+  CompCtx.addCoreFunc();
+  return {};
+}
+
+Expect<void> Validator::validateCanonResourceDrop(
+    const AST::Component::Canonical &Canon) noexcept {
+  const uint32_t Idx = Canon.getIndex();
+  const uint32_t TypeSpaceSize =
+      CompCtx.getSortIndexSize(AST::Component::Sort::SortType::Type);
+  // 1. Type index bounds.
+  if (Idx >= TypeSpaceSize) {
+    spdlog::error(ErrCode::Value::InvalidIndex);
+    spdlog::error(
+        "    canon resource.drop: type index {} exceeds type index space size {}"sv,
+        Idx, TypeSpaceSize);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidIndex);
+  }
+  // 2. Type must be a resource type.
+  if (!CompCtx.isResourceType(Idx)) {
+    spdlog::error(ErrCode::Value::InvalidTypeReference);
+    spdlog::error(
+        "    canon resource.drop: type index {} does not reference a resource"sv,
+        Idx);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+    return Unexpect(ErrCode::Value::InvalidTypeReference);
+  }
+  // 3. resource.drop accepts both local and imported resources — no locality
+  // check.
+  // 4. Validate canonical options.
+  EXPECTED_TRY(validateCanonOptions(Canon.getOpCode(), Canon.getOptions()));
+  // 5. Allocate the resulting core func. Full signature tracking deferred.
+  CompCtx.addCoreFunc();
+  return {};
 }
 
 Expect<void> Validator::validate(const AST::Component::Import &Im) noexcept {
@@ -1306,13 +1656,13 @@ Validator::validate(const AST::Component::ExternDesc &Desc) noexcept {
       }
       // Create alias: propagate resource property if referenced type is
       // resource
-      uint32_t NewIdx = CompCtx.addType();
+      uint32_t NewIdx = CompCtx.addTypeImported(nullptr);
       if (CompCtx.isResourceType(RefIdx)) {
         CompCtx.getCurrentContext().ResourceTypes[NewIdx] = nullptr;
       }
     } else {
       // (type (sub resource)) — fresh abstract resource type
-      uint32_t NewIdx = CompCtx.addType();
+      uint32_t NewIdx = CompCtx.addTypeImported(nullptr);
       CompCtx.getCurrentContext().ResourceTypes[NewIdx] = nullptr;
     }
     break;
@@ -1472,7 +1822,7 @@ Validator::validate(const AST::Component::ExportDecl &Decl) noexcept {
     CompCtx.addValue();
     break;
   case AST::Component::ExternDesc::DescType::TypeBound: {
-    uint32_t NewIdx = CompCtx.addType();
+    uint32_t NewIdx = CompCtx.addTypeImported(nullptr);
     if (!Desc.isEqType()) {
       // (type (sub resource)) — fresh abstract resource type
       CompCtx.getCurrentContext().ResourceTypes[NewIdx] = nullptr;

--- a/test/component/ComponentValidatorTest.cpp
+++ b/test/component/ComponentValidatorTest.cpp
@@ -1065,4 +1065,446 @@ TEST(ComponentValidatorTest, InstanceInlineExportDuplicateName) {
   ASSERT_FALSE(V.validate(Comp));
 }
 
+// =============================================================================
+// Canonical built-in validation tests (GAP-C-1 .. GAP-C-5)
+// =============================================================================
+
+// Helper: build a Component with a single ResourceType in type index 0.
+inline AST::Component::Component makeCompWithLocalResource() {
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setResourceType(AST::Component::ResourceType{});
+  return Comp;
+}
+
+// Helper: append a CanonSection with a single canonical to the component.
+inline AST::Component::CanonSection &
+appendCanonSection(AST::Component::Component &Comp) {
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CanonSection>();
+  return std::get<AST::Component::CanonSection>(Comp.getSections().back());
+}
+
+inline AST::Component::CanonOpt mkOpt(AST::Component::CanonOpt::OptCode Code,
+                                      uint32_t Idx = 0) {
+  AST::Component::CanonOpt O;
+  O.setCode(Code);
+  O.setIndex(Idx);
+  return O;
+}
+
+// Helper: build a Component with an imported component func (func index 0).
+inline AST::Component::Component makeCompWithImportedFunc() {
+  AST::Component::Component Comp;
+  // Need a FuncType at type index 0.
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setFuncType(AST::Component::FuncType());
+  // Import a func of that type.
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+  auto &ImpSec =
+      std::get<AST::Component::ImportSection>(Comp.getSections().back());
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "f";
+  ImpSec.getContent().back().getDesc().setFuncTypeIdx(0);
+  return Comp;
+}
+
+// Helper: build a Component with a resource (type 0), a FuncType (type 1),
+// and a core func allocated via resource.new 0 (core func index 0).
+inline AST::Component::Component makeCompWithCoreFuncAndFuncType() {
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+  // Type 0: ResourceType (local).
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setResourceType(AST::Component::ResourceType{});
+  // Type 1: FuncType.
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setFuncType(AST::Component::FuncType());
+  // Canon section: allocate core func 0 via resource.new 0.
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CanonSection>();
+  auto &CanonSec =
+      std::get<AST::Component::CanonSection>(Comp.getSections().back());
+  AST::Component::Canonical ResNew;
+  ResNew.setOpCode(AST::Component::Canonical::OpCode::Resource__new);
+  ResNew.setIndex(0); // resource at type 0
+  CanonSec.getContent().emplace_back(std::move(ResNew));
+  return Comp;
+}
+
+TEST(ComponentValidatorTest, CanonResourceNew_OnLocalResource_Passes) {
+  auto Comp = makeCompWithLocalResource();
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Resource__new);
+  C.setIndex(0); // type index 0 = local resource
+  CanonSec.getContent().emplace_back(std::move(C));
+
+  Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonResourceNew_TypeIndexOutOfBounds_Fails) {
+  AST::Component::Component Comp;
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Resource__new);
+  C.setIndex(0); // no type section → index 0 is out of bounds
+  CanonSec.getContent().emplace_back(std::move(C));
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonResourceNew_TypeIsNotResource_Fails) {
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+  // Type 0: FuncType, not a resource.
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setFuncType(AST::Component::FuncType());
+
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Resource__new);
+  C.setIndex(0);
+  CanonSec.getContent().emplace_back(std::move(C));
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonResourceNew_OnImportedResource_Fails) {
+  // resource.new requires a LOCAL resource; imported resources are rejected.
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+  auto &ImpSec =
+      std::get<AST::Component::ImportSection>(Comp.getSections().back());
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "r";
+  ImpSec.getContent().back().getDesc().setTypeBound(); // (sub resource)
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Resource__new);
+  C.setIndex(0); // imported resource at type 0
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonResourceRep_OnLocalResource_Passes) {
+  auto Comp = makeCompWithLocalResource();
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Resource__rep);
+  C.setIndex(0);
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonResourceRep_TypeIndexOutOfBounds_Fails) {
+  AST::Component::Component Comp;
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Resource__rep);
+  C.setIndex(0);
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonResourceRep_TypeIsNotResource_Fails) {
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setFuncType(AST::Component::FuncType());
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Resource__rep);
+  C.setIndex(0);
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonResourceRep_OnImportedResource_Fails) {
+  // resource.rep requires a LOCAL resource; imported resources are rejected.
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+  auto &ImpSec =
+      std::get<AST::Component::ImportSection>(Comp.getSections().back());
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "r";
+  ImpSec.getContent().back().getDesc().setTypeBound(); // (sub resource)
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Resource__rep);
+  C.setIndex(0);
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonResourceDrop_OnLocalResource_Passes) {
+  auto Comp = makeCompWithLocalResource();
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Resource__drop);
+  C.setIndex(0);
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonResourceDrop_OnImportedResource_Passes) {
+  // Import a resource via a type import bound to (sub resource).
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+  auto &ImpSec =
+      std::get<AST::Component::ImportSection>(Comp.getSections().back());
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "r";
+  ImpSec.getContent().back().getDesc().setTypeBound(); // (sub resource)
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Resource__drop);
+  C.setIndex(0); // the imported type now occupies type index 0
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonResourceDrop_TypeIsNotResource_Fails) {
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setFuncType(AST::Component::FuncType());
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Resource__drop);
+  C.setIndex(0);
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonResourceDrop_TypeIndexOutOfBounds_Fails) {
+  AST::Component::Component Comp;
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Resource__drop);
+  C.setIndex(0);
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonResourceDropAsync_OnLocalResource_Passes) {
+  auto Comp = makeCompWithLocalResource();
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Resource__drop_async);
+  C.setIndex(0);
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonResourceNew_RejectsOptions) {
+  auto Comp = makeCompWithLocalResource();
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Resource__new);
+  C.setIndex(0);
+  C.setOptions({mkOpt(AST::Component::CanonOpt::OptCode::Encode_UTF8)});
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonResourceDrop_RejectsOptions) {
+  auto Comp = makeCompWithLocalResource();
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Resource__drop);
+  C.setIndex(0);
+  C.setOptions({mkOpt(AST::Component::CanonOpt::OptCode::Memory, 0)});
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonLower_ValidFuncIndex_Passes) {
+  auto Comp = makeCompWithImportedFunc();
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Lower);
+  C.setIndex(0); // component func 0 exists
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonLower_FuncIndexOutOfBounds_Fails) {
+  AST::Component::Component Comp;
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Lower);
+  C.setIndex(0);
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonLower_RejectsPostReturn) {
+  auto Comp = makeCompWithImportedFunc();
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Lower);
+  C.setIndex(0);
+  C.setOptions({mkOpt(AST::Component::CanonOpt::OptCode::PostReturn, 0)});
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonLower_RejectsCallback) {
+  auto Comp = makeCompWithImportedFunc();
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Lower);
+  C.setIndex(0);
+  // Async included to satisfy structural rule;
+  // site-whitelist should still reject callback on Lower.
+  C.setOptions({mkOpt(AST::Component::CanonOpt::OptCode::Async),
+                mkOpt(AST::Component::CanonOpt::OptCode::Callback, 0)});
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonLower_RejectsAlwaysTaskReturn) {
+  auto Comp = makeCompWithImportedFunc();
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Lower);
+  C.setIndex(0);
+  // Async included to satisfy structural rule;
+  // site-whitelist should still reject always-task-return on Lower.
+  C.setOptions({mkOpt(AST::Component::CanonOpt::OptCode::Async),
+                mkOpt(AST::Component::CanonOpt::OptCode::AlwaysTaskReturn)});
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonLower_ReallocWithoutMemory_Fails) {
+  auto Comp = makeCompWithImportedFunc();
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Lower);
+  C.setIndex(0);
+  C.setOptions({mkOpt(AST::Component::CanonOpt::OptCode::Realloc, 0)});
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonLift_CoreFuncIndexOutOfBounds_Fails) {
+  // No core funcs; index 0 is out of bounds.
+  AST::Component::Component Comp;
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(AST::Component::Canonical::OpCode::Lift);
+  C.setIndex(0);
+  C.setTargetIndex(0);
+  CanonSec.getContent().emplace_back(std::move(C));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonLift_TypeIndexOutOfBounds_Fails) {
+  // Fixture provides core func 0 and types 0 (resource), 1 (func). Target
+  // index 2 is out of bounds.
+  auto Comp = makeCompWithCoreFuncAndFuncType();
+  auto &CanonSec =
+      std::get<AST::Component::CanonSection>(Comp.getSections().back());
+  AST::Component::Canonical Lift;
+  Lift.setOpCode(AST::Component::Canonical::OpCode::Lift);
+  Lift.setIndex(0);       // core func 0 exists
+  Lift.setTargetIndex(2); // no type at index 2
+  CanonSec.getContent().emplace_back(std::move(Lift));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonLift_TargetIsNotFuncType_Fails) {
+  // Target type 0 is a ResourceType, not a FuncType.
+  auto Comp = makeCompWithCoreFuncAndFuncType();
+  auto &CanonSec =
+      std::get<AST::Component::CanonSection>(Comp.getSections().back());
+  AST::Component::Canonical Lift;
+  Lift.setOpCode(AST::Component::Canonical::OpCode::Lift);
+  Lift.setIndex(0);
+  Lift.setTargetIndex(0); // type 0 is ResourceType
+  CanonSec.getContent().emplace_back(std::move(Lift));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonLift_Valid_Passes) {
+  // Happy path: core func 0 + FuncType at type 1.
+  auto Comp = makeCompWithCoreFuncAndFuncType();
+  auto &CanonSec =
+      std::get<AST::Component::CanonSection>(Comp.getSections().back());
+  AST::Component::Canonical Lift;
+  Lift.setOpCode(AST::Component::Canonical::OpCode::Lift);
+  Lift.setIndex(0);
+  Lift.setTargetIndex(1); // type 1 is FuncType
+  CanonSec.getContent().emplace_back(std::move(Lift));
+  Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonLift_WithPostReturn_Passes) {
+  // post-return is a Lift-only option; exercise the happy path.
+  auto Comp = makeCompWithCoreFuncAndFuncType();
+  auto &CanonSec =
+      std::get<AST::Component::CanonSection>(Comp.getSections().back());
+  AST::Component::Canonical Lift;
+  Lift.setOpCode(AST::Component::Canonical::OpCode::Lift);
+  Lift.setIndex(0);
+  Lift.setTargetIndex(1);
+  // post-return points to core func 0 (the resource.new result from the
+  // fixture).
+  Lift.setOptions({mkOpt(AST::Component::CanonOpt::OptCode::PostReturn, 0)});
+  CanonSec.getContent().emplace_back(std::move(Lift));
+  Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
 } // namespace


### PR DESCRIPTION
## Description

Implement structural validation for component-model canonical built-ins (canon lift, canon lower, resource.new/rep/drop/drop_async) and the shared canonical-options rules. Replaces the prior stub that only bumped index-space counters.

ComponentContext infrastructure:
- Replace FuncCount/CoreFuncCount counters with Funcs/CoreFuncs vectors of type pointers so canon lift/lower can bind and resolve func types by index.
- Track locally-defined resources via a DefinedResources set populated by addType(); imports and outer aliases go through a new addTypeImported() path that registers the resource type without marking it local. Factor the two into a shared addTypeImpl helper.
- Add isLocalResource(), getFunc(), getCoreFunc() accessors.

Canonical validation:
- Split validate(Canonical) into per-opcode helpers; both Resource__drop and Resource__drop_async route to the same validator.
- validateCanonOptions takes the Canonical::OpCode directly (no extra context enum) and enforces: at-most-one per option (string-encoding slot shared across UTF-8/UTF-16/Latin-1), per-opcode whitelist (lift accepts every option, lower rejects the lift-only options post-return/callback/always-task-return, every other built-in rejects all options), structural rules (callback requires async, always-task-return requires async, post-return/async mutually exclusive, realloc requires memory), and index bounds on memory/realloc/callback/post-return. Unknown codes emit UnknownCanonicalOption.
- resource.new / resource.rep require bounds + isResourceType + isLocalResource; resource.drop permits imported resources.
- canon lift resolves the target type to a FuncType via getDefType() and binds the pointer on addFunc(); unresolved type slots emit a dedicated diagnostic distinct from wrong-kind.
- Other canonical opcodes continue to return ComponentNotImplValidator.

Tests: 26 new unit tests in ComponentValidatorTest covering bounds, wrong-kind, imported/local resource rules, async variant, option whitelist, structural rules, and happy paths, via reusable helpers makeCompWithLocalResource / appendCanonSection / mkOpt / makeCompWithImportedFunc / makeCompWithCoreFuncAndFuncType.

Deferred: canon lift/lower ABI signature match against flatten_functype (for the core func's flattened params/results); realloc/callback/ post-return signature-body shape checks; post-MVP canon opcodes (backpressure.set, task.*, context.*, stream.*, future.*, error-context.*, waitable.*, thread.*).

Assisted-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

## Checklist

Before submitting this PR, please ensure the following:

- [ ] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [ ] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
