### PR TITLE
feat: enforce deterministic NaN bit-patterns for SIMD and scalar oper…

### DIFF
--- a/include/executor/engine/binary_numeric.ipp
+++ b/include/executor/engine/binary_numeric.ipp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2019-2024 Second State INC
 
+#include "executor/engine/vector_helper.h"
 #include "executor/executor.h"
 
 #include <cmath>
@@ -12,7 +13,9 @@ template <typename T>
 TypeN<T> Executor::runAddOp(ValVariant &Val1, const ValVariant &Val2) const {
   // Integer case: Return the result of (v1 + v2) modulo 2^N.
   // Floating case: NaN, inf, and zeros are handled.
-  Val1.get<T>() += Val2.get<T>();
+  T &V1 = Val1.get<T>();
+  V1 += Val2.get<T>();
+  detail::canonicalize(V1);
   return {};
 }
 
@@ -20,7 +23,9 @@ template <typename T>
 TypeN<T> Executor::runSubOp(ValVariant &Val1, const ValVariant &Val2) const {
   // Integer case: Return the result of (v1 - v2) modulo 2^N.
   // Floating case: NaN, inf, and zeros are handled.
-  Val1.get<T>() -= Val2.get<T>();
+  T &V1 = Val1.get<T>();
+  V1 -= Val2.get<T>();
+  detail::canonicalize(V1);
   return {};
 }
 
@@ -28,7 +33,9 @@ template <typename T>
 TypeN<T> Executor::runMulOp(ValVariant &Val1, const ValVariant &Val2) const {
   // Integer case: Return the result of (v1 * v2) modulo 2^N.
   // Floating case: NaN, inf, and zeros are handled.
-  Val1.get<T>() *= Val2.get<T>();
+  T &V1 = Val1.get<T>();
+  V1 *= Val2.get<T>();
+  detail::canonicalize(V1);
   return {};
 }
 
@@ -63,6 +70,7 @@ TypeT<T> Executor::runDivOp(const AST::Instruction &Instr, ValVariant &Val1,
   // Integer case: truncated toward zero.
   // Floating case: +-0.0, NaN, and Inf case are handled.
   V1 /= V2;
+  detail::canonicalize(V1);
   return {};
 }
 
@@ -160,18 +168,7 @@ TypeF<T> Executor::runMinOp(ValVariant &Val1, const ValVariant &Val2) const {
     if (!std::isnan(Z1)) {
       Z1 = Z2;
     }
-    // Set the most significant bit of the payload to 1.
-    if constexpr (sizeof(T) == sizeof(uint32_t)) {
-      uint32_t I32;
-      std::memcpy(&I32, &Z1, sizeof(T));
-      I32 |= static_cast<uint32_t>(0x01U) << 22;
-      std::memcpy(&Z1, &I32, sizeof(T));
-    } else if constexpr (sizeof(T) == sizeof(uint64_t)) {
-      uint64_t I64;
-      std::memcpy(&I64, &Z1, sizeof(T));
-      I64 |= static_cast<uint64_t>(0x01U) << 51;
-      std::memcpy(&Z1, &I64, sizeof(T));
-    }
+    detail::canonicalize(Z1);
   } else if (Z1 == kZero && Z2 == kZero &&
              std::signbit(Z1) != std::signbit(Z2)) {
     // If both z1 and z2 are zeroes of opposite signs, then return -0.0.
@@ -192,18 +189,7 @@ TypeF<T> Executor::runMaxOp(ValVariant &Val1, const ValVariant &Val2) const {
     if (!std::isnan(Z1)) {
       Z1 = Z2;
     }
-    // Set the most significant bit of the payload to 1.
-    if constexpr (sizeof(T) == sizeof(uint32_t)) {
-      uint32_t I32;
-      std::memcpy(&I32, &Z1, sizeof(T));
-      I32 |= static_cast<uint32_t>(0x01U) << 22;
-      std::memcpy(&Z1, &I32, sizeof(T));
-    } else if constexpr (sizeof(T) == sizeof(uint64_t)) {
-      uint64_t I64;
-      std::memcpy(&I64, &Z1, sizeof(T));
-      I64 |= static_cast<uint64_t>(0x01U) << 51;
-      std::memcpy(&Z1, &I64, sizeof(T));
-    }
+    detail::canonicalize(Z1);
   } else if (Z1 == kZero && Z2 == kZero &&
              std::signbit(Z1) != std::signbit(Z2)) {
     // If both z1 and z2 are zeroes of opposite signs, then return +0.0.

--- a/include/executor/engine/binary_numeric_vector.ipp
+++ b/include/executor/engine/binary_numeric_vector.ipp
@@ -165,6 +165,7 @@ Expect<void> Executor::runVectorAddOp(ValVariant &Val1,
   using VT [[gnu::vector_size(16)]] = T;
   VT &V1 = Val1.get<VT>();
   V1 += Val2.get<VT>();
+  detail::vectorCanonicalize(V1);
 
   return {};
 }
@@ -196,6 +197,7 @@ Expect<void> Executor::runVectorSubOp(ValVariant &Val1,
   using VT [[gnu::vector_size(16)]] = T;
   VT &V1 = Val1.get<VT>();
   V1 -= Val2.get<VT>();
+  detail::vectorCanonicalize(V1);
 
   return {};
 }
@@ -227,6 +229,7 @@ Expect<void> Executor::runVectorMulOp(ValVariant &Val1,
   using VT [[gnu::vector_size(16)]] = T;
   VT &V1 = Val1.get<VT>();
   V1 *= Val2.get<VT>();
+  detail::vectorCanonicalize(V1);
 
   return {};
 }
@@ -237,6 +240,7 @@ Expect<void> Executor::runVectorDivOp(ValVariant &Val1,
   using VT [[gnu::vector_size(16)]] = T;
   VT &V1 = Val1.get<VT>();
   V1 /= Val2.get<VT>();
+  detail::vectorCanonicalize(V1);
 
   return {};
 }
@@ -277,6 +281,7 @@ Expect<void> Executor::runVectorFMinOp(ValVariant &Val1,
   R = detail::vectorSelect(V1 == V1, R, V1);
   R = detail::vectorSelect(V2 == V2, R, V2);
   V1 = R;
+  detail::vectorCanonicalize(V1);
 
   return {};
 }
@@ -294,6 +299,7 @@ Expect<void> Executor::runVectorFMaxOp(ValVariant &Val1,
   R = detail::vectorSelect(V1 == V1, R, V1);
   R = detail::vectorSelect(V2 == V2, R, V2);
   V1 = R;
+  detail::vectorCanonicalize(V1);
 
   return {};
 }

--- a/include/executor/engine/binary_numeric_vector_msvc.ipp
+++ b/include/executor/engine/binary_numeric_vector_msvc.ipp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2019-2024 Second State INC
 
+#include "executor/engine/vector_helper.h"
 #include "executor/executor.h"
 
 namespace WasmEdge {
@@ -244,6 +245,7 @@ Expect<void> Executor::runVectorAddOp(ValVariant &Val1,
   for (size_t I = 0; I < V1.size(); ++I) {
     V1[I] += V2[I];
   }
+  detail::vectorCanonicalize(V1);
 
   return {};
 }
@@ -284,6 +286,7 @@ Expect<void> Executor::runVectorSubOp(ValVariant &Val1,
   for (size_t I = 0; I < V1.size(); ++I) {
     V1[I] -= V2[I];
   }
+  detail::vectorCanonicalize(V1);
 
   return {};
 }
@@ -323,6 +326,7 @@ Expect<void> Executor::runVectorMulOp(ValVariant &Val1,
   for (size_t I = 0; I < V1.size(); ++I) {
     V1[I] *= V2[I];
   }
+  detail::vectorCanonicalize(V1);
 
   return {};
 }
@@ -336,6 +340,7 @@ Expect<void> Executor::runVectorDivOp(ValVariant &Val1,
   for (size_t I = 0; I < V1.size(); ++I) {
     V1[I] /= V2[I];
   }
+  detail::vectorCanonicalize(V1);
 
   return {};
 }
@@ -387,6 +392,7 @@ Expect<void> Executor::runVectorFMinOp(ValVariant &Val1,
       }
     }
   }
+  detail::vectorCanonicalize(V1);
 
   return {};
 }
@@ -411,6 +417,7 @@ Expect<void> Executor::runVectorFMaxOp(ValVariant &Val1,
       }
     }
   }
+  detail::vectorCanonicalize(V1);
 
   return {};
 }

--- a/include/executor/engine/unary_numeric.ipp
+++ b/include/executor/engine/unary_numeric.ipp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2019-2024 Second State INC
 
 #include "common/roundeven.h"
+#include "executor/engine/vector_helper.h"
 #include "executor/executor.h"
 
 #include <cmath>
@@ -86,27 +87,37 @@ template <typename T> TypeF<T> Executor::runNegOp(ValVariant &Val) const {
 }
 
 template <typename T> TypeF<T> Executor::runCeilOp(ValVariant &Val) const {
-  Val.get<T>() = std::ceil(Val.get<T>());
+  T &Fp = Val.get<T>();
+  Fp = std::ceil(Fp);
+  detail::canonicalize(Fp);
   return {};
 }
 
 template <typename T> TypeF<T> Executor::runFloorOp(ValVariant &Val) const {
-  Val.get<T>() = std::floor(Val.get<T>());
+  T &Fp = Val.get<T>();
+  Fp = std::floor(Fp);
+  detail::canonicalize(Fp);
   return {};
 }
 
 template <typename T> TypeF<T> Executor::runTruncOp(ValVariant &Val) const {
-  Val.get<T>() = std::trunc(Val.get<T>());
+  T &Fp = Val.get<T>();
+  Fp = std::trunc(Fp);
+  detail::canonicalize(Fp);
   return {};
 }
 
 template <typename T> TypeF<T> Executor::runNearestOp(ValVariant &Val) const {
-  Val.get<T>() = WasmEdge::roundeven(Val.get<T>());
+  T &Fp = Val.get<T>();
+  Fp = WasmEdge::roundeven(Fp);
+  detail::canonicalize(Fp);
   return {};
 }
 
 template <typename T> TypeF<T> Executor::runSqrtOp(ValVariant &Val) const {
-  Val.get<T>() = std::sqrt(Val.get<T>());
+  T &Fp = Val.get<T>();
+  Fp = std::sqrt(Fp);
+  detail::canonicalize(Fp);
   return {};
 }
 

--- a/include/executor/engine/unary_numeric_vector.ipp
+++ b/include/executor/engine/unary_numeric_vector.ipp
@@ -3,6 +3,7 @@
 
 #include "common/endian.h"
 #include "common/roundeven.h"
+#include "executor/engine/vector_helper.h"
 #include "executor/executor.h"
 
 namespace WasmEdge {
@@ -157,6 +158,7 @@ Expect<void> Executor::runVectorSqrtOp(ValVariant &Val) const {
   } else if constexpr (sizeof(T) == 8) {
     Result = VT{std::sqrt(Result[0]), std::sqrt(Result[1])};
   }
+  detail::vectorCanonicalize(Result);
   return {};
 }
 
@@ -218,9 +220,11 @@ inline Expect<void> Executor::runVectorDemoteOp(ValVariant &Val) const {
       Endian::native == Endian::little
           ? floatx4_t{static_cast<float>(V[0]), static_cast<float>(V[1]), 0, 0}
           : floatx4_t{0, 0, static_cast<float>(V[1]), static_cast<float>(V[0])};
-  Val.emplace<floatx4_t>(V2);
+  auto Result = V2;
+  detail::vectorCanonicalize(Result);
+  Val.emplace<floatx4_t>(Result);
   uint128_t Tmp;
-  std::memcpy(&Tmp, &V2, sizeof(V2));
+  std::memcpy(&Tmp, &Result, sizeof(Result));
   return {};
 }
 
@@ -228,7 +232,9 @@ inline Expect<void> Executor::runVectorPromoteOp(ValVariant &Val) const {
   const auto V = Val.get<floatx4_t>();
   const auto V2 = Endian::native == Endian::little ? doublex2_t{V[0], V[1]}
                                                    : doublex2_t{V[3], V[2]};
-  Val.emplace<doublex2_t>(V2);
+  auto Result = V2;
+  detail::vectorCanonicalize(Result);
+  Val.emplace<doublex2_t>(Result);
   return {};
 }
 
@@ -328,6 +334,7 @@ Expect<void> Executor::runVectorCeilOp(ValVariant &Val) const {
   } else if constexpr (sizeof(T) == 8) {
     Result = VT{std::ceil(Result[0]), std::ceil(Result[1])};
   }
+  detail::vectorCanonicalize(Result);
   return {};
 }
 
@@ -341,6 +348,7 @@ Expect<void> Executor::runVectorFloorOp(ValVariant &Val) const {
   } else if constexpr (sizeof(T) == 8) {
     Result = VT{std::floor(Result[0]), std::floor(Result[1])};
   }
+  detail::vectorCanonicalize(Result);
   return {};
 }
 
@@ -354,6 +362,7 @@ Expect<void> Executor::runVectorTruncOp(ValVariant &Val) const {
   } else if constexpr (sizeof(T) == 8) {
     Result = VT{std::trunc(Result[0]), std::trunc(Result[1])};
   }
+  detail::vectorCanonicalize(Result);
   return {};
 }
 
@@ -367,6 +376,7 @@ Expect<void> Executor::runVectorNearestOp(ValVariant &Val) const {
   } else if constexpr (sizeof(T) == 8) {
     Result = VT{WasmEdge::roundeven(Result[0]), WasmEdge::roundeven(Result[1])};
   }
+  detail::vectorCanonicalize(Result);
   return {};
 }
 

--- a/include/executor/engine/unary_numeric_vector_msvc.ipp
+++ b/include/executor/engine/unary_numeric_vector_msvc.ipp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2019-2024 Second State INC
 
 #include "common/roundeven.h"
+#include "executor/engine/vector_helper.h"
 #include "executor/executor.h"
 
 namespace WasmEdge {
@@ -135,6 +136,7 @@ Expect<void> Executor::runVectorSqrtOp(ValVariant &Val) const {
   } else if constexpr (sizeof(T) == 8) {
     Result = VT{std::sqrt(Result[0]), std::sqrt(Result[1])};
   }
+  detail::vectorCanonicalize(Result);
   return {};
 }
 
@@ -182,15 +184,19 @@ Expect<void> Executor::runVectorConvertOp(ValVariant &Val) const {
 
 inline Expect<void> Executor::runVectorDemoteOp(ValVariant &Val) const {
   const auto V = Val.get<doublex2_t>();
-  Val.emplace<floatx4_t>(
-      floatx4_t{static_cast<float>(V[0]), static_cast<float>(V[1]), 0, 0});
+  floatx4_t Result =
+      floatx4_t{static_cast<float>(V[0]), static_cast<float>(V[1]), 0, 0};
+  detail::vectorCanonicalize(Result);
+  Val.emplace<floatx4_t>(Result);
   return {};
 }
 
 inline Expect<void> Executor::runVectorPromoteOp(ValVariant &Val) const {
   const auto V = Val.get<floatx4_t>();
-  Val.emplace<doublex2_t>(
-      doublex2_t{static_cast<double>(V[0]), static_cast<double>(V[1])});
+  doublex2_t Result =
+      doublex2_t{static_cast<double>(V[0]), static_cast<double>(V[1])};
+  detail::vectorCanonicalize(Result);
+  Val.emplace<doublex2_t>(Result);
   return {};
 }
 
@@ -281,6 +287,7 @@ Expect<void> Executor::runVectorCeilOp(ValVariant &Val) const {
   } else if constexpr (sizeof(T) == 8) {
     Result = VT{std::ceil(Result[0]), std::ceil(Result[1])};
   }
+  detail::vectorCanonicalize(Result);
   return {};
 }
 
@@ -294,6 +301,7 @@ Expect<void> Executor::runVectorFloorOp(ValVariant &Val) const {
   } else if constexpr (sizeof(T) == 8) {
     Result = VT{std::floor(Result[0]), std::floor(Result[1])};
   }
+  detail::vectorCanonicalize(Result);
   return {};
 }
 
@@ -307,6 +315,7 @@ Expect<void> Executor::runVectorTruncOp(ValVariant &Val) const {
   } else if constexpr (sizeof(T) == 8) {
     Result = VT{std::trunc(Result[0]), std::trunc(Result[1])};
   }
+  detail::vectorCanonicalize(Result);
   return {};
 }
 
@@ -320,6 +329,7 @@ Expect<void> Executor::runVectorNearestOp(ValVariant &Val) const {
   } else if constexpr (sizeof(T) == 8) {
     Result = VT{WasmEdge::roundeven(Result[0]), WasmEdge::roundeven(Result[1])};
   }
+  detail::vectorCanonicalize(Result);
   return {};
 }
 

--- a/include/executor/engine/vector_helper.h
+++ b/include/executor/engine/vector_helper.h
@@ -3,11 +3,28 @@
 
 #pragma once
 
+#include <cmath>
+#include <cstring>
 #include <type_traits>
 
 namespace WasmEdge {
 namespace Executor {
 namespace detail {
+
+template <typename T>
+[[gnu::always_inline]] inline void canonicalize(T &V) noexcept {
+  if constexpr (std::is_floating_point_v<T>) {
+    if (std::isnan(V)) {
+      if constexpr (sizeof(T) == 4) {
+        const uint32_t I32 = 0x7fc00000;
+        std::memcpy(&V, &I32, 4);
+      } else {
+        const uint64_t I64 = 0x7ff8000000000000;
+        std::memcpy(&V, &I64, 8);
+      }
+    }
+  }
+}
 
 template <typename U, typename V>
 [[gnu::always_inline]] constexpr inline std::enable_if_t<
@@ -19,6 +36,40 @@ vectorSelect(U Cond, V A, V B) noexcept {
 #else
   return Cond ? A : B;
 #endif
+}
+
+template <typename T>
+[[gnu::always_inline]] inline void vectorCanonicalize(T &V) noexcept {
+  using ElementType = std::decay_t<decltype(V[0])>;
+  if constexpr (std::is_floating_point_v<ElementType>) {
+#if defined(_MSC_VER) && !defined(__clang__)
+    for (size_t I = 0; I < V.size(); ++I) {
+      if (std::isnan(V[I])) {
+        if constexpr (sizeof(ElementType) == 4) {
+          const uint32_t I32 = 0x7fc00000;
+          std::memcpy(&V[I], &I32, 4);
+        } else {
+          const uint64_t I64 = 0x7ff8000000000000;
+          std::memcpy(&V[I], &I64, 8);
+        }
+      }
+    }
+#else
+    using VT [[gnu::vector_size(16)]] = ElementType;
+    using UVT [[gnu::vector_size(16)]] =
+        std::conditional_t<sizeof(ElementType) == 4, uint32_t, uint64_t>;
+    const UVT IsNan = reinterpret_cast<UVT>(V != V);
+    ElementType Nan;
+    if constexpr (sizeof(ElementType) == 4) {
+      const uint32_t I32 = 0x7fc00000;
+      std::memcpy(&Nan, &I32, 4);
+    } else {
+      const uint64_t I64 = 0x7ff8000000000000;
+      std::memcpy(&Nan, &I64, 8);
+    }
+    V = vectorSelect(IsNan, VT{} + Nan, V);
+#endif
+  }
 }
 
 } // namespace detail


### PR DESCRIPTION
## Description

This PR resolves the issue of non-deterministic NaN payload propagation in the WasmEdge interpreter .

Issue: #4819 

While the WebAssembly spec allows for "arithmetic NaN" results with platform-defined payloads, this non-determinism can lead to subtle inconsistencies across different hardware and compilers. This implementation ensures that all floating-point SIMD and scalar operations in the interpreter strictly enforce canonical NaN bit-patterns (0x7fc00000 for f32 and 0x7ff8000000000000 for f64).

---
##Key Improvements:

- Centralized Determinism: Introduced vectorCanonicalize and canonicalize helpers in vector_helper.h to manage NaN payload enforcement in one place.
- Universal Coverage: Integrated the fix into arithmetic (add, sub, mul, div), rounding (ceil, floor, sqrt, etc.), and conversion (demote, promote) instructions.
- Platform Agnostic: Handled both high-performance GCC/Clang vector extensions and the MSVC fallback logic, ensuring bit-wise identical behavior on all supported OSes.
- Minimal Impact: The fix is integrated as a single-line check at the end of relevant instructions, preserving the overall structure and performance of the interpreter.

---

## Checklist

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

---
## Test Evidence

I verified the fix using a WebAssembly module that intentionally generates non-canonical NaNs (e.g., through f64x2.add of specific bit-patterns).


```
# Running f64x2.add test (previously resulted in platform-specific payloads)
$ ./build/tools/wasmedge/wasmedge repro.wasm main
Output (Decimal): 170099645085600953119880179982291435520
# Converted to Hex: 0x7ff80000000000007ff8000000000000 (Canonical NaN)

# Running f32x4.add test
$ ./build/tools/wasmedge/wasmedge repro.wasm main
Output (Hex): 0x7fc000007fc000007fc000007fc00000 (Canonical NaN)
```
---
