### PR TITLE
fix(po,cli): reject negative input for unsigned numeric options

### DIFF
--- a/include/driver/tool.h
+++ b/include/driver/tool.h
@@ -183,8 +183,8 @@ struct DriverToolOptions {
   PO::Option<std::string> ConfRunMode;
   PO::Option<PO::Toggle> ConfAFUNIX;
   PO::Option<uint64_t> TimeLim;
-  PO::List<int> GasLim;
-  PO::List<int> MemLim;
+  PO::List<uint64_t> GasLim;
+  PO::List<uint64_t> MemLim;
   PO::List<std::string> ForbiddenPlugins;
   PO::Option<std::string> LogLevel;
 

--- a/include/po/parser.h
+++ b/include/po/parser.h
@@ -10,9 +10,12 @@
 
 #include "po/error.h"
 #include <algorithm>
+#include <cctype>
 #include <cstdint>
 #include <fmt/format.h>
 #include <string>
+#include <string_view>
+#include <type_traits>
 #include <utility>
 
 namespace WasmEdge {
@@ -29,6 +32,21 @@ inline cxx20::expected<ResultT, Error>
 stringToInteger(ConvResultT (&Conv)(const char *, char **, int),
                 std::string Value) noexcept {
   using namespace std::literals;
+  // strtoul / strtoull silently wrap a leading '-' to a large unsigned value
+  // without setting ERANGE. Reject negatives explicitly when the target type
+  // is unsigned so users see a range error instead of an unintended limit.
+  if constexpr (std::is_unsigned_v<ResultT>) {
+    std::string_view Trimmed(Value);
+    while (!Trimmed.empty() &&
+           std::isspace(static_cast<unsigned char>(Trimmed.front()))) {
+      Trimmed.remove_prefix(1);
+    }
+    if (!Trimmed.empty() && Trimmed.front() == '-') {
+      return cxx20::unexpected<Error>(
+          std::in_place, ErrCode::OutOfRange,
+          fmt::format("integer value out of range: {}", Value));
+    }
+  }
   char *EndPtr;
   const char *CStr = Value.c_str();
   auto SavedErrNo = std::exchange(errno, 0);

--- a/lib/driver/fuzzPO.cpp
+++ b/lib/driver/fuzzPO.cpp
@@ -194,12 +194,12 @@ int FuzzPO(const uint8_t *Data, size_t Size) noexcept {
           "Limitation of maximum time(in milliseconds) for execution, default value is 0 for no limitations"sv),
       PO::MetaVar("TIMEOUT"sv), PO::DefaultValue<uint64_t>(0));
 
-  PO::List<int> GasLim(
+  PO::List<uint64_t> GasLim(
       PO::Description(
           "Limitation of execution gas. Upper bound can be specified as --gas-limit `GAS_LIMIT`."sv),
       PO::MetaVar("GAS_LIMIT"sv));
 
-  PO::List<int> MemLim(
+  PO::List<uint64_t> MemLim(
       PO::Description(
           "Limitation of pages(as size of 64 KiB) in every memory instance. Upper bound can be specified as --memory-page-limit `PAGE_COUNT`."sv),
       PO::MetaVar("PAGE_COUNT"sv));

--- a/lib/driver/runtimeTool.cpp
+++ b/lib/driver/runtimeTool.cpp
@@ -466,12 +466,10 @@ int Tool(struct DriverToolOptions &Opt) noexcept {
   }
   if (Opt.GasLim.value().size() > 0) {
     Conf.getStatisticsConfigure().setCostMeasuring(true);
-    Conf.getStatisticsConfigure().setCostLimit(
-        static_cast<uint32_t>(Opt.GasLim.value().back()));
+    Conf.getStatisticsConfigure().setCostLimit(Opt.GasLim.value().back());
   }
   if (Opt.MemLim.value().size() > 0) {
-    Conf.getRuntimeConfigure().setMaxMemoryPage(
-        static_cast<uint32_t>(Opt.MemLim.value().back()));
+    Conf.getRuntimeConfigure().setMaxMemoryPage(Opt.MemLim.value().back());
   }
   if (Opt.ConfEnableAllStatistics.value()) {
     Conf.getStatisticsConfigure().setInstructionCounting(true);

--- a/test/po/po.cpp
+++ b/test/po/po.cpp
@@ -113,3 +113,61 @@ INSTANTIATE_TEST_SUITE_P(
       }
       return Name;
     });
+
+struct UnsignedParam {
+  bool R;
+  std::vector<uint64_t> C;
+  std::vector<const char *> Args;
+  UnsignedParam(bool R, std::vector<uint64_t> C, std::vector<const char *> Args)
+      : R(R), C(std::move(C)), Args(std::move(Args)) {}
+  UnsignedParam(bool R, std::vector<const char *> Args)
+      : R(R), Args(std::move(Args)) {}
+};
+
+class UnsignedListOptions : public ::testing::TestWithParam<UnsignedParam> {
+public:
+  UnsignedListOptions() : C(Description("c option"sv), ZeroOrMore()) {
+    Parser.add_option("c"sv, C);
+  }
+  List<uint64_t> C;
+  ArgumentParser Parser;
+};
+
+TEST_P(UnsignedListOptions, Test) {
+  auto P = GetParam();
+  EXPECT_EQ(P.R, Parser.parse(stdout, static_cast<int>(P.Args.size()),
+                              P.Args.data()));
+  if (P.R) {
+    EXPECT_EQ(P.C.size(), C.value().size());
+    for (size_t I = 0; I < P.C.size(); ++I) {
+      SCOPED_TRACE(I);
+      EXPECT_EQ(P.C[I], C.value()[I]);
+    }
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    InstantiationName, UnsignedListOptions,
+    testing::Values(
+        UnsignedParam(true, {0ULL}, {"test", "--c=0"}),
+        UnsignedParam(true, {1ULL}, {"test", "--c=1"}),
+        UnsignedParam(true, {9999999999ULL}, {"test", "--c=9999999999"}),
+        UnsignedParam(true, {UINT64_MAX}, {"test", "--c=18446744073709551615"}),
+        UnsignedParam(false, {"test", "--c=-1"}),
+        UnsignedParam(false, {"test", "--c=18446744073709551616"}),
+        UnsignedParam(false, {"test", "--c=abc"}),
+        UnsignedParam(false, {"test", "--c=1.5"}),
+        UnsignedParam(false, {"test", "--c=1abc"})),
+    [](const testing::TestParamInfo<UnsignedListOptions::ParamType> &Info) {
+      std::string Name;
+      for (const auto &Arg : Info.param.Args) {
+        Name += Arg;
+        Name += ' ';
+      }
+      Name.pop_back();
+      for (auto &Ch : Name) {
+        if (!std::isalnum(Ch))
+          Ch = '_';
+      }
+      return Name;
+    });


### PR DESCRIPTION
## Description

`--gas-limit` and `--memory-page-limit` are declared `PO::List<int>` in
`include/driver/tool.h` but consumed as `uint64_t` via `setCostLimit` /
`setMaxMemoryPage`, with a `static_cast<uint32_t>` in between. That hand-off
is wrong in two directions:

- `--gas-limit=-1` slips through the int parser and the cast turns it into
  `4294967295` — the user gets a finite limit they never asked for instead
  of a clean rejection.
- `--gas-limit=9999999999` (10 billion, well within `uint64_t`) is rejected
  as "out of range" because the parser is targeting `int`, capping users
  at about 2.1 billion.

`TimeLim` right next door is already `PO::Option<uint64_t>` — these two
were the outliers.

Just retyping to `uint64_t` isn't enough on its own: `strtoul`/`strtoull`
accept a leading minus and silently wrap to `ULLONG_MAX` without setting
`ERANGE`, so `--gas-limit=-1` would still be accepted, just as "unlimited"
instead of 4G. Same surprise, different value. So this patch also hardens
`PO::stringToInteger` to reject a leading `-` whenever the result type is
unsigned. Every present and future unsigned PO option benefits — not just
these two.

### Before / after

```
# pre-fix
$ wasmedge --enable-all-statistics --gas-limit=-1 fib.wasm fib 20
[info]  Gas costs: 229851          # silently accepted; limit became 4294967295
$ wasmedge --enable-all-statistics --gas-limit=9999999999 fib.wasm fib 20
integer value out of range: 9999999999

# post-fix
$ wasmedge --enable-all-statistics --gas-limit=-1 fib.wasm fib 20
integer value out of range: -1
$ wasmedge --enable-all-statistics --gas-limit=18446744073709551615 fib.wasm fib 20
[info]  Gas costs: 229851          # full uint64_t range now
$ wasmedge --enable-all-statistics --gas-limit=18446744073709551616 fib.wasm fib 20
integer value out of range: 18446744073709551616
```

`--memory-page-limit=-1` was the same shape — silently became 4 294 967 295
pages (~256 TiB) — and is now rejected.

## Checklist

- [x] DCO Signed-off
- [x] Conventional Commits (`fix(po,cli): ...`)
- [x] Local tests passed (see below)

## Test Evidence

Built on macOS 26.3 (arm64) with brew `llvm@22` + `WasmEdge/llvm/lld@22`,
`WASMEDGE_BUILD_TESTS=ON`, Debug. Added a parametric test class in
`test/po/po.cpp` for `List<uint64_t>` covering full-range positives,
negative rejection, overflow rejection, and non-numeric rejection.

```
1/1 Test #28: poTests .................... Passed    0.50 sec
```

The other 27 unit tests pass too. The two heavy AOT-spec-iteration tests
(`wasmedgeLLVMCoreTests`, `wasmedgeAPIAOTCoreTests`) timed out on this
local box because of an LLVM-22 `lld` warning storm hitting every spec
test — unrelated to this change, which is entirely in PO and the CLI
driver.
