### PR TITLE
fix(plugin): improve plugin registration and wasi_logging option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,6 @@ option(WASMEDGE_PLUGIN_WASI_CRYPTO "Enable and build WasmEdge wasi-crypto plugin
 #   WASI plug-in: WASI-Http proposal.
 option(WASMEDGE_PLUGIN_WASI_HTTP "Enable and build WasmEdge wasi-http plugin." OFF)
 #   WASI plug-in: WASI-Logging proposal.
-#     Note: WASMEDGE_PLUGIN_WASI_LOGGING is not used until the new plug-in mechanism is ready in 0.15.0.
 option(WASMEDGE_PLUGIN_WASI_LOGGING "Enable and build WasmEdge wasi-logging plugin." ON)
 #   WASI plug-in: WASI-NN proposal with backends.
 set(WASMEDGE_PLUGIN_WASI_NN_BACKEND "" CACHE STRING "Enable and build WasmEdge Wasi-NN plugin with backends.")

--- a/lib/api/CMakeLists.txt
+++ b/lib/api/CMakeLists.txt
@@ -164,7 +164,9 @@ if(WASMEDGE_BUILD_STATIC_LIB)
   wasmedge_add_static_lib_component_command(wasmedgePlugin)
   # BUILTIN-PLUGIN: Temporarily add the wasi-logging plugin here until the new
   # plugin architecture is ready in the future.
-  wasmedge_add_static_lib_component_command(wasmedgePluginWasiLogging)
+  if(WASMEDGE_PLUGIN_WASI_LOGGING)
+    wasmedge_add_static_lib_component_command(wasmedgePluginWasiLogging)
+  endif()
   wasmedge_add_static_lib_component_command(wasmedgeVM)
   wasmedge_add_static_lib_component_command(wasmedgeDriver)
 

--- a/lib/plugin/CMakeLists.txt
+++ b/lib/plugin/CMakeLists.txt
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2019-2024 Second State INC
 
-add_subdirectory(wasi_logging)
+if(WASMEDGE_PLUGIN_WASI_LOGGING)
+  add_subdirectory(wasi_logging)
+endif()
 
 wasmedge_add_library(wasmedgePlugin
   plugin.cpp
@@ -17,8 +19,11 @@ target_link_libraries(wasmedgePlugin
   PUBLIC
   # BUILTIN-PLUGIN: Temporarily add the wasi-logging plugin here until the new
   # plugin architecture is ready in 0.15.0.
-  wasmedgePluginWasiLogging
+  $<$<BOOL:${WASMEDGE_PLUGIN_WASI_LOGGING}>:wasmedgePluginWasiLogging>
   wasmedgeCommon
   wasmedgeLoaderFileMgr
   wasmedgePO
 )
+if(WASMEDGE_PLUGIN_WASI_LOGGING)
+  target_compile_definitions(wasmedgePlugin PRIVATE WASMEDGE_PLUGIN_WASI_LOGGING)
+endif()

--- a/lib/plugin/plugin.cpp
+++ b/lib/plugin/plugin.cpp
@@ -7,8 +7,11 @@
 #include "wasmedge/wasmedge.h"
 
 // BUILTIN-PLUGIN: Headers for built-in plug-ins.
+#ifdef WASMEDGE_PLUGIN_WASI_LOGGING
 #include "plugin/wasi_logging/module.h"
+#endif
 
+#include <shared_mutex>
 #include <type_traits>
 #include <variant>
 
@@ -74,14 +77,17 @@ public:
   CAPIPluginRegister &operator=(const CAPIPluginRegister &) = delete;
 
   CAPIPluginRegister(const WasmEdge_PluginDescriptor *Desc) noexcept {
-    ModuleDescriptions.resize(Desc->ModuleCount);
-    for (size_t I = 0; I < ModuleDescriptions.size(); ++I) {
-      ModuleDescriptions[I].Name = Desc->ModuleDescriptions[I].Name;
-      ModuleDescriptions[I].Description =
-          Desc->ModuleDescriptions[I].Description;
-      ModuleDescriptions[I].Create = &createWrapper;
-      DescriptionLookup.emplace(&ModuleDescriptions[I],
-                                &Desc->ModuleDescriptions[I]);
+    {
+      std::unique_lock Lock(DescriptionLookupMutex);
+      ModuleDescriptions.resize(Desc->ModuleCount);
+      for (size_t I = 0; I < ModuleDescriptions.size(); ++I) {
+        ModuleDescriptions[I].Name = Desc->ModuleDescriptions[I].Name;
+        ModuleDescriptions[I].Description =
+            Desc->ModuleDescriptions[I].Description;
+        ModuleDescriptions[I].Create = &createWrapper;
+        DescriptionLookup.emplace(&ModuleDescriptions[I],
+                                  &Desc->ModuleDescriptions[I]);
+      }
     }
 
     Descriptor.Name = Desc->Name;
@@ -178,13 +184,17 @@ private:
   static Runtime::Instance::ModuleInstance *
   createWrapper(const PluginModule::ModuleDescriptor *Descriptor) noexcept {
     static_assert(std::is_standard_layout_v<CAPIPluginRegister>);
-    if (auto Iter = DescriptionLookup.find(Descriptor);
-        unlikely(Iter == DescriptionLookup.end())) {
-      return nullptr;
-    } else {
-      return reinterpret_cast<Runtime::Instance::ModuleInstance *>(
-          Iter->second->Create(Iter->second));
+    const WasmEdge_ModuleDescriptor *CDesc = nullptr;
+    {
+      std::shared_lock Lock(DescriptionLookupMutex);
+      auto Iter = DescriptionLookup.find(Descriptor);
+      if (unlikely(Iter == DescriptionLookup.end())) {
+        return nullptr;
+      }
+      CDesc = Iter->second;
     }
+    return reinterpret_cast<Runtime::Instance::ModuleInstance *>(
+        CDesc->Create(CDesc));
   }
   static void addOptionsWrapper(const Plugin::PluginDescriptor *Descriptor,
                                 PO::ArgumentParser &Parser
@@ -213,12 +223,14 @@ private:
                    PO::Option<double *>, PO::Option<WasmEdge_String *>>>>
       Options;
   std::vector<PluginModule::ModuleDescriptor> ModuleDescriptions;
+  static std::shared_mutex DescriptionLookupMutex;
   static std::unordered_map<const PluginModule::ModuleDescriptor *,
                             const WasmEdge_ModuleDescriptor *>
       DescriptionLookup;
 
   bool Result = false;
 };
+std::shared_mutex CAPIPluginRegister::DescriptionLookupMutex;
 std::unordered_map<const PluginModule::ModuleDescriptor *,
                    const WasmEdge_ModuleDescriptor *>
     CAPIPluginRegister::DescriptionLookup;
@@ -436,8 +448,10 @@ bool Plugin::loadFile(const std::filesystem::path &Path) noexcept {
 
 void Plugin::registerBuiltInPlugins() noexcept {
   std::unique_lock Lock(Mutex);
+#ifdef WASMEDGE_PLUGIN_WASI_LOGGING
   // BUILTIN-PLUGIN: Register wasi-logging here. May be refactored in 0.15.0.
   registerPlugin(&Host::WasiLoggingModule::PluginDescriptor);
+#endif
 }
 
 Plugin::Plugin(const PluginDescriptor *D) noexcept : Desc(D) {

--- a/test/plugins/CMakeLists.txt
+++ b/test/plugins/CMakeLists.txt
@@ -7,7 +7,9 @@ if(WASMEDGE_PLUGIN_WASI_CRYPTO)
 endif()
 
 # WASI plug-in: WASI-Logging proposal.
-add_subdirectory(wasi_logging)
+if(WASMEDGE_PLUGIN_WASI_LOGGING)
+  add_subdirectory(wasi_logging)
+endif()
 
 # WASI plug-in: WASI-NN proposal with backends.
 if(WASMEDGE_PLUGIN_WASI_NN_BACKEND)


### PR DESCRIPTION
## Description

This PR fixes two plugin issues.

## Fix 1: Make C API plugin lookup safer

When a C API plugin is loaded, WasmEdge stores its module descriptions in a shared map called `DescriptionLookup`.

Later, when a plugin module is created, WasmEdge reads from that same map.

Before this PR, one thread could write to the map while another thread was reading from it. That can cause a data race in C++.

### What changed

- Added a lock for `DescriptionLookup`.
- Used a write lock when adding new plugin descriptions.
- Used a read lock when looking up a plugin description.
- Released the lock before running plugin-owned `Create()` code.

## Fix 2: Make `WASMEDGE_PLUGIN_WASI_LOGGING=OFF` work

`WASMEDGE_PLUGIN_WASI_LOGGING` was already a CMake option, but turning it `OFF` did not actually disable the built-in wasi_logging plugin.

Even with the option set to `OFF`, the plugin was still built, linked, and registered.

This PR connects the option to all the places that use wasi_logging, so when it is `OFF`, the plugin is not built, linked, registered, bundled into the static library, or tested.

The default behavior stays the same because the option is still `ON` by default.


| File | Change |
|---|---|
| `CMakeLists.txt` | Removed stale “not used” comment |
| `lib/plugin/CMakeLists.txt` | Gated `add_subdirectory(wasi_logging)` |
| `lib/plugin/CMakeLists.txt` | Gated link to `wasmedgePluginWasiLogging` |
| `lib/plugin/CMakeLists.txt` | Added compile definition when enabled |
| `lib/plugin/plugin.cpp` | Guarded wasi_logging include |
| `lib/plugin/plugin.cpp` | Guarded built-in registration |
| `lib/api/CMakeLists.txt` | Gated static lib bundler entry |
| `test/plugins/CMakeLists.txt` | Gated wasi_logging test subdirectory |

Default behavior is preserved because `WASMEDGE_PLUGIN_WASI_LOGGING` remains `ON` by default.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence

Configured with wasi_logging disabled, tests enabled, and static lib enabled:

```bash
cmake -S . -B build-wasi-logging-off \
  -DWASMEDGE_PLUGIN_WASI_LOGGING=OFF \
  -DWASMEDGE_BUILD_TESTS=ON \
  -DWASMEDGE_BUILD_STATIC_LIB=ON \
  -DWASMEDGE_USE_LLVM=OFF

Result:
-- Configuring done (15.4s)
-- Generating done (0.2s)
-- Build files have been written to: /Users/mrinalchaturvedi/CLionProjects/WasmEdge/build-wasi-logging-off
