### PR TITLE
test(wasi): add pointer alignment checks for args/environ host functions

### DIFF
--- a/test/host/wasi/wasi.cpp
+++ b/test/host/wasi/wasi.cpp
@@ -4396,6 +4396,146 @@ TEST(WasiTest, PointerAlignment) {
   // CustomFds pointer alignment tests
   const fs::path TempPath = fs::u8path("wasi_custom_fd_test.tmp");
 
+  // Test WasiArgsGet alignment checks
+  {
+    Env.init({}, "test"s, {}, {});
+    WasmEdge::Host::WasiArgsGet WasiArgsGet(Env);
+    const uint32_t MisalignedArgvPtr = alignof(uint8_t_ptr) - 1;
+    const uint32_t AlignedArgvPtr =
+        static_cast<uint32_t>(alignof(uint8_t_ptr) * 2);
+    const uint32_t ArgvBufPtr =
+        static_cast<uint32_t>(alignof(uint8_t_ptr) * 4);
+
+    // Test misaligned ArgvPtr
+    EXPECT_TRUE(WasiArgsGet.run(CallFrame,
+                                std::initializer_list<WasmEdge::ValVariant>{
+                                    MisalignedArgvPtr, // misaligned
+                                    ArgvBufPtr},
+                                Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+
+    writeDummyMemoryContent(MemInst);
+    // Test correctly aligned ArgvPtr (should succeed)
+    EXPECT_TRUE(WasiArgsGet.run(CallFrame,
+                                std::initializer_list<WasmEdge::ValVariant>{
+                                    AlignedArgvPtr, // aligned
+                                    ArgvBufPtr},
+                                Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    Env.fini();
+  }
+
+  // Test WasiArgsSizesGet alignment checks
+  {
+    Env.init({}, "test"s, {}, {});
+    WasmEdge::Host::WasiArgsSizesGet WasiArgsSizesGet(Env);
+    const uint32_t MisalignedArgcPtr = alignof(__wasi_size_t) - 1;
+    const uint32_t MisalignedArgvBufSizePtr = alignof(__wasi_size_t) - 1;
+    const uint32_t AlignedArgcPtr =
+        static_cast<uint32_t>(alignof(__wasi_size_t) * 2);
+    const uint32_t AlignedArgvBufSizePtr =
+        static_cast<uint32_t>(alignof(__wasi_size_t) * 4);
+
+    // Test misaligned ArgcPtr
+    EXPECT_TRUE(WasiArgsSizesGet.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            MisalignedArgcPtr,      // misaligned
+            AlignedArgvBufSizePtr}, // aligned
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+
+    // Test misaligned ArgvBufSizePtr
+    EXPECT_TRUE(WasiArgsSizesGet.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            AlignedArgcPtr,            // aligned
+            MisalignedArgvBufSizePtr}, // misaligned
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+
+    writeDummyMemoryContent(MemInst);
+    // Test correctly aligned pointers (should succeed)
+    EXPECT_TRUE(WasiArgsSizesGet.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            AlignedArgcPtr,         // aligned
+            AlignedArgvBufSizePtr}, // aligned
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    Env.fini();
+  }
+
+  // Test WasiEnvironGet alignment checks
+  {
+    Env.init({}, "test"s, {}, {"KEY=VAL"s});
+    WasmEdge::Host::WasiEnvironGet WasiEnvironGet(Env);
+    const uint32_t MisalignedEnvPtr = alignof(uint8_t_ptr) - 1;
+    const uint32_t AlignedEnvPtr =
+        static_cast<uint32_t>(alignof(uint8_t_ptr) * 2);
+    const uint32_t EnvBufPtr =
+        static_cast<uint32_t>(alignof(uint8_t_ptr) * 4);
+
+    // Test misaligned EnvPtr
+    EXPECT_TRUE(WasiEnvironGet.run(CallFrame,
+                                   std::initializer_list<WasmEdge::ValVariant>{
+                                       MisalignedEnvPtr, // misaligned
+                                       EnvBufPtr},
+                                   Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+
+    writeDummyMemoryContent(MemInst);
+    // Test correctly aligned EnvPtr (should succeed)
+    EXPECT_TRUE(WasiEnvironGet.run(CallFrame,
+                                   std::initializer_list<WasmEdge::ValVariant>{
+                                       AlignedEnvPtr, // aligned
+                                       EnvBufPtr},
+                                   Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    Env.fini();
+  }
+
+  // Test WasiEnvironSizesGet alignment checks
+  {
+    Env.init({}, "test"s, {}, {"KEY=VAL"s});
+    WasmEdge::Host::WasiEnvironSizesGet WasiEnvironSizesGet(Env);
+    const uint32_t MisalignedEnvCntPtr = alignof(__wasi_size_t) - 1;
+    const uint32_t MisalignedEnvBufSizePtr = alignof(__wasi_size_t) - 1;
+    const uint32_t AlignedEnvCntPtr =
+        static_cast<uint32_t>(alignof(__wasi_size_t) * 2);
+    const uint32_t AlignedEnvBufSizePtr =
+        static_cast<uint32_t>(alignof(__wasi_size_t) * 4);
+
+    // Test misaligned EnvCntPtr
+    EXPECT_TRUE(WasiEnvironSizesGet.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            MisalignedEnvCntPtr,   // misaligned
+            AlignedEnvBufSizePtr}, // aligned
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+
+    // Test misaligned EnvBufSizePtr
+    EXPECT_TRUE(WasiEnvironSizesGet.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            AlignedEnvCntPtr,         // aligned
+            MisalignedEnvBufSizePtr}, // misaligned
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+
+    writeDummyMemoryContent(MemInst);
+    // Test correctly aligned pointers (should succeed)
+    EXPECT_TRUE(WasiEnvironSizesGet.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            AlignedEnvCntPtr,        // aligned
+            AlignedEnvBufSizePtr},   // aligned
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    Env.fini();
+  }
+
   // Test WasiFdFdstatGet alignment checks
   {
     Env.init({}, "test"s, {}, {});


### PR DESCRIPTION
## Description

Add alignment tests to `WasiTest.PointerAlignment` for the four WASI host functions that gained `isMisaligned<>` guards in commit `acbe7db1` but had no corresponding unit test coverage:

| Function | Parameter guarded | wasifunc.cpp line |
|---|---|---|
| `WasiArgsGet` | `ArgvPtr` | [L382](https://github.com/WasmEdge/WasmEdge/blob/master/lib/host/wasi/wasifunc.cpp#L382) |
| `WasiArgsSizesGet` | `ArgcPtr`, `ArgvBufSizePtr` | [L423–L426](https://github.com/WasmEdge/WasmEdge/blob/master/lib/host/wasi/wasifunc.cpp#L423) |
| `WasiEnvironGet` | `EnvPtr` | [L456](https://github.com/WasmEdge/WasmEdge/blob/master/lib/host/wasi/wasifunc.cpp#L456) |
| `WasiEnvironSizesGet` | `EnvCntPtr`, `EnvBufSizePtr` | [L497–L500](https://github.com/WasmEdge/WasmEdge/blob/master/lib/host/wasi/wasifunc.cpp#L497) |

Each block verifies:
1. A misaligned pointer returns `__WASI_ERRNO_ADDRNOTAVAIL`
2. A correctly-aligned pointer does **not** trigger the guard (succeeds)

This provides regression coverage for #2694 and #2733, where a shadow-stack pointer corrupted by a mutated `i32.and → i32.or` instruction was passed to `args_get` / `environ_get` without triggering an error. The alignment guard in `acbe7db1` is now backed by explicit tests.

Related: #2694, #2733, #2881, #4820

## Checklist

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Commit title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (`test(wasi): …`).
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<img width="644" height="493" alt="Screenshot 2026-05-10 at 2 30 45 AM" src="https://github.com/user-attachments/assets/ce4e07a0-8c78-4bf2-ac38-ce86146f6ce8" />

