### PR TITLE
fix(llvm): dispose LLVM21 AOT context in DataContext

### DIFF
--- a/lib/llvm/data.h
+++ b/lib/llvm/data.h
@@ -10,7 +10,7 @@ struct WasmEdge::LLVM::Data::DataContext {
   LLVM::Context LLContext = LLVM::Context::create();
   LLVM::Context getLLContext() noexcept { return LLContext; }
   LLVM::OrcThreadSafeContext getTSContext() noexcept {
-    return LLVM::OrcThreadSafeContext(LLContext);
+    return LLVM::OrcThreadSafeContext(LLContext.release());
   }
 #else
   LLVM::OrcThreadSafeContext TSContext;
@@ -22,4 +22,7 @@ struct WasmEdge::LLVM::Data::DataContext {
   LLVM::Module LLModule;
   LLVM::TargetMachine TM;
   DataContext() noexcept : LLModule(getLLContext(), "wasm") {}
+#if LLVM_VERSION_MAJOR >= 21
+  ~DataContext() noexcept { LLVMContextDispose(LLContext.release()); }
+#endif
 };


### PR DESCRIPTION
### Motivation
- LLVM 21+ path created an owned `LLVMContext` in `DataContext` but did not dispose it on the AOT codegen path, causing one leaked LLVM context per compile and enabling unbounded memory growth. 

### Description
- Change `getTSContext()` to transfer ownership by calling `LLContext.release()` so construction of `OrcThreadSafeContext` consumes the raw context for JIT paths. 
- Add an LLVM 21+ destructor to `DataContext` that calls `LLVMContextDispose(LLContext.release())` to free any context left owned by the `DataContext` when the object is destroyed (AOT path). 
- Only `lib/llvm/data.h` was modified and behavior for `LLVM_VERSION_MAJOR < 21` is unchanged. 
- This is a minimal fix that preserves existing semantics while preventing the context leak. 

### Testing
- Ran `git diff --check` which passed with no whitespace or diff-check errors. 
- Attempted `cmake --build build -j2` but the build directory is not present in this environment so a full build/test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12c5f085c8320b33b616080482f0e)