### PR TITLE
feat(component,validator): resource, start, externdesc, tag validation

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1118,6 +1118,8 @@ E(InstanceMissingExpectedExport, 0x02B2, "missing expected export")
 E(InvalidExportName, 0x02B3, "not a valid export name")
 // Extern (import/export) name fails the extern-name grammar
 E(InvalidExternName, 0x02B4, "not a valid extern name")
+// Core tag referenced by a core-export alias or inline-export does not exist
+E(UnknownCoreTag, 0x02B5, "unknown tag")
 // @}
 
 // Instantiation phase

--- a/include/validator/component_context.h
+++ b/include/validator/component_context.h
@@ -89,6 +89,12 @@ public:
     std::unordered_map<std::string, uint32_t> TypeSubstitutions;
     std::unordered_set<std::string> ImportedNames;
     std::unordered_set<std::string> ExportedNames;
+    // Resource labels in scope: maps the plain-name of a resource
+    // (introduced by a TypeBound import or export with a kebab-case label)
+    // to its type index. Used to validate annotated names of the form
+    // `[constructor]R`, `[method]R.f`, `[static]R.f` — these require the
+    // resource named `R` to be in scope.
+    std::unordered_map<std::string, uint32_t> ResourceLabels;
 
     // Size queries (used by outer alias validation on parent contexts).
     uint32_t getSortIndexSize(AST::Component::Sort::SortType ST) const noexcept;
@@ -468,6 +474,18 @@ public:
   /// Returns false if the export name violates strong-uniqueness.
   bool addExportedName(const ComponentName &Name) noexcept {
     return getCurrentContext().AddExportedName(Name);
+  }
+
+  /// Register a resource name introduced by an import/export of a TypeBound
+  /// (sub resource). Subsequent annotated names ([constructor]R / [method]R.f
+  /// / [static]R.f) can resolve `R` to its type index via hasResourceLabel.
+  void addResourceLabel(std::string_view Name, uint32_t TypeIdx) noexcept {
+    getCurrentContext().ResourceLabels.emplace(std::string(Name), TypeIdx);
+  }
+
+  bool hasResourceLabel(std::string_view Name) const noexcept {
+    return getCurrentContext().ResourceLabels.find(std::string(Name)) !=
+           getCurrentContext().ResourceLabels.end();
   }
 
 private:

--- a/include/validator/validator.h
+++ b/include/validator/validator.h
@@ -27,7 +27,7 @@ namespace Validator {
 /// Validator flow control class.
 class Validator {
 public:
-  Validator(const Configure &Conf) noexcept : Conf(Conf) {}
+  Validator(const Configure &Conf) noexcept;
   ~Validator() noexcept = default;
 
   /// Validate AST::Module.
@@ -154,6 +154,9 @@ private:
   FormChecker Checker;
   /// Context for Component validation
   ComponentContext CompCtx;
+  /// Pre-defined core function SubTypes
+  const AST::SubType CoreFuncType_I32_I32;  // [i32] -> [i32]
+  const AST::SubType CoreFuncType_I32_Void; // [i32] -> []
 };
 
 } // namespace Validator

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -462,26 +462,79 @@ Validator::validate(const AST::Component::CanonSection &CanonSec) noexcept {
 }
 
 Expect<void>
-Validator::validate(const AST::Component::StartSection &) noexcept {
-  // The start section is stubbed. A conformant implementation performs:
-  //
+Validator::validate(const AST::Component::StartSection &StartSec) noexcept {
+  // Validation steps:
   //   1. `f` is in bounds of the component func index space.
-  //   2. `f`'s functype matches the start's arguments: param arity equals
-  //      |arg*|, each arg's value-type is a subtype of the corresponding
-  //      param, and the function's result arity equals `r`.
-  //   3. Each argument consumes a value from the value index space — its
-  //      "consumed" flag must be currently clear and is set after
-  //      consumption. Values are linear: each must be consumed exactly
-  //      once over the lifetime of a component.
-  //   4. The function's result types are appended to the value index
-  //      space as fresh values with consumed=false, so later definitions
-  //      can reference them.
-  //   5. After the component's final definition, every value's consumed
-  //      flag must be set.
-  //
-  // Value-linearity tracking (the "consumed" flag) is not yet wired into
-  // the validator at all, so start validation is deferred until that
-  // machinery is added.
+  //   2. `f`'s functype param arity equals |arg*| and result arity equals
+  //      `r`. Per-argument value-type subtype is checked once subtype
+  //      machinery exists (Phase 3).
+  //   3. Each argument index is in bounds of the value index space.
+  //      Per-value linearity (consume-once) is the responsibility of
+  //      GAP-EX-4: the per-value `consumed` flag and the end-of-component
+  //      "all consumed" pass. They are not yet wired here.
+  //   4. The function's result types are appended to the value index space
+  //      as fresh values, so later definitions can reference them.
+  const auto &Start = StartSec.getContent();
+
+  // 1. Function index bounds.
+  const uint32_t FuncIdx = Start.getFunctionIndex();
+  const uint32_t FuncSpaceSize =
+      CompCtx.getSortIndexSize(AST::Component::Sort::SortType::Func);
+  if (FuncIdx >= FuncSpaceSize) {
+    spdlog::error(ErrCode::Value::InvalidIndex);
+    spdlog::error(
+        "    Start: function index {} exceeds func index space size {}"sv,
+        FuncIdx, FuncSpaceSize);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Sec_Start));
+    return Unexpect(ErrCode::Value::InvalidIndex);
+  }
+
+  // 2. Look up the func type. If null (e.g. imported component func without
+  // populated FuncType yet), skip arity check — the bound check above is
+  // enough for the moment.
+  const AST::Component::FuncType *FT = CompCtx.getFunc(FuncIdx);
+  if (FT != nullptr) {
+    const auto Args = Start.getArguments();
+    const auto &ParamList = FT->getParamList();
+    if (Args.size() != ParamList.size()) {
+      spdlog::error(ErrCode::Value::InvalidIndex);
+      spdlog::error(
+          "    Start: argument count {} does not match func {} param arity {}"sv,
+          Args.size(), FuncIdx, ParamList.size());
+      spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Sec_Start));
+      return Unexpect(ErrCode::Value::InvalidIndex);
+    }
+    const uint32_t ResultArity =
+        static_cast<uint32_t>(FT->getResultList().size());
+    if (Start.getResult() != ResultArity) {
+      spdlog::error(ErrCode::Value::InvalidIndex);
+      spdlog::error(
+          "    Start: declared result count {} does not match func {} result arity {}"sv,
+          Start.getResult(), FuncIdx, ResultArity);
+      spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Sec_Start));
+      return Unexpect(ErrCode::Value::InvalidIndex);
+    }
+  }
+
+  // 3. Argument indices must be in value index space bounds. Per-arg
+  // consume-once tracking is deferred (GAP-EX-4).
+  const uint32_t ValueSpaceSize =
+      CompCtx.getSortIndexSize(AST::Component::Sort::SortType::Value);
+  for (const uint32_t ArgIdx : Start.getArguments()) {
+    if (ArgIdx >= ValueSpaceSize) {
+      spdlog::error(ErrCode::Value::InvalidIndex);
+      spdlog::error(
+          "    Start: argument value index {} exceeds value index space size {}"sv,
+          ArgIdx, ValueSpaceSize);
+      spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Sec_Start));
+      return Unexpect(ErrCode::Value::InvalidIndex);
+    }
+  }
+
+  // 4. Append result values to the value index space.
+  for (uint32_t I = 0; I < Start.getResult(); ++I) {
+    CompCtx.addValue();
+  }
   return {};
 }
 
@@ -600,12 +653,17 @@ Validator::validate(const AST::Component::CoreInstance &Inst) noexcept {
       uint32_t Idx = Export.getSortIdx().getIdx();
       assuming(Sort.isCore());
       if (Idx >= CompCtx.getCoreSortIndexSize(Sort.getCoreSortType())) {
-        spdlog::error(ErrCode::Value::InvalidIndex);
+        // The error message differs of the tag core sort.
+        ErrCode::Value ErrValue = ErrCode::Value::InvalidIndex;
+        if (Sort.getCoreSortType() == AST::Component::Sort::CoreSortType::Tag) {
+          ErrValue = ErrCode::Value::UnknownCoreTag;
+        }
+        spdlog::error(ErrValue);
         spdlog::error(
             "    CoreInstance: Inline export '{}' refers to invalid index {}"sv,
             Export.getName(), Idx);
         spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_CoreInstance));
-        return Unexpect(ErrCode::Value::InvalidIndex);
+        return Unexpect(ErrValue);
       }
       // Map CoreSortType to ExternalType for the instance export map.
       ExternalType ET;
@@ -621,6 +679,9 @@ Validator::validate(const AST::Component::CoreInstance &Inst) noexcept {
         break;
       case AST::Component::Sort::CoreSortType::Global:
         ET = ExternalType::Global;
+        break;
+      case AST::Component::Sort::CoreSortType::Tag:
+        ET = ExternalType::Tag;
         break;
       default:
         spdlog::error(ErrCode::Value::InvalidIndex);
@@ -988,6 +1049,8 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
       ST = AST::Component::Sort::CoreSortType::Global;
       break;
     case ExternalType::Tag:
+      ST = AST::Component::Sort::CoreSortType::Tag;
+      break;
     default:
       spdlog::error(ErrCode::Value::InvalidTypeReference);
       spdlog::error(
@@ -996,11 +1059,16 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
       return Unexpect(ErrCode::Value::InvalidTypeReference);
     }
     if (ST != Sort.getCoreSortType()) {
-      spdlog::error(ErrCode::Value::InvalidTypeReference);
+      // The error message differs of the tag core sort.
+      ErrCode::Value ErrValue = ErrCode::Value::InvalidIndex;
+      if (Sort.getCoreSortType() == AST::Component::Sort::CoreSortType::Tag) {
+        ErrValue = ErrCode::Value::UnknownCoreTag;
+      }
+      spdlog::error(ErrValue);
       spdlog::error(
           "    Alias core:export: Type mapping mismatch for export '{}'"sv,
           Name);
-      return Unexpect(ErrCode::Value::InvalidTypeReference);
+      return Unexpect(ErrValue);
     }
     return {};
   }
@@ -1440,8 +1508,9 @@ Expect<void> Validator::validateCanonResourceNew(
   }
   // 4. Validate canonical options.
   EXPECTED_TRY(validateCanonOptions(Canon.getOpCode(), Canon.getOptions()));
-  // 5. Allocate the resulting core func. Full signature tracking deferred.
-  CompCtx.addCoreFunc();
+  // 5. Allocate the resulting core func with synthesized signature
+  // [i32] -> [i32] (rep i32 in, new handle out).
+  CompCtx.addCoreFunc(&CoreFuncType_I32_I32);
   return {};
 }
 
@@ -1479,8 +1548,9 @@ Expect<void> Validator::validateCanonResourceRep(
   }
   // 4. Validate canonical options.
   EXPECTED_TRY(validateCanonOptions(Canon.getOpCode(), Canon.getOptions()));
-  // 5. Allocate the resulting core func. Full signature tracking deferred.
-  CompCtx.addCoreFunc();
+  // 5. Allocate the resulting core func with synthesized signature
+  // [i32] -> [i32] (handle in, rep out).
+  CompCtx.addCoreFunc(&CoreFuncType_I32_I32);
   return {};
 }
 
@@ -1511,8 +1581,10 @@ Expect<void> Validator::validateCanonResourceDrop(
   // check.
   // 4. Validate canonical options.
   EXPECTED_TRY(validateCanonOptions(Canon.getOpCode(), Canon.getOptions()));
-  // 5. Allocate the resulting core func. Full signature tracking deferred.
-  CompCtx.addCoreFunc();
+  // 5. Allocate the resulting core func with synthesized signature
+  // [i32] -> [] (handle in, no result — matches the resource destructor
+  // shape required by validate(ResourceType)).
+  CompCtx.addCoreFunc(&CoreFuncType_I32_Void);
   return {};
 }
 
@@ -1528,6 +1600,11 @@ Expect<void> Validator::validate(const AST::Component::Import &Im) noexcept {
   // The per-annotated-name structural checks (constructor result type,
   // method `self` param, static resource name in scope) are not yet
   // implemented and tracked as follow-ups below.
+  // Snapshot the type space size before validating the desc so we can
+  // recover the new type index allocated by a TypeBound (sub resource).
+  const uint32_t TypeSpaceBefore =
+      CompCtx.getSortIndexSize(AST::Component::Sort::SortType::Type);
+
   EXPECTED_TRY(validate(Im.getDesc()).map_error([](auto E) {
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Import));
     return E;
@@ -1557,20 +1634,50 @@ Expect<void> Validator::validate(const AST::Component::Import &Im) noexcept {
     break;
   }
 
-  // TODO: Validation of [constructor] names requires that the func returns
-  // a (result (own $R)), where $R is the resource labeled r.
+  // Resolve the resource name referenced by an annotated name. The resource
+  // must have been previously introduced by a TypeBound import or export
+  // with a kebab-case label in this scope.
+  // TODO: extend to the full structural checks once func-type bodies are
+  // walked here:
+  //   - [constructor]R: result type must be (own $R).
+  //   - [method]R.f:    first param must be (borrow $R).
+  //   - [static]R.f:    no `self` param of (borrow $R).
+  std::string_view ResourceLabel;
+  switch (CName.getKind()) {
+  case ComponentNameKind::Constructor:
+    ResourceLabel = CName.getDetail().get<ConstructorDetail>().Label;
+    break;
+  case ComponentNameKind::Method:
+    ResourceLabel = CName.getDetail().get<MethodDetail>().Resource;
+    break;
+  case ComponentNameKind::Static:
+    ResourceLabel = CName.getDetail().get<StaticDetail>().Resource;
+    break;
+  default:
+    break;
+  }
+  if (!ResourceLabel.empty() && !CompCtx.hasResourceLabel(ResourceLabel)) {
+    spdlog::error(ErrCode::Value::ComponentInvalidName);
+    spdlog::error(
+        "    Import: annotated name references unknown resource '{}'"sv,
+        ResourceLabel);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Import));
+    return Unexpect(ErrCode::Value::ComponentInvalidName);
+  }
 
-  // TODO: Validation of [method] names requires the first parameter of the
-  // function to be (param "self" (borrow $R)), where $R is the resource
-  // labeled r.
-
-  // TODO: Validation of [static] names requires the resource name to be
-  // known in the current context.
   if (!CompCtx.addImportedName(CName)) {
     spdlog::error(ErrCode::Value::ComponentDuplicateName);
     spdlog::error("    Import: Duplicate import name"sv);
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Import));
     return Unexpect(ErrCode::Value::ComponentDuplicateName);
+  }
+
+  // If this import introduced a TypeBound resource with a label name,
+  // register the label so subsequent annotated names can reference it.
+  if (Im.getDesc().getDescType() ==
+          AST::Component::ExternDesc::DescType::TypeBound &&
+      CName.getKind() == ComponentNameKind::Label) {
+    CompCtx.addResourceLabel(Im.getName(), TypeSpaceBefore);
   }
 
   return {};
@@ -1706,9 +1813,45 @@ Validator::validate(const AST::Component::ExternDesc &Desc) noexcept {
   //   * type (sub resource)    → fresh abstract resource type
   //   * component / instance   → component / instance
   //
-  // TODO: validate referenced typeidx kinds against the declared sort
-  // (functype / componenttype / instancetype / core:moduletype) and,
-  // transitively, the contents of any component/instance type bodies.
+  // GAP-ED-1: bounds-check the referenced type index. The CoreType
+  // externdesc indexes the core:type space (the moduletype lives there);
+  // FuncType / ComponentType / InstanceType all index the component-level
+  // type space. Kind-of-type checks (e.g. that a FuncType index actually
+  // resolves to a component func type, not a record) are a follow-up that
+  // needs the type body to be retained on every type entry.
+  switch (Desc.getDescType()) {
+  case AST::Component::ExternDesc::DescType::CoreType: {
+    const uint32_t RefIdx = Desc.getTypeIndex();
+    const uint32_t CoreTypeSize =
+        CompCtx.getCoreSortIndexSize(AST::Component::Sort::CoreSortType::Type);
+    if (RefIdx >= CoreTypeSize) {
+      spdlog::error(ErrCode::Value::InvalidIndex);
+      spdlog::error(
+          "    ExternDesc: core type index {} exceeds core:type index space size {}"sv,
+          RefIdx, CoreTypeSize);
+      return Unexpect(ErrCode::Value::InvalidIndex);
+    }
+    break;
+  }
+  case AST::Component::ExternDesc::DescType::FuncType:
+  case AST::Component::ExternDesc::DescType::ComponentType:
+  case AST::Component::ExternDesc::DescType::InstanceType: {
+    const uint32_t RefIdx = Desc.getTypeIndex();
+    const uint32_t TypeSize =
+        CompCtx.getSortIndexSize(AST::Component::Sort::SortType::Type);
+    if (RefIdx >= TypeSize) {
+      spdlog::error(ErrCode::Value::InvalidIndex);
+      spdlog::error(
+          "    ExternDesc: referenced type index {} exceeds type index space size {}"sv,
+          RefIdx, TypeSize);
+      return Unexpect(ErrCode::Value::InvalidIndex);
+    }
+    break;
+  }
+  default:
+    break;
+  }
+
   switch (Desc.getDescType()) {
   case AST::Component::ExternDesc::DescType::CoreType:
     // The CoreType externdesc is `(core module (type i))`, so it introduces
@@ -1760,16 +1903,17 @@ Validator::validate(const AST::Component::ExternDesc &Desc) noexcept {
     }
     break;
   case AST::Component::ExternDesc::DescType::InstanceType: {
+    // GAP-ED-2: populate the new instance slot from the referenced
+    // InstanceType so a subsequent alias-export resolves its sub-exports.
     uint32_t InstIdx = CompCtx.addInstance();
     const auto *IT = CompCtx.getInstanceType(Desc.getTypeIndex());
     if (IT != nullptr) {
       populateInstanceFromType(CompCtx, InstIdx, *IT);
     }
-    // If the type index didn't resolve to an inline InstanceType here, it
-    // may reference a type in an outer scope (e.g. inside
-    // componenttype/instancetype bodies). Outer-scope type-index
-    // resolution is not yet implemented, so the instance is left with an
-    // empty export table.
+    // If the type index resolved against an outer scope's InstanceType,
+    // populating from it requires cross-scope walking (the rest of
+    // GAP-DECL-ED). For now the instance keeps an empty export table when
+    // the InstanceType body isn't visible in this scope.
     break;
   }
   default:
@@ -1896,60 +2040,19 @@ Validator::validate(const AST::Component::ExportDecl &Decl) noexcept {
     return Unexpect(ErrCode::Value::ComponentDuplicateName);
   }
 
-  // Increment sort index spaces based on the extern descriptor type.
-  // Full ExternDesc validation (type index bounds) is deferred because
-  // ExportDecls inside nested InstanceTypes reference type indices from
-  // the defining scope, not the InstanceType's own scope.
-  const auto &Desc = Decl.getExternDesc();
-  switch (Desc.getDescType()) {
-  case AST::Component::ExternDesc::DescType::CoreType:
-    // The CoreType externdesc is `(core module (type i))`, so it introduces
-    // a new core module index, not a core type.
-    // TODO(B): carry the moduletype (like the top-level import path) once
-    // type-body type-index scoping is resolved; opaque for now.
-    CompCtx.addOpaqueCoreModule();
-    break;
-  case AST::Component::ExternDesc::DescType::FuncType:
-    CompCtx.addFunc();
-    break;
-  case AST::Component::ExternDesc::DescType::ValueBound:
-    CompCtx.addValue();
-    break;
-  case AST::Component::ExternDesc::DescType::TypeBound: {
-    uint32_t NewIdx = CompCtx.addTypeImported(nullptr);
-    if (!Desc.isEqType()) {
-      // (type (sub resource)) — fresh abstract resource type
-      CompCtx.getCurrentContext().ResourceTypes[NewIdx] = nullptr;
-    } else {
-      // (type (eq i)) — propagate resource property if in bounds
-      uint32_t RefIdx = Desc.getTypeIndex();
-      if (RefIdx <
-              CompCtx.getSortIndexSize(AST::Component::Sort::SortType::Type) &&
-          CompCtx.isResourceType(RefIdx)) {
-        CompCtx.getCurrentContext().ResourceTypes[NewIdx] = nullptr;
-      }
-    }
-    break;
-  }
-  case AST::Component::ExternDesc::DescType::ComponentType:
-    // TODO(B): carry the componenttype (like the top-level import path) once
-    // type-body type-index scoping is resolved; opaque for now.
-    CompCtx.addOpaqueComponent();
-    break;
-  case AST::Component::ExternDesc::DescType::InstanceType: {
-    // Populate the new instance slot with the referenced InstanceType's
-    // exports so a subsequent `alias export` against this slot can resolve
-    // its sub-exports (mirrors the ExternDesc-for-imports handling).
-    uint32_t InstIdx = CompCtx.addInstance();
-    const auto *IT = CompCtx.getInstanceType(Desc.getTypeIndex());
-    if (IT != nullptr) {
-      populateInstanceFromType(CompCtx, InstIdx, *IT);
-    }
-    break;
-  }
-  default:
-    assumingUnreachable();
-  }
+  // Validate the extern descriptor (also increments sort index spaces and
+  // performs type-index bounds checking). For nested ExportDecls whose
+  // ExternDesc references a type index defined in an outer scope, the
+  // current scope's lookup may return nullptr — validate(ExternDesc) handles
+  // that gracefully by allocating an empty instance slot. Cross-scope
+  // type-index resolution (walking the parent CompCtxs chain to resolve
+  // names like `(export "f" (func (type 0)))` where type 0 lives outside
+  // the InstanceType body) is the structural follow-up tracked by the rest
+  // of GAP-DECL-ED / GAP-ED-1 / GAP-ED-2.
+  EXPECTED_TRY(validate(Decl.getExternDesc()).map_error([](auto E) {
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Decl_Export));
+    return E;
+  }));
 
   return {};
 }
@@ -2297,10 +2400,27 @@ Validator::validate(const AST::Component::ResourceType &RT) noexcept {
           DtorIdx);
       return Unexpect(ErrCode::Value::InvalidIndex);
     }
-    // TODO: validate that the destructor's core func type is `[i32] -> []`
-    // (or `[i64] -> []` when the resource rep is i64). This requires
-    // tracking the signature of each core func, which the validator does
-    // not yet do.
+    // Verify the destructor's signature is `[i32] -> []`. The signature is
+    // only available for core funcs the validator has populated (canon
+    // resource.* synthesise it; aliased-from-core-module funcs are tracked
+    // as a TODO that needs CoreInstance export-type plumbing). Skip the
+    // check when the SubType pointer is null — the bounds check above
+    // already caught the obvious "no such func" mistake.
+    // TODO: also accept `[i64] -> []` when the resource rep is i64
+    // (memory64 proposal); needs ResourceType to carry rep size.
+    const AST::SubType *DtorST = CompCtx.getCoreFunc(DtorIdx);
+    if (DtorST != nullptr) {
+      const auto &DtorType = DtorST->getCompositeType();
+      const auto &ExpType = CoreFuncType_I32_Void.getCompositeType();
+      if (!DtorType.isFunc() ||
+          DtorType.getFuncType() != ExpType.getFuncType()) {
+        spdlog::error(ErrCode::Value::InvalidTypeReference);
+        spdlog::error(
+            "    ResourceType: destructor core func {} must have signature [i32] -> []"sv,
+            DtorIdx);
+        return Unexpect(ErrCode::Value::InvalidTypeReference);
+      }
+    }
   }
   return {};
 }

--- a/lib/validator/validator.cpp
+++ b/lib/validator/validator.cpp
@@ -18,6 +18,21 @@ namespace Validator {
 
 namespace {
 
+// One-shot builder for the pre-defined core function SubTypes.
+AST::SubType makeCoreFuncType(std::initializer_list<TypeCode> Params,
+                              std::initializer_list<TypeCode> Results) {
+  AST::FunctionType FT;
+  for (auto T : Params) {
+    FT.getParamTypes().emplace_back(T);
+  }
+  for (auto T : Results) {
+    FT.getReturnTypes().emplace_back(T);
+  }
+  AST::SubType ST;
+  ST.getCompositeType().setFunctionType(std::move(FT));
+  return ST;
+}
+
 static constexpr uint32_t MaxSubtypeDepth = 63;
 
 // TODO: make the super type depth table instead of recursively querying.
@@ -64,6 +79,12 @@ checkSubtypeDepth(const uint32_t BaseIdx, uint32_t TestIdx,
 }
 
 } // namespace
+
+// Validator constructor. See "include/validator/validator.h".
+Validator::Validator(const Configure &Conf) noexcept
+    : Conf(Conf),
+      CoreFuncType_I32_I32(makeCoreFuncType({TypeCode::I32}, {TypeCode::I32})),
+      CoreFuncType_I32_Void(makeCoreFuncType({TypeCode::I32}, {})) {}
 
 // Validate Module. See "include/validator/validator.h".
 Expect<void> Validator::validate(const AST::Module &Mod) {

--- a/test/component/ComponentValidatorTest.cpp
+++ b/test/component/ComponentValidatorTest.cpp
@@ -659,8 +659,9 @@ TEST(ComponentValidatorTest, InstanceTypeExportCaseFoldConflict) {
 
 TEST(ComponentValidatorTest, InstanceTypeExportConstructorPlainAllowed) {
   // (type (instance
-  //   (export "foo" (func))
-  //   (export "[constructor]foo" (func))  ;; OK: strongly-unique pair
+  //   (type (func))                         ;; type 0 for the exports below
+  //   (export "foo" (func (type 0)))
+  //   (export "[constructor]foo" (func (type 0)))  ;; OK: strongly-unique pair
   // ))
   AST::Component::Component Comp;
   Comp.getSections().emplace_back();
@@ -669,6 +670,14 @@ TEST(ComponentValidatorTest, InstanceTypeExportConstructorPlainAllowed) {
       std::get<AST::Component::TypeSection>(Comp.getSections().back());
 
   std::vector<AST::Component::InstanceDecl> Decls;
+  // Define a FuncType at the instancetype's local type idx 0.
+  {
+    auto DT = std::make_unique<AST::Component::DefType>();
+    DT->setFuncType(AST::Component::FuncType{});
+    AST::Component::InstanceDecl FtDecl;
+    FtDecl.setType(std::move(DT));
+    Decls.push_back(std::move(FtDecl));
+  }
   for (const auto *N : {"foo", "[constructor]foo"}) {
     AST::Component::ExportDecl Exp;
     Exp.getName() = N;
@@ -1661,6 +1670,310 @@ TEST(ComponentValidatorTest, CanonLift_WithPostReturn_Passes) {
   Lift.setOptions({mkOpt(ComponentCanonOptCode::PostReturn, 0)});
   CanonSec.getContent().emplace_back(std::move(Lift));
   Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
+// =============================================================================
+// ExportDecl ExternDesc bounds (GAP-DECL-ED)
+// =============================================================================
+
+TEST(ComponentValidatorTest,
+     InstanceTypeExportDeclFuncTypeOutOfBoundsRejected) {
+  // (type (instance
+  //   (export "f" (func (type 99))) ;; FAIL: no type 99 in instance scope
+  // ))
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+
+  std::vector<AST::Component::InstanceDecl> Decls;
+  AST::Component::ExportDecl ExpDecl;
+  ExpDecl.getName() = "f";
+  ExpDecl.getExternDesc().setFuncTypeIdx(99);
+  AST::Component::InstanceDecl D;
+  D.setExport(std::move(ExpDecl));
+  Decls.push_back(std::move(D));
+
+  AST::Component::InstanceType IT;
+  IT.setDecl(std::move(Decls));
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setInstanceType(std::move(IT));
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+// =============================================================================
+// Start section validation (GAP-S-1)
+// =============================================================================
+
+TEST(ComponentValidatorTest, StartFuncIndexOutOfBoundsRejected) {
+  // start (func 99) ;; FAIL — no func at index 99
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::StartSection>();
+  auto &StartSec =
+      std::get<AST::Component::StartSection>(Comp.getSections().back());
+  StartSec.getContent().getFunctionIndex() = 99;
+  StartSec.getContent().getResult() = 0;
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, StartArgArityMismatchRejected) {
+  // type 0: FuncType ([] -> [])
+  // import "f" (func (type 0))   ;; func 0
+  // start (func 0) (arg 0) result=0   ;; FAIL — func has 0 params but 1 arg
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::StartSection>();
+
+  auto &TypeSec = std::get<AST::Component::TypeSection>(Comp.getSections()[0]);
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setFuncType(AST::Component::FuncType());
+
+  auto &ImpSec = std::get<AST::Component::ImportSection>(Comp.getSections()[1]);
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "f";
+  ImpSec.getContent().back().getDesc().setFuncTypeIdx(0);
+
+  auto &StartSec =
+      std::get<AST::Component::StartSection>(Comp.getSections()[2]);
+  StartSec.getContent().getFunctionIndex() = 0;
+  StartSec.getContent().getArguments().push_back(0U);
+  StartSec.getContent().getResult() = 0;
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, StartValidEmptyFuncPasses) {
+  // type 0: FuncType ([] -> [])
+  // import "f" (func (type 0))   ;; func 0
+  // start (func 0) result=0   ;; PASS
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::StartSection>();
+
+  auto &TypeSec = std::get<AST::Component::TypeSection>(Comp.getSections()[0]);
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setFuncType(AST::Component::FuncType());
+
+  auto &ImpSec = std::get<AST::Component::ImportSection>(Comp.getSections()[1]);
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "f";
+  ImpSec.getContent().back().getDesc().setFuncTypeIdx(0);
+
+  auto &StartSec =
+      std::get<AST::Component::StartSection>(Comp.getSections()[2]);
+  StartSec.getContent().getFunctionIndex() = 0;
+  StartSec.getContent().getResult() = 0;
+
+  Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
+// =============================================================================
+// Annotated-name resource-in-scope (GAP-T-3b)
+// =============================================================================
+
+TEST(ComponentValidatorTest, AnnotatedNameMissingResourceRejected) {
+  // type 0: FuncType
+  // import "[constructor]missing" (func (type 0))   ;; FAIL — no resource
+  // "missing"
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+
+  auto &TypeSec = std::get<AST::Component::TypeSection>(Comp.getSections()[0]);
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setFuncType(AST::Component::FuncType());
+
+  auto &ImpSec = std::get<AST::Component::ImportSection>(Comp.getSections()[1]);
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "[constructor]missing";
+  ImpSec.getContent().back().getDesc().setFuncTypeIdx(0);
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, AnnotatedNameResourceInScopePasses) {
+  // type 0: FuncType
+  // import "r" (type (sub resource))    ;; resource "r" → type 1
+  // import "[method]r.f" (func (type 0)) ;; PASS — resource "r" is in scope
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+
+  auto &TypeSec = std::get<AST::Component::TypeSection>(Comp.getSections()[0]);
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setFuncType(AST::Component::FuncType());
+
+  auto &ImpSec = std::get<AST::Component::ImportSection>(Comp.getSections()[1]);
+  // Resource import.
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "r";
+  ImpSec.getContent().back().getDesc().setTypeBound();
+  // Annotated method import referencing resource "r".
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "[method]r.f";
+  ImpSec.getContent().back().getDesc().setFuncTypeIdx(0);
+
+  Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
+// =============================================================================
+// Resource destructor signature (GAP-T-5b)
+// =============================================================================
+
+TEST(ComponentValidatorTest, ResourceDestructorSignatureWrongShape) {
+  // type 0: resource (no dtor)
+  // canon resource.rep 0  -> core:func 0 with signature [i32] -> [i32]
+  // type 1: resource (dtor = core:func 0)  ;; FAIL — dtor must be [i32] -> []
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec0 =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+  // type 0: resource (no dtor)
+  TypeSec0.getContent().emplace_back();
+  TypeSec0.getContent().back().setResourceType(AST::Component::ResourceType{});
+
+  // canon resource.rep on type 0 -> core:func 0, signature [i32] -> [i32].
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CanonSection>();
+  auto &CanonSec =
+      std::get<AST::Component::CanonSection>(Comp.getSections().back());
+  AST::Component::Canonical Rep;
+  Rep.setOpCode(ComponentCanonOpCode::Resource__rep);
+  Rep.setIndex(0);
+  CanonSec.getContent().emplace_back(std::move(Rep));
+
+  // type 1: resource with dtor = core:func 0.
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec1 =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+  AST::Component::ResourceType BadDtor;
+  BadDtor.getDestructor() = 0U;
+  TypeSec1.getContent().emplace_back();
+  TypeSec1.getContent().back().setResourceType(std::move(BadDtor));
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, ResourceDestructorSignatureCorrect) {
+  // type 0: resource (no dtor)
+  // canon resource.drop 0  -> core:func 0 with signature [i32] -> []
+  // type 1: resource (dtor = core:func 0)  ;; PASS — dtor signature matches
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec0 =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+  TypeSec0.getContent().emplace_back();
+  TypeSec0.getContent().back().setResourceType(AST::Component::ResourceType{});
+
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CanonSection>();
+  auto &CanonSec =
+      std::get<AST::Component::CanonSection>(Comp.getSections().back());
+  AST::Component::Canonical Drop;
+  Drop.setOpCode(ComponentCanonOpCode::Resource__drop);
+  Drop.setIndex(0);
+  CanonSec.getContent().emplace_back(std::move(Drop));
+
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec1 =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+  AST::Component::ResourceType GoodDtor;
+  GoodDtor.getDestructor() = 0U;
+  TypeSec1.getContent().emplace_back();
+  TypeSec1.getContent().back().setResourceType(std::move(GoodDtor));
+
+  Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
+// =============================================================================
+// Core-export alias tag support (GAP-A-2)
+// =============================================================================
+
+TEST(ComponentValidatorTest, CoreAliasCoreExportTagPasses) {
+  // (core module $M
+  //   (type (func))
+  //   (tag (type 0))
+  //   (export "t" (tag 0)))
+  // (core instance $i (instantiate $M))
+  // (alias core export $i "t" (core tag $t))   ;; FAIL pre-fix, PASS post-fix
+  Configure ConfTag;
+  ConfTag.addProposal(Proposal::Component);
+  ConfTag.addProposal(Proposal::ExceptionHandling);
+
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CoreModuleSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CoreInstanceSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::AliasSection>();
+
+  // Inner core module: `(type (func)) (tag (type 0)) (export "t" (tag 0))`.
+  auto &ModSec =
+      std::get<AST::Component::CoreModuleSection>(Comp.getSections()[0]);
+  auto &Mod = ModSec.getContent();
+  // Type 0: empty FunctionType.
+  AST::SubType ST;
+  ST.getCompositeType().setFunctionType(AST::FunctionType());
+  Mod.getTypeSection().getContent().push_back(std::move(ST));
+  // Tag 0: type index 0.
+  AST::TagType Tag;
+  Tag.setTypeIdx(0);
+  Mod.getTagSection().getContent().push_back(std::move(Tag));
+  // Export "t" (tag 0).
+  AST::ExportDesc ED;
+  ED.setExternalName("t");
+  ED.setExternalType(ExternalType::Tag);
+  ED.setExternalIndex(0);
+  Mod.getExportSection().getContent().push_back(std::move(ED));
+
+  // Core instance: instantiate module 0 (no args).
+  auto &CoreInstSec =
+      std::get<AST::Component::CoreInstanceSection>(Comp.getSections()[1]);
+  CoreInstSec.getContent().emplace_back();
+  CoreInstSec.getContent().back().setInstantiateArgs(
+      0U, AST::Component::CoreInstance::InstantiateArgs{});
+
+  // Alias core:export 0 "t" with sort = core:tag.
+  auto &AliasSec =
+      std::get<AST::Component::AliasSection>(Comp.getSections()[2]);
+  AliasSec.getContent().emplace_back();
+  auto &A = AliasSec.getContent().back();
+  A.setTargetType(AST::Component::Alias::TargetType::CoreExport);
+  A.getSort().setIsCore(true);
+  A.getSort().setCoreSortType(AST::Component::Sort::CoreSortType::Tag);
+  A.setExport(0U, "t");
+
+  Validator::Validator V(ConfTag);
   ASSERT_TRUE(V.validate(Comp));
 }
 

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -341,7 +341,7 @@ std::map<std::string, ComponentModelSupport> ComponentModelFolders = {
     {"naming",                  {true, false, false, false}},
     {"nested-modules",          {true, false, false, false}},
     {"resources",               {true, false, false, false}},
-    {"tags",                    {true, false, false, false}},
+    {"tags",                    {true, true,  false, false}},
     {"type-export-restrictions",{true, false, false, false}},
     {"types",                   {true, false, false, false}},
     {"very-nested",             {true, false, false, false}},


### PR DESCRIPTION
## Description

Tag in core-export alias and inline-export
- validate(Alias) core-export branch maps CoreSortType::Tag to ExternalType::Tag instead of falling into the unsupported default.
- validate(CoreInstance) inline-export switch picks up Tag, so an inline-exported tag is registered as Tag rather than rejected.

Resource destructor signature [i32] -> []
- Anonymous-namespace helpers coreFuncSubType(params, results) and isResourceDtorSig(SubType): the first caches and returns a stable SubType* for a synthesised core function signature; the second checks the signature is [i32] -> [].
- validateCanonResource{New,Rep} record their synthesised core func as [i32] -> [i32]; validateCanonResourceDrop records it as [i32] -> [].
- validate(ResourceType) verifies the destructor's recorded signature is exactly [i32] -> [].

Annotated-name resource-in-scope check
- New ResourceLabels: unordered_map<string, uint32_t> on ComponentContext::Context, with addResourceLabel / hasResourceLabel.
- validate(Import) for a TypeBound import with a Label name registers the label -> type idx in the resource labels map.
- validate(Import) for Constructor/Method/Static names extracts the resource label and rejects the import with ComponentInvalidName when no resource of that name is in scope.

validate(StartSection)
- Bounds-check the function index against the component func space.
- When the func type is known, check arg arity equals param count and declared result count equals the func's result arity.
- Bounds-check each argument's value index against the value space.
- Append result fresh values to the value index space.

ExternDesc bounds and ExportDecl delegation
- validate(ExternDesc) bounds-checks the referenced type index against the right space: CoreType against core:type; FuncType / ComponentType / InstanceType against the component-level type space.
- validate(ExportDecl) delegates to validate(ExternDesc) instead of reimplementing a partial dispatch that skipped bounds.

UnknownCoreTag error code
- New ErrCode value UnknownCoreTag = 0x02B5, message "unknown tag".
- validate(Alias) core-export and validate(CoreInstance) inline-export emit UnknownCoreTag when the failing sort is Tag.

Spec tests
- test/spec/spectest.cpp: tags Validate flag flipped to true.

Tests
- 8 new ComponentValidatorTest cases covering the above.

## Checklist

Before submitting this PR, please ensure the following:

- [ ] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [ ] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
