### PR TITLE
fix(api): document log callback lifetime

### DIFF
--- a/include/api/wasmedge/wasmedge_basic.h
+++ b/include/api/wasmedge/wasmedge_basic.h
@@ -148,6 +148,10 @@ typedef struct WasmEdge_LogMessage {
   uint64_t ThreadId;
 } WasmEdge_LogMessage;
 
+/// The `WasmEdge_LogMessage` pointer and embedded strings are borrowed. They
+/// are only valid during the callback. Copy the string contents before
+/// returning if they are needed later. The caller should __NOT__ call
+/// `WasmEdge_StringDelete` on the embedded strings.
 typedef void (*WasmEdge_LogCallback_t)(const WasmEdge_LogMessage *Message);
 
 WASMEDGE_CAPI_EXPORT extern void

--- a/test/api/APIUnitTest.cpp
+++ b/test/api/APIUnitTest.cpp
@@ -479,6 +479,33 @@ TEST(APICoreTest, Version) {
 TEST(APICoreTest, Log) {
   WasmEdge_LogSetCallback([](const WasmEdge_LogMessage *) {});
   EXPECT_TRUE(true);
+
+  static bool CallbackCalled = false;
+  static std::string CopiedMessage;
+  static std::string CopiedLoggerName;
+  CallbackCalled = false;
+  CopiedMessage.clear();
+  CopiedLoggerName.clear();
+  WasmEdge_LogSetCallback([](const WasmEdge_LogMessage *Message) {
+    CallbackCalled = true;
+    if (Message->Message.Buf && Message->Message.Length > 0) {
+      CopiedMessage.assign(Message->Message.Buf, Message->Message.Length);
+    }
+    if (Message->LoggerName.Buf && Message->LoggerName.Length > 0) {
+      CopiedLoggerName.assign(Message->LoggerName.Buf,
+                              Message->LoggerName.Length);
+    }
+  });
+  WasmEdge_LogSetErrorLevel();
+  WasmEdge_LoaderContext *Loader = WasmEdge_LoaderCreate(nullptr);
+  WasmEdge_ASTModuleContext *Mod = nullptr;
+  EXPECT_FALSE(
+      WasmEdge_ResultOK(WasmEdge_LoaderParseFromFile(Loader, &Mod, "file")));
+  WasmEdge_LoaderDelete(Loader);
+  EXPECT_TRUE(CallbackCalled);
+  EXPECT_FALSE(CopiedMessage.empty());
+  EXPECT_EQ(CopiedLoggerName, "WasmEdge"sv);
+
   std::vector<WasmEdge_LogLevel> LogLevels = {
       WasmEdge_LogLevel_Trace, WasmEdge_LogLevel_Debug,
       WasmEdge_LogLevel_Info,  WasmEdge_LogLevel_Warn,


### PR DESCRIPTION
## Description
I fixed the C API docs for `WasmEdge_LogSetCallback`.

The callback was already getting borrowed strings. The issue was that the header did not clearly say how long those strings are valid. Now it says that the message pointer and the `WasmEdge_String` buffers are valid only while the callback is running.

If a user wants to keep the log text for later, they have to copy it inside the callback.

## How I found it

I checked `lib/api/wasmedge.cpp` first. `WasmEdge_LogSetCallback` creates a local `WasmEdge_LogMessage` and fills it using string views from `spdlog::details::log_msg`.

Then I checked `include/api/wasmedge/wasmedge_basic.h`. Other string APIs explain owned and wrapped strings properly, but the log callback did not say that its strings are borrowed. So the main fix was to make this clear in the header.

## What I changed

- Added a clear lifetime note for `WasmEdge_LogCallback_t`.
- Mentioned that users should copy the string contents before returning from the callback.
- Mentioned that users should not call `WasmEdge_StringDelete` on these embedded strings.
- Added a small API test which installs a log callback and copies the message and logger name inside the callback.

## Why this is safe

This does not change the ABI, struct layout, callback signature, or logging code.

The test only checks the safe usage pattern. It does not try to read the raw pointers after the callback returns.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence

- <img width="979" height="711" alt="Screenshot 2026-05-11 at 10 02 34 PM" src="https://github.com/user-attachments/assets/44505d0c-08e5-4821-8cd6-810465e32ca8" />

- <img width="893" height="127" alt="Screenshot 2026-05-11 at 10 03 11 PM" src="https://github.com/user-attachments/assets/5f5feeca-aedb-4dfd-b594-891b5914c01c" />

