### PR TITLE
refactor(component): move AST::Component::Canonical enums to enums.inc

### DIFF
--- a/include/ast/component/canonical.h
+++ b/include/ast/component/canonical.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "ast/component/valtype.h"
+#include "common/enum_ast.hpp"
 #include "common/span.h"
 
 #include <cstdint>
@@ -36,28 +37,16 @@ namespace Component {
 /// AST Component::CanonOpt definition.
 class CanonOpt {
 public:
-  enum class OptCode : uint8_t {
-    Encode_UTF8 = 0x00,
-    Encode_UTF16 = 0x01,
-    Encode_Latin1 = 0x02,
-    Memory = 0x03,
-    Realloc = 0x04,
-    PostReturn = 0x05,
-    Async = 0x06,
-    Callback = 0x07,
-    AlwaysTaskReturn = 0x08,
-  };
+  CanonOpt() noexcept : Code(ComponentCanonOptCode::Encode_UTF8), Idx(0) {}
 
-  CanonOpt() noexcept : Code(OptCode::Encode_UTF8), Idx(0) {}
-
-  OptCode getCode() const noexcept { return Code; }
-  void setCode(const OptCode C) noexcept { Code = C; }
+  ComponentCanonOptCode getCode() const noexcept { return Code; }
+  void setCode(const ComponentCanonOptCode C) noexcept { Code = C; }
 
   uint32_t getIndex() const noexcept { return Idx; }
   void setIndex(const uint32_t I) noexcept { Idx = I; }
 
 private:
-  OptCode Code;
+  ComponentCanonOptCode Code;
   uint32_t Idx;
 };
 
@@ -130,53 +119,10 @@ private:
 
 class Canonical {
 public:
-  // TODO: COMPONENT - move to enum.inc.
-  enum class OpCode : uint8_t {
-    Lift = 0x00,
-    Lower = 0x01,
-    Resource__new = 0x02,
-    Resource__drop = 0x03,
-    Resource__drop_async = 0x07,
-    Resource__rep = 0x04,
-    Backpressure__set = 0x08,
-    Task__return = 0x09,
-    Task__cancel = 0x05,
-    Context__get = 0x0A,
-    Context__set = 0x0B,
-    Yield = 0x0C,
-    Subtask__cancel = 0x06,
-    Subtask__drop = 0x0D,
-    Stream__new = 0x0E,
-    Stream__read = 0x0F,
-    Stream__write = 0x10,
-    Stream__cancel_read = 0x11,
-    Stream__cancel_write = 0x12,
-    Stream__close_readable = 0x13,
-    Stream__close_writable = 0x14,
-    Future__new = 0x15,
-    Future__read = 0x16,
-    Future__write = 0x17,
-    Future__cancel_read = 0x18,
-    Future__cancel_write = 0x19,
-    Future__close_readable = 0x1A,
-    Future__close_writable = 0x1B,
-    Error_context__new = 0x1C,
-    Error_context__debug_message = 0x1D,
-    Error_context__drop = 0x1E,
-    Waitable_set__new = 0x1F,
-    Waitable_set__wait = 0x20,
-    Waitable_set__poll = 0x21,
-    Waitable_set__drop = 0x22,
-    Waitable__join = 0x23,
-    Thread__spawn_ref = 0x40,
-    Thread__spawn_indirect = 0x41,
-    Thread__available_parallelism = 0x42,
-  };
-
   Canonical() noexcept = default;
 
-  OpCode getOpCode() const noexcept { return Code; }
-  void setOpCode(const OpCode C) noexcept { Code = C; }
+  ComponentCanonOpCode getOpCode() const noexcept { return Code; }
+  void setOpCode(const ComponentCanonOpCode C) noexcept { Code = C; }
 
   bool isAsync() const noexcept { return IsAsync; }
   void setAsync(const bool A) noexcept { IsAsync = A; }
@@ -205,7 +151,7 @@ public:
   }
 
 private:
-  OpCode Code;
+  ComponentCanonOpCode Code;
   bool IsAsync;
   uint32_t Idx, TargetIdx;
   uint32_t I32;

--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1363,3 +1363,65 @@ T(ErrContext, 0x64, "error-context") // error-context
 
 #undef T
 #endif // UseComponentTypeCode
+
+#ifdef UseComponentCanonOpCode
+#define T Line
+
+T(Lift, 0x00, "lift")
+T(Lower, 0x01, "lower")
+T(Resource__new, 0x02, "resource.new")
+T(Resource__drop, 0x03, "resource.drop")
+T(Resource__drop_async, 0x07, "resource.drop_async")
+T(Resource__rep, 0x04, "resource.rep")
+T(Backpressure__set, 0x08, "backpressure.set")
+T(Task__return, 0x09, "task.return")
+T(Task__cancel, 0x05, "task.cancel")
+T(Context__get, 0x0A, "context.get")
+T(Context__set, 0x0B, "context.set")
+T(Yield, 0x0C, "yield")
+T(Subtask__cancel, 0x06, "subtask.cancel")
+T(Subtask__drop, 0x0D, "subtask.drop")
+T(Stream__new, 0x0E, "stream.new")
+T(Stream__read, 0x0F, "stream.read")
+T(Stream__write, 0x10, "stream.write")
+T(Stream__cancel_read, 0x11, "stream.cancel_read")
+T(Stream__cancel_write, 0x12, "stream.cancel_write")
+T(Stream__close_readable, 0x13, "stream.close_readable")
+T(Stream__close_writable, 0x14, "stream.close_writable")
+T(Future__new, 0x15, "future.new")
+T(Future__read, 0x16, "future.read")
+T(Future__write, 0x17, "future.write")
+T(Future__cancel_read, 0x18, "future.cancel_read")
+T(Future__cancel_write, 0x19, "future.cancel_write")
+T(Future__close_readable, 0x1A, "future.close_readable")
+T(Future__close_writable, 0x1B, "future.close_writable")
+T(Error_context__new, 0x1C, "error-context.new")
+T(Error_context__debug_message, 0x1D, "error-context.debug_message")
+T(Error_context__drop, 0x1E, "error-context.drop")
+T(Waitable_set__new, 0x1F, "waitable-set.new")
+T(Waitable_set__wait, 0x20, "waitable-set.wait")
+T(Waitable_set__poll, 0x21, "waitable-set.poll")
+T(Waitable_set__drop, 0x22, "waitable-set.drop")
+T(Waitable__join, 0x23, "waitable.join")
+T(Thread__spawn_ref, 0x40, "thread.spawn_ref")
+T(Thread__spawn_indirect, 0x41, "thread.spawn_indirect")
+T(Thread__available_parallelism, 0x42, "thread.available_parallelism")
+
+#undef T
+#endif // UseComponentCanonOpCode
+
+#ifdef UseComponentCanonOptCode
+#define T Line
+
+T(Encode_UTF8, 0x00, "string-encoding=utf8")
+T(Encode_UTF16, 0x01, "string-encoding=utf16")
+T(Encode_Latin1, 0x02, "string-encoding=latin1+utf16")
+T(Memory, 0x03, "memory")
+T(Realloc, 0x04, "realloc")
+T(PostReturn, 0x05, "post-return")
+T(Async, 0x06, "async")
+T(Callback, 0x07, "callback")
+T(AlwaysTaskReturn, 0x08, "always-task-return")
+
+#undef T
+#endif // UseComponentCanonOptCode

--- a/include/common/enum_ast.hpp
+++ b/include/common/enum_ast.hpp
@@ -86,6 +86,48 @@ static inline constexpr const auto OpCodeStr = []() constexpr {
   return SpareEnumMap(Array);
 }();
 
+/// Component Model Value opcode C++ enumeration class.
+enum class ComponentCanonOpCode : uint8_t {
+#define UseComponentCanonOpCode
+#define Line(NAME, VALUE, STRING) NAME = VALUE,
+#include "enum.inc"
+#undef Line
+#undef UseComponentCanonOpCode
+};
+
+static inline constexpr const auto ComponentCanonOpCodeStr = []() constexpr {
+  using namespace std::literals::string_view_literals;
+  std::pair<ComponentCanonOpCode, std::string_view> Array[] = {
+#define UseComponentCanonOpCode
+#define Line(NAME, VALUE, STRING) {ComponentCanonOpCode::NAME, STRING},
+#include "enum.inc"
+#undef Line
+#undef UseComponentCanonOpCode
+  };
+  return SpareEnumMap(Array);
+}();
+
+/// Component Model Value Opt code C++ enumeration class.
+enum class ComponentCanonOptCode : uint8_t {
+#define UseComponentCanonOptCode
+#define Line(NAME, VALUE, STRING) NAME = VALUE,
+#include "enum.inc"
+#undef Line
+#undef UseComponentCanonOptCode
+};
+
+static inline constexpr const auto ComponentCanonOptCodeStr = []() constexpr {
+  using namespace std::literals::string_view_literals;
+  std::pair<ComponentCanonOptCode, std::string_view> Array[] = {
+#define UseComponentCanonOptCode
+#define Line(NAME, VALUE, STRING) {ComponentCanonOptCode::NAME, STRING},
+#include "enum.inc"
+#undef Line
+#undef UseComponentCanonOptCode
+  };
+  return DenseEnumMap(Array);
+}();
+
 } // namespace WasmEdge
 
 template <>

--- a/include/common/types.h
+++ b/include/common/types.h
@@ -442,7 +442,7 @@ using ValVariant =
 // ----------------------------------------------------
 //  byte |      0th ~ 3rd       |      4th ~ 7th
 // ------|----------------------|----------------------
-//  code | ComponentValTypeCode |      Type index
+//  code | ComponentTypeCode    |      Type index
 // ----------------------------------------------------
 
 /// ComponentValType class definition.

--- a/include/validator/validator.h
+++ b/include/validator/validator.h
@@ -106,7 +106,7 @@ private:
   // Validate component canonical
   Expect<void> validate(const AST::Component::Canonical &Canon) noexcept;
   Expect<void>
-  validateCanonOptions(AST::Component::Canonical::OpCode Code,
+  validateCanonOptions(ComponentCanonOpCode Code,
                        Span<const AST::Component::CanonOpt> Opts) noexcept;
   // Per-opcode canonical built-in validators.
   Expect<void>

--- a/lib/executor/instantiate/component/component_canon.cpp
+++ b/lib/executor/instantiate/component/component_canon.cpp
@@ -97,7 +97,7 @@ Executor::instantiate(Runtime::Instance::ComponentInstance &CompInst,
                       const AST::Component::CanonSection &CanonSec) {
   for (const auto &Canon : CanonSec.getContent()) {
     switch (Canon.getOpCode()) {
-    case AST::Component::Canonical::OpCode::Lift: {
+    case ComponentCanonOpCode::Lift: {
       // Lift wraps a core Wasm function to a component function with proper
       // canonical ABI modification.
       const auto &Opts = Canon.getOptions();
@@ -105,20 +105,20 @@ Executor::instantiate(Runtime::Instance::ComponentInstance &CompInst,
       Runtime::Instance::FunctionInstance *ReallocFunc = nullptr;
       for (auto &Opt : Opts) {
         switch (Opt.getCode()) {
-        case AST::Component::CanonOpt::OptCode::Encode_UTF8:
-        case AST::Component::CanonOpt::OptCode::Encode_UTF16:
-        case AST::Component::CanonOpt::OptCode::Encode_Latin1:
+        case ComponentCanonOptCode::Encode_UTF8:
+        case ComponentCanonOptCode::Encode_UTF16:
+        case ComponentCanonOptCode::Encode_Latin1:
           spdlog::error(ErrCode::Value::ComponentNotImplInstantiate);
           spdlog::error("    incomplete canonincal options"sv);
           return Unexpect(ErrCode::Value::ComponentNotImplInstantiate);
-        case AST::Component::CanonOpt::OptCode::Memory:
+        case ComponentCanonOptCode::Memory:
           MemInst = CompInst.getCoreMemory(Opt.getIndex());
           break;
-        case AST::Component::CanonOpt::OptCode::Realloc:
+        case ComponentCanonOptCode::Realloc:
           ReallocFunc = CompInst.getCoreFunction(Opt.getIndex());
           break;
-        case AST::Component::CanonOpt::OptCode::PostReturn:
-        case AST::Component::CanonOpt::OptCode::Async:
+        case ComponentCanonOptCode::PostReturn:
+        case ComponentCanonOptCode::Async:
           // TODO: incomplete validation of these cases.
         default:
           assumingUnreachable();
@@ -139,7 +139,7 @@ Executor::instantiate(Runtime::Instance::ComponentInstance &CompInst,
               DType->getFuncType(), FuncInst, MemInst, ReallocFunc));
       break;
     }
-    case AST::Component::Canonical::OpCode::Lower: {
+    case ComponentCanonOpCode::Lower: {
       // Lower sends a component function to a core Wasm function with proper
       // canonical ABI modification.
 
@@ -153,20 +153,20 @@ Executor::instantiate(Runtime::Instance::ComponentInstance &CompInst,
       Runtime::Instance::FunctionInstance *ReallocFunc = nullptr;
       for (auto &Opt : Opts) {
         switch (Opt.getCode()) {
-        case AST::Component::CanonOpt::OptCode::Encode_UTF8:
-        case AST::Component::CanonOpt::OptCode::Encode_UTF16:
-        case AST::Component::CanonOpt::OptCode::Encode_Latin1:
+        case ComponentCanonOptCode::Encode_UTF8:
+        case ComponentCanonOptCode::Encode_UTF16:
+        case ComponentCanonOptCode::Encode_Latin1:
           spdlog::error(ErrCode::Value::ComponentNotImplInstantiate);
           spdlog::error("    incomplete canonincal options"sv);
           return Unexpect(ErrCode::Value::ComponentNotImplInstantiate);
-        case AST::Component::CanonOpt::OptCode::Memory:
+        case ComponentCanonOptCode::Memory:
           MemInst = CompInst.getCoreMemory(Opt.getIndex());
           break;
-        case AST::Component::CanonOpt::OptCode::Realloc:
+        case ComponentCanonOptCode::Realloc:
           ReallocFunc = CompInst.getCoreFunction(Opt.getIndex());
           break;
-        case AST::Component::CanonOpt::OptCode::PostReturn:
-        case AST::Component::CanonOpt::OptCode::Async:
+        case ComponentCanonOptCode::PostReturn:
+        case ComponentCanonOptCode::Async:
           // TODO: incomplete validation of these cases.
         default:
           assumingUnreachable();
@@ -179,9 +179,9 @@ Executor::instantiate(Runtime::Instance::ComponentInstance &CompInst,
       CompInst.addCoreFunction(CoreFuncInst);
       break;
     }
-    case AST::Component::Canonical::OpCode::Resource__new:
-    case AST::Component::Canonical::OpCode::Resource__drop:
-    case AST::Component::Canonical::OpCode::Resource__rep:
+    case ComponentCanonOpCode::Resource__new:
+    case ComponentCanonOpCode::Resource__drop:
+    case ComponentCanonOpCode::Resource__rep:
     default:
       spdlog::error(ErrCode::Value::ComponentNotImplInstantiate);
       spdlog::error("    incomplete canonincal"sv);

--- a/lib/loader/ast/component/component_canonical.cpp
+++ b/lib/loader/ast/component/component_canonical.cpp
@@ -98,11 +98,11 @@ Expect<void> Loader::loadCanonical(AST::Component::Canonical &C) {
   };
 
   EXPECTED_TRY(uint8_t Flag, FMgr.readByte().map_error(ReportError));
-  auto Code = static_cast<AST::Component::Canonical::OpCode>(Flag);
+  auto Code = static_cast<ComponentCanonOpCode>(Flag);
   switch (Code) {
 
   // 0x00 0x00 f:<core:funcidx> opts:<opts> ft:<typeidx>
-  case AST::Component::Canonical::OpCode::Lift: {
+  case ComponentCanonOpCode::Lift: {
     EXPECTED_TRY(uint8_t B, FMgr.readByte().map_error(ReportError));
     if (unlikely(B != 0x00)) {
       return ReportError(ErrCode::Value::MalformedCanonical);
@@ -116,7 +116,7 @@ Expect<void> Loader::loadCanonical(AST::Component::Canonical &C) {
   }
 
   // 0x01 0x00 f:<funcidx> opts:<opts>
-  case AST::Component::Canonical::OpCode::Lower: {
+  case ComponentCanonOpCode::Lower: {
     EXPECTED_TRY(uint8_t B, FMgr.readByte().map_error(ReportError));
     if (unlikely(B != 0x00)) {
       return ReportError(ErrCode::Value::MalformedCanonical);
@@ -128,35 +128,35 @@ Expect<void> Loader::loadCanonical(AST::Component::Canonical &C) {
   }
 
   // typeidx-only opcodes
-  case AST::Component::Canonical::OpCode::Resource__new:
-  case AST::Component::Canonical::OpCode::Resource__drop:
-  case AST::Component::Canonical::OpCode::Resource__drop_async:
-  case AST::Component::Canonical::OpCode::Resource__rep:
-  case AST::Component::Canonical::OpCode::Stream__new:
-  case AST::Component::Canonical::OpCode::Stream__close_readable:
-  case AST::Component::Canonical::OpCode::Stream__close_writable:
-  case AST::Component::Canonical::OpCode::Future__new:
-  case AST::Component::Canonical::OpCode::Future__close_readable:
-  case AST::Component::Canonical::OpCode::Future__close_writable:
-  case AST::Component::Canonical::OpCode::Thread__spawn_ref: {
+  case ComponentCanonOpCode::Resource__new:
+  case ComponentCanonOpCode::Resource__drop:
+  case ComponentCanonOpCode::Resource__drop_async:
+  case ComponentCanonOpCode::Resource__rep:
+  case ComponentCanonOpCode::Stream__new:
+  case ComponentCanonOpCode::Stream__close_readable:
+  case ComponentCanonOpCode::Stream__close_writable:
+  case ComponentCanonOpCode::Future__new:
+  case ComponentCanonOpCode::Future__close_readable:
+  case ComponentCanonOpCode::Future__close_writable:
+  case ComponentCanonOpCode::Thread__spawn_ref: {
     EXPECTED_TRY(uint32_t Idx, FMgr.readU32().map_error(ReportError));
     C.setIndex(Idx);
     break;
   }
 
   // no-arg opcodes
-  case AST::Component::Canonical::OpCode::Backpressure__set:
-  case AST::Component::Canonical::OpCode::Task__cancel:
-  case AST::Component::Canonical::OpCode::Subtask__drop:
-  case AST::Component::Canonical::OpCode::Error_context__drop:
-  case AST::Component::Canonical::OpCode::Waitable_set__new:
-  case AST::Component::Canonical::OpCode::Waitable_set__drop:
-  case AST::Component::Canonical::OpCode::Waitable__join:
-  case AST::Component::Canonical::OpCode::Thread__available_parallelism:
+  case ComponentCanonOpCode::Backpressure__set:
+  case ComponentCanonOpCode::Task__cancel:
+  case ComponentCanonOpCode::Subtask__drop:
+  case ComponentCanonOpCode::Error_context__drop:
+  case ComponentCanonOpCode::Waitable_set__new:
+  case ComponentCanonOpCode::Waitable_set__drop:
+  case ComponentCanonOpCode::Waitable__join:
+  case ComponentCanonOpCode::Thread__available_parallelism:
     break;
 
   // 0x09 rs:<resultlist> opts:<opts>
-  case AST::Component::Canonical::OpCode::Task__return: {
+  case ComponentCanonOpCode::Task__return: {
     // Load resultlist (same encoding as functype resultlist).
     EXPECTED_TRY(uint8_t RFlag, FMgr.readByte().map_error(ReportError));
     switch (RFlag) {
@@ -185,8 +185,8 @@ Expect<void> Loader::loadCanonical(AST::Component::Canonical &C) {
   }
 
   // 0x0a 0x7f i:<u32> and 0x0b 0x7f i:<u32>
-  case AST::Component::Canonical::OpCode::Context__get:
-  case AST::Component::Canonical::OpCode::Context__set: {
+  case ComponentCanonOpCode::Context__get:
+  case ComponentCanonOpCode::Context__set: {
     EXPECTED_TRY(uint8_t B, FMgr.readByte().map_error(ReportError));
     if (unlikely(B != 0x7f)) {
       return ReportError(ErrCode::Value::MalformedCanonical);
@@ -197,17 +197,17 @@ Expect<void> Loader::loadCanonical(AST::Component::Canonical &C) {
   }
 
   // async?-only opcodes
-  case AST::Component::Canonical::OpCode::Yield:
-  case AST::Component::Canonical::OpCode::Subtask__cancel: {
+  case ComponentCanonOpCode::Yield:
+  case ComponentCanonOpCode::Subtask__cancel: {
     EXPECTED_TRY(LoadAsync());
     break;
   }
 
   // typeidx + opts opcodes
-  case AST::Component::Canonical::OpCode::Stream__read:
-  case AST::Component::Canonical::OpCode::Stream__write:
-  case AST::Component::Canonical::OpCode::Future__read:
-  case AST::Component::Canonical::OpCode::Future__write: {
+  case ComponentCanonOpCode::Stream__read:
+  case ComponentCanonOpCode::Stream__write:
+  case ComponentCanonOpCode::Future__read:
+  case ComponentCanonOpCode::Future__write: {
     EXPECTED_TRY(uint32_t Idx, FMgr.readU32().map_error(ReportError));
     C.setIndex(Idx);
     EXPECTED_TRY(LoadOpts());
@@ -215,10 +215,10 @@ Expect<void> Loader::loadCanonical(AST::Component::Canonical &C) {
   }
 
   // typeidx + async? opcodes
-  case AST::Component::Canonical::OpCode::Stream__cancel_read:
-  case AST::Component::Canonical::OpCode::Stream__cancel_write:
-  case AST::Component::Canonical::OpCode::Future__cancel_read:
-  case AST::Component::Canonical::OpCode::Future__cancel_write: {
+  case ComponentCanonOpCode::Stream__cancel_read:
+  case ComponentCanonOpCode::Stream__cancel_write:
+  case ComponentCanonOpCode::Future__cancel_read:
+  case ComponentCanonOpCode::Future__cancel_write: {
     EXPECTED_TRY(uint32_t Idx, FMgr.readU32().map_error(ReportError));
     C.setIndex(Idx);
     EXPECTED_TRY(LoadAsync());
@@ -226,15 +226,15 @@ Expect<void> Loader::loadCanonical(AST::Component::Canonical &C) {
   }
 
   // opts-only opcodes
-  case AST::Component::Canonical::OpCode::Error_context__new:
-  case AST::Component::Canonical::OpCode::Error_context__debug_message: {
+  case ComponentCanonOpCode::Error_context__new:
+  case ComponentCanonOpCode::Error_context__debug_message: {
     EXPECTED_TRY(LoadOpts());
     break;
   }
 
   // async? + memidx opcodes
-  case AST::Component::Canonical::OpCode::Waitable_set__wait:
-  case AST::Component::Canonical::OpCode::Waitable_set__poll: {
+  case ComponentCanonOpCode::Waitable_set__wait:
+  case ComponentCanonOpCode::Waitable_set__poll: {
     EXPECTED_TRY(LoadAsync());
     EXPECTED_TRY(uint32_t MemIdx, FMgr.readU32().map_error(ReportError));
     C.setIndex(MemIdx);
@@ -242,7 +242,7 @@ Expect<void> Loader::loadCanonical(AST::Component::Canonical &C) {
   }
 
   // 0x41 ft:<typeidx> tbl:<core:tableidx>
-  case AST::Component::Canonical::OpCode::Thread__spawn_indirect: {
+  case ComponentCanonOpCode::Thread__spawn_indirect: {
     EXPECTED_TRY(uint32_t TypeIdx, FMgr.readU32().map_error(ReportError));
     C.setIndex(TypeIdx);
     EXPECTED_TRY(uint32_t TblIdx, FMgr.readU32().map_error(ReportError));
@@ -290,7 +290,7 @@ Expect<void> Loader::loadCanonicalOption(AST::Component::CanonOpt &Opt) {
   default:
     return ReportError(ErrCode::Value::UnknownCanonicalOption);
   }
-  Opt.setCode(static_cast<AST::Component::CanonOpt::OptCode>(Flag));
+  Opt.setCode(static_cast<ComponentCanonOptCode>(Flag));
   return {};
 }
 

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -1055,16 +1055,16 @@ Validator::validate(const AST::Component::DefType &DType) noexcept {
 Expect<void>
 Validator::validate(const AST::Component::Canonical &Canon) noexcept {
   switch (Canon.getOpCode()) {
-  case AST::Component::Canonical::OpCode::Lift:
+  case ComponentCanonOpCode::Lift:
     return validateCanonLift(Canon);
-  case AST::Component::Canonical::OpCode::Lower:
+  case ComponentCanonOpCode::Lower:
     return validateCanonLower(Canon);
-  case AST::Component::Canonical::OpCode::Resource__new:
+  case ComponentCanonOpCode::Resource__new:
     return validateCanonResourceNew(Canon);
-  case AST::Component::Canonical::OpCode::Resource__rep:
+  case ComponentCanonOpCode::Resource__rep:
     return validateCanonResourceRep(Canon);
-  case AST::Component::Canonical::OpCode::Resource__drop:
-  case AST::Component::Canonical::OpCode::Resource__drop_async:
+  case ComponentCanonOpCode::Resource__drop:
+  case ComponentCanonOpCode::Resource__drop_async:
     return validateCanonResourceDrop(Canon);
   default:
     spdlog::error(ErrCode::Value::ComponentNotImplValidator);
@@ -1074,10 +1074,10 @@ Validator::validate(const AST::Component::Canonical &Canon) noexcept {
 }
 
 Expect<void> Validator::validateCanonOptions(
-    AST::Component::Canonical::OpCode Code,
+    ComponentCanonOpCode Code,
     Span<const AST::Component::CanonOpt> Opts) noexcept {
-  using OptCode = AST::Component::CanonOpt::OptCode;
-  using CanonOp = AST::Component::Canonical::OpCode;
+  using OptCode = ComponentCanonOptCode;
+  using CanonOp = ComponentCanonOpCode;
 
   // Only canon lift/lower accept canonical options. Any other built-in
   // (resource.new/rep/drop, drop_async, ...) must be invoked without options.

--- a/test/component/ComponentValidatorTest.cpp
+++ b/test/component/ComponentValidatorTest.cpp
@@ -1089,7 +1089,7 @@ appendCanonSection(AST::Component::Component &Comp) {
   return std::get<AST::Component::CanonSection>(Comp.getSections().back());
 }
 
-inline AST::Component::CanonOpt mkOpt(AST::Component::CanonOpt::OptCode Code,
+inline AST::Component::CanonOpt mkOpt(ComponentCanonOptCode Code,
                                       uint32_t Idx = 0) {
   AST::Component::CanonOpt O;
   O.setCode(Code);
@@ -1138,7 +1138,7 @@ inline AST::Component::Component makeCompWithCoreFuncAndFuncType() {
   auto &CanonSec =
       std::get<AST::Component::CanonSection>(Comp.getSections().back());
   AST::Component::Canonical ResNew;
-  ResNew.setOpCode(AST::Component::Canonical::OpCode::Resource__new);
+  ResNew.setOpCode(ComponentCanonOpCode::Resource__new);
   ResNew.setIndex(0); // resource at type 0
   CanonSec.getContent().emplace_back(std::move(ResNew));
   return Comp;
@@ -1148,7 +1148,7 @@ TEST(ComponentValidatorTest, CanonResourceNew_OnLocalResource_Passes) {
   auto Comp = makeCompWithLocalResource();
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Resource__new);
+  C.setOpCode(ComponentCanonOpCode::Resource__new);
   C.setIndex(0); // type index 0 = local resource
   CanonSec.getContent().emplace_back(std::move(C));
 
@@ -1160,7 +1160,7 @@ TEST(ComponentValidatorTest, CanonResourceNew_TypeIndexOutOfBounds_Fails) {
   AST::Component::Component Comp;
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Resource__new);
+  C.setOpCode(ComponentCanonOpCode::Resource__new);
   C.setIndex(0); // no type section → index 0 is out of bounds
   CanonSec.getContent().emplace_back(std::move(C));
 
@@ -1180,7 +1180,7 @@ TEST(ComponentValidatorTest, CanonResourceNew_TypeIsNotResource_Fails) {
 
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Resource__new);
+  C.setOpCode(ComponentCanonOpCode::Resource__new);
   C.setIndex(0);
   CanonSec.getContent().emplace_back(std::move(C));
 
@@ -1200,7 +1200,7 @@ TEST(ComponentValidatorTest, CanonResourceNew_OnImportedResource_Fails) {
   ImpSec.getContent().back().getDesc().setTypeBound(); // (sub resource)
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Resource__new);
+  C.setOpCode(ComponentCanonOpCode::Resource__new);
   C.setIndex(0); // imported resource at type 0
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
@@ -1211,7 +1211,7 @@ TEST(ComponentValidatorTest, CanonResourceRep_OnLocalResource_Passes) {
   auto Comp = makeCompWithLocalResource();
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Resource__rep);
+  C.setOpCode(ComponentCanonOpCode::Resource__rep);
   C.setIndex(0);
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
@@ -1222,7 +1222,7 @@ TEST(ComponentValidatorTest, CanonResourceRep_TypeIndexOutOfBounds_Fails) {
   AST::Component::Component Comp;
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Resource__rep);
+  C.setOpCode(ComponentCanonOpCode::Resource__rep);
   C.setIndex(0);
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
@@ -1239,7 +1239,7 @@ TEST(ComponentValidatorTest, CanonResourceRep_TypeIsNotResource_Fails) {
   TypeSec.getContent().back().setFuncType(AST::Component::FuncType());
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Resource__rep);
+  C.setOpCode(ComponentCanonOpCode::Resource__rep);
   C.setIndex(0);
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
@@ -1258,7 +1258,7 @@ TEST(ComponentValidatorTest, CanonResourceRep_OnImportedResource_Fails) {
   ImpSec.getContent().back().getDesc().setTypeBound(); // (sub resource)
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Resource__rep);
+  C.setOpCode(ComponentCanonOpCode::Resource__rep);
   C.setIndex(0);
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
@@ -1269,7 +1269,7 @@ TEST(ComponentValidatorTest, CanonResourceDrop_OnLocalResource_Passes) {
   auto Comp = makeCompWithLocalResource();
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Resource__drop);
+  C.setOpCode(ComponentCanonOpCode::Resource__drop);
   C.setIndex(0);
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
@@ -1288,7 +1288,7 @@ TEST(ComponentValidatorTest, CanonResourceDrop_OnImportedResource_Passes) {
   ImpSec.getContent().back().getDesc().setTypeBound(); // (sub resource)
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Resource__drop);
+  C.setOpCode(ComponentCanonOpCode::Resource__drop);
   C.setIndex(0); // the imported type now occupies type index 0
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
@@ -1305,7 +1305,7 @@ TEST(ComponentValidatorTest, CanonResourceDrop_TypeIsNotResource_Fails) {
   TypeSec.getContent().back().setFuncType(AST::Component::FuncType());
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Resource__drop);
+  C.setOpCode(ComponentCanonOpCode::Resource__drop);
   C.setIndex(0);
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
@@ -1316,7 +1316,7 @@ TEST(ComponentValidatorTest, CanonResourceDrop_TypeIndexOutOfBounds_Fails) {
   AST::Component::Component Comp;
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Resource__drop);
+  C.setOpCode(ComponentCanonOpCode::Resource__drop);
   C.setIndex(0);
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
@@ -1327,7 +1327,7 @@ TEST(ComponentValidatorTest, CanonResourceDropAsync_OnLocalResource_Passes) {
   auto Comp = makeCompWithLocalResource();
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Resource__drop_async);
+  C.setOpCode(ComponentCanonOpCode::Resource__drop_async);
   C.setIndex(0);
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
@@ -1338,9 +1338,9 @@ TEST(ComponentValidatorTest, CanonResourceNew_RejectsOptions) {
   auto Comp = makeCompWithLocalResource();
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Resource__new);
+  C.setOpCode(ComponentCanonOpCode::Resource__new);
   C.setIndex(0);
-  C.setOptions({mkOpt(AST::Component::CanonOpt::OptCode::Encode_UTF8)});
+  C.setOptions({mkOpt(ComponentCanonOptCode::Encode_UTF8)});
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
   ASSERT_FALSE(V.validate(Comp));
@@ -1350,9 +1350,9 @@ TEST(ComponentValidatorTest, CanonResourceDrop_RejectsOptions) {
   auto Comp = makeCompWithLocalResource();
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Resource__drop);
+  C.setOpCode(ComponentCanonOpCode::Resource__drop);
   C.setIndex(0);
-  C.setOptions({mkOpt(AST::Component::CanonOpt::OptCode::Memory, 0)});
+  C.setOptions({mkOpt(ComponentCanonOptCode::Memory, 0)});
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
   ASSERT_FALSE(V.validate(Comp));
@@ -1362,7 +1362,7 @@ TEST(ComponentValidatorTest, CanonLower_ValidFuncIndex_Passes) {
   auto Comp = makeCompWithImportedFunc();
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Lower);
+  C.setOpCode(ComponentCanonOpCode::Lower);
   C.setIndex(0); // component func 0 exists
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
@@ -1373,7 +1373,7 @@ TEST(ComponentValidatorTest, CanonLower_FuncIndexOutOfBounds_Fails) {
   AST::Component::Component Comp;
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Lower);
+  C.setOpCode(ComponentCanonOpCode::Lower);
   C.setIndex(0);
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
@@ -1384,9 +1384,9 @@ TEST(ComponentValidatorTest, CanonLower_RejectsPostReturn) {
   auto Comp = makeCompWithImportedFunc();
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Lower);
+  C.setOpCode(ComponentCanonOpCode::Lower);
   C.setIndex(0);
-  C.setOptions({mkOpt(AST::Component::CanonOpt::OptCode::PostReturn, 0)});
+  C.setOptions({mkOpt(ComponentCanonOptCode::PostReturn, 0)});
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
   ASSERT_FALSE(V.validate(Comp));
@@ -1396,12 +1396,12 @@ TEST(ComponentValidatorTest, CanonLower_RejectsCallback) {
   auto Comp = makeCompWithImportedFunc();
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Lower);
+  C.setOpCode(ComponentCanonOpCode::Lower);
   C.setIndex(0);
   // Async included to satisfy structural rule;
   // site-whitelist should still reject callback on Lower.
-  C.setOptions({mkOpt(AST::Component::CanonOpt::OptCode::Async),
-                mkOpt(AST::Component::CanonOpt::OptCode::Callback, 0)});
+  C.setOptions({mkOpt(ComponentCanonOptCode::Async),
+                mkOpt(ComponentCanonOptCode::Callback, 0)});
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
   ASSERT_FALSE(V.validate(Comp));
@@ -1411,12 +1411,12 @@ TEST(ComponentValidatorTest, CanonLower_RejectsAlwaysTaskReturn) {
   auto Comp = makeCompWithImportedFunc();
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Lower);
+  C.setOpCode(ComponentCanonOpCode::Lower);
   C.setIndex(0);
   // Async included to satisfy structural rule;
   // site-whitelist should still reject always-task-return on Lower.
-  C.setOptions({mkOpt(AST::Component::CanonOpt::OptCode::Async),
-                mkOpt(AST::Component::CanonOpt::OptCode::AlwaysTaskReturn)});
+  C.setOptions({mkOpt(ComponentCanonOptCode::Async),
+                mkOpt(ComponentCanonOptCode::AlwaysTaskReturn)});
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
   ASSERT_FALSE(V.validate(Comp));
@@ -1426,9 +1426,9 @@ TEST(ComponentValidatorTest, CanonLower_ReallocWithoutMemory_Fails) {
   auto Comp = makeCompWithImportedFunc();
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Lower);
+  C.setOpCode(ComponentCanonOpCode::Lower);
   C.setIndex(0);
-  C.setOptions({mkOpt(AST::Component::CanonOpt::OptCode::Realloc, 0)});
+  C.setOptions({mkOpt(ComponentCanonOptCode::Realloc, 0)});
   CanonSec.getContent().emplace_back(std::move(C));
   Validator::Validator V(Conf);
   ASSERT_FALSE(V.validate(Comp));
@@ -1439,7 +1439,7 @@ TEST(ComponentValidatorTest, CanonLift_CoreFuncIndexOutOfBounds_Fails) {
   AST::Component::Component Comp;
   auto &CanonSec = appendCanonSection(Comp);
   AST::Component::Canonical C;
-  C.setOpCode(AST::Component::Canonical::OpCode::Lift);
+  C.setOpCode(ComponentCanonOpCode::Lift);
   C.setIndex(0);
   C.setTargetIndex(0);
   CanonSec.getContent().emplace_back(std::move(C));
@@ -1454,7 +1454,7 @@ TEST(ComponentValidatorTest, CanonLift_TypeIndexOutOfBounds_Fails) {
   auto &CanonSec =
       std::get<AST::Component::CanonSection>(Comp.getSections().back());
   AST::Component::Canonical Lift;
-  Lift.setOpCode(AST::Component::Canonical::OpCode::Lift);
+  Lift.setOpCode(ComponentCanonOpCode::Lift);
   Lift.setIndex(0);       // core func 0 exists
   Lift.setTargetIndex(2); // no type at index 2
   CanonSec.getContent().emplace_back(std::move(Lift));
@@ -1468,7 +1468,7 @@ TEST(ComponentValidatorTest, CanonLift_TargetIsNotFuncType_Fails) {
   auto &CanonSec =
       std::get<AST::Component::CanonSection>(Comp.getSections().back());
   AST::Component::Canonical Lift;
-  Lift.setOpCode(AST::Component::Canonical::OpCode::Lift);
+  Lift.setOpCode(ComponentCanonOpCode::Lift);
   Lift.setIndex(0);
   Lift.setTargetIndex(0); // type 0 is ResourceType
   CanonSec.getContent().emplace_back(std::move(Lift));
@@ -1482,7 +1482,7 @@ TEST(ComponentValidatorTest, CanonLift_Valid_Passes) {
   auto &CanonSec =
       std::get<AST::Component::CanonSection>(Comp.getSections().back());
   AST::Component::Canonical Lift;
-  Lift.setOpCode(AST::Component::Canonical::OpCode::Lift);
+  Lift.setOpCode(ComponentCanonOpCode::Lift);
   Lift.setIndex(0);
   Lift.setTargetIndex(1); // type 1 is FuncType
   CanonSec.getContent().emplace_back(std::move(Lift));
@@ -1496,12 +1496,12 @@ TEST(ComponentValidatorTest, CanonLift_WithPostReturn_Passes) {
   auto &CanonSec =
       std::get<AST::Component::CanonSection>(Comp.getSections().back());
   AST::Component::Canonical Lift;
-  Lift.setOpCode(AST::Component::Canonical::OpCode::Lift);
+  Lift.setOpCode(ComponentCanonOpCode::Lift);
   Lift.setIndex(0);
   Lift.setTargetIndex(1);
   // post-return points to core func 0 (the resource.new result from the
   // fixture).
-  Lift.setOptions({mkOpt(AST::Component::CanonOpt::OptCode::PostReturn, 0)});
+  Lift.setOptions({mkOpt(ComponentCanonOptCode::PostReturn, 0)});
   CanonSec.getContent().emplace_back(std::move(Lift));
   Validator::Validator V(Conf);
   ASSERT_TRUE(V.validate(Comp));


### PR DESCRIPTION
A DenseEnumMap was used for ComponentCanonOptCode as it has contiguous values from 0x00 to 0x08.

## Description
Moved AST::Component::Canonical enums to enums.inc.
I had made a PR for this a while back (#4746), but I forgot to update it. The fixes from that PR have been incorporated here

## Checklist

Before submitting this PR, please ensure the following:

- [X] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [X] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [X] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->
```
Test project /home/pranjal/Projects/WasmEdge/build
      Start  1: wasmedgeAOTCacheTests
 1/30 Test  #1: wasmedgeAOTCacheTests ..............   Passed    0.01 sec
      Start  2: wasmedgeAOTBlake3Tests
 2/30 Test  #2: wasmedgeAOTBlake3Tests .............   Passed    0.00 sec
      Start  3: wasmedgeLLVMCoreTests
 3/30 Test  #3: wasmedgeLLVMCoreTests ..............   Passed   89.11 sec
      Start  4: wasmedgeMixcallTests
 4/30 Test  #4: wasmedgeMixcallTests ...............   Passed    0.04 sec
      Start  5: wasmedgeCommonTests
 5/30 Test  #5: wasmedgeCommonTests ................   Passed    0.00 sec
      Start  6: wasmedgeLoaderFileMgrTests
 6/30 Test  #6: wasmedgeLoaderFileMgrTests .........   Passed    0.01 sec
      Start  7: wasmedgeLoaderASTTests
 7/30 Test  #7: wasmedgeLoaderASTTests .............   Passed    0.01 sec
      Start  8: wasmedgeLoaderSerializerTests
 8/30 Test  #8: wasmedgeLoaderSerializerTests ......   Passed    0.00 sec
      Start  9: wasmedgeExecutorCoreTests
 9/30 Test  #9: wasmedgeExecutorCoreTests ..........   Passed    1.76 sec
      Start 10: wasmedgeExecutorRegressionTests
10/30 Test #10: wasmedgeExecutorRegressionTests ....   Passed    0.04 sec
      Start 11: wasmedgeValidatorRegressionTests
11/30 Test #11: wasmedgeValidatorRegressionTests ...   Passed    0.02 sec
      Start 12: wasmedgeComponentRegressionTests
12/30 Test #12: wasmedgeComponentRegressionTests ...   Passed    0.02 sec
      Start 13: wasmedgeThreadTests
13/30 Test #13: wasmedgeThreadTests ................   Passed    1.02 sec
      Start 14: wasmedgeAPIUnitTests
14/30 Test #14: wasmedgeAPIUnitTests ...............   Passed    0.14 sec
      Start 15: wasmedgeAPIVMCoreTests
15/30 Test #15: wasmedgeAPIVMCoreTests .............   Passed    1.79 sec
      Start 16: wasmedgeAPIStepsCoreTests
16/30 Test #16: wasmedgeAPIStepsCoreTests ..........   Passed    1.73 sec
      Start 17: wasmedgeAPIAOTCoreTests
17/30 Test #17: wasmedgeAPIAOTCoreTests ............   Passed   17.49 sec
      Start 18: wasmedgeAPIAOTNestedVMTests
18/30 Test #18: wasmedgeAPIAOTNestedVMTests ........   Passed    0.03 sec
      Start 19: wasmedgeExternrefTests
19/30 Test #19: wasmedgeExternrefTests .............   Passed    0.01 sec
      Start 20: wasiLoggingTests
20/30 Test #20: wasiLoggingTests ...................   Passed    0.01 sec
      Start 21: wasmedgePluginUnittestsC
21/30 Test #21: wasmedgePluginUnittestsC ...........   Passed    0.01 sec
      Start 22: wasmedgePluginUnittestsCPP
22/30 Test #22: wasmedgePluginUnittestsCPP .........   Passed    0.01 sec
      Start 23: wasiSocketTests
23/30 Test #23: wasiSocketTests ....................   Passed    0.09 sec
      Start 24: wasiTests
24/30 Test #24: wasiTests ..........................   Passed    6.68 sec
      Start 25: wasmedgeHostMockTests
25/30 Test #25: wasmedgeHostMockTests ..............   Passed    0.03 sec
      Start 26: expectedTests
26/30 Test #26: expectedTests ......................   Passed    0.01 sec
      Start 27: spanTests
27/30 Test #27: spanTests ..........................   Passed    0.01 sec
      Start 28: poTests
28/30 Test #28: poTests ............................   Passed    0.01 sec
      Start 29: wasmedgeMemInstanceTests
29/30 Test #29: wasmedgeMemInstanceTests ...........   Passed    0.03 sec
      Start 30: wasmedgeErrinfoTests
30/30 Test #30: wasmedgeErrinfoTests ...............   Passed    0.01 sec

100% tests passed, 0 tests failed out of 30

Total Test time (real) = 120.17 sec
```
---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
