### PR TITLE
feat(component,validator): apply strong-uniqueness rule to export names

### DIFF
--- a/include/validator/component_context.h
+++ b/include/validator/component_context.h
@@ -81,6 +81,7 @@ public:
     getCoreSortIndexSize(AST::Component::Sort::CoreSortType ST) const noexcept;
 
     bool AddImportedName(const ComponentName &Name) noexcept;
+    bool AddExportedName(const ComponentName &Name) noexcept;
   };
 
   // ==========================================================================
@@ -362,9 +363,9 @@ public:
     return getCurrentContext().AddImportedName(Name);
   }
 
-  /// Returns false if the export name already exists (duplicate).
-  bool addExportedName(std::string_view Name) noexcept {
-    return getCurrentContext().ExportedNames.emplace(Name).second;
+  /// Returns false if the export name violates strong-uniqueness.
+  bool addExportedName(const ComponentName &Name) noexcept {
+    return getCurrentContext().AddExportedName(Name);
   }
 
 private:

--- a/lib/validator/component_context.cpp
+++ b/lib/validator/component_context.cpp
@@ -88,8 +88,11 @@ ComponentContext::incCoreSortIndexSize(Sort::CoreSortType ST) noexcept {
   }
 }
 
-bool ComponentContext::Context::AddImportedName(
-    const ComponentName &Name) noexcept {
+namespace {
+constexpr std::string_view ConstructorTag{"[constructor]"};
+
+bool addStronglyUniqueName(std::unordered_set<std::string> &Names,
+                           const ComponentName &Name) noexcept {
   switch (Name.getKind()) {
   case ComponentNameKind::Constructor:
   case ComponentNameKind::Method:
@@ -118,19 +121,19 @@ bool ComponentContext::Context::AddImportedName(
     std::string LowerCase = toLowerString(Name.getOriginalName());
     std::string Label = std::string(Name.getNoTagName());
     // Check for conflicts with existing constructors.
-    if (ImportedNames.count(LowerCase)) {
+    if (Names.count(LowerCase)) {
       return false;
     }
 
-    if (ImportedNames.count(toLowerString(Label))) {
-      if (!ImportedNames.count(Label)) {
+    if (Names.count(toLowerString(Label))) {
+      if (!Names.count(Label)) {
         return false;
       }
       // By rule, a constructor [constructor]X and X are strongly-unique.
       // If X and its lower-case x form both exist, it means x comes from X.
     }
-    ImportedNames.insert(LowerCase);
-    ImportedNames.insert(std::string(Name.getOriginalName()));
+    Names.insert(LowerCase);
+    Names.insert(std::string(Name.getOriginalName()));
     return true;
   }
 
@@ -140,7 +143,7 @@ bool ComponentContext::Context::AddImportedName(
   std::string LdL =
       std::string(Name.getNoTagName()) + "." + std::string(Name.getNoTagName());
 
-  if (ImportedNames.count(LdL)) {
+  if (Names.count(LdL)) {
     return false;
   }
 
@@ -151,30 +154,41 @@ bool ComponentContext::Context::AddImportedName(
     Right = Normal.substr(Pos + 1);
     if (Left == Right) {
       // Conflict with l.l and [*]l.
-      if (ImportedNames.count(toLowerString(Left))) {
+      if (Names.count(toLowerString(Left))) {
         return false;
       }
     }
   }
 
   // Case 3: check existing names.
-  if (ImportedNames.count(UniForm)) {
+  if (Names.count(UniForm)) {
     return false;
   }
 
   // Special case: check conflicts with constructor names.
-  std::string ConstrName = "[constructor]" + UniForm;
-  if (ImportedNames.count(ConstrName)) {
-    if (!ImportedNames.count("[constructor]" + Normal)) {
+  std::string ConstrName = std::string(ConstructorTag) + UniForm;
+  if (Names.count(ConstrName)) {
+    if (!Names.count(std::string(ConstructorTag) + Normal)) {
       return false;
     }
     // By rule, a constructor [constructor]X and X are strongly-unique.
     // If [constructor]X and its lower-case [constructor]x form both exist, it
     // means [constructor]x comes from [constructor]X.
   }
-  ImportedNames.insert(Normal);
-  ImportedNames.insert(UniForm);
+  Names.insert(Normal);
+  Names.insert(UniForm);
   return true;
+}
+} // namespace
+
+bool ComponentContext::Context::AddImportedName(
+    const ComponentName &Name) noexcept {
+  return addStronglyUniqueName(ImportedNames, Name);
+}
+
+bool ComponentContext::Context::AddExportedName(
+    const ComponentName &Name) noexcept {
+  return addStronglyUniqueName(ExportedNames, Name);
 }
 } // namespace Validator
 } // namespace WasmEdge

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -209,7 +209,7 @@ resolveChildInstanceType(const AST::Component::Component &Comp,
 // Validate that a name may appear at an export position: reject the
 // `relative-url=` prefix (not part of the extern-name grammar) and any
 // plainname/interfacename kind that isn't allowed on an export.
-Expect<void> validateExportName(std::string_view Name) noexcept {
+Expect<ComponentName> validateExportName(std::string_view Name) noexcept {
   if (Name.rfind("relative-url="sv, 0) == 0) {
     spdlog::error(ErrCode::Value::InvalidExternName);
     spdlog::error("    Export name '{}' is not a valid extern name"sv, Name);
@@ -222,7 +222,7 @@ Expect<void> validateExportName(std::string_view Name) noexcept {
   case ComponentNameKind::Method:
   case ComponentNameKind::Static:
   case ComponentNameKind::InterfaceType:
-    return {};
+    return CName;
   default:
     spdlog::error(ErrCode::Value::InvalidExportName);
     spdlog::error("    Export name '{}' kind is not valid for exports"sv, Name);
@@ -1502,23 +1502,17 @@ Expect<void> Validator::validate(const AST::Component::Import &Im) noexcept {
 
 Expect<void> Validator::validate(const AST::Component::Export &Ex) noexcept {
   // Validation steps:
-  //   1. Export name is strongly-unique across exports.
-  //   2. `sortidx` is in-bounds and (for core sorts) must be `core module`.
-  //   3. If an `externdesc` ascription is present, it must be a supertype
+  //   1. `sortidx` is in-bounds and (for core sorts) must be `core module`.
+  //   2. If an `externdesc` ascription is present, it must be a supertype
   //      of the inferred externdesc of the `sortidx` (kind-only check for
   //      now; structural subtype is a follow-up).
-  //   4. The export name parses under the export-name grammar.
+  //   3. The export name parses under the export-name grammar.
+  //   4. The export name is strongly-unique across exports.
   //   5. The export introduces a new index aliasing the definition in the
   //      component's own index space for its sort.
   //
   // Not yet enforced: transitive resource-avoidance in exported types;
   // flipping the "consumed" flag for value exports.
-  if (!CompCtx.addExportedName(Ex.getName())) {
-    spdlog::error(ErrCode::Value::ComponentDuplicateName);
-    spdlog::error("    Export: Duplicate export name '{}'"sv, Ex.getName());
-    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Export));
-    return Unexpect(ErrCode::Value::ComponentDuplicateName);
-  }
 
   // Validate the sortidx bounds.
   const auto &Sort = Ex.getSortIndex().getSort();
@@ -1562,11 +1556,18 @@ Expect<void> Validator::validate(const AST::Component::Export &Ex) noexcept {
     return Unexpect(ErrCode::Value::ExportAscriptionIncompatible);
   }
 
-  // exportname ::= <plainname> | <interfacename>
-  EXPECTED_TRY(validateExportName(Ex.getName()).map_error([](auto E) {
+  // Validate name grammar, then enforce strong-uniqueness across exports.
+  EXPECTED_TRY(ComponentName CName,
+               validateExportName(Ex.getName()).map_error([](auto E) {
+                 spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Export));
+                 return E;
+               }));
+  if (!CompCtx.addExportedName(CName)) {
+    spdlog::error(ErrCode::Value::ComponentDuplicateName);
+    spdlog::error("    Export: Duplicate export name '{}'"sv, Ex.getName());
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Export));
-    return E;
-  }));
+    return Unexpect(ErrCode::Value::ComponentDuplicateName);
+  }
 
   // Every export introduces a new index that aliases the exported
   // definition in the component's own index space for that sort. For
@@ -1791,19 +1792,21 @@ Validator::validate(const AST::Component::ImportDecl &Decl) noexcept {
 
 Expect<void>
 Validator::validate(const AST::Component::ExportDecl &Decl) noexcept {
-  // Check export name uniqueness before mutating the index spaces so a
-  // duplicate or malformed name doesn't widen the scope's sort counts.
-  if (!CompCtx.addExportedName(Decl.getName())) {
+  // Check export name grammar and uniqueness before mutating the index
+  // spaces so a duplicate or malformed name doesn't widen the scope's
+  // sort counts.
+  EXPECTED_TRY(ComponentName CName,
+               validateExportName(Decl.getName()).map_error([](auto E) {
+                 spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Decl_Export));
+                 return E;
+               }));
+  if (!CompCtx.addExportedName(CName)) {
     spdlog::error(ErrCode::Value::ComponentDuplicateName);
     spdlog::error("    ExportDecl: Duplicate export name '{}'"sv,
                   Decl.getName());
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Decl_Export));
     return Unexpect(ErrCode::Value::ComponentDuplicateName);
   }
-  EXPECTED_TRY(validateExportName(Decl.getName()).map_error([](auto E) {
-    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Decl_Export));
-    return E;
-  }));
 
   // Increment sort index spaces based on the extern descriptor type.
   // Full ExternDesc validation (type index bounds) is deferred because

--- a/test/component/ComponentLoaderTest.cpp
+++ b/test/component/ComponentLoaderTest.cpp
@@ -166,6 +166,68 @@ TEST(ComponentNameParserTest, StronglyUnique) {
   EXPECT_FALSE(add("[static]foo.abc"sv));
 }
 
+TEST(ComponentNameParserTest, StronglyUniqueExportBasicCases) {
+  // Mirrors StronglyUniqueBasicCases on the export-side name set: the
+  // strong-uniqueness rule must apply symmetrically to import and export
+  // name sets (Explainer §Import and Export Definitions).
+  Validator::ComponentContext::Context Ctx(nullptr);
+
+  auto add = [&](std::string_view S) -> bool {
+    auto CN = Validator::ComponentName::parse(S);
+    if (!CN.has_value()) {
+      return false;
+    }
+    return Ctx.AddExportedName(*CN);
+  };
+
+  EXPECT_TRUE(add("foo"sv));
+  EXPECT_TRUE(add("foo-bar"sv));
+  EXPECT_TRUE(add("[constructor]foo"sv));
+  EXPECT_TRUE(add("[method]foo.bar"sv));
+  EXPECT_TRUE(add("[method]foo.baz"sv));
+
+  EXPECT_FALSE(add("foo"sv));
+  EXPECT_FALSE(add("foo-BAR"sv));
+  EXPECT_FALSE(add("[constructor]foo-BAR"sv));
+  EXPECT_FALSE(add("[method]foo.foo"sv));
+  EXPECT_FALSE(add("[method]foo.BAR"sv));
+}
+
+TEST(ComponentNameParserTest, StronglyUniqueExport) {
+  Validator::ComponentContext::Context Ctx(nullptr);
+
+  auto add = [&](std::string_view S) -> bool {
+    auto CN = Validator::ComponentName::parse(S);
+    if (!CN.has_value()) {
+      return false;
+    }
+    return Ctx.AddExportedName(*CN);
+  };
+
+  EXPECT_TRUE(add("[method]foo.abc"sv));
+  EXPECT_TRUE(add("[constructor]foo"sv));
+  EXPECT_TRUE(add("foo-bar"sv));
+  EXPECT_TRUE(add("foo"sv));
+
+  EXPECT_FALSE(add("[method]foo"sv));
+  EXPECT_FALSE(add("[static]foo.abc"sv));
+}
+
+TEST(ComponentNameParserTest, StronglyUniqueImportExportIndependence) {
+  // Spec: import and export name sets are checked *separately* — an import
+  // and an export sharing a name is not a strong-uniqueness violation.
+  Validator::ComponentContext::Context Ctx(nullptr);
+
+  auto parse = [](std::string_view S) {
+    return *Validator::ComponentName::parse(S);
+  };
+
+  EXPECT_TRUE(Ctx.AddImportedName(parse("foo"sv)));
+  EXPECT_TRUE(Ctx.AddExportedName(parse("foo"sv)));
+  EXPECT_FALSE(Ctx.AddImportedName(parse("foo"sv)));
+  EXPECT_FALSE(Ctx.AddExportedName(parse("foo"sv)));
+}
+
 TEST(ComponentNameParserTest, LockedDep) {
   // Valid: no version, no integrity.
   {

--- a/test/component/ComponentValidatorTest.cpp
+++ b/test/component/ComponentValidatorTest.cpp
@@ -626,6 +626,163 @@ TEST(ComponentValidatorTest, InstanceTypeDuplicateExportName) {
   ASSERT_FALSE(V.validate(Comp));
 }
 
+TEST(ComponentValidatorTest, InstanceTypeExportCaseFoldConflict) {
+  // (type (instance
+  //   (export "foo" (func))
+  //   (export "foo-BAR" (func))  ;; OK: distinct
+  //   (export "FOO" (func))       ;; FAIL: case-folds to existing "foo"
+  // ))
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+
+  std::vector<AST::Component::InstanceDecl> Decls;
+  for (const auto *N : {"foo", "foo-BAR", "FOO"}) {
+    AST::Component::ExportDecl Exp;
+    Exp.getName() = N;
+    Exp.getExternDesc().setFuncTypeIdx(0);
+    AST::Component::InstanceDecl D;
+    D.setExport(std::move(Exp));
+    Decls.push_back(std::move(D));
+  }
+
+  AST::Component::InstanceType IT;
+  IT.setDecl(std::move(Decls));
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setInstanceType(std::move(IT));
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, InstanceTypeExportConstructorPlainAllowed) {
+  // (type (instance
+  //   (export "foo" (func))
+  //   (export "[constructor]foo" (func))  ;; OK: strongly-unique pair
+  // ))
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+
+  std::vector<AST::Component::InstanceDecl> Decls;
+  for (const auto *N : {"foo", "[constructor]foo"}) {
+    AST::Component::ExportDecl Exp;
+    Exp.getName() = N;
+    Exp.getExternDesc().setFuncTypeIdx(0);
+    AST::Component::InstanceDecl D;
+    D.setExport(std::move(Exp));
+    Decls.push_back(std::move(D));
+  }
+
+  AST::Component::InstanceType IT;
+  IT.setDecl(std::move(Decls));
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setInstanceType(std::move(IT));
+
+  Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, InstanceTypeExportMethodSelfDotConflict) {
+  // (type (instance
+  //   (export "foo" (func))
+  //   (export "[method]foo.foo" (func))   ;; FAIL: L and [*]L.L conflict
+  // ))
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+
+  std::vector<AST::Component::InstanceDecl> Decls;
+  for (const auto *N : {"foo", "[method]foo.foo"}) {
+    AST::Component::ExportDecl Exp;
+    Exp.getName() = N;
+    Exp.getExternDesc().setFuncTypeIdx(0);
+    AST::Component::InstanceDecl D;
+    D.setExport(std::move(Exp));
+    Decls.push_back(std::move(D));
+  }
+
+  AST::Component::InstanceType IT;
+  IT.setDecl(std::move(Decls));
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setInstanceType(std::move(IT));
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, ComponentTopLevelDuplicateExportName) {
+  // (component
+  //   (import "i0" (func (type 0)))
+  //   (export "foo" (func 0))
+  //   (export "foo" (func 0))     ;; FAIL: duplicate
+  // )
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+  auto &ImpSec =
+      std::get<AST::Component::ImportSection>(Comp.getSections().back());
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "i0";
+  ImpSec.getContent().back().getDesc().setFuncTypeIdx(0);
+
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ExportSection>();
+  auto &ExpSec =
+      std::get<AST::Component::ExportSection>(Comp.getSections().back());
+  for (int I = 0; I < 2; ++I) {
+    AST::Component::Export Ex;
+    Ex.getName() = "foo";
+    Ex.getSortIndex().getSort().setIsCore(false);
+    Ex.getSortIndex().getSort().setSortType(
+        AST::Component::Sort::SortType::Func);
+    Ex.getSortIndex().setIdx(0);
+    ExpSec.getContent().push_back(std::move(Ex));
+  }
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, ComponentTopLevelExportCaseFoldConflict) {
+  // (component
+  //   (import "i0" (func (type 0)))
+  //   (export "foo" (func 0))
+  //   (export "FOO" (func 0))   ;; FAIL: case-folds to existing "foo"
+  // )
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+  auto &ImpSec =
+      std::get<AST::Component::ImportSection>(Comp.getSections().back());
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "i0";
+  ImpSec.getContent().back().getDesc().setFuncTypeIdx(0);
+
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ExportSection>();
+  auto &ExpSec =
+      std::get<AST::Component::ExportSection>(Comp.getSections().back());
+  for (const auto *N : {"foo", "FOO"}) {
+    AST::Component::Export Ex;
+    Ex.getName() = N;
+    Ex.getSortIndex().getSort().setIsCore(false);
+    Ex.getSortIndex().getSort().setSortType(
+        AST::Component::Sort::SortType::Func);
+    Ex.getSortIndex().setIdx(0);
+    ExpSec.getContent().push_back(std::move(Ex));
+  }
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
 TEST(ComponentValidatorTest, ComponentTypeDuplicateImportName) {
   // (type (component
   //   (import "f" (func))


### PR DESCRIPTION
The export-name path previously deduplicated via a plain std::unordered_set insert and missed the Component Model "strongly-unique" rule already enforced on the import side: case-folded acronyms, the [constructor]X / X exception, and the L / [*]L.L conflict (Explainer.md §Import and Export Definitions).

Extract the import-side algorithm into a shared anonymous-namespace helper keyed on a caller-supplied name set, and add Context::AddExportedName as a symmetric wrapper. validateExportName now returns the parsed ComponentName so validate(Export) and validate(ExportDecl) can perform grammar validation and strong-uniqueness in one parse pass.

## Description

Because the message for the spec test error issue do not be solved, this pr do not update the error enum code.

* the order of the "Expect<void> Validator::validate(const AST::Component::Export &Ex)"

Because this order match the spec error message if there are more than 2 errors in input.

## Checklist

Before submitting this PR, please ensure the following:

- [ ] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [ ] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
