### PR TITLE
fix(wasi): trap on misaligned pointers per WITX spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,10 @@ node_modules/
 
 # generated jni files
 bindings/java/wasmedge-java/wasmedge-jni/jni/*.h
+run.log
+tests-local/
+misalign-test.wat
+lib/host/wasi/misalignedtests/
+CHECKSUM_VERIFICATION.md
+MISALIGN_TEST_RESULTS.md
+WASI_FUNCTIONS_CALL_CHAIN.md

--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -374,14 +374,20 @@ bool AllowAFUNIX(const Runtime::CallingFrame &Frame,
 template <typename T> inline bool isMisaligned(uint32_t Ptr) noexcept {
   return (Ptr & (alignof(T) - 1)) != 0;
 }
+
+// WITX spec: misaligned pointer passed to a WASI function SHALL trap.
+
+#define WASI_TRAP_ON_MISALIGN(Ptr, T)                          \
+  if (unlikely(isMisaligned<T>(Ptr))) {                        \
+    return Unexpect(ErrCode::Value::Unreachable);              \
+  }
 } // namespace
 
 Expect<uint32_t> WasiArgsGet::body(const Runtime::CallingFrame &Frame,
                                    uint32_t ArgvPtr, uint32_t ArgvBufPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<uint8_t_ptr>(ArgvPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(ArgvPtr, uint8_t_ptr)
+
   // ArgvBufPtr should be aligned to at least 1 byte (which is always true)
 
   // Check memory instance from module.
@@ -420,12 +426,10 @@ Expect<uint32_t> WasiArgsSizesGet::body(const Runtime::CallingFrame &Frame,
                                         uint32_t /* Out */ ArgcPtr,
                                         uint32_t /* Out */ ArgvBufSizePtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_size_t>(ArgcPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
-  if (unlikely(isMisaligned<__wasi_size_t>(ArgvBufSizePtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(ArgcPtr, __wasi_size_t)
+
+  WASI_TRAP_ON_MISALIGN(ArgvBufSizePtr, __wasi_size_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -453,9 +457,8 @@ Expect<uint32_t> WasiArgsSizesGet::body(const Runtime::CallingFrame &Frame,
 Expect<uint32_t> WasiEnvironGet::body(const Runtime::CallingFrame &Frame,
                                       uint32_t EnvPtr, uint32_t EnvBufPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<uint8_t_ptr>(EnvPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(EnvPtr, uint8_t_ptr)
+
   // EnvBufPtr should be aligned to at least 1 byte (which is always true)
 
   // Check memory instance from module.
@@ -494,12 +497,10 @@ Expect<uint32_t> WasiEnvironSizesGet::body(const Runtime::CallingFrame &Frame,
                                            uint32_t /* Out */ EnvCntPtr,
                                            uint32_t /* Out */ EnvBufSizePtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_size_t>(EnvCntPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
-  if (unlikely(isMisaligned<__wasi_size_t>(EnvBufSizePtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(EnvCntPtr, __wasi_size_t)
+
+  WASI_TRAP_ON_MISALIGN(EnvBufSizePtr, __wasi_size_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -529,9 +530,8 @@ Expect<uint32_t> WasiClockResGet::body(const Runtime::CallingFrame &Frame,
                                        uint32_t ClockId,
                                        uint32_t /* Out */ ResolutionPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_timestamp_t>(ResolutionPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(ResolutionPtr, __wasi_timestamp_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -562,9 +562,8 @@ Expect<uint32_t> WasiClockTimeGet::body(const Runtime::CallingFrame &Frame,
                                         uint32_t ClockId, uint64_t Precision,
                                         uint32_t /* Out */ TimePtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_timestamp_t>(TimePtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(TimePtr, __wasi_timestamp_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -649,9 +648,8 @@ Expect<uint32_t> WasiFdFdstatGet::body(const Runtime::CallingFrame &Frame,
                                        int32_t Fd,
                                        uint32_t /* Out */ FdStatPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_fdstat_t>(FdStatPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(FdStatPtr, __wasi_fdstat_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -720,9 +718,8 @@ Expect<uint32_t> WasiFdFilestatGet::body(const Runtime::CallingFrame &Frame,
                                          int32_t Fd,
                                          uint32_t /* Out */ FilestatPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_filestat_t>(FilestatPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(FilestatPtr, __wasi_filestat_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -782,13 +779,11 @@ Expect<uint32_t> WasiFdPread::body(const Runtime::CallingFrame &Frame,
                                    uint32_t IOVsLen, uint64_t Offset,
                                    uint32_t /* Out */ NReadPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_iovec_t>(IOVsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(IOVsPtr, __wasi_iovec_t)
 
-  if (unlikely(isMisaligned<__wasi_size_t>(NReadPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+
+  WASI_TRAP_ON_MISALIGN(NReadPtr, __wasi_size_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -872,9 +867,8 @@ Expect<uint32_t> WasiFdPrestatGet::body(const Runtime::CallingFrame &Frame,
                                         int32_t Fd,
                                         uint32_t /* Out */ PreStatPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_prestat_t>(PreStatPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(PreStatPtr, __wasi_prestat_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -901,13 +895,11 @@ Expect<uint32_t> WasiFdPwrite::body(const Runtime::CallingFrame &Frame,
                                     uint32_t IOVsLen, uint64_t Offset,
                                     uint32_t /* Out */ NWrittenPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_ciovec_t>(IOVsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(IOVsPtr, __wasi_ciovec_t)
 
-  if (unlikely(isMisaligned<__wasi_size_t>(NWrittenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+
+  WASI_TRAP_ON_MISALIGN(NWrittenPtr, __wasi_size_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -970,13 +962,11 @@ Expect<uint32_t> WasiFdRead::body(const Runtime::CallingFrame &Frame,
                                   uint32_t IOVsLen,
                                   uint32_t /* Out */ NReadPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_iovec_t>(IOVsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(IOVsPtr, __wasi_iovec_t)
 
-  if (unlikely(isMisaligned<__wasi_size_t>(NReadPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+
+  WASI_TRAP_ON_MISALIGN(NReadPtr, __wasi_size_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -1034,9 +1024,8 @@ Expect<uint32_t> WasiFdReadDir::body(const Runtime::CallingFrame &Frame,
                                      uint32_t BufLen, uint64_t Cookie,
                                      uint32_t /* Out */ NReadPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_size_t>(NReadPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(NReadPtr, __wasi_size_t)
+
   // BufPtr should be aligned to at least 1 byte (which is always true)
 
   // Check memory instance from module.
@@ -1083,9 +1072,8 @@ Expect<int32_t> WasiFdSeek::body(const Runtime::CallingFrame &Frame, int32_t Fd,
                                  int64_t Offset, uint32_t Whence,
                                  uint32_t /* Out */ NewOffsetPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_filesize_t>(NewOffsetPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(NewOffsetPtr, __wasi_filesize_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -1128,9 +1116,8 @@ Expect<uint32_t> WasiFdSync::body(const Runtime::CallingFrame &, int32_t Fd) {
 Expect<uint32_t> WasiFdTell::body(const Runtime::CallingFrame &Frame,
                                   int32_t Fd, uint32_t /* Out */ OffsetPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_filesize_t>(OffsetPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(OffsetPtr, __wasi_filesize_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -1158,13 +1145,8 @@ Expect<uint32_t> WasiFdWrite::body(const Runtime::CallingFrame &Frame,
                                    uint32_t IOVsLen,
                                    uint32_t /* Out */ NWrittenPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_ciovec_t>(IOVsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
-
-  if (unlikely(isMisaligned<__wasi_size_t>(NWrittenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(IOVsPtr, __wasi_ciovec_t)
+  WASI_TRAP_ON_MISALIGN(NWrittenPtr, __wasi_size_t)
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -1248,9 +1230,8 @@ Expect<uint32_t> WasiPathFilestatGet::body(const Runtime::CallingFrame &Frame,
                                            uint32_t PathPtr, uint32_t PathLen,
                                            uint32_t /* Out */ FilestatPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_filestat_t>(FilestatPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(FilestatPtr, __wasi_filestat_t)
+
   // PathPtr should be aligned to at least 1 byte (which is always true)
 
   // Check memory instance from module.
@@ -1380,9 +1361,8 @@ Expect<uint32_t> WasiPathOpen::body(
     uint32_t PathPtr, uint32_t PathLen, uint32_t OFlags, uint64_t FsRightsBase,
     uint64_t FsRightsInheriting, uint32_t FsFlags, uint32_t /* Out */ FdPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_fd_t>(FdPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(FdPtr, __wasi_fd_t)
+
   // PathPtr should be aligned to at least 1 byte (which is always true)
 
   // Check memory instance from module.
@@ -1463,9 +1443,8 @@ Expect<uint32_t> WasiPathReadLink::body(const Runtime::CallingFrame &Frame,
                                         uint32_t BufLen,
                                         uint32_t /* Out */ NReadPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_size_t>(NReadPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(NReadPtr, __wasi_size_t)
+
   // BufPtr and PathPtr should be aligned to at least 1 byte (which is always
   // true)
 
@@ -1632,15 +1611,12 @@ Expect<uint32_t> WasiPollOneoff<Trigger>::body(
     const Runtime::CallingFrame &Frame, uint32_t InPtr, uint32_t OutPtr,
     uint32_t NSubscriptions, uint32_t /* Out */ NEventsPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_subscription_t>(InPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
-  if (unlikely(isMisaligned<__wasi_event_t>(OutPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
-  if (unlikely(isMisaligned<__wasi_size_t>(NEventsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(InPtr, __wasi_subscription_t)
+
+  WASI_TRAP_ON_MISALIGN(OutPtr, __wasi_event_t)
+
+  WASI_TRAP_ON_MISALIGN(NEventsPtr, __wasi_size_t)
+
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -1801,9 +1777,8 @@ Expect<uint32_t> WasiSockOpenV1::body(const Runtime::CallingFrame &Frame,
                                       uint32_t AddressFamily, uint32_t SockType,
                                       uint32_t /* Out */ RoFdPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_fd_t>(RoFdPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(RoFdPtr, __wasi_fd_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -1848,9 +1823,8 @@ Expect<uint32_t> WasiSockBindV1::body(const Runtime::CallingFrame &Frame,
                                       int32_t Fd, uint32_t AddressPtr,
                                       uint32_t Port) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(AddressPtr, __wasi_address_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -1904,9 +1878,8 @@ Expect<uint32_t> WasiSockAcceptV1::body(const Runtime::CallingFrame &Frame,
                                         int32_t Fd,
                                         uint32_t /* Out */ RoFdPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_fd_t>(RoFdPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(RoFdPtr, __wasi_fd_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -1932,9 +1905,8 @@ Expect<uint32_t> WasiSockAcceptV2::body(const Runtime::CallingFrame &Frame,
                                         int32_t Fd, uint32_t FsFlags,
                                         uint32_t /* Out */ RoFdPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_fd_t>(RoFdPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(RoFdPtr, __wasi_fd_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -1967,9 +1939,8 @@ Expect<uint32_t> WasiSockConnectV1::body(const Runtime::CallingFrame &Frame,
                                          int32_t Fd, uint32_t AddressPtr,
                                          uint32_t Port) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(AddressPtr, __wasi_address_t)
+
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -2016,17 +1987,14 @@ Expect<uint32_t> WasiSockRecvV1::body(const Runtime::CallingFrame &Frame,
                                       uint32_t /* Out */ RoDataLenPtr,
                                       uint32_t /* Out */ RoFlagsPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_iovec_t>(RiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(RiDataPtr, __wasi_iovec_t)
 
-  if (unlikely(isMisaligned<__wasi_size_t>(RoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
 
-  if (unlikely(isMisaligned<__wasi_roflags_t>(RoFlagsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(RoDataLenPtr, __wasi_size_t)
+
+
+  WASI_TRAP_ON_MISALIGN(RoFlagsPtr, __wasi_roflags_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -2102,21 +2070,17 @@ Expect<uint32_t> WasiSockRecvFromV1::body(const Runtime::CallingFrame &Frame,
                                           uint32_t /* Out */ RoDataLenPtr,
                                           uint32_t /* Out */ RoFlagsPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(AddressPtr, __wasi_address_t)
 
-  if (unlikely(isMisaligned<__wasi_iovec_t>(RiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
 
-  if (unlikely(isMisaligned<__wasi_size_t>(RoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(RiDataPtr, __wasi_iovec_t)
 
-  if (unlikely(isMisaligned<__wasi_roflags_t>(RoFlagsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+
+  WASI_TRAP_ON_MISALIGN(RoDataLenPtr, __wasi_size_t)
+
+
+  WASI_TRAP_ON_MISALIGN(RoFlagsPtr, __wasi_roflags_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -2200,13 +2164,11 @@ Expect<uint32_t> WasiSockSendV1::body(const Runtime::CallingFrame &Frame,
                                       uint32_t SiDataLen, uint32_t SiFlags,
                                       uint32_t /* Out */ SoDataLenPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_ciovec_t>(SiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(SiDataPtr, __wasi_ciovec_t)
 
-  if (unlikely(isMisaligned<__wasi_size_t>(SoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+
+  WASI_TRAP_ON_MISALIGN(SoDataLenPtr, __wasi_size_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -2274,17 +2236,14 @@ Expect<uint32_t> WasiSockSendToV1::body(const Runtime::CallingFrame &Frame,
                                         int32_t Port, uint32_t SiFlags,
                                         uint32_t /* Out */ SoDataLenPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(AddressPtr, __wasi_address_t)
 
-  if (unlikely(isMisaligned<__wasi_ciovec_t>(SiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
 
-  if (unlikely(isMisaligned<__wasi_size_t>(SoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(SiDataPtr, __wasi_ciovec_t)
+
+
+  WASI_TRAP_ON_MISALIGN(SoDataLenPtr, __wasi_size_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -2440,15 +2399,12 @@ Expect<uint32_t> WasiSockGetAddrinfo::body(
   // NodePtr, ServicePtr should be aligned to at least 1 byte (which is always
   // true)
 
-  if (unlikely(isMisaligned<__wasi_addrinfo_t>(HintsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
-  if (unlikely(isMisaligned<uint8_t_ptr>(ResPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
-  if (unlikely(isMisaligned<__wasi_size_t>(ResLengthPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(HintsPtr, __wasi_addrinfo_t)
+
+  WASI_TRAP_ON_MISALIGN(ResPtr, uint8_t_ptr)
+
+  WASI_TRAP_ON_MISALIGN(ResLengthPtr, __wasi_size_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -2617,17 +2573,14 @@ WasiSockGetLocalAddrV1::body(const Runtime::CallingFrame &Frame, int32_t Fd,
                              uint32_t AddressPtr, uint32_t AddressTypePtr,
                              uint32_t PortPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(AddressPtr, __wasi_address_t)
 
-  if (unlikely(isMisaligned<uint32_t>(AddressTypePtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
 
-  if (unlikely(isMisaligned<uint32_t>(PortPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(AddressTypePtr, uint32_t)
+
+
+  WASI_TRAP_ON_MISALIGN(PortPtr, uint32_t)
+
 
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -2697,17 +2650,14 @@ Expect<uint32_t> WasiSockGetPeerAddrV1::body(const Runtime::CallingFrame &Frame,
                                              uint32_t AddressTypePtr,
                                              uint32_t PortPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(AddressPtr, __wasi_address_t)
 
-  if (unlikely(isMisaligned<uint32_t>(AddressTypePtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
 
-  if (unlikely(isMisaligned<uint32_t>(PortPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(AddressTypePtr, uint32_t)
+
+
+  WASI_TRAP_ON_MISALIGN(PortPtr, uint32_t)
+
 
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -2777,9 +2727,8 @@ Expect<uint32_t> WasiSockOpenV2::body(const Runtime::CallingFrame &Frame,
                                       uint32_t AddressFamily, uint32_t SockType,
                                       uint32_t /* Out */ RoFdPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_fd_t>(RoFdPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(RoFdPtr, __wasi_fd_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -2824,9 +2773,8 @@ Expect<uint32_t> WasiSockBindV2::body(const Runtime::CallingFrame &Frame,
                                       int32_t Fd, uint32_t AddressPtr,
                                       uint32_t Port) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(AddressPtr, __wasi_address_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -2887,9 +2835,8 @@ Expect<uint32_t> WasiSockConnectV2::body(const Runtime::CallingFrame &Frame,
                                          int32_t Fd, uint32_t AddressPtr,
                                          uint32_t Port) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(AddressPtr, __wasi_address_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -2944,17 +2891,14 @@ Expect<uint32_t> WasiSockRecvV2::body(const Runtime::CallingFrame &Frame,
                                       uint32_t /* Out */ RoDataLenPtr,
                                       uint32_t /* Out */ RoFlagsPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_iovec_t>(RiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(RiDataPtr, __wasi_iovec_t)
 
-  if (unlikely(isMisaligned<__wasi_size_t>(RoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
 
-  if (unlikely(isMisaligned<__wasi_roflags_t>(RoFlagsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(RoDataLenPtr, __wasi_size_t)
+
+
+  WASI_TRAP_ON_MISALIGN(RoFlagsPtr, __wasi_roflags_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -3029,25 +2973,20 @@ Expect<uint32_t> WasiSockRecvFromV2::body(const Runtime::CallingFrame &Frame,
                                           uint32_t /* Out */ RoDataLenPtr,
                                           uint32_t /* Out */ RoFlagsPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_iovec_t>(RiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(RiDataPtr, __wasi_iovec_t)
 
-  if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
 
-  if (unlikely(isMisaligned<uint16_t>(PortPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(AddressPtr, __wasi_address_t)
 
-  if (unlikely(isMisaligned<__wasi_size_t>(RoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
 
-  if (unlikely(isMisaligned<__wasi_roflags_t>(RoFlagsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(PortPtr, uint16_t)
+
+
+  WASI_TRAP_ON_MISALIGN(RoDataLenPtr, __wasi_size_t)
+
+
+  WASI_TRAP_ON_MISALIGN(RoFlagsPtr, __wasi_roflags_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -3155,13 +3094,11 @@ Expect<uint32_t> WasiSockSendV2::body(const Runtime::CallingFrame &Frame,
                                       uint32_t SiDataLen, uint32_t SiFlags,
                                       uint32_t /* Out */ SoDataLenPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_ciovec_t>(SiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(SiDataPtr, __wasi_ciovec_t)
 
-  if (unlikely(isMisaligned<__wasi_size_t>(SoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+
+  WASI_TRAP_ON_MISALIGN(SoDataLenPtr, __wasi_size_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -3229,17 +3166,14 @@ Expect<uint32_t> WasiSockSendToV2::body(const Runtime::CallingFrame &Frame,
                                         int32_t Port, uint32_t SiFlags,
                                         uint32_t /* Out */ SoDataLenPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_ciovec_t>(SiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(SiDataPtr, __wasi_ciovec_t)
 
-  if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
 
-  if (unlikely(isMisaligned<__wasi_size_t>(SoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(AddressPtr, __wasi_address_t)
+
+
+  WASI_TRAP_ON_MISALIGN(SoDataLenPtr, __wasi_size_t)
+
 
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -3342,9 +3276,8 @@ Expect<uint32_t> WasiSockGetOpt::body(const Runtime::CallingFrame &Frame,
   // Alignment checks
   // no alignment requirement for FlagPtr as it's a byte array
 
-  if (unlikely(isMisaligned<uint32_t>(FlagSizePtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(FlagSizePtr, uint32_t)
+
 
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -3391,13 +3324,11 @@ Expect<uint32_t>
 WasiSockGetLocalAddrV2::body(const Runtime::CallingFrame &Frame, int32_t Fd,
                              uint32_t AddressPtr, uint32_t PortPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(AddressPtr, __wasi_address_t)
 
-  if (unlikely(isMisaligned<uint32_t>(PortPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+
+  WASI_TRAP_ON_MISALIGN(PortPtr, uint32_t)
+
 
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {
@@ -3447,13 +3378,11 @@ Expect<uint32_t> WasiSockGetPeerAddrV2::body(const Runtime::CallingFrame &Frame,
                                              int32_t Fd, uint32_t AddressPtr,
                                              uint32_t PortPtr) {
   // Alignment checks
-  if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+  WASI_TRAP_ON_MISALIGN(AddressPtr, __wasi_address_t)
 
-  if (unlikely(isMisaligned<uint32_t>(PortPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
-  }
+
+  WASI_TRAP_ON_MISALIGN(PortPtr, uint32_t)
+
 
   auto *MemInst = Frame.getMemoryByIndex(0);
   if (MemInst == nullptr) {


### PR DESCRIPTION

## Description

### Summary

This PR fixes the misaligned-pointer behavior described in #2694, where a mutated wasm file that passes a misaligned shadow-stack pointer into WASI, but WasmEdge runs to completion instead of trapping.

- All misalignment checks at the WASI boundary now trap instead of returning `__WASI_ERRNO_ADDRNOTAVAIL`.
- The original mutated testcase now traps instead of printing the checksum.
- Valid WASI programs using correctly aligned pointers are unaffected.

---

### Design

**Context**
- Guest program (Csmith-generated C compiled with Emscripten) maintains an internal shadow stack pointer in linear memory.
- WASI functions like `fd_write` receive pointers (e.g., `iovs_ptr`, `nwritten_ptr`) into that same linear memory.
- WITX requires misaligned pointer arguments to WASI functions to trap.

**Intended flow**

Guest calls a WASI function, e.g. `fd_write(fd, iovs_ptr, iovs_len, nwritten_ptr)`.

At the WASI boundary, the runtime must:
1. Check each pointer argument is within bounds and properly aligned for its type.
2. If any pointer is **misaligned**: raise a trap — do not proceed, do not return an errno.
3. If all pointers are **aligned and in bounds**: execute the WASI function normally.

---

### Implementation

**Core change in `lib/host/wasi/wasifunc.cpp`:**

| | Before | After |
|---|---|---|
| Misalignment helper | `isMisaligned<T>(Ptr)` used inline in each WASI function | Same helper, only used via macro |
| Misalignment handling | `if (unlikely(isMisaligned<T>(Ptr))) return __WASI_ERRNO_ADDRNOTAVAIL;` | `WASI_TRAP_ON_MISALIGN(Ptr, T)` → returns `Unexpect(ErrCode::Value::Unreachable)` |
| Scope | ~75 separate inline guard sites | All 75 sites now share one consistent trap path via the macro |

The macro is defined as:
```cpp
// WITX spec: misaligned pointer passed to a WASI function SHALL trap.
#define WASI_TRAP_ON_MISALIGN(Ptr, T) \
  if (unlikely(isMisaligned<T>(Ptr))) \
    return Unexpect(ErrCode::Value::Unreachable);
```

---

## Checklist

- [ ✓] **DCO Signed-off**: All commits are signed-off (`git commit -s`).
- [ ✓] **Commit Messages**: Commit title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ✓] **Local Tests Passed**: See Test Evidence below.

---

## Test Evidence

### 1. Reproducer from issue #2694

```bash
wasmedge tests-local/misaligned/07-26/mutated.wasm
echo "exit: $?"
```

| | Before fix | After fix |
|---|---|---|
| Output | `checksum = DAFC642C` | *(no output)* |
| Exit code | `0` | `134` (trap) |

### 2. Targeted WASI boundary tests

**`fd_write_misaligned.wasm`** — IOVsPtr intentionally misaligned
- Result: exit `134` (trap) 
- Confirms: `WasiFdWrite::body` traps on misaligned `__wasi_ciovec_t*`

**`fd_write_aligned.wasm`** — same module, aligned IOVsPtr
- Result: exit `0`, output printed 

**`args_sizes_misaligned.wasm`** — `argc`/`argv_buf_size` pointers intentionally misaligned
- Result: exit `134` (trap) 
- Confirms: `WasiArgsSizesGet::body` traps on misaligned `__wasi_size_t*`

**`args_sizes_aligned.wasm`** — same module, aligned pointers
- Result: exit `0` 

**`poll_oneoff_misaligned.wasm`** — subscription array pointer intentionally misaligned
- Result: exit `134` (trap) 
- Confirms: `WasiPollOneoff::body` traps on misaligned `__wasi_subscription_t*`

### 3. Static sanity check on `wasifunc.cpp`

```bash
grep -n "isMisaligned" lib/host/wasi/wasifunc.cpp
# Line 374: template definition
# Line 381: WASI_TRAP_ON_MISALIGN macro — only 2 references total

grep -n "ADDRNOTAVAIL" lib/host/wasi/wasifunc.cpp
# (no output) — zero remaining misalignment errno paths
```

All misalignment checks flow through `WASI_TRAP_ON_MISALIGN`. No stray errno paths remain.

###4. Test Outputs Screenshots
### Aligned control case

`tests-local/misaligned/07-26/wasm_file.wasm` is the aligned control case.

It prints `checksum = DAFC642C` and exits with `0`, which shows that normal WASI execution still works when pointers are properly aligned.

**Observed output**
```text
checksum = DAFC642C
exit: 0
```
<img width="730" height="96" alt="Screenshot From 2026-05-16 01-21-23" src="https://github.com/user-attachments/assets/d7698b77-a8b6-4d49-bafa-4c62d41f3e5d" />



---

### Misaligned failure case

`tests-local/misaligned/07-26/mutated.wasm` is the misaligned failure case.

It now traps during `_start` and exits with `134`, which shows that the misaligned pointer is being rejected at the WASI boundary as intended.


**Observed output**
```text
[error] calling stack:
[error]     When executing function name: "_start"
exit: 134
```
<img width="724" height="129" alt="Screenshot From 2026-05-16 01-21-32" src="https://github.com/user-attachments/assets/36b87efa-4719-475f-9597-50b58f508397" />



---
## Environment

-  **Hardware Architecture:** x86_64 
-  **Operating system:** Arch Linux
---