### PR TITLE
test(wasi_crypto): POC Show bug by add publickeyVerify regression for RSA public key 

### DIFF
--- a/test/plugins/wasi_crypto/asymmetric.cpp
+++ b/test/plugins/wasi_crypto/asymmetric.cpp
@@ -200,6 +200,26 @@ TEST_F(WasiCryptoTest, Asymmetric) {
         }
       };
 
+  {
+    SCOPED_TRACE("RSA publickeyVerify bug");
+    WASI_CRYPTO_EXPECT_SUCCESS(
+        PkHandle,
+        publickeyImport(
+            __WASI_ALGORITHM_TYPE_SIGNATURES, "RSA_PKCS1_2048_SHA256"sv,
+            "-----BEGIN PUBLIC KEY-----\n"
+            "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtoGqtGXL6bqbDK0IJ2pJ\n"
+            "fM7hfMpyYVXWxtEdv5oNErvGWpHKiH1NIeQxn0ks1QFmkHoK8Quvzyn5/anHLxiZ\n"
+            "ecWbzRA01MTfs1y7HMBlrToZhRTZPFe7VRGJ+Liv1jpIiRHPzqabZrssgs3Kj5fG\n"
+            "0EYXITaQRfn0kfZcYtJLYi0OvU18DBi64MrLwABr3wqn2UZgMgiw3MhKvyXRybca\n"
+            "x0ASO1RTxAJIm21XuFWTztHcJBvl66ygDAzzRdOJyPWvG+TuhNXvZ7dtA0N4iU8p\n"
+            "SwJljzLEzWzwKOgAizx3Q3EdS+9P+pTdKtei9UGWVunoj46kCw+0QasQE958NPa3\n"
+            "uQIDAQAB\n"
+            "-----END PUBLIC KEY-----\n"_u8,
+            __WASI_PUBLICKEY_ENCODING_PEM));
+    WASI_CRYPTO_EXPECT_TRUE(publickeyVerify(PkHandle));
+    WASI_CRYPTO_EXPECT_TRUE(publickeyClose(PkHandle));
+  }
+
   RsaCheck(
       "2048"sv,
       {{__WASI_PUBLICKEY_ENCODING_PEM,


### PR DESCRIPTION
PR shows bug, as mentioned in https://github.com/WasmEdge/WasmEdge/issues/4881

This is a more comprehensive showcase of it. 

## Description
In this pr, we:

1. Imports a RSA-2048 public key
2. Use publickeyVerify
3. Assert for success

So the issue being that we get an RSA public key and asserts publickeyVerify should succeeds because that's the purpose. But with the PR, we can see that this is not the case. Thus, in my original issue I showed that we need to change rsa to use the appropriate methods.

This is just the showcase of what is the current behaviour not matching expectations 

## Checklist

Before submitting this PR, please ensure the following:

- [X] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [X] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

**I have to show the failling test intentionally to show the issue.** 

## Test Evidence

```
╰─$ ctest -R wasiCryptoTests --output-on-failure                                                                                                                                                                                        
Test project /home/aclfe/Desktop/coding/Wasmedge/WasmEdge/build
    Start 14: wasiCryptoTests
1/1 Test #14: wasiCryptoTests ..................***Failed   16.78 sec
Running main() from /home/aclfe/Desktop/coding/Wasmedge/WasmEdge/build/_deps/gtest-src/googletest/src/gtest_main.cc
[==========] Running 9 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 9 tests from WasiCryptoTest
[ RUN      ] WasiCryptoTest.Aeads
[       OK ] WasiCryptoTest.Aeads (3 ms)
[ RUN      ] WasiCryptoTest.Asymmetric
/home/aclfe/Desktop/coding/Wasmedge/WasmEdge/test/plugins/wasi_crypto/asymmetric.cpp:221: Failure
Value of: publickeyVerify(PkHandle)
  Actual: false
Expected: true
Wasi Crypto Error code: 8
Google Test trace:
/home/aclfe/Desktop/coding/Wasmedge/WasmEdge/test/plugins/wasi_crypto/asymmetric.cpp:206: RSA publickeyVerify bug
```

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.

╰─$ npx commitlint --from master --to rsa-verify-poc
(no output)
