### PR TITLE
fix(executor): trap on OOB string lift and reject indirect-return

### DIFF
--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -377,10 +377,10 @@ private:
                      Runtime::Instance::FunctionInstance *RFuncInst,
                      Runtime::Instance::MemoryInstance *MemInst) noexcept;
 
-  std::vector<std::pair<ComponentValVariant, ComponentValType>>
+  Expect<std::vector<std::pair<ComponentValVariant, ComponentValType>>>
   convValsToComponent(Span<const std::pair<ValVariant, ValType>> CoreVals,
                       Span<const ComponentValType> ValTypes,
-                      Runtime::Instance::MemoryInstance *MemInst) noexcept;
+                      Runtime::Instance::MemoryInstance *MemInst);
   /// @}
 
   /// \name Helper Functions for block controls.

--- a/lib/executor/executor.cpp
+++ b/lib/executor/executor.cpp
@@ -256,8 +256,8 @@ Executor::invoke(const Runtime::Instance::Component::FunctionInstance *FuncInst,
   for (const auto &Type : FuncInst->getFuncType().getResultList()) {
     ReturnTypes.push_back(Type.getValType());
   }
-  std::vector<std::pair<ComponentValVariant, ComponentValType>> Returns =
-      convValsToComponent(CoreWASMReturns, ReturnTypes, MemInst);
+  EXPECTED_TRY(auto Returns,
+               convValsToComponent(CoreWASMReturns, ReturnTypes, MemInst));
   assuming(Returns.size() == ReturnTypes.size());
   return Returns;
 }

--- a/lib/executor/instantiate/component/component_canon.cpp
+++ b/lib/executor/instantiate/component/component_canon.cpp
@@ -6,12 +6,43 @@
 #include "common/errinfo.h"
 #include "common/spdlog.h"
 
+#include <cstdint>
+#include <optional>
 #include <string_view>
 
 namespace WasmEdge {
 namespace Executor {
 
 using namespace std::literals;
+
+namespace {
+
+constexpr uint32_t MaxFlatResults = 1;
+
+std::optional<uint32_t> flatSize(ComponentTypeCode TC) noexcept {
+  switch (TC) {
+  case ComponentTypeCode::Bool:
+  case ComponentTypeCode::U8:
+  case ComponentTypeCode::U16:
+  case ComponentTypeCode::U32:
+  case ComponentTypeCode::U64:
+  case ComponentTypeCode::S8:
+  case ComponentTypeCode::S16:
+  case ComponentTypeCode::S32:
+  case ComponentTypeCode::S64:
+  case ComponentTypeCode::F32:
+  case ComponentTypeCode::F64:
+  case ComponentTypeCode::Char:
+  case ComponentTypeCode::Flags:
+    return 1u;
+  case ComponentTypeCode::String:
+    return 2u;
+  default:
+    return std::nullopt;
+  }
+}
+
+} // namespace
 
 std::vector<ValVariant> Executor::convValsToCoreWASM(
     Span<const ComponentValVariant> Vals, Span<const ComponentValType> ValTypes,
@@ -63,24 +94,49 @@ std::vector<ValVariant> Executor::convValsToCoreWASM(
   return CoreVals;
 }
 
-std::vector<std::pair<ComponentValVariant, ComponentValType>>
+Expect<std::vector<std::pair<ComponentValVariant, ComponentValType>>>
 Executor::convValsToComponent(
     Span<const std::pair<ValVariant, ValType>> CoreVals,
     Span<const ComponentValType> ValTypes,
-    Runtime::Instance::MemoryInstance *MemInst) noexcept {
+    Runtime::Instance::MemoryInstance *MemInst) {
+  uint32_t FlatCount = 0;
+  for (const auto &Type : ValTypes) {
+    auto Size = flatSize(Type.getCode());
+    if (!Size.has_value()) {
+      spdlog::error(ErrCode::Value::ComponentNotImplInstantiate);
+      spdlog::error(
+          "    canonical lifting of component type 0x{:02x} not implemented"sv,
+          static_cast<uint8_t>(Type.getCode()));
+      return Unexpect(ErrCode::Value::ComponentNotImplInstantiate);
+    }
+    FlatCount += *Size;
+  }
+
+  if (FlatCount > MaxFlatResults) {
+    spdlog::error(ErrCode::Value::ComponentNotImplInstantiate);
+    spdlog::error(
+        "    canonical lifting via return-area pointer (flat count {} > {}) "
+        "not implemented"sv,
+        FlatCount, MaxFlatResults);
+    return Unexpect(ErrCode::Value::ComponentNotImplInstantiate);
+  }
+
   uint32_t I = 0;
   std::vector<std::pair<ComponentValVariant, ComponentValType>> Vals;
+  Vals.reserve(ValTypes.size());
   for (const auto &Type : ValTypes) {
     switch (Type.getCode()) {
     case ComponentTypeCode::String: {
+      assuming(MemInst != nullptr);
       auto Off = CoreVals[I++].first.get<uint32_t>();
       auto Size = CoreVals[I++].first.get<uint32_t>();
+      if (unlikely(!MemInst->checkAccessBound(Off, Size))) {
+        spdlog::error(ErrCode::Value::MemoryOutOfBounds);
+        spdlog::error("    string pointer/length out of bounds of memory"sv);
+        return Unexpect(ErrCode::Value::MemoryOutOfBounds);
+      }
       auto Str = MemInst->getStringView(Off, Size);
       Vals.emplace_back(std::string(Str), Type);
-      break;
-    }
-    case ComponentTypeCode::TypeIndex: {
-      // TODO: COMPONENT - Not implemented.
       break;
     }
     default: {


### PR DESCRIPTION
`convValsToComponent` previously read `(offset, length)` from core return values without checking bounds, and silently fell back to an empty `std::string_view` when the range exceeded linear memory. The Canonical ABI requires `trap_if(ptr + byte_length > len(memory))` (CanonicalABI.md L2140) in `load_string_from_range`. The function also had no way to signal an error since it returned a `std::vector` and was marked `noexcept`.

In addition, any return type whose flattened representation exceeds MAX_FLAT_RESULTS (= 1) must be lifted through a return-area pointer written by the core function (CanonicalABI.md L2825-2828), not read directly from core results. WasmEdge does not yet implement that indirect path; the prior code instead consumed CoreVals positionally as if the values were flat, which masked the indirect-return shape entirely and could read past the actual core arity.

- Change `convValsToComponent` to return `Expect<std::vector<...>>` so canonical-ABI errors propagate.
- Add a `flatSize(ComponentTypeCode)` helper covering primitives (1) and String (2); other component types return nullopt and the conversion aborts with `ComponentNotImplInstantiate`.
- Compute the total flat count up front: when it exceeds MAX_FLAT_RESULTS, abort with the same not-implemented error rather than misinterpreting CoreVals. This leaves a clear dispatch point for a future indirect-return implementation.
- In the remaining flat path, bounds-check the string range via `MemoryInstance::checkAccessBound` and return `MemoryOutOfBounds` on failure.
- Update the `invoke` caller in `executor.cpp` to use `EXPECTED_TRY` for the new error channel.

## Description
<!-- Describe your changes here -->

## Checklist

Before submitting this PR, please ensure the following:

- [ ] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [ ] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
