### PR TITLE
fix(wasi): report out-of-bounds memory access errors instead of silently failing

### DIFF
--- a/lib/driver/runtimeTool.cpp
+++ b/lib/driver/runtimeTool.cpp
@@ -197,7 +197,7 @@ ToolOnModule(WasmEdge::VM::VM &VM, const std::string &FuncName,
     }
     return EXIT_SUCCESS;
   } else {
-    // It indicates that the execution of wasm has been aborted.
+    spdlog::error(Result.error());
     return 128 + SIGABRT;
   }
 }
@@ -350,7 +350,7 @@ ToolOnComponent(WasmEdge::VM::VM &VM, const std::string &FuncName,
 
     return EXIT_SUCCESS;
   } else {
-    // It indicates that the execution of wasm has been aborted.
+    spdlog::error(Result.error());
     return 128 + SIGABRT;
   }
 }
@@ -593,7 +593,7 @@ int Tool(struct DriverToolOptions &Opt) noexcept {
         Result || Result.error() == ErrCode::Value::Terminated) {
       return static_cast<int>(WasiMod->getExitCode());
     } else {
-      // It indicates that the execution of wasm has been aborted.
+      spdlog::error(Result.error());
       return 128 + SIGABRT;
     }
   } else {
@@ -643,7 +643,7 @@ int Tool(struct DriverToolOptions &Opt) noexcept {
           }
         }
         if (auto Result = AsyncResult.get(); unlikely(!Result)) {
-          // It indicates that the execution of wasm has been aborted.
+          spdlog::error(Result.error());
           return 128 + SIGABRT;
         }
       }

--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -1181,13 +1181,13 @@ Expect<uint32_t> WasiFdWrite::body(const Runtime::CallingFrame &Frame,
   const auto IOVsArray =
       MemInst->getSpan<__wasi_ciovec_t>(IOVsPtr, WasiIOVsLen);
   if (unlikely(IOVsArray.size() != WasiIOVsLen)) {
-    return __WASI_ERRNO_FAULT;
+    return Unexpect(ErrCode::Value::MemoryOutOfBounds);
   }
 
   // Check for invalid address.
   auto *const NWritten = MemInst->getPointer<__wasi_size_t *>(NWrittenPtr);
   if (unlikely(NWritten == nullptr)) {
-    return __WASI_ERRNO_FAULT;
+    return Unexpect(ErrCode::Value::MemoryOutOfBounds);
   }
 
   __wasi_size_t TotalSize = 0;
@@ -1206,7 +1206,7 @@ Expect<uint32_t> WasiFdWrite::body(const Runtime::CallingFrame &Frame,
     const auto WriteArr =
         MemInst->getSpan<const uint8_t>(EndianValue(IOV.buf).le(), BufLen);
     if (unlikely(WriteArr.size() != BufLen)) {
-      return __WASI_ERRNO_FAULT;
+      return Unexpect(ErrCode::Value::MemoryOutOfBounds);
     }
     WasiIOVs.emplace_back_unchecked(WriteArr);
   }


### PR DESCRIPTION

## Description
When a WebAssembly program attempted an out-of-bounds memory access, WasmEdge would:
- Exit but produce NO error output
- Other runtimes (wasmtime, WAMR) correctly report "out of bounds memory access"

Example: Running a mutated WASM program that calls `fd_write` with invalid buffer pointers would silently fail instead of reporting the error.

<img width="1263" height="284" alt="image" src="https://github.com/user-attachments/assets/b230812c-212a-4cf0-9414-83c93a324706" />


## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

close #4281
