### PR TITLE
fix(wasi): trap on misaligned pointer arguments in WASI host functions

### DIFF
--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -380,7 +380,7 @@ Expect<uint32_t> WasiArgsGet::body(const Runtime::CallingFrame &Frame,
                                    uint32_t ArgvPtr, uint32_t ArgvBufPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<uint8_t_ptr>(ArgvPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
   // ArgvBufPtr should be aligned to at least 1 byte (which is always true)
 
@@ -421,10 +421,10 @@ Expect<uint32_t> WasiArgsSizesGet::body(const Runtime::CallingFrame &Frame,
                                         uint32_t /* Out */ ArgvBufSizePtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_size_t>(ArgcPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
   if (unlikely(isMisaligned<__wasi_size_t>(ArgvBufSizePtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -454,7 +454,7 @@ Expect<uint32_t> WasiEnvironGet::body(const Runtime::CallingFrame &Frame,
                                       uint32_t EnvPtr, uint32_t EnvBufPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<uint8_t_ptr>(EnvPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
   // EnvBufPtr should be aligned to at least 1 byte (which is always true)
 
@@ -495,10 +495,10 @@ Expect<uint32_t> WasiEnvironSizesGet::body(const Runtime::CallingFrame &Frame,
                                            uint32_t /* Out */ EnvBufSizePtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_size_t>(EnvCntPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
   if (unlikely(isMisaligned<__wasi_size_t>(EnvBufSizePtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -530,7 +530,7 @@ Expect<uint32_t> WasiClockResGet::body(const Runtime::CallingFrame &Frame,
                                        uint32_t /* Out */ ResolutionPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_timestamp_t>(ResolutionPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -563,7 +563,7 @@ Expect<uint32_t> WasiClockTimeGet::body(const Runtime::CallingFrame &Frame,
                                         uint32_t /* Out */ TimePtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_timestamp_t>(TimePtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -650,7 +650,7 @@ Expect<uint32_t> WasiFdFdstatGet::body(const Runtime::CallingFrame &Frame,
                                        uint32_t /* Out */ FdStatPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_fdstat_t>(FdStatPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -721,7 +721,7 @@ Expect<uint32_t> WasiFdFilestatGet::body(const Runtime::CallingFrame &Frame,
                                          uint32_t /* Out */ FilestatPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_filestat_t>(FilestatPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -783,11 +783,11 @@ Expect<uint32_t> WasiFdPread::body(const Runtime::CallingFrame &Frame,
                                    uint32_t /* Out */ NReadPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_iovec_t>(IOVsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(NReadPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -873,7 +873,7 @@ Expect<uint32_t> WasiFdPrestatGet::body(const Runtime::CallingFrame &Frame,
                                         uint32_t /* Out */ PreStatPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_prestat_t>(PreStatPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -902,11 +902,11 @@ Expect<uint32_t> WasiFdPwrite::body(const Runtime::CallingFrame &Frame,
                                     uint32_t /* Out */ NWrittenPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_ciovec_t>(IOVsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(NWrittenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -971,11 +971,11 @@ Expect<uint32_t> WasiFdRead::body(const Runtime::CallingFrame &Frame,
                                   uint32_t /* Out */ NReadPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_iovec_t>(IOVsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(NReadPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -1035,7 +1035,7 @@ Expect<uint32_t> WasiFdReadDir::body(const Runtime::CallingFrame &Frame,
                                      uint32_t /* Out */ NReadPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_size_t>(NReadPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
   // BufPtr should be aligned to at least 1 byte (which is always true)
 
@@ -1084,7 +1084,7 @@ Expect<int32_t> WasiFdSeek::body(const Runtime::CallingFrame &Frame, int32_t Fd,
                                  uint32_t /* Out */ NewOffsetPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_filesize_t>(NewOffsetPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -1129,7 +1129,7 @@ Expect<uint32_t> WasiFdTell::body(const Runtime::CallingFrame &Frame,
                                   int32_t Fd, uint32_t /* Out */ OffsetPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_filesize_t>(OffsetPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -1159,11 +1159,11 @@ Expect<uint32_t> WasiFdWrite::body(const Runtime::CallingFrame &Frame,
                                    uint32_t /* Out */ NWrittenPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_ciovec_t>(IOVsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(NWrittenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -1249,7 +1249,7 @@ Expect<uint32_t> WasiPathFilestatGet::body(const Runtime::CallingFrame &Frame,
                                            uint32_t /* Out */ FilestatPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_filestat_t>(FilestatPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
   // PathPtr should be aligned to at least 1 byte (which is always true)
 
@@ -1381,7 +1381,7 @@ Expect<uint32_t> WasiPathOpen::body(
     uint64_t FsRightsInheriting, uint32_t FsFlags, uint32_t /* Out */ FdPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_fd_t>(FdPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
   // PathPtr should be aligned to at least 1 byte (which is always true)
 
@@ -1464,7 +1464,7 @@ Expect<uint32_t> WasiPathReadLink::body(const Runtime::CallingFrame &Frame,
                                         uint32_t /* Out */ NReadPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_size_t>(NReadPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
   // BufPtr and PathPtr should be aligned to at least 1 byte (which is always
   // true)
@@ -1633,13 +1633,13 @@ Expect<uint32_t> WasiPollOneoff<Trigger>::body(
     uint32_t NSubscriptions, uint32_t /* Out */ NEventsPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_subscription_t>(InPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
   if (unlikely(isMisaligned<__wasi_event_t>(OutPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
   if (unlikely(isMisaligned<__wasi_size_t>(NEventsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -1802,7 +1802,7 @@ Expect<uint32_t> WasiSockOpenV1::body(const Runtime::CallingFrame &Frame,
                                       uint32_t /* Out */ RoFdPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_fd_t>(RoFdPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -1849,7 +1849,7 @@ Expect<uint32_t> WasiSockBindV1::body(const Runtime::CallingFrame &Frame,
                                       uint32_t Port) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -1905,7 +1905,7 @@ Expect<uint32_t> WasiSockAcceptV1::body(const Runtime::CallingFrame &Frame,
                                         uint32_t /* Out */ RoFdPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_fd_t>(RoFdPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -1933,7 +1933,7 @@ Expect<uint32_t> WasiSockAcceptV2::body(const Runtime::CallingFrame &Frame,
                                         uint32_t /* Out */ RoFdPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_fd_t>(RoFdPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -1968,7 +1968,7 @@ Expect<uint32_t> WasiSockConnectV1::body(const Runtime::CallingFrame &Frame,
                                          uint32_t Port) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -2017,15 +2017,15 @@ Expect<uint32_t> WasiSockRecvV1::body(const Runtime::CallingFrame &Frame,
                                       uint32_t /* Out */ RoFlagsPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_iovec_t>(RiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(RoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_roflags_t>(RoFlagsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -2103,19 +2103,19 @@ Expect<uint32_t> WasiSockRecvFromV1::body(const Runtime::CallingFrame &Frame,
                                           uint32_t /* Out */ RoFlagsPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_iovec_t>(RiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(RoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_roflags_t>(RoFlagsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -2201,11 +2201,11 @@ Expect<uint32_t> WasiSockSendV1::body(const Runtime::CallingFrame &Frame,
                                       uint32_t /* Out */ SoDataLenPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_ciovec_t>(SiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(SoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -2275,15 +2275,15 @@ Expect<uint32_t> WasiSockSendToV1::body(const Runtime::CallingFrame &Frame,
                                         uint32_t /* Out */ SoDataLenPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_ciovec_t>(SiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(SoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -2441,13 +2441,13 @@ Expect<uint32_t> WasiSockGetAddrinfo::body(
   // true)
 
   if (unlikely(isMisaligned<__wasi_addrinfo_t>(HintsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
   if (unlikely(isMisaligned<uint8_t_ptr>(ResPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
   if (unlikely(isMisaligned<__wasi_size_t>(ResLengthPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -2618,15 +2618,15 @@ WasiSockGetLocalAddrV1::body(const Runtime::CallingFrame &Frame, int32_t Fd,
                              uint32_t PortPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<uint32_t>(AddressTypePtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<uint32_t>(PortPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -2698,15 +2698,15 @@ Expect<uint32_t> WasiSockGetPeerAddrV1::body(const Runtime::CallingFrame &Frame,
                                              uint32_t PortPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<uint32_t>(AddressTypePtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<uint32_t>(PortPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -2778,7 +2778,7 @@ Expect<uint32_t> WasiSockOpenV2::body(const Runtime::CallingFrame &Frame,
                                       uint32_t /* Out */ RoFdPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_fd_t>(RoFdPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -2825,7 +2825,7 @@ Expect<uint32_t> WasiSockBindV2::body(const Runtime::CallingFrame &Frame,
                                       uint32_t Port) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -2888,7 +2888,7 @@ Expect<uint32_t> WasiSockConnectV2::body(const Runtime::CallingFrame &Frame,
                                          uint32_t Port) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -2945,15 +2945,15 @@ Expect<uint32_t> WasiSockRecvV2::body(const Runtime::CallingFrame &Frame,
                                       uint32_t /* Out */ RoFlagsPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_iovec_t>(RiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(RoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_roflags_t>(RoFlagsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -3030,23 +3030,23 @@ Expect<uint32_t> WasiSockRecvFromV2::body(const Runtime::CallingFrame &Frame,
                                           uint32_t /* Out */ RoFlagsPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_iovec_t>(RiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<uint16_t>(PortPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(RoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_roflags_t>(RoFlagsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -3156,11 +3156,11 @@ Expect<uint32_t> WasiSockSendV2::body(const Runtime::CallingFrame &Frame,
                                       uint32_t /* Out */ SoDataLenPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_ciovec_t>(SiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(SoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -3230,15 +3230,15 @@ Expect<uint32_t> WasiSockSendToV2::body(const Runtime::CallingFrame &Frame,
                                         uint32_t /* Out */ SoDataLenPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_ciovec_t>(SiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(SoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   // Check memory instance from module.
@@ -3343,7 +3343,7 @@ Expect<uint32_t> WasiSockGetOpt::body(const Runtime::CallingFrame &Frame,
   // no alignment requirement for FlagPtr as it's a byte array
 
   if (unlikely(isMisaligned<uint32_t>(FlagSizePtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -3392,11 +3392,11 @@ WasiSockGetLocalAddrV2::body(const Runtime::CallingFrame &Frame, int32_t Fd,
                              uint32_t AddressPtr, uint32_t PortPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<uint32_t>(PortPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   auto *MemInst = Frame.getMemoryByIndex(0);
@@ -3448,11 +3448,11 @@ Expect<uint32_t> WasiSockGetPeerAddrV2::body(const Runtime::CallingFrame &Frame,
                                              uint32_t PortPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   if (unlikely(isMisaligned<uint32_t>(PortPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError);
   }
 
   auto *MemInst = Frame.getMemoryByIndex(0);

--- a/test/host/wasi/wasi.cpp
+++ b/test/host/wasi/wasi.cpp
@@ -4405,12 +4405,12 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_fdstat_t) * 3);
 
     // Test misaligned FdStatPtr
-    EXPECT_TRUE(WasiFdFdstatGet.run(CallFrame,
+    EXPECT_FALSE(WasiFdFdstatGet.run(CallFrame,
                                     std::initializer_list<WasmEdge::ValVariant>{
                                         static_cast<int32_t>(0), // stdin fd
                                         MisalignedFdStatPtr},    // misaligned
                                     Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned FdStatPtr (should succeed)
@@ -4432,13 +4432,13 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_filestat_t) * 3);
 
     // Test misaligned FilestatPtr
-    EXPECT_TRUE(
+    EXPECT_FALSE(
         WasiFdFilestatGet.run(CallFrame,
                               std::initializer_list<WasmEdge::ValVariant>{
                                   static_cast<int32_t>(0), // stdin fd
                                   MisalignedFilestatPtr},  // misaligned
                               Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned FilestatPtr (should succeed)
@@ -4464,7 +4464,7 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_size_t) * 4);
 
     // Test misaligned IOVsPtr
-    EXPECT_TRUE(WasiFdPread.run(CallFrame,
+    EXPECT_FALSE(WasiFdPread.run(CallFrame,
                                 std::initializer_list<WasmEdge::ValVariant>{
                                     static_cast<int32_t>(0), // stdin fd
                                     MisalignedIOVsPtr, // misaligned IOVsPtr
@@ -4472,10 +4472,10 @@ TEST(WasiTest, PointerAlignment) {
                                     static_cast<uint64_t>(0), // Offset
                                     AlignedNReadPtr}, // aligned NReadPtr
                                 Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     // Test misaligned NReadPtr
-    EXPECT_TRUE(WasiFdPread.run(CallFrame,
+    EXPECT_FALSE(WasiFdPread.run(CallFrame,
                                 std::initializer_list<WasmEdge::ValVariant>{
                                     static_cast<int32_t>(0),  // stdin fd
                                     AlignedIOVsPtr,           // aligned IOVsPtr
@@ -4483,7 +4483,7 @@ TEST(WasiTest, PointerAlignment) {
                                     static_cast<uint64_t>(0), // Offset
                                     MisalignedNReadPtr}, // misaligned NReadPtr
                                 Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned pointers (should pass alignment but may fail on
@@ -4509,13 +4509,13 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_prestat_t) * 2);
 
     // Test misaligned PreStatPtr
-    EXPECT_TRUE(
+    EXPECT_FALSE(
         WasiFdPrestatGet.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  static_cast<int32_t>(3), // preopen fd
                                  MisalignedPreStatPtr},   // misaligned
                              Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned PreStatPtr (should succeed)
@@ -4541,7 +4541,7 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_ciovec_t) * 2);
 
     // Test misaligned IOVsPtr
-    EXPECT_TRUE(WasiFdPwrite.run(CallFrame,
+    EXPECT_FALSE(WasiFdPwrite.run(CallFrame,
                                  std::initializer_list<WasmEdge::ValVariant>{
                                      static_cast<int32_t>(1), // stdout fd
                                      MisalignedIOVsPtr, // misaligned IOVsPtr
@@ -4549,10 +4549,10 @@ TEST(WasiTest, PointerAlignment) {
                                      static_cast<uint64_t>(0), // Offset
                                      AlignedNWrittenPtr}, // aligned NWrittenPtr
                                  Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     // Test misaligned NWrittenPtr
-    EXPECT_TRUE(
+    EXPECT_FALSE(
         WasiFdPwrite.run(CallFrame,
                          std::initializer_list<WasmEdge::ValVariant>{
                              static_cast<int32_t>(1),  // stdout fd
@@ -4561,7 +4561,7 @@ TEST(WasiTest, PointerAlignment) {
                              static_cast<uint64_t>(0), // Offset
                              MisalignedNWrittenPtr},   // misaligned NWrittenPtr
                          Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned pointers (should pass alignment but may fail on
@@ -4590,24 +4590,24 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_size_t) * 2);
 
     // Test misaligned IOVsPtr
-    EXPECT_TRUE(WasiFdRead.run(CallFrame,
+    EXPECT_FALSE(WasiFdRead.run(CallFrame,
                                std::initializer_list<WasmEdge::ValVariant>{
                                    static_cast<int32_t>(0), // stdin fd
                                    MisalignedIOVsPtr, // misaligned IOVsPtr
                                    static_cast<uint32_t>(1), // IOVsLen
                                    AlignedNReadPtr},         // aligned NReadPtr
                                Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     // Test misaligned NReadPtr
-    EXPECT_TRUE(WasiFdRead.run(CallFrame,
+    EXPECT_FALSE(WasiFdRead.run(CallFrame,
                                std::initializer_list<WasmEdge::ValVariant>{
                                    static_cast<int32_t>(0),  // stdin fd
                                    AlignedIOVsPtr,           // aligned IOVsPtr
                                    static_cast<uint32_t>(1), // IOVsLen
                                    MisalignedNReadPtr}, // misaligned NReadPtr
                                Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned pointers (should pass alignment but may fail on
@@ -4632,7 +4632,7 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_size_t) * 2);
 
     // Test misaligned NReadPtr
-    EXPECT_TRUE(WasiFdReadDir.run(
+    EXPECT_FALSE(WasiFdReadDir.run(
         CallFrame,
         std::initializer_list<WasmEdge::ValVariant>{
             static_cast<int32_t>(3),    // preopen directory fd
@@ -4641,7 +4641,7 @@ TEST(WasiTest, PointerAlignment) {
             static_cast<uint64_t>(0),   // Cookie
             MisalignedNReadPtr},        // misaligned NReadPtr
         Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned NReadPtr (should succeed)
@@ -4667,7 +4667,7 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_filesize_t) * 4);
 
     // Test misaligned NewOffsetPtr
-    EXPECT_TRUE(
+    EXPECT_FALSE(
         WasiFdSeek.run(CallFrame,
                        std::initializer_list<WasmEdge::ValVariant>{
                            static_cast<int32_t>(0),                  // stdin fd
@@ -4675,7 +4675,7 @@ TEST(WasiTest, PointerAlignment) {
                            static_cast<uint32_t>(__WASI_WHENCE_SET), // Whence
                            MisalignedNewOffsetPtr}, // misaligned NewOffsetPtr
                        Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned NewOffsetPtr (should pass alignment but may fail
@@ -4701,12 +4701,12 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_filesize_t) * 2);
 
     // Test misaligned OffsetPtr
-    EXPECT_TRUE(WasiFdTell.run(CallFrame,
+    EXPECT_FALSE(WasiFdTell.run(CallFrame,
                                std::initializer_list<WasmEdge::ValVariant>{
                                    static_cast<int32_t>(0), // stdin fd
                                    MisalignedOffsetPtr}, // misaligned OffsetPtr
                                Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned OffsetPtr (should pass alignment but may fail on
@@ -4734,14 +4734,14 @@ TEST(WasiTest, PointerAlignment) {
     writeDummyMemoryContent(MemInst);
 
     // Test misaligned IOVsPtr
-    EXPECT_TRUE(WasiFdWrite.run(CallFrame,
+    EXPECT_FALSE(WasiFdWrite.run(CallFrame,
                                 std::initializer_list<WasmEdge::ValVariant>{
                                     static_cast<uint32_t>(1), // stdout
                                     MisalignedIOVsPtr, // misaligned IOVsPtr
                                     static_cast<uint32_t>(1), // IOVsLen
                                     AlignedNWrittenPtr}, // aligned NWrittenPtr
                                 Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     writeDummyMemoryContent(MemInst);
     const uint32_t DataPtr = 64;
@@ -4754,7 +4754,7 @@ TEST(WasiTest, PointerAlignment) {
     writeString(MemInst, TestData, DataPtr);
 
     // Test misaligned NWrittenPtr
-    EXPECT_TRUE(
+    EXPECT_FALSE(
         WasiFdWrite.run(CallFrame,
                         std::initializer_list<WasmEdge::ValVariant>{
                             static_cast<uint32_t>(1), // stdout
@@ -4762,7 +4762,7 @@ TEST(WasiTest, PointerAlignment) {
                             static_cast<uint32_t>(1), // IOVsLen
                             MisalignedNWrittenPtr},   // misaligned NWrittenPtr
                         Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
     Env.fini();
   }
 
@@ -4775,7 +4775,7 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_filestat_t) * 2);
 
     // Test misaligned FilestatPtr
-    EXPECT_TRUE(WasiPathFilestatGet.run(
+    EXPECT_FALSE(WasiPathFilestatGet.run(
         CallFrame,
         std::initializer_list<WasmEdge::ValVariant>{
             static_cast<int32_t>(0),                                  // fd
@@ -4784,7 +4784,7 @@ TEST(WasiTest, PointerAlignment) {
             static_cast<uint32_t>(4), // path len
             MisalignedFilestatPtr},   // misaligned FilestatPtr
         Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned FilestatPtr (should not fail due to alignment)
@@ -4811,7 +4811,7 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_fd_t) * 4);
 
     // Test misaligned FdPtr
-    EXPECT_TRUE(
+    EXPECT_FALSE(
         WasiPathOpen.run(CallFrame,
                          std::initializer_list<WasmEdge::ValVariant>{
                              static_cast<int32_t>(0),  // DirFd
@@ -4824,7 +4824,7 @@ TEST(WasiTest, PointerAlignment) {
                              static_cast<uint32_t>(0), // FsFlags
                              MisalignedFdPtr},         // misaligned FdPtr
                          Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned FdPtr (should not fail due to alignment)
@@ -4855,7 +4855,7 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_size_t) * 2);
 
     // Test misaligned NReadPtr
-    EXPECT_TRUE(
+    EXPECT_FALSE(
         WasiPathReadLink.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  static_cast<int32_t>(0),  // Fd
@@ -4865,7 +4865,7 @@ TEST(WasiTest, PointerAlignment) {
                                  static_cast<uint32_t>(4), // BufLen
                                  MisalignedNReadPtr}, // misaligned NReadPtr
                              Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned NReadPtr (should not fail due to alignment)
@@ -4896,14 +4896,14 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_fd_t) * 2);
 
       // Test misaligned RoFdPtr
-      EXPECT_TRUE(WasiSockOpen.run(
+      EXPECT_FALSE(WasiSockOpen.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<uint32_t>(__WASI_ADDRESS_FAMILY_INET4),
               static_cast<uint32_t>(__WASI_SOCK_TYPE_SOCK_STREAM),
               MisalignedRoFdPtr},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned RoFdPtr (should succeed)
       EXPECT_TRUE(WasiSockOpen.run(
@@ -4935,13 +4935,13 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_address_t) * 2);
 
       // Test misaligned AddressPtr
-      EXPECT_TRUE(WasiSockBind.run(CallFrame,
+      EXPECT_FALSE(WasiSockBind.run(CallFrame,
                                    std::initializer_list<WasmEdge::ValVariant>{
                                        static_cast<int32_t>(3), // dummy fd
                                        MisalignedAddressPtr,
                                        static_cast<uint32_t>(8080)},
                                    Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned AddressPtr (should pass alignment check but
       // fail on invalid fd)
@@ -4962,13 +4962,13 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_fd_t) * 2);
 
       // Test misaligned RoFdPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockAccept.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  static_cast<int32_t>(3), // dummy fd
                                  MisalignedRoFdPtr},
                              Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned RoFdPtr (should pass alignment check but fail
       // on invalid fd)
@@ -4989,14 +4989,14 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_fd_t) * 2);
 
       // Test misaligned RoFdPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockAccept.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  static_cast<int32_t>(3),  // dummy fd
                                  static_cast<uint32_t>(0), // flags
                                  MisalignedRoFdPtr},
                              Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned RoFdPtr (should pass alignment check but fail
       // on invalid fd)
@@ -5018,13 +5018,13 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_address_t) * 2);
 
       // Test misaligned AddressPtr
-      EXPECT_TRUE(WasiSockConnect.run(
+      EXPECT_FALSE(WasiSockConnect.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<int32_t>(3), // dummy fd
               MisalignedAddressPtr, static_cast<uint32_t>(8080)},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned AddressPtr (should pass alignment check but
       // fail on invalid fd)
@@ -5051,7 +5051,7 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_roflags_t) * 4);
 
       // Test misaligned RiDataPtr
-      EXPECT_TRUE(WasiSockRecv.run(CallFrame,
+      EXPECT_FALSE(WasiSockRecv.run(CallFrame,
                                    std::initializer_list<WasmEdge::ValVariant>{
                                        static_cast<int32_t>(3), // dummy fd
                                        MisalignedRiDataPtr,
@@ -5059,10 +5059,10 @@ TEST(WasiTest, PointerAlignment) {
                                        static_cast<uint32_t>(0), // RiFlags
                                        AlignedRoDataLenPtr, AlignedRoFlagsPtr},
                                    Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned RoDataLenPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockRecv.run(CallFrame,
                            std::initializer_list<WasmEdge::ValVariant>{
                                static_cast<int32_t>(3), // dummy fd
@@ -5071,10 +5071,10 @@ TEST(WasiTest, PointerAlignment) {
                                static_cast<uint32_t>(0), // RiFlags
                                MisalignedRoDataLenPtr, AlignedRoFlagsPtr},
                            Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned RoFlagsPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockRecv.run(CallFrame,
                            std::initializer_list<WasmEdge::ValVariant>{
                                static_cast<int32_t>(3), // dummy fd
@@ -5083,7 +5083,7 @@ TEST(WasiTest, PointerAlignment) {
                                static_cast<uint32_t>(0), // RiFlags
                                AlignedRoDataLenPtr, MisalignedRoFlagsPtr},
                            Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned parameters (should pass alignment but fail on
       // invalid fd)
@@ -5109,7 +5109,7 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_ciovec_t) * 2);
 
       // Test misaligned SiDataPtr
-      EXPECT_TRUE(WasiSockSend.run(CallFrame,
+      EXPECT_FALSE(WasiSockSend.run(CallFrame,
                                    std::initializer_list<WasmEdge::ValVariant>{
                                        static_cast<int32_t>(3), // dummy fd
                                        MisalignedSiDataPtr,
@@ -5117,10 +5117,10 @@ TEST(WasiTest, PointerAlignment) {
                                        static_cast<uint32_t>(0), // SiFlags
                                        AlignedSoDataLenPtr},
                                    Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned SoDataLenPtr
-      EXPECT_TRUE(WasiSockSend.run(CallFrame,
+      EXPECT_FALSE(WasiSockSend.run(CallFrame,
                                    std::initializer_list<WasmEdge::ValVariant>{
                                        static_cast<int32_t>(3), // dummy fd
                                        AlignedSiDataPtr,
@@ -5128,7 +5128,7 @@ TEST(WasiTest, PointerAlignment) {
                                        static_cast<uint32_t>(0), // SiFlags
                                        MisalignedSoDataLenPtr},
                                    Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned parameters (should pass alignment but fail on
       // invalid fd)
@@ -5160,7 +5160,7 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_roflags_t) * 5);
 
       // Test misaligned AddressPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockRecvFrom.run(CallFrame,
                                std::initializer_list<WasmEdge::ValVariant>{
                                    static_cast<int32_t>(3), // dummy fd
@@ -5170,10 +5170,10 @@ TEST(WasiTest, PointerAlignment) {
                                    static_cast<uint32_t>(0), // RiFlags
                                    AlignedRoDataLenPtr, AlignedRoFlagsPtr},
                                Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned RiDataPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockRecvFrom.run(CallFrame,
                                std::initializer_list<WasmEdge::ValVariant>{
                                    static_cast<int32_t>(3), // dummy fd
@@ -5183,10 +5183,10 @@ TEST(WasiTest, PointerAlignment) {
                                    static_cast<uint32_t>(0), // RiFlags
                                    AlignedRoDataLenPtr, AlignedRoFlagsPtr},
                                Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned RoDataLenPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockRecvFrom.run(CallFrame,
                                std::initializer_list<WasmEdge::ValVariant>{
                                    static_cast<int32_t>(3), // dummy fd
@@ -5196,10 +5196,10 @@ TEST(WasiTest, PointerAlignment) {
                                    static_cast<uint32_t>(0), // RiFlags
                                    MisalignedRoDataLenPtr, AlignedRoFlagsPtr},
                                Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned RoFlagsPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockRecvFrom.run(CallFrame,
                                std::initializer_list<WasmEdge::ValVariant>{
                                    static_cast<int32_t>(3), // dummy fd
@@ -5209,7 +5209,7 @@ TEST(WasiTest, PointerAlignment) {
                                    static_cast<uint32_t>(0), // RiFlags
                                    AlignedRoDataLenPtr, MisalignedRoFlagsPtr},
                                Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned parameters (should pass alignment but fail on
       // invalid fd)
@@ -5240,7 +5240,7 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_size_t) * 4);
 
       // Test misaligned AddressPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockSendTo.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  static_cast<int32_t>(3), // dummy fd
@@ -5251,10 +5251,10 @@ TEST(WasiTest, PointerAlignment) {
                                  static_cast<uint32_t>(0),   // SiFlags
                                  AlignedSoDataLenPtr},
                              Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned SiDataPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockSendTo.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  static_cast<int32_t>(3), // dummy fd
@@ -5265,10 +5265,10 @@ TEST(WasiTest, PointerAlignment) {
                                  static_cast<uint32_t>(0),   // SiFlags
                                  AlignedSoDataLenPtr},
                              Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned SoDataLenPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockSendTo.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  static_cast<int32_t>(3), // dummy fd
@@ -5279,7 +5279,7 @@ TEST(WasiTest, PointerAlignment) {
                                  static_cast<uint32_t>(0),   // SiFlags
                                  MisalignedSoDataLenPtr},
                              Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned parameters (should pass alignment but fail on
       // invalid fd)
@@ -5311,7 +5311,7 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_size_t) * 4);
 
       // Test misaligned HintsPtr alignment
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockGetAddrinfo.run(CallFrame,
                                   std::initializer_list<WasmEdge::ValVariant>{
                                       static_cast<uint32_t>(0), // NodePtr
@@ -5322,10 +5322,10 @@ TEST(WasiTest, PointerAlignment) {
                                       static_cast<uint32_t>(1), // MaxResLength
                                       AlignedResLengthPtr},
                                   Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned HintsPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockGetAddrinfo.run(CallFrame,
                                   std::initializer_list<WasmEdge::ValVariant>{
                                       static_cast<uint32_t>(0), // NodePtr
@@ -5336,10 +5336,10 @@ TEST(WasiTest, PointerAlignment) {
                                       static_cast<uint32_t>(1), // MaxResLength
                                       AlignedResLengthPtr},
                                   Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned ResLengthPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockGetAddrinfo.run(CallFrame,
                                   std::initializer_list<WasmEdge::ValVariant>{
                                       static_cast<uint32_t>(0), // NodePtr
@@ -5350,7 +5350,7 @@ TEST(WasiTest, PointerAlignment) {
                                       static_cast<uint32_t>(1), // MaxResLength
                                       MisalignedResLengthPtr},
                                   Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned parameters (should pass alignment but fail on
       // other validations)
@@ -5382,31 +5382,31 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(uint32_t) * 4);
 
       // Test misaligned AddressPtr
-      EXPECT_TRUE(WasiSockGetPeerAddr.run(
+      EXPECT_FALSE(WasiSockGetPeerAddr.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<int32_t>(3), // dummy fd
               MisalignedAddressPtr, AlignedAddressTypePtr, AlignedPortPtr},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned AddressTypePtr
-      EXPECT_TRUE(WasiSockGetPeerAddr.run(
+      EXPECT_FALSE(WasiSockGetPeerAddr.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<int32_t>(3), // dummy fd
               AlignedAddressPtr, MisalignedAddressTypePtr, AlignedPortPtr},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned PortPtr
-      EXPECT_TRUE(WasiSockGetPeerAddr.run(
+      EXPECT_FALSE(WasiSockGetPeerAddr.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<int32_t>(3), // dummy fd
               AlignedAddressPtr, AlignedAddressTypePtr, MisalignedPortPtr},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned parameters (should pass alignment but fail on
       // invalid fd)
@@ -5427,14 +5427,14 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_fd_t) * 2);
 
       // Test misaligned RoFdPtr
-      EXPECT_TRUE(WasiSockOpen.run(
+      EXPECT_FALSE(WasiSockOpen.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<uint32_t>(__WASI_ADDRESS_FAMILY_INET4),
               static_cast<uint32_t>(__WASI_SOCK_TYPE_SOCK_STREAM),
               MisalignedRoFdPtr},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned RoFdPtr (should pass alignment but fail on
       // other validations)
@@ -5456,13 +5456,13 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_address_t) * 2);
 
       // Test misaligned AddressPtr
-      EXPECT_TRUE(WasiSockBind.run(CallFrame,
+      EXPECT_FALSE(WasiSockBind.run(CallFrame,
                                    std::initializer_list<WasmEdge::ValVariant>{
                                        static_cast<int32_t>(3), // dummy fd
                                        MisalignedAddressPtr,
                                        static_cast<uint32_t>(8080)},
                                    Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned AddressPtr (should pass alignment but fail on
       // invalid fd)
@@ -5483,13 +5483,13 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_address_t) * 2);
 
       // Test misaligned AddressPtr
-      EXPECT_TRUE(WasiSockConnect.run(
+      EXPECT_FALSE(WasiSockConnect.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<int32_t>(3), // dummy fd
               MisalignedAddressPtr, static_cast<uint32_t>(8080)},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned AddressPtr (should pass alignment but fail on
       // invalid fd)
@@ -5517,7 +5517,7 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_roflags_t) * 4);
 
       // Test misaligned RiDataPtr
-      EXPECT_TRUE(WasiSockRecv.run(CallFrame,
+      EXPECT_FALSE(WasiSockRecv.run(CallFrame,
                                    std::initializer_list<WasmEdge::ValVariant>{
                                        static_cast<int32_t>(3), // dummy fd
                                        MisalignedRiDataPtr,
@@ -5525,10 +5525,10 @@ TEST(WasiTest, PointerAlignment) {
                                        static_cast<uint32_t>(0), // RiFlags
                                        AlignedRoDataLenPtr, AlignedRoFlagsPtr},
                                    Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned RoDataLenPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockRecv.run(CallFrame,
                            std::initializer_list<WasmEdge::ValVariant>{
                                static_cast<int32_t>(3), // dummy fd
@@ -5537,10 +5537,10 @@ TEST(WasiTest, PointerAlignment) {
                                static_cast<uint32_t>(0), // RiFlags
                                MisalignedRoDataLenPtr, AlignedRoFlagsPtr},
                            Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned RoFlagsPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockRecv.run(CallFrame,
                            std::initializer_list<WasmEdge::ValVariant>{
                                static_cast<int32_t>(3), // dummy fd
@@ -5549,7 +5549,7 @@ TEST(WasiTest, PointerAlignment) {
                                static_cast<uint32_t>(0), // RiFlags
                                AlignedRoDataLenPtr, MisalignedRoFlagsPtr},
                            Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned parameters (should pass alignment but fail on
       // invalid fd)
@@ -5584,7 +5584,7 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_roflags_t) * 6);
 
       // Test misaligned RiDataPtr
-      EXPECT_TRUE(WasiSockRecvFrom.run(
+      EXPECT_FALSE(WasiSockRecvFrom.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<int32_t>(3), // dummy fd
@@ -5594,10 +5594,10 @@ TEST(WasiTest, PointerAlignment) {
               static_cast<uint32_t>(0), // RiFlags
               AlignedPortPtr, AlignedRoDataLenPtr, AlignedRoFlagsPtr},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned AddressPtr
-      EXPECT_TRUE(WasiSockRecvFrom.run(
+      EXPECT_FALSE(WasiSockRecvFrom.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<int32_t>(3), // dummy fd
@@ -5607,10 +5607,10 @@ TEST(WasiTest, PointerAlignment) {
               static_cast<uint32_t>(0), // RiFlags
               AlignedPortPtr, AlignedRoDataLenPtr, AlignedRoFlagsPtr},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned PortPtr
-      EXPECT_TRUE(WasiSockRecvFrom.run(
+      EXPECT_FALSE(WasiSockRecvFrom.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<int32_t>(3), // dummy fd
@@ -5620,10 +5620,10 @@ TEST(WasiTest, PointerAlignment) {
               static_cast<uint32_t>(0), // RiFlags
               MisalignedPortPtr, AlignedRoDataLenPtr, AlignedRoFlagsPtr},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned RoDataLenPtr
-      EXPECT_TRUE(WasiSockRecvFrom.run(
+      EXPECT_FALSE(WasiSockRecvFrom.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<int32_t>(3), // dummy fd
@@ -5633,10 +5633,10 @@ TEST(WasiTest, PointerAlignment) {
               static_cast<uint32_t>(0), // RiFlags
               AlignedPortPtr, MisalignedRoDataLenPtr, AlignedRoFlagsPtr},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned RoFlagsPtr
-      EXPECT_TRUE(WasiSockRecvFrom.run(
+      EXPECT_FALSE(WasiSockRecvFrom.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<int32_t>(3), // dummy fd
@@ -5646,7 +5646,7 @@ TEST(WasiTest, PointerAlignment) {
               static_cast<uint32_t>(0), // RiFlags
               AlignedPortPtr, AlignedRoDataLenPtr, MisalignedRoFlagsPtr},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned parameters (should pass alignment but fail on
       // invalid fd)
@@ -5674,7 +5674,7 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_size_t) * 3);
 
       // Test misaligned SiDataPtr
-      EXPECT_TRUE(WasiSockSend.run(CallFrame,
+      EXPECT_FALSE(WasiSockSend.run(CallFrame,
                                    std::initializer_list<WasmEdge::ValVariant>{
                                        static_cast<int32_t>(3), // dummy fd
                                        MisalignedSiDataPtr,
@@ -5682,10 +5682,10 @@ TEST(WasiTest, PointerAlignment) {
                                        static_cast<uint32_t>(0), // SiFlags
                                        AlignedSoDataLenPtr},
                                    Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned SoDataLenPtr
-      EXPECT_TRUE(WasiSockSend.run(CallFrame,
+      EXPECT_FALSE(WasiSockSend.run(CallFrame,
                                    std::initializer_list<WasmEdge::ValVariant>{
                                        static_cast<int32_t>(3), // dummy fd
                                        AlignedSiDataPtr,
@@ -5693,7 +5693,7 @@ TEST(WasiTest, PointerAlignment) {
                                        static_cast<uint32_t>(0), // SiFlags
                                        MisalignedSoDataLenPtr},
                                    Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned parameters (should pass alignment but fail on
       // invalid fd)
@@ -5723,7 +5723,7 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_size_t) * 4);
 
       // Test misaligned SiDataPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockSendTo.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  static_cast<int32_t>(3), // dummy fd
@@ -5734,10 +5734,10 @@ TEST(WasiTest, PointerAlignment) {
                                  static_cast<uint32_t>(0),   // SiFlags
                                  AlignedSoDataLenPtr},
                              Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned AddressPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockSendTo.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  static_cast<int32_t>(3), // dummy fd
@@ -5748,10 +5748,10 @@ TEST(WasiTest, PointerAlignment) {
                                  static_cast<uint32_t>(0),   // SiFlags
                                  AlignedSoDataLenPtr},
                              Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned SoDataLenPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockSendTo.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  static_cast<int32_t>(3), // dummy fd
@@ -5762,7 +5762,7 @@ TEST(WasiTest, PointerAlignment) {
                                  static_cast<uint32_t>(0),   // SiFlags
                                  MisalignedSoDataLenPtr},
                              Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned parameters (should pass alignment but fail on
       // invalid fd)
@@ -5792,22 +5792,22 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(uint32_t) * 3);
 
       // Test misaligned AddressPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockGetLocalAddr.run(CallFrame,
                                    std::initializer_list<WasmEdge::ValVariant>{
                                        static_cast<int32_t>(3), // dummy fd
                                        MisalignedAddressPtr, AlignedPortPtr},
                                    Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned PortPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockGetLocalAddr.run(CallFrame,
                                    std::initializer_list<WasmEdge::ValVariant>{
                                        static_cast<int32_t>(3), // dummy fd
                                        AlignedAddressPtr, MisalignedPortPtr},
                                    Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned parameters (should pass alignment but fail on
       // invalid fd)
@@ -5831,22 +5831,22 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(uint32_t) * 3);
 
       // Test misaligned AddressPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockGetPeerAddr.run(CallFrame,
                                   std::initializer_list<WasmEdge::ValVariant>{
                                       static_cast<int32_t>(3), // dummy fd
                                       MisalignedAddressPtr, AlignedPortPtr},
                                   Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned PortPtr
-      EXPECT_TRUE(
+      EXPECT_FALSE(
           WasiSockGetPeerAddr.run(CallFrame,
                                   std::initializer_list<WasmEdge::ValVariant>{
                                       static_cast<int32_t>(3), // dummy fd
                                       AlignedAddressPtr, MisalignedPortPtr},
                                   Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned parameters (should pass alignment but fail on
       // invalid fd)
@@ -5873,31 +5873,31 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(uint32_t) * 3);
 
       // Test misaligned AddressPtr
-      EXPECT_TRUE(WasiSockGetLocalAddr.run(
+      EXPECT_FALSE(WasiSockGetLocalAddr.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<int32_t>(3), // dummy fd
               MisalignedAddressPtr, AlignedAddressTypePtr, AlignedPortPtr},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned AddressTypePtr
-      EXPECT_TRUE(WasiSockGetLocalAddr.run(
+      EXPECT_FALSE(WasiSockGetLocalAddr.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<int32_t>(3), // dummy fd
               AlignedAddressPtr, MisalignedAddressTypePtr, AlignedPortPtr},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned PortPtr
-      EXPECT_TRUE(WasiSockGetLocalAddr.run(
+      EXPECT_FALSE(WasiSockGetLocalAddr.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<int32_t>(3), // dummy fd
               AlignedAddressPtr, AlignedAddressTypePtr, MisalignedPortPtr},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned parameters (should pass alignment but fail on
       // invalid fd)
@@ -5926,28 +5926,28 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_size_t) * 3);
 
       // Test misaligned InPtr
-      EXPECT_TRUE(WasiPollOneoff.run(
+      EXPECT_FALSE(WasiPollOneoff.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               MisalignedInPtr, AlignedOutPtr, Count, AlignedNEventsPtr},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned OutPtr
-      EXPECT_TRUE(WasiPollOneoff.run(
+      EXPECT_FALSE(WasiPollOneoff.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               AlignedInPtr, MisalignedOutPtr, Count, AlignedNEventsPtr},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test misaligned for NEventsPtr
-      EXPECT_TRUE(WasiPollOneoff.run(
+      EXPECT_FALSE(WasiPollOneoff.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               AlignedInPtr, AlignedOutPtr, Count, MisalignedNEventsPtr},
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Test properly aligned parameters (should pass alignment but may fail
       // on subscription validation)
@@ -5973,12 +5973,12 @@ TEST(WasiTest, PointerAlignment) {
     const uint32_t AlignedArgvPtr = static_cast<uint32_t>(alignof(uint8_t_ptr));
 
     // Test misaligned ArgvPtr
-    EXPECT_TRUE(WasiArgsGet.run(CallFrame,
+    EXPECT_FALSE(WasiArgsGet.run(CallFrame,
                                 std::initializer_list<WasmEdge::ValVariant>{
                                     MisalignedArgvPtr, // misaligned
                                     static_cast<uint32_t>(0)},
                                 Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned pointers (should succeed)
@@ -6002,21 +6002,21 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_size_t) * 3);
 
     // Test misaligned ArgcPtr
-    EXPECT_TRUE(
+    EXPECT_FALSE(
         WasiArgsSizesGet.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  MisalignedArgcPtr, // misaligned
                                  AlignedArgvBufSizePtr},
                              Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     // Test misaligned ArgvBufSizePtr
-    EXPECT_TRUE(WasiArgsSizesGet.run(
+    EXPECT_FALSE(WasiArgsSizesGet.run(
         CallFrame,
         std::initializer_list<WasmEdge::ValVariant>{
             AlignedArgcPtr, MisalignedArgvBufSizePtr}, // misaligned
         Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     writeDummyMemoryContent(MemInst);
     // Test properly aligned parameters (should succeed)
@@ -6041,12 +6041,12 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(uint8_t_ptr) * 3);
 
     // Test misaligned EnvPtr
-    EXPECT_TRUE(WasiEnvironGet.run(CallFrame,
+    EXPECT_FALSE(WasiEnvironGet.run(CallFrame,
                                    std::initializer_list<WasmEdge::ValVariant>{
                                        MisalignedEnvPtr, // misaligned
                                        static_cast<uint32_t>(0)},
                                    Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned pointers (should succeed)
@@ -6070,21 +6070,21 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_size_t) * 5);
 
     // Test misaligned EnvCntPtr
-    EXPECT_TRUE(
+    EXPECT_FALSE(
         WasiEnvironSizesGet.run(CallFrame,
                                 std::initializer_list<WasmEdge::ValVariant>{
                                     MisalignedEnvCntPtr, // misaligned
                                     AlignedEnvBufSizePtr},
                                 Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     // Test misaligned EnvBufSizePtr
-    EXPECT_TRUE(WasiEnvironSizesGet.run(
+    EXPECT_FALSE(WasiEnvironSizesGet.run(
         CallFrame,
         std::initializer_list<WasmEdge::ValVariant>{
             AlignedEnvCntPtr, MisalignedEnvBufSizePtr}, // misaligned
         Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    // Trap expected: no errno written
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned pointers (should succeed)
@@ -6109,13 +6109,13 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(uint64_t) * 2);
 
       // Test misaligned ResolutionPtr
-      EXPECT_TRUE(WasiClockResGet.run(
+      EXPECT_FALSE(WasiClockResGet.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<uint32_t>(__WASI_CLOCKID_REALTIME),
               MisalignedResolutionPtr}, // misaligned
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       writeDummyMemoryContent(MemInst);
       // Test correctly aligned pointer (should succeed)
@@ -6143,13 +6143,13 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(uint64_t) * 3);
 
       // Test misaligned timestamp pointer
-      EXPECT_TRUE(WasiClockTimeGet.run(
+      EXPECT_FALSE(WasiClockTimeGet.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<uint32_t>(__WASI_CLOCKID_REALTIME), UINT64_C(0),
               MisalignedTimePtr}, // misaligned
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       writeDummyMemoryContent(MemInst);
       // Test correctly aligned timestamp pointer (should succeed)
@@ -6184,13 +6184,13 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_filestat_t));
 
       // Test misaligned filestat pointer
-      EXPECT_TRUE(WasiPathFilestatGet.run(
+      EXPECT_FALSE(WasiPathFilestatGet.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               Fd, static_cast<uint32_t>(__WASI_LOOKUPFLAGS_SYMLINK_FOLLOW),
               PathPtr, PathSize, MisalignedFilestatPtr}, // misaligned
           Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      // Trap expected: no errno written
 
       // Correctly aligned filestat pointer (should succeed)
       EXPECT_TRUE(WasiPathFilestatGet.run(


### PR DESCRIPTION
## Description
Previously, `isMisaligned<T>()` checks in `wasifunc.cpp` returned `__WASI_ERRNO_ADDRNOTAVAIL` as a plain `uint32_t` errno value, allowing execution to continue on misaligned pointer arguments. Per the WITX specification, misaligned pointers passed to WASI host functions must cause a trap.

Changed all 75 misalignment return sites to return `WasmEdge::Unexpect(WasmEdge::ErrCode::Value::HostFuncError)` and updated existing `PointerAlignment` unit tests accordingly.

Fixes: #2694, #2733, #2881
Related: #4820

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<img width="741" height="346" alt="5" src="https://github.com/user-attachments/assets/6fe9b913-dcdd-406c-a70a-a3abbf940b3f" />


---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
