### PR TITLE
feat: add Fish shell env script support

### DIFF
--- a/.github/scripts/installer-test-helpers.sh
+++ b/.github/scripts/installer-test-helpers.sh
@@ -25,3 +25,25 @@ verify_plugin() {
     exit 1
   fi
 }
+
+# Verify env.fish was created (Fish shell users)
+verify_fish_env() {
+  local ipath=${1:-~/.wasmedge}
+  if [ -f "$ipath/env.fish" ]; then
+    echo "✓ env.fish found: $ipath/env.fish"
+  else
+    echo "✗ env.fish not found: $ipath/env.fish"
+    exit 1
+  fi
+}
+
+# Verify env.fish was NOT created (non-Fish shell users)
+verify_no_fish_env() {
+  local ipath=${1:-~/.wasmedge}
+  if [ ! -f "$ipath/env.fish" ]; then
+    echo "✓ env.fish correctly absent for non-Fish shell"
+  else
+    echo "✗ env.fish unexpectedly created for non-Fish shell"
+    exit 1
+  fi
+}

--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -306,6 +306,22 @@ jobs:
         # Test uninstallation
         bash utils/uninstall.sh -q -V
 
+    - name: Test Fish Shell Detection
+      shell: bash
+      run: |
+        . ./.github/scripts/installer-test-helpers.sh
+        IPATH="$HOME/.wasmedge"
+
+        printf "\n=== Test: env.fish created when SHELL=fish ===\n"
+        SHELL=/usr/bin/fish bash utils/install_v2.sh -V
+        verify_fish_env "${IPATH}"
+        bash utils/uninstall.sh -q -V
+
+        printf "\n=== Test: env.fish NOT created when SHELL=bash ===\n"
+        SHELL=/bin/bash bash utils/install_v2.sh -V
+        verify_no_fish_env "${IPATH}"
+        bash utils/uninstall.sh -q -V
+
     - name: Test NoAVX Installation
       if: ${{ matrix.test_noavx }}
       run: |

--- a/utils/install_v2.sh
+++ b/utils/install_v2.sh
@@ -609,7 +609,8 @@ main() {
 
 	echo "$ENV" >"$IPATH/env"
 	echo "# Please do not edit comments below this for uninstallation purpose" >> "$IPATH/env"
-	# Generate env.fish for Fish shell users
+	# Generate env.fish only if user is running Fish shell
+	if echo "$SHELL" | grep -qi "fish"; then
 	local FISH_ENV="# wasmedge shell setup for fish
 fish_add_path -p \"$IPATH/bin\"
 if test -n \"\$DYLD_LIBRARY_PATH\"
@@ -634,6 +635,7 @@ else
 end"
 	echo "$FISH_ENV" >"$IPATH/env.fish"
 	echo "# Please do not edit comments below this for uninstallation purpose" >> "$IPATH/env.fish"
+	fi
 	local _source="source \"$IPATH/env\""
 	local _grep=$(cat "$__HOME__/.profile" 2>/dev/null | grep "$IPATH/env")
 	if [ "$_grep" = "" ]; then

--- a/utils/install_v2.sh
+++ b/utils/install_v2.sh
@@ -609,7 +609,31 @@ main() {
 
 	echo "$ENV" >"$IPATH/env"
 	echo "# Please do not edit comments below this for uninstallation purpose" >> "$IPATH/env"
-
+	# Generate env.fish for Fish shell users
+	local FISH_ENV="# wasmedge shell setup for fish
+fish_add_path -p \"$IPATH/bin\"
+if test -n \"\$DYLD_LIBRARY_PATH\"
+    set -gx DYLD_LIBRARY_PATH \"$IPATH/lib\" \$DYLD_LIBRARY_PATH
+else
+    set -gx DYLD_LIBRARY_PATH \"$IPATH/lib\"
+end
+if test -n \"\$LIBRARY_PATH\"
+    set -gx LIBRARY_PATH \"$IPATH/lib\" \$LIBRARY_PATH
+else
+    set -gx LIBRARY_PATH \"$IPATH/lib\"
+end
+if test -n \"\$C_INCLUDE_PATH\"
+    set -gx C_INCLUDE_PATH \"$IPATH/include\" \$C_INCLUDE_PATH
+else
+    set -gx C_INCLUDE_PATH \"$IPATH/include\"
+end
+if test -n \"\$CPLUS_INCLUDE_PATH\"
+    set -gx CPLUS_INCLUDE_PATH \"$IPATH/include\" \$CPLUS_INCLUDE_PATH
+else
+    set -gx CPLUS_INCLUDE_PATH \"$IPATH/include\"
+end"
+	echo "$FISH_ENV" >"$IPATH/env.fish"
+	echo "# Please do not edit comments below this for uninstallation purpose" >> "$IPATH/env.fish"
 	local _source="source \"$IPATH/env\""
 	local _grep=$(cat "$__HOME__/.profile" 2>/dev/null | grep "$IPATH/env")
 	if [ "$_grep" = "" ]; then
@@ -639,6 +663,15 @@ main() {
 				[ ! -f "$__HOME__/.profile" ] && touch "$__HOME__/.profile"
 				echo "$_source" >>"$__HOME__/.profile"
 			fi
+		fi
+	fi
+	# Fish shell support
+	if [[ "$_shell_" =~ "fish" ]]; then
+		local _fish_config="$__HOME__/.config/fish/config.fish"
+		local _fish_source="source \"$IPATH/env.fish\""
+		local _fish_grep=$(cat "$_fish_config" 2>/dev/null | grep "$IPATH/env.fish")
+		if [ "$_fish_grep" = "" ]; then
+			[ -f "$_fish_config" ] && echo "$_fish_source" >>"$_fish_config"
 		fi
 	fi
 


### PR DESCRIPTION
Fixes #4838

## Changes
- Generate `env.fish` alongside `env` during installation
- Auto-hook into `~/.config/fish/config.fish` when fish shell detected
- Fish-compatible syntax using `fish_add_path` and `set -gx`

## Testing
Verified `env.fish` is generated correctly with proper fish syntax.

Closes #4838