### PR TITLE
fix(wasi_crypto): validate RSA public keys with EVP_PKEY_public_check

### DIFF
--- a/plugins/wasi_crypto/signatures/rsa.cpp
+++ b/plugins/wasi_crypto/signatures/rsa.cpp
@@ -52,7 +52,9 @@ Rsa<PadMode, KeyBits, ShaNid>::PublicKey::checkValid(EvpPkeyPtr Ctx) noexcept {
 template <int PadMode, int KeyBits, int ShaNid>
 WasiCryptoExpect<void>
 Rsa<PadMode, KeyBits, ShaNid>::PublicKey::verify() const noexcept {
-  ensureOrReturn(RSA_check_key(EVP_PKEY_get0_RSA(Ctx.get())),
+  EvpPkeyCtxPtr CheckCtx{EVP_PKEY_CTX_new(Ctx.get(), nullptr)};
+  ensureOrReturn(CheckCtx, __WASI_CRYPTO_ERRNO_INVALID_KEY);
+  ensureOrReturn(EVP_PKEY_public_check(CheckCtx.get()),
                  __WASI_CRYPTO_ERRNO_INVALID_KEY);
   return {};
 }

--- a/test/plugins/wasi_crypto/signatures.cpp
+++ b/test/plugins/wasi_crypto/signatures.cpp
@@ -52,6 +52,29 @@ TEST_F(WasiCryptoTest, Signatures) {
   SigTest(__WASI_ALGORITHM_TYPE_SIGNATURES, "RSA_PSS_3072_SHA512"sv);
   SigTest(__WASI_ALGORITHM_TYPE_SIGNATURES, "RSA_PSS_4096_SHA512"sv);
 
+  // Export a public key and re-import it as a public-only key, then verify it.
+  auto PublickeyVerifyTest = [this](__wasi_algorithm_type_e_t AlgType,
+                                    std::string_view Alg) {
+    SCOPED_TRACE(Alg);
+    WASI_CRYPTO_EXPECT_SUCCESS(KpHandle,
+                               keypairGenerate(AlgType, Alg, std::nullopt));
+    WASI_CRYPTO_EXPECT_SUCCESS(PkHandle, keypairPublickey(KpHandle));
+    WASI_CRYPTO_EXPECT_SUCCESS(
+        PkOutputHandle,
+        publickeyExport(PkHandle, __WASI_PUBLICKEY_ENCODING_PKCS8));
+    WASI_CRYPTO_EXPECT_SUCCESS(PkSize, arrayOutputLen(PkOutputHandle));
+    std::vector<uint8_t> EncodedPk(PkSize);
+    WASI_CRYPTO_EXPECT_TRUE(arrayOutputPull(PkOutputHandle, EncodedPk));
+    WASI_CRYPTO_EXPECT_SUCCESS(
+        ImportedPkHandle, publickeyImport(AlgType, Alg, EncodedPk,
+                                          __WASI_PUBLICKEY_ENCODING_PKCS8));
+    WASI_CRYPTO_EXPECT_TRUE(publickeyVerify(ImportedPkHandle));
+  };
+  PublickeyVerifyTest(__WASI_ALGORITHM_TYPE_SIGNATURES,
+                      "RSA_PKCS1_2048_SHA256"sv);
+  PublickeyVerifyTest(__WASI_ALGORITHM_TYPE_SIGNATURES,
+                      "RSA_PSS_2048_SHA256"sv);
+
   auto SigEncodingTest =
       [this](
           std::string_view Alg,


### PR DESCRIPTION
## Description

Fixes the RSA public key validation path in the WASI-Crypto plugin.

`Rsa::PublicKey::verify()` used `RSA_check_key()` to validate a public key:

```cpp
ensureOrReturn(RSA_check_key(EVP_PKEY_get0_RSA(Ctx.get())),
               __WASI_CRYPTO_ERRNO_INVALID_KEY);
```

`RSA_check_key()` validates an RSA **private** key. It checks that `p` and
`q` are prime, that `n == p*q`, and that the private exponent and CRT
parameters are consistent. A public key only carries the modulus and the
public exponent, so those private components are absent and
`RSA_check_key()` can never succeed on a public-only key. As a result,
`publickey_verify` rejected **every** valid imported RSA public key with
`__WASI_CRYPTO_ERRNO_INVALID_KEY`.

Both `RSA_check_key()` and `EVP_PKEY_get0_RSA()` are also deprecated since
OpenSSL 3.0.

This PR switches to `EVP_PKEY_public_check()`, the API intended for
validating the public component of a key, following the same
`EVP_PKEY_CTX_new(...)` pattern already used elsewhere in the plugin
(`kx/dh/ecdsa.cpp`, `kx/dh/x25519.cpp`):

```cpp
EvpPkeyCtxPtr CheckCtx{EVP_PKEY_CTX_new(Ctx.get(), nullptr)};
ensureOrReturn(CheckCtx, __WASI_CRYPTO_ERRNO_INVALID_KEY);
ensureOrReturn(EVP_PKEY_public_check(CheckCtx.get()),
               __WASI_CRYPTO_ERRNO_INVALID_KEY);
```

A regression test is added to `test/plugins/wasi_crypto/signatures.cpp`.
The existing sign/verify test never exercised `publickey_verify`, and the
public key returned by `keypair_publickey` still references the full key
pair (so `RSA_check_key` accidentally succeeded there). The new test
exports the public key and re-imports it as a **public-only** key before
calling `publickey_verify`, which is the path that previously failed. It
covers both RSA PKCS1 and PSS padding modes.

Closes #4881

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence

The change is small and self-contained. The behavioural difference and the
OpenSSL API usage were validated against the system OpenSSL (3.0.13) with an
isolated program that builds a real RSA key pair, serialises the public key
(SubjectPublicKeyInfo) and reloads it as a public-only key, then runs both
the old and the new validation paths on it:

```
on a public-only RSA key:
  RSA_check_key()         (old) -> != 1  (fails, as expected for a public key)
  EVP_PKEY_public_check() (new) -> 1     (succeeds)
=> exit code 0
```

`clang-format` (v18, LLVM style, as run by the `Clang-Format` CI job) reports
no violations on the modified files:

```
clang-format -style=file -Werror --dry-run plugins/wasi_crypto/signatures/rsa.cpp        # clean
clang-format -style=file -Werror --dry-run test/plugins/wasi_crypto/signatures.cpp        # clean
```

The full `wasiCryptoTests` GoogleTest suite (including the new
`WasiCryptoTest.Signatures` assertions) is compiled and executed by the
`build-extensions` CI workflow, which builds the plugin with OpenSSL.
