### PR TITLE
fix(WASI-NN, piper): handle piper_synthesize_next error returns in streaming loop

### DIFF
--- a/plugins/wasi_nn/wasinn_piper.cpp
+++ b/plugins/wasi_nn/wasinn_piper.cpp
@@ -438,11 +438,19 @@ Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
   }
 
   std::vector<int16_t> AudioBuffer;
-  piper_audio_chunk Chunk;
   int SampleRate = 0;
   constexpr float MaxWavValue = 32767.0f;
 
-  while (piper_synthesize_next(GraphRef.Synth.get(), &Chunk) != PIPER_DONE) {
+  while (true) {
+    piper_audio_chunk Chunk{};
+    int const NextRes = piper_synthesize_next(GraphRef.Synth.get(), &Chunk);
+    if (NextRes == PIPER_DONE) {
+      break;
+    }
+    if (NextRes != PIPER_OK) {
+      spdlog::error("[WASI-NN] Piper backend: piper_synthesize_next failed."sv);
+      return WASINN::ErrNo::RuntimeError;
+    }
     if (Chunk.num_samples == 0) {
       continue;
     }


### PR DESCRIPTION
## Description

Capture the piper_synthesize_next status and return RuntimeError on a non-OK/non-DONE result instead of treating every non-DONE status as a data-producing iteration. Value-initialize the chunk per iteration so its fields are well-defined on all paths.

An inference error previously yielded empty/truncated audio with a Success result; it is now surfaced to the caller.

Assisted-by: Claude (Anthropic)

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.
