### PR TITLE
fix(plugins/ffmpeg): harden guest-facing host calls and handle lifecycle

### DIFF
--- a/.github/workflows/ignore_words
+++ b/.github/workflows/ignore_words
@@ -24,3 +24,4 @@ totalin
 cann
 thats
 fo
+statics

--- a/plugins/wasmedge_ffmpeg/avcodec/avCodec.cpp
+++ b/plugins/wasmedge_ffmpeg/avcodec/avCodec.cpp
@@ -15,30 +15,35 @@ namespace AVcodec {
 Expect<uint32_t> AVCodecID::body(const Runtime::CallingFrame &,
                                  uint32_t AvCodecId) {
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, 0);
   return FFmpegUtils::CodecID::fromAVCodecID(AvCodec->id);
 }
 
 Expect<int32_t> AVCodecType::body(const Runtime::CallingFrame &,
                                   uint32_t AvCodecId) {
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, 0);
   return FFmpegUtils::MediaType::fromMediaType(AvCodec->type);
 }
 
 Expect<int32_t> AVCodecMaxLowres::body(const Runtime::CallingFrame &,
                                        uint32_t AvCodecId) {
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, 0);
   return AvCodec->max_lowres;
 }
 
 Expect<int32_t> AVCodecCapabilities::body(const Runtime::CallingFrame &,
                                           uint32_t AvCodecId) {
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, 0);
   return AvCodec->capabilities;
 }
 
 Expect<int32_t> AVCodecGetNameLen::body(const Runtime::CallingFrame &,
                                         uint32_t AvCodecId) {
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, 0);
   return strlen(AvCodec->name);
 }
 
@@ -48,15 +53,20 @@ Expect<int32_t> AVCodecGetName::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_SPAN_CHECK(NameBuf, MemInst, char, NamePtr, NameLen, "");
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *Name = AvCodec->name;
-  std::copy_n(Name, NameLen, NameBuf.data());
+  copyCStringToBuffer(NameBuf.data(), NameLen, Name);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> AVCodecGetLongNameLen::body(const Runtime::CallingFrame &,
                                             uint32_t AvCodecId) {
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, 0);
+  if (AvCodec->long_name == nullptr) {
+    return 0;
+  }
   return strlen(AvCodec->long_name);
 }
 
@@ -67,15 +77,17 @@ Expect<int32_t> AVCodecGetLongName::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_SPAN_CHECK(LongNameBuf, MemInst, char, LongNamePtr, LongNameLen, "");
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *LongName = AvCodec->long_name;
-  std::copy_n(LongName, LongNameLen, LongNameBuf.data());
+  copyCStringToBuffer(LongNameBuf.data(), LongNameLen, LongName);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> AVCodecProfiles::body(const Runtime::CallingFrame &,
                                       uint32_t AvCodecId) {
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, 0);
   if (AvCodec->profiles) {
     return 1;
   }
@@ -85,6 +97,7 @@ Expect<int32_t> AVCodecProfiles::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecPixFmtsIsNull::body(const Runtime::CallingFrame &,
                                            uint32_t AvCodecId) {
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, 1);
   if (AvCodec->pix_fmts == nullptr) {
     return 1;
   }
@@ -94,6 +107,7 @@ Expect<int32_t> AVCodecPixFmtsIsNull::body(const Runtime::CallingFrame &,
 Expect<uint32_t> AVCodecPixFmtsIter::body(const Runtime::CallingFrame &,
                                           uint32_t AvCodecId, uint32_t Idx) {
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, 0);
   AVPixelFormat const *PixelFormat = AvCodec->pix_fmts;
   if (PixelFormat == nullptr) {
     return 0;
@@ -101,6 +115,9 @@ Expect<uint32_t> AVCodecPixFmtsIter::body(const Runtime::CallingFrame &,
 
   uint32_t Curr = 0;
   while (Curr < Idx) {
+    if (*PixelFormat == AV_PIX_FMT_NONE) {
+      return 0;
+    }
     PixelFormat++;
     Curr++;
   }
@@ -112,6 +129,7 @@ Expect<int32_t>
 AVCodecSupportedFrameratesIsNull::body(const Runtime::CallingFrame &,
                                        uint32_t AvCodecId) {
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, 1);
   if (AvCodec->supported_framerates == nullptr) {
     return 1;
   }
@@ -129,6 +147,11 @@ AVCodecSupportedFrameratesIter::body(const Runtime::CallingFrame &Frame,
                 "Failed when accessing the return DenPtr Memory"sv);
 
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  if (AvCodec == nullptr) {
+    *NumId = 0;
+    *DenId = 0;
+    return static_cast<int32_t>(ErrNo::Success);
+  }
   AVRational const *Rational = AvCodec->supported_framerates;
 
   if (Rational == nullptr) {
@@ -139,6 +162,11 @@ AVCodecSupportedFrameratesIter::body(const Runtime::CallingFrame &Frame,
 
   uint32_t Curr = 0;
   while (Curr < Idx) {
+    if (Rational->num == 0 && Rational->den == 0) {
+      *NumId = 0;
+      *DenId = 0;
+      return static_cast<int32_t>(ErrNo::Success);
+    }
     Rational++;
     Curr++;
   }
@@ -152,6 +180,7 @@ Expect<int32_t>
 AVCodecSupportedSampleRatesIsNull::body(const Runtime::CallingFrame &,
                                         uint32_t AvCodecId) {
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, 1);
   if (AvCodec->supported_samplerates == nullptr) {
     return 1;
   }
@@ -162,6 +191,7 @@ Expect<int32_t>
 AVCodecSupportedSampleRatesIter::body(const Runtime::CallingFrame &,
                                       uint32_t AvCodecId, uint32_t Idx) {
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, 0);
   const int32_t *SampleRates = AvCodec->supported_samplerates;
   if (SampleRates == nullptr) {
     return 0;
@@ -169,6 +199,9 @@ AVCodecSupportedSampleRatesIter::body(const Runtime::CallingFrame &,
 
   uint32_t Curr = 0;
   while (Curr < Idx) {
+    if (*SampleRates == 0) {
+      return 0;
+    }
     SampleRates++;
     Curr++;
   }
@@ -179,6 +212,7 @@ AVCodecSupportedSampleRatesIter::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecChannelLayoutIsNull::body(const Runtime::CallingFrame &,
                                                  uint32_t AvCodecId) {
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, 1);
   if (AvCodec->ch_layouts == nullptr) {
     return 1;
   }
@@ -190,6 +224,7 @@ Expect<uint64_t> AVCodecChannelLayoutIter::body(const Runtime::CallingFrame &,
                                                 uint32_t Idx) {
 
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, 0);
   const AVChannelLayout *ChannelLayout = AvCodec->ch_layouts;
   if (ChannelLayout == nullptr) {
     return 0;
@@ -197,16 +232,20 @@ Expect<uint64_t> AVCodecChannelLayoutIter::body(const Runtime::CallingFrame &,
 
   uint32_t Curr = 0;
   while (Curr < Idx) {
+    if (ChannelLayout->nb_channels == 0) {
+      return 0;
+    }
     ChannelLayout++;
     Curr++;
   }
 
-  return FFmpegUtils::ChannelLayout::intoChannelLayoutID(ChannelLayout->u.mask);
+  return FFmpegUtils::ChannelLayout::intoChannelLayoutID(*ChannelLayout);
 }
 
 Expect<int32_t> AVCodecSampleFmtsIsNull::body(const Runtime::CallingFrame &,
                                               uint32_t AvCodecId) {
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, 1);
   if (AvCodec->sample_fmts == nullptr) {
     return 1;
   }
@@ -217,6 +256,7 @@ Expect<uint32_t> AVCodecSampleFmtsIter::body(const Runtime::CallingFrame &,
                                              uint32_t AvCodecId, uint32_t Idx) {
 
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK(AvCodec, 0);
   AVSampleFormat const *SampleFormat = AvCodec->sample_fmts;
   if (SampleFormat == nullptr) {
     return 0;
@@ -224,6 +264,9 @@ Expect<uint32_t> AVCodecSampleFmtsIter::body(const Runtime::CallingFrame &,
 
   uint32_t Curr = 0;
   while (Curr < Idx) {
+    if (*SampleFormat == AV_SAMPLE_FMT_NONE) {
+      return 0;
+    }
     SampleFormat++;
     Curr++;
   }

--- a/plugins/wasmedge_ffmpeg/avcodec/avCodecContext.cpp
+++ b/plugins/wasmedge_ffmpeg/avcodec/avCodecContext.cpp
@@ -15,6 +15,7 @@ namespace AVcodec {
 Expect<uint32_t> AVCodecCtxCodecID::body(const Runtime::CallingFrame &,
                                          uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   AVCodecID const AvCodecId = AvCodecCtx->codec_id;
   return FFmpegUtils::CodecID::fromAVCodecID(AvCodecId);
 }
@@ -22,6 +23,7 @@ Expect<uint32_t> AVCodecCtxCodecID::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxCodecType::body(const Runtime::CallingFrame &,
                                           uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   AVMediaType const AvMediaType = AvCodecCtx->codec_type;
   return FFmpegUtils::MediaType::fromMediaType(AvMediaType);
 }
@@ -30,6 +32,7 @@ Expect<int32_t> AVCodecCtxSetCodecType::body(const Runtime::CallingFrame &,
                                              uint32_t AvCodecCtxId,
                                              int32_t CodecTypeId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AVMediaType const AvMediaType =
       FFmpegUtils::MediaType::intoMediaType(CodecTypeId);
 
@@ -41,6 +44,7 @@ Expect<int32_t> AVCodecCtxSetTimebase::body(const Runtime::CallingFrame &,
                                             uint32_t AvCodecCtxId, int32_t Num,
                                             int32_t Den) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AVRational const Rational = av_make_q(Num, Den);
   AvCodecCtx->time_base = Rational;
   return static_cast<int32_t>(ErrNo::Success);
@@ -56,6 +60,7 @@ Expect<int32_t> AVCodecCtxTimeBase::body(const Runtime::CallingFrame &Frame,
                 "Failed to access Denominator Ptr for AVRational"sv);
 
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AVRational const AvRational = AvCodecCtx->time_base;
   *Num = AvRational.num;
   *Den = AvRational.den;
@@ -65,12 +70,14 @@ Expect<int32_t> AVCodecCtxTimeBase::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> AVCodecCtxWidth::body(const Runtime::CallingFrame &,
                                       uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   return AvCodecCtx->width;
 }
 
 Expect<int32_t> AVCodecCtxSetWidth::body(const Runtime::CallingFrame &,
                                          uint32_t AvCodecCtxId, int32_t Width) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->width = Width;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -78,6 +85,7 @@ Expect<int32_t> AVCodecCtxSetWidth::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxHeight::body(const Runtime::CallingFrame &,
                                        uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   return AvCodecCtx->height;
 }
 
@@ -85,6 +93,7 @@ Expect<int32_t> AVCodecCtxSetHeight::body(const Runtime::CallingFrame &,
                                           uint32_t AvCodecCtxId,
                                           int32_t Height) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->height = Height;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -99,6 +108,7 @@ AVCodecCtxSampleAspectRatio::body(const Runtime::CallingFrame &Frame,
   MEM_PTR_CHECK(Den, MemInst, int32_t, DenPtr,
                 "Failed to access Denominator Ptr for AVRational"sv);
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
 
   const AVRational AvRational = AvCodecCtx->sample_aspect_ratio;
   *Num = AvRational.num;
@@ -111,6 +121,7 @@ AVCodecCtxSetSampleAspectRatio::body(const Runtime::CallingFrame &,
                                      uint32_t AvCodecCtxId, int32_t Num,
                                      int32_t Den) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   const AVRational AspectRatio = av_make_q(Num, Den);
   AvCodecCtx->sample_aspect_ratio = AspectRatio;
   return static_cast<int32_t>(ErrNo::Success);
@@ -119,24 +130,32 @@ AVCodecCtxSetSampleAspectRatio::body(const Runtime::CallingFrame &,
 Expect<uint64_t> AVCodecCtxChannelLayout::body(const Runtime::CallingFrame &,
                                                uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
-  // Deprecated method
-  uint64_t const AvChannel = AvCodecCtx->ch_layout.u.mask;
-  return FFmpegUtils::ChannelLayout::intoChannelLayoutID(AvChannel);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
+  return FFmpegUtils::ChannelLayout::intoChannelLayoutID(AvCodecCtx->ch_layout);
 }
 
 Expect<int32_t> AVCodecCtxSetChannelLayout::body(const Runtime::CallingFrame &,
                                                  uint32_t AvCodecCtxId,
                                                  uint64_t ChannelLayoutId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   uint64_t const AvChannel =
       FFmpegUtils::ChannelLayout::fromChannelLayoutID(ChannelLayoutId);
-  av_channel_layout_from_mask(&AvCodecCtx->ch_layout, AvChannel);
+  int const Ret =
+      av_channel_layout_from_mask(&AvCodecCtx->ch_layout, AvChannel);
+  if (Ret < 0) {
+    spdlog::error("[WasmEdge-FFmpeg] AVCodecCtxSetChannelLayout: "
+                  "av_channel_layout_from_mask failed ({}) for mask {:#x}"sv,
+                  Ret, AvChannel);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<uint32_t> AVCodecCtxPixFormat::body(const Runtime::CallingFrame &,
                                            uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   AVPixelFormat const PixFmt = AvCodecCtx->pix_fmt;
   return FFmpegUtils::PixFmt::fromAVPixFmt(PixFmt);
 }
@@ -145,6 +164,7 @@ Expect<int32_t> AVCodecCtxSetPixFormat::body(const Runtime::CallingFrame &,
                                              uint32_t AvCodecCtxId,
                                              uint32_t PixFmtId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AVPixelFormat const PixFmt = FFmpegUtils::PixFmt::intoAVPixFmt(PixFmtId);
   AvCodecCtx->pix_fmt = PixFmt;
   return static_cast<int32_t>(ErrNo::Success);
@@ -153,6 +173,7 @@ Expect<int32_t> AVCodecCtxSetPixFormat::body(const Runtime::CallingFrame &,
 Expect<uint32_t> AVCodecCtxSampleFormat::body(const Runtime::CallingFrame &,
                                               uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   AVSampleFormat const AvSampleFormat = AvCodecCtx->sample_fmt;
   return FFmpegUtils::SampleFmt::toSampleID(AvSampleFormat);
 }
@@ -161,6 +182,7 @@ Expect<int32_t> AVCodecCtxSetSampleFormat::body(const Runtime::CallingFrame &,
                                                 uint32_t AvCodecCtxId,
                                                 uint32_t SampleFmtId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AVSampleFormat const SampleFormat =
       FFmpegUtils::SampleFmt::fromSampleID(SampleFmtId);
   AvCodecCtx->sample_fmt = SampleFormat;
@@ -170,6 +192,7 @@ Expect<int32_t> AVCodecCtxSetSampleFormat::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxSampleRate::body(const Runtime::CallingFrame &,
                                            uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   return AvCodecCtx->sample_rate;
 }
 
@@ -177,6 +200,7 @@ Expect<int32_t> AVCodecCtxSetSampleRate::body(const Runtime::CallingFrame &,
                                               uint32_t AvCodecCtxId,
                                               int32_t SampleRate) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->sample_rate = SampleRate;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -185,6 +209,7 @@ Expect<int32_t> AVCodecCtxSetGopSize::body(const Runtime::CallingFrame &,
                                            uint32_t AvCodecCtxId,
                                            int32_t GopSize) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->gop_size = GopSize;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -193,6 +218,7 @@ Expect<int32_t> AVCodecCtxSetMaxBFrames::body(const Runtime::CallingFrame &,
                                               uint32_t AvCodecCtxId,
                                               int32_t MaxBFrames) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->max_b_frames = MaxBFrames;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -201,6 +227,7 @@ Expect<int32_t> AVCodecCtxSetBQuantFactor::body(const Runtime::CallingFrame &,
                                                 uint32_t AvCodecCtxId,
                                                 float BQuantFactor) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->b_quant_factor = BQuantFactor;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -209,6 +236,7 @@ Expect<int32_t> AVCodecCtxSetBQuantOffset::body(const Runtime::CallingFrame &,
                                                 uint32_t AvCodecCtxId,
                                                 float BQuantOffset) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->b_quant_offset = BQuantOffset;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -217,6 +245,7 @@ Expect<int32_t> AVCodecCtxSetIQuantFactor::body(const Runtime::CallingFrame &,
                                                 uint32_t AvCodecCtxId,
                                                 float IQuantFactor) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->i_quant_factor = IQuantFactor;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -225,6 +254,7 @@ Expect<int32_t> AVCodecCtxSetIQuantOffset::body(const Runtime::CallingFrame &,
                                                 uint32_t AvCodecCtxId,
                                                 float IQuantOffset) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->i_quant_offset = IQuantOffset;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -233,6 +263,7 @@ Expect<int32_t> AVCodecCtxSetLumiMasking::body(const Runtime::CallingFrame &,
                                                uint32_t AvCodecCtxId,
                                                float LumiMasking) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->lumi_masking = LumiMasking;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -242,6 +273,7 @@ AVCodecCtxSetTemporalCplxMasking::body(const Runtime::CallingFrame &,
                                        uint32_t AvCodecCtxId,
                                        float TemporalCplxMasking) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->temporal_cplx_masking = TemporalCplxMasking;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -251,6 +283,7 @@ AVCodecCtxSetSpatialCplxMasking::body(const Runtime::CallingFrame &,
                                       uint32_t AvCodecCtxId,
                                       float SpatialCplxMasking) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->spatial_cplx_masking = SpatialCplxMasking;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -259,6 +292,7 @@ Expect<int32_t> AVCodecCtxSetPMasking::body(const Runtime::CallingFrame &,
                                             uint32_t AvCodecCtxId,
                                             float PMasking) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->p_masking = PMasking;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -267,6 +301,7 @@ Expect<int32_t> AVCodecCtxSetDarkMasking::body(const Runtime::CallingFrame &,
                                                uint32_t AvCodecCtxId,
                                                float DarkMasking) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->dark_masking = DarkMasking;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -274,6 +309,7 @@ Expect<int32_t> AVCodecCtxSetDarkMasking::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxSetMeCmp::body(const Runtime::CallingFrame &,
                                          uint32_t AvCodecCtxId, int32_t MeCmp) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->me_cmp = MeCmp;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -282,6 +318,7 @@ Expect<int32_t> AVCodecCtxSetMeSubCmp::body(const Runtime::CallingFrame &,
                                             uint32_t AvCodecCtxId,
                                             int32_t MeSubCmp) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->me_sub_cmp = MeSubCmp;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -289,6 +326,7 @@ Expect<int32_t> AVCodecCtxSetMeSubCmp::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxSetMbCmp::body(const Runtime::CallingFrame &,
                                          uint32_t AvCodecCtxId, int32_t MbCmp) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->mb_cmp = MbCmp;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -297,6 +335,7 @@ Expect<int32_t> AVCodecCtxSetIldctCmp::body(const Runtime::CallingFrame &,
                                             uint32_t AvCodecCtxId,
                                             int32_t IldctCmp) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->ildct_cmp = IldctCmp;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -305,6 +344,7 @@ Expect<int32_t> AVCodecCtxSetDiaSize::body(const Runtime::CallingFrame &,
                                            uint32_t AvCodecCtxId,
                                            int32_t DiaSize) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->dia_size = DiaSize;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -314,6 +354,7 @@ AVCodecCtxSetLastPredictorsCount::body(const Runtime::CallingFrame &,
                                        uint32_t AvCodecCtxId,
                                        int32_t LastPredictorCount) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->last_predictor_count = LastPredictorCount;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -322,6 +363,7 @@ Expect<int32_t> AVCodecCtxSetMePreCmp::body(const Runtime::CallingFrame &,
                                             uint32_t AvCodecCtxId,
                                             int32_t MePreCmp) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->me_pre_cmp = MePreCmp;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -330,6 +372,7 @@ Expect<int32_t> AVCodecCtxSetPreDiaSize::body(const Runtime::CallingFrame &,
                                               uint32_t AvCodecCtxId,
                                               int32_t PreDiaSize) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->pre_dia_size = PreDiaSize;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -339,6 +382,7 @@ AVCodecCtxSetMeSubpelQuality::body(const Runtime::CallingFrame &,
                                    uint32_t AvCodecCtxId,
                                    int32_t MeSubpelQuality) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->me_subpel_quality = MeSubpelQuality;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -347,6 +391,7 @@ Expect<int32_t> AVCodecCtxSetMeRange::body(const Runtime::CallingFrame &,
                                            uint32_t AvCodecCtxId,
                                            int32_t MeRange) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->me_range = MeRange;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -355,6 +400,7 @@ Expect<int32_t> AVCodecCtxSetMbDecision::body(const Runtime::CallingFrame &,
                                               uint32_t AvCodecCtxId,
                                               int32_t MbDecision) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->mb_decision = MbDecision;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -363,6 +409,7 @@ Expect<int32_t> AVCodecCtxSetMbLMin::body(const Runtime::CallingFrame &,
                                           uint32_t AvCodecCtxId,
                                           int32_t MbLMin) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->mb_lmin = MbLMin;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -371,6 +418,7 @@ Expect<int32_t> AVCodecCtxSetMbLMax::body(const Runtime::CallingFrame &,
                                           uint32_t AvCodecCtxId,
                                           int32_t MbLMax) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->mb_lmax = MbLMax;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -378,6 +426,7 @@ Expect<int32_t> AVCodecCtxSetMbLMax::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxIntraDcPrecision::body(const Runtime::CallingFrame &,
                                                  uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   return AvCodecCtx->intra_dc_precision;
 }
 
@@ -386,6 +435,7 @@ AVCodecCtxSetIntraDcPrecision::body(const Runtime::CallingFrame &,
                                     uint32_t AvCodecCtxId,
                                     int32_t IntraDcPrecision) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->intra_dc_precision = IntraDcPrecision;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -393,6 +443,7 @@ AVCodecCtxSetIntraDcPrecision::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxSetQMin::body(const Runtime::CallingFrame &,
                                         uint32_t AvCodecCtxId, int32_t QMin) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->qmin = QMin;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -400,6 +451,7 @@ Expect<int32_t> AVCodecCtxSetQMin::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxSetQMax::body(const Runtime::CallingFrame &,
                                         uint32_t AvCodecCtxId, int32_t QMax) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->qmax = QMax;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -408,6 +460,7 @@ Expect<int32_t> AVCodecCtxSetGlobalQuality::body(const Runtime::CallingFrame &,
                                                  uint32_t AvCodecCtxId,
                                                  int32_t GlobalQuality) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->global_quality = GlobalQuality;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -416,6 +469,7 @@ Expect<int32_t> AVCodecCtxSetColorspace::body(const Runtime::CallingFrame &,
                                               uint32_t AvCodecCtxId,
                                               int32_t ColorspaceId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AVColorSpace const ColorSpace =
       FFmpegUtils::ColorSpace::intoAVColorSpace(ColorspaceId);
   AvCodecCtx->colorspace = ColorSpace;
@@ -425,6 +479,7 @@ Expect<int32_t> AVCodecCtxSetColorspace::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxColorspace::body(const Runtime::CallingFrame &,
                                            uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   AVColorSpace const Colorspace = AvCodecCtx->colorspace;
   return FFmpegUtils::ColorSpace::fromAVColorSpace(Colorspace);
 }
@@ -433,6 +488,7 @@ Expect<int32_t> AVCodecCtxSetColorRange::body(const Runtime::CallingFrame &,
                                               uint32_t AvCodecCtxId,
                                               int32_t ColorRangeId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->color_range = static_cast<AVColorRange>(ColorRangeId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -440,6 +496,7 @@ Expect<int32_t> AVCodecCtxSetColorRange::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxColorRange::body(const Runtime::CallingFrame &,
                                            uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   AVColorRange const ColorRange = AvCodecCtx->color_range;
   return static_cast<int32_t>(ColorRange);
 }
@@ -447,12 +504,14 @@ Expect<int32_t> AVCodecCtxColorRange::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxFrameSize::body(const Runtime::CallingFrame &,
                                           uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   return AvCodecCtx->frame_size;
 }
 
 Expect<int64_t> AVCodecCtxBitRate::body(const Runtime::CallingFrame &,
                                         uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   return AvCodecCtx->bit_rate;
 }
 
@@ -460,6 +519,7 @@ Expect<int32_t> AVCodecCtxSetBitRate::body(const Runtime::CallingFrame &,
                                            uint32_t AvCodecCtxId,
                                            int64_t BitRate) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->bit_rate = BitRate;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -467,6 +527,7 @@ Expect<int32_t> AVCodecCtxSetBitRate::body(const Runtime::CallingFrame &,
 Expect<int64_t> AVCodecCtxRcMaxRate::body(const Runtime::CallingFrame &,
                                           uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   return AvCodecCtx->rc_max_rate;
 }
 
@@ -474,6 +535,7 @@ Expect<int32_t> AVCodecCtxSetRcMaxRate::body(const Runtime::CallingFrame &,
                                              uint32_t AvCodecCtxId,
                                              int64_t RcMaxRate) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->rc_max_rate = RcMaxRate;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -483,6 +545,7 @@ AVCodecCtxSetBitRateTolerance::body(const Runtime::CallingFrame &,
                                     uint32_t AvCodecCtxId,
                                     int32_t BitRateTolerance) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->bit_rate_tolerance = BitRateTolerance;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -492,6 +555,7 @@ AVCodecCtxSetCompressionLevel::body(const Runtime::CallingFrame &,
                                     uint32_t AvCodecCtxId,
                                     int32_t CompressionLevel) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->compression_level = CompressionLevel;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -506,6 +570,7 @@ Expect<int32_t> AVCodecCtxFrameRate::body(const Runtime::CallingFrame &Frame,
                 "Failed to access Denominator Ptr for AVRational"sv);
 
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
 
   AVRational const FrameRate = AvCodecCtx->framerate;
   *Num = FrameRate.num;
@@ -517,6 +582,7 @@ Expect<int32_t> AVCodecCtxSetFrameRate::body(const Runtime::CallingFrame &,
                                              uint32_t AvCodecCtxId, int32_t Num,
                                              int32_t Den) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AVRational const Rational = av_make_q(Num, Den);
   AvCodecCtx->framerate = Rational;
   return static_cast<int32_t>(ErrNo::Success);
@@ -525,6 +591,7 @@ Expect<int32_t> AVCodecCtxSetFrameRate::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxSetFlags::body(const Runtime::CallingFrame &,
                                          uint32_t AvCodecCtxId, int32_t Flags) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->flags = Flags;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -534,6 +601,7 @@ AVCodecCtxSetStrictStdCompliance::body(const Runtime::CallingFrame &,
                                        uint32_t AvCodecCtxId,
                                        int32_t ComplianceId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->strict_std_compliance = ComplianceId;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -541,6 +609,7 @@ AVCodecCtxSetStrictStdCompliance::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxSetDebug::body(const Runtime::CallingFrame &,
                                          uint32_t AvCodecCtxId, int32_t Debug) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->debug = Debug;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -553,6 +622,7 @@ Expect<int32_t> AVCodecCtxCodec::body(const Runtime::CallingFrame &Frame,
                 "Failed to access Ptr for AvCodecPtr"sv);
 
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_FETCH(AvCodec, *AVCodecId, const AVCodec);
 
   AvCodec = AvCodecCtx->codec;
@@ -566,6 +636,7 @@ Expect<int32_t> AVCodecCtxCodec::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> AVCodecCtxChannels::body(const Runtime::CallingFrame &,
                                          uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   return AvCodecCtx->ch_layout.nb_channels;
 }
 
@@ -573,6 +644,7 @@ Expect<int32_t> AVCodecCtxSetChannels::body(const Runtime::CallingFrame &,
                                             uint32_t AvCodecCtxId,
                                             int32_t Channels) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->ch_layout.nb_channels = Channels;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -581,6 +653,7 @@ Expect<int32_t> AVCodecCtxSetSkipLoopFilter::body(const Runtime::CallingFrame &,
                                                   uint32_t AvCodecCtxId,
                                                   int32_t AVDiscardId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->skip_loop_filter = static_cast<AVDiscard>(AVDiscardId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -589,6 +662,7 @@ Expect<int32_t> AVCodecCtxSetSkipFrame::body(const Runtime::CallingFrame &,
                                              uint32_t AvCodecCtxId,
                                              int32_t AVDiscardId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->skip_frame = static_cast<AVDiscard>(AVDiscardId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -597,6 +671,7 @@ Expect<int32_t> AVCodecCtxSetSkipIdct::body(const Runtime::CallingFrame &,
                                             uint32_t AvCodecCtxId,
                                             int32_t AVDiscardId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->skip_idct = static_cast<AVDiscard>(AVDiscardId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -606,6 +681,7 @@ AVCodecCtxSetErrorConcealment::body(const Runtime::CallingFrame &,
                                     uint32_t AvCodecCtxId,
                                     int32_t ErrorConcealment) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->error_concealment = ErrorConcealment;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -615,6 +691,7 @@ AVCodecCtxSetErrorRecognition::body(const Runtime::CallingFrame &,
                                     uint32_t AvCodecCtxId,
                                     int32_t ErrRecognition) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->err_recognition = ErrRecognition;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -622,6 +699,7 @@ AVCodecCtxSetErrorRecognition::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxDelay::body(const Runtime::CallingFrame &,
                                       uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   return AvCodecCtx->delay;
 }
 
@@ -629,6 +707,7 @@ Expect<int32_t> AVCodecCtxSetSkipTop::body(const Runtime::CallingFrame &,
                                            uint32_t AvCodecCtxId,
                                            int32_t Value) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->skip_top = Value;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -637,6 +716,7 @@ Expect<int32_t> AVCodecCtxSetSkipBottom::body(const Runtime::CallingFrame &,
                                               uint32_t AvCodecCtxId,
                                               int32_t Value) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->skip_bottom = Value;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -644,6 +724,7 @@ Expect<int32_t> AVCodecCtxSetSkipBottom::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxRefs::body(const Runtime::CallingFrame &,
                                      uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   return AvCodecCtx->refs;
 }
 
@@ -651,6 +732,7 @@ Expect<int32_t> AVCodecCtxSetSliceFlags::body(const Runtime::CallingFrame &,
                                               uint32_t AvCodecCtxId,
                                               int32_t Value) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->slice_flags = Value;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -658,6 +740,7 @@ Expect<int32_t> AVCodecCtxSetSliceCount::body(const Runtime::CallingFrame &,
                                               uint32_t AvCodecCtxId,
                                               int32_t Value) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->slices = Value;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -666,6 +749,7 @@ Expect<int32_t> AVCodecCtxSetFieldOrder::body(const Runtime::CallingFrame &,
                                               uint32_t AvCodecCtxId,
                                               int32_t Value) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->field_order = static_cast<AVFieldOrder>(Value);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -673,6 +757,7 @@ Expect<int32_t> AVCodecCtxSetFieldOrder::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxColorTrc::body(const Runtime::CallingFrame &,
                                          uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   return static_cast<int32_t>(AvCodecCtx->color_trc);
 }
 
@@ -680,6 +765,7 @@ Expect<int32_t>
 AVCodecCtxChromaSampleLocation::body(const Runtime::CallingFrame &,
                                      uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   AVChromaLocation const Chroma = AvCodecCtx->chroma_sample_location;
   return FFmpegUtils::ChromaLocation::fromAVChromaLocation(Chroma);
 }
@@ -687,12 +773,14 @@ AVCodecCtxChromaSampleLocation::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxFrameNumber::body(const Runtime::CallingFrame &,
                                             uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   return AvCodecCtx->frame_num;
 }
 
 Expect<int32_t> AVCodecCtxBlockAlign::body(const Runtime::CallingFrame &,
                                            uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   return AvCodecCtx->block_align;
 }
 
@@ -701,6 +789,7 @@ AVCodecCtxSetRequestSampleFmt::body(const Runtime::CallingFrame &,
                                     uint32_t AvCodecCtxId,
                                     uint32_t SampleFmtId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AVSampleFormat const SampleFmt =
       FFmpegUtils::SampleFmt::fromSampleID(SampleFmtId);
   AvCodecCtx->request_sample_fmt = SampleFmt;
@@ -710,6 +799,7 @@ AVCodecCtxSetRequestSampleFmt::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxAudioServiceType::body(const Runtime::CallingFrame &,
                                                  uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   AVAudioServiceType const AudioServiceType = AvCodecCtx->audio_service_type;
   return static_cast<int32_t>(AudioServiceType);
 }
@@ -717,12 +807,14 @@ Expect<int32_t> AVCodecCtxAudioServiceType::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxHasBFrames::body(const Runtime::CallingFrame &,
                                            uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   return AvCodecCtx->has_b_frames;
 }
 
 Expect<int32_t> AVCodecCtxActiveThreadType::body(const Runtime::CallingFrame &,
                                                  uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   return AvCodecCtx->active_thread_type;
 }
 
@@ -730,6 +822,7 @@ Expect<int32_t> AVCodecCtxSetThreadType::body(const Runtime::CallingFrame &,
                                               uint32_t AvCodecCtxId,
                                               int32_t ThreadType) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->thread_type = ThreadType;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -737,6 +830,7 @@ Expect<int32_t> AVCodecCtxSetThreadType::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxThreadCount::body(const Runtime::CallingFrame &,
                                             uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   return AvCodecCtx->thread_count;
 }
 
@@ -744,6 +838,7 @@ Expect<int32_t> AVCodecCtxSetThreadCount::body(const Runtime::CallingFrame &,
                                                uint32_t AvCodecCtxId,
                                                int32_t ThreadCount) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecCtx->thread_count = ThreadCount;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -751,6 +846,7 @@ Expect<int32_t> AVCodecCtxSetThreadCount::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecCtxColorPrimaries::body(const Runtime::CallingFrame &,
                                                uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, 0);
   AVColorPrimaries const ColorPrimaries = AvCodecCtx->color_primaries;
   return FFmpegUtils::ColorPrimaries::fromAVColorPrimaries(ColorPrimaries);
 }

--- a/plugins/wasmedge_ffmpeg/avcodec/avCodecParameters.cpp
+++ b/plugins/wasmedge_ffmpeg/avcodec/avCodecParameters.cpp
@@ -15,12 +15,14 @@ namespace AVcodec {
 Expect<uint32_t> AVCodecParamCodecId::body(const Runtime::CallingFrame &,
                                            uint32_t AvCodecParamId) {
   FFMPEG_PTR_FETCH(AvCodecParams, AvCodecParamId, AVCodecParameters);
+  FFMPEG_PTR_CHECK(AvCodecParams, 0);
   return FFmpegUtils::CodecID::fromAVCodecID(AvCodecParams->codec_id);
 }
 
 Expect<int32_t> AVCodecParamCodecType::body(const Runtime::CallingFrame &,
                                             uint32_t AvCodecParamId) {
   FFMPEG_PTR_FETCH(AvCodecParams, AvCodecParamId, AVCodecParameters);
+  FFMPEG_PTR_CHECK(AvCodecParams, 0);
   return FFmpegUtils::MediaType::fromMediaType(AvCodecParams->codec_type);
 }
 
@@ -28,6 +30,7 @@ Expect<int32_t> AVCodecParamSetCodecTag::body(const Runtime::CallingFrame &,
                                               uint32_t AvCodecParamId,
                                               uint32_t CodecTag) {
   FFMPEG_PTR_FETCH(AvCodecParams, AvCodecParamId, AVCodecParameters);
+  FFMPEG_PTR_CHECK(AvCodecParams, static_cast<int32_t>(ErrNo::InternalError));
   AvCodecParams->codec_tag = CodecTag;
   return static_cast<int32_t>(ErrNo::Success);
 }

--- a/plugins/wasmedge_ffmpeg/avcodec/avPacket.cpp
+++ b/plugins/wasmedge_ffmpeg/avcodec/avPacket.cpp
@@ -27,6 +27,7 @@ Expect<int32_t> AVPacketAlloc::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> AVNewPacket::body(const Runtime::CallingFrame &,
                                   uint32_t AvPacketId, int32_t Size) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   return av_new_packet(AvPacket, Size);
 }
 
@@ -34,6 +35,8 @@ Expect<int32_t> AVPacketRef::body(const Runtime::CallingFrame &,
                                   uint32_t DestPacketId, uint32_t SrcPacketId) {
   FFMPEG_PTR_FETCH(DestAvPacket, DestPacketId, AVPacket);
   FFMPEG_PTR_FETCH(SrcAvPacket, SrcPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(DestAvPacket, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK(SrcAvPacket, static_cast<int32_t>(ErrNo::InternalError));
 
   return av_packet_ref(DestAvPacket, SrcAvPacket);
 }
@@ -41,6 +44,8 @@ Expect<int32_t> AVPacketRef::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVPacketUnref::body(const Runtime::CallingFrame &,
                                     uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket); // Free packet.
+  FFMPEG_PTR_CHECK_FREE(AvPacket, AvPacketId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   av_packet_unref(AvPacket);
   FFMPEG_PTR_DELETE(AvPacketId);
   return static_cast<int32_t>(ErrNo::Success);
@@ -49,12 +54,14 @@ Expect<int32_t> AVPacketUnref::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVGrowPacket::body(const Runtime::CallingFrame &,
                                    uint32_t AvPacketId, int32_t Size) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   return av_grow_packet(AvPacket, Size);
 }
 
 Expect<int32_t> AVShrinkPacket::body(const Runtime::CallingFrame &,
                                      uint32_t AvPacketId, int32_t Size) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   av_shrink_packet(AvPacket, Size);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -62,6 +69,7 @@ Expect<int32_t> AVShrinkPacket::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVPacketStreamIndex::body(const Runtime::CallingFrame &,
                                           uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, 0);
   return AvPacket->stream_index;
 }
 
@@ -69,6 +77,7 @@ Expect<int32_t> AVPacketSetStreamIndex::body(const Runtime::CallingFrame &,
                                              uint32_t AvPacketId,
                                              int32_t StreamIdx) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   AvPacket->stream_index = StreamIdx;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -76,18 +85,21 @@ Expect<int32_t> AVPacketSetStreamIndex::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVPacketSize::body(const Runtime::CallingFrame &,
                                    uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, 0);
   return AvPacket->size;
 }
 
 Expect<int32_t> AVPacketFlags::body(const Runtime::CallingFrame &,
                                     uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, 0);
   return AvPacket->flags;
 }
 
 Expect<int32_t> AVPacketSetFlags::body(const Runtime::CallingFrame &,
                                        uint32_t AvPacketId, int32_t Flags) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   AvPacket->flags = Flags;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -95,12 +107,14 @@ Expect<int32_t> AVPacketSetFlags::body(const Runtime::CallingFrame &,
 Expect<int64_t> AVPacketPos::body(const Runtime::CallingFrame &,
                                   uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, 0);
   return AvPacket->pos;
 }
 
 Expect<int32_t> AVPacketSetPos::body(const Runtime::CallingFrame &,
                                      uint32_t AvPacketId, int64_t Pos) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   AvPacket->pos = Pos;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -108,6 +122,7 @@ Expect<int32_t> AVPacketSetPos::body(const Runtime::CallingFrame &,
 Expect<int64_t> AVPacketDuration::body(const Runtime::CallingFrame &,
                                        uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, 0);
   return AvPacket->duration;
 }
 
@@ -115,6 +130,7 @@ Expect<int32_t> AVPacketSetDuration::body(const Runtime::CallingFrame &,
                                           uint32_t AvPacketId,
                                           int64_t Duration) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   AvPacket->duration = Duration;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -122,12 +138,14 @@ Expect<int32_t> AVPacketSetDuration::body(const Runtime::CallingFrame &,
 Expect<int64_t> AVPacketDts::body(const Runtime::CallingFrame &,
                                   uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, 0);
   return AvPacket->dts;
 }
 
 Expect<int32_t> AVPacketSetDts::body(const Runtime::CallingFrame &,
                                      uint32_t AvPacketId, int64_t Dts) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   AvPacket->dts = Dts;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -135,12 +153,14 @@ Expect<int32_t> AVPacketSetDts::body(const Runtime::CallingFrame &,
 Expect<int64_t> AVPacketPts::body(const Runtime::CallingFrame &,
                                   uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, 0);
   return AvPacket->pts;
 }
 
 Expect<int32_t> AVPacketSetPts::body(const Runtime::CallingFrame &,
                                      uint32_t AvPacketId, int64_t Pts) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   AvPacket->pts = Pts;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -148,6 +168,7 @@ Expect<int32_t> AVPacketSetPts::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVPacketIsDataNull::body(const Runtime::CallingFrame &,
                                          uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, 1);
   if (AvPacket->data == nullptr)
     return 1;
   return 0;
@@ -160,8 +181,24 @@ Expect<int32_t> AVPacketData::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(Buffer, MemInst, uint8_t, DataPtr, DataLen, "");
 
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
-  uint8_t *Data = AvPacket->data;
-  std::copy_n(Data, DataLen, Buffer.data());
+  // A valid empty packet has data == null and size == 0, so a null data
+  // pointer is rejected only when the guest actually asks for bytes.
+  if (AvPacket == nullptr || AvPacket->size < 0 ||
+      (DataLen > 0 && AvPacket->data == nullptr)) {
+    spdlog::error("[WasmEdge-FFmpeg] AVPacketData: invalid packet id {} or "
+                  "packet has no readable data"sv,
+                  AvPacketId);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  if (static_cast<uint32_t>(AvPacket->size) < DataLen) {
+    spdlog::error("[WasmEdge-FFmpeg] AVPacketData: requested {} bytes from "
+                  "packet id {}, but only {} bytes are readable"sv,
+                  DataLen, AvPacketId, AvPacket->size);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  if (DataLen > 0) {
+    std::copy_n(AvPacket->data, DataLen, Buffer.data());
+  }
   return static_cast<int32_t>(ErrNo::Success);
 }
 

--- a/plugins/wasmedge_ffmpeg/avcodec/avPacket.cpp
+++ b/plugins/wasmedge_ffmpeg/avcodec/avPacket.cpp
@@ -27,6 +27,7 @@ Expect<int32_t> AVPacketAlloc::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> AVNewPacket::body(const Runtime::CallingFrame &,
                                   uint32_t AvPacketId, int32_t Size) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   return av_new_packet(AvPacket, Size);
 }
 
@@ -34,6 +35,8 @@ Expect<int32_t> AVPacketRef::body(const Runtime::CallingFrame &,
                                   uint32_t DestPacketId, uint32_t SrcPacketId) {
   FFMPEG_PTR_FETCH(DestAvPacket, DestPacketId, AVPacket);
   FFMPEG_PTR_FETCH(SrcAvPacket, SrcPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(DestAvPacket, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK(SrcAvPacket, static_cast<int32_t>(ErrNo::InternalError));
 
   return av_packet_ref(DestAvPacket, SrcAvPacket);
 }
@@ -41,6 +44,8 @@ Expect<int32_t> AVPacketRef::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVPacketUnref::body(const Runtime::CallingFrame &,
                                     uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket); // Free packet.
+  FFMPEG_PTR_CHECK_FREE(AvPacket, AvPacketId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   av_packet_unref(AvPacket);
   FFMPEG_PTR_DELETE(AvPacketId);
   return static_cast<int32_t>(ErrNo::Success);
@@ -49,12 +54,14 @@ Expect<int32_t> AVPacketUnref::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVGrowPacket::body(const Runtime::CallingFrame &,
                                    uint32_t AvPacketId, int32_t Size) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   return av_grow_packet(AvPacket, Size);
 }
 
 Expect<int32_t> AVShrinkPacket::body(const Runtime::CallingFrame &,
                                      uint32_t AvPacketId, int32_t Size) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   av_shrink_packet(AvPacket, Size);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -62,6 +69,7 @@ Expect<int32_t> AVShrinkPacket::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVPacketStreamIndex::body(const Runtime::CallingFrame &,
                                           uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, 0);
   return AvPacket->stream_index;
 }
 
@@ -69,6 +77,7 @@ Expect<int32_t> AVPacketSetStreamIndex::body(const Runtime::CallingFrame &,
                                              uint32_t AvPacketId,
                                              int32_t StreamIdx) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   AvPacket->stream_index = StreamIdx;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -76,18 +85,21 @@ Expect<int32_t> AVPacketSetStreamIndex::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVPacketSize::body(const Runtime::CallingFrame &,
                                    uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, 0);
   return AvPacket->size;
 }
 
 Expect<int32_t> AVPacketFlags::body(const Runtime::CallingFrame &,
                                     uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, 0);
   return AvPacket->flags;
 }
 
 Expect<int32_t> AVPacketSetFlags::body(const Runtime::CallingFrame &,
                                        uint32_t AvPacketId, int32_t Flags) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   AvPacket->flags = Flags;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -95,12 +107,14 @@ Expect<int32_t> AVPacketSetFlags::body(const Runtime::CallingFrame &,
 Expect<int64_t> AVPacketPos::body(const Runtime::CallingFrame &,
                                   uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, 0);
   return AvPacket->pos;
 }
 
 Expect<int32_t> AVPacketSetPos::body(const Runtime::CallingFrame &,
                                      uint32_t AvPacketId, int64_t Pos) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   AvPacket->pos = Pos;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -108,6 +122,7 @@ Expect<int32_t> AVPacketSetPos::body(const Runtime::CallingFrame &,
 Expect<int64_t> AVPacketDuration::body(const Runtime::CallingFrame &,
                                        uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, 0);
   return AvPacket->duration;
 }
 
@@ -115,6 +130,7 @@ Expect<int32_t> AVPacketSetDuration::body(const Runtime::CallingFrame &,
                                           uint32_t AvPacketId,
                                           int64_t Duration) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   AvPacket->duration = Duration;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -122,12 +138,14 @@ Expect<int32_t> AVPacketSetDuration::body(const Runtime::CallingFrame &,
 Expect<int64_t> AVPacketDts::body(const Runtime::CallingFrame &,
                                   uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, 0);
   return AvPacket->dts;
 }
 
 Expect<int32_t> AVPacketSetDts::body(const Runtime::CallingFrame &,
                                      uint32_t AvPacketId, int64_t Dts) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   AvPacket->dts = Dts;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -135,12 +153,14 @@ Expect<int32_t> AVPacketSetDts::body(const Runtime::CallingFrame &,
 Expect<int64_t> AVPacketPts::body(const Runtime::CallingFrame &,
                                   uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, 0);
   return AvPacket->pts;
 }
 
 Expect<int32_t> AVPacketSetPts::body(const Runtime::CallingFrame &,
                                      uint32_t AvPacketId, int64_t Pts) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   AvPacket->pts = Pts;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -148,6 +168,7 @@ Expect<int32_t> AVPacketSetPts::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVPacketIsDataNull::body(const Runtime::CallingFrame &,
                                          uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, 1);
   if (AvPacket->data == nullptr)
     return 1;
   return 0;
@@ -160,8 +181,22 @@ Expect<int32_t> AVPacketData::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(Buffer, MemInst, uint8_t, DataPtr, DataLen, "");
 
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
-  uint8_t *Data = AvPacket->data;
-  std::copy_n(Data, DataLen, Buffer.data());
+  if (AvPacket == nullptr || AvPacket->size < 0 ||
+      (DataLen > 0 && AvPacket->data == nullptr)) {
+    spdlog::error("[WasmEdge-FFmpeg] AVPacketData: invalid packet id {} or "
+                  "packet has no readable data"sv,
+                  AvPacketId);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  if (static_cast<uint32_t>(AvPacket->size) < DataLen) {
+    spdlog::error("[WasmEdge-FFmpeg] AVPacketData: requested {} bytes from "
+                  "packet id {}, but only {} bytes are readable"sv,
+                  DataLen, AvPacketId, AvPacket->size);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  if (DataLen > 0) {
+    std::copy_n(AvPacket->data, DataLen, Buffer.data());
+  }
   return static_cast<int32_t>(ErrNo::Success);
 }
 

--- a/plugins/wasmedge_ffmpeg/avcodec/avcodec_func.cpp
+++ b/plugins/wasmedge_ffmpeg/avcodec/avcodec_func.cpp
@@ -20,6 +20,8 @@ Expect<int32_t> AVCodecAllocContext3::body(const Runtime::CallingFrame &Frame,
   MEM_PTR_CHECK(AvCodecCtxId, MemInst, uint32_t, AvCodecCtxPtr,
                 "Failed when accessing the return AVCodecContext Memory"sv);
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, AVCodec);
+  FFMPEG_PTR_CHECK_NONZERO(AvCodec, AvCodecId,
+                           static_cast<int32_t>(ErrNo::InternalError));
 
   AVCodecContext *AvCodecCtx = avcodec_alloc_context3(AvCodec);
   FFMPEG_PTR_STORE(AvCodecCtx, AvCodecCtxId);
@@ -32,14 +34,20 @@ AVCodecParametersFromContext::body(const Runtime::CallingFrame &,
                                    uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecParam, AvCodecParamId, AVCodecParameters);
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecParam, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   return avcodec_parameters_from_context(AvCodecParam, AvCodecCtx);
 }
 
 Expect<int32_t> AVCodecParametersFree::body(const Runtime::CallingFrame &,
                                             uint32_t AvCodecParamId) {
   FFMPEG_PTR_FETCH(AvCodecParam, AvCodecParamId, AVCodecParameters);
+  FFMPEG_PTR_CHECK_FREE(AvCodecParam, AvCodecParamId,
+                        static_cast<int32_t>(ErrNo::InternalError));
 
-  avcodec_parameters_free(&AvCodecParam);
+  if (!Env.get()->isBorrowed(AvCodecParamId)) {
+    avcodec_parameters_free(&AvCodecParam);
+  }
   FFMPEG_PTR_DELETE(AvCodecParamId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -47,6 +55,8 @@ Expect<int32_t> AVCodecParametersFree::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecFreeContext::body(const Runtime::CallingFrame &,
                                          uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK_FREE(AvCodecCtx, AvCodecCtxId,
+                        static_cast<int32_t>(ErrNo::InternalError));
 
   avcodec_free_context(&AvCodecCtx);
   FFMPEG_PTR_DELETE(AvCodecCtxId);
@@ -79,6 +89,11 @@ Expect<int32_t> AVCodecOpen2::body(const Runtime::CallingFrame &,
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
   FFMPEG_PTR_FETCH(AvDictionary, AvDictionaryId, AVDictionary *);
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, AVCodec);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(AvDictionary, AvDictionaryId,
+                           static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(AvCodec, AvCodecId,
+                           static_cast<int32_t>(ErrNo::InternalError));
   return avcodec_open2(AvCodecCtx, AvCodec, AvDictionary);
 }
 
@@ -117,6 +132,8 @@ Expect<int32_t> AVCodecIsDecoder::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVCodecClose::body(const Runtime::CallingFrame &,
                                    uint32_t AvCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK_FREE(AvCodecCtx, AvCodecCtxId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   int Res = avcodec_close(AvCodecCtx);
   FFMPEG_PTR_DELETE(AvCodecCtxId);
   return Res;
@@ -127,6 +144,8 @@ Expect<int32_t> AVCodecParametersToContext::body(const Runtime::CallingFrame &,
                                                  uint32_t AvCodecParamId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
   FFMPEG_PTR_FETCH(AvCodecParam, AvCodecParamId, AVCodecParameters);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK(AvCodecParam, static_cast<int32_t>(ErrNo::InternalError));
 
   return avcodec_parameters_to_context(AvCodecCtx, AvCodecParam);
 }
@@ -136,6 +155,8 @@ Expect<int32_t> AVCodecReceiveFrame::body(const Runtime::CallingFrame &,
                                           uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AvCodecCtxId, AVCodecContext);
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK(AvFrame, static_cast<int32_t>(ErrNo::InternalError));
   return avcodec_receive_frame(AvCodecCtx, AvFrame);
 }
 
@@ -145,6 +166,9 @@ Expect<int32_t> AVCodecSendPacket::body(const Runtime::CallingFrame &,
   FFMPEG_PTR_FETCH(AVCodecCtx, AvCodecCtxId, AVCodecContext);
   FFMPEG_PTR_FETCH(AvPacket, PacketId,
                    AVPacket); // Can send Null AVPacket, to close the stream.
+  FFMPEG_PTR_CHECK(AVCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(AvPacket, PacketId,
+                           static_cast<int32_t>(ErrNo::InternalError));
   return avcodec_send_packet(AVCodecCtx, AvPacket);
 }
 
@@ -173,6 +197,8 @@ Expect<int32_t> AVCodecReceivePacket::body(const Runtime::CallingFrame &,
                                            uint32_t PacketId) {
   FFMPEG_PTR_FETCH(AVCodecCtx, AVCodecCtxId, AVCodecContext);
   FFMPEG_PTR_FETCH(AvPacket, PacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AVCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   return avcodec_receive_packet(AVCodecCtx, AvPacket);
 }
 
@@ -181,6 +207,9 @@ Expect<int32_t> AVCodecSendFrame::body(const Runtime::CallingFrame &,
                                        uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AVCodecCtx, AVCodecCtxId, AVCodecContext);
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AVCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(AvFrame, FrameId,
+                           static_cast<int32_t>(ErrNo::InternalError));
   return avcodec_send_frame(AVCodecCtx, AvFrame);
 }
 
@@ -191,11 +220,10 @@ AVCodecFindDecoderByName::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_PTR_CHECK(AVCodecId, MemInst, uint32_t, AVCodecPtr,
                 "Failed when accessing the return AVCodec Memory"sv);
-  MEM_PTR_CHECK(NameId, MemInst, char, NamePtr,
-                "Failed when accessing the return URL memory"sv);
+  MEM_SPAN_CHECK(NameId, MemInst, char, NamePtr, NameLen,
+                 "Failed when accessing the return URL memory"sv);
 
-  std::string Name;
-  std::copy_n(NameId, NameLen, std::back_inserter(Name));
+  std::string Name(NameId.data(), NameLen);
 
   AVCodec const *AvCodec = avcodec_find_decoder_by_name(Name.c_str());
 
@@ -215,11 +243,10 @@ AVCodecFindEncoderByName::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_PTR_CHECK(AVCodecId, MemInst, uint32_t, AVCodecPtr,
                 "Failed when accessing the return AVCodec Memory"sv);
-  MEM_PTR_CHECK(NameId, MemInst, char, NamePtr,
-                "Failed when accessing the return URL memory"sv);
+  MEM_SPAN_CHECK(NameId, MemInst, char, NamePtr, NameLen,
+                 "Failed when accessing the return URL memory"sv);
 
-  std::string Name;
-  std::copy_n(NameId, NameLen, std::back_inserter(Name));
+  std::string Name(NameId.data(), NameLen);
 
   AVCodec const *AvCodec = avcodec_find_encoder_by_name(Name.c_str());
 
@@ -237,6 +264,7 @@ Expect<int32_t> AVPacketRescaleTs::body(const Runtime::CallingFrame &,
                                         int32_t SrcDen, int32_t DestNum,
                                         int32_t DestDen) {
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   AVRational const Src = av_make_q(SrcNum, SrcDen);
   AVRational const Dest = av_make_q(DestNum, DestDen);
 
@@ -247,6 +275,7 @@ Expect<int32_t> AVPacketRescaleTs::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVPacketMakeWritable::body(const Runtime::CallingFrame &,
                                            uint32_t AVPacketId) {
   FFMPEG_PTR_FETCH(AvPacket, AVPacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
   return av_packet_make_writable(AvPacket);
 }
 
@@ -257,13 +286,21 @@ Expect<int32_t> AVCodecParametersCopy::body(const Runtime::CallingFrame &,
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
   FFMPEG_PTR_FETCH(AvCodecParam, AVCodecParamId, AVCodecParameters);
 
-  AVStream **AvStream = AvFormatCtx->streams;
+  if (AvFormatCtx == nullptr || AvCodecParam == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVCodecParametersCopy: invalid format "
+                  "context id {} or codec parameters id {}"sv,
+                  AvFormatCtxId, AVCodecParamId);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
 
-  // No check here (Check)
-  // Raw Pointer Iteration.
-  for (unsigned int I = 1; I <= StreamIdx; I++)
-    AvStream++;
-
+  AVStream **AvStream = checkedArraySlot(AvFormatCtx->streams,
+                                         AvFormatCtx->nb_streams, StreamIdx);
+  if (AvStream == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVCodecParametersCopy: invalid stream "
+                  "index {} (nb_streams={})"sv,
+                  StreamIdx, AvFormatCtx->nb_streams);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
   return avcodec_parameters_copy((*AvStream)->codecpar, AvCodecParam);
 }
 
@@ -274,6 +311,7 @@ Expect<uint32_t> AVCodecVersion::body(const Runtime::CallingFrame &) {
 Expect<int32_t> AVCodecFlushBuffers::body(const Runtime::CallingFrame &,
                                           uint32_t AVCodecCtxId) {
   FFMPEG_PTR_FETCH(AvCodecCtx, AVCodecCtxId, AVCodecContext);
+  FFMPEG_PTR_CHECK(AvCodecCtx, static_cast<int32_t>(ErrNo::InternalError));
   avcodec_flush_buffers(AvCodecCtx);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -291,9 +329,7 @@ Expect<int32_t> AVCodecConfiguration::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(ConfigBuf, MemInst, char, ConfigPtr, ConfigLen, "");
 
   const char *Config = avcodec_configuration();
-  auto Actual = std::strlen(Config);
-  auto N = std::min<uint32_t>(ConfigLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(Config, N, ConfigBuf.data());
+  copyCStringToBuffer(ConfigBuf.data(), ConfigLen, Config);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -308,9 +344,7 @@ Expect<int32_t> AVCodecLicense::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(LicenseBuf, MemInst, char, LicensePtr, LicenseLen, "");
 
   const char *License = avcodec_license();
-  auto Actual = std::strlen(License);
-  auto N = std::min<uint32_t>(LicenseLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(License, N, LicenseBuf.data());
+  copyCStringToBuffer(LicenseBuf.data(), LicenseLen, License);
   return static_cast<int32_t>(ErrNo::Success);
 }
 

--- a/plugins/wasmedge_ffmpeg/avdevice/avDevice_func.cpp
+++ b/plugins/wasmedge_ffmpeg/avdevice/avDevice_func.cpp
@@ -28,9 +28,13 @@ Expect<int32_t> AVDeviceListDevices::body(const Runtime::CallingFrame &Frame,
   MEM_PTR_CHECK(AVDeviceInfoListId, MemInst, uint32_t, AVDeviceInfoListPtr, "")
 
   FFMPEG_PTR_FETCH(AvFormatCtx, AVFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatCtx, static_cast<int32_t>(ErrNo::InternalError));
 
   AVDeviceInfoList **AvDeviceInfoList =
       static_cast<AVDeviceInfoList **>(av_malloc(sizeof(AVDeviceInfoList *)));
+  if (AvDeviceInfoList == nullptr) {
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
 
   int Res = avdevice_list_devices(AvFormatCtx, AvDeviceInfoList);
   FFMPEG_PTR_STORE(AvDeviceInfoList, AVDeviceInfoListId);
@@ -64,6 +68,8 @@ Expect<int32_t> AVOutputVideoDeviceNext::body(const Runtime::CallingFrame &) {
 Expect<int32_t> AVDeviceFreeListDevices::body(const Runtime::CallingFrame &,
                                               uint32_t AVDeviceInfoListId) {
   FFMPEG_PTR_FETCH(AvDeviceInfoList, AVDeviceInfoListId, AVDeviceInfoList *);
+  FFMPEG_PTR_CHECK_FREE(AvDeviceInfoList, AVDeviceInfoListId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   avdevice_free_list_devices(AvDeviceInfoList);
   FFMPEG_PTR_DELETE(AVDeviceInfoListId);
   return static_cast<int32_t>(ErrNo::Success);
@@ -72,12 +78,14 @@ Expect<int32_t> AVDeviceFreeListDevices::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVDeviceNbDevices::body(const Runtime::CallingFrame &,
                                         uint32_t AVDeviceInfoListId) {
   FFMPEG_PTR_FETCH(AvDeviceInfoList, AVDeviceInfoListId, AVDeviceInfoList *);
+  FFMPEG_PTR_CHECK(AvDeviceInfoList, 0);
   return (*AvDeviceInfoList)->nb_devices;
 }
 
 Expect<int32_t> AVDeviceDefaultDevice::body(const Runtime::CallingFrame &,
                                             uint32_t AVDeviceInfoListId) {
   FFMPEG_PTR_FETCH(AvDeviceInfoList, AVDeviceInfoListId, AVDeviceInfoList *);
+  FFMPEG_PTR_CHECK(AvDeviceInfoList, 0);
   return (*AvDeviceInfoList)->default_device;
 }
 
@@ -94,9 +102,7 @@ Expect<int32_t> AVDeviceConfiguration::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(ConfigBuf, MemInst, char, ConfigPtr, ConfigLen, "");
 
   const char *Config = avdevice_configuration();
-  auto Actual = std::strlen(Config);
-  auto N = std::min<uint32_t>(ConfigLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(Config, N, ConfigBuf.data());
+  copyCStringToBuffer(ConfigBuf.data(), ConfigLen, Config);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -112,9 +118,7 @@ Expect<int32_t> AVDeviceLicense::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(LicenseBuf, MemInst, char, LicensePtr, LicenseLen, "");
 
   const char *License = avdevice_license();
-  auto Actual = std::strlen(License);
-  auto N = std::min<uint32_t>(LicenseLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(License, N, LicenseBuf.data());
+  copyCStringToBuffer(LicenseBuf.data(), LicenseLen, License);
   return static_cast<int32_t>(ErrNo::Success);
 }
 

--- a/plugins/wasmedge_ffmpeg/avfilter/avFilter.cpp
+++ b/plugins/wasmedge_ffmpeg/avfilter/avFilter.cpp
@@ -7,6 +7,8 @@ extern "C" {
 #include "libavfilter/avfilter.h"
 }
 
+#include <new>
+
 namespace WasmEdge {
 namespace Host {
 namespace WasmEdgeFFmpeg {
@@ -15,6 +17,7 @@ namespace AVFilter {
 Expect<int32_t> AVFilterNameLength::body(const Runtime::CallingFrame &,
                                          uint32_t FilterId) {
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, 0);
   return strlen(Filter->name);
 }
 
@@ -25,14 +28,19 @@ Expect<int32_t> AVFilterName::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(NameBuf, MemInst, char, NamePtr, NameLen, "");
 
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, static_cast<int32_t>(ErrNo::InternalError));
   const char *Name = Filter->name;
-  std::copy_n(Name, NameLen, NameBuf.data());
+  copyCStringToBuffer(NameBuf.data(), NameLen, Name);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> AVFilterDescriptionLength::body(const Runtime::CallingFrame &,
                                                 uint32_t FilterId) {
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, 0);
+  if (Filter->description == nullptr) {
+    return 0;
+  }
   return strlen(Filter->description);
 }
 
@@ -43,26 +51,30 @@ Expect<int32_t> AVFilterDescription::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(DescBuf, MemInst, char, DescPtr, DescLen, "");
 
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, static_cast<int32_t>(ErrNo::InternalError));
   const char *Desc = Filter->description;
-  std::copy_n(Desc, DescLen, DescBuf.data());
+  copyCStringToBuffer(DescBuf.data(), DescLen, Desc);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<uint32_t> AVFilterNbInputs::body(const Runtime::CallingFrame &,
                                         uint32_t FilterId) {
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, 0);
   return Filter->nb_inputs;
 }
 
 Expect<uint32_t> AVFilterNbOutputs::body(const Runtime::CallingFrame &,
                                          uint32_t FilterId) {
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, 0);
   return Filter->nb_outputs;
 }
 
 Expect<int32_t> AVFilterFlags::body(const Runtime::CallingFrame &,
                                     uint32_t FilterId) {
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, 0);
   return Filter->flags;
 }
 
@@ -73,13 +85,16 @@ Expect<int32_t> AVFilterInOutSetName::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(NameBuf, MemInst, char, NamePtr, NameLen, "");
 
   FFMPEG_PTR_FETCH(InOut, InOutId, AVFilterInOut);
+  FFMPEG_PTR_CHECK(InOut, static_cast<int32_t>(ErrNo::InternalError));
 
-  std::string Name;
-  std::copy_n(NameBuf.data(), NameLen, std::back_inserter(Name));
+  std::string Name(NameBuf.data(), NameLen);
   char *CName = av_strdup(Name.c_str());
   if (CName == nullptr) {
-    return static_cast<int32_t>(ErrNo::Success);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
+  // The InOut node owns its name (avfilter_inout_free releases it with
+  // av_freep), so drop any previous allocation before installing the new one.
+  av_freep(&InOut->name);
   InOut->name = CName;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -89,6 +104,12 @@ Expect<int32_t> AVFilterInOutSetFilterCtx::body(const Runtime::CallingFrame &,
                                                 uint32_t FilterCtxId) {
   FFMPEG_PTR_FETCH(InOut, InOutId, AVFilterInOut);
   FFMPEG_PTR_FETCH(FilterCtx, FilterCtxId, AVFilterContext);
+  FFMPEG_PTR_CHECK(InOut, static_cast<int32_t>(ErrNo::InternalError));
+  // id 0 clears filter_ctx; a nonzero id must resolve, else a stale id would be
+  // silently treated as a clear.
+  if (FilterCtxId != 0) {
+    FFMPEG_PTR_CHECK(FilterCtx, static_cast<int32_t>(ErrNo::InternalError));
+  }
 
   InOut->filter_ctx = FilterCtx;
   return static_cast<int32_t>(ErrNo::Success);
@@ -97,6 +118,7 @@ Expect<int32_t> AVFilterInOutSetFilterCtx::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVFilterInOutSetPadIdx::body(const Runtime::CallingFrame &,
                                              uint32_t InOutId, int32_t PadIdx) {
   FFMPEG_PTR_FETCH(InOut, InOutId, AVFilterInOut);
+  FFMPEG_PTR_CHECK(InOut, static_cast<int32_t>(ErrNo::InternalError));
   InOut->pad_idx = PadIdx;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -106,7 +128,45 @@ Expect<int32_t> AVFilterInOutSetNext::body(const Runtime::CallingFrame &,
                                            uint32_t NextInOutId) {
   FFMPEG_PTR_FETCH(InOut, InOutId, AVFilterInOut);
   FFMPEG_PTR_FETCH(NextInOut, NextInOutId, AVFilterInOut);
+  FFMPEG_PTR_CHECK(InOut, static_cast<int32_t>(ErrNo::InternalError));
+  // id 0 clears the link; a nonzero id must resolve, else a stale id would be
+  // silently treated as a clear and detach the previous next node.
+  if (NextInOutId != 0) {
+    FFMPEG_PTR_CHECK(NextInOut, static_cast<int32_t>(ErrNo::InternalError));
+  }
+  AVFilterInOut *const OldNext = InOut->next;
+  // Relinking to the node already installed is a no-op: leave ownership and the
+  // borrowed mark untouched so an idempotent call neither detaches nor rejects.
+  if (OldNext == NextInOut) {
+    return static_cast<int32_t>(ErrNo::Success);
+  }
+  if (NextInOut != nullptr) {
+    // The in/out nodes form a forest of disjoint singly linked chains; a next
+    // node already owned by another chain (its id is borrowed) would gain two
+    // owning heads. Reject it.
+    if (Env.get()->isBorrowed(NextInOutId)) {
+      return static_cast<int32_t>(ErrNo::InternalError);
+    }
+    // Reject a link that would close a cycle, which avfilter_inout_free()
+    // would walk forever or free twice. The chain is acyclic (every prior
+    // link passed this guard), so the walk terminates.
+    for (AVFilterInOut *Node = NextInOut; Node != nullptr; Node = Node->next) {
+      if (Node == InOut) {
+        return static_cast<int32_t>(ErrNo::InternalError);
+      }
+    }
+  }
   InOut->next = NextInOut;
+  // Relinking detaches the previous next node; no chain head owns it anymore,
+  // so restore its id's right to free it.
+  if (OldNext != nullptr) {
+    Env.get()->unmarkBorrowedByValue(OldNext);
+  }
+  // NextInOut is now owned by InOut's chain and released with its head, so
+  // mark its id borrowed; a null next just clears the link.
+  if (NextInOut != nullptr) {
+    Env.get()->markBorrowed(NextInOutId);
+  }
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -117,11 +177,18 @@ AVFilterGetInputsFilterPad::body(const Runtime::CallingFrame &Frame,
   MEM_PTR_CHECK(FilterPadId, MemInst, uint32_t, FilterPadPtr, "")
 
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, static_cast<int32_t>(ErrNo::InternalError));
   const AVFilterPad *FilterPad = Filter->inputs;
   if (FilterPad == nullptr) {
+    *FilterPadId = 0;
     return static_cast<int32_t>(ErrNo::Success);
   }
-  FFMPEG_PTR_STORE(const_cast<AVFilterPad *>(FilterPad), FilterPadId);
+  auto *FilterPadHandle =
+      new (std::nothrow) FilterPadView{FilterPad, Filter->nb_inputs};
+  if (FilterPadHandle == nullptr) {
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  FFMPEG_PTR_STORE(FilterPadHandle, FilterPadId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -132,11 +199,18 @@ AVFilterGetOutputsFilterPad::body(const Runtime::CallingFrame &Frame,
   MEM_PTR_CHECK(FilterPadId, MemInst, uint32_t, FilterPadPtr, "")
 
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, static_cast<int32_t>(ErrNo::InternalError));
   const AVFilterPad *FilterPad = Filter->outputs;
   if (FilterPad == nullptr) {
+    *FilterPadId = 0;
     return static_cast<int32_t>(ErrNo::Success);
   }
-  FFMPEG_PTR_STORE(const_cast<AVFilterPad *>(FilterPad), FilterPadId);
+  auto *FilterPadHandle =
+      new (std::nothrow) FilterPadView{FilterPad, Filter->nb_outputs};
+  if (FilterPadHandle == nullptr) {
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  FFMPEG_PTR_STORE(FilterPadHandle, FilterPadId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 

--- a/plugins/wasmedge_ffmpeg/avfilter/avFilter.cpp
+++ b/plugins/wasmedge_ffmpeg/avfilter/avFilter.cpp
@@ -7,6 +7,8 @@ extern "C" {
 #include "libavfilter/avfilter.h"
 }
 
+#include <new>
+
 namespace WasmEdge {
 namespace Host {
 namespace WasmEdgeFFmpeg {
@@ -15,6 +17,7 @@ namespace AVFilter {
 Expect<int32_t> AVFilterNameLength::body(const Runtime::CallingFrame &,
                                          uint32_t FilterId) {
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, 0);
   return strlen(Filter->name);
 }
 
@@ -25,14 +28,19 @@ Expect<int32_t> AVFilterName::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(NameBuf, MemInst, char, NamePtr, NameLen, "");
 
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, static_cast<int32_t>(ErrNo::InternalError));
   const char *Name = Filter->name;
-  std::copy_n(Name, NameLen, NameBuf.data());
+  copyCStringToBuffer(NameBuf.data(), NameLen, Name);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> AVFilterDescriptionLength::body(const Runtime::CallingFrame &,
                                                 uint32_t FilterId) {
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, 0);
+  if (Filter->description == nullptr) {
+    return 0;
+  }
   return strlen(Filter->description);
 }
 
@@ -43,26 +51,30 @@ Expect<int32_t> AVFilterDescription::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(DescBuf, MemInst, char, DescPtr, DescLen, "");
 
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, static_cast<int32_t>(ErrNo::InternalError));
   const char *Desc = Filter->description;
-  std::copy_n(Desc, DescLen, DescBuf.data());
+  copyCStringToBuffer(DescBuf.data(), DescLen, Desc);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<uint32_t> AVFilterNbInputs::body(const Runtime::CallingFrame &,
                                         uint32_t FilterId) {
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, 0);
   return Filter->nb_inputs;
 }
 
 Expect<uint32_t> AVFilterNbOutputs::body(const Runtime::CallingFrame &,
                                          uint32_t FilterId) {
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, 0);
   return Filter->nb_outputs;
 }
 
 Expect<int32_t> AVFilterFlags::body(const Runtime::CallingFrame &,
                                     uint32_t FilterId) {
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, 0);
   return Filter->flags;
 }
 
@@ -73,13 +85,14 @@ Expect<int32_t> AVFilterInOutSetName::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(NameBuf, MemInst, char, NamePtr, NameLen, "");
 
   FFMPEG_PTR_FETCH(InOut, InOutId, AVFilterInOut);
+  FFMPEG_PTR_CHECK(InOut, static_cast<int32_t>(ErrNo::InternalError));
 
-  std::string Name;
-  std::copy_n(NameBuf.data(), NameLen, std::back_inserter(Name));
+  std::string Name(NameBuf.data(), NameLen);
   char *CName = av_strdup(Name.c_str());
   if (CName == nullptr) {
-    return static_cast<int32_t>(ErrNo::Success);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
+  av_freep(&InOut->name);
   InOut->name = CName;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -89,6 +102,10 @@ Expect<int32_t> AVFilterInOutSetFilterCtx::body(const Runtime::CallingFrame &,
                                                 uint32_t FilterCtxId) {
   FFMPEG_PTR_FETCH(InOut, InOutId, AVFilterInOut);
   FFMPEG_PTR_FETCH(FilterCtx, FilterCtxId, AVFilterContext);
+  FFMPEG_PTR_CHECK(InOut, static_cast<int32_t>(ErrNo::InternalError));
+  if (FilterCtxId != 0) {
+    FFMPEG_PTR_CHECK(FilterCtx, static_cast<int32_t>(ErrNo::InternalError));
+  }
 
   InOut->filter_ctx = FilterCtx;
   return static_cast<int32_t>(ErrNo::Success);
@@ -97,6 +114,7 @@ Expect<int32_t> AVFilterInOutSetFilterCtx::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVFilterInOutSetPadIdx::body(const Runtime::CallingFrame &,
                                              uint32_t InOutId, int32_t PadIdx) {
   FFMPEG_PTR_FETCH(InOut, InOutId, AVFilterInOut);
+  FFMPEG_PTR_CHECK(InOut, static_cast<int32_t>(ErrNo::InternalError));
   InOut->pad_idx = PadIdx;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -106,7 +124,31 @@ Expect<int32_t> AVFilterInOutSetNext::body(const Runtime::CallingFrame &,
                                            uint32_t NextInOutId) {
   FFMPEG_PTR_FETCH(InOut, InOutId, AVFilterInOut);
   FFMPEG_PTR_FETCH(NextInOut, NextInOutId, AVFilterInOut);
+  FFMPEG_PTR_CHECK(InOut, static_cast<int32_t>(ErrNo::InternalError));
+  if (NextInOutId != 0) {
+    FFMPEG_PTR_CHECK(NextInOut, static_cast<int32_t>(ErrNo::InternalError));
+  }
+  AVFilterInOut *const OldNext = InOut->next;
+  if (OldNext == NextInOut) {
+    return static_cast<int32_t>(ErrNo::Success);
+  }
+  if (NextInOut != nullptr) {
+    if (Env.get()->isBorrowed(NextInOutId)) {
+      return static_cast<int32_t>(ErrNo::InternalError);
+    }
+    for (AVFilterInOut *Node = NextInOut; Node != nullptr; Node = Node->next) {
+      if (Node == InOut) {
+        return static_cast<int32_t>(ErrNo::InternalError);
+      }
+    }
+  }
   InOut->next = NextInOut;
+  if (OldNext != nullptr) {
+    Env.get()->unmarkBorrowedByValue(OldNext);
+  }
+  if (NextInOut != nullptr) {
+    Env.get()->markBorrowed(NextInOutId);
+  }
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -117,11 +159,18 @@ AVFilterGetInputsFilterPad::body(const Runtime::CallingFrame &Frame,
   MEM_PTR_CHECK(FilterPadId, MemInst, uint32_t, FilterPadPtr, "")
 
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, static_cast<int32_t>(ErrNo::InternalError));
   const AVFilterPad *FilterPad = Filter->inputs;
   if (FilterPad == nullptr) {
+    *FilterPadId = 0;
     return static_cast<int32_t>(ErrNo::Success);
   }
-  FFMPEG_PTR_STORE(const_cast<AVFilterPad *>(FilterPad), FilterPadId);
+  auto *FilterPadHandle =
+      new (std::nothrow) FilterPadView{FilterPad, Filter->nb_inputs};
+  if (FilterPadHandle == nullptr) {
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  FFMPEG_PTR_STORE(FilterPadHandle, FilterPadId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -132,11 +181,18 @@ AVFilterGetOutputsFilterPad::body(const Runtime::CallingFrame &Frame,
   MEM_PTR_CHECK(FilterPadId, MemInst, uint32_t, FilterPadPtr, "")
 
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
+  FFMPEG_PTR_CHECK(Filter, static_cast<int32_t>(ErrNo::InternalError));
   const AVFilterPad *FilterPad = Filter->outputs;
   if (FilterPad == nullptr) {
+    *FilterPadId = 0;
     return static_cast<int32_t>(ErrNo::Success);
   }
-  FFMPEG_PTR_STORE(const_cast<AVFilterPad *>(FilterPad), FilterPadId);
+  auto *FilterPadHandle =
+      new (std::nothrow) FilterPadView{FilterPad, Filter->nb_outputs};
+  if (FilterPadHandle == nullptr) {
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  FFMPEG_PTR_STORE(FilterPadHandle, FilterPadId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 

--- a/plugins/wasmedge_ffmpeg/avfilter/avFilter.h
+++ b/plugins/wasmedge_ffmpeg/avfilter/avFilter.h
@@ -5,10 +5,17 @@
 
 #include "ffmpeg_base.h"
 
+struct AVFilterPad;
+
 namespace WasmEdge {
 namespace Host {
 namespace WasmEdgeFFmpeg {
 namespace AVFilter {
+
+struct FilterPadView {
+  const AVFilterPad *Pads;
+  unsigned NbPads;
+};
 
 class AVFilterNameLength : public HostFunction<AVFilterNameLength> {
 public:

--- a/plugins/wasmedge_ffmpeg/avfilter/avfilter_func.cpp
+++ b/plugins/wasmedge_ffmpeg/avfilter/avfilter_func.cpp
@@ -2,10 +2,13 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "avfilter_func.h"
+#include "avFilter.h"
 
 extern "C" {
 #include "libavfilter/avfilter.h"
 }
+
+#include <unordered_set>
 
 namespace WasmEdge {
 namespace Host {
@@ -30,6 +33,7 @@ Expect<int32_t> AVFilterGraphAlloc::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> AVFilterGraphConfig::body(const Runtime::CallingFrame &,
                                           uint32_t FilterGraphId) {
   FFMPEG_PTR_FETCH(FilterGraph, FilterGraphId, AVFilterGraph);
+  FFMPEG_PTR_CHECK(FilterGraph, static_cast<int32_t>(ErrNo::InternalError));
   return avfilter_graph_config(FilterGraph,
                                nullptr); // log_ctx always NULL on Rust SDK.
 }
@@ -37,7 +41,12 @@ Expect<int32_t> AVFilterGraphConfig::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVFilterGraphFree::body(const Runtime::CallingFrame &,
                                         uint32_t FilterGraphId) {
   FFMPEG_PTR_FETCH(FilterGraph, FilterGraphId, AVFilterGraph);
+  FFMPEG_PTR_CHECK_FREE(FilterGraph, FilterGraphId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   avfilter_graph_free(&FilterGraph);
+  // The graph owns its filter contexts, so every child context id minted by
+  // AVFilterGraphCreateFilter or AVFilterGraphGetFilter is dropped with it.
+  Env.get()->deallocChildren(FilterGraphId);
   FFMPEG_PTR_DELETE(FilterGraphId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -48,21 +57,22 @@ Expect<int32_t> AVFilterGraphGetFilter::body(const Runtime::CallingFrame &Frame,
                                              uint32_t NamePtr,
                                              uint32_t NameSize) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(NameId, MemInst, char, NamePtr,
-                "Failed when accessing the return Name memory"sv);
+  MEM_SPAN_CHECK(NameId, MemInst, char, NamePtr, NameSize,
+                 "Failed when accessing the return Name memory"sv);
   MEM_PTR_CHECK(FilterCtxId, MemInst, uint32_t, FilterCtxPtr, "");
 
   FFMPEG_PTR_FETCH(FilterGraph, FilterGraphId, AVFilterGraph);
+  FFMPEG_PTR_CHECK(FilterGraph, static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_FETCH(FilterCtx, *FilterCtxId, AVFilterContext);
 
-  std::string Name;
-  std::copy_n(NameId, NameSize, std::back_inserter(Name));
+  std::string Name(NameId.data(), NameSize);
 
   FilterCtx = avfilter_graph_get_filter(FilterGraph, Name.c_str());
   if (FilterCtx == nullptr) {
+    *FilterCtxId = 0;
     return static_cast<int32_t>(ErrNo::Success);
   }
-  FFMPEG_PTR_STORE(FilterCtx, FilterCtxId);
+  FFMPEG_PTR_STORE_CHILD(FilterCtx, FilterCtxId, FilterGraphId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -73,23 +83,89 @@ Expect<int32_t> AVFilterGraphParsePtr::body(const Runtime::CallingFrame &Frame,
                                             uint32_t InputsId,
                                             uint32_t OutputsId) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(FiltersId, MemInst, char, FiltersString, "");
+  MEM_SPAN_CHECK(FiltersId, MemInst, char, FiltersString, FiltersSize, "");
 
   FFMPEG_PTR_FETCH(Inputs, InputsId, AVFilterInOut);
   FFMPEG_PTR_FETCH(Outputs, OutputsId, AVFilterInOut);
   FFMPEG_PTR_FETCH(FiltersGraph, FilterGraphId, AVFilterGraph);
+  FFMPEG_PTR_CHECK(FiltersGraph, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(Inputs, InputsId,
+                           static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(Outputs, OutputsId,
+                           static_cast<int32_t>(ErrNo::InternalError));
 
-  std::string Filters;
-  std::copy_n(FiltersId, FiltersSize, std::back_inserter(Filters));
-  return avfilter_graph_parse_ptr(FiltersGraph, Filters.c_str(), &Inputs,
-                                  &Outputs, nullptr);
+  // A borrowed id is a non-head node already owned by another chain (via
+  // AVFilterInOutSetNext); parsing it as a list head would free it while the
+  // owning head still points at it. Reject it.
+  if (Env.get()->isBorrowed(InputsId) || Env.get()->isBorrowed(OutputsId)) {
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+
+  // avfilter_graph_parse_ptr() takes ownership of the supplied in/out lists:
+  // it frees the nodes it links into the graph and returns the still-open
+  // pads via *Inputs/*Outputs. Record every original node first (a guest may
+  // chain several, each with its own id) so every aliasing handle id can be
+  // dropped afterwards; the same walk rejects a cyclic chain or an
+  // Inputs/Outputs pair that shares a node.
+  std::vector<AVFilterInOut *> Consumed;
+  std::unordered_set<AVFilterInOut *> Seen;
+  auto Collect = [&](AVFilterInOut *Head) {
+    for (AVFilterInOut *Node = Head; Node != nullptr; Node = Node->next) {
+      if (!Seen.insert(Node).second) {
+        return false;
+      }
+      Consumed.push_back(Node);
+    }
+    return true;
+  };
+  if (!Collect(Inputs) || !Collect(Outputs)) {
+    // A collected node repeats, so the lists alias a node or form a cycle.
+    // Break each collected node's link and restore its handle's ownership so
+    // the guest can still free every node on its own.
+    for (AVFilterInOut *const Node : Consumed) {
+      Node->next = nullptr;
+      Env.get()->unmarkBorrowedByValue(Node);
+    }
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+
+  std::string Filters(FiltersId.data(), FiltersSize);
+  int32_t const Res = avfilter_graph_parse_ptr(FiltersGraph, Filters.c_str(),
+                                               &Inputs, &Outputs, nullptr);
+
+  // On failure FFmpeg frees every filter context already in the graph, so
+  // drop their child handle ids.
+  if (Res < 0) {
+    Env.get()->deallocChildren(FilterGraphId);
+  }
+
+  for (AVFilterInOut *const Node : Consumed) {
+    Env.get()->deallocByValue(Node);
+  }
+  // The lists returned in *Inputs/*Outputs are unreachable from the guest now
+  // that their ids are dropped, so free them here per the documented contract.
+  avfilter_inout_free(&Inputs);
+  avfilter_inout_free(&Outputs);
+  return Res;
 }
 
 Expect<int32_t> AVFilterInOutFree::body(const Runtime::CallingFrame &,
                                         uint32_t InOutId) {
   FFMPEG_PTR_FETCH(InOut, InOutId, AVFilterInOut);
+  FFMPEG_PTR_CHECK_FREE(InOut, InOutId,
+                        static_cast<int32_t>(ErrNo::InternalError));
+  // A node linked via AVFilterInOutSetNext is owned by that chain's head and
+  // released with it; freeing it on its own would leave the head's ->next
+  // dangling for a later double free. Refuse it.
+  if (Env.get()->isBorrowed(InOutId)) {
+    return static_cast<int32_t>(ErrNo::Success);
+  }
+  // avfilter_inout_free releases the entire linked list, so drop the handle
+  // ids of every node in the chain, not just the head.
+  for (AVFilterInOut *Node = InOut; Node != nullptr; Node = Node->next) {
+    Env.get()->deallocByValue(Node);
+  }
   avfilter_inout_free(&InOut);
-  FFMPEG_PTR_DELETE(InOutId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -101,17 +177,17 @@ Expect<int32_t> AVFilterGetByName::body(const Runtime::CallingFrame &Frame,
                                         uint32_t FilterPtr, uint32_t StrPtr,
                                         uint32_t StrLen) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(StrId, MemInst, char, StrPtr,
-                "Failed when accessing the return Str memory"sv);
+  MEM_SPAN_CHECK(StrId, MemInst, char, StrPtr, StrLen,
+                 "Failed when accessing the return Str memory"sv);
   MEM_PTR_CHECK(FilterId, MemInst, uint32_t, FilterPtr,
                 "Failed when accessing the return Filter memory"sv);
 
   FFMPEG_PTR_FETCH(Filter, *FilterId, const struct AVFilter);
-  std::string Name;
-  std::copy_n(StrId, StrLen, std::back_inserter(Name));
+  std::string Name(StrId.data(), StrLen);
 
   Filter = avfilter_get_by_name(Name.c_str());
   if (Filter == nullptr) {
+    *FilterId = 0;
     return static_cast<int32_t>(ErrNo::Success);
   }
 
@@ -132,9 +208,7 @@ Expect<int32_t> AVFilterConfiguration::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(ConfigBuf, MemInst, char, ConfigPtr, ConfigLen, "");
 
   const char *Config = avfilter_configuration();
-  auto Actual = std::strlen(Config);
-  auto N = std::min<uint32_t>(ConfigLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(Config, N, ConfigBuf.data());
+  copyCStringToBuffer(ConfigBuf.data(), ConfigLen, Config);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -150,9 +224,7 @@ Expect<int32_t> AVFilterLicense::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(LicenseBuf, MemInst, char, LicensePtr, LicenseLen, "");
 
   const char *License = avfilter_license();
-  auto Actual = std::strlen(License);
-  auto N = std::min<uint32_t>(LicenseLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(License, N, LicenseBuf.data());
+  copyCStringToBuffer(LicenseBuf.data(), LicenseLen, License);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -165,22 +237,23 @@ Expect<int32_t> AVFilterGraphCreateFilter::body(
   MEM_SPAN_CHECK(ArgsBuf, MemInst, char, ArgsPtr, ArgsLen, "");
   MEM_PTR_CHECK(FilterCtxId, MemInst, uint32_t, FilterCtxPtr, "")
 
-  FFMPEG_PTR_FETCH(FilterCtx, *FilterCtxId, AVFilterContext);
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
   FFMPEG_PTR_FETCH(FilterGraph, FilterGraphId, AVFilterGraph);
+  if (Filter == nullptr || FilterGraph == nullptr) {
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
 
-  std::string Name;
-  std::string Args;
-  std::copy_n(NameBuf.data(), NameLen, std::back_inserter(Name));
-  std::copy_n(ArgsBuf.data(), ArgsLen, std::back_inserter(Args));
+  std::string Name(NameBuf.data(), NameLen);
+  std::string Args(ArgsBuf.data(), ArgsLen);
 
+  AVFilterContext *FilterCtx = nullptr;
   int Res = avfilter_graph_create_filter(&FilterCtx, Filter, Name.c_str(),
                                          Args.c_str(), nullptr, FilterGraph);
   if (Res < 0) {
     return Res;
   }
 
-  FFMPEG_PTR_STORE(FilterCtx, FilterCtxId);
+  FFMPEG_PTR_STORE_CHILD(FilterCtx, FilterCtxId, FilterGraphId);
   return Res;
 }
 
@@ -201,9 +274,16 @@ Expect<int32_t> AVFilterInOutAlloc::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> AVFilterPadGetNameLength::body(const Runtime::CallingFrame &,
                                                uint32_t FilterPadId,
                                                int32_t Idx) {
-  FFMPEG_PTR_FETCH(FilterPad, FilterPadId, AVFilterPad);
+  FFMPEG_PTR_FETCH(FilterPad, FilterPadId, FilterPadView);
+  if (FilterPad == nullptr || Idx < 0 ||
+      static_cast<unsigned>(Idx) >= FilterPad->NbPads) {
+    return 0;
+  }
 
-  const char *Name = avfilter_pad_get_name(FilterPad, Idx);
+  const char *Name = avfilter_pad_get_name(FilterPad->Pads, Idx);
+  if (Name == nullptr) {
+    return 0;
+  }
   return strlen(Name);
 }
 
@@ -213,27 +293,41 @@ Expect<int32_t> AVFilterPadGetName::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_SPAN_CHECK(NameBuf, MemInst, char, NamePtr, NameLen, "");
 
-  FFMPEG_PTR_FETCH(FilterPad, FilterPadId, AVFilterPad);
+  FFMPEG_PTR_FETCH(FilterPad, FilterPadId, FilterPadView);
+  if (FilterPad == nullptr || Idx < 0 ||
+      static_cast<unsigned>(Idx) >= FilterPad->NbPads) {
+    spdlog::error("[WasmEdge-FFmpeg] AVFilterPadGetName: invalid filter pad "
+                  "id {} or pad index {} (nb_pads={})"sv,
+                  FilterPadId, Idx, FilterPad ? FilterPad->NbPads : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
 
-  const char *Name = avfilter_pad_get_name(FilterPad, Idx);
-  auto Actual = std::strlen(Name);
-  auto N = std::min<uint32_t>(NameLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(Name, N, NameBuf.data());
+  const char *Name = avfilter_pad_get_name(FilterPad->Pads, Idx);
+  copyCStringToBuffer(NameBuf.data(), NameLen, Name);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> AVFilterPadGetType::body(const Runtime::CallingFrame &,
                                          uint32_t FilterPadId, int32_t Idx) {
-  FFMPEG_PTR_FETCH(FilterPad, FilterPadId, AVFilterPad);
-  AVMediaType const MediaType = avfilter_pad_get_type(FilterPad, Idx);
+  FFMPEG_PTR_FETCH(FilterPad, FilterPadId, FilterPadView);
+  if (FilterPad == nullptr || Idx < 0 ||
+      static_cast<unsigned>(Idx) >= FilterPad->NbPads) {
+    return FFmpegUtils::MediaType::fromMediaType(AVMEDIA_TYPE_UNKNOWN);
+  }
+  AVMediaType const MediaType = avfilter_pad_get_type(FilterPad->Pads, Idx);
   return FFmpegUtils::MediaType::fromMediaType(MediaType);
 }
 
 Expect<int32_t> AVFilterGraphDumpLength::body(const Runtime::CallingFrame &,
                                               uint32_t FilterGraphId) {
   FFMPEG_PTR_FETCH(FilterGraph, FilterGraphId, AVFilterGraph);
-  char *Graph = avfilter_graph_dump(FilterGraph, nullptr);
-  return strlen(Graph);
+  FFMPEG_PTR_CHECK(FilterGraph, 0);
+  std::unique_ptr<char, decltype(&av_free)> Graph{
+      avfilter_graph_dump(FilterGraph, nullptr), &av_free};
+  if (Graph == nullptr) {
+    return 0;
+  }
+  return static_cast<int32_t>(strlen(Graph.get()));
 }
 
 Expect<int32_t> AVFilterGraphDump::body(const Runtime::CallingFrame &Frame,
@@ -244,37 +338,43 @@ Expect<int32_t> AVFilterGraphDump::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(GraphStr, MemInst, char, GraphStrPtr, GraphStrLen, "");
 
   FFMPEG_PTR_FETCH(FilterGraph, FilterGraphId, AVFilterGraph);
+  FFMPEG_PTR_CHECK(FilterGraph, static_cast<int32_t>(ErrNo::InternalError));
 
-  char *Graph = avfilter_graph_dump(FilterGraph, nullptr);
-  std::copy_n(Graph, GraphStrLen, GraphStr.data());
+  std::unique_ptr<char, decltype(&av_free)> Graph{
+      avfilter_graph_dump(FilterGraph, nullptr), &av_free};
+  if (Graph == nullptr) {
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  copyCStringToBuffer(GraphStr.data(), GraphStrLen, Graph.get());
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> AVFilterFreeGraphStr::body(const Runtime::CallingFrame &,
                                            uint32_t FilterGraphId) {
   FFMPEG_PTR_FETCH(FilterGraph, FilterGraphId, AVFilterGraph);
+  FFMPEG_PTR_CHECK_FREE(FilterGraph, FilterGraphId,
+                        static_cast<int32_t>(ErrNo::InternalError));
 
-  char *Graph = avfilter_graph_dump(FilterGraph, nullptr);
-  av_free(Graph);
+  std::unique_ptr<char, decltype(&av_free)> Graph{
+      avfilter_graph_dump(FilterGraph, nullptr), &av_free};
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> AVFilterDrop::body(const Runtime::CallingFrame &,
                                    uint32_t FilterId) {
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
-  if (Filter == nullptr) {
-    return static_cast<int32_t>(ErrNo::Success);
-  }
+  FFMPEG_PTR_CHECK_FREE(Filter, FilterId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_DELETE(FilterId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> AVFilterPadDrop::body(const Runtime::CallingFrame &,
                                       uint32_t FilterPadId) {
-  FFMPEG_PTR_FETCH(FilterPad, FilterPadId, AVFilterPad);
-  if (FilterPad == nullptr) {
-    return static_cast<int32_t>(ErrNo::Success);
-  }
+  FFMPEG_PTR_FETCH(FilterPad, FilterPadId, FilterPadView);
+  FFMPEG_PTR_CHECK_FREE(FilterPad, FilterPadId,
+                        static_cast<int32_t>(ErrNo::InternalError));
+  delete FilterPad;
   FFMPEG_PTR_DELETE(FilterPadId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -282,9 +382,8 @@ Expect<int32_t> AVFilterPadDrop::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVFilterContextDrop::body(const Runtime::CallingFrame &,
                                           uint32_t FilterCtxId) {
   FFMPEG_PTR_FETCH(FilterCtx, FilterCtxId, AVFilterContext);
-  if (FilterCtx == nullptr) {
-    return static_cast<int32_t>(ErrNo::Success);
-  }
+  FFMPEG_PTR_CHECK_FREE(FilterCtx, FilterCtxId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_DELETE(FilterCtxId);
   return static_cast<int32_t>(ErrNo::Success);
 }

--- a/plugins/wasmedge_ffmpeg/avfilter/avfilter_func.cpp
+++ b/plugins/wasmedge_ffmpeg/avfilter/avfilter_func.cpp
@@ -2,10 +2,13 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "avfilter_func.h"
+#include "avFilter.h"
 
 extern "C" {
 #include "libavfilter/avfilter.h"
 }
+
+#include <unordered_set>
 
 namespace WasmEdge {
 namespace Host {
@@ -30,6 +33,7 @@ Expect<int32_t> AVFilterGraphAlloc::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> AVFilterGraphConfig::body(const Runtime::CallingFrame &,
                                           uint32_t FilterGraphId) {
   FFMPEG_PTR_FETCH(FilterGraph, FilterGraphId, AVFilterGraph);
+  FFMPEG_PTR_CHECK(FilterGraph, static_cast<int32_t>(ErrNo::InternalError));
   return avfilter_graph_config(FilterGraph,
                                nullptr); // log_ctx always NULL on Rust SDK.
 }
@@ -37,7 +41,10 @@ Expect<int32_t> AVFilterGraphConfig::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVFilterGraphFree::body(const Runtime::CallingFrame &,
                                         uint32_t FilterGraphId) {
   FFMPEG_PTR_FETCH(FilterGraph, FilterGraphId, AVFilterGraph);
+  FFMPEG_PTR_CHECK_FREE(FilterGraph, FilterGraphId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   avfilter_graph_free(&FilterGraph);
+  Env.get()->deallocChildren(FilterGraphId);
   FFMPEG_PTR_DELETE(FilterGraphId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -48,21 +55,22 @@ Expect<int32_t> AVFilterGraphGetFilter::body(const Runtime::CallingFrame &Frame,
                                              uint32_t NamePtr,
                                              uint32_t NameSize) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(NameId, MemInst, char, NamePtr,
-                "Failed when accessing the return Name memory"sv);
+  MEM_SPAN_CHECK(NameId, MemInst, char, NamePtr, NameSize,
+                 "Failed when accessing the return Name memory"sv);
   MEM_PTR_CHECK(FilterCtxId, MemInst, uint32_t, FilterCtxPtr, "");
 
   FFMPEG_PTR_FETCH(FilterGraph, FilterGraphId, AVFilterGraph);
+  FFMPEG_PTR_CHECK(FilterGraph, static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_FETCH(FilterCtx, *FilterCtxId, AVFilterContext);
 
-  std::string Name;
-  std::copy_n(NameId, NameSize, std::back_inserter(Name));
+  std::string Name(NameId.data(), NameSize);
 
   FilterCtx = avfilter_graph_get_filter(FilterGraph, Name.c_str());
   if (FilterCtx == nullptr) {
+    *FilterCtxId = 0;
     return static_cast<int32_t>(ErrNo::Success);
   }
-  FFMPEG_PTR_STORE(FilterCtx, FilterCtxId);
+  FFMPEG_PTR_STORE_CHILD(FilterCtx, FilterCtxId, FilterGraphId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -73,23 +81,68 @@ Expect<int32_t> AVFilterGraphParsePtr::body(const Runtime::CallingFrame &Frame,
                                             uint32_t InputsId,
                                             uint32_t OutputsId) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(FiltersId, MemInst, char, FiltersString, "");
+  MEM_SPAN_CHECK(FiltersId, MemInst, char, FiltersString, FiltersSize, "");
 
   FFMPEG_PTR_FETCH(Inputs, InputsId, AVFilterInOut);
   FFMPEG_PTR_FETCH(Outputs, OutputsId, AVFilterInOut);
   FFMPEG_PTR_FETCH(FiltersGraph, FilterGraphId, AVFilterGraph);
+  FFMPEG_PTR_CHECK(FiltersGraph, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(Inputs, InputsId,
+                           static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(Outputs, OutputsId,
+                           static_cast<int32_t>(ErrNo::InternalError));
 
-  std::string Filters;
-  std::copy_n(FiltersId, FiltersSize, std::back_inserter(Filters));
-  return avfilter_graph_parse_ptr(FiltersGraph, Filters.c_str(), &Inputs,
-                                  &Outputs, nullptr);
+  if (Env.get()->isBorrowed(InputsId) || Env.get()->isBorrowed(OutputsId)) {
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+
+  std::vector<AVFilterInOut *> Consumed;
+  std::unordered_set<AVFilterInOut *> Seen;
+  auto Collect = [&](AVFilterInOut *Head) {
+    for (AVFilterInOut *Node = Head; Node != nullptr; Node = Node->next) {
+      if (!Seen.insert(Node).second) {
+        return false;
+      }
+      Consumed.push_back(Node);
+    }
+    return true;
+  };
+  if (!Collect(Inputs) || !Collect(Outputs)) {
+    for (AVFilterInOut *const Node : Consumed) {
+      Node->next = nullptr;
+      Env.get()->unmarkBorrowedByValue(Node);
+    }
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+
+  std::string Filters(FiltersId.data(), FiltersSize);
+  int32_t const Res = avfilter_graph_parse_ptr(FiltersGraph, Filters.c_str(),
+                                               &Inputs, &Outputs, nullptr);
+
+  if (Res < 0) {
+    Env.get()->deallocChildren(FilterGraphId);
+  }
+
+  for (AVFilterInOut *const Node : Consumed) {
+    Env.get()->deallocByValue(Node);
+  }
+  avfilter_inout_free(&Inputs);
+  avfilter_inout_free(&Outputs);
+  return Res;
 }
 
 Expect<int32_t> AVFilterInOutFree::body(const Runtime::CallingFrame &,
                                         uint32_t InOutId) {
   FFMPEG_PTR_FETCH(InOut, InOutId, AVFilterInOut);
+  FFMPEG_PTR_CHECK_FREE(InOut, InOutId,
+                        static_cast<int32_t>(ErrNo::InternalError));
+  if (Env.get()->isBorrowed(InOutId)) {
+    return static_cast<int32_t>(ErrNo::Success);
+  }
+  for (AVFilterInOut *Node = InOut; Node != nullptr; Node = Node->next) {
+    Env.get()->deallocByValue(Node);
+  }
   avfilter_inout_free(&InOut);
-  FFMPEG_PTR_DELETE(InOutId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -101,17 +154,17 @@ Expect<int32_t> AVFilterGetByName::body(const Runtime::CallingFrame &Frame,
                                         uint32_t FilterPtr, uint32_t StrPtr,
                                         uint32_t StrLen) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(StrId, MemInst, char, StrPtr,
-                "Failed when accessing the return Str memory"sv);
+  MEM_SPAN_CHECK(StrId, MemInst, char, StrPtr, StrLen,
+                 "Failed when accessing the return Str memory"sv);
   MEM_PTR_CHECK(FilterId, MemInst, uint32_t, FilterPtr,
                 "Failed when accessing the return Filter memory"sv);
 
   FFMPEG_PTR_FETCH(Filter, *FilterId, const struct AVFilter);
-  std::string Name;
-  std::copy_n(StrId, StrLen, std::back_inserter(Name));
+  std::string Name(StrId.data(), StrLen);
 
   Filter = avfilter_get_by_name(Name.c_str());
   if (Filter == nullptr) {
+    *FilterId = 0;
     return static_cast<int32_t>(ErrNo::Success);
   }
 
@@ -132,9 +185,7 @@ Expect<int32_t> AVFilterConfiguration::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(ConfigBuf, MemInst, char, ConfigPtr, ConfigLen, "");
 
   const char *Config = avfilter_configuration();
-  auto Actual = std::strlen(Config);
-  auto N = std::min<uint32_t>(ConfigLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(Config, N, ConfigBuf.data());
+  copyCStringToBuffer(ConfigBuf.data(), ConfigLen, Config);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -150,9 +201,7 @@ Expect<int32_t> AVFilterLicense::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(LicenseBuf, MemInst, char, LicensePtr, LicenseLen, "");
 
   const char *License = avfilter_license();
-  auto Actual = std::strlen(License);
-  auto N = std::min<uint32_t>(LicenseLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(License, N, LicenseBuf.data());
+  copyCStringToBuffer(LicenseBuf.data(), LicenseLen, License);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -165,22 +214,23 @@ Expect<int32_t> AVFilterGraphCreateFilter::body(
   MEM_SPAN_CHECK(ArgsBuf, MemInst, char, ArgsPtr, ArgsLen, "");
   MEM_PTR_CHECK(FilterCtxId, MemInst, uint32_t, FilterCtxPtr, "")
 
-  FFMPEG_PTR_FETCH(FilterCtx, *FilterCtxId, AVFilterContext);
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
   FFMPEG_PTR_FETCH(FilterGraph, FilterGraphId, AVFilterGraph);
+  if (Filter == nullptr || FilterGraph == nullptr) {
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
 
-  std::string Name;
-  std::string Args;
-  std::copy_n(NameBuf.data(), NameLen, std::back_inserter(Name));
-  std::copy_n(ArgsBuf.data(), ArgsLen, std::back_inserter(Args));
+  std::string Name(NameBuf.data(), NameLen);
+  std::string Args(ArgsBuf.data(), ArgsLen);
 
+  AVFilterContext *FilterCtx = nullptr;
   int Res = avfilter_graph_create_filter(&FilterCtx, Filter, Name.c_str(),
                                          Args.c_str(), nullptr, FilterGraph);
   if (Res < 0) {
     return Res;
   }
 
-  FFMPEG_PTR_STORE(FilterCtx, FilterCtxId);
+  FFMPEG_PTR_STORE_CHILD(FilterCtx, FilterCtxId, FilterGraphId);
   return Res;
 }
 
@@ -201,9 +251,16 @@ Expect<int32_t> AVFilterInOutAlloc::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> AVFilterPadGetNameLength::body(const Runtime::CallingFrame &,
                                                uint32_t FilterPadId,
                                                int32_t Idx) {
-  FFMPEG_PTR_FETCH(FilterPad, FilterPadId, AVFilterPad);
+  FFMPEG_PTR_FETCH(FilterPad, FilterPadId, FilterPadView);
+  if (FilterPad == nullptr || Idx < 0 ||
+      static_cast<unsigned>(Idx) >= FilterPad->NbPads) {
+    return 0;
+  }
 
-  const char *Name = avfilter_pad_get_name(FilterPad, Idx);
+  const char *Name = avfilter_pad_get_name(FilterPad->Pads, Idx);
+  if (Name == nullptr) {
+    return 0;
+  }
   return strlen(Name);
 }
 
@@ -213,27 +270,41 @@ Expect<int32_t> AVFilterPadGetName::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_SPAN_CHECK(NameBuf, MemInst, char, NamePtr, NameLen, "");
 
-  FFMPEG_PTR_FETCH(FilterPad, FilterPadId, AVFilterPad);
+  FFMPEG_PTR_FETCH(FilterPad, FilterPadId, FilterPadView);
+  if (FilterPad == nullptr || Idx < 0 ||
+      static_cast<unsigned>(Idx) >= FilterPad->NbPads) {
+    spdlog::error("[WasmEdge-FFmpeg] AVFilterPadGetName: invalid filter pad "
+                  "id {} or pad index {} (nb_pads={})"sv,
+                  FilterPadId, Idx, FilterPad ? FilterPad->NbPads : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
 
-  const char *Name = avfilter_pad_get_name(FilterPad, Idx);
-  auto Actual = std::strlen(Name);
-  auto N = std::min<uint32_t>(NameLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(Name, N, NameBuf.data());
+  const char *Name = avfilter_pad_get_name(FilterPad->Pads, Idx);
+  copyCStringToBuffer(NameBuf.data(), NameLen, Name);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> AVFilterPadGetType::body(const Runtime::CallingFrame &,
                                          uint32_t FilterPadId, int32_t Idx) {
-  FFMPEG_PTR_FETCH(FilterPad, FilterPadId, AVFilterPad);
-  AVMediaType const MediaType = avfilter_pad_get_type(FilterPad, Idx);
+  FFMPEG_PTR_FETCH(FilterPad, FilterPadId, FilterPadView);
+  if (FilterPad == nullptr || Idx < 0 ||
+      static_cast<unsigned>(Idx) >= FilterPad->NbPads) {
+    return FFmpegUtils::MediaType::fromMediaType(AVMEDIA_TYPE_UNKNOWN);
+  }
+  AVMediaType const MediaType = avfilter_pad_get_type(FilterPad->Pads, Idx);
   return FFmpegUtils::MediaType::fromMediaType(MediaType);
 }
 
 Expect<int32_t> AVFilterGraphDumpLength::body(const Runtime::CallingFrame &,
                                               uint32_t FilterGraphId) {
   FFMPEG_PTR_FETCH(FilterGraph, FilterGraphId, AVFilterGraph);
-  char *Graph = avfilter_graph_dump(FilterGraph, nullptr);
-  return strlen(Graph);
+  FFMPEG_PTR_CHECK(FilterGraph, 0);
+  std::unique_ptr<char, decltype(&av_free)> Graph{
+      avfilter_graph_dump(FilterGraph, nullptr), &av_free};
+  if (Graph == nullptr) {
+    return 0;
+  }
+  return static_cast<int32_t>(strlen(Graph.get()));
 }
 
 Expect<int32_t> AVFilterGraphDump::body(const Runtime::CallingFrame &Frame,
@@ -244,37 +315,43 @@ Expect<int32_t> AVFilterGraphDump::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(GraphStr, MemInst, char, GraphStrPtr, GraphStrLen, "");
 
   FFMPEG_PTR_FETCH(FilterGraph, FilterGraphId, AVFilterGraph);
+  FFMPEG_PTR_CHECK(FilterGraph, static_cast<int32_t>(ErrNo::InternalError));
 
-  char *Graph = avfilter_graph_dump(FilterGraph, nullptr);
-  std::copy_n(Graph, GraphStrLen, GraphStr.data());
+  std::unique_ptr<char, decltype(&av_free)> Graph{
+      avfilter_graph_dump(FilterGraph, nullptr), &av_free};
+  if (Graph == nullptr) {
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  copyCStringToBuffer(GraphStr.data(), GraphStrLen, Graph.get());
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> AVFilterFreeGraphStr::body(const Runtime::CallingFrame &,
                                            uint32_t FilterGraphId) {
   FFMPEG_PTR_FETCH(FilterGraph, FilterGraphId, AVFilterGraph);
+  FFMPEG_PTR_CHECK_FREE(FilterGraph, FilterGraphId,
+                        static_cast<int32_t>(ErrNo::InternalError));
 
-  char *Graph = avfilter_graph_dump(FilterGraph, nullptr);
-  av_free(Graph);
+  std::unique_ptr<char, decltype(&av_free)> Graph{
+      avfilter_graph_dump(FilterGraph, nullptr), &av_free};
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> AVFilterDrop::body(const Runtime::CallingFrame &,
                                    uint32_t FilterId) {
   FFMPEG_PTR_FETCH(Filter, FilterId, struct AVFilter);
-  if (Filter == nullptr) {
-    return static_cast<int32_t>(ErrNo::Success);
-  }
+  FFMPEG_PTR_CHECK_FREE(Filter, FilterId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_DELETE(FilterId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> AVFilterPadDrop::body(const Runtime::CallingFrame &,
                                       uint32_t FilterPadId) {
-  FFMPEG_PTR_FETCH(FilterPad, FilterPadId, AVFilterPad);
-  if (FilterPad == nullptr) {
-    return static_cast<int32_t>(ErrNo::Success);
-  }
+  FFMPEG_PTR_FETCH(FilterPad, FilterPadId, FilterPadView);
+  FFMPEG_PTR_CHECK_FREE(FilterPad, FilterPadId,
+                        static_cast<int32_t>(ErrNo::InternalError));
+  delete FilterPad;
   FFMPEG_PTR_DELETE(FilterPadId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -282,9 +359,8 @@ Expect<int32_t> AVFilterPadDrop::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVFilterContextDrop::body(const Runtime::CallingFrame &,
                                           uint32_t FilterCtxId) {
   FFMPEG_PTR_FETCH(FilterCtx, FilterCtxId, AVFilterContext);
-  if (FilterCtx == nullptr) {
-    return static_cast<int32_t>(ErrNo::Success);
-  }
+  FFMPEG_PTR_CHECK_FREE(FilterCtx, FilterCtxId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_DELETE(FilterCtxId);
   return static_cast<int32_t>(ErrNo::Success);
 }

--- a/plugins/wasmedge_ffmpeg/avfilter/buffer_source_sink.cpp
+++ b/plugins/wasmedge_ffmpeg/avfilter/buffer_source_sink.cpp
@@ -18,6 +18,8 @@ Expect<int32_t> AVBufferSinkGetFrame::body(const Runtime::CallingFrame &,
                                            uint32_t FrameId) {
   FFMPEG_PTR_FETCH(FilterCtx, FilterContextId, AVFilterContext);
   FFMPEG_PTR_FETCH(Frame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(FilterCtx, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK(Frame, static_cast<int32_t>(ErrNo::InternalError));
   return av_buffersink_get_frame(FilterCtx, Frame);
 }
 
@@ -27,6 +29,8 @@ Expect<int32_t> AVBufferSinkGetSamples::body(const Runtime::CallingFrame &,
                                              int32_t Samples) {
   FFMPEG_PTR_FETCH(FilterCtx, FilterContextId, AVFilterContext);
   FFMPEG_PTR_FETCH(Frame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(FilterCtx, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK(Frame, static_cast<int32_t>(ErrNo::InternalError));
   return av_buffersink_get_samples(FilterCtx, Frame, Samples);
 }
 
@@ -34,6 +38,7 @@ Expect<int32_t> AvBufferSinkSetFrameSize::body(const Runtime::CallingFrame &,
                                                uint32_t FilterContextId,
                                                int32_t Value) {
   FFMPEG_PTR_FETCH(FilterCtx, FilterContextId, AVFilterContext);
+  FFMPEG_PTR_CHECK(FilterCtx, static_cast<int32_t>(ErrNo::InternalError));
   av_buffersink_set_frame_size(FilterCtx, Value);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -42,6 +47,7 @@ Expect<int32_t>
 AVBufferSrcGetNbFailedRequests::body(const Runtime::CallingFrame &,
                                      uint32_t FilterContextId) {
   FFMPEG_PTR_FETCH(FilterCtx, FilterContextId, AVFilterContext);
+  FFMPEG_PTR_CHECK(FilterCtx, static_cast<int32_t>(ErrNo::InternalError));
   return av_buffersrc_get_nb_failed_requests(FilterCtx);
 }
 
@@ -50,6 +56,10 @@ Expect<int32_t> AVBufferSrcAddFrame::body(const Runtime::CallingFrame &,
                                           uint32_t FrameId) {
   FFMPEG_PTR_FETCH(FilterCtx, FilterContextId, AVFilterContext);
   FFMPEG_PTR_FETCH(Frame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(FilterCtx, static_cast<int32_t>(ErrNo::InternalError));
+  if (FrameId != 0) {
+    FFMPEG_PTR_CHECK(Frame, static_cast<int32_t>(ErrNo::InternalError));
+  }
   return av_buffersrc_add_frame(FilterCtx, Frame);
 }
 
@@ -57,6 +67,7 @@ Expect<int32_t> AVBufferSrcClose::body(const Runtime::CallingFrame &,
                                        uint32_t FilterContextId, int64_t Pts,
                                        uint32_t Flags) {
   FFMPEG_PTR_FETCH(FilterCtx, FilterContextId, AVFilterContext);
+  FFMPEG_PTR_CHECK(FilterCtx, static_cast<int32_t>(ErrNo::InternalError));
   return av_buffersrc_close(FilterCtx, Pts, Flags);
 }
 

--- a/plugins/wasmedge_ffmpeg/avformat/avChapter.cpp
+++ b/plugins/wasmedge_ffmpeg/avformat/avChapter.cpp
@@ -12,15 +12,25 @@ namespace Host {
 namespace WasmEdgeFFmpeg {
 namespace AVFormat {
 
+namespace {
+AVChapter **chapterAt(AVFormatContext *Ctx, uint32_t Idx) {
+  if (Ctx == nullptr) {
+    return nullptr;
+  }
+  return checkedArraySlot(Ctx->chapters, Ctx->nb_chapters, Idx);
+}
+} // namespace
+
 Expect<int64_t> AVChapterId::body(const Runtime::CallingFrame &,
                                   uint32_t AvFormatCtxId, uint32_t ChapterIdx) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  AVChapter **AvChapter = AvFormatContext->chapters;
-
-  // No check here (Check)
-  // Raw Pointer Iteration.
-  for (unsigned int I = 1; I <= ChapterIdx; I++) {
-    AvChapter++;
+  AVChapter **AvChapter = chapterAt(AvFormatContext, ChapterIdx);
+  if (AvChapter == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVChapterId: invalid chapter index {} "
+                  "(format context id {}, nb_chapters={})"sv,
+                  ChapterIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_chapters : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   return static_cast<AVChapter *>(*AvChapter)->id;
@@ -30,12 +40,13 @@ Expect<int32_t> AVChapterSetId::body(const Runtime::CallingFrame &,
                                      uint32_t AvFormatCtxId,
                                      uint32_t ChapterIdx, int64_t ChapterId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  AVChapter **AvChapter = AvFormatContext->chapters;
-
-  // No check here (Check)
-  // Raw Pointer Iteration.
-  for (unsigned int I = 1; I <= ChapterIdx; I++) {
-    AvChapter++;
+  AVChapter **AvChapter = chapterAt(AvFormatContext, ChapterIdx);
+  if (AvChapter == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVChapterSetId: invalid chapter index "
+                  "{} (format context id {}, nb_chapters={})"sv,
+                  ChapterIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_chapters : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   (*AvChapter)->id = ChapterId;
@@ -51,12 +62,13 @@ Expect<int32_t> AVChapterTimebase::body(const Runtime::CallingFrame &Frame,
   MEM_PTR_CHECK(Den, MemInst, int32_t, DenPtr, "");
 
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  AVChapter **AvChapter = AvFormatContext->chapters;
-
-  // No check here (Check)
-  // Raw Pointer Iteration.
-  for (unsigned int I = 1; I <= ChapterIdx; I++) {
-    AvChapter++;
+  AVChapter **AvChapter = chapterAt(AvFormatContext, ChapterIdx);
+  if (AvChapter == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVChapterTimebase: invalid chapter "
+                  "index {} (format context id {}, nb_chapters={})"sv,
+                  ChapterIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_chapters : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   AVRational const AvRational = static_cast<AVChapter *>(*AvChapter)->time_base;
@@ -72,12 +84,13 @@ Expect<int32_t> AVChapterSetTimebase::body(const Runtime::CallingFrame &,
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
   AVRational const Timebase = av_make_q(Num, Den);
 
-  AVChapter **AvChapter = AvFormatContext->chapters;
-
-  // No check here (Check)
-  // Raw Pointer Iteration.
-  for (unsigned int I = 1; I <= ChapterIdx; I++) {
-    AvChapter++;
+  AVChapter **AvChapter = chapterAt(AvFormatContext, ChapterIdx);
+  if (AvChapter == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVChapterSetTimebase: invalid chapter "
+                  "index {} (format context id {}, nb_chapters={})"sv,
+                  ChapterIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_chapters : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   (*AvChapter)->time_base = Timebase;
@@ -88,12 +101,13 @@ Expect<int64_t> AVChapterStart::body(const Runtime::CallingFrame &,
                                      uint32_t AvFormatCtxId,
                                      uint32_t ChapterIdx) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  AVChapter **AvChapter = AvFormatContext->chapters;
-
-  // No check here (Check)
-  // Raw Pointer Iteration.
-  for (unsigned int I = 1; I <= ChapterIdx; I++) {
-    AvChapter++;
+  AVChapter **AvChapter = chapterAt(AvFormatContext, ChapterIdx);
+  if (AvChapter == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVChapterStart: invalid chapter index "
+                  "{} (format context id {}, nb_chapters={})"sv,
+                  ChapterIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_chapters : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   return static_cast<AVChapter *>(*AvChapter)->start;
@@ -104,12 +118,13 @@ Expect<int32_t> AVChapterSetStart::body(const Runtime::CallingFrame &,
                                         uint32_t ChapterIdx,
                                         int64_t StartValue) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  AVChapter **AvChapter = AvFormatContext->chapters;
-
-  // No check here (Check)
-  // Raw Pointer Iteration.
-  for (unsigned int I = 1; I <= ChapterIdx; I++) {
-    AvChapter++;
+  AVChapter **AvChapter = chapterAt(AvFormatContext, ChapterIdx);
+  if (AvChapter == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVChapterSetStart: invalid chapter "
+                  "index {} (format context id {}, nb_chapters={})"sv,
+                  ChapterIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_chapters : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   (*AvChapter)->start = StartValue;
@@ -120,12 +135,13 @@ Expect<int64_t> AVChapterEnd::body(const Runtime::CallingFrame &,
                                    uint32_t AvFormatCtxId,
                                    uint32_t ChapterIdx) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  AVChapter **AvChapter = AvFormatContext->chapters;
-
-  // No check here (Check)
-  // Raw Pointer Iteration.
-  for (unsigned int I = 1; I <= ChapterIdx; I++) {
-    AvChapter++;
+  AVChapter **AvChapter = chapterAt(AvFormatContext, ChapterIdx);
+  if (AvChapter == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVChapterEnd: invalid chapter index {} "
+                  "(format context id {}, nb_chapters={})"sv,
+                  ChapterIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_chapters : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   return static_cast<AVChapter *>(*AvChapter)->end;
@@ -135,12 +151,13 @@ Expect<int32_t> AVChapterSetEnd::body(const Runtime::CallingFrame &,
                                       uint32_t AvFormatCtxId,
                                       uint32_t ChapterIdx, int64_t EndValue) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  AVChapter **AvChapter = AvFormatContext->chapters;
-
-  // No check here (Check)
-  // Raw Pointer Iteration.
-  for (unsigned int I = 1; I <= ChapterIdx; I++) {
-    AvChapter++;
+  AVChapter **AvChapter = chapterAt(AvFormatContext, ChapterIdx);
+  if (AvChapter == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVChapterSetEnd: invalid chapter index "
+                  "{} (format context id {}, nb_chapters={})"sv,
+                  ChapterIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_chapters : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   (*AvChapter)->end = EndValue;
@@ -156,18 +173,16 @@ Expect<int32_t> AVChapterMetadata::body(const Runtime::CallingFrame &Frame,
 
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
 
-  AVDictionary **AvDictionary =
-      static_cast<AVDictionary **>(av_malloc(sizeof(AVDictionary *)));
-  AVChapter **AvChapter = AvFormatCtx->chapters;
-
-  // No check here (Check)
-  // Raw Pointer Iteration.
-  for (unsigned int I = 1; I <= ChapterIdx; I++) {
-    AvChapter++;
+  AVChapter **AvChapter = chapterAt(AvFormatCtx, ChapterIdx);
+  if (AvChapter == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVChapterMetadata: invalid chapter "
+                  "index {} (format context id {}, nb_chapters={})"sv,
+                  ChapterIdx, AvFormatCtxId,
+                  AvFormatCtx ? AvFormatCtx->nb_chapters : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
-  *AvDictionary = (*AvChapter)->metadata;
-  FFMPEG_PTR_STORE(AvDictionary, DictId);
+  FFMPEG_PTR_STORE_CHILD(&(*AvChapter)->metadata, DictId, AvFormatCtxId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -178,20 +193,18 @@ Expect<int32_t> AVChapterSetMetadata::body(const Runtime::CallingFrame &,
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
   FFMPEG_PTR_FETCH(AvDictionary, DictId, AVDictionary *);
 
-  AVChapter **AvChapter = AvFormatCtx->chapters;
-
-  // No check here (Check)
-  // Raw Pointer Iteration.
-  for (unsigned int I = 1; I <= ChapterIdx; I++) {
-    AvChapter++;
+  AVChapter **AvChapter = chapterAt(AvFormatCtx, ChapterIdx);
+  if (AvChapter == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVChapterSetMetadata: invalid chapter "
+                  "index {} (format context id {}, nb_chapters={})"sv,
+                  ChapterIdx, AvFormatCtxId,
+                  AvFormatCtx ? AvFormatCtx->nb_chapters : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
-  if (AvDictionary == nullptr) {
-    (*AvChapter)->metadata = nullptr;
-  } else {
-    (*AvChapter)->metadata = *AvDictionary;
-  }
-  return static_cast<int32_t>(ErrNo::Success);
+  FFMPEG_PTR_CHECK_NONZERO(AvDictionary, DictId,
+                           static_cast<int32_t>(ErrNo::InternalError));
+  return applyMetadataCopy(&(*AvChapter)->metadata, AvDictionary);
 }
 
 } // namespace AVFormat

--- a/plugins/wasmedge_ffmpeg/avformat/avInputOutputFormat.cpp
+++ b/plugins/wasmedge_ffmpeg/avformat/avInputOutputFormat.cpp
@@ -19,9 +19,11 @@ Expect<int32_t> AVIOFormatNameLength::body(const Runtime::CallingFrame &,
 
   if (FormatType == 0) {
     FFMPEG_PTR_FETCH(AvInputFormat, AVIOFormatId, AVInputFormat);
+    FFMPEG_PTR_CHECK(AvInputFormat, 0);
     Name = AvInputFormat->name;
   } else {
     FFMPEG_PTR_FETCH(AvOutputFormat, AVIOFormatId, AVOutputFormat);
+    FFMPEG_PTR_CHECK(AvOutputFormat, 0);
     Name = AvOutputFormat->name;
   }
 
@@ -37,9 +39,10 @@ Expect<int32_t> AVInputFormatName::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_SPAN_CHECK(NameBuf, MemInst, char, NamePtr, NameLen, "");
   FFMPEG_PTR_FETCH(AvInputFormat, AVInputFormatId, AVInputFormat);
+  FFMPEG_PTR_CHECK(AvInputFormat, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *Name = AvInputFormat->name;
-  std::copy_n(Name, NameLen, NameBuf.data());
+  copyCStringToBuffer(NameBuf.data(), NameLen, Name);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -49,9 +52,10 @@ Expect<int32_t> AVOutputFormatName::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_SPAN_CHECK(NameBuf, MemInst, char, NamePtr, NameLen, "");
   FFMPEG_PTR_FETCH(AvOutputFormat, AVOutputFormatId, AVOutputFormat);
+  FFMPEG_PTR_CHECK(AvOutputFormat, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *Name = AvOutputFormat->name;
-  std::copy_n(Name, NameLen, NameBuf.data());
+  copyCStringToBuffer(NameBuf.data(), NameLen, Name);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -62,9 +66,11 @@ Expect<int32_t> AVIOFormatLongNameLength::body(const Runtime::CallingFrame &,
 
   if (FormatType == 0) {
     FFMPEG_PTR_FETCH(AvInputFormat, AVIOFormatId, AVInputFormat);
+    FFMPEG_PTR_CHECK(AvInputFormat, 0);
     LongName = AvInputFormat->long_name;
   } else {
     FFMPEG_PTR_FETCH(AvOutputFormat, AVIOFormatId, AVOutputFormat);
+    FFMPEG_PTR_CHECK(AvOutputFormat, 0);
     LongName = AvOutputFormat->long_name;
   }
 
@@ -81,9 +87,10 @@ Expect<int32_t> AVInputFormatLongName::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_SPAN_CHECK(LongNameBuf, MemInst, char, LongNamePtr, LongNameLen, "");
   FFMPEG_PTR_FETCH(AvInputFormat, AVInputFormatId, AVInputFormat);
+  FFMPEG_PTR_CHECK(AvInputFormat, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *LongName = AvInputFormat->long_name;
-  std::copy_n(LongName, LongNameLen, LongNameBuf.data());
+  copyCStringToBuffer(LongNameBuf.data(), LongNameLen, LongName);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -94,9 +101,10 @@ Expect<int32_t> AVOutputFormatLongName::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_SPAN_CHECK(LongNameBuf, MemInst, char, LongNamePtr, LongNameLen, "");
   FFMPEG_PTR_FETCH(AvOutputFormat, AVOutputFormatId, AVOutputFormat);
+  FFMPEG_PTR_CHECK(AvOutputFormat, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *LongName = AvOutputFormat->long_name;
-  std::copy_n(LongName, LongNameLen, LongNameBuf.data());
+  copyCStringToBuffer(LongNameBuf.data(), LongNameLen, LongName);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -107,9 +115,11 @@ Expect<int32_t> AVIOFormatExtensionsLength::body(const Runtime::CallingFrame &,
 
   if (FormatType == 0) {
     FFMPEG_PTR_FETCH(AvInputFormat, AVIOFormatId, AVInputFormat);
+    FFMPEG_PTR_CHECK(AvInputFormat, 0);
     Extensions = AvInputFormat->extensions;
   } else {
     FFMPEG_PTR_FETCH(AvOutputFormat, AVIOFormatId, AVOutputFormat);
+    FFMPEG_PTR_CHECK(AvOutputFormat, 0);
     Extensions = AvOutputFormat->extensions;
   }
 
@@ -127,9 +137,10 @@ AVInputFormatExtensions::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(ExtensionsBuf, MemInst, char, ExtensionsPtr, ExtensionsLen,
                  "");
   FFMPEG_PTR_FETCH(AvInputFormat, AVInputFormatId, AVInputFormat);
+  FFMPEG_PTR_CHECK(AvInputFormat, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *Extensions = AvInputFormat->extensions;
-  std::copy_n(Extensions, ExtensionsLen, ExtensionsBuf.data());
+  copyCStringToBuffer(ExtensionsBuf.data(), ExtensionsLen, Extensions);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -141,9 +152,10 @@ AVOutputFormatExtensions::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(ExtensionsBuf, MemInst, char, ExtensionsPtr, ExtensionsLen,
                  "");
   FFMPEG_PTR_FETCH(AvOutputFormat, AVOutputFormatId, AVOutputFormat);
+  FFMPEG_PTR_CHECK(AvOutputFormat, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *Extensions = AvOutputFormat->extensions;
-  std::copy_n(Extensions, ExtensionsLen, ExtensionsBuf.data());
+  copyCStringToBuffer(ExtensionsBuf.data(), ExtensionsLen, Extensions);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -154,9 +166,11 @@ Expect<int32_t> AVIOFormatMimeTypeLength::body(const Runtime::CallingFrame &,
 
   if (FormatType == 0) {
     FFMPEG_PTR_FETCH(AvInputFormat, AVIOFormatId, AVInputFormat);
+    FFMPEG_PTR_CHECK(AvInputFormat, 0);
     MimeType = AvInputFormat->mime_type;
   } else {
     FFMPEG_PTR_FETCH(AvOutputFormat, AVIOFormatId, AVOutputFormat);
+    FFMPEG_PTR_CHECK(AvOutputFormat, 0);
     MimeType = AvOutputFormat->mime_type;
   }
 
@@ -173,9 +187,10 @@ Expect<int32_t> AVInputFormatMimeType::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_SPAN_CHECK(MimeTypeBuf, MemInst, char, MimeTypePtr, MimeTypeLen, "");
   FFMPEG_PTR_FETCH(AvInputFormat, AVInputFormatId, AVInputFormat);
+  FFMPEG_PTR_CHECK(AvInputFormat, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *MimeType = AvInputFormat->mime_type;
-  std::copy_n(MimeType, MimeTypeLen, MimeTypeBuf.data());
+  copyCStringToBuffer(MimeTypeBuf.data(), MimeTypeLen, MimeType);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -186,20 +201,33 @@ Expect<int32_t> AVOutputFormatMimeType::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_SPAN_CHECK(MimeTypeBuf, MemInst, char, MimeTypePtr, MimeTypeLen, "");
   FFMPEG_PTR_FETCH(AvOutputFormat, AVOutputFormatId, AVOutputFormat);
+  FFMPEG_PTR_CHECK(AvOutputFormat, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *MimeType = AvOutputFormat->mime_type;
-  std::copy_n(MimeType, MimeTypeLen, MimeTypeBuf.data());
+  copyCStringToBuffer(MimeTypeBuf.data(), MimeTypeLen, MimeType);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> AVOutputFormatFlags::body(const Runtime::CallingFrame &,
                                           uint32_t AVOutputFormatId) {
   FFMPEG_PTR_FETCH(AvOutputFormat, AVOutputFormatId, AVOutputFormat);
+  FFMPEG_PTR_CHECK(AvOutputFormat, 0);
   return AvOutputFormat->flags;
 }
 
 Expect<int32_t> AVInputOutputFormatFree::body(const Runtime::CallingFrame &,
                                               uint32_t AVInputOutputId) {
+  // The id may hold either an AVInputFormat or an AVOutputFormat (both
+  // library-owned statics; freeing only drops the id), so accept either type.
+  // Id 0 and stale ids stay no-ops, matching the other free wrappers.
+  FFMPEG_PTR_FETCH(AvInputFormat, AVInputOutputId, AVInputFormat);
+  FFMPEG_PTR_FETCH(AvOutputFormat, AVInputOutputId, AVOutputFormat);
+  if (AvInputFormat == nullptr && AvOutputFormat == nullptr) {
+    if (Env.get()->fetchData(AVInputOutputId) != nullptr) {
+      return static_cast<int32_t>(ErrNo::InternalError);
+    }
+    return static_cast<int32_t>(ErrNo::Success);
+  }
   FFMPEG_PTR_DELETE(AVInputOutputId);
   return static_cast<int32_t>(ErrNo::Success);
 }

--- a/plugins/wasmedge_ffmpeg/avformat/avInputOutputFormat.cpp
+++ b/plugins/wasmedge_ffmpeg/avformat/avInputOutputFormat.cpp
@@ -19,9 +19,11 @@ Expect<int32_t> AVIOFormatNameLength::body(const Runtime::CallingFrame &,
 
   if (FormatType == 0) {
     FFMPEG_PTR_FETCH(AvInputFormat, AVIOFormatId, AVInputFormat);
+    FFMPEG_PTR_CHECK(AvInputFormat, 0);
     Name = AvInputFormat->name;
   } else {
     FFMPEG_PTR_FETCH(AvOutputFormat, AVIOFormatId, AVOutputFormat);
+    FFMPEG_PTR_CHECK(AvOutputFormat, 0);
     Name = AvOutputFormat->name;
   }
 
@@ -37,9 +39,10 @@ Expect<int32_t> AVInputFormatName::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_SPAN_CHECK(NameBuf, MemInst, char, NamePtr, NameLen, "");
   FFMPEG_PTR_FETCH(AvInputFormat, AVInputFormatId, AVInputFormat);
+  FFMPEG_PTR_CHECK(AvInputFormat, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *Name = AvInputFormat->name;
-  std::copy_n(Name, NameLen, NameBuf.data());
+  copyCStringToBuffer(NameBuf.data(), NameLen, Name);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -49,9 +52,10 @@ Expect<int32_t> AVOutputFormatName::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_SPAN_CHECK(NameBuf, MemInst, char, NamePtr, NameLen, "");
   FFMPEG_PTR_FETCH(AvOutputFormat, AVOutputFormatId, AVOutputFormat);
+  FFMPEG_PTR_CHECK(AvOutputFormat, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *Name = AvOutputFormat->name;
-  std::copy_n(Name, NameLen, NameBuf.data());
+  copyCStringToBuffer(NameBuf.data(), NameLen, Name);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -62,9 +66,11 @@ Expect<int32_t> AVIOFormatLongNameLength::body(const Runtime::CallingFrame &,
 
   if (FormatType == 0) {
     FFMPEG_PTR_FETCH(AvInputFormat, AVIOFormatId, AVInputFormat);
+    FFMPEG_PTR_CHECK(AvInputFormat, 0);
     LongName = AvInputFormat->long_name;
   } else {
     FFMPEG_PTR_FETCH(AvOutputFormat, AVIOFormatId, AVOutputFormat);
+    FFMPEG_PTR_CHECK(AvOutputFormat, 0);
     LongName = AvOutputFormat->long_name;
   }
 
@@ -81,9 +87,10 @@ Expect<int32_t> AVInputFormatLongName::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_SPAN_CHECK(LongNameBuf, MemInst, char, LongNamePtr, LongNameLen, "");
   FFMPEG_PTR_FETCH(AvInputFormat, AVInputFormatId, AVInputFormat);
+  FFMPEG_PTR_CHECK(AvInputFormat, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *LongName = AvInputFormat->long_name;
-  std::copy_n(LongName, LongNameLen, LongNameBuf.data());
+  copyCStringToBuffer(LongNameBuf.data(), LongNameLen, LongName);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -94,9 +101,10 @@ Expect<int32_t> AVOutputFormatLongName::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_SPAN_CHECK(LongNameBuf, MemInst, char, LongNamePtr, LongNameLen, "");
   FFMPEG_PTR_FETCH(AvOutputFormat, AVOutputFormatId, AVOutputFormat);
+  FFMPEG_PTR_CHECK(AvOutputFormat, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *LongName = AvOutputFormat->long_name;
-  std::copy_n(LongName, LongNameLen, LongNameBuf.data());
+  copyCStringToBuffer(LongNameBuf.data(), LongNameLen, LongName);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -107,9 +115,11 @@ Expect<int32_t> AVIOFormatExtensionsLength::body(const Runtime::CallingFrame &,
 
   if (FormatType == 0) {
     FFMPEG_PTR_FETCH(AvInputFormat, AVIOFormatId, AVInputFormat);
+    FFMPEG_PTR_CHECK(AvInputFormat, 0);
     Extensions = AvInputFormat->extensions;
   } else {
     FFMPEG_PTR_FETCH(AvOutputFormat, AVIOFormatId, AVOutputFormat);
+    FFMPEG_PTR_CHECK(AvOutputFormat, 0);
     Extensions = AvOutputFormat->extensions;
   }
 
@@ -127,9 +137,10 @@ AVInputFormatExtensions::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(ExtensionsBuf, MemInst, char, ExtensionsPtr, ExtensionsLen,
                  "");
   FFMPEG_PTR_FETCH(AvInputFormat, AVInputFormatId, AVInputFormat);
+  FFMPEG_PTR_CHECK(AvInputFormat, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *Extensions = AvInputFormat->extensions;
-  std::copy_n(Extensions, ExtensionsLen, ExtensionsBuf.data());
+  copyCStringToBuffer(ExtensionsBuf.data(), ExtensionsLen, Extensions);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -141,9 +152,10 @@ AVOutputFormatExtensions::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(ExtensionsBuf, MemInst, char, ExtensionsPtr, ExtensionsLen,
                  "");
   FFMPEG_PTR_FETCH(AvOutputFormat, AVOutputFormatId, AVOutputFormat);
+  FFMPEG_PTR_CHECK(AvOutputFormat, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *Extensions = AvOutputFormat->extensions;
-  std::copy_n(Extensions, ExtensionsLen, ExtensionsBuf.data());
+  copyCStringToBuffer(ExtensionsBuf.data(), ExtensionsLen, Extensions);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -154,9 +166,11 @@ Expect<int32_t> AVIOFormatMimeTypeLength::body(const Runtime::CallingFrame &,
 
   if (FormatType == 0) {
     FFMPEG_PTR_FETCH(AvInputFormat, AVIOFormatId, AVInputFormat);
+    FFMPEG_PTR_CHECK(AvInputFormat, 0);
     MimeType = AvInputFormat->mime_type;
   } else {
     FFMPEG_PTR_FETCH(AvOutputFormat, AVIOFormatId, AVOutputFormat);
+    FFMPEG_PTR_CHECK(AvOutputFormat, 0);
     MimeType = AvOutputFormat->mime_type;
   }
 
@@ -173,9 +187,10 @@ Expect<int32_t> AVInputFormatMimeType::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_SPAN_CHECK(MimeTypeBuf, MemInst, char, MimeTypePtr, MimeTypeLen, "");
   FFMPEG_PTR_FETCH(AvInputFormat, AVInputFormatId, AVInputFormat);
+  FFMPEG_PTR_CHECK(AvInputFormat, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *MimeType = AvInputFormat->mime_type;
-  std::copy_n(MimeType, MimeTypeLen, MimeTypeBuf.data());
+  copyCStringToBuffer(MimeTypeBuf.data(), MimeTypeLen, MimeType);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -186,20 +201,30 @@ Expect<int32_t> AVOutputFormatMimeType::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_SPAN_CHECK(MimeTypeBuf, MemInst, char, MimeTypePtr, MimeTypeLen, "");
   FFMPEG_PTR_FETCH(AvOutputFormat, AVOutputFormatId, AVOutputFormat);
+  FFMPEG_PTR_CHECK(AvOutputFormat, static_cast<int32_t>(ErrNo::InternalError));
 
   const char *MimeType = AvOutputFormat->mime_type;
-  std::copy_n(MimeType, MimeTypeLen, MimeTypeBuf.data());
+  copyCStringToBuffer(MimeTypeBuf.data(), MimeTypeLen, MimeType);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> AVOutputFormatFlags::body(const Runtime::CallingFrame &,
                                           uint32_t AVOutputFormatId) {
   FFMPEG_PTR_FETCH(AvOutputFormat, AVOutputFormatId, AVOutputFormat);
+  FFMPEG_PTR_CHECK(AvOutputFormat, 0);
   return AvOutputFormat->flags;
 }
 
 Expect<int32_t> AVInputOutputFormatFree::body(const Runtime::CallingFrame &,
                                               uint32_t AVInputOutputId) {
+  FFMPEG_PTR_FETCH(AvInputFormat, AVInputOutputId, AVInputFormat);
+  FFMPEG_PTR_FETCH(AvOutputFormat, AVInputOutputId, AVOutputFormat);
+  if (AvInputFormat == nullptr && AvOutputFormat == nullptr) {
+    if (Env.get()->fetchData(AVInputOutputId) != nullptr) {
+      return static_cast<int32_t>(ErrNo::InternalError);
+    }
+    return static_cast<int32_t>(ErrNo::Success);
+  }
   FFMPEG_PTR_DELETE(AVInputOutputId);
   return static_cast<int32_t>(ErrNo::Success);
 }

--- a/plugins/wasmedge_ffmpeg/avformat/avStream.cpp
+++ b/plugins/wasmedge_ffmpeg/avformat/avStream.cpp
@@ -12,15 +12,25 @@ namespace Host {
 namespace WasmEdgeFFmpeg {
 namespace AVFormat {
 
+namespace {
+AVStream **streamAt(AVFormatContext *Ctx, uint32_t Idx) {
+  if (Ctx == nullptr) {
+    return nullptr;
+  }
+  return checkedArraySlot(Ctx->streams, Ctx->nb_streams, Idx);
+}
+} // namespace
+
 Expect<int32_t> AVStreamId::body(const Runtime::CallingFrame &,
                                  uint32_t AvFormatCtxId, uint32_t StreamIdx) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  AVStream **AvStream = AvFormatContext->streams;
-
-  // No check here (Check)
-  // Raw Pointer Iteration.
-  for (unsigned int I = 1; I <= StreamIdx; I++) {
-    AvStream++;
+  AVStream **AvStream = streamAt(AvFormatContext, StreamIdx);
+  if (AvStream == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVStreamId: invalid stream index {} "
+                  "(format context id {}, nb_streams={})"sv,
+                  StreamIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_streams : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   return static_cast<AVStream *>(*AvStream)->id;
@@ -30,10 +40,13 @@ Expect<int32_t> AVStreamIndex::body(const Runtime::CallingFrame &,
                                     uint32_t AvFormatCtxId,
                                     uint32_t StreamIdx) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  AVStream **AvStream = AvFormatContext->streams;
-
-  for (unsigned int I = 1; I <= StreamIdx; I++) {
-    AvStream++;
+  AVStream **AvStream = streamAt(AvFormatContext, StreamIdx);
+  if (AvStream == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVStreamIndex: invalid stream index {} "
+                  "(format context id {}, nb_streams={})"sv,
+                  StreamIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_streams : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   return static_cast<AVStream *>(*AvStream)->index;
@@ -48,15 +61,18 @@ Expect<int32_t> AVStreamCodecPar::body(const Runtime::CallingFrame &Frame,
                 "Failed when accessing the return CodecParameter Memory"sv);
 
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  AVStream **AvStream = AvFormatContext->streams;
-
-  for (unsigned int I = 1; I <= StreamIdx; I++) {
-    AvStream++;
+  AVStream **AvStream = streamAt(AvFormatContext, StreamIdx);
+  if (AvStream == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVStreamCodecPar: invalid stream index "
+                  "{} (format context id {}, nb_streams={})"sv,
+                  StreamIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_streams : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   AVCodecParameters *CodecParam =
       (static_cast<AVStream *>(*AvStream))->codecpar;
-  FFMPEG_PTR_STORE(CodecParam, CodecParamId);
+  FFMPEG_PTR_STORE_CHILD(CodecParam, CodecParamId, AvFormatCtxId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -69,10 +85,13 @@ Expect<int32_t> AVStreamTimebase::body(const Runtime::CallingFrame &Frame,
   MEM_PTR_CHECK(Den, MemInst, int32_t, DenPtr, "");
 
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  AVStream **AvStream = AvFormatContext->streams;
-
-  for (unsigned int I = 1; I <= StreamIdx; I++) {
-    AvStream++;
+  AVStream **AvStream = streamAt(AvFormatContext, StreamIdx);
+  if (AvStream == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVStreamTimebase: invalid stream index "
+                  "{} (format context id {}, nb_streams={})"sv,
+                  StreamIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_streams : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   AVRational const AvRational = static_cast<AVStream *>(*AvStream)->time_base;
@@ -87,9 +106,13 @@ Expect<int32_t> AVStreamSetTimebase::body(const Runtime::CallingFrame &,
                                           uint32_t StreamIdx) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
 
-  AVStream **AvStream = AvFormatContext->streams;
-  for (unsigned int I = 1; I <= StreamIdx; I++) {
-    AvStream++;
+  AVStream **AvStream = streamAt(AvFormatContext, StreamIdx);
+  if (AvStream == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVStreamSetTimebase: invalid stream "
+                  "index {} (format context id {}, nb_streams={})"sv,
+                  StreamIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_streams : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   AVRational const Timebase = av_make_q(Num, Den);
@@ -101,10 +124,13 @@ Expect<int64_t> AVStreamDuration::body(const Runtime::CallingFrame &,
                                        uint32_t AvFormatCtxId,
                                        uint32_t StreamIdx) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  AVStream **AvStream = AvFormatContext->streams;
-
-  for (unsigned int I = 1; I <= StreamIdx; I++) {
-    AvStream++;
+  AVStream **AvStream = streamAt(AvFormatContext, StreamIdx);
+  if (AvStream == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVStreamDuration: invalid stream index "
+                  "{} (format context id {}, nb_streams={})"sv,
+                  StreamIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_streams : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   return static_cast<AVStream *>(*AvStream)->duration;
@@ -114,10 +140,13 @@ Expect<int64_t> AVStreamStartTime::body(const Runtime::CallingFrame &,
                                         uint32_t AvFormatCtxId,
                                         uint32_t StreamIdx) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  AVStream **AvStream = AvFormatContext->streams;
-
-  for (unsigned int I = 1; I <= StreamIdx; I++) {
-    AvStream++;
+  AVStream **AvStream = streamAt(AvFormatContext, StreamIdx);
+  if (AvStream == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVStreamStartTime: invalid stream index "
+                  "{} (format context id {}, nb_streams={})"sv,
+                  StreamIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_streams : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   return static_cast<AVStream *>(*AvStream)->start_time;
@@ -127,10 +156,13 @@ Expect<int64_t> AVStreamNbFrames::body(const Runtime::CallingFrame &,
                                        uint32_t AvFormatCtxId,
                                        uint32_t StreamIdx) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  AVStream **AvStream = AvFormatContext->streams;
-
-  for (unsigned int I = 1; I <= StreamIdx; I++) {
-    AvStream++;
+  AVStream **AvStream = streamAt(AvFormatContext, StreamIdx);
+  if (AvStream == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVStreamNbFrames: invalid stream index "
+                  "{} (format context id {}, nb_streams={})"sv,
+                  StreamIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_streams : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   return static_cast<AVStream *>(*AvStream)->nb_frames;
@@ -141,10 +173,13 @@ Expect<int32_t> AVStreamDisposition::body(const Runtime::CallingFrame &,
                                           uint32_t StreamIdx) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
 
-  AVStream **AvStream = AvFormatContext->streams;
-
-  for (unsigned int I = 1; I <= StreamIdx; I++) {
-    AvStream++;
+  AVStream **AvStream = streamAt(AvFormatContext, StreamIdx);
+  if (AvStream == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVStreamDisposition: invalid stream "
+                  "index {} (format context id {}, nb_streams={})"sv,
+                  StreamIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_streams : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   return static_cast<AVStream *>(*AvStream)->disposition;
@@ -159,10 +194,13 @@ Expect<int32_t> AVStreamRFrameRate::body(const Runtime::CallingFrame &Frame,
   MEM_PTR_CHECK(Den, MemInst, int32_t, DenPtr, "");
 
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  AVStream **AvStream = AvFormatContext->streams;
-
-  for (unsigned int I = 1; I <= StreamIdx; I++) {
-    AvStream++;
+  AVStream **AvStream = streamAt(AvFormatContext, StreamIdx);
+  if (AvStream == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVStreamRFrameRate: invalid stream "
+                  "index {} (format context id {}, nb_streams={})"sv,
+                  StreamIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_streams : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   AVRational const AvRational =
@@ -178,9 +216,13 @@ Expect<int32_t> AVStreamSetRFrameRate::body(const Runtime::CallingFrame &,
                                             uint32_t StreamIdx) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
 
-  AVStream **AvStream = AvFormatContext->streams;
-  for (unsigned int I = 1; I <= StreamIdx; I++) {
-    AvStream++;
+  AVStream **AvStream = streamAt(AvFormatContext, StreamIdx);
+  if (AvStream == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVStreamSetRFrameRate: invalid stream "
+                  "index {} (format context id {}, nb_streams={})"sv,
+                  StreamIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_streams : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   AVRational const RFrameRate = av_make_q(Num, Den);
@@ -197,10 +239,13 @@ Expect<int32_t> AVStreamAvgFrameRate::body(const Runtime::CallingFrame &Frame,
   MEM_PTR_CHECK(Den, MemInst, int32_t, DenPtr, "");
 
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  AVStream **AvStream = AvFormatContext->streams;
-
-  for (unsigned int I = 1; I <= StreamIdx; I++) {
-    AvStream++;
+  AVStream **AvStream = streamAt(AvFormatContext, StreamIdx);
+  if (AvStream == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVStreamAvgFrameRate: invalid stream "
+                  "index {} (format context id {}, nb_streams={})"sv,
+                  StreamIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_streams : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   AVRational const AvRational =
@@ -216,10 +261,13 @@ Expect<int32_t> AVStreamSetAvgFrameRate::body(const Runtime::CallingFrame &,
                                               uint32_t StreamIdx) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
 
-  AVStream **AvStream = AvFormatContext->streams;
-
-  for (unsigned int I = 1; I <= StreamIdx; I++) {
-    AvStream++;
+  AVStream **AvStream = streamAt(AvFormatContext, StreamIdx);
+  if (AvStream == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVStreamSetAvgFrameRate: invalid stream "
+                  "index {} (format context id {}, nb_streams={})"sv,
+                  StreamIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_streams : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   AVRational const AvgFrameRate = av_make_q(Num, Den);
@@ -236,17 +284,16 @@ Expect<int32_t> AVStreamMetadata::body(const Runtime::CallingFrame &Frame,
 
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
 
-  AVStream **AvStream = AvFormatContext->streams;
-
-  for (unsigned int I = 1; I <= StreamIdx; I++) {
-    AvStream++;
+  AVStream **AvStream = streamAt(AvFormatContext, StreamIdx);
+  if (AvStream == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVStreamMetadata: invalid stream index "
+                  "{} (format context id {}, nb_streams={})"sv,
+                  StreamIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_streams : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
-  AVDictionary **AvDictionary =
-      static_cast<AVDictionary **>(av_malloc(sizeof(AVDictionary *)));
-
-  *AvDictionary = (*AvStream)->metadata;
-  FFMPEG_PTR_STORE(AvDictionary, DictId);
+  FFMPEG_PTR_STORE_CHILD(&(*AvStream)->metadata, DictId, AvFormatCtxId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -256,29 +303,31 @@ Expect<int32_t> AVStreamSetMetadata::body(const Runtime::CallingFrame &,
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
   FFMPEG_PTR_FETCH(AvDictionary, DictId, AVDictionary *);
 
-  AVStream **AvStream = AvFormatContext->streams;
-
-  for (unsigned int I = 1; I <= StreamIdx; I++) {
-    AvStream++;
+  AVStream **AvStream = streamAt(AvFormatContext, StreamIdx);
+  if (AvStream == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVStreamSetMetadata: invalid stream "
+                  "index {} (format context id {}, nb_streams={})"sv,
+                  StreamIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_streams : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
-  if (AvDictionary == nullptr) {
-    (*AvStream)->metadata = nullptr;
-  } else {
-    (*AvStream)->metadata = *AvDictionary;
-  }
-
-  return static_cast<int32_t>(ErrNo::Success);
+  FFMPEG_PTR_CHECK_NONZERO(AvDictionary, DictId,
+                           static_cast<int32_t>(ErrNo::InternalError));
+  return applyMetadataCopy(&(*AvStream)->metadata, AvDictionary);
 }
 
 Expect<int32_t> AVStreamDiscard::body(const Runtime::CallingFrame &,
                                       uint32_t AvFormatCtxId,
                                       uint32_t StreamIdx) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  AVStream **AvStream = AvFormatContext->streams;
-
-  for (unsigned int I = 1; I <= StreamIdx; I++) {
-    AvStream++;
+  AVStream **AvStream = streamAt(AvFormatContext, StreamIdx);
+  if (AvStream == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVStreamDiscard: invalid stream index "
+                  "{} (format context id {}, nb_streams={})"sv,
+                  StreamIdx, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_streams : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   return static_cast<int32_t>((*AvStream)->discard);

--- a/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
+++ b/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
@@ -20,6 +20,7 @@ Expect<int32_t> AVFormatCtxIFormat::body(const Runtime::CallingFrame &Frame,
                 "Failed when accessing the return AVInputFormat Memory"sv);
 
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatCtx, static_cast<int32_t>(ErrNo::InternalError));
 
   AVInputFormat const *AvInputFormat = AvFormatCtx->iformat;
   FFMPEG_PTR_STORE(const_cast<AVInputFormat *>(AvInputFormat), AvInputFormatId);
@@ -34,6 +35,7 @@ Expect<int32_t> AVFormatCtxOFormat::body(const Runtime::CallingFrame &Frame,
                 "Failed when accessing the return AVOutputFormat Memory"sv);
 
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatCtx, static_cast<int32_t>(ErrNo::InternalError));
 
   AVOutputFormat const *AvOutputFormat = AvFormatCtx->oformat;
   FFMPEG_PTR_STORE(const_cast<AVOutputFormat *>(AvOutputFormat),
@@ -44,30 +46,35 @@ Expect<int32_t> AVFormatCtxOFormat::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> AVFormatCtxProbeScore::body(const Runtime::CallingFrame &,
                                             uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, 0);
   return AvFormatContext->probe_score;
 }
 
 Expect<uint32_t> AVFormatCtxNbStreams::body(const Runtime::CallingFrame &,
                                             uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, 0);
   return AvFormatContext->nb_streams;
 };
 
 Expect<int64_t> AVFormatCtxBitRate::body(const Runtime::CallingFrame &,
                                          uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, 0);
   return AvFormatContext->bit_rate;
 }
 
 Expect<int64_t> AVFormatCtxDuration::body(const Runtime::CallingFrame &,
                                           uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, 0);
   return AvFormatContext->duration;
 }
 
 Expect<uint32_t> AVFormatCtxNbChapters::body(const Runtime::CallingFrame &,
                                              uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, 0);
   return AvFormatContext->nb_chapters;
 }
 
@@ -75,6 +82,18 @@ Expect<int32_t> AVFormatCtxSetNbChapters::body(const Runtime::CallingFrame &,
                                                uint32_t AvFormatCtxId,
                                                uint32_t NbChapters) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  // nb_chapters is the allocation count that chapterAt, av_dynarray_add, and
+  // FFmpeg's teardown all trust: raising it indexes past the allocation and
+  // lowering it leaks chapters on close, so only the current value (a no-op)
+  // is accepted.
+  if (AvFormatContext == nullptr ||
+      NbChapters != AvFormatContext->nb_chapters) {
+    spdlog::error("[WasmEdge-FFmpeg] AVFormatCtxSetNbChapters: cannot set "
+                  "nb_chapters to {} (format context id {}, current {})"sv,
+                  NbChapters, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_chapters : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
   AvFormatContext->nb_chapters = NbChapters;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -88,11 +107,14 @@ Expect<int32_t> AVFormatCtxMetadata::body(const Runtime::CallingFrame &Frame,
 
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
 
-  AVDictionary **AvDictionary =
-      static_cast<AVDictionary **>(av_malloc(sizeof(AVDictionary *)));
+  if (AvFormatCtx == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVFormatCtxMetadata: invalid format "
+                  "context id {}"sv,
+                  AvFormatCtxId);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
 
-  *AvDictionary = AvFormatCtx->metadata;
-  FFMPEG_PTR_STORE(AvDictionary, DictId);
+  FFMPEG_PTR_STORE_CHILD(&AvFormatCtx->metadata, DictId, AvFormatCtxId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -102,12 +124,15 @@ Expect<int32_t> AVFormatCtxSetMetadata::body(const Runtime::CallingFrame &,
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
   FFMPEG_PTR_FETCH(AvDictionary, DictId, AVDictionary *);
 
-  if (AvDictionary == nullptr) {
-    AvFormatCtx->metadata = nullptr;
-  } else {
-    AvFormatCtx->metadata = *AvDictionary;
+  if (AvFormatCtx == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVFormatCtxSetMetadata: invalid format "
+                  "context id {}"sv,
+                  AvFormatCtxId);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
-  return static_cast<int32_t>(ErrNo::Success);
+  FFMPEG_PTR_CHECK_NONZERO(AvDictionary, DictId,
+                           static_cast<int32_t>(ErrNo::InternalError));
+  return applyMetadataCopy(&AvFormatCtx->metadata, AvDictionary);
 }
 
 } // namespace AVFormat

--- a/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
+++ b/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
@@ -20,6 +20,7 @@ Expect<int32_t> AVFormatCtxIFormat::body(const Runtime::CallingFrame &Frame,
                 "Failed when accessing the return AVInputFormat Memory"sv);
 
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatCtx, static_cast<int32_t>(ErrNo::InternalError));
 
   AVInputFormat const *AvInputFormat = AvFormatCtx->iformat;
   FFMPEG_PTR_STORE(const_cast<AVInputFormat *>(AvInputFormat), AvInputFormatId);
@@ -34,6 +35,7 @@ Expect<int32_t> AVFormatCtxOFormat::body(const Runtime::CallingFrame &Frame,
                 "Failed when accessing the return AVOutputFormat Memory"sv);
 
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatCtx, static_cast<int32_t>(ErrNo::InternalError));
 
   AVOutputFormat const *AvOutputFormat = AvFormatCtx->oformat;
   FFMPEG_PTR_STORE(const_cast<AVOutputFormat *>(AvOutputFormat),
@@ -44,30 +46,35 @@ Expect<int32_t> AVFormatCtxOFormat::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> AVFormatCtxProbeScore::body(const Runtime::CallingFrame &,
                                             uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, 0);
   return AvFormatContext->probe_score;
 }
 
 Expect<uint32_t> AVFormatCtxNbStreams::body(const Runtime::CallingFrame &,
                                             uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, 0);
   return AvFormatContext->nb_streams;
 };
 
 Expect<int64_t> AVFormatCtxBitRate::body(const Runtime::CallingFrame &,
                                          uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, 0);
   return AvFormatContext->bit_rate;
 }
 
 Expect<int64_t> AVFormatCtxDuration::body(const Runtime::CallingFrame &,
                                           uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, 0);
   return AvFormatContext->duration;
 }
 
 Expect<uint32_t> AVFormatCtxNbChapters::body(const Runtime::CallingFrame &,
                                              uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, 0);
   return AvFormatContext->nb_chapters;
 }
 
@@ -75,6 +82,14 @@ Expect<int32_t> AVFormatCtxSetNbChapters::body(const Runtime::CallingFrame &,
                                                uint32_t AvFormatCtxId,
                                                uint32_t NbChapters) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  if (AvFormatContext == nullptr ||
+      NbChapters != AvFormatContext->nb_chapters) {
+    spdlog::error("[WasmEdge-FFmpeg] AVFormatCtxSetNbChapters: cannot set "
+                  "nb_chapters to {} (format context id {}, current {})"sv,
+                  NbChapters, AvFormatCtxId,
+                  AvFormatContext ? AvFormatContext->nb_chapters : 0);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
   AvFormatContext->nb_chapters = NbChapters;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -88,11 +103,14 @@ Expect<int32_t> AVFormatCtxMetadata::body(const Runtime::CallingFrame &Frame,
 
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
 
-  AVDictionary **AvDictionary =
-      static_cast<AVDictionary **>(av_malloc(sizeof(AVDictionary *)));
+  if (AvFormatCtx == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVFormatCtxMetadata: invalid format "
+                  "context id {}"sv,
+                  AvFormatCtxId);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
 
-  *AvDictionary = AvFormatCtx->metadata;
-  FFMPEG_PTR_STORE(AvDictionary, DictId);
+  FFMPEG_PTR_STORE_CHILD(&AvFormatCtx->metadata, DictId, AvFormatCtxId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -102,12 +120,15 @@ Expect<int32_t> AVFormatCtxSetMetadata::body(const Runtime::CallingFrame &,
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
   FFMPEG_PTR_FETCH(AvDictionary, DictId, AVDictionary *);
 
-  if (AvDictionary == nullptr) {
-    AvFormatCtx->metadata = nullptr;
-  } else {
-    AvFormatCtx->metadata = *AvDictionary;
+  if (AvFormatCtx == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVFormatCtxSetMetadata: invalid format "
+                  "context id {}"sv,
+                  AvFormatCtxId);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
-  return static_cast<int32_t>(ErrNo::Success);
+  FFMPEG_PTR_CHECK_NONZERO(AvDictionary, DictId,
+                           static_cast<int32_t>(ErrNo::InternalError));
+  return applyMetadataCopy(&AvFormatCtx->metadata, AvDictionary);
 }
 
 } // namespace AVFormat

--- a/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
+++ b/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
@@ -19,20 +19,26 @@ Expect<int32_t> AVFormatOpenInput::body(const Runtime::CallingFrame &Frame,
                                         uint32_t AvInputFormatId,
                                         uint32_t AvDictionaryId) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(urlId, MemInst, char, UrlPtr,
-                "Failed when accessing the return URL memory"sv);
+  MEM_SPAN_CHECK(UrlId, MemInst, char, UrlPtr, UrlSize,
+                 "Failed when accessing the return URL memory"sv);
   MEM_PTR_CHECK(AvFormatCtxId, MemInst, uint32_t, AvFormatCtxPtr,
                 "Failed when accessing the return AVFormatContext Memory"sv);
 
-  std::string TargetUrl;
-  std::copy_n(urlId, UrlSize, std::back_inserter(TargetUrl));
+  std::string TargetUrl(UrlId.data(), UrlSize);
 
   AVFormatContext *AvFormatContext = nullptr;
   FFMPEG_PTR_FETCH(AvDictionary, AvDictionaryId, AVDictionary *);
   FFMPEG_PTR_FETCH(AvInputFormat, AvInputFormatId, AVInputFormat);
+  FFMPEG_PTR_CHECK_NONZERO(AvDictionary, AvDictionaryId,
+                           static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(AvInputFormat, AvInputFormatId,
+                           static_cast<int32_t>(ErrNo::InternalError));
 
   int const Res = avformat_open_input(&AvFormatContext, TargetUrl.c_str(),
                                       AvInputFormat, AvDictionary);
+  if (Res < 0) {
+    return Res;
+  }
   FFMPEG_PTR_STORE(AvFormatContext, AvFormatCtxId);
   return Res;
 }
@@ -41,14 +47,20 @@ Expect<int32_t> AVFormatFindStreamInfo::body(const Runtime::CallingFrame &,
                                              uint32_t AvFormatCtxId,
                                              uint32_t AvDictionaryId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_FETCH(AvDictionary, AvDictionaryId, AVDictionary *);
+  FFMPEG_PTR_CHECK_NONZERO(AvDictionary, AvDictionaryId,
+                           static_cast<int32_t>(ErrNo::InternalError));
   return avformat_find_stream_info(AvFormatContext, AvDictionary);
 }
 
 Expect<int32_t> AVFormatCloseInput::body(const Runtime::CallingFrame &,
                                          uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK_FREE(AvFormatCtx, AvFormatCtxId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   avformat_close_input(&AvFormatCtx);
+  Env.get()->deallocChildren(AvFormatCtxId);
   FFMPEG_PTR_DELETE(AvFormatCtxId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -56,12 +68,14 @@ Expect<int32_t> AVFormatCloseInput::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVReadPause::body(const Runtime::CallingFrame &,
                                   uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
   return av_read_pause(AvFormatContext);
 }
 
 Expect<int32_t> AVReadPlay::body(const Runtime::CallingFrame &,
                                  uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
   return av_read_play(AvFormatContext);
 }
 
@@ -71,6 +85,7 @@ Expect<int32_t> AVFormatSeekFile::body(const Runtime::CallingFrame &,
                                        int64_t Ts, int64_t MaxTs,
                                        int32_t Flags) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
   return avformat_seek_file(AvFormatContext, StreamIdx, MinTs, Ts, MaxTs,
                             Flags);
 }
@@ -79,13 +94,12 @@ Expect<int32_t> AVDumpFormat::body(const Runtime::CallingFrame &Frame,
                                    uint32_t AvFormatCtxId, int32_t Idx,
                                    uint32_t UrlPtr, uint32_t UrlSize,
                                    int32_t IsOutput) {
-  std::string TargetUrl;
-
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(UrlBuf, MemInst, char, UrlPtr, "");
+  MEM_SPAN_CHECK(UrlBuf, MemInst, char, UrlPtr, UrlSize, "");
 
-  std::copy_n(UrlBuf, UrlSize, std::back_inserter(TargetUrl));
+  std::string TargetUrl(UrlBuf.data(), UrlSize);
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatCtx, static_cast<int32_t>(ErrNo::InternalError));
 
   av_dump_format(AvFormatCtx, Idx, TargetUrl.c_str(), IsOutput);
   return static_cast<int32_t>(ErrNo::Success);
@@ -94,7 +108,10 @@ Expect<int32_t> AVDumpFormat::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> AVFormatFreeContext::body(const Runtime::CallingFrame &,
                                           uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK_FREE(AvFormatCtx, AvFormatCtxId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   avformat_free_context(AvFormatCtx);
+  Env.get()->deallocChildren(AvFormatCtxId);
   FFMPEG_PTR_DELETE(AvFormatCtxId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -106,18 +123,28 @@ Expect<int32_t> AVFindBestStream::body(const Runtime::CallingFrame &,
                                        int32_t RelatedStream,
                                        uint32_t DecoderRetId, int32_t Flags) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  FFMPEG_PTR_FETCH(DecoderRet, DecoderRetId, const AVCodec *);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
+
+  // No host function mints ids for a const AVCodec ** output cell, and tag
+  // normalization makes a stored AVCodec handle indistinguishable from one;
+  // passing it through would let av_find_best_stream overwrite the static
+  // AVCodec object. Reject any nonzero id and always pass NULL.
+  if (DecoderRetId != 0) {
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
 
   AVMediaType const AvMediaType =
       FFmpegUtils::MediaType::intoMediaType(MediaTypeId);
   return av_find_best_stream(AvFormatContext, AvMediaType, WantedStream,
-                             RelatedStream, DecoderRet, Flags);
+                             RelatedStream, nullptr, Flags);
 }
 
 Expect<int32_t> AVReadFrame::body(const Runtime::CallingFrame &,
                                   uint32_t AvFormatCtxId, uint32_t PacketId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_FETCH(AvPacket, PacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
 
   return av_read_frame(AvFormatContext, AvPacket);
 }
@@ -125,7 +152,9 @@ Expect<int32_t> AVReadFrame::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVIOClose::body(const Runtime::CallingFrame &,
                                 uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
-  avio_close(AvFormatCtx->pb);
+  FFMPEG_PTR_CHECK_FREE(AvFormatCtx, AvFormatCtxId,
+                        static_cast<int32_t>(ErrNo::InternalError));
+  avio_closep(&AvFormatCtx->pb);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -141,13 +170,17 @@ Expect<int32_t> AVFormatWriteHeader::body(const Runtime::CallingFrame &,
                                           uint32_t AvFormatCtxId,
                                           uint32_t DictId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_FETCH(AvDict, DictId, AVDictionary *);
+  FFMPEG_PTR_CHECK_NONZERO(AvDict, DictId,
+                           static_cast<int32_t>(ErrNo::InternalError));
   return avformat_write_header(AvFormatContext, AvDict);
 }
 
 Expect<int32_t> AVFormatWriteTrailer::body(const Runtime::CallingFrame &,
                                            uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
   return av_write_trailer(AvFormatContext);
 }
 
@@ -157,22 +190,23 @@ Expect<int32_t> AVFormatAllocOutputContext2::body(
     uint32_t FileNamePtr, uint32_t FileNameLen) {
   std::string Format;
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(FileId, MemInst, char, FileNamePtr,
-                "Failed when accessing the return FileName memory"sv);
+  MEM_SPAN_CHECK(FileId, MemInst, char, FileNamePtr, FileNameLen,
+                 "Failed when accessing the return FileName memory"sv);
   if (FormatLen > 0) {
-    MEM_PTR_CHECK(FormatId, MemInst, char, FormatNamePtr,
-                  "Failed when accessing the return FormatName memory"sv);
+    MEM_SPAN_CHECK(FormatId, MemInst, char, FormatNamePtr, FormatLen,
+                   "Failed when accessing the return FormatName memory"sv);
 
-    std::copy_n(FormatId, FormatLen, std::back_inserter(Format));
+    Format.assign(FormatId.data(), FormatLen);
   }
   MEM_PTR_CHECK(AvFormatCtxId, MemInst, uint32_t, AvFormatCtxPtr,
                 "Failed when accessing the return AVFormatContext Memory"sv);
 
-  std::string File;
-  std::copy_n(FileId, FileNameLen, std::back_inserter(File));
+  std::string File(FileId.data(), FileNameLen);
 
   AVFormatContext *AvFormatContext = nullptr;
   FFMPEG_PTR_FETCH(AvOutputFormat, AVOutputFormatId, AVOutputFormat);
+  FFMPEG_PTR_CHECK_NONZERO(AvOutputFormat, AVOutputFormatId,
+                           static_cast<int32_t>(ErrNo::InternalError));
 
   int Res = 0;
   if (FormatLen == 0) {
@@ -182,6 +216,9 @@ Expect<int32_t> AVFormatAllocOutputContext2::body(
     Res = avformat_alloc_output_context2(&AvFormatContext, AvOutputFormat,
                                          Format.c_str(), File.c_str());
   }
+  if (Res < 0) {
+    return Res;
+  }
   FFMPEG_PTR_STORE(AvFormatContext, AvFormatCtxId);
   return Res;
 }
@@ -190,13 +227,13 @@ Expect<int32_t> AVIOOpen::body(const Runtime::CallingFrame &Frame,
                                uint32_t AvFormatCtxId, uint32_t FileNamePtr,
                                uint32_t FileNameLen, int32_t Flags) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(FileId, MemInst, char, FileNamePtr,
-                "Failed when accessing the return FileName memory"sv);
+  MEM_SPAN_CHECK(FileId, MemInst, char, FileNamePtr, FileNameLen,
+                 "Failed when accessing the return FileName memory"sv);
 
-  std::string File;
-  std::copy_n(FileId, FileNameLen, std::back_inserter(File));
+  std::string File(FileId.data(), FileNameLen);
 
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
 
   return avio_open(&(AvFormatContext->pb), File.c_str(), Flags);
 }
@@ -207,15 +244,19 @@ Expect<int32_t> AVIOOpen2::body(const Runtime::CallingFrame &Frame,
                                 uint32_t AVIOInterruptCBId,
                                 uint32_t AVDictionaryId) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(UrlId, MemInst, char, UrlPtr,
-                "Failed when accessing the return Url memory"sv);
+  MEM_SPAN_CHECK(UrlId, MemInst, char, UrlPtr, UrlLen,
+                 "Failed when accessing the return Url memory"sv);
 
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxtId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatCtx, static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_FETCH(AvDictionary, AVDictionaryId, AVDictionary *);
   FFMPEG_PTR_FETCH(AvIOInterruptCB, AVIOInterruptCBId, AVIOInterruptCB);
+  FFMPEG_PTR_CHECK_NONZERO(AvDictionary, AVDictionaryId,
+                           static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(AvIOInterruptCB, AVIOInterruptCBId,
+                           static_cast<int32_t>(ErrNo::InternalError));
 
-  std::string TargetUrl;
-  std::copy_n(UrlId, UrlLen, std::back_inserter(TargetUrl));
+  std::string TargetUrl(UrlId.data(), UrlLen);
 
   return avio_open2(&(AvFormatCtx->pb), TargetUrl.c_str(), Flags,
                     AvIOInterruptCB, AvDictionary);
@@ -248,17 +289,68 @@ Expect<int32_t> AVChapterDynarrayAdd::body(const Runtime::CallingFrame &Frame,
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
   FFMPEG_PTR_FETCH(AvChapter, AvChapterId, AVChapter);
 
-  av_dynarray_add(&(AvFormatContext->chapters), NbChapters, AvChapter);
-  if (*(AvFormatContext->chapters) == nullptr && *(NbChapters) == 0) {
+  if (AvFormatContext == nullptr || AvChapter == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVChapterDynarrayAdd: invalid format "
+                  "context id {} or chapter id {}"sv,
+                  AvFormatCtxId, AvChapterId);
     return static_cast<int32_t>(ErrNo::InternalError);
   }
+
+  // A chapter already linked into a context is borrowed; re-adding it would
+  // append the same pointer twice and double-free it on teardown.
+  if (Env.get()->isBorrowed(AvChapterId)) {
+    spdlog::error("[WasmEdge-FFmpeg] AVChapterDynarrayAdd: chapter id {} is "
+                  "already linked into a format context"sv,
+                  AvChapterId);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+
+  // On a realloc failure av_dynarray_add frees and NULLs the array but leaves
+  // nb_chapters at the old count; resync it to 0 and free the orphaned
+  // chapters from the snapshot taken before the add.
+  int const OldNbChaptersValue = static_cast<int>(AvFormatContext->nb_chapters);
+  std::vector<AVChapter *> ExistingChapters;
+  if (AvFormatContext->chapters != nullptr && OldNbChaptersValue > 0) {
+    ExistingChapters.assign(AvFormatContext->chapters,
+                            AvFormatContext->chapters + OldNbChaptersValue);
+  }
+  int NbChaptersValue = OldNbChaptersValue;
+  av_dynarray_add(&(AvFormatContext->chapters), &NbChaptersValue, AvChapter);
+  if (AvFormatContext->chapters == nullptr ||
+      NbChaptersValue <= OldNbChaptersValue) {
+    AvFormatContext->nb_chapters = 0;
+    *NbChapters = 0;
+    for (AVChapter *const OrphanChapter : ExistingChapters) {
+      if (OrphanChapter == nullptr) {
+        continue;
+      }
+      void *const MetadataKey = &OrphanChapter->metadata;
+      av_dict_free(&OrphanChapter->metadata);
+      AVChapter *ToFree = OrphanChapter;
+      av_freep(&ToFree);
+      Env.get()->deallocByValue(OrphanChapter);
+      Env.get()->deallocByValue(MetadataKey);
+    }
+    spdlog::error("[WasmEdge-FFmpeg] AVChapterDynarrayAdd: av_dynarray_add "
+                  "failed (format context id {})"sv,
+                  AvFormatCtxId);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  AvFormatContext->nb_chapters = static_cast<unsigned int>(NbChaptersValue);
+  *NbChapters = NbChaptersValue;
+  Env.get()->markBorrowedChild(AvChapterId, AvFormatCtxId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> AVFreeP::body(const Runtime::CallingFrame &,
                               uint32_t AvChapterId) {
   FFMPEG_PTR_FETCH(AvChapter, AvChapterId, AVChapter);
-  av_freep(AvChapter);
+  FFMPEG_PTR_CHECK_FREE(AvChapter, AvChapterId,
+                        static_cast<int32_t>(ErrNo::InternalError));
+  if (!Env.get()->isBorrowed(AvChapterId)) {
+    av_dict_free(&AvChapter->metadata);
+    av_freep(&AvChapter);
+  }
   FFMPEG_PTR_DELETE(AvChapterId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -267,7 +359,10 @@ Expect<int32_t> AVInterleavedWriteFrame::body(const Runtime::CallingFrame &,
                                               uint32_t AvFormatCtxId,
                                               uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatCtx, static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK_NONZERO(AvPacket, AvPacketId,
+                           static_cast<int32_t>(ErrNo::InternalError));
 
   return av_interleaved_write_frame(AvFormatCtx, AvPacket);
 }
@@ -276,7 +371,10 @@ Expect<int32_t> AVWriteFrame::body(const Runtime::CallingFrame &,
                                    uint32_t AvFormatCtxId,
                                    uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatCtx, static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK_NONZERO(AvPacket, AvPacketId,
+                           static_cast<int32_t>(ErrNo::InternalError));
 
   return av_write_frame(AvFormatCtx, AvPacket);
 }
@@ -285,7 +383,9 @@ Expect<int32_t> AVFormatNewStream::body(const Runtime::CallingFrame &,
                                         uint32_t AvFormatCtxId,
                                         uint32_t AvCodecId) {
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatCtx, 0);
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK_NONZERO(AvCodec, AvCodecId, 0);
   AVStream *Stream = avformat_new_stream(AvFormatCtx, AvCodec);
   if (Stream == nullptr) {
     return 0;
@@ -299,21 +399,28 @@ Expect<uint32_t> AVGuessCodec::body(const Runtime::CallingFrame &Frame,
                                     uint32_t ShortNameLen, uint32_t FileNamePtr,
                                     uint32_t FileNameLen, uint32_t MimeTypePtr,
                                     uint32_t MimeTypeLen, int32_t MediaTypeId) {
-  MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(ShortNameBuf, MemInst, char, ShortNamePtr,
-                "Failed when accessing the return ShortName memory"sv);
-  MEM_PTR_CHECK(FileNameBuf, MemInst, char, FileNamePtr,
-                "Failed when accessing the return FileName memory"sv);
-  MEM_PTR_CHECK(MimeTypeBuf, MemInst, char, MimeTypePtr,
-                "Failed when accessing the return MimeType memory"sv);
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (unlikely(MemInst == nullptr)) {
+    spdlog::error("[WasmEdge-FFmpeg] Memory instance not found."sv);
+    return FFmpegUtils::CodecID::fromAVCodecID(AV_CODEC_ID_NONE);
+  }
+  auto ShortNameBuf = MemInst->getSpan<char>(ShortNamePtr, ShortNameLen);
+  auto FileNameBuf = MemInst->getSpan<char>(FileNamePtr, FileNameLen);
+  auto MimeTypeBuf = MemInst->getSpan<char>(MimeTypePtr, MimeTypeLen);
+  if (unlikely(ShortNameBuf.size() != ShortNameLen ||
+               FileNameBuf.size() != FileNameLen ||
+               MimeTypeBuf.size() != MimeTypeLen)) {
+    spdlog::error("[WasmEdge-FFmpeg] AVGuessCodec: failed when accessing the "
+                  "return string memory"sv);
+    return FFmpegUtils::CodecID::fromAVCodecID(AV_CODEC_ID_NONE);
+  }
   FFMPEG_PTR_FETCH(AvOutputFormat, AVIOFormatId, AVOutputFormat);
+  FFMPEG_PTR_CHECK(AvOutputFormat,
+                   FFmpegUtils::CodecID::fromAVCodecID(AV_CODEC_ID_NONE));
 
-  std::string ShortName;
-  std::string FileName;
-  std::string MimeType;
-  std::copy_n(ShortNameBuf, ShortNameLen, std::back_inserter(ShortName));
-  std::copy_n(FileNameBuf, FileNameLen, std::back_inserter(FileName));
-  std::copy_n(MimeTypeBuf, MimeTypeLen, std::back_inserter(MimeType));
+  std::string ShortName(ShortNameBuf.data(), ShortNameLen);
+  std::string FileName(FileNameBuf.data(), FileNameLen);
+  std::string MimeType(MimeTypeBuf.data(), MimeTypeLen);
 
   AVMediaType const MediaType =
       FFmpegUtils::MediaType::intoMediaType(MediaTypeId);
@@ -337,9 +444,7 @@ Expect<int32_t> AVFormatConfiguration::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(ConfigBuf, MemInst, char, ConfigPtr, ConfigLen, "");
 
   const char *Config = avformat_configuration();
-  auto Actual = std::strlen(Config);
-  auto N = std::min<uint32_t>(ConfigLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(Config, N, ConfigBuf.data());
+  copyCStringToBuffer(ConfigBuf.data(), ConfigLen, Config);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -355,9 +460,7 @@ Expect<int32_t> AVFormatLicense::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(LicenseBuf, MemInst, char, LicensePtr, LicenseLen, "");
 
   const char *License = avformat_license();
-  auto Actual = std::strlen(License);
-  auto N = std::min<uint32_t>(LicenseLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(License, N, LicenseBuf.data());
+  copyCStringToBuffer(LicenseBuf.data(), LicenseLen, License);
   return static_cast<int32_t>(ErrNo::Success);
 }
 

--- a/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
+++ b/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
@@ -19,20 +19,26 @@ Expect<int32_t> AVFormatOpenInput::body(const Runtime::CallingFrame &Frame,
                                         uint32_t AvInputFormatId,
                                         uint32_t AvDictionaryId) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(urlId, MemInst, char, UrlPtr,
-                "Failed when accessing the return URL memory"sv);
+  MEM_SPAN_CHECK(UrlId, MemInst, char, UrlPtr, UrlSize,
+                 "Failed when accessing the return URL memory"sv);
   MEM_PTR_CHECK(AvFormatCtxId, MemInst, uint32_t, AvFormatCtxPtr,
                 "Failed when accessing the return AVFormatContext Memory"sv);
 
-  std::string TargetUrl;
-  std::copy_n(urlId, UrlSize, std::back_inserter(TargetUrl));
+  std::string TargetUrl(UrlId.data(), UrlSize);
 
   AVFormatContext *AvFormatContext = nullptr;
   FFMPEG_PTR_FETCH(AvDictionary, AvDictionaryId, AVDictionary *);
   FFMPEG_PTR_FETCH(AvInputFormat, AvInputFormatId, AVInputFormat);
+  FFMPEG_PTR_CHECK_NONZERO(AvDictionary, AvDictionaryId,
+                           static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(AvInputFormat, AvInputFormatId,
+                           static_cast<int32_t>(ErrNo::InternalError));
 
   int const Res = avformat_open_input(&AvFormatContext, TargetUrl.c_str(),
                                       AvInputFormat, AvDictionary);
+  if (Res < 0) {
+    return Res;
+  }
   FFMPEG_PTR_STORE(AvFormatContext, AvFormatCtxId);
   return Res;
 }
@@ -41,14 +47,20 @@ Expect<int32_t> AVFormatFindStreamInfo::body(const Runtime::CallingFrame &,
                                              uint32_t AvFormatCtxId,
                                              uint32_t AvDictionaryId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_FETCH(AvDictionary, AvDictionaryId, AVDictionary *);
+  FFMPEG_PTR_CHECK_NONZERO(AvDictionary, AvDictionaryId,
+                           static_cast<int32_t>(ErrNo::InternalError));
   return avformat_find_stream_info(AvFormatContext, AvDictionary);
 }
 
 Expect<int32_t> AVFormatCloseInput::body(const Runtime::CallingFrame &,
                                          uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK_FREE(AvFormatCtx, AvFormatCtxId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   avformat_close_input(&AvFormatCtx);
+  Env.get()->deallocChildren(AvFormatCtxId);
   FFMPEG_PTR_DELETE(AvFormatCtxId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -56,12 +68,14 @@ Expect<int32_t> AVFormatCloseInput::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVReadPause::body(const Runtime::CallingFrame &,
                                   uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
   return av_read_pause(AvFormatContext);
 }
 
 Expect<int32_t> AVReadPlay::body(const Runtime::CallingFrame &,
                                  uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
   return av_read_play(AvFormatContext);
 }
 
@@ -71,6 +85,7 @@ Expect<int32_t> AVFormatSeekFile::body(const Runtime::CallingFrame &,
                                        int64_t Ts, int64_t MaxTs,
                                        int32_t Flags) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
   return avformat_seek_file(AvFormatContext, StreamIdx, MinTs, Ts, MaxTs,
                             Flags);
 }
@@ -79,13 +94,12 @@ Expect<int32_t> AVDumpFormat::body(const Runtime::CallingFrame &Frame,
                                    uint32_t AvFormatCtxId, int32_t Idx,
                                    uint32_t UrlPtr, uint32_t UrlSize,
                                    int32_t IsOutput) {
-  std::string TargetUrl;
-
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(UrlBuf, MemInst, char, UrlPtr, "");
+  MEM_SPAN_CHECK(UrlBuf, MemInst, char, UrlPtr, UrlSize, "");
 
-  std::copy_n(UrlBuf, UrlSize, std::back_inserter(TargetUrl));
+  std::string TargetUrl(UrlBuf.data(), UrlSize);
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatCtx, static_cast<int32_t>(ErrNo::InternalError));
 
   av_dump_format(AvFormatCtx, Idx, TargetUrl.c_str(), IsOutput);
   return static_cast<int32_t>(ErrNo::Success);
@@ -94,7 +108,10 @@ Expect<int32_t> AVDumpFormat::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> AVFormatFreeContext::body(const Runtime::CallingFrame &,
                                           uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK_FREE(AvFormatCtx, AvFormatCtxId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   avformat_free_context(AvFormatCtx);
+  Env.get()->deallocChildren(AvFormatCtxId);
   FFMPEG_PTR_DELETE(AvFormatCtxId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -106,18 +123,24 @@ Expect<int32_t> AVFindBestStream::body(const Runtime::CallingFrame &,
                                        int32_t RelatedStream,
                                        uint32_t DecoderRetId, int32_t Flags) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
-  FFMPEG_PTR_FETCH(DecoderRet, DecoderRetId, const AVCodec *);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
+
+  if (DecoderRetId != 0) {
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
 
   AVMediaType const AvMediaType =
       FFmpegUtils::MediaType::intoMediaType(MediaTypeId);
   return av_find_best_stream(AvFormatContext, AvMediaType, WantedStream,
-                             RelatedStream, DecoderRet, Flags);
+                             RelatedStream, nullptr, Flags);
 }
 
 Expect<int32_t> AVReadFrame::body(const Runtime::CallingFrame &,
                                   uint32_t AvFormatCtxId, uint32_t PacketId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_FETCH(AvPacket, PacketId, AVPacket);
+  FFMPEG_PTR_CHECK(AvPacket, static_cast<int32_t>(ErrNo::InternalError));
 
   return av_read_frame(AvFormatContext, AvPacket);
 }
@@ -125,7 +148,9 @@ Expect<int32_t> AVReadFrame::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVIOClose::body(const Runtime::CallingFrame &,
                                 uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
-  avio_close(AvFormatCtx->pb);
+  FFMPEG_PTR_CHECK_FREE(AvFormatCtx, AvFormatCtxId,
+                        static_cast<int32_t>(ErrNo::InternalError));
+  avio_closep(&AvFormatCtx->pb);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -141,13 +166,17 @@ Expect<int32_t> AVFormatWriteHeader::body(const Runtime::CallingFrame &,
                                           uint32_t AvFormatCtxId,
                                           uint32_t DictId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_FETCH(AvDict, DictId, AVDictionary *);
+  FFMPEG_PTR_CHECK_NONZERO(AvDict, DictId,
+                           static_cast<int32_t>(ErrNo::InternalError));
   return avformat_write_header(AvFormatContext, AvDict);
 }
 
 Expect<int32_t> AVFormatWriteTrailer::body(const Runtime::CallingFrame &,
                                            uint32_t AvFormatCtxId) {
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
   return av_write_trailer(AvFormatContext);
 }
 
@@ -157,22 +186,23 @@ Expect<int32_t> AVFormatAllocOutputContext2::body(
     uint32_t FileNamePtr, uint32_t FileNameLen) {
   std::string Format;
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(FileId, MemInst, char, FileNamePtr,
-                "Failed when accessing the return FileName memory"sv);
+  MEM_SPAN_CHECK(FileId, MemInst, char, FileNamePtr, FileNameLen,
+                 "Failed when accessing the return FileName memory"sv);
   if (FormatLen > 0) {
-    MEM_PTR_CHECK(FormatId, MemInst, char, FormatNamePtr,
-                  "Failed when accessing the return FormatName memory"sv);
+    MEM_SPAN_CHECK(FormatId, MemInst, char, FormatNamePtr, FormatLen,
+                   "Failed when accessing the return FormatName memory"sv);
 
-    std::copy_n(FormatId, FormatLen, std::back_inserter(Format));
+    Format.assign(FormatId.data(), FormatLen);
   }
   MEM_PTR_CHECK(AvFormatCtxId, MemInst, uint32_t, AvFormatCtxPtr,
                 "Failed when accessing the return AVFormatContext Memory"sv);
 
-  std::string File;
-  std::copy_n(FileId, FileNameLen, std::back_inserter(File));
+  std::string File(FileId.data(), FileNameLen);
 
   AVFormatContext *AvFormatContext = nullptr;
   FFMPEG_PTR_FETCH(AvOutputFormat, AVOutputFormatId, AVOutputFormat);
+  FFMPEG_PTR_CHECK_NONZERO(AvOutputFormat, AVOutputFormatId,
+                           static_cast<int32_t>(ErrNo::InternalError));
 
   int Res = 0;
   if (FormatLen == 0) {
@@ -182,6 +212,9 @@ Expect<int32_t> AVFormatAllocOutputContext2::body(
     Res = avformat_alloc_output_context2(&AvFormatContext, AvOutputFormat,
                                          Format.c_str(), File.c_str());
   }
+  if (Res < 0) {
+    return Res;
+  }
   FFMPEG_PTR_STORE(AvFormatContext, AvFormatCtxId);
   return Res;
 }
@@ -190,13 +223,13 @@ Expect<int32_t> AVIOOpen::body(const Runtime::CallingFrame &Frame,
                                uint32_t AvFormatCtxId, uint32_t FileNamePtr,
                                uint32_t FileNameLen, int32_t Flags) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(FileId, MemInst, char, FileNamePtr,
-                "Failed when accessing the return FileName memory"sv);
+  MEM_SPAN_CHECK(FileId, MemInst, char, FileNamePtr, FileNameLen,
+                 "Failed when accessing the return FileName memory"sv);
 
-  std::string File;
-  std::copy_n(FileId, FileNameLen, std::back_inserter(File));
+  std::string File(FileId.data(), FileNameLen);
 
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatContext, static_cast<int32_t>(ErrNo::InternalError));
 
   return avio_open(&(AvFormatContext->pb), File.c_str(), Flags);
 }
@@ -207,15 +240,19 @@ Expect<int32_t> AVIOOpen2::body(const Runtime::CallingFrame &Frame,
                                 uint32_t AVIOInterruptCBId,
                                 uint32_t AVDictionaryId) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(UrlId, MemInst, char, UrlPtr,
-                "Failed when accessing the return Url memory"sv);
+  MEM_SPAN_CHECK(UrlId, MemInst, char, UrlPtr, UrlLen,
+                 "Failed when accessing the return Url memory"sv);
 
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxtId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatCtx, static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_FETCH(AvDictionary, AVDictionaryId, AVDictionary *);
   FFMPEG_PTR_FETCH(AvIOInterruptCB, AVIOInterruptCBId, AVIOInterruptCB);
+  FFMPEG_PTR_CHECK_NONZERO(AvDictionary, AVDictionaryId,
+                           static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(AvIOInterruptCB, AVIOInterruptCBId,
+                           static_cast<int32_t>(ErrNo::InternalError));
 
-  std::string TargetUrl;
-  std::copy_n(UrlId, UrlLen, std::back_inserter(TargetUrl));
+  std::string TargetUrl(UrlId.data(), UrlLen);
 
   return avio_open2(&(AvFormatCtx->pb), TargetUrl.c_str(), Flags,
                     AvIOInterruptCB, AvDictionary);
@@ -248,17 +285,63 @@ Expect<int32_t> AVChapterDynarrayAdd::body(const Runtime::CallingFrame &Frame,
   FFMPEG_PTR_FETCH(AvFormatContext, AvFormatCtxId, AVFormatContext);
   FFMPEG_PTR_FETCH(AvChapter, AvChapterId, AVChapter);
 
-  av_dynarray_add(&(AvFormatContext->chapters), NbChapters, AvChapter);
-  if (*(AvFormatContext->chapters) == nullptr && *(NbChapters) == 0) {
+  if (AvFormatContext == nullptr || AvChapter == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVChapterDynarrayAdd: invalid format "
+                  "context id {} or chapter id {}"sv,
+                  AvFormatCtxId, AvChapterId);
     return static_cast<int32_t>(ErrNo::InternalError);
   }
+
+  if (Env.get()->isBorrowed(AvChapterId)) {
+    spdlog::error("[WasmEdge-FFmpeg] AVChapterDynarrayAdd: chapter id {} is "
+                  "already linked into a format context"sv,
+                  AvChapterId);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+
+  int const OldNbChaptersValue = static_cast<int>(AvFormatContext->nb_chapters);
+  std::vector<AVChapter *> ExistingChapters;
+  if (AvFormatContext->chapters != nullptr && OldNbChaptersValue > 0) {
+    ExistingChapters.assign(AvFormatContext->chapters,
+                            AvFormatContext->chapters + OldNbChaptersValue);
+  }
+  int NbChaptersValue = OldNbChaptersValue;
+  av_dynarray_add(&(AvFormatContext->chapters), &NbChaptersValue, AvChapter);
+  if (AvFormatContext->chapters == nullptr ||
+      NbChaptersValue <= OldNbChaptersValue) {
+    AvFormatContext->nb_chapters = 0;
+    *NbChapters = 0;
+    for (AVChapter *const OrphanChapter : ExistingChapters) {
+      if (OrphanChapter == nullptr) {
+        continue;
+      }
+      void *const MetadataKey = &OrphanChapter->metadata;
+      av_dict_free(&OrphanChapter->metadata);
+      AVChapter *ToFree = OrphanChapter;
+      av_freep(&ToFree);
+      Env.get()->deallocByValue(OrphanChapter);
+      Env.get()->deallocByValue(MetadataKey);
+    }
+    spdlog::error("[WasmEdge-FFmpeg] AVChapterDynarrayAdd: av_dynarray_add "
+                  "failed (format context id {})"sv,
+                  AvFormatCtxId);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  AvFormatContext->nb_chapters = static_cast<unsigned int>(NbChaptersValue);
+  *NbChapters = NbChaptersValue;
+  Env.get()->markBorrowedChild(AvChapterId, AvFormatCtxId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> AVFreeP::body(const Runtime::CallingFrame &,
                               uint32_t AvChapterId) {
   FFMPEG_PTR_FETCH(AvChapter, AvChapterId, AVChapter);
-  av_freep(AvChapter);
+  FFMPEG_PTR_CHECK_FREE(AvChapter, AvChapterId,
+                        static_cast<int32_t>(ErrNo::InternalError));
+  if (!Env.get()->isBorrowed(AvChapterId)) {
+    av_dict_free(&AvChapter->metadata);
+    av_freep(&AvChapter);
+  }
   FFMPEG_PTR_DELETE(AvChapterId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -267,7 +350,10 @@ Expect<int32_t> AVInterleavedWriteFrame::body(const Runtime::CallingFrame &,
                                               uint32_t AvFormatCtxId,
                                               uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatCtx, static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK_NONZERO(AvPacket, AvPacketId,
+                           static_cast<int32_t>(ErrNo::InternalError));
 
   return av_interleaved_write_frame(AvFormatCtx, AvPacket);
 }
@@ -276,7 +362,10 @@ Expect<int32_t> AVWriteFrame::body(const Runtime::CallingFrame &,
                                    uint32_t AvFormatCtxId,
                                    uint32_t AvPacketId) {
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatCtx, static_cast<int32_t>(ErrNo::InternalError));
   FFMPEG_PTR_FETCH(AvPacket, AvPacketId, AVPacket);
+  FFMPEG_PTR_CHECK_NONZERO(AvPacket, AvPacketId,
+                           static_cast<int32_t>(ErrNo::InternalError));
 
   return av_write_frame(AvFormatCtx, AvPacket);
 }
@@ -285,7 +374,9 @@ Expect<int32_t> AVFormatNewStream::body(const Runtime::CallingFrame &,
                                         uint32_t AvFormatCtxId,
                                         uint32_t AvCodecId) {
   FFMPEG_PTR_FETCH(AvFormatCtx, AvFormatCtxId, AVFormatContext);
+  FFMPEG_PTR_CHECK(AvFormatCtx, 0);
   FFMPEG_PTR_FETCH(AvCodec, AvCodecId, const AVCodec);
+  FFMPEG_PTR_CHECK_NONZERO(AvCodec, AvCodecId, 0);
   AVStream *Stream = avformat_new_stream(AvFormatCtx, AvCodec);
   if (Stream == nullptr) {
     return 0;
@@ -299,21 +390,28 @@ Expect<uint32_t> AVGuessCodec::body(const Runtime::CallingFrame &Frame,
                                     uint32_t ShortNameLen, uint32_t FileNamePtr,
                                     uint32_t FileNameLen, uint32_t MimeTypePtr,
                                     uint32_t MimeTypeLen, int32_t MediaTypeId) {
-  MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(ShortNameBuf, MemInst, char, ShortNamePtr,
-                "Failed when accessing the return ShortName memory"sv);
-  MEM_PTR_CHECK(FileNameBuf, MemInst, char, FileNamePtr,
-                "Failed when accessing the return FileName memory"sv);
-  MEM_PTR_CHECK(MimeTypeBuf, MemInst, char, MimeTypePtr,
-                "Failed when accessing the return MimeType memory"sv);
+  auto *MemInst = Frame.getMemoryByIndex(0);
+  if (unlikely(MemInst == nullptr)) {
+    spdlog::error("[WasmEdge-FFmpeg] Memory instance not found."sv);
+    return FFmpegUtils::CodecID::fromAVCodecID(AV_CODEC_ID_NONE);
+  }
+  auto ShortNameBuf = MemInst->getSpan<char>(ShortNamePtr, ShortNameLen);
+  auto FileNameBuf = MemInst->getSpan<char>(FileNamePtr, FileNameLen);
+  auto MimeTypeBuf = MemInst->getSpan<char>(MimeTypePtr, MimeTypeLen);
+  if (unlikely(ShortNameBuf.size() != ShortNameLen ||
+               FileNameBuf.size() != FileNameLen ||
+               MimeTypeBuf.size() != MimeTypeLen)) {
+    spdlog::error("[WasmEdge-FFmpeg] AVGuessCodec: failed when accessing the "
+                  "return string memory"sv);
+    return FFmpegUtils::CodecID::fromAVCodecID(AV_CODEC_ID_NONE);
+  }
   FFMPEG_PTR_FETCH(AvOutputFormat, AVIOFormatId, AVOutputFormat);
+  FFMPEG_PTR_CHECK(AvOutputFormat,
+                   FFmpegUtils::CodecID::fromAVCodecID(AV_CODEC_ID_NONE));
 
-  std::string ShortName;
-  std::string FileName;
-  std::string MimeType;
-  std::copy_n(ShortNameBuf, ShortNameLen, std::back_inserter(ShortName));
-  std::copy_n(FileNameBuf, FileNameLen, std::back_inserter(FileName));
-  std::copy_n(MimeTypeBuf, MimeTypeLen, std::back_inserter(MimeType));
+  std::string ShortName(ShortNameBuf.data(), ShortNameLen);
+  std::string FileName(FileNameBuf.data(), FileNameLen);
+  std::string MimeType(MimeTypeBuf.data(), MimeTypeLen);
 
   AVMediaType const MediaType =
       FFmpegUtils::MediaType::intoMediaType(MediaTypeId);
@@ -337,9 +435,7 @@ Expect<int32_t> AVFormatConfiguration::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(ConfigBuf, MemInst, char, ConfigPtr, ConfigLen, "");
 
   const char *Config = avformat_configuration();
-  auto Actual = std::strlen(Config);
-  auto N = std::min<uint32_t>(ConfigLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(Config, N, ConfigBuf.data());
+  copyCStringToBuffer(ConfigBuf.data(), ConfigLen, Config);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -355,9 +451,7 @@ Expect<int32_t> AVFormatLicense::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(LicenseBuf, MemInst, char, LicensePtr, LicenseLen, "");
 
   const char *License = avformat_license();
-  auto Actual = std::strlen(License);
-  auto N = std::min<uint32_t>(LicenseLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(License, N, LicenseBuf.data());
+  copyCStringToBuffer(LicenseBuf.data(), LicenseLen, License);
   return static_cast<int32_t>(ErrNo::Success);
 }
 

--- a/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
+++ b/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
@@ -12,22 +12,39 @@ namespace Host {
 namespace WasmEdgeFFmpeg {
 namespace AVUtil {
 
+namespace {
+// Advances to the (PrevIdx + 1)-th entry matching Key, returning it (or nullptr
+// if the chain ends first) and reporting how many lookups it consumed.
+AVDictionaryEntry *dictEntryAt(AVDictionary *Dict, const char *Key,
+                               uint32_t PrevIdx, int Flags, uint32_t &Steps) {
+  AVDictionaryEntry *Entry = nullptr;
+  uint32_t Curr = 0;
+  while (Curr <= PrevIdx) {
+    Entry = av_dict_get(Dict, Key, Entry, Flags);
+    Curr++;
+    if (Entry == nullptr) {
+      break;
+    }
+  }
+  Steps = Curr;
+  return Entry;
+}
+} // namespace
+
 Expect<int32_t> AVDictSet::body(const Runtime::CallingFrame &Frame,
                                 uint32_t DictPtr, uint32_t KeyPtr,
                                 uint32_t KeyLen, uint32_t ValuePtr,
                                 uint32_t ValueLen, int32_t Flags) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(KeyBuf, MemInst, char, KeyPtr,
-                "Failed when accessing the return Key memory"sv);
-  MEM_PTR_CHECK(ValueBuf, MemInst, char, ValuePtr,
-                "Failed when accessing the return Value memory"sv);
+  MEM_SPAN_CHECK(KeyBuf, MemInst, char, KeyPtr, KeyLen,
+                 "Failed when accessing the return Key memory"sv);
+  MEM_SPAN_CHECK(ValueBuf, MemInst, char, ValuePtr, ValueLen,
+                 "Failed when accessing the return Value memory"sv);
   MEM_PTR_CHECK(DictId, MemInst, uint32_t, DictPtr,
                 "Failed to access Memory for AVDict"sv)
 
-  std::string Key;
-  std::string Value;
-  std::copy_n(KeyBuf, KeyLen, std::back_inserter(Key));
-  std::copy_n(ValueBuf, ValueLen, std::back_inserter(Value));
+  std::string Key(KeyBuf.data(), KeyLen);
+  std::string Value(ValueBuf.data(), ValueLen);
 
   int Res = 0;
 
@@ -35,10 +52,18 @@ Expect<int32_t> AVDictSet::body(const Runtime::CallingFrame &Frame,
   // passed. Else the Ptr contains a Number.
   if (*DictId) {
     FFMPEG_PTR_FETCH(AvDict, *DictId, AVDictionary *);
+    if (AvDict == nullptr) {
+      spdlog::error("[WasmEdge-FFmpeg] AVDictSet: invalid dictionary id {}"sv,
+                    *DictId);
+      return static_cast<int32_t>(ErrNo::InternalError);
+    }
     Res = av_dict_set(AvDict, Key.c_str(), Value.c_str(), Flags);
   } else {
     AVDictionary **AvDict =
         static_cast<AVDictionary **>(av_mallocz(sizeof(AVDictionary *)));
+    if (AvDict == nullptr) {
+      return static_cast<int32_t>(ErrNo::InternalError);
+    }
     Res = av_dict_set(AvDict, Key.c_str(), Value.c_str(), Flags);
     FFMPEG_PTR_STORE(AvDict, DictId);
   }
@@ -58,16 +83,28 @@ Expect<int32_t> AVDictCopy::body(const Runtime::CallingFrame &Frame,
   int Res = 0;
 
   if (SrcAvDict == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVDictCopy: invalid source dictionary "
+                  "id {}"sv,
+                  SrcDictId);
     return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   if (*DestDictId) {
     FFMPEG_PTR_FETCH(DestAvDict, *DestDictId, AVDictionary *);
+    if (DestAvDict == nullptr) {
+      spdlog::error("[WasmEdge-FFmpeg] AVDictCopy: invalid destination "
+                    "dictionary id {}"sv,
+                    *DestDictId);
+      return static_cast<int32_t>(ErrNo::InternalError);
+    }
     Res = av_dict_copy(DestAvDict, *SrcAvDict, Flags);
   } else {
     AVDictionary **DestAvDict =
         static_cast<AVDictionary **>(av_mallocz(sizeof(AVDictionary *)));
-    av_dict_copy(DestAvDict, *SrcAvDict, Flags);
+    if (DestAvDict == nullptr) {
+      return static_cast<int32_t>(ErrNo::InternalError);
+    }
+    Res = av_dict_copy(DestAvDict, *SrcAvDict, Flags);
     FFMPEG_PTR_STORE(DestAvDict, DestDictId);
   }
 
@@ -80,8 +117,8 @@ Expect<int32_t> AVDictGet::body(const Runtime::CallingFrame &Frame,
                                 uint32_t Flags, uint32_t KeyLenPtr,
                                 uint32_t ValueLenPtr) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(KeyStr, MemInst, char, KeyPtr,
-                "Failed when accessing the return Key memory"sv);
+  MEM_SPAN_CHECK(KeyStr, MemInst, char, KeyPtr, KeyLen,
+                 "Failed when accessing the return Key memory"sv);
   MEM_PTR_CHECK(KeyLenId, MemInst, uint32_t, KeyLenPtr,
                 "Failed when accessing the return KeyLen memory"sv);
   MEM_PTR_CHECK(ValueLenId, MemInst, uint32_t, ValueLenPtr,
@@ -91,19 +128,20 @@ Expect<int32_t> AVDictGet::body(const Runtime::CallingFrame &Frame,
 
   // Return if Dict was not created (i.e. 0 is passed as AVDictId).
   if (AvDict == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVDictGet: invalid dictionary id {}"sv,
+                  DictId);
     return static_cast<int32_t>(ErrNo::InternalError);
   }
-  std::string Key;
-  std::copy_n(KeyStr, KeyLen, std::back_inserter(Key));
+  std::string Key(KeyStr.data(), KeyLen);
 
-  AVDictionaryEntry *DictEntry = nullptr;
   uint32_t Curr = 0;
-  while (Curr <= PrevDictEntryIdx) {
-    DictEntry = av_dict_get(*AvDict, Key.c_str(), DictEntry, Flags);
-    Curr++;
-  }
+  AVDictionaryEntry *DictEntry =
+      dictEntryAt(*AvDict, Key.c_str(), PrevDictEntryIdx, Flags, Curr);
 
   if (DictEntry == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVDictGet: no dictionary entry found "
+                  "(dictionary id {}, prev entry index {})"sv,
+                  DictId, PrevDictEntryIdx);
     return static_cast<int32_t>(ErrNo::InternalError);
   }
 
@@ -117,8 +155,8 @@ Expect<int32_t> AVDictGetKeyValue::body(
     uint32_t KeyLen, uint32_t ValBufPtr, uint32_t ValBufLen, uint32_t KeyBufPtr,
     uint32_t KeyBufLen, uint32_t PrevDictEntryIdx, uint32_t Flags) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(KeyStr, MemInst, char, KeyPtr,
-                "Failed when accessing the return Key memory"sv);
+  MEM_SPAN_CHECK(KeyStr, MemInst, char, KeyPtr, KeyLen,
+                 "Failed when accessing the return Key memory"sv);
   MEM_SPAN_CHECK(KeyBuf, MemInst, char, KeyBufPtr, KeyBufLen, "");
   MEM_SPAN_CHECK(ValBuf, MemInst, char, ValBufPtr, ValBufLen, "");
 
@@ -126,33 +164,39 @@ Expect<int32_t> AVDictGetKeyValue::body(
 
   // Return if Dict was not created (i.e. 0 is passed as AVDictId).
   if (AvDict == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVDictGetKeyValue: invalid dictionary "
+                  "id {}"sv,
+                  DictId);
     return static_cast<int32_t>(ErrNo::InternalError);
   }
 
-  std::string Key;
-  std::copy_n(KeyStr, KeyLen, std::back_inserter(Key));
+  std::string Key(KeyStr.data(), KeyLen);
 
-  AVDictionaryEntry *DictEntry = nullptr;
   uint32_t Curr = 0;
-  while (Curr <= PrevDictEntryIdx) {
-    DictEntry = av_dict_get(*AvDict, Key.c_str(), DictEntry, Flags);
-    Curr++;
-  }
+  AVDictionaryEntry *DictEntry =
+      dictEntryAt(*AvDict, Key.c_str(), PrevDictEntryIdx, Flags, Curr);
   if (DictEntry == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVDictGetKeyValue: no dictionary entry "
+                  "found (dictionary id {}, prev entry index {})"sv,
+                  DictId, PrevDictEntryIdx);
     return static_cast<int32_t>(ErrNo::InternalError);
   }
-  std::copy_n(DictEntry->value, strlen(DictEntry->value), ValBuf.data());
-  std::copy_n(DictEntry->key, strlen(DictEntry->key), KeyBuf.data());
+  copyCStringToBuffer(ValBuf.data(), ValBufLen, DictEntry->value);
+  copyCStringToBuffer(KeyBuf.data(), KeyBufLen, DictEntry->key);
   return Curr;
 }
 
 Expect<int32_t> AVDictFree::body(const Runtime::CallingFrame &,
                                  uint32_t DictId) {
-  if (DictId == 0) {
-    return static_cast<int32_t>(ErrNo::Success);
-  }
   FFMPEG_PTR_FETCH(AvDict, DictId, AVDictionary *);
-  av_dict_free(AvDict);
+  FFMPEG_PTR_CHECK_FREE(AvDict, DictId,
+                        static_cast<int32_t>(ErrNo::InternalError));
+  // Owned ids free both the dictionary and its host-allocated ** holder; a
+  // borrowed id points into a parent-owned struct and frees neither.
+  if (!Env.get()->isBorrowed(DictId)) {
+    av_dict_free(AvDict);
+    av_free(AvDict);
+  }
   FFMPEG_PTR_DELETE(DictId);
   return static_cast<int32_t>(ErrNo::Success);
 }

--- a/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
+++ b/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
@@ -13,6 +13,17 @@ namespace WasmEdgeFFmpeg {
 namespace AVUtil {
 
 namespace {
+// AV_DICT_DONT_STRDUP_KEY / AV_DICT_DONT_STRDUP_VAL make FFmpeg adopt (and
+// later av_free) the key/value pointers, which here are borrowed from host
+// std::strings or alias the source dictionary. Keep only the flags that
+// affect lookup/insert behavior, so an ownership-transfer flag can never
+// reach FFmpeg; entries are still stored, just always copied.
+constexpr int SafeDictFlags = AV_DICT_MATCH_CASE | AV_DICT_IGNORE_SUFFIX |
+                              AV_DICT_DONT_OVERWRITE | AV_DICT_APPEND |
+                              AV_DICT_MULTIKEY;
+
+int sanitizeDictFlags(int Flags) { return Flags & SafeDictFlags; }
+
 // Advances to the (PrevIdx + 1)-th entry matching Key, returning it (or nullptr
 // if the chain ends first) and reporting how many lookups it consumed.
 AVDictionaryEntry *dictEntryAt(AVDictionary *Dict, const char *Key,
@@ -46,6 +57,7 @@ Expect<int32_t> AVDictSet::body(const Runtime::CallingFrame &Frame,
   std::string Key(KeyBuf.data(), KeyLen);
   std::string Value(ValueBuf.data(), ValueLen);
 
+  int const SafeFlags = sanitizeDictFlags(Flags);
   int Res = 0;
 
   // Using Maybe::uninit(); in Rust. If Uninitialized, zero is
@@ -57,14 +69,19 @@ Expect<int32_t> AVDictSet::body(const Runtime::CallingFrame &Frame,
                     *DictId);
       return static_cast<int32_t>(ErrNo::InternalError);
     }
-    Res = av_dict_set(AvDict, Key.c_str(), Value.c_str(), Flags);
+    Res = av_dict_set(AvDict, Key.c_str(), Value.c_str(), SafeFlags);
   } else {
     AVDictionary **AvDict =
         static_cast<AVDictionary **>(av_mallocz(sizeof(AVDictionary *)));
     if (AvDict == nullptr) {
       return static_cast<int32_t>(ErrNo::InternalError);
     }
-    Res = av_dict_set(AvDict, Key.c_str(), Value.c_str(), Flags);
+    Res = av_dict_set(AvDict, Key.c_str(), Value.c_str(), SafeFlags);
+    if (Res < 0) {
+      av_dict_free(AvDict);
+      av_free(AvDict);
+      return Res;
+    }
     FFMPEG_PTR_STORE(AvDict, DictId);
   }
 
@@ -80,6 +97,7 @@ Expect<int32_t> AVDictCopy::body(const Runtime::CallingFrame &Frame,
 
   FFMPEG_PTR_FETCH(SrcAvDict, SrcDictId, AVDictionary *);
 
+  int const SafeFlags = sanitizeDictFlags(static_cast<int>(Flags));
   int Res = 0;
 
   if (SrcAvDict == nullptr) {
@@ -97,14 +115,19 @@ Expect<int32_t> AVDictCopy::body(const Runtime::CallingFrame &Frame,
                     *DestDictId);
       return static_cast<int32_t>(ErrNo::InternalError);
     }
-    Res = av_dict_copy(DestAvDict, *SrcAvDict, Flags);
+    Res = av_dict_copy(DestAvDict, *SrcAvDict, SafeFlags);
   } else {
     AVDictionary **DestAvDict =
         static_cast<AVDictionary **>(av_mallocz(sizeof(AVDictionary *)));
     if (DestAvDict == nullptr) {
       return static_cast<int32_t>(ErrNo::InternalError);
     }
-    Res = av_dict_copy(DestAvDict, *SrcAvDict, Flags);
+    Res = av_dict_copy(DestAvDict, *SrcAvDict, SafeFlags);
+    if (Res < 0) {
+      av_dict_free(DestAvDict);
+      av_free(DestAvDict);
+      return Res;
+    }
     FFMPEG_PTR_STORE(DestAvDict, DestDictId);
   }
 

--- a/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
+++ b/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
@@ -12,22 +12,37 @@ namespace Host {
 namespace WasmEdgeFFmpeg {
 namespace AVUtil {
 
+namespace {
+AVDictionaryEntry *dictEntryAt(AVDictionary *Dict, const char *Key,
+                               uint32_t PrevIdx, int Flags, uint32_t &Steps) {
+  AVDictionaryEntry *Entry = nullptr;
+  uint32_t Curr = 0;
+  while (Curr <= PrevIdx) {
+    Entry = av_dict_get(Dict, Key, Entry, Flags);
+    Curr++;
+    if (Entry == nullptr) {
+      break;
+    }
+  }
+  Steps = Curr;
+  return Entry;
+}
+} // namespace
+
 Expect<int32_t> AVDictSet::body(const Runtime::CallingFrame &Frame,
                                 uint32_t DictPtr, uint32_t KeyPtr,
                                 uint32_t KeyLen, uint32_t ValuePtr,
                                 uint32_t ValueLen, int32_t Flags) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(KeyBuf, MemInst, char, KeyPtr,
-                "Failed when accessing the return Key memory"sv);
-  MEM_PTR_CHECK(ValueBuf, MemInst, char, ValuePtr,
-                "Failed when accessing the return Value memory"sv);
+  MEM_SPAN_CHECK(KeyBuf, MemInst, char, KeyPtr, KeyLen,
+                 "Failed when accessing the return Key memory"sv);
+  MEM_SPAN_CHECK(ValueBuf, MemInst, char, ValuePtr, ValueLen,
+                 "Failed when accessing the return Value memory"sv);
   MEM_PTR_CHECK(DictId, MemInst, uint32_t, DictPtr,
                 "Failed to access Memory for AVDict"sv)
 
-  std::string Key;
-  std::string Value;
-  std::copy_n(KeyBuf, KeyLen, std::back_inserter(Key));
-  std::copy_n(ValueBuf, ValueLen, std::back_inserter(Value));
+  std::string Key(KeyBuf.data(), KeyLen);
+  std::string Value(ValueBuf.data(), ValueLen);
 
   int Res = 0;
 
@@ -35,10 +50,18 @@ Expect<int32_t> AVDictSet::body(const Runtime::CallingFrame &Frame,
   // passed. Else the Ptr contains a Number.
   if (*DictId) {
     FFMPEG_PTR_FETCH(AvDict, *DictId, AVDictionary *);
+    if (AvDict == nullptr) {
+      spdlog::error("[WasmEdge-FFmpeg] AVDictSet: invalid dictionary id {}"sv,
+                    *DictId);
+      return static_cast<int32_t>(ErrNo::InternalError);
+    }
     Res = av_dict_set(AvDict, Key.c_str(), Value.c_str(), Flags);
   } else {
     AVDictionary **AvDict =
         static_cast<AVDictionary **>(av_mallocz(sizeof(AVDictionary *)));
+    if (AvDict == nullptr) {
+      return static_cast<int32_t>(ErrNo::InternalError);
+    }
     Res = av_dict_set(AvDict, Key.c_str(), Value.c_str(), Flags);
     FFMPEG_PTR_STORE(AvDict, DictId);
   }
@@ -58,16 +81,28 @@ Expect<int32_t> AVDictCopy::body(const Runtime::CallingFrame &Frame,
   int Res = 0;
 
   if (SrcAvDict == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVDictCopy: invalid source dictionary "
+                  "id {}"sv,
+                  SrcDictId);
     return static_cast<int32_t>(ErrNo::InternalError);
   }
 
   if (*DestDictId) {
     FFMPEG_PTR_FETCH(DestAvDict, *DestDictId, AVDictionary *);
+    if (DestAvDict == nullptr) {
+      spdlog::error("[WasmEdge-FFmpeg] AVDictCopy: invalid destination "
+                    "dictionary id {}"sv,
+                    *DestDictId);
+      return static_cast<int32_t>(ErrNo::InternalError);
+    }
     Res = av_dict_copy(DestAvDict, *SrcAvDict, Flags);
   } else {
     AVDictionary **DestAvDict =
         static_cast<AVDictionary **>(av_mallocz(sizeof(AVDictionary *)));
-    av_dict_copy(DestAvDict, *SrcAvDict, Flags);
+    if (DestAvDict == nullptr) {
+      return static_cast<int32_t>(ErrNo::InternalError);
+    }
+    Res = av_dict_copy(DestAvDict, *SrcAvDict, Flags);
     FFMPEG_PTR_STORE(DestAvDict, DestDictId);
   }
 
@@ -80,8 +115,8 @@ Expect<int32_t> AVDictGet::body(const Runtime::CallingFrame &Frame,
                                 uint32_t Flags, uint32_t KeyLenPtr,
                                 uint32_t ValueLenPtr) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(KeyStr, MemInst, char, KeyPtr,
-                "Failed when accessing the return Key memory"sv);
+  MEM_SPAN_CHECK(KeyStr, MemInst, char, KeyPtr, KeyLen,
+                 "Failed when accessing the return Key memory"sv);
   MEM_PTR_CHECK(KeyLenId, MemInst, uint32_t, KeyLenPtr,
                 "Failed when accessing the return KeyLen memory"sv);
   MEM_PTR_CHECK(ValueLenId, MemInst, uint32_t, ValueLenPtr,
@@ -91,19 +126,20 @@ Expect<int32_t> AVDictGet::body(const Runtime::CallingFrame &Frame,
 
   // Return if Dict was not created (i.e. 0 is passed as AVDictId).
   if (AvDict == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVDictGet: invalid dictionary id {}"sv,
+                  DictId);
     return static_cast<int32_t>(ErrNo::InternalError);
   }
-  std::string Key;
-  std::copy_n(KeyStr, KeyLen, std::back_inserter(Key));
+  std::string Key(KeyStr.data(), KeyLen);
 
-  AVDictionaryEntry *DictEntry = nullptr;
   uint32_t Curr = 0;
-  while (Curr <= PrevDictEntryIdx) {
-    DictEntry = av_dict_get(*AvDict, Key.c_str(), DictEntry, Flags);
-    Curr++;
-  }
+  AVDictionaryEntry *DictEntry =
+      dictEntryAt(*AvDict, Key.c_str(), PrevDictEntryIdx, Flags, Curr);
 
   if (DictEntry == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVDictGet: no dictionary entry found "
+                  "(dictionary id {}, prev entry index {})"sv,
+                  DictId, PrevDictEntryIdx);
     return static_cast<int32_t>(ErrNo::InternalError);
   }
 
@@ -117,8 +153,8 @@ Expect<int32_t> AVDictGetKeyValue::body(
     uint32_t KeyLen, uint32_t ValBufPtr, uint32_t ValBufLen, uint32_t KeyBufPtr,
     uint32_t KeyBufLen, uint32_t PrevDictEntryIdx, uint32_t Flags) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(KeyStr, MemInst, char, KeyPtr,
-                "Failed when accessing the return Key memory"sv);
+  MEM_SPAN_CHECK(KeyStr, MemInst, char, KeyPtr, KeyLen,
+                 "Failed when accessing the return Key memory"sv);
   MEM_SPAN_CHECK(KeyBuf, MemInst, char, KeyBufPtr, KeyBufLen, "");
   MEM_SPAN_CHECK(ValBuf, MemInst, char, ValBufPtr, ValBufLen, "");
 
@@ -126,33 +162,37 @@ Expect<int32_t> AVDictGetKeyValue::body(
 
   // Return if Dict was not created (i.e. 0 is passed as AVDictId).
   if (AvDict == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVDictGetKeyValue: invalid dictionary "
+                  "id {}"sv,
+                  DictId);
     return static_cast<int32_t>(ErrNo::InternalError);
   }
 
-  std::string Key;
-  std::copy_n(KeyStr, KeyLen, std::back_inserter(Key));
+  std::string Key(KeyStr.data(), KeyLen);
 
-  AVDictionaryEntry *DictEntry = nullptr;
   uint32_t Curr = 0;
-  while (Curr <= PrevDictEntryIdx) {
-    DictEntry = av_dict_get(*AvDict, Key.c_str(), DictEntry, Flags);
-    Curr++;
-  }
+  AVDictionaryEntry *DictEntry =
+      dictEntryAt(*AvDict, Key.c_str(), PrevDictEntryIdx, Flags, Curr);
   if (DictEntry == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVDictGetKeyValue: no dictionary entry "
+                  "found (dictionary id {}, prev entry index {})"sv,
+                  DictId, PrevDictEntryIdx);
     return static_cast<int32_t>(ErrNo::InternalError);
   }
-  std::copy_n(DictEntry->value, strlen(DictEntry->value), ValBuf.data());
-  std::copy_n(DictEntry->key, strlen(DictEntry->key), KeyBuf.data());
+  copyCStringToBuffer(ValBuf.data(), ValBufLen, DictEntry->value);
+  copyCStringToBuffer(KeyBuf.data(), KeyBufLen, DictEntry->key);
   return Curr;
 }
 
 Expect<int32_t> AVDictFree::body(const Runtime::CallingFrame &,
                                  uint32_t DictId) {
-  if (DictId == 0) {
-    return static_cast<int32_t>(ErrNo::Success);
-  }
   FFMPEG_PTR_FETCH(AvDict, DictId, AVDictionary *);
-  av_dict_free(AvDict);
+  FFMPEG_PTR_CHECK_FREE(AvDict, DictId,
+                        static_cast<int32_t>(ErrNo::InternalError));
+  if (!Env.get()->isBorrowed(DictId)) {
+    av_dict_free(AvDict);
+    av_free(AvDict);
+  }
   FFMPEG_PTR_DELETE(DictId);
   return static_cast<int32_t>(ErrNo::Success);
 }

--- a/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
+++ b/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
@@ -13,6 +13,12 @@ namespace WasmEdgeFFmpeg {
 namespace AVUtil {
 
 namespace {
+constexpr int SafeDictFlags = AV_DICT_MATCH_CASE | AV_DICT_IGNORE_SUFFIX |
+                              AV_DICT_DONT_OVERWRITE | AV_DICT_APPEND |
+                              AV_DICT_MULTIKEY;
+
+int sanitizeDictFlags(int Flags) { return Flags & SafeDictFlags; }
+
 AVDictionaryEntry *dictEntryAt(AVDictionary *Dict, const char *Key,
                                uint32_t PrevIdx, int Flags, uint32_t &Steps) {
   AVDictionaryEntry *Entry = nullptr;
@@ -44,6 +50,7 @@ Expect<int32_t> AVDictSet::body(const Runtime::CallingFrame &Frame,
   std::string Key(KeyBuf.data(), KeyLen);
   std::string Value(ValueBuf.data(), ValueLen);
 
+  int const SafeFlags = sanitizeDictFlags(Flags);
   int Res = 0;
 
   // Using Maybe::uninit(); in Rust. If Uninitialized, zero is
@@ -55,14 +62,19 @@ Expect<int32_t> AVDictSet::body(const Runtime::CallingFrame &Frame,
                     *DictId);
       return static_cast<int32_t>(ErrNo::InternalError);
     }
-    Res = av_dict_set(AvDict, Key.c_str(), Value.c_str(), Flags);
+    Res = av_dict_set(AvDict, Key.c_str(), Value.c_str(), SafeFlags);
   } else {
     AVDictionary **AvDict =
         static_cast<AVDictionary **>(av_mallocz(sizeof(AVDictionary *)));
     if (AvDict == nullptr) {
       return static_cast<int32_t>(ErrNo::InternalError);
     }
-    Res = av_dict_set(AvDict, Key.c_str(), Value.c_str(), Flags);
+    Res = av_dict_set(AvDict, Key.c_str(), Value.c_str(), SafeFlags);
+    if (Res < 0) {
+      av_dict_free(AvDict);
+      av_free(AvDict);
+      return Res;
+    }
     FFMPEG_PTR_STORE(AvDict, DictId);
   }
 
@@ -78,6 +90,7 @@ Expect<int32_t> AVDictCopy::body(const Runtime::CallingFrame &Frame,
 
   FFMPEG_PTR_FETCH(SrcAvDict, SrcDictId, AVDictionary *);
 
+  int const SafeFlags = sanitizeDictFlags(static_cast<int>(Flags));
   int Res = 0;
 
   if (SrcAvDict == nullptr) {
@@ -95,14 +108,19 @@ Expect<int32_t> AVDictCopy::body(const Runtime::CallingFrame &Frame,
                     *DestDictId);
       return static_cast<int32_t>(ErrNo::InternalError);
     }
-    Res = av_dict_copy(DestAvDict, *SrcAvDict, Flags);
+    Res = av_dict_copy(DestAvDict, *SrcAvDict, SafeFlags);
   } else {
     AVDictionary **DestAvDict =
         static_cast<AVDictionary **>(av_mallocz(sizeof(AVDictionary *)));
     if (DestAvDict == nullptr) {
       return static_cast<int32_t>(ErrNo::InternalError);
     }
-    Res = av_dict_copy(DestAvDict, *SrcAvDict, Flags);
+    Res = av_dict_copy(DestAvDict, *SrcAvDict, SafeFlags);
+    if (Res < 0) {
+      av_dict_free(DestAvDict);
+      av_free(DestAvDict);
+      return Res;
+    }
     FFMPEG_PTR_STORE(DestAvDict, DestDictId);
   }
 

--- a/plugins/wasmedge_ffmpeg/avutil/avFrame.cpp
+++ b/plugins/wasmedge_ffmpeg/avutil/avFrame.cpp
@@ -27,7 +27,10 @@ Expect<int32_t> AVFrameAlloc::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> AVFrameFree::body(const Runtime::CallingFrame &,
                                   uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK_FREE(AvFrame, FrameId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   av_frame_free(&AvFrame);
+  Env.get()->deallocChildren(FrameId);
   FFMPEG_PTR_DELETE(FrameId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -35,18 +38,21 @@ Expect<int32_t> AVFrameFree::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVFrameWidth::body(const Runtime::CallingFrame &,
                                    uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   return AvFrame->width;
 }
 
 Expect<int32_t> AVFrameHeight::body(const Runtime::CallingFrame &,
                                     uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   return AvFrame->height;
 }
 
 Expect<int32_t> AVFrameSetHeight::body(const Runtime::CallingFrame &,
                                        uint32_t FrameId, uint32_t Height) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, static_cast<int32_t>(ErrNo::InternalError));
   AvFrame->height = Height;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -54,6 +60,7 @@ Expect<int32_t> AVFrameSetHeight::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVFrameSetWidth::body(const Runtime::CallingFrame &,
                                       uint32_t FrameId, uint32_t Width) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, static_cast<int32_t>(ErrNo::InternalError));
   AvFrame->width = Width;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -61,6 +68,7 @@ Expect<int32_t> AVFrameSetWidth::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVFrameVideoFormat::body(const Runtime::CallingFrame &,
                                          uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   int const Format = AvFrame->format;
   if (Format == -1) {
     return -1;
@@ -69,10 +77,11 @@ Expect<int32_t> AVFrameVideoFormat::body(const Runtime::CallingFrame &,
   return FFmpegUtils::PixFmt::fromAVPixFmt(PixelFormat);
 }
 
-Expect<uint32_t> AVFrameSetVideoFormat::body(const Runtime::CallingFrame &,
-                                             uint32_t FrameId,
-                                             uint32_t AvPixFormatId) {
+Expect<int32_t> AVFrameSetVideoFormat::body(const Runtime::CallingFrame &,
+                                            uint32_t FrameId,
+                                            uint32_t AvPixFormatId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, static_cast<int32_t>(ErrNo::InternalError));
   AVPixelFormat const PixelFormat =
       FFmpegUtils::PixFmt::intoAVPixFmt(AvPixFormatId);
   AvFrame->format = PixelFormat;
@@ -82,12 +91,17 @@ Expect<uint32_t> AVFrameSetVideoFormat::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVFrameIsNull::body(const Runtime::CallingFrame &,
                                     uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   return AvFrame->data[0] == nullptr;
 }
 
 Expect<int32_t> AVFrameLinesize::body(const Runtime::CallingFrame &,
                                       uint32_t FrameId, uint32_t Idx) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
+  if (Idx >= AV_NUM_DATA_POINTERS) {
+    return 0;
+  }
   return AvFrame->linesize[Idx];
 }
 
@@ -98,7 +112,49 @@ Expect<int32_t> AVFrameData::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(Buffer, MemInst, uint8_t, FrameBufPtr, FrameBufLen, "");
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
 
-  uint8_t *Data = AvFrame->data[Index];
+  if (AvFrame == nullptr || Index >= AV_NUM_DATA_POINTERS) {
+    spdlog::error("[WasmEdge-FFmpeg] AVFrameData: invalid frame id {} or "
+                  "plane index {}"sv,
+                  FrameId, Index);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  if (FrameBufLen == 0) {
+    return static_cast<int32_t>(ErrNo::Success);
+  }
+  uint8_t const *Data = AvFrame->data[Index];
+  if (Data == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVFrameData: frame id {} plane {} has "
+                  "no data"sv,
+                  FrameId, Index);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+
+  uintptr_t const Plane = reinterpret_cast<uintptr_t>(Data);
+  size_t Readable = 0;
+  for (int I = 0; I < AV_NUM_DATA_POINTERS; ++I) {
+    const AVBufferRef *Buf = AvFrame->buf[I];
+    if (Buf == nullptr || Buf->data == nullptr) {
+      continue;
+    }
+    uintptr_t const Start = reinterpret_cast<uintptr_t>(Buf->data);
+    if (Plane >= Start && Plane < Start + Buf->size) {
+      Readable = Start + Buf->size - Plane;
+      break;
+    }
+  }
+  if (Readable == 0) {
+    spdlog::error("[WasmEdge-FFmpeg] AVFrameData: frame id {} plane {} is "
+                  "not backed by any frame buffer"sv,
+                  FrameId, Index);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+
+  if (Readable < static_cast<size_t>(FrameBufLen)) {
+    spdlog::error("[WasmEdge-FFmpeg] AVFrameData: requested {} bytes from "
+                  "frame id {} plane {}, but only {} bytes are readable"sv,
+                  FrameBufLen, FrameId, Index, Readable);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
   std::copy_n(Data, FrameBufLen, Buffer.data());
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -106,12 +162,14 @@ Expect<int32_t> AVFrameData::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> AVFrameGetBuffer::body(const Runtime::CallingFrame &,
                                        uint32_t FrameId, int32_t Align) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, static_cast<int32_t>(ErrNo::InternalError));
   return av_frame_get_buffer(AvFrame, Align);
 }
 
 Expect<int32_t> AVFrameAudioFormat::body(const Runtime::CallingFrame &,
                                          uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   int const Format = AvFrame->format;
   if (Format == -1) {
     return -1;
@@ -125,6 +183,7 @@ Expect<int32_t> AVFrameSetAudioFormat::body(const Runtime::CallingFrame &,
                                             uint32_t FrameId,
                                             uint32_t SampleFormatId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, static_cast<int32_t>(ErrNo::InternalError));
   AVSampleFormat const SampleFormat =
       FFmpegUtils::SampleFmt::fromSampleID(SampleFormatId);
   AvFrame->format = SampleFormat;
@@ -135,15 +194,25 @@ Expect<int32_t> AVFrameSetChannelLayout::body(const Runtime::CallingFrame &,
                                               uint32_t FrameId,
                                               uint64_t ChannelLayoutID) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, static_cast<int32_t>(ErrNo::InternalError));
   uint64_t const ChannelLayout =
       FFmpegUtils::ChannelLayout::fromChannelLayoutID(ChannelLayoutID);
-  av_channel_layout_from_mask(&AvFrame->ch_layout, ChannelLayout);
+  int const Ret =
+      av_channel_layout_from_mask(&AvFrame->ch_layout, ChannelLayout);
+  if (Ret < 0) {
+    spdlog::error("[WasmEdge-FFmpeg] AVFrameSetChannelLayout: "
+                  "av_channel_layout_from_mask failed ({}) for mask {:#x} "
+                  "(frame id {})"sv,
+                  Ret, ChannelLayout, FrameId);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> AVFrameSetNbSamples::body(const Runtime::CallingFrame &,
                                           uint32_t FrameId, int32_t Samples) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, static_cast<int32_t>(ErrNo::InternalError));
   AvFrame->nb_samples = Samples;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -151,12 +220,14 @@ Expect<int32_t> AVFrameSetNbSamples::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVFrameNbSamples::body(const Runtime::CallingFrame &,
                                        uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   return AvFrame->nb_samples;
 }
 
 Expect<int32_t> AVFrameSampleRate::body(const Runtime::CallingFrame &,
                                         uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   return AvFrame->sample_rate;
 }
 
@@ -164,6 +235,7 @@ Expect<int32_t> AVFrameSetSampleRate::body(const Runtime::CallingFrame &,
                                            uint32_t FrameId,
                                            int32_t SampleRate) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, static_cast<int32_t>(ErrNo::InternalError));
   AvFrame->sample_rate = SampleRate;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -171,12 +243,14 @@ Expect<int32_t> AVFrameSetSampleRate::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVFrameChannels::body(const Runtime::CallingFrame &,
                                       uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   return AvFrame->ch_layout.nb_channels;
 }
 
 Expect<int32_t> AVFrameSetChannels::body(const Runtime::CallingFrame &,
                                          uint32_t FrameId, int32_t Channels) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, static_cast<int32_t>(ErrNo::InternalError));
   AvFrame->ch_layout.nb_channels = Channels;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -184,19 +258,21 @@ Expect<int32_t> AVFrameSetChannels::body(const Runtime::CallingFrame &,
 Expect<uint64_t> AVFrameChannelLayout::body(const Runtime::CallingFrame &,
                                             uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
-  uint64_t const ChannelLayout = AvFrame->ch_layout.u.mask;
-  return FFmpegUtils::ChannelLayout::intoChannelLayoutID(ChannelLayout);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
+  return FFmpegUtils::ChannelLayout::intoChannelLayoutID(AvFrame->ch_layout);
 }
 
 Expect<int64_t> AVFrameBestEffortTimestamp::body(const Runtime::CallingFrame &,
                                                  uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   return AvFrame->best_effort_timestamp;
 }
 
 Expect<int32_t> AVFramePictType::body(const Runtime::CallingFrame &,
                                       uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   AVPictureType const AvPictureType = AvFrame->pict_type;
   return FFmpegUtils::PictureType::fromAVPictureType(AvPictureType);
 }
@@ -204,6 +280,7 @@ Expect<int32_t> AVFramePictType::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVFrameSetPictType::body(const Runtime::CallingFrame &,
                                          uint32_t FrameId, int32_t PictureId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, static_cast<int32_t>(ErrNo::InternalError));
   AVPictureType const AvPictureType =
       FFmpegUtils::PictureType::intoAVPictureType(PictureId);
 
@@ -214,24 +291,28 @@ Expect<int32_t> AVFrameSetPictType::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVFrameInterlacedFrame::body(const Runtime::CallingFrame &,
                                              uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   return AvFrame->interlaced_frame;
 }
 
 Expect<int32_t> AVFrameTopFieldFirst::body(const Runtime::CallingFrame &,
                                            uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   return AvFrame->top_field_first;
 }
 
 Expect<int32_t> AVFramePaletteHasChanged::body(const Runtime::CallingFrame &,
                                                uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   return AvFrame->palette_has_changed;
 }
 
 Expect<int32_t> AVFrameColorSpace::body(const Runtime::CallingFrame &,
                                         uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   AVColorSpace const AvColorSpace = AvFrame->colorspace;
   return FFmpegUtils::ColorSpace::fromAVColorSpace(AvColorSpace);
 }
@@ -240,6 +321,7 @@ Expect<int32_t> AVFrameSetColorSpace::body(const Runtime::CallingFrame &,
                                            uint32_t FrameId,
                                            int32_t ColorSpaceId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, static_cast<int32_t>(ErrNo::InternalError));
   AvFrame->colorspace = FFmpegUtils::ColorSpace::intoAVColorSpace(ColorSpaceId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -247,6 +329,7 @@ Expect<int32_t> AVFrameSetColorSpace::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVFrameColorRange::body(const Runtime::CallingFrame &,
                                         uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   AVColorRange const AvColorRange = AvFrame->color_range;
 
   return static_cast<int32_t>(AvColorRange);
@@ -256,6 +339,7 @@ Expect<int32_t> AVFrameSetColorRange::body(const Runtime::CallingFrame &,
                                            uint32_t FrameId,
                                            int32_t ColorRangeId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, static_cast<int32_t>(ErrNo::InternalError));
   AvFrame->color_range = static_cast<AVColorRange>(ColorRangeId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -264,6 +348,7 @@ Expect<int32_t>
 AVFrameColorTransferCharacteristic::body(const Runtime::CallingFrame &,
                                          uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   AVColorTransferCharacteristic const Characteristic = AvFrame->color_trc;
 
   // The binding can be used as well. Currently, the binding is commented out.
@@ -274,6 +359,7 @@ Expect<int32_t> AVFrameSetColorTransferCharacteristic::body(
     const Runtime::CallingFrame &, uint32_t FrameId,
     int32_t ColorTransferCharacteristicId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, static_cast<int32_t>(ErrNo::InternalError));
   AvFrame->color_trc =
       static_cast<AVColorTransferCharacteristic>(ColorTransferCharacteristicId);
   return static_cast<int32_t>(ErrNo::Success);
@@ -282,6 +368,7 @@ Expect<int32_t> AVFrameSetColorTransferCharacteristic::body(
 Expect<int32_t> AVFrameChromaLocation::body(const Runtime::CallingFrame &,
                                             uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   AVChromaLocation const AvChromaLocation = AvFrame->chroma_location;
   return FFmpegUtils::ChromaLocation::fromAVChromaLocation(AvChromaLocation);
 }
@@ -289,18 +376,21 @@ Expect<int32_t> AVFrameChromaLocation::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVFrameRepeatPict::body(const Runtime::CallingFrame &,
                                         uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   return AvFrame->repeat_pict;
 }
 
 Expect<int32_t> AVFrameFlags::body(const Runtime::CallingFrame &,
                                    uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   return AvFrame->flags;
 }
 
 Expect<int32_t> AVFrameQuality::body(const Runtime::CallingFrame &,
                                      uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   return AvFrame->quality;
 }
 
@@ -312,11 +402,13 @@ Expect<int32_t> AVFrameMetadata::body(const Runtime::CallingFrame &Frame,
 
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
 
-  AVDictionary **AvDictionary =
-      static_cast<AVDictionary **>(av_malloc(sizeof(AVDictionary *)));
+  if (AvFrame == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVFrameMetadata: invalid frame id {}"sv,
+                  FrameId);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
 
-  *AvDictionary = AvFrame->metadata;
-  FFMPEG_PTR_STORE(AvDictionary, DictId);
+  FFMPEG_PTR_STORE_CHILD(&AvFrame->metadata, DictId, FrameId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -325,29 +417,35 @@ Expect<int32_t> AVFrameSetMetadata::body(const Runtime::CallingFrame &,
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
   FFMPEG_PTR_FETCH(AvDict, DictId, AVDictionary *);
 
-  if (AvDict == nullptr) {
-    AvFrame->metadata = nullptr;
-  } else {
-    AvFrame->metadata = *AvDict;
+  if (AvFrame == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AVFrameSetMetadata: invalid frame id "
+                  "{}"sv,
+                  FrameId);
+    return static_cast<int32_t>(ErrNo::InternalError);
   }
-  return static_cast<int32_t>(ErrNo::Success);
+  FFMPEG_PTR_CHECK_NONZERO(AvDict, DictId,
+                           static_cast<int32_t>(ErrNo::InternalError));
+  return applyMetadataCopy(&AvFrame->metadata, AvDict);
 }
 
 Expect<int32_t> AVFrameKeyFrame::body(const Runtime::CallingFrame &,
                                       uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   return AvFrame->key_frame;
 }
 
 Expect<int64_t> AVFramePts::body(const Runtime::CallingFrame &,
                                  uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   return AvFrame->pts;
 }
 
 Expect<int32_t> AVFrameSetPts::body(const Runtime::CallingFrame &,
                                     uint32_t FrameId, int64_t Pts) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, static_cast<int32_t>(ErrNo::InternalError));
   AvFrame->pts = Pts;
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -356,6 +454,8 @@ Expect<int32_t> AVFrameCopy::body(const Runtime::CallingFrame &,
                                   uint32_t DestFrameId, uint32_t SrcFrameId) {
   FFMPEG_PTR_FETCH(DestAvFrame, DestFrameId, AVFrame);
   FFMPEG_PTR_FETCH(SrcAvFrame, SrcFrameId, AVFrame);
+  FFMPEG_PTR_CHECK(DestAvFrame, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK(SrcAvFrame, static_cast<int32_t>(ErrNo::InternalError));
 
   av_frame_copy(DestAvFrame, SrcAvFrame);
   return static_cast<int32_t>(ErrNo::Success);
@@ -366,6 +466,8 @@ Expect<int32_t> AVFrameCopyProps::body(const Runtime::CallingFrame &,
                                        uint32_t SrcFrameId) {
   FFMPEG_PTR_FETCH(DestAvFrame, DestFrameId, AVFrame);
   FFMPEG_PTR_FETCH(SrcAvFrame, SrcFrameId, AVFrame);
+  FFMPEG_PTR_CHECK(DestAvFrame, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK(SrcAvFrame, static_cast<int32_t>(ErrNo::InternalError));
 
   av_frame_copy_props(DestAvFrame, SrcAvFrame);
   return static_cast<int32_t>(ErrNo::Success);
@@ -377,6 +479,7 @@ AVFrameSampleAspectRatio::body(const Runtime::CallingFrame &Frame,
                                uint32_t DenPtr) {
   MEMINST_CHECK(MemInst, Frame, 0)
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, static_cast<int32_t>(ErrNo::InternalError));
 
   MEM_PTR_CHECK(Num, MemInst, int32_t, NumPtr,
                 "Failed to access Numerator Ptr for AVRational"sv);
@@ -392,6 +495,7 @@ AVFrameSampleAspectRatio::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> AVFrameColorPrimaries::body(const Runtime::CallingFrame &,
                                             uint32_t FrameId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, 0);
   AVColorPrimaries const ColorPrimaries = AvFrame->color_primaries;
   return FFmpegUtils::ColorPrimaries::fromAVColorPrimaries(ColorPrimaries);
 }
@@ -400,6 +504,7 @@ Expect<int32_t> AVFrameSetColorPrimaries::body(const Runtime::CallingFrame &,
                                                uint32_t FrameId,
                                                int32_t ColorPrimariesId) {
   FFMPEG_PTR_FETCH(AvFrame, FrameId, AVFrame);
+  FFMPEG_PTR_CHECK(AvFrame, static_cast<int32_t>(ErrNo::InternalError));
   AVColorPrimaries const ColorPrimaries =
       FFmpegUtils::ColorPrimaries::intoAVColorPrimaries(ColorPrimariesId);
   AvFrame->color_primaries = ColorPrimaries;

--- a/plugins/wasmedge_ffmpeg/avutil/avFrame.h
+++ b/plugins/wasmedge_ffmpeg/avutil/avFrame.h
@@ -57,8 +57,8 @@ public:
 class AVFrameSetVideoFormat : public HostFunction<AVFrameSetVideoFormat> {
 public:
   using HostFunction::HostFunction;
-  Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t FrameId,
-                        uint32_t AvPixFormatId);
+  Expect<int32_t> body(const Runtime::CallingFrame &Frame, uint32_t FrameId,
+                       uint32_t AvPixFormatId);
 };
 
 class AVFrameIsNull : public HostFunction<AVFrameIsNull> {

--- a/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
+++ b/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
@@ -8,6 +8,9 @@ extern "C" {
 #include "libavutil/time.h"
 }
 
+#include <optional>
+#include <string>
+
 namespace WasmEdge {
 namespace Host {
 namespace WasmEdgeFFmpeg {
@@ -71,25 +74,38 @@ AVGetChannelLayoutNbChannels::body(const Runtime::CallingFrame &,
 }
 
 namespace {
-// Writes the name of the channel layout given by the FFmpeg mask ChannelLayout
-// into Buf. A single-channel layout is named by its channel (e.g. "FL", "LFE"),
-// a layout with more than one channel by its description (e.g. "stereo",
-// "5.1"). Returns the underlying av_* return code, negative when the mask does
-// not form a valid layout.
-int describeChannelLayoutName(uint64_t ChannelLayout, char *Buf, size_t Size) {
+// Returns the name of the channel layout given by the FFmpeg mask, or nullopt
+// when the mask does not form a valid layout. A single-channel layout is named
+// by its channel (e.g. "FL"), a multi-channel layout by its description (e.g.
+// "stereo"); the buffer is sized to the length FFmpeg reports, so large custom
+// layouts are returned in full.
+std::optional<std::string> describeChannelLayoutName(uint64_t ChannelLayout) {
   AVChannelLayout TmpChLayout;
   if (av_channel_layout_from_mask(&TmpChLayout, ChannelLayout) < 0) {
-    return -1;
+    return std::nullopt;
   }
-  int Ret;
-  if (TmpChLayout.nb_channels == 1) {
-    Ret = av_channel_name(
-        Buf, Size, FFmpegUtils::ChannelLayout::channelFromMask(ChannelLayout));
-  } else {
-    Ret = av_channel_layout_describe(&TmpChLayout, Buf, Size);
+  auto Describe = [&](char *Buf, size_t Size) {
+    return TmpChLayout.nb_channels == 1
+               ? av_channel_name(
+                     Buf, Size,
+                     FFmpegUtils::ChannelLayout::channelFromMask(ChannelLayout))
+               : av_channel_layout_describe(&TmpChLayout, Buf, Size);
+  };
+  // Both calls report the size the full string needs, terminator included,
+  // like snprintf, so query it first and size the buffer to it.
+  int const Needed = Describe(nullptr, 0);
+  if (Needed <= 0) {
+    av_channel_layout_uninit(&TmpChLayout);
+    return std::nullopt;
   }
+  std::string Name(static_cast<size_t>(Needed), '\0');
+  int const Ret = Describe(Name.data(), Name.size());
   av_channel_layout_uninit(&TmpChLayout);
-  return Ret;
+  if (Ret < 0) {
+    return std::nullopt;
+  }
+  Name.resize(std::strlen(Name.c_str()));
+  return Name;
 }
 } // namespace
 
@@ -97,11 +113,12 @@ Expect<int32_t> AVGetChannelLayoutNameLen::body(const Runtime::CallingFrame &,
                                                 uint64_t ChannelLayoutId) {
   uint64_t const ChannelLayout =
       FFmpegUtils::ChannelLayout::fromChannelLayoutID(ChannelLayoutId);
-  char Name[64] = {0};
-  if (describeChannelLayoutName(ChannelLayout, Name, sizeof(Name)) < 0) {
+  std::optional<std::string> const Name =
+      describeChannelLayoutName(ChannelLayout);
+  if (!Name) {
     return 0;
   }
-  return std::strlen(Name);
+  return static_cast<int32_t>(Name->size());
 }
 
 Expect<int32_t> AVGetChannelLayoutName::body(const Runtime::CallingFrame &Frame,
@@ -113,15 +130,15 @@ Expect<int32_t> AVGetChannelLayoutName::body(const Runtime::CallingFrame &Frame,
 
   uint64_t const ChannelLayout =
       FFmpegUtils::ChannelLayout::fromChannelLayoutID(ChannelLayoutId);
-  char Name[64] = {0};
-  int const Ret = describeChannelLayoutName(ChannelLayout, Name, sizeof(Name));
-  if (Ret < 0) {
+  std::optional<std::string> const Name =
+      describeChannelLayoutName(ChannelLayout);
+  if (!Name) {
     spdlog::error("[WasmEdge-FFmpeg] AVGetChannelLayoutName: cannot describe "
-                  "channel layout mask {:#x} ({})"sv,
-                  ChannelLayout, Ret);
+                  "channel layout mask {:#x}"sv,
+                  ChannelLayout);
     return static_cast<int32_t>(ErrNo::InternalError);
   }
-  copyCStringToBuffer(NameBuf.data(), NameLen, Name);
+  copyCStringToBuffer(NameBuf.data(), NameLen, Name->c_str());
   return static_cast<int32_t>(ErrNo::Success);
 }
 

--- a/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
+++ b/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
@@ -61,26 +61,47 @@ AVGetChannelLayoutNbChannels::body(const Runtime::CallingFrame &,
       FFmpegUtils::ChannelLayout::fromChannelLayoutID(ChannelLayoutId);
 
   AVChannelLayout TmpChLayout;
-  av_channel_layout_from_mask(&TmpChLayout, ChannelLayout);
+  if (av_channel_layout_from_mask(&TmpChLayout, ChannelLayout) < 0) {
+    return 0;
+  }
   int32_t ChannelLayoutNbChannels = TmpChLayout.nb_channels;
   av_channel_layout_uninit(&TmpChLayout);
 
   return ChannelLayoutNbChannels;
 }
 
+namespace {
+// Writes the name of the channel layout given by the FFmpeg mask ChannelLayout
+// into Buf. A single-channel layout is named by its channel (e.g. "FL", "LFE"),
+// a layout with more than one channel by its description (e.g. "stereo",
+// "5.1"). Returns the underlying av_* return code, negative when the mask does
+// not form a valid layout.
+int describeChannelLayoutName(uint64_t ChannelLayout, char *Buf, size_t Size) {
+  AVChannelLayout TmpChLayout;
+  if (av_channel_layout_from_mask(&TmpChLayout, ChannelLayout) < 0) {
+    return -1;
+  }
+  int Ret;
+  if (TmpChLayout.nb_channels == 1) {
+    Ret = av_channel_name(
+        Buf, Size, FFmpegUtils::ChannelLayout::channelFromMask(ChannelLayout));
+  } else {
+    Ret = av_channel_layout_describe(&TmpChLayout, Buf, Size);
+  }
+  av_channel_layout_uninit(&TmpChLayout);
+  return Ret;
+}
+} // namespace
+
 Expect<int32_t> AVGetChannelLayoutNameLen::body(const Runtime::CallingFrame &,
                                                 uint64_t ChannelLayoutId) {
   uint64_t const ChannelLayout =
       FFmpegUtils::ChannelLayout::fromChannelLayoutID(ChannelLayoutId);
-  char ChName[16] = {0}; // bufsize based on AVChannelCustom.name
-  // mask ChannelLayout to AVChannel before passing
-  int Code =
-      av_channel_name(ChName, 16, static_cast<AVChannel>(ChannelLayout >> 1));
-
-  if (Code < 0) {
+  char Name[64] = {0};
+  if (describeChannelLayoutName(ChannelLayout, Name, sizeof(Name)) < 0) {
     return 0;
   }
-  return strlen(ChName);
+  return std::strlen(Name);
 }
 
 Expect<int32_t> AVGetChannelLayoutName::body(const Runtime::CallingFrame &Frame,
@@ -92,11 +113,15 @@ Expect<int32_t> AVGetChannelLayoutName::body(const Runtime::CallingFrame &Frame,
 
   uint64_t const ChannelLayout =
       FFmpegUtils::ChannelLayout::fromChannelLayoutID(ChannelLayoutId);
-  char ChName[16] = {0}; // bufsize based on AVChannelCustom.name
-  // mask ChannelLayout to AVChannel before passing
-  av_channel_name(ChName, 16, static_cast<AVChannel>(ChannelLayout >> 1));
-
-  std::copy_n(ChName, NameLen, NameBuf.data());
+  char Name[64] = {0};
+  int const Ret = describeChannelLayoutName(ChannelLayout, Name, sizeof(Name));
+  if (Ret < 0) {
+    spdlog::error("[WasmEdge-FFmpeg] AVGetChannelLayoutName: cannot describe "
+                  "channel layout mask {:#x} ({})"sv,
+                  ChannelLayout, Ret);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  copyCStringToBuffer(NameBuf.data(), NameLen, Name);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -111,8 +136,8 @@ Expect<uint64_t> AVGetDefaultChannelLayout::body(const Runtime::CallingFrame &,
                                                  int32_t Number) {
   AVChannelLayout TmpChLayout;
   av_channel_layout_default(&TmpChLayout, Number);
-  uint64_t DefaultChannelLayout =
-      FFmpegUtils::ChannelLayout::intoChannelLayoutID(TmpChLayout.u.mask);
+  uint64_t const DefaultChannelLayout =
+      FFmpegUtils::ChannelLayout::intoChannelLayoutID(TmpChLayout);
   av_channel_layout_uninit(&TmpChLayout);
 
   return DefaultChannelLayout;
@@ -130,9 +155,7 @@ Expect<int32_t> AVUtilConfiguration::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(ConfigBuf, MemInst, char, ConfigPtr, ConfigLen, "");
 
   const char *Config = avutil_configuration();
-  auto Actual = std::strlen(Config);
-  auto N = std::min<uint32_t>(ConfigLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(Config, N, ConfigBuf.data());
+  copyCStringToBuffer(ConfigBuf.data(), ConfigLen, Config);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -147,9 +170,7 @@ Expect<int32_t> AVUtilLicense::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(LicenseBuf, MemInst, char, LicensePtr, LicenseLen, "");
 
   const char *License = avutil_license();
-  auto Actual = std::strlen(License);
-  auto N = std::min<uint32_t>(LicenseLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(License, N, LicenseBuf.data());
+  copyCStringToBuffer(LicenseBuf.data(), LicenseLen, License);
   return static_cast<int32_t>(ErrNo::Success);
 }
 

--- a/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
+++ b/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
@@ -8,6 +8,9 @@ extern "C" {
 #include "libavutil/time.h"
 }
 
+#include <optional>
+#include <string>
+
 namespace WasmEdge {
 namespace Host {
 namespace WasmEdgeFFmpeg {
@@ -71,20 +74,31 @@ AVGetChannelLayoutNbChannels::body(const Runtime::CallingFrame &,
 }
 
 namespace {
-int describeChannelLayoutName(uint64_t ChannelLayout, char *Buf, size_t Size) {
+std::optional<std::string> describeChannelLayoutName(uint64_t ChannelLayout) {
   AVChannelLayout TmpChLayout;
   if (av_channel_layout_from_mask(&TmpChLayout, ChannelLayout) < 0) {
-    return -1;
+    return std::nullopt;
   }
-  int Ret;
-  if (TmpChLayout.nb_channels == 1) {
-    Ret = av_channel_name(
-        Buf, Size, FFmpegUtils::ChannelLayout::channelFromMask(ChannelLayout));
-  } else {
-    Ret = av_channel_layout_describe(&TmpChLayout, Buf, Size);
+  auto Describe = [&](char *Buf, size_t Size) {
+    return TmpChLayout.nb_channels == 1
+               ? av_channel_name(
+                     Buf, Size,
+                     FFmpegUtils::ChannelLayout::channelFromMask(ChannelLayout))
+               : av_channel_layout_describe(&TmpChLayout, Buf, Size);
+  };
+  int const Needed = Describe(nullptr, 0);
+  if (Needed <= 0) {
+    av_channel_layout_uninit(&TmpChLayout);
+    return std::nullopt;
   }
+  std::string Name(static_cast<size_t>(Needed), '\0');
+  int const Ret = Describe(Name.data(), Name.size());
   av_channel_layout_uninit(&TmpChLayout);
-  return Ret;
+  if (Ret < 0) {
+    return std::nullopt;
+  }
+  Name.resize(std::strlen(Name.c_str()));
+  return Name;
 }
 } // namespace
 
@@ -92,11 +106,12 @@ Expect<int32_t> AVGetChannelLayoutNameLen::body(const Runtime::CallingFrame &,
                                                 uint64_t ChannelLayoutId) {
   uint64_t const ChannelLayout =
       FFmpegUtils::ChannelLayout::fromChannelLayoutID(ChannelLayoutId);
-  char Name[64] = {0};
-  if (describeChannelLayoutName(ChannelLayout, Name, sizeof(Name)) < 0) {
+  std::optional<std::string> const Name =
+      describeChannelLayoutName(ChannelLayout);
+  if (!Name) {
     return 0;
   }
-  return std::strlen(Name);
+  return static_cast<int32_t>(Name->size());
 }
 
 Expect<int32_t> AVGetChannelLayoutName::body(const Runtime::CallingFrame &Frame,
@@ -108,15 +123,15 @@ Expect<int32_t> AVGetChannelLayoutName::body(const Runtime::CallingFrame &Frame,
 
   uint64_t const ChannelLayout =
       FFmpegUtils::ChannelLayout::fromChannelLayoutID(ChannelLayoutId);
-  char Name[64] = {0};
-  int const Ret = describeChannelLayoutName(ChannelLayout, Name, sizeof(Name));
-  if (Ret < 0) {
+  std::optional<std::string> const Name =
+      describeChannelLayoutName(ChannelLayout);
+  if (!Name) {
     spdlog::error("[WasmEdge-FFmpeg] AVGetChannelLayoutName: cannot describe "
-                  "channel layout mask {:#x} ({})"sv,
-                  ChannelLayout, Ret);
+                  "channel layout mask {:#x}"sv,
+                  ChannelLayout);
     return static_cast<int32_t>(ErrNo::InternalError);
   }
-  copyCStringToBuffer(NameBuf.data(), NameLen, Name);
+  copyCStringToBuffer(NameBuf.data(), NameLen, Name->c_str());
   return static_cast<int32_t>(ErrNo::Success);
 }
 

--- a/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
+++ b/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
@@ -61,26 +61,42 @@ AVGetChannelLayoutNbChannels::body(const Runtime::CallingFrame &,
       FFmpegUtils::ChannelLayout::fromChannelLayoutID(ChannelLayoutId);
 
   AVChannelLayout TmpChLayout;
-  av_channel_layout_from_mask(&TmpChLayout, ChannelLayout);
+  if (av_channel_layout_from_mask(&TmpChLayout, ChannelLayout) < 0) {
+    return 0;
+  }
   int32_t ChannelLayoutNbChannels = TmpChLayout.nb_channels;
   av_channel_layout_uninit(&TmpChLayout);
 
   return ChannelLayoutNbChannels;
 }
 
+namespace {
+int describeChannelLayoutName(uint64_t ChannelLayout, char *Buf, size_t Size) {
+  AVChannelLayout TmpChLayout;
+  if (av_channel_layout_from_mask(&TmpChLayout, ChannelLayout) < 0) {
+    return -1;
+  }
+  int Ret;
+  if (TmpChLayout.nb_channels == 1) {
+    Ret = av_channel_name(
+        Buf, Size, FFmpegUtils::ChannelLayout::channelFromMask(ChannelLayout));
+  } else {
+    Ret = av_channel_layout_describe(&TmpChLayout, Buf, Size);
+  }
+  av_channel_layout_uninit(&TmpChLayout);
+  return Ret;
+}
+} // namespace
+
 Expect<int32_t> AVGetChannelLayoutNameLen::body(const Runtime::CallingFrame &,
                                                 uint64_t ChannelLayoutId) {
   uint64_t const ChannelLayout =
       FFmpegUtils::ChannelLayout::fromChannelLayoutID(ChannelLayoutId);
-  char ChName[16] = {0}; // bufsize based on AVChannelCustom.name
-  // mask ChannelLayout to AVChannel before passing
-  int Code =
-      av_channel_name(ChName, 16, static_cast<AVChannel>(ChannelLayout >> 1));
-
-  if (Code < 0) {
+  char Name[64] = {0};
+  if (describeChannelLayoutName(ChannelLayout, Name, sizeof(Name)) < 0) {
     return 0;
   }
-  return strlen(ChName);
+  return std::strlen(Name);
 }
 
 Expect<int32_t> AVGetChannelLayoutName::body(const Runtime::CallingFrame &Frame,
@@ -92,11 +108,15 @@ Expect<int32_t> AVGetChannelLayoutName::body(const Runtime::CallingFrame &Frame,
 
   uint64_t const ChannelLayout =
       FFmpegUtils::ChannelLayout::fromChannelLayoutID(ChannelLayoutId);
-  char ChName[16] = {0}; // bufsize based on AVChannelCustom.name
-  // mask ChannelLayout to AVChannel before passing
-  av_channel_name(ChName, 16, static_cast<AVChannel>(ChannelLayout >> 1));
-
-  std::copy_n(ChName, NameLen, NameBuf.data());
+  char Name[64] = {0};
+  int const Ret = describeChannelLayoutName(ChannelLayout, Name, sizeof(Name));
+  if (Ret < 0) {
+    spdlog::error("[WasmEdge-FFmpeg] AVGetChannelLayoutName: cannot describe "
+                  "channel layout mask {:#x} ({})"sv,
+                  ChannelLayout, Ret);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  copyCStringToBuffer(NameBuf.data(), NameLen, Name);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -111,8 +131,8 @@ Expect<uint64_t> AVGetDefaultChannelLayout::body(const Runtime::CallingFrame &,
                                                  int32_t Number) {
   AVChannelLayout TmpChLayout;
   av_channel_layout_default(&TmpChLayout, Number);
-  uint64_t DefaultChannelLayout =
-      FFmpegUtils::ChannelLayout::intoChannelLayoutID(TmpChLayout.u.mask);
+  uint64_t const DefaultChannelLayout =
+      FFmpegUtils::ChannelLayout::intoChannelLayoutID(TmpChLayout);
   av_channel_layout_uninit(&TmpChLayout);
 
   return DefaultChannelLayout;
@@ -130,9 +150,7 @@ Expect<int32_t> AVUtilConfiguration::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(ConfigBuf, MemInst, char, ConfigPtr, ConfigLen, "");
 
   const char *Config = avutil_configuration();
-  auto Actual = std::strlen(Config);
-  auto N = std::min<uint32_t>(ConfigLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(Config, N, ConfigBuf.data());
+  copyCStringToBuffer(ConfigBuf.data(), ConfigLen, Config);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -147,9 +165,7 @@ Expect<int32_t> AVUtilLicense::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(LicenseBuf, MemInst, char, LicensePtr, LicenseLen, "");
 
   const char *License = avutil_license();
-  auto Actual = std::strlen(License);
-  auto N = std::min<uint32_t>(LicenseLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(License, N, LicenseBuf.data());
+  copyCStringToBuffer(LicenseBuf.data(), LicenseLen, License);
   return static_cast<int32_t>(ErrNo::Success);
 }
 

--- a/plugins/wasmedge_ffmpeg/avutil/error.cpp
+++ b/plugins/wasmedge_ffmpeg/avutil/error.cpp
@@ -17,12 +17,10 @@ Expect<int32_t> AVUtilAVStrError::body(const Runtime::CallingFrame &Frame,
                                        uint32_t BufLen) {
   MEMINST_CHECK(MemInst, Frame, 0);
 
-  MEM_PTR_CHECK(ErrId, MemInst, char, ErrBuf,
-                "Failed when accessing the return URL memory"sv);
+  MEM_SPAN_CHECK(ErrId, MemInst, char, ErrBuf, BufLen,
+                 "Failed when accessing the return URL memory"sv);
 
-  std::string Error;
-  std::copy_n(ErrId, BufLen, std::back_inserter(Error));
-  return av_strerror(ErrNum, const_cast<char *>(Error.c_str()), BufLen);
+  return av_strerror(ErrNum, ErrId.data(), BufLen);
 }
 
 Expect<int32_t> AVUtilAVError::body(const Runtime::CallingFrame &,

--- a/plugins/wasmedge_ffmpeg/avutil/pixfmt.cpp
+++ b/plugins/wasmedge_ffmpeg/avutil/pixfmt.cpp
@@ -19,6 +19,12 @@ AvPixFmtDescriptorNbComponents::body(const Runtime::CallingFrame &,
       FFmpegUtils::PixFmt::intoAVPixFmt(PixFormatId);
   const AVPixFmtDescriptor *AvPixFmtDescriptor =
       av_pix_fmt_desc_get(PixelFormat);
+  if (AvPixFmtDescriptor == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AvPixFmtDescriptorNbComponents: no "
+                  "descriptor for pixel format id {}"sv,
+                  PixFormatId);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
   return AvPixFmtDescriptor->nb_components;
 }
 
@@ -29,6 +35,12 @@ AvPixFmtDescriptorLog2ChromaW::body(const Runtime::CallingFrame &,
       FFmpegUtils::PixFmt::intoAVPixFmt(PixFormatId);
   const AVPixFmtDescriptor *AvPixFmtDescriptor =
       av_pix_fmt_desc_get(PixelFormat);
+  if (AvPixFmtDescriptor == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AvPixFmtDescriptorLog2ChromaW: no "
+                  "descriptor for pixel format id {}"sv,
+                  PixFormatId);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
   return AvPixFmtDescriptor->log2_chroma_w;
 }
 
@@ -39,6 +51,12 @@ AvPixFmtDescriptorLog2ChromaH::body(const Runtime::CallingFrame &,
       FFmpegUtils::PixFmt::intoAVPixFmt(PixFormatId);
   const AVPixFmtDescriptor *AvPixFmtDescriptor =
       av_pix_fmt_desc_get(PixelFormat);
+  if (AvPixFmtDescriptor == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] AvPixFmtDescriptorLog2ChromaH: no "
+                  "descriptor for pixel format id {}"sv,
+                  PixFormatId);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
   return AvPixFmtDescriptor->log2_chroma_h;
 }
 
@@ -46,6 +64,9 @@ Expect<int32_t> AVColorRangeNameLength::body(const Runtime::CallingFrame &,
                                              int32_t RangeId) {
   AVColorRange const ColorRange = static_cast<AVColorRange>(RangeId);
   const char *Name = av_color_range_name(ColorRange);
+  if (Name == nullptr) {
+    return 0;
+  }
   return strlen(Name);
 }
 
@@ -57,9 +78,7 @@ Expect<int32_t> AVColorRangeName::body(const Runtime::CallingFrame &Frame,
 
   AVColorRange const ColorRange = static_cast<AVColorRange>(RangeId);
   const char *RangeName = av_color_range_name(ColorRange);
-  auto Actual = std::strlen(RangeName);
-  auto N = std::min<uint32_t>(RangeLength, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(RangeName, N, RangeNameBuf.data());
+  copyCStringToBuffer(RangeNameBuf.data(), RangeLength, RangeName);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -68,6 +87,9 @@ Expect<int32_t> AVColorTransferNameLength::body(const Runtime::CallingFrame &,
   AVColorTransferCharacteristic const Characteristic =
       static_cast<AVColorTransferCharacteristic>(TransferId);
   const char *Name = av_color_transfer_name(Characteristic);
+  if (Name == nullptr) {
+    return 0;
+  }
   return strlen(Name);
 }
 
@@ -82,10 +104,7 @@ Expect<int32_t> AVColorTransferName::body(const Runtime::CallingFrame &Frame,
   AVColorTransferCharacteristic const Characteristic =
       static_cast<AVColorTransferCharacteristic>(TransferId);
   const char *TransferName = av_color_transfer_name(Characteristic);
-  auto Actual = std::strlen(TransferName);
-  auto N =
-      std::min<uint32_t>(TransferLength, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(TransferName, N, TransferNameBuf.data());
+  copyCStringToBuffer(TransferNameBuf.data(), TransferLength, TransferName);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -93,6 +112,9 @@ Expect<int32_t> AVColorSpaceNameLength::body(const Runtime::CallingFrame &,
                                              int32_t ColorSpaceId) {
   AVColorSpace const ColorSpace = static_cast<AVColorSpace>(ColorSpaceId);
   const char *Name = av_color_space_name(ColorSpace);
+  if (Name == nullptr) {
+    return 0;
+  }
   return strlen(Name);
 }
 
@@ -106,9 +128,7 @@ Expect<int32_t> AVColorSpaceName::body(const Runtime::CallingFrame &Frame,
 
   AVColorSpace const ColorSpace = static_cast<AVColorSpace>(ColorSpaceId);
   const char *ColorSpaceName = av_color_space_name(ColorSpace);
-  auto Actual = std::strlen(ColorSpaceName);
-  auto N = std::min<uint32_t>(ColorSpaceLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(ColorSpaceName, N, ColorSpaceBuf.data());
+  copyCStringToBuffer(ColorSpaceBuf.data(), ColorSpaceLen, ColorSpaceName);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -117,6 +137,9 @@ Expect<int32_t> AVColorPrimariesNameLength::body(const Runtime::CallingFrame &,
   AVColorPrimaries const ColorPrimaries =
       FFmpegUtils::ColorPrimaries::intoAVColorPrimaries(ColorPrimariesId);
   const char *Name = av_color_primaries_name(ColorPrimaries);
+  if (Name == nullptr) {
+    return 0;
+  }
   return strlen(Name);
 }
 
@@ -131,10 +154,8 @@ Expect<int32_t> AVColorPrimariesName::body(const Runtime::CallingFrame &Frame,
   AVColorPrimaries const ColorPrimaries =
       FFmpegUtils::ColorPrimaries::intoAVColorPrimaries(ColorPrimariesId);
   const char *PrimariesName = av_color_primaries_name(ColorPrimaries);
-  auto Actual = std::strlen(PrimariesName);
-  auto N =
-      std::min<uint32_t>(ColorPrimariesLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(PrimariesName, N, ColorPrimariesBuf.data());
+  copyCStringToBuffer(ColorPrimariesBuf.data(), ColorPrimariesLen,
+                      PrimariesName);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -143,7 +164,9 @@ Expect<int32_t> AVPixelFormatNameLength::body(const Runtime::CallingFrame &,
   AVPixelFormat const PixFormat =
       FFmpegUtils::PixFmt::intoAVPixFmt(AvPixFormatId);
   const AVPixFmtDescriptor *PixFmtDescriptor = av_pix_fmt_desc_get(PixFormat);
-
+  if (PixFmtDescriptor == nullptr) {
+    return 0;
+  }
   return strlen(PixFmtDescriptor->name);
 }
 
@@ -158,11 +181,9 @@ Expect<int32_t> AVPixelFormatName::body(const Runtime::CallingFrame &Frame,
   AVPixelFormat const PixFormat =
       FFmpegUtils::PixFmt::intoAVPixFmt(PixFormatId);
   const AVPixFmtDescriptor *PixFmtDescriptor = av_pix_fmt_desc_get(PixFormat);
-  const char *PixFormatName = PixFmtDescriptor->name;
-  auto Actual = std::strlen(PixFormatName);
-  auto N =
-      std::min<uint32_t>(PixFormatNameLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(PixFormatName, N, PixFormatBuf.data());
+  const char *Name =
+      (PixFmtDescriptor == nullptr) ? nullptr : PixFmtDescriptor->name;
+  copyCStringToBuffer(PixFormatBuf.data(), PixFormatNameLen, Name);
   return static_cast<int32_t>(ErrNo::Success);
 }
 

--- a/plugins/wasmedge_ffmpeg/avutil/samplefmt.cpp
+++ b/plugins/wasmedge_ffmpeg/avutil/samplefmt.cpp
@@ -47,10 +47,9 @@ Expect<int32_t> AVGetBytesPerSample::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVGetSampleFmt::body(const Runtime::CallingFrame &Frame,
                                      uint32_t Str, uint32_t StrLen) {
   MEMINST_CHECK(MemInst, Frame, 0);
-  MEM_PTR_CHECK(StrId, MemInst, char, Str, "");
+  MEM_SPAN_CHECK(StrId, MemInst, char, Str, StrLen, "");
 
-  std::string TargetUrl;
-  std::copy_n(StrId, StrLen, std::back_inserter(TargetUrl));
+  std::string TargetUrl(StrId.data(), StrLen);
 
   AVSampleFormat const AvSampleFormat = av_get_sample_fmt(TargetUrl.c_str());
   return FFmpegUtils::SampleFmt::toSampleID(AvSampleFormat);
@@ -95,6 +94,9 @@ Expect<int32_t> AVGetSampleFmtNameLength::body(const Runtime::CallingFrame &,
       FFmpegUtils::SampleFmt::fromSampleID(SampleFmtId);
 
   const char *Name = av_get_sample_fmt_name(SampleFmt);
+  if (Name == nullptr) {
+    return 0;
+  }
   return strlen(Name);
 }
 
@@ -109,7 +111,7 @@ Expect<int32_t> AVGetSampleFmtName::body(const Runtime::CallingFrame &Frame,
   AVSampleFormat const SampleFmt =
       FFmpegUtils::SampleFmt::fromSampleID(SampleFmtId);
   const char *Name = av_get_sample_fmt_name(SampleFmt);
-  std::copy_n(Name, SampleFmtNameLen, SampleFmtBuf.data());
+  copyCStringToBuffer(SampleFmtBuf.data(), SampleFmtNameLen, Name);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -123,6 +125,8 @@ Expect<int32_t> AVGetSampleFmtMask::body(const Runtime::CallingFrame &,
 Expect<int32_t> AVFreep::body(const Runtime::CallingFrame &,
                               uint32_t BufferId) {
   FFMPEG_PTR_FETCH(Buffer, BufferId, uint8_t *);
+  FFMPEG_PTR_CHECK_FREE(Buffer, BufferId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   av_freep(Buffer);
   FFMPEG_PTR_DELETE(BufferId);
   return static_cast<int32_t>(ErrNo::Success);

--- a/plugins/wasmedge_ffmpeg/avutil/samplefmt.cpp
+++ b/plugins/wasmedge_ffmpeg/avutil/samplefmt.cpp
@@ -127,7 +127,10 @@ Expect<int32_t> AVFreep::body(const Runtime::CallingFrame &,
   FFMPEG_PTR_FETCH(Buffer, BufferId, uint8_t *);
   FFMPEG_PTR_CHECK_FREE(Buffer, BufferId,
                         static_cast<int32_t>(ErrNo::InternalError));
+  // Ids of this type come from AVSamplesAllocArrayAndSamples: plane 0 owns
+  // the joint sample buffer and the plane-pointer array is its own allocation.
   av_freep(Buffer);
+  av_free(Buffer);
   FFMPEG_PTR_DELETE(BufferId);
   return static_cast<int32_t>(ErrNo::Success);
 }

--- a/plugins/wasmedge_ffmpeg/avutil/samplefmt.cpp
+++ b/plugins/wasmedge_ffmpeg/avutil/samplefmt.cpp
@@ -128,6 +128,7 @@ Expect<int32_t> AVFreep::body(const Runtime::CallingFrame &,
   FFMPEG_PTR_CHECK_FREE(Buffer, BufferId,
                         static_cast<int32_t>(ErrNo::InternalError));
   av_freep(Buffer);
+  av_free(Buffer);
   FFMPEG_PTR_DELETE(BufferId);
   return static_cast<int32_t>(ErrNo::Success);
 }

--- a/plugins/wasmedge_ffmpeg/bindings.h
+++ b/plugins/wasmedge_ffmpeg/bindings.h
@@ -3671,6 +3671,25 @@ public:
     return Channel;
   }
 
+  static AVChannel channelFromMask(uint64_t ChannelMask) {
+    if (ChannelMask == 0) {
+      return AV_CHAN_NONE;
+    }
+    unsigned Index = 0;
+    while ((ChannelMask & 1ULL) == 0ULL) {
+      ChannelMask >>= 1;
+      ++Index;
+    }
+    return static_cast<AVChannel>(Index);
+  }
+
+  static uint64_t intoChannelLayoutID(const AVChannelLayout &ChLayout) {
+    if (ChLayout.order != AV_CHANNEL_ORDER_NATIVE) {
+      return 0;
+    }
+    return intoChannelLayoutID(ChLayout.u.mask);
+  }
+
   // Perfect Logic :)
   static uint64_t intoChannelLayoutID(uint64_t ChannelLayout) {
     uint64_t Channel = 0;

--- a/plugins/wasmedge_ffmpeg/ffmpeg_base.h
+++ b/plugins/wasmedge_ffmpeg/ffmpeg_base.h
@@ -17,6 +17,10 @@ public:
   HostFunction(std::shared_ptr<WasmEdgeFFmpegEnv> HostEnv)
       : Runtime::HostFunction<T>(0), Env(HostEnv) {}
 
+  const std::shared_ptr<WasmEdgeFFmpegEnv> &getEnv() const noexcept {
+    return Env;
+  }
+
 protected:
   std::shared_ptr<WasmEdgeFFmpegEnv> Env;
 };

--- a/plugins/wasmedge_ffmpeg/ffmpeg_env.cpp
+++ b/plugins/wasmedge_ffmpeg/ffmpeg_env.cpp
@@ -3,6 +3,7 @@
 
 #include "avcodec/module.h"
 #include "avdevice/module.h"
+#include "avfilter/avFilter.h"
 #include "avfilter/module.h"
 #include "avformat/module.h"
 #include "avutil/module.h"
@@ -106,6 +107,14 @@ Plugin::Plugin::PluginDescriptor Descriptor{
 EXPORT_GET_DESCRIPTOR(Descriptor)
 
 } // namespace
+
+WasmEdgeFFmpeg::WasmEdgeFFmpegEnv::~WasmEdgeFFmpegEnv() {
+  for (const auto &Pair : FfmpegPtrMap) {
+    if (Pair.second.Tag == detail::handleTag<AVFilter::FilterPadView>()) {
+      delete static_cast<AVFilter::FilterPadView *>(Pair.second.Ptr);
+    }
+  }
+}
 
 std::weak_ptr<WasmEdgeFFmpeg::WasmEdgeFFmpegEnv>
     WasmEdgeFFmpeg::WasmEdgeFFmpegEnv::Instance =

--- a/plugins/wasmedge_ffmpeg/ffmpeg_env.h
+++ b/plugins/wasmedge_ffmpeg/ffmpeg_env.h
@@ -186,6 +186,11 @@ public:
 
   WasmEdgeFFmpegEnv() noexcept {}
 
+  // Reclaims the FilterPadView entries still in the table: they are the only
+  // plugin-owned objects in it, and a view whose id the guest discarded would
+  // otherwise leak. Defined in ffmpeg_env.cpp, where FilterPadView is complete.
+  ~WasmEdgeFFmpegEnv();
+
 private:
   void eraseKeyByValue(void *Data, uint32_t Key) {
     auto Range = KeysByValue.equal_range(Data);

--- a/plugins/wasmedge_ffmpeg/ffmpeg_env.h
+++ b/plugins/wasmedge_ffmpeg/ffmpeg_env.h
@@ -6,12 +6,38 @@
 #include "bindings.h"
 #include "plugin/plugin.h"
 
+#include <algorithm>
+#include <cstring>
+#include <map>
 #include <memory>
+#include <set>
+#include <type_traits>
 #include <vector>
 
 namespace WasmEdge {
 namespace Host {
 namespace WasmEdgeFFmpeg {
+
+namespace detail {
+// Address-based type tag: &HandleTypeId<T>::Id is unique per distinct T and
+// well-defined even for the forward-declared ffmpeg types this header never
+// completes. A fetch whose recorded tag mismatches the requested type is
+// rejected instead of reinterpreting the pointer.
+template <typename T> struct HandleTypeId {
+  static const char Id;
+};
+template <typename T> const char HandleTypeId<T>::Id = 0;
+
+// Collapses cv-qualifiers and one level of pointer so that AVCodec,
+// const AVCodec and const AVCodec * all share a tag.
+template <typename T>
+using NormalizeHandle =
+    std::remove_cv_t<std::remove_pointer_t<std::remove_cv_t<T>>>;
+
+template <typename T> inline const void *handleTag() {
+  return &HandleTypeId<NormalizeHandle<T>>::Id;
+}
+} // namespace detail
 
 class WasmEdgeFFmpegEnv {
 public:
@@ -30,21 +56,90 @@ public:
   WasmEdgeFFmpegEnv(const WasmEdgeFFmpegEnv &) = delete;
   void operator=(const WasmEdgeFFmpegEnv &) = delete;
 
-  void alloc(void *Data, uint32_t *DataPtr) {
-    FfmpegPtrMap[FfmpegPtrAllocateKey++] = Data;
+  // Maps a null pointer to the reserved id 0 and stores no entry; a null
+  // entry would be unreclaimable and grow the handle maps without bound.
+  template <typename T> void alloc(T *Data, uint32_t *DataPtr) {
+    if (Data == nullptr) {
+      *DataPtr = 0;
+      return;
+    }
+    void *const Raw = const_cast<void *>(static_cast<const void *>(Data));
+    FfmpegPtrMap[FfmpegPtrAllocateKey++] = Entry{Raw, detail::handleTag<T>()};
     *DataPtr = FfmpegPtrAllocateKey - 1;
+    KeysByValue.emplace(Raw, *DataPtr);
+  }
+
+  // Stores a borrowed (non-owning) pointer: the object is owned by another
+  // structure, so freeing the returned id must not free it.
+  template <typename T> void allocRef(T *Data, uint32_t *DataPtr) {
+    alloc(Data, DataPtr);
+    if (*DataPtr != 0) {
+      BorrowedKeys.insert(*DataPtr);
+    }
+  }
+
+  bool isBorrowed(uint32_t Index) const {
+    return BorrowedKeys.find(Index) != BorrowedKeys.end();
+  }
+
+  // Stores a borrowed child owned by ParentId; deallocChildren drops the child
+  // id with its parent, so it cannot outlive the object it points into.
+  template <typename T>
+  void allocChild(T *Data, uint32_t *DataPtr, uint32_t ParentId) {
+    allocRef(Data, DataPtr);
+    if (*DataPtr != 0 && ParentIdByChild.emplace(*DataPtr, ParentId).second) {
+      ChildIdsByParent.emplace(ParentId, *DataPtr);
+    }
+  }
+
+  // Marks an already-stored id borrowed without linking it to a parent, e.g.
+  // an AVFilterInOut adopted by another chain via AVFilterInOutSetNext.
+  void markBorrowed(uint32_t Index) { BorrowedKeys.insert(Index); }
+
+  // Transfers an already-stored id to ParentId: it becomes borrowed and is
+  // dropped when the parent is freed via deallocChildren.
+  void markBorrowedChild(uint32_t Index, uint32_t ParentId) {
+    BorrowedKeys.insert(Index);
+    if (ParentIdByChild.emplace(Index, ParentId).second) {
+      ChildIdsByParent.emplace(ParentId, Index);
+    }
+  }
+
+  void deallocChildren(uint32_t ParentId) {
+    auto Range = ChildIdsByParent.equal_range(ParentId);
+    std::vector<uint32_t> Children;
+    for (auto It = Range.first; It != Range.second; ++It) {
+      Children.push_back(It->second);
+      ParentIdByChild.erase(It->second);
+    }
+    ChildIdsByParent.erase(ParentId);
+    for (uint32_t const ChildId : Children) {
+      dealloc(ChildId);
+    }
   }
 
   void *fetchData(const size_t Index) {
     if (Index >= FfmpegPtrAllocateKey) {
       return nullptr;
     }
-    // Check this condition.
-    if (FfmpegPtrMap[Index] == nullptr) {
+    // find(), not operator[]: an absent id must not insert a null entry.
+    auto It = FfmpegPtrMap.find(static_cast<uint32_t>(Index));
+    if (It == FfmpegPtrMap.end()) {
       return nullptr;
     }
+    return It->second.Ptr;
+  }
 
-    return FfmpegPtrMap[Index];
+  // Returns the stored pointer only when its recorded tag matches T.
+  template <typename T> T *fetchTyped(const size_t Index) {
+    if (Index >= FfmpegPtrAllocateKey) {
+      return nullptr;
+    }
+    auto It = FfmpegPtrMap.find(static_cast<uint32_t>(Index));
+    if (It == FfmpegPtrMap.end() || It->second.Tag != detail::handleTag<T>()) {
+      return nullptr;
+    }
+    return static_cast<T *>(It->second.Ptr);
   }
 
   void dealloc(size_t Index) {
@@ -53,16 +148,87 @@ public:
       return;
     }
 
-    FfmpegPtrMap.erase(Index);
+    auto It = FfmpegPtrMap.find(static_cast<uint32_t>(Index));
+    if (It != FfmpegPtrMap.end()) {
+      eraseKeyByValue(It->second.Ptr, static_cast<uint32_t>(Index));
+      FfmpegPtrMap.erase(It);
+    }
+    BorrowedKeys.erase(static_cast<uint32_t>(Index));
+    eraseChildLink(static_cast<uint32_t>(Index));
+  }
+
+  // Clears the borrowed mark on every id aliasing Data. Used when a node is
+  // detached from its owning chain and must regain the right to be freed.
+  void unmarkBorrowedByValue(void *Data) {
+    if (Data == nullptr) {
+      return;
+    }
+    auto Range = KeysByValue.equal_range(Data);
+    for (auto It = Range.first; It != Range.second; ++It) {
+      BorrowedKeys.erase(It->second);
+    }
+  }
+
+  // Removes every id mapping to Data plus its parent/child bookkeeping, so no
+  // alias id dangles when the underlying object is freed.
+  void deallocByValue(void *Data) {
+    if (Data == nullptr) {
+      return;
+    }
+    auto Range = KeysByValue.equal_range(Data);
+    for (auto It = Range.first; It != Range.second; ++It) {
+      FfmpegPtrMap.erase(It->second);
+      BorrowedKeys.erase(It->second);
+      eraseChildLink(It->second);
+    }
+    KeysByValue.erase(Data);
   }
 
   WasmEdgeFFmpegEnv() noexcept {}
 
 private:
+  void eraseKeyByValue(void *Data, uint32_t Key) {
+    auto Range = KeysByValue.equal_range(Data);
+    for (auto It = Range.first; It != Range.second; ++It) {
+      if (It->second == Key) {
+        KeysByValue.erase(It);
+        return;
+      }
+    }
+  }
+
+  void eraseChildLink(uint32_t ChildId) {
+    auto It = ParentIdByChild.find(ChildId);
+    if (It == ParentIdByChild.end()) {
+      return;
+    }
+    auto Range = ChildIdsByParent.equal_range(It->second);
+    for (auto CIt = Range.first; CIt != Range.second; ++CIt) {
+      if (CIt->second == ChildId) {
+        ChildIdsByParent.erase(CIt);
+        break;
+      }
+    }
+    ParentIdByChild.erase(It);
+  }
+
+  // A stored pointer plus the tag of the type it was stored as.
+  struct Entry {
+    void *Ptr;
+    const void *Tag;
+  };
+
   //  Using zero as NULL Value.
   uint32_t FfmpegPtrAllocateKey = 1;
   // Can update this to uint64_t to get more memory.
-  std::map<uint32_t, void *> FfmpegPtrMap;
+  std::map<uint32_t, Entry> FfmpegPtrMap;
+  std::set<uint32_t> BorrowedKeys;
+  std::multimap<uint32_t, uint32_t> ChildIdsByParent;
+  // Reverse index of ChildIdsByParent, so a child freed on its own can drop
+  // its entry without leaking it for the parent's lifetime.
+  std::map<uint32_t, uint32_t> ParentIdByChild;
+  // Reverse index of FfmpegPtrMap: every id aliasing a stored pointer.
+  std::multimap<void *, uint32_t> KeysByValue;
   static std::weak_ptr<WasmEdgeFFmpegEnv> Instance;
   static std::shared_mutex Mutex;
 };
@@ -76,9 +242,36 @@ private:
   }
 
 #define FFMPEG_PTR_FETCH(StructPtr, FFmpegStructId, Type)                      \
-  Type *StructPtr = nullptr;                                                   \
-  if (FFmpegStructId != 0)                                                     \
-    StructPtr = static_cast<Type *>(Env.get()->fetchData(FFmpegStructId));
+  Type *StructPtr = Env.get()->fetchTyped<Type>(FFmpegStructId);
+
+// Returns Ret when a guest-supplied handle id did not resolve. The id is
+// intentionally not logged, so a stream of bad ids cannot become log spam.
+#define FFMPEG_PTR_CHECK(StructPtr, Ret)                                       \
+  if (unlikely(StructPtr == nullptr)) {                                        \
+    return Ret;                                                                \
+  }
+
+// For handles ffmpeg accepts as NULL (drain/flush packets and frames,
+// optional filters, dicts, and codecs): id 0 keeps meaning "pass NULL", but a
+// nonzero id that failed the typed fetch is rejected instead of silently
+// triggering the NULL semantics.
+#define FFMPEG_PTR_CHECK_NONZERO(StructPtr, FFmpegStructId, Ret)               \
+  if (unlikely((FFmpegStructId) != 0 && (StructPtr) == nullptr)) {             \
+    return Ret;                                                                \
+  }
+
+// Keeps the free/drop wrappers idempotent: id 0 and stale ids succeed as
+// no-ops, mirroring FFmpeg's free(NULL), while a nonzero id resolving to a
+// live handle of another type is rejected before an id-keyed deallocation
+// could erase that handle.
+#define FFMPEG_PTR_CHECK_FREE(StructPtr, FFmpegStructId, Ret)                  \
+  if (unlikely((StructPtr) == nullptr)) {                                      \
+    if ((FFmpegStructId) != 0 &&                                               \
+        Env.get()->fetchData(FFmpegStructId) != nullptr) {                     \
+      return Ret;                                                              \
+    }                                                                          \
+    return static_cast<int32_t>(ErrNo::Success);                               \
+  }
 
 #define MEM_SPAN_CHECK(OutSpan, MemInst, Type, BufPtr, BufLen, Message)        \
   auto OutSpan = MemInst->getSpan<Type>(BufPtr, BufLen);                       \
@@ -89,6 +282,12 @@ private:
 
 #define FFMPEG_PTR_STORE(StructPtr, FFmpegStructId)                            \
   Env.get()->alloc(StructPtr, FFmpegStructId);
+
+#define FFMPEG_PTR_STORE_REF(StructPtr, FFmpegStructId)                        \
+  Env.get()->allocRef(StructPtr, FFmpegStructId);
+
+#define FFMPEG_PTR_STORE_CHILD(StructPtr, FFmpegStructId, ParentId)            \
+  Env.get()->allocChild(StructPtr, FFmpegStructId, ParentId);
 
 #define FFMPEG_PTR_DELETE(FFmpegStructId) Env.get()->dealloc(FFmpegStructId);
 
@@ -108,6 +307,61 @@ enum class ErrNo : int32_t {
   InternalError = -203,
   UnImplemented = -204 // Unimplemented funcs.
 };
+
+// Bounded C-string copy: never writes past DstLen, treats a null Src as an
+// empty string, and appends the terminator only when the buffer has room, so
+// a buffer sized exactly to the reported strlen still gets the full string.
+inline void copyCStringToBuffer(char *Dst, uint32_t DstLen, const char *Src) {
+  if (Src == nullptr) {
+    if (DstLen > 0) {
+      Dst[0] = '\0';
+    }
+    return;
+  }
+  size_t const SrcLen = std::strlen(Src);
+  size_t const N = std::min<size_t>(DstLen, SrcLen + 1);
+  std::copy_n(Src, N, Dst);
+}
+
+// Returns &Array[Idx], or nullptr when Array is null or Idx is out of range.
+template <typename T>
+T **checkedArraySlot(T **Array, uint32_t Count, uint32_t Idx) {
+  if (Array == nullptr || Idx >= Count) {
+    return nullptr;
+  }
+  return &Array[Idx];
+}
+
+// Replaces *Dst with an independent copy of Src (self-assignment is a no-op)
+// and frees the previous *Dst: metadata handles are borrowed pointers to the
+// field itself, so they observe the replacement instead of dangling. Returns
+// the av_dict_copy code, negative on failure.
+inline int setMetadataCopy(AVDictionary **Dst, AVDictionary *Src) {
+  if (Src == *Dst) {
+    return 0;
+  }
+  AVDictionary *Copy = nullptr;
+  if (Src != nullptr) {
+    int const Ret = av_dict_copy(&Copy, Src, 0);
+    if (Ret < 0) {
+      av_dict_free(&Copy);
+      return Ret;
+    }
+  }
+  av_dict_free(Dst);
+  *Dst = Copy;
+  return 0;
+}
+
+// setMetadataCopy for a guest dict handle, treating a null handle as an empty
+// source. Shared by the stream/frame/chapter/format metadata setters.
+inline int32_t applyMetadataCopy(AVDictionary **Dst, AVDictionary **Handle) {
+  AVDictionary *const Src = (Handle == nullptr) ? nullptr : *Handle;
+  if (setMetadataCopy(Dst, Src) < 0) {
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  return static_cast<int32_t>(ErrNo::Success);
+}
 
 } // namespace WasmEdgeFFmpeg
 } // namespace Host

--- a/plugins/wasmedge_ffmpeg/ffmpeg_env.h
+++ b/plugins/wasmedge_ffmpeg/ffmpeg_env.h
@@ -6,12 +6,32 @@
 #include "bindings.h"
 #include "plugin/plugin.h"
 
+#include <algorithm>
+#include <cstring>
+#include <map>
 #include <memory>
+#include <set>
+#include <type_traits>
 #include <vector>
 
 namespace WasmEdge {
 namespace Host {
 namespace WasmEdgeFFmpeg {
+
+namespace detail {
+template <typename T> struct HandleTypeId {
+  static const char Id;
+};
+template <typename T> const char HandleTypeId<T>::Id = 0;
+
+template <typename T>
+using NormalizeHandle =
+    std::remove_cv_t<std::remove_pointer_t<std::remove_cv_t<T>>>;
+
+template <typename T> inline const void *handleTag() {
+  return &HandleTypeId<NormalizeHandle<T>>::Id;
+}
+} // namespace detail
 
 class WasmEdgeFFmpegEnv {
 public:
@@ -30,21 +50,78 @@ public:
   WasmEdgeFFmpegEnv(const WasmEdgeFFmpegEnv &) = delete;
   void operator=(const WasmEdgeFFmpegEnv &) = delete;
 
-  void alloc(void *Data, uint32_t *DataPtr) {
-    FfmpegPtrMap[FfmpegPtrAllocateKey++] = Data;
+  template <typename T> void alloc(T *Data, uint32_t *DataPtr) {
+    if (Data == nullptr) {
+      *DataPtr = 0;
+      return;
+    }
+    void *const Raw = const_cast<void *>(static_cast<const void *>(Data));
+    FfmpegPtrMap[FfmpegPtrAllocateKey++] = Entry{Raw, detail::handleTag<T>()};
     *DataPtr = FfmpegPtrAllocateKey - 1;
+    KeysByValue.emplace(Raw, *DataPtr);
+  }
+
+  template <typename T> void allocRef(T *Data, uint32_t *DataPtr) {
+    alloc(Data, DataPtr);
+    if (*DataPtr != 0) {
+      BorrowedKeys.insert(*DataPtr);
+    }
+  }
+
+  bool isBorrowed(uint32_t Index) const {
+    return BorrowedKeys.find(Index) != BorrowedKeys.end();
+  }
+
+  template <typename T>
+  void allocChild(T *Data, uint32_t *DataPtr, uint32_t ParentId) {
+    allocRef(Data, DataPtr);
+    if (*DataPtr != 0 && ParentIdByChild.emplace(*DataPtr, ParentId).second) {
+      ChildIdsByParent.emplace(ParentId, *DataPtr);
+    }
+  }
+
+  void markBorrowed(uint32_t Index) { BorrowedKeys.insert(Index); }
+
+  void markBorrowedChild(uint32_t Index, uint32_t ParentId) {
+    BorrowedKeys.insert(Index);
+    if (ParentIdByChild.emplace(Index, ParentId).second) {
+      ChildIdsByParent.emplace(ParentId, Index);
+    }
+  }
+
+  void deallocChildren(uint32_t ParentId) {
+    auto Range = ChildIdsByParent.equal_range(ParentId);
+    std::vector<uint32_t> Children;
+    for (auto It = Range.first; It != Range.second; ++It) {
+      Children.push_back(It->second);
+      ParentIdByChild.erase(It->second);
+    }
+    ChildIdsByParent.erase(ParentId);
+    for (uint32_t const ChildId : Children) {
+      dealloc(ChildId);
+    }
   }
 
   void *fetchData(const size_t Index) {
     if (Index >= FfmpegPtrAllocateKey) {
       return nullptr;
     }
-    // Check this condition.
-    if (FfmpegPtrMap[Index] == nullptr) {
+    auto It = FfmpegPtrMap.find(static_cast<uint32_t>(Index));
+    if (It == FfmpegPtrMap.end()) {
       return nullptr;
     }
+    return It->second.Ptr;
+  }
 
-    return FfmpegPtrMap[Index];
+  template <typename T> T *fetchTyped(const size_t Index) {
+    if (Index >= FfmpegPtrAllocateKey) {
+      return nullptr;
+    }
+    auto It = FfmpegPtrMap.find(static_cast<uint32_t>(Index));
+    if (It == FfmpegPtrMap.end() || It->second.Tag != detail::handleTag<T>()) {
+      return nullptr;
+    }
+    return static_cast<T *>(It->second.Ptr);
   }
 
   void dealloc(size_t Index) {
@@ -53,16 +130,79 @@ public:
       return;
     }
 
-    FfmpegPtrMap.erase(Index);
+    auto It = FfmpegPtrMap.find(static_cast<uint32_t>(Index));
+    if (It != FfmpegPtrMap.end()) {
+      eraseKeyByValue(It->second.Ptr, static_cast<uint32_t>(Index));
+      FfmpegPtrMap.erase(It);
+    }
+    BorrowedKeys.erase(static_cast<uint32_t>(Index));
+    eraseChildLink(static_cast<uint32_t>(Index));
+  }
+
+  void unmarkBorrowedByValue(void *Data) {
+    if (Data == nullptr) {
+      return;
+    }
+    auto Range = KeysByValue.equal_range(Data);
+    for (auto It = Range.first; It != Range.second; ++It) {
+      BorrowedKeys.erase(It->second);
+    }
+  }
+
+  void deallocByValue(void *Data) {
+    if (Data == nullptr) {
+      return;
+    }
+    auto Range = KeysByValue.equal_range(Data);
+    for (auto It = Range.first; It != Range.second; ++It) {
+      FfmpegPtrMap.erase(It->second);
+      BorrowedKeys.erase(It->second);
+      eraseChildLink(It->second);
+    }
+    KeysByValue.erase(Data);
   }
 
   WasmEdgeFFmpegEnv() noexcept {}
 
 private:
+  void eraseKeyByValue(void *Data, uint32_t Key) {
+    auto Range = KeysByValue.equal_range(Data);
+    for (auto It = Range.first; It != Range.second; ++It) {
+      if (It->second == Key) {
+        KeysByValue.erase(It);
+        return;
+      }
+    }
+  }
+
+  void eraseChildLink(uint32_t ChildId) {
+    auto It = ParentIdByChild.find(ChildId);
+    if (It == ParentIdByChild.end()) {
+      return;
+    }
+    auto Range = ChildIdsByParent.equal_range(It->second);
+    for (auto CIt = Range.first; CIt != Range.second; ++CIt) {
+      if (CIt->second == ChildId) {
+        ChildIdsByParent.erase(CIt);
+        break;
+      }
+    }
+    ParentIdByChild.erase(It);
+  }
+
+  struct Entry {
+    void *Ptr;
+    const void *Tag;
+  };
+
   //  Using zero as NULL Value.
   uint32_t FfmpegPtrAllocateKey = 1;
   // Can update this to uint64_t to get more memory.
-  std::map<uint32_t, void *> FfmpegPtrMap;
+  std::map<uint32_t, Entry> FfmpegPtrMap;
+  std::set<uint32_t> BorrowedKeys;
+  std::multimap<uint32_t, uint32_t> ChildIdsByParent;
+  std::map<uint32_t, uint32_t> ParentIdByChild;
+  std::multimap<void *, uint32_t> KeysByValue;
   static std::weak_ptr<WasmEdgeFFmpegEnv> Instance;
   static std::shared_mutex Mutex;
 };
@@ -76,9 +216,26 @@ private:
   }
 
 #define FFMPEG_PTR_FETCH(StructPtr, FFmpegStructId, Type)                      \
-  Type *StructPtr = nullptr;                                                   \
-  if (FFmpegStructId != 0)                                                     \
-    StructPtr = static_cast<Type *>(Env.get()->fetchData(FFmpegStructId));
+  Type *StructPtr = Env.get()->fetchTyped<Type>(FFmpegStructId);
+
+#define FFMPEG_PTR_CHECK(StructPtr, Ret)                                       \
+  if (unlikely(StructPtr == nullptr)) {                                        \
+    return Ret;                                                                \
+  }
+
+#define FFMPEG_PTR_CHECK_NONZERO(StructPtr, FFmpegStructId, Ret)               \
+  if (unlikely((FFmpegStructId) != 0 && (StructPtr) == nullptr)) {             \
+    return Ret;                                                                \
+  }
+
+#define FFMPEG_PTR_CHECK_FREE(StructPtr, FFmpegStructId, Ret)                  \
+  if (unlikely((StructPtr) == nullptr)) {                                      \
+    if ((FFmpegStructId) != 0 &&                                               \
+        Env.get()->fetchData(FFmpegStructId) != nullptr) {                     \
+      return Ret;                                                              \
+    }                                                                          \
+    return static_cast<int32_t>(ErrNo::Success);                               \
+  }
 
 #define MEM_SPAN_CHECK(OutSpan, MemInst, Type, BufPtr, BufLen, Message)        \
   auto OutSpan = MemInst->getSpan<Type>(BufPtr, BufLen);                       \
@@ -89,6 +246,12 @@ private:
 
 #define FFMPEG_PTR_STORE(StructPtr, FFmpegStructId)                            \
   Env.get()->alloc(StructPtr, FFmpegStructId);
+
+#define FFMPEG_PTR_STORE_REF(StructPtr, FFmpegStructId)                        \
+  Env.get()->allocRef(StructPtr, FFmpegStructId);
+
+#define FFMPEG_PTR_STORE_CHILD(StructPtr, FFmpegStructId, ParentId)            \
+  Env.get()->allocChild(StructPtr, FFmpegStructId, ParentId);
 
 #define FFMPEG_PTR_DELETE(FFmpegStructId) Env.get()->dealloc(FFmpegStructId);
 
@@ -108,6 +271,51 @@ enum class ErrNo : int32_t {
   InternalError = -203,
   UnImplemented = -204 // Unimplemented funcs.
 };
+
+inline void copyCStringToBuffer(char *Dst, uint32_t DstLen, const char *Src) {
+  if (Src == nullptr) {
+    if (DstLen > 0) {
+      Dst[0] = '\0';
+    }
+    return;
+  }
+  size_t const SrcLen = std::strlen(Src);
+  size_t const N = std::min<size_t>(DstLen, SrcLen + 1);
+  std::copy_n(Src, N, Dst);
+}
+
+template <typename T>
+T **checkedArraySlot(T **Array, uint32_t Count, uint32_t Idx) {
+  if (Array == nullptr || Idx >= Count) {
+    return nullptr;
+  }
+  return &Array[Idx];
+}
+
+inline int setMetadataCopy(AVDictionary **Dst, AVDictionary *Src) {
+  if (Src == *Dst) {
+    return 0;
+  }
+  AVDictionary *Copy = nullptr;
+  if (Src != nullptr) {
+    int const Ret = av_dict_copy(&Copy, Src, 0);
+    if (Ret < 0) {
+      av_dict_free(&Copy);
+      return Ret;
+    }
+  }
+  av_dict_free(Dst);
+  *Dst = Copy;
+  return 0;
+}
+
+inline int32_t applyMetadataCopy(AVDictionary **Dst, AVDictionary **Handle) {
+  AVDictionary *const Src = (Handle == nullptr) ? nullptr : *Handle;
+  if (setMetadataCopy(Dst, Src) < 0) {
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  return static_cast<int32_t>(ErrNo::Success);
+}
 
 } // namespace WasmEdgeFFmpeg
 } // namespace Host

--- a/plugins/wasmedge_ffmpeg/ffmpeg_env.h
+++ b/plugins/wasmedge_ffmpeg/ffmpeg_env.h
@@ -164,6 +164,8 @@ public:
 
   WasmEdgeFFmpegEnv() noexcept {}
 
+  ~WasmEdgeFFmpegEnv();
+
 private:
   void eraseKeyByValue(void *Data, uint32_t Key) {
     auto Range = KeysByValue.equal_range(Data);

--- a/plugins/wasmedge_ffmpeg/swresample/swresample_func.cpp
+++ b/plugins/wasmedge_ffmpeg/swresample/swresample_func.cpp
@@ -21,12 +21,14 @@ Expect<uint32_t> SWResampleVersion::body(const Runtime::CallingFrame &) {
 Expect<int64_t> SWRGetDelay::body(const Runtime::CallingFrame &,
                                   uint32_t SWRContextId, int64_t Base) {
   FFMPEG_PTR_FETCH(SWRContext, SWRContextId, SwrContext);
+  FFMPEG_PTR_CHECK(SWRContext, 0);
   return swr_get_delay(SWRContext, Base);
 }
 
 Expect<int32_t> SWRInit::body(const Runtime::CallingFrame &,
                               uint32_t SWRContextId) {
   FFMPEG_PTR_FETCH(SWRContext, SWRContextId, SwrContext);
+  FFMPEG_PTR_CHECK(SWRContext, static_cast<int32_t>(ErrNo::InternalError));
   return swr_init(SWRContext);
 }
 
@@ -38,8 +40,15 @@ SWRAllocSetOpts::body(const Runtime::CallingFrame &Frame, uint32_t SwrCtxPtr,
                       int32_t InSampleRate, int32_t LogOffset) {
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_PTR_CHECK(SwrCtxId, MemInst, uint32_t, SwrCtxPtr, "")
-  FFMPEG_PTR_FETCH(CurrSwrCtx, *SwrCtxId, SwrContext);
   FFMPEG_PTR_FETCH(ExistSWRContext, SWRContextId, SwrContext);
+
+  // Id 0 is the legitimate "allocate a fresh context" request; a nonzero id
+  // that does not resolve is rejected instead of silently allocating anew.
+  // Leave *SwrCtxId unchanged: it may alias the guest's live handle (the
+  // in-place reconfigure idiom), and clearing it would strand that handle.
+  if (SWRContextId != 0 && ExistSWRContext == nullptr) {
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
 
   uint64_t const OutChLayout =
       FFmpegUtils::ChannelLayout::fromChannelLayoutID(OutChLayoutId);
@@ -51,21 +60,50 @@ SWRAllocSetOpts::body(const Runtime::CallingFrame &Frame, uint32_t SwrCtxPtr,
       FFmpegUtils::SampleFmt::fromSampleID(InSampleFmtId);
 
   AVChannelLayout AVOutChLayout;
-  av_channel_layout_from_mask(&AVOutChLayout, OutChLayout);
+  int const OutRet = av_channel_layout_from_mask(&AVOutChLayout, OutChLayout);
+  if (OutRet < 0) {
+    // Validation failed before swr_alloc_set_opts2 touched the existing
+    // context, so it is still live; leave the guest's handle intact.
+    spdlog::error("[WasmEdge-FFmpeg] SWRAllocSetOpts: "
+                  "av_channel_layout_from_mask failed ({}) for output "
+                  "channel layout mask {:#x}"sv,
+                  OutRet, OutChLayout);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
 
   AVChannelLayout AVInChLayout;
-  av_channel_layout_from_mask(&AVInChLayout, InChLayout);
+  int const InRet = av_channel_layout_from_mask(&AVInChLayout, InChLayout);
+  if (InRet < 0) {
+    av_channel_layout_uninit(&AVOutChLayout);
+    // As above: the context is untouched; preserve the guest's handle.
+    spdlog::error("[WasmEdge-FFmpeg] SWRAllocSetOpts: "
+                  "av_channel_layout_from_mask failed ({}) for input channel "
+                  "layout mask {:#x}"sv,
+                  InRet, InChLayout);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
 
-  swr_alloc_set_opts2(&ExistSWRContext, &AVOutChLayout, OutSampleFmt,
-                      OutSampleRate, &AVInChLayout, InSampleFmt, InSampleRate,
-                      LogOffset,
-                      nullptr); // Always being used as null in rust sdk.
-  CurrSwrCtx = ExistSWRContext;
-
+  SwrContext *const PrevSWRContext = ExistSWRContext;
+  int const AllocRet = swr_alloc_set_opts2(
+      &ExistSWRContext, &AVOutChLayout, OutSampleFmt, OutSampleRate,
+      &AVInChLayout, InSampleFmt, InSampleRate, LogOffset,
+      nullptr); // Always being used as null in rust sdk.
+  if (AllocRet < 0) {
+    av_channel_layout_uninit(&AVOutChLayout);
+    av_channel_layout_uninit(&AVInChLayout);
+    if (PrevSWRContext != nullptr) {
+      Env.get()->deallocByValue(PrevSWRContext);
+    }
+    *SwrCtxId = 0;
+    spdlog::error("[WasmEdge-FFmpeg] SWRAllocSetOpts: swr_alloc_set_opts2 "
+                  "failed ({})"sv,
+                  AllocRet);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
   av_channel_layout_uninit(&AVOutChLayout);
   av_channel_layout_uninit(&AVInChLayout);
 
-  FFMPEG_PTR_STORE(CurrSwrCtx, SwrCtxId);
+  FFMPEG_PTR_STORE(ExistSWRContext, SwrCtxId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -73,6 +111,9 @@ Expect<int32_t> AVOptSetDict::body(const Runtime::CallingFrame &,
                                    uint32_t SWRContextId, uint32_t DictId) {
   FFMPEG_PTR_FETCH(SWRContext, SWRContextId, SwrContext);
   FFMPEG_PTR_FETCH(AvDictionary, DictId, AVDictionary *);
+  FFMPEG_PTR_CHECK(SWRContext, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(AvDictionary, DictId,
+                           static_cast<int32_t>(ErrNo::InternalError));
   return av_opt_set_dict(SWRContext, AvDictionary);
 }
 
@@ -83,6 +124,13 @@ Expect<int32_t> SWRConvertFrame::body(const Runtime::CallingFrame &,
   FFMPEG_PTR_FETCH(SWRContext, SWRContextId, SwrContext);
   FFMPEG_PTR_FETCH(OuputFrame, FrameOutputId, AVFrame);
   FFMPEG_PTR_FETCH(InputFrame, FrameInputId, AVFrame);
+  // swr_convert_frame accepts a NULL output (query buffered samples) or NULL
+  // input (drain), so a null frame is allowed only for handle id 0.
+  FFMPEG_PTR_CHECK(SWRContext, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(OuputFrame, FrameOutputId,
+                           static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(InputFrame, FrameInputId,
+                           static_cast<int32_t>(ErrNo::InternalError));
 
   return swr_convert_frame(SWRContext, OuputFrame, InputFrame);
 }
@@ -90,8 +138,11 @@ Expect<int32_t> SWRConvertFrame::body(const Runtime::CallingFrame &,
 Expect<int32_t> SWRFree::body(const Runtime::CallingFrame &,
                               uint32_t SWRContextId) {
   FFMPEG_PTR_FETCH(SWRContext, SWRContextId, SwrContext);
-  swr_close(SWRContext);
-  FFMPEG_PTR_DELETE(SWRContextId);
+  FFMPEG_PTR_CHECK_FREE(SWRContext, SWRContextId,
+                        static_cast<int32_t>(ErrNo::InternalError));
+  SwrContext *const FreedCtx = SWRContext;
+  swr_free(&SWRContext);
+  Env.get()->deallocByValue(FreedCtx);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -108,9 +159,7 @@ SWResampleConfiguration::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(ConfigBuf, MemInst, char, ConfigPtr, ConfigLen, "");
 
   const char *Config = swresample_configuration();
-  auto Actual = std::strlen(Config);
-  auto N = std::min<uint32_t>(ConfigLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(Config, N, ConfigBuf.data());
+  copyCStringToBuffer(ConfigBuf.data(), ConfigLen, Config);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -126,9 +175,7 @@ Expect<int32_t> SWResampleLicense::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(LicenseBuf, MemInst, char, LicensePtr, LicenseLen, "");
 
   const char *License = swresample_license();
-  auto Actual = std::strlen(License);
-  auto N = std::min<uint32_t>(LicenseLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(License, N, LicenseBuf.data());
+  copyCStringToBuffer(LicenseBuf.data(), LicenseLen, License);
   return static_cast<int32_t>(ErrNo::Success);
 }
 

--- a/plugins/wasmedge_ffmpeg/swresample/swresample_func.cpp
+++ b/plugins/wasmedge_ffmpeg/swresample/swresample_func.cpp
@@ -21,12 +21,14 @@ Expect<uint32_t> SWResampleVersion::body(const Runtime::CallingFrame &) {
 Expect<int64_t> SWRGetDelay::body(const Runtime::CallingFrame &,
                                   uint32_t SWRContextId, int64_t Base) {
   FFMPEG_PTR_FETCH(SWRContext, SWRContextId, SwrContext);
+  FFMPEG_PTR_CHECK(SWRContext, 0);
   return swr_get_delay(SWRContext, Base);
 }
 
 Expect<int32_t> SWRInit::body(const Runtime::CallingFrame &,
                               uint32_t SWRContextId) {
   FFMPEG_PTR_FETCH(SWRContext, SWRContextId, SwrContext);
+  FFMPEG_PTR_CHECK(SWRContext, static_cast<int32_t>(ErrNo::InternalError));
   return swr_init(SWRContext);
 }
 
@@ -38,8 +40,11 @@ SWRAllocSetOpts::body(const Runtime::CallingFrame &Frame, uint32_t SwrCtxPtr,
                       int32_t InSampleRate, int32_t LogOffset) {
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_PTR_CHECK(SwrCtxId, MemInst, uint32_t, SwrCtxPtr, "")
-  FFMPEG_PTR_FETCH(CurrSwrCtx, *SwrCtxId, SwrContext);
   FFMPEG_PTR_FETCH(ExistSWRContext, SWRContextId, SwrContext);
+
+  if (SWRContextId != 0 && ExistSWRContext == nullptr) {
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
 
   uint64_t const OutChLayout =
       FFmpegUtils::ChannelLayout::fromChannelLayoutID(OutChLayoutId);
@@ -51,21 +56,46 @@ SWRAllocSetOpts::body(const Runtime::CallingFrame &Frame, uint32_t SwrCtxPtr,
       FFmpegUtils::SampleFmt::fromSampleID(InSampleFmtId);
 
   AVChannelLayout AVOutChLayout;
-  av_channel_layout_from_mask(&AVOutChLayout, OutChLayout);
+  int const OutRet = av_channel_layout_from_mask(&AVOutChLayout, OutChLayout);
+  if (OutRet < 0) {
+    spdlog::error("[WasmEdge-FFmpeg] SWRAllocSetOpts: "
+                  "av_channel_layout_from_mask failed ({}) for output "
+                  "channel layout mask {:#x}"sv,
+                  OutRet, OutChLayout);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
 
   AVChannelLayout AVInChLayout;
-  av_channel_layout_from_mask(&AVInChLayout, InChLayout);
+  int const InRet = av_channel_layout_from_mask(&AVInChLayout, InChLayout);
+  if (InRet < 0) {
+    av_channel_layout_uninit(&AVOutChLayout);
+    spdlog::error("[WasmEdge-FFmpeg] SWRAllocSetOpts: "
+                  "av_channel_layout_from_mask failed ({}) for input channel "
+                  "layout mask {:#x}"sv,
+                  InRet, InChLayout);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
 
-  swr_alloc_set_opts2(&ExistSWRContext, &AVOutChLayout, OutSampleFmt,
-                      OutSampleRate, &AVInChLayout, InSampleFmt, InSampleRate,
-                      LogOffset,
-                      nullptr); // Always being used as null in rust sdk.
-  CurrSwrCtx = ExistSWRContext;
-
+  SwrContext *const PrevSWRContext = ExistSWRContext;
+  int const AllocRet = swr_alloc_set_opts2(
+      &ExistSWRContext, &AVOutChLayout, OutSampleFmt, OutSampleRate,
+      &AVInChLayout, InSampleFmt, InSampleRate, LogOffset, nullptr);
+  if (AllocRet < 0) {
+    av_channel_layout_uninit(&AVOutChLayout);
+    av_channel_layout_uninit(&AVInChLayout);
+    if (PrevSWRContext != nullptr) {
+      Env.get()->deallocByValue(PrevSWRContext);
+    }
+    *SwrCtxId = 0;
+    spdlog::error("[WasmEdge-FFmpeg] SWRAllocSetOpts: swr_alloc_set_opts2 "
+                  "failed ({})"sv,
+                  AllocRet);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
   av_channel_layout_uninit(&AVOutChLayout);
   av_channel_layout_uninit(&AVInChLayout);
 
-  FFMPEG_PTR_STORE(CurrSwrCtx, SwrCtxId);
+  FFMPEG_PTR_STORE(ExistSWRContext, SwrCtxId);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -73,6 +103,9 @@ Expect<int32_t> AVOptSetDict::body(const Runtime::CallingFrame &,
                                    uint32_t SWRContextId, uint32_t DictId) {
   FFMPEG_PTR_FETCH(SWRContext, SWRContextId, SwrContext);
   FFMPEG_PTR_FETCH(AvDictionary, DictId, AVDictionary *);
+  FFMPEG_PTR_CHECK(SWRContext, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(AvDictionary, DictId,
+                           static_cast<int32_t>(ErrNo::InternalError));
   return av_opt_set_dict(SWRContext, AvDictionary);
 }
 
@@ -83,6 +116,11 @@ Expect<int32_t> SWRConvertFrame::body(const Runtime::CallingFrame &,
   FFMPEG_PTR_FETCH(SWRContext, SWRContextId, SwrContext);
   FFMPEG_PTR_FETCH(OuputFrame, FrameOutputId, AVFrame);
   FFMPEG_PTR_FETCH(InputFrame, FrameInputId, AVFrame);
+  FFMPEG_PTR_CHECK(SWRContext, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(OuputFrame, FrameOutputId,
+                           static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(InputFrame, FrameInputId,
+                           static_cast<int32_t>(ErrNo::InternalError));
 
   return swr_convert_frame(SWRContext, OuputFrame, InputFrame);
 }
@@ -90,8 +128,11 @@ Expect<int32_t> SWRConvertFrame::body(const Runtime::CallingFrame &,
 Expect<int32_t> SWRFree::body(const Runtime::CallingFrame &,
                               uint32_t SWRContextId) {
   FFMPEG_PTR_FETCH(SWRContext, SWRContextId, SwrContext);
-  swr_close(SWRContext);
-  FFMPEG_PTR_DELETE(SWRContextId);
+  FFMPEG_PTR_CHECK_FREE(SWRContext, SWRContextId,
+                        static_cast<int32_t>(ErrNo::InternalError));
+  SwrContext *const FreedCtx = SWRContext;
+  swr_free(&SWRContext);
+  Env.get()->deallocByValue(FreedCtx);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -108,9 +149,7 @@ SWResampleConfiguration::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(ConfigBuf, MemInst, char, ConfigPtr, ConfigLen, "");
 
   const char *Config = swresample_configuration();
-  auto Actual = std::strlen(Config);
-  auto N = std::min<uint32_t>(ConfigLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(Config, N, ConfigBuf.data());
+  copyCStringToBuffer(ConfigBuf.data(), ConfigLen, Config);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -126,9 +165,7 @@ Expect<int32_t> SWResampleLicense::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(LicenseBuf, MemInst, char, LicensePtr, LicenseLen, "");
 
   const char *License = swresample_license();
-  auto Actual = std::strlen(License);
-  auto N = std::min<uint32_t>(LicenseLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(License, N, LicenseBuf.data());
+  copyCStringToBuffer(LicenseBuf.data(), LicenseLen, License);
   return static_cast<int32_t>(ErrNo::Success);
 }
 

--- a/plugins/wasmedge_ffmpeg/swscale/swscale_func.cpp
+++ b/plugins/wasmedge_ffmpeg/swscale/swscale_func.cpp
@@ -25,6 +25,10 @@ SwsGetContext::body(const Runtime::CallingFrame &Frame, uint32_t SwsCtxPtr,
   FFMPEG_PTR_FETCH(SwsCtx, *SwsCtxId, SwsContext)
   FFMPEG_PTR_FETCH(SrcSwsFilter, SrcFilterId, SwsFilter)
   FFMPEG_PTR_FETCH(DesSwsFilter, DesFilterId, SwsFilter)
+  FFMPEG_PTR_CHECK_NONZERO(SrcSwsFilter, SrcFilterId,
+                           static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(DesSwsFilter, DesFilterId,
+                           static_cast<int32_t>(ErrNo::InternalError));
 
   AVPixelFormat const SrcPixelFormat =
       FFmpegUtils::PixFmt::intoAVPixFmt(SrcPixFormatId);
@@ -34,6 +38,9 @@ SwsGetContext::body(const Runtime::CallingFrame &Frame, uint32_t SwsCtxPtr,
                           DestPixelFormat, Flags, SrcSwsFilter, DesSwsFilter,
                           nullptr); // Not using param anywhere in Rust SDK.
   if (SwsCtx == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] SwsGetContext: sws_getContext failed "
+                  "({}x{} format id {} -> {}x{} format id {})"sv,
+                  SrcW, SrcH, SrcPixFormatId, DesW, DesH, DesPixFormatId);
     return static_cast<int32_t>(ErrNo::InternalError);
   }
   FFMPEG_PTR_STORE(SwsCtx, SwsCtxId);
@@ -43,8 +50,10 @@ SwsGetContext::body(const Runtime::CallingFrame &Frame, uint32_t SwsCtxPtr,
 Expect<int32_t> SwsFreeContext::body(const Runtime::CallingFrame &,
                                      uint32_t SwsCtxId) {
   FFMPEG_PTR_FETCH(SwsCtx, SwsCtxId, SwsContext)
+  FFMPEG_PTR_CHECK_FREE(SwsCtx, SwsCtxId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   sws_freeContext(SwsCtx);
-  FFMPEG_PTR_DELETE(SwsCtxId);
+  Env.get()->deallocByValue(SwsCtx);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -54,6 +63,9 @@ Expect<int32_t> SwsScale::body(const Runtime::CallingFrame &, uint32_t SwsCtxId,
   FFMPEG_PTR_FETCH(SwsCtx, SwsCtxId, SwsContext);
   FFMPEG_PTR_FETCH(InputFrame, InputFrameId, AVFrame);
   FFMPEG_PTR_FETCH(OutputFrame, OutputFrameId, AVFrame);
+  FFMPEG_PTR_CHECK(SwsCtx, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK(InputFrame, static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK(OutputFrame, static_cast<int32_t>(ErrNo::InternalError));
   return sws_scale(SwsCtx, InputFrame->data, InputFrame->linesize, SrcSliceY,
                    SrcSliceH, OutputFrame->data, OutputFrame->linesize);
 }
@@ -66,22 +78,37 @@ Expect<int32_t> SwsGetCachedContext::body(
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_PTR_CHECK(SwsCachedCtxId, MemInst, uint32_t, SwsCachedCtxPtr, "")
 
-  FFMPEG_PTR_FETCH(SwsCachedCtx, *SwsCachedCtxId, SwsContext);
   FFMPEG_PTR_FETCH(SwsCtx, SwsCtxId, SwsContext);
   FFMPEG_PTR_FETCH(SrcSwsFilter, SrcFilterId, SwsFilter)
   FFMPEG_PTR_FETCH(DesSwsFilter, DesFilterId, SwsFilter)
+  FFMPEG_PTR_CHECK_NONZERO(SwsCtx, SwsCtxId,
+                           static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(SrcSwsFilter, SrcFilterId,
+                           static_cast<int32_t>(ErrNo::InternalError));
+  FFMPEG_PTR_CHECK_NONZERO(DesSwsFilter, DesFilterId,
+                           static_cast<int32_t>(ErrNo::InternalError));
 
   AVPixelFormat const SrcPixelFormat =
       FFmpegUtils::PixFmt::intoAVPixFmt(SrcPixFormatId);
   AVPixelFormat const DestPixelFormat =
       FFmpegUtils::PixFmt::intoAVPixFmt(DesPixFormatId);
-  SwsCachedCtx = sws_getCachedContext(SwsCtx, SrcW, SrcH, SrcPixelFormat, DesW,
-                                      DesH, DestPixelFormat, Flags,
-                                      SrcSwsFilter, DesSwsFilter, nullptr);
+  SwsContext *const PrevSwsCtx = SwsCtx;
+  SwsContext *SwsCachedCtx = sws_getCachedContext(
+      SwsCtx, SrcW, SrcH, SrcPixelFormat, DesW, DesH, DestPixelFormat, Flags,
+      SrcSwsFilter, DesSwsFilter, nullptr);
   if (SwsCachedCtx == nullptr) {
+    Env.get()->deallocByValue(PrevSwsCtx);
+    *SwsCachedCtxId = 0;
+    spdlog::error("[WasmEdge-FFmpeg] SwsGetCachedContext: "
+                  "sws_getCachedContext failed ({}x{} format id {} -> {}x{} "
+                  "format id {})"sv,
+                  SrcW, SrcH, SrcPixFormatId, DesW, DesH, DesPixFormatId);
     return static_cast<int32_t>(ErrNo::InternalError);
   }
 
+  if (SwsCachedCtx != PrevSwsCtx) {
+    Env.get()->deallocByValue(PrevSwsCtx);
+  }
   FFMPEG_PTR_STORE(SwsCachedCtx, SwsCachedCtxId);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -119,6 +146,8 @@ Expect<int32_t> SwsGetDefaultFilter::body(
       sws_getDefaultFilter(LumaGBlur, ChromaGBlur, LumaSharpen, ChromaSharpen,
                            ChromaHShift, ChromaVShift, Verbose);
   if (Filter == nullptr) {
+    spdlog::error("[WasmEdge-FFmpeg] SwsGetDefaultFilter: "
+                  "sws_getDefaultFilter failed"sv);
     return static_cast<int32_t>(ErrNo::InternalError);
   }
   FFMPEG_PTR_STORE(Filter, SwsFilterId);
@@ -130,6 +159,7 @@ Expect<int32_t> SwsGetLumaH::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_PTR_CHECK(SwsVectorId, MemInst, uint32_t, SwsVectorPtr, "")
   FFMPEG_PTR_FETCH(Filter, SwsFilterId, SwsFilter);
+  FFMPEG_PTR_CHECK(Filter, static_cast<int32_t>(ErrNo::InternalError));
 
   SwsVector *Vector = Filter->lumH;
   FFMPEG_PTR_STORE(Vector, SwsVectorId);
@@ -141,6 +171,7 @@ Expect<int32_t> SwsGetLumaV::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_PTR_CHECK(SwsVectorId, MemInst, uint32_t, SwsVectorPtr, "")
   FFMPEG_PTR_FETCH(Filter, SwsFilterId, SwsFilter);
+  FFMPEG_PTR_CHECK(Filter, static_cast<int32_t>(ErrNo::InternalError));
 
   SwsVector *Vector = Filter->lumV;
   FFMPEG_PTR_STORE(Vector, SwsVectorId);
@@ -153,6 +184,7 @@ Expect<int32_t> SwsGetChromaH::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_PTR_CHECK(SwsVectorId, MemInst, uint32_t, SwsVectorPtr, "")
   FFMPEG_PTR_FETCH(Filter, SwsFilterId, SwsFilter);
+  FFMPEG_PTR_CHECK(Filter, static_cast<int32_t>(ErrNo::InternalError));
 
   SwsVector *Vector = Filter->chrH;
   FFMPEG_PTR_STORE(Vector, SwsVectorId);
@@ -165,6 +197,7 @@ Expect<int32_t> SwsGetChromaV::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0);
   MEM_PTR_CHECK(SwsVectorId, MemInst, uint32_t, SwsVectorPtr, "")
   FFMPEG_PTR_FETCH(Filter, SwsFilterId, SwsFilter);
+  FFMPEG_PTR_CHECK(Filter, static_cast<int32_t>(ErrNo::InternalError));
 
   SwsVector *Vector = Filter->chrV;
   FFMPEG_PTR_STORE(Vector, SwsVectorId);
@@ -174,6 +207,8 @@ Expect<int32_t> SwsGetChromaV::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> SwsFreeFilter::body(const Runtime::CallingFrame &,
                                     uint32_t SwsFilterId) {
   FFMPEG_PTR_FETCH(Filter, SwsFilterId, SwsFilter);
+  FFMPEG_PTR_CHECK_FREE(Filter, SwsFilterId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   sws_freeFilter(Filter);
   FFMPEG_PTR_DELETE(SwsFilterId);
   return static_cast<int32_t>(ErrNo::Success);
@@ -203,6 +238,7 @@ Expect<int32_t> SwsGetGaussianVec::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> SwsScaleVec::body(const Runtime::CallingFrame &,
                                   uint32_t SwsVectorId, double Scalar) {
   FFMPEG_PTR_FETCH(Vector, SwsVectorId, SwsVector);
+  FFMPEG_PTR_CHECK(Vector, static_cast<int32_t>(ErrNo::InternalError));
   sws_scaleVec(Vector, Scalar);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -210,6 +246,7 @@ Expect<int32_t> SwsScaleVec::body(const Runtime::CallingFrame &,
 Expect<int32_t> SwsNormalizeVec::body(const Runtime::CallingFrame &,
                                       uint32_t SwsVectorId, double Height) {
   FFMPEG_PTR_FETCH(Vector, SwsVectorId, SwsVector);
+  FFMPEG_PTR_CHECK(Vector, static_cast<int32_t>(ErrNo::InternalError));
   sws_normalizeVec(Vector, Height);
   return static_cast<int32_t>(ErrNo::Success);
 }
@@ -217,6 +254,7 @@ Expect<int32_t> SwsNormalizeVec::body(const Runtime::CallingFrame &,
 Expect<int32_t> SwsGetCoeffVecLength::body(const Runtime::CallingFrame &,
                                            uint32_t SwsVectorId) {
   FFMPEG_PTR_FETCH(Vector, SwsVectorId, SwsVector);
+  FFMPEG_PTR_CHECK(Vector, 0);
   return Vector->length *
          sizeof(double); // Getting the size in uint_8* (Cuz Passing uint8_t*
                          // array from Rust SDK).
@@ -229,14 +267,29 @@ Expect<int32_t> SwsGetCoeff::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(Buffer, MemInst, uint8_t, CoeffBufPtr, Len, "");
   FFMPEG_PTR_FETCH(Vector, SwsVectorId, SwsVector);
 
-  double *Coeff = Vector->coeff;
-  std::copy_n(Coeff, Len, Buffer.data());
+  if (Vector == nullptr || Vector->coeff == nullptr || Vector->length < 0) {
+    spdlog::error("[WasmEdge-FFmpeg] SwsGetCoeff: invalid scaler vector id "
+                  "{} or vector has no coefficients"sv,
+                  SwsVectorId);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  size_t const Available = static_cast<size_t>(Vector->length) * sizeof(double);
+  if (Available < static_cast<size_t>(Len)) {
+    spdlog::error("[WasmEdge-FFmpeg] SwsGetCoeff: requested {} bytes from "
+                  "scaler vector id {}, but only {} bytes are readable"sv,
+                  Len, SwsVectorId, Available);
+    return static_cast<int32_t>(ErrNo::InternalError);
+  }
+  std::copy_n(reinterpret_cast<const uint8_t *>(Vector->coeff), Len,
+              Buffer.data());
   return static_cast<int32_t>(ErrNo::Success);
 }
 
 Expect<int32_t> SwsFreeVec::body(const Runtime::CallingFrame &,
                                  uint32_t SwsVectorId) {
   FFMPEG_PTR_FETCH(Vector, SwsVectorId, SwsVector);
+  FFMPEG_PTR_CHECK_FREE(Vector, SwsVectorId,
+                        static_cast<int32_t>(ErrNo::InternalError));
   sws_freeVec(Vector);
   FFMPEG_PTR_DELETE(SwsVectorId);
   return static_cast<int32_t>(ErrNo::Success);
@@ -259,9 +312,7 @@ Expect<int32_t> SwscaleConfiguration::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(ConfigBuf, MemInst, char, ConfigPtr, ConfigLen, "");
 
   const char *Config = swscale_configuration();
-  auto Actual = std::strlen(Config);
-  auto N = std::min<uint32_t>(ConfigLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(Config, N, ConfigBuf.data());
+  copyCStringToBuffer(ConfigBuf.data(), ConfigLen, Config);
   return static_cast<int32_t>(ErrNo::Success);
 }
 
@@ -276,9 +327,7 @@ Expect<int32_t> SwscaleLicense::body(const Runtime::CallingFrame &Frame,
   MEM_SPAN_CHECK(LicenseBuf, MemInst, char, LicensePtr, LicenseLen, "");
 
   const char *License = swscale_license();
-  auto Actual = std::strlen(License);
-  auto N = std::min<uint32_t>(LicenseLen, static_cast<uint32_t>(Actual + 1));
-  std::copy_n(License, N, LicenseBuf.data());
+  copyCStringToBuffer(LicenseBuf.data(), LicenseLen, License);
   return static_cast<int32_t>(ErrNo::Success);
 }
 

--- a/test/plugins/wasmedge_ffmpeg/CMakeLists.txt
+++ b/test/plugins/wasmedge_ffmpeg/CMakeLists.txt
@@ -10,6 +10,8 @@ wasmedge_add_executable(wasmedgeFFmpegTests
   avcodec/avPacket.cpp
   avcodec/avCodecCtx.cpp
 
+  avdevice/avDevice.cpp
+
   avfilter/avfilter_func.cpp
   avfilter/avfilter.cpp
 

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avCodec.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avCodec.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "avcodec/avCodec.h"
+#include "avcodec/avcodec_func.h"
 #include "avcodec/module.h"
 #include "utils.h"
 
@@ -328,6 +329,417 @@ TEST_F(FFmpegTest, AVCodec) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{AVCodecId, 0},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), 0);
+  }
+}
+
+TEST_F(FFmpegTest, AVCodecChannelLayoutIterBounds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  // ac3 is an audio encoder that publishes a zero-terminated ch_layouts array.
+  std::string CodecName = "ac3";
+  uint32_t CodecPtr = UINT32_C(20);
+  uint32_t NamePtr = UINT32_C(40);
+  fillMemContent(MemInst, NamePtr, CodecName);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
+  auto &HostFuncFindEncoder = FuncInst->getHostFunc();
+  HostFuncFindEncoder.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CodecPtr, NamePtr, static_cast<uint32_t>(CodecName.length())},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t CodecId = readUInt32(MemInst, CodecPtr);
+  if (CodecId == 0) {
+    GTEST_SKIP() << "encoder \"" << CodecName
+                 << "\" not available in this FFmpeg build";
+  }
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_channel_layouts_is_null");
+  auto &HostFuncIsNull = FuncInst->getHostFunc();
+  HostFuncIsNull.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecId}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), 0);
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_channel_layouts_iter");
+  auto &HostFuncIter = FuncInst->getHostFunc();
+
+  // An in-range index must return a nonzero layout id: the clamp below also
+  // returns 0, so a conversion that always returned 0 would go unnoticed.
+  HostFuncIter.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecId, UINT32_C(0)},
+      Result);
+  EXPECT_GT(Result[0].get<uint64_t>(), UINT64_C(0));
+
+  // An index far past the zero-terminated ch_layouts array must clamp to 0
+  // instead of reading past the array bounds.
+  HostFuncIter.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecId, UINT32_C(100000)},
+      Result);
+  EXPECT_EQ(Result[0].get<uint64_t>(), UINT64_C(0));
+}
+
+TEST_F(FFmpegTest, AVCodecPixFmtsIterBounds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  // mpeg4 is a video encoder that publishes a NONE-terminated pix_fmts array.
+  std::string CodecName = "mpeg4";
+  uint32_t CodecPtr = UINT32_C(20);
+  uint32_t NamePtr = UINT32_C(40);
+  fillMemContent(MemInst, NamePtr, CodecName);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
+  auto &HostFuncFindEncoder = FuncInst->getHostFunc();
+  HostFuncFindEncoder.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CodecPtr, NamePtr, static_cast<uint32_t>(CodecName.length())},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t CodecId = readUInt32(MemInst, CodecPtr);
+  if (CodecId == 0) {
+    GTEST_SKIP() << "encoder \"" << CodecName
+                 << "\" not available in this FFmpeg build";
+  }
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_pix_fmts_is_null");
+  auto &HostFuncIsNull = FuncInst->getHostFunc();
+  HostFuncIsNull.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecId}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), 0);
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_pix_fmts_iter");
+  auto &HostFuncIter = FuncInst->getHostFunc();
+
+  // An index far past the NONE-terminated pix_fmts array must clamp to 0
+  // instead of reading past the array bounds.
+  HostFuncIter.run(CallFrame,
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       CodecId, UINT32_C(0xFFFFFFFF)},
+                   Result);
+  EXPECT_EQ(Result[0].get<uint32_t>(), UINT32_C(0));
+}
+
+TEST_F(FFmpegTest, AVCodecSupportedFrameratesIterBounds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  // mpeg1video publishes a {0,0}-terminated supported_framerates array.
+  std::string CodecName = "mpeg1video";
+  uint32_t CodecPtr = UINT32_C(20);
+  uint32_t NamePtr = UINT32_C(40);
+  fillMemContent(MemInst, NamePtr, CodecName);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
+  auto &HostFuncFindEncoder = FuncInst->getHostFunc();
+  HostFuncFindEncoder.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CodecPtr, NamePtr, static_cast<uint32_t>(CodecName.length())},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t CodecId = readUInt32(MemInst, CodecPtr);
+  if (CodecId == 0) {
+    GTEST_SKIP() << "encoder \"" << CodecName
+                 << "\" not available in this FFmpeg build";
+  }
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_supported_framerate_is_null");
+  auto &HostFuncIsNull = FuncInst->getHostFunc();
+  HostFuncIsNull.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecId}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), 0);
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_supported_framerate_iter");
+  auto &HostFuncIter = FuncInst->getHostFunc();
+
+  uint32_t NumPtr = UINT32_C(60);
+  uint32_t DenPtr = UINT32_C(64);
+  // Poison the output slots: linear memory is zero-initialised, so the {0,0}
+  // assertions below would pass even if the host wrote nothing.
+  fillMemContent(MemInst, NumPtr, sizeof(int32_t), UINT8_C(0xAA));
+  fillMemContent(MemInst, DenPtr, sizeof(int32_t), UINT8_C(0xAA));
+  // An index far past the {0,0}-terminated array must clamp to {0,0} instead
+  // of reading past the array bounds.
+  HostFuncIter.run(CallFrame,
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       CodecId, UINT32_C(100000), NumPtr, DenPtr},
+                   Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(readUInt32(MemInst, NumPtr), UINT32_C(0));
+  EXPECT_EQ(readUInt32(MemInst, DenPtr), UINT32_C(0));
+}
+
+TEST_F(FFmpegTest, AVCodecSupportedSampleRatesIterBounds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  // ac3 publishes a 0-terminated supported_samplerates array.
+  std::string CodecName = "ac3";
+  uint32_t CodecPtr = UINT32_C(20);
+  uint32_t NamePtr = UINT32_C(40);
+  fillMemContent(MemInst, NamePtr, CodecName);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
+  auto &HostFuncFindEncoder = FuncInst->getHostFunc();
+  HostFuncFindEncoder.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CodecPtr, NamePtr, static_cast<uint32_t>(CodecName.length())},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t CodecId = readUInt32(MemInst, CodecPtr);
+  if (CodecId == 0) {
+    GTEST_SKIP() << "encoder \"" << CodecName
+                 << "\" not available in this FFmpeg build";
+  }
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_supported_samplerates_is_null");
+  auto &HostFuncIsNull = FuncInst->getHostFunc();
+  HostFuncIsNull.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecId}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), 0);
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_supported_samplerates_iter");
+  auto &HostFuncIter = FuncInst->getHostFunc();
+
+  // An index far past the 0-terminated array must clamp to 0 instead of
+  // reading past the array bounds.
+  HostFuncIter.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecId, UINT32_C(100000)},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 0);
+}
+
+TEST_F(FFmpegTest, AVCodecSampleFmtsIterBounds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  // ac3 publishes a NONE-terminated sample_fmts array.
+  std::string CodecName = "ac3";
+  uint32_t CodecPtr = UINT32_C(20);
+  uint32_t NamePtr = UINT32_C(40);
+  fillMemContent(MemInst, NamePtr, CodecName);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
+  auto &HostFuncFindEncoder = FuncInst->getHostFunc();
+  HostFuncFindEncoder.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CodecPtr, NamePtr, static_cast<uint32_t>(CodecName.length())},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t CodecId = readUInt32(MemInst, CodecPtr);
+  if (CodecId == 0) {
+    GTEST_SKIP() << "encoder \"" << CodecName
+                 << "\" not available in this FFmpeg build";
+  }
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_sample_fmts_is_null");
+  auto &HostFuncIsNull = FuncInst->getHostFunc();
+  HostFuncIsNull.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecId}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), 0);
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_sample_fmts_iter");
+  auto &HostFuncIter = FuncInst->getHostFunc();
+
+  // An index far past the NONE-terminated sample_fmts array must clamp to 0
+  // instead of reading past the array bounds.
+  HostFuncIter.run(CallFrame,
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       CodecId, UINT32_C(0xFFFFFFFF)},
+                   Result);
+  EXPECT_EQ(Result[0].get<uint32_t>(), UINT32_C(0));
+}
+
+TEST_F(FFmpegTest, AVCodecGetNameBounds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  std::string CodecName = "mpeg4";
+  uint32_t CodecPtr = UINT32_C(20);
+  uint32_t NamePtr = UINT32_C(40);
+  fillMemContent(MemInst, NamePtr, CodecName);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
+  auto &HostFuncFindEncoder = FuncInst->getHostFunc();
+  HostFuncFindEncoder.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CodecPtr, NamePtr, static_cast<uint32_t>(CodecName.length())},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t CodecId = readUInt32(MemInst, CodecPtr);
+  if (CodecId == 0) {
+    GTEST_SKIP() << "encoder \"" << CodecName
+                 << "\" not available in this FFmpeg build";
+  }
+
+  uint32_t StrPtr = UINT32_C(200);
+
+  // The guest buffer is larger than the host name and fenced with 0xAA; the
+  // host must copy only the name plus terminator, leaving the fence intact.
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_get_name_len");
+  auto &HostFuncNameLen = FuncInst->getHostFunc();
+  HostFuncNameLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecId}, Result);
+  uint32_t NameLen = Result[0].get<int32_t>();
+  ASSERT_TRUE(NameLen > 0);
+
+  FuncInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_get_name");
+  auto &HostFuncGetName = FuncInst->getHostFunc();
+  uint32_t NameBufLen = NameLen + UINT32_C(32);
+  fillMemContent(MemInst, StrPtr, NameBufLen, UINT8_C(0xAA));
+  HostFuncGetName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecId, StrPtr, NameBufLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  {
+    char *Buf = MemInst->getPointer<char *>(StrPtr);
+    for (uint32_t I = NameLen + 1; I < NameBufLen; ++I) {
+      EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+    }
+  }
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_get_long_name_len");
+  auto &HostFuncLongNameLen = FuncInst->getHostFunc();
+  HostFuncLongNameLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecId}, Result);
+  uint32_t LongNameLen = Result[0].get<int32_t>();
+  ASSERT_TRUE(LongNameLen > 0);
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_get_long_name");
+  auto &HostFuncGetLongName = FuncInst->getHostFunc();
+  uint32_t LongNameBufLen = LongNameLen + UINT32_C(32);
+  fillMemContent(MemInst, StrPtr, LongNameBufLen, UINT8_C(0xAA));
+  HostFuncGetLongName.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              CodecId, StrPtr, LongNameBufLen},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  {
+    char *Buf = MemInst->getPointer<char *>(StrPtr);
+    for (uint32_t I = LongNameLen + 1; I < LongNameBufLen; ++I) {
+      EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+    }
+  }
+}
+TEST_F(FFmpegTest, AVCodecFindEncoderByNameBounds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
+  auto &HostFuncFindEncoder = FuncInst->getHostFunc();
+
+  // CodecPtr is in bounds but the guest-declared name length runs off the end
+  // of linear memory; the host must reject it, not read past the page.
+  uint32_t CodecPtr = UINT32_C(20);
+  uint32_t OutOfBoundsNamePtr = UINT32_C(65000);
+  uint32_t OutOfBoundsNameLen = UINT32_C(2000);
+  HostFuncFindEncoder.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              CodecPtr, OutOfBoundsNamePtr, OutOfBoundsNameLen},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::MissingMemory));
+}
+
+TEST_F(FFmpegTest, AVCodecGetNameLengthContract) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  std::string CodecName = "mpeg4";
+  uint32_t CodecPtr = UINT32_C(20);
+  uint32_t NamePtr = UINT32_C(40);
+  uint32_t StrPtr = UINT32_C(200);
+  fillMemContent(MemInst, NamePtr, CodecName);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
+  auto &HostFuncFindEncoder = FuncInst->getHostFunc();
+  HostFuncFindEncoder.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CodecPtr, NamePtr, static_cast<uint32_t>(CodecName.length())},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t CodecId = readUInt32(MemInst, CodecPtr);
+  if (CodecId == 0) {
+    GTEST_SKIP() << "encoder \"" << CodecName
+                 << "\" not available in this FFmpeg build";
+  }
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_get_name_len");
+  auto &HostFuncNameLen = FuncInst->getHostFunc();
+  HostFuncNameLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecId}, Result);
+  uint32_t NameLen = Result[0].get<int32_t>();
+  EXPECT_EQ(NameLen, CodecName.length());
+
+  // The length getter reports the exact string length, so a buffer of exactly
+  // that size receives the full name without a terminator, fence untouched.
+  FuncInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_get_name");
+  auto &HostFuncGetName = FuncInst->getHostFunc();
+  uint32_t FenceLen = NameLen + UINT32_C(8);
+  fillMemContent(MemInst, StrPtr, FenceLen, UINT8_C(0xAA));
+  HostFuncGetName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecId, StrPtr, NameLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  char *Buf = MemInst->getPointer<char *>(StrPtr);
+  EXPECT_EQ(std::string(Buf, NameLen), CodecName);
+  for (uint32_t I = NameLen; I < FenceLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+  }
+
+  // A larger buffer additionally receives the terminator right after the name,
+  // and nothing past it.
+  fillMemContent(MemInst, StrPtr, FenceLen, UINT8_C(0xAA));
+  HostFuncGetName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecId, StrPtr, FenceLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(std::string(Buf, NameLen), CodecName);
+  EXPECT_EQ(Buf[NameLen], '\0');
+  for (uint32_t I = NameLen + 1; I < FenceLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+  }
+
+  // A buffer smaller than the name receives only the bytes that fit.
+  fillMemContent(MemInst, StrPtr, FenceLen, UINT8_C(0xAA));
+  HostFuncGetName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecId, StrPtr, UINT32_C(3)},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(std::string(Buf, 3), CodecName.substr(0, 3));
+  for (uint32_t I = UINT32_C(3); I < FenceLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
   }
 }
 } // namespace WasmEdgeFFmpeg

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avCodec.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avCodec.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "avcodec/avCodec.h"
+#include "avcodec/avcodec_func.h"
 #include "avcodec/module.h"
 #include "utils.h"
 
@@ -328,6 +329,389 @@ TEST_F(FFmpegTest, AVCodec) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{AVCodecId, 0},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), 0);
+  }
+}
+
+TEST_F(FFmpegTest, AVCodecChannelLayoutIterBounds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  std::string CodecName = "ac3";
+  uint32_t CodecPtr = UINT32_C(20);
+  uint32_t NamePtr = UINT32_C(40);
+  fillMemContent(MemInst, NamePtr, CodecName);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
+  auto &HostFuncFindEncoder = FuncInst->getHostFunc();
+  HostFuncFindEncoder.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CodecPtr, NamePtr, static_cast<uint32_t>(CodecName.length())},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t CodecId = readUInt32(MemInst, CodecPtr);
+  if (CodecId == 0) {
+    GTEST_SKIP() << "encoder \"" << CodecName
+                 << "\" not available in this FFmpeg build";
+  }
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_channel_layouts_is_null");
+  auto &HostFuncIsNull = FuncInst->getHostFunc();
+  HostFuncIsNull.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecId}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), 0);
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_channel_layouts_iter");
+  auto &HostFuncIter = FuncInst->getHostFunc();
+
+  HostFuncIter.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecId, UINT32_C(0)},
+      Result);
+  EXPECT_GT(Result[0].get<uint64_t>(), UINT64_C(0));
+
+  HostFuncIter.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecId, UINT32_C(100000)},
+      Result);
+  EXPECT_EQ(Result[0].get<uint64_t>(), UINT64_C(0));
+}
+
+TEST_F(FFmpegTest, AVCodecPixFmtsIterBounds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  std::string CodecName = "mpeg4";
+  uint32_t CodecPtr = UINT32_C(20);
+  uint32_t NamePtr = UINT32_C(40);
+  fillMemContent(MemInst, NamePtr, CodecName);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
+  auto &HostFuncFindEncoder = FuncInst->getHostFunc();
+  HostFuncFindEncoder.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CodecPtr, NamePtr, static_cast<uint32_t>(CodecName.length())},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t CodecId = readUInt32(MemInst, CodecPtr);
+  if (CodecId == 0) {
+    GTEST_SKIP() << "encoder \"" << CodecName
+                 << "\" not available in this FFmpeg build";
+  }
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_pix_fmts_is_null");
+  auto &HostFuncIsNull = FuncInst->getHostFunc();
+  HostFuncIsNull.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecId}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), 0);
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_pix_fmts_iter");
+  auto &HostFuncIter = FuncInst->getHostFunc();
+
+  HostFuncIter.run(CallFrame,
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       CodecId, UINT32_C(0xFFFFFFFF)},
+                   Result);
+  EXPECT_EQ(Result[0].get<uint32_t>(), UINT32_C(0));
+}
+
+TEST_F(FFmpegTest, AVCodecSupportedFrameratesIterBounds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  std::string CodecName = "mpeg1video";
+  uint32_t CodecPtr = UINT32_C(20);
+  uint32_t NamePtr = UINT32_C(40);
+  fillMemContent(MemInst, NamePtr, CodecName);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
+  auto &HostFuncFindEncoder = FuncInst->getHostFunc();
+  HostFuncFindEncoder.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CodecPtr, NamePtr, static_cast<uint32_t>(CodecName.length())},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t CodecId = readUInt32(MemInst, CodecPtr);
+  if (CodecId == 0) {
+    GTEST_SKIP() << "encoder \"" << CodecName
+                 << "\" not available in this FFmpeg build";
+  }
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_supported_framerate_is_null");
+  auto &HostFuncIsNull = FuncInst->getHostFunc();
+  HostFuncIsNull.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecId}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), 0);
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_supported_framerate_iter");
+  auto &HostFuncIter = FuncInst->getHostFunc();
+
+  uint32_t NumPtr = UINT32_C(60);
+  uint32_t DenPtr = UINT32_C(64);
+  fillMemContent(MemInst, NumPtr, sizeof(int32_t), UINT8_C(0xAA));
+  fillMemContent(MemInst, DenPtr, sizeof(int32_t), UINT8_C(0xAA));
+  HostFuncIter.run(CallFrame,
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       CodecId, UINT32_C(100000), NumPtr, DenPtr},
+                   Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(readUInt32(MemInst, NumPtr), UINT32_C(0));
+  EXPECT_EQ(readUInt32(MemInst, DenPtr), UINT32_C(0));
+}
+
+TEST_F(FFmpegTest, AVCodecSupportedSampleRatesIterBounds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  std::string CodecName = "ac3";
+  uint32_t CodecPtr = UINT32_C(20);
+  uint32_t NamePtr = UINT32_C(40);
+  fillMemContent(MemInst, NamePtr, CodecName);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
+  auto &HostFuncFindEncoder = FuncInst->getHostFunc();
+  HostFuncFindEncoder.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CodecPtr, NamePtr, static_cast<uint32_t>(CodecName.length())},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t CodecId = readUInt32(MemInst, CodecPtr);
+  if (CodecId == 0) {
+    GTEST_SKIP() << "encoder \"" << CodecName
+                 << "\" not available in this FFmpeg build";
+  }
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_supported_samplerates_is_null");
+  auto &HostFuncIsNull = FuncInst->getHostFunc();
+  HostFuncIsNull.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecId}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), 0);
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_supported_samplerates_iter");
+  auto &HostFuncIter = FuncInst->getHostFunc();
+
+  HostFuncIter.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecId, UINT32_C(100000)},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 0);
+}
+
+TEST_F(FFmpegTest, AVCodecSampleFmtsIterBounds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  std::string CodecName = "ac3";
+  uint32_t CodecPtr = UINT32_C(20);
+  uint32_t NamePtr = UINT32_C(40);
+  fillMemContent(MemInst, NamePtr, CodecName);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
+  auto &HostFuncFindEncoder = FuncInst->getHostFunc();
+  HostFuncFindEncoder.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CodecPtr, NamePtr, static_cast<uint32_t>(CodecName.length())},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t CodecId = readUInt32(MemInst, CodecPtr);
+  if (CodecId == 0) {
+    GTEST_SKIP() << "encoder \"" << CodecName
+                 << "\" not available in this FFmpeg build";
+  }
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_sample_fmts_is_null");
+  auto &HostFuncIsNull = FuncInst->getHostFunc();
+  HostFuncIsNull.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecId}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), 0);
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_sample_fmts_iter");
+  auto &HostFuncIter = FuncInst->getHostFunc();
+
+  HostFuncIter.run(CallFrame,
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       CodecId, UINT32_C(0xFFFFFFFF)},
+                   Result);
+  EXPECT_EQ(Result[0].get<uint32_t>(), UINT32_C(0));
+}
+
+TEST_F(FFmpegTest, AVCodecGetNameBounds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  std::string CodecName = "mpeg4";
+  uint32_t CodecPtr = UINT32_C(20);
+  uint32_t NamePtr = UINT32_C(40);
+  fillMemContent(MemInst, NamePtr, CodecName);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
+  auto &HostFuncFindEncoder = FuncInst->getHostFunc();
+  HostFuncFindEncoder.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CodecPtr, NamePtr, static_cast<uint32_t>(CodecName.length())},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t CodecId = readUInt32(MemInst, CodecPtr);
+  if (CodecId == 0) {
+    GTEST_SKIP() << "encoder \"" << CodecName
+                 << "\" not available in this FFmpeg build";
+  }
+
+  uint32_t StrPtr = UINT32_C(200);
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_get_name_len");
+  auto &HostFuncNameLen = FuncInst->getHostFunc();
+  HostFuncNameLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecId}, Result);
+  uint32_t NameLen = Result[0].get<int32_t>();
+  ASSERT_TRUE(NameLen > 0);
+
+  FuncInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_get_name");
+  auto &HostFuncGetName = FuncInst->getHostFunc();
+  uint32_t NameBufLen = NameLen + UINT32_C(32);
+  fillMemContent(MemInst, StrPtr, NameBufLen, UINT8_C(0xAA));
+  HostFuncGetName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecId, StrPtr, NameBufLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  {
+    char *Buf = MemInst->getPointer<char *>(StrPtr);
+    for (uint32_t I = NameLen + 1; I < NameBufLen; ++I) {
+      EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+    }
+  }
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_get_long_name_len");
+  auto &HostFuncLongNameLen = FuncInst->getHostFunc();
+  HostFuncLongNameLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecId}, Result);
+  uint32_t LongNameLen = Result[0].get<int32_t>();
+  ASSERT_TRUE(LongNameLen > 0);
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_get_long_name");
+  auto &HostFuncGetLongName = FuncInst->getHostFunc();
+  uint32_t LongNameBufLen = LongNameLen + UINT32_C(32);
+  fillMemContent(MemInst, StrPtr, LongNameBufLen, UINT8_C(0xAA));
+  HostFuncGetLongName.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              CodecId, StrPtr, LongNameBufLen},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  {
+    char *Buf = MemInst->getPointer<char *>(StrPtr);
+    for (uint32_t I = LongNameLen + 1; I < LongNameBufLen; ++I) {
+      EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+    }
+  }
+}
+TEST_F(FFmpegTest, AVCodecFindEncoderByNameBounds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
+  auto &HostFuncFindEncoder = FuncInst->getHostFunc();
+
+  uint32_t CodecPtr = UINT32_C(20);
+  uint32_t OutOfBoundsNamePtr = UINT32_C(65000);
+  uint32_t OutOfBoundsNameLen = UINT32_C(2000);
+  HostFuncFindEncoder.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              CodecPtr, OutOfBoundsNamePtr, OutOfBoundsNameLen},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::MissingMemory));
+}
+
+TEST_F(FFmpegTest, AVCodecGetNameLengthContract) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  std::string CodecName = "mpeg4";
+  uint32_t CodecPtr = UINT32_C(20);
+  uint32_t NamePtr = UINT32_C(40);
+  uint32_t StrPtr = UINT32_C(200);
+  fillMemContent(MemInst, NamePtr, CodecName);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
+  auto &HostFuncFindEncoder = FuncInst->getHostFunc();
+  HostFuncFindEncoder.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CodecPtr, NamePtr, static_cast<uint32_t>(CodecName.length())},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t CodecId = readUInt32(MemInst, CodecPtr);
+  if (CodecId == 0) {
+    GTEST_SKIP() << "encoder \"" << CodecName
+                 << "\" not available in this FFmpeg build";
+  }
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_get_name_len");
+  auto &HostFuncNameLen = FuncInst->getHostFunc();
+  HostFuncNameLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecId}, Result);
+  uint32_t NameLen = Result[0].get<int32_t>();
+  EXPECT_EQ(NameLen, CodecName.length());
+
+  FuncInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_get_name");
+  auto &HostFuncGetName = FuncInst->getHostFunc();
+  uint32_t FenceLen = NameLen + UINT32_C(8);
+  fillMemContent(MemInst, StrPtr, FenceLen, UINT8_C(0xAA));
+  HostFuncGetName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecId, StrPtr, NameLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  char *Buf = MemInst->getPointer<char *>(StrPtr);
+  EXPECT_EQ(std::string(Buf, NameLen), CodecName);
+  for (uint32_t I = NameLen; I < FenceLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+  }
+
+  fillMemContent(MemInst, StrPtr, FenceLen, UINT8_C(0xAA));
+  HostFuncGetName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecId, StrPtr, FenceLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(std::string(Buf, NameLen), CodecName);
+  EXPECT_EQ(Buf[NameLen], '\0');
+  for (uint32_t I = NameLen + 1; I < FenceLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+  }
+
+  fillMemContent(MemInst, StrPtr, FenceLen, UINT8_C(0xAA));
+  HostFuncGetName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecId, StrPtr, UINT32_C(3)},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(std::string(Buf, 3), CodecName.substr(0, 3));
+  for (uint32_t I = UINT32_C(3); I < FenceLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
   }
 }
 } // namespace WasmEdgeFFmpeg

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avCodecParameters.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avCodecParameters.cpp
@@ -2,7 +2,11 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "avcodec/avCodecParameters.h"
+#include "avcodec/avcodec_func.h"
 #include "avcodec/module.h"
+#include "avformat/avformatContext.h"
+#include "avformat/avformat_func.h"
+#include "avutil/avDictionary.h"
 
 #include "utils.h"
 
@@ -67,6 +71,168 @@ TEST_F(FFmpegTest, AVCodecParameters) {
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
   }
+}
+
+TEST_F(FFmpegTest, BorrowedHandlesSurviveGuestFree) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+  ASSERT_TRUE(AVFormatMod != nullptr);
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t AVCodecParamPtr = UINT32_C(60);
+  uint32_t FormatCtxPtr = UINT32_C(24);
+  std::string FileName = "ffmpeg-assets/sample_video.mp4"; // 32 chars
+  initFFmpegStructs(UINT32_C(20), FormatCtxPtr, UINT32_C(28), FileName,
+                    AVCodecParamPtr, UINT32_C(64), UINT32_C(68), UINT32_C(72));
+
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  uint32_t CodecParamId = readUInt32(MemInst, AVCodecParamPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+  ASSERT_TRUE(CodecParamId > 0);
+
+  // codecpar obtained from a stream is borrowed: the AVFormatContext owns it.
+  auto *CodecIdFunc = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodecparam_codec_id");
+  ASSERT_NE(CodecIdFunc, nullptr);
+  auto &HostFuncCodecId = CodecIdFunc->getHostFunc();
+  HostFuncCodecId.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{CodecParamId},
+                      Result);
+  EXPECT_GT(Result[0].get<int32_t>(), 0);
+
+  // Freeing the borrowed codecpar must drop the id without freeing the
+  // stream-owned object.
+  auto *ParamFreeFunc = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_parameters_free");
+  ASSERT_NE(ParamFreeFunc, nullptr);
+  auto &HostFuncParamFree = ParamFreeFunc->getHostFunc();
+  HostFuncParamFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecParamId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  // Borrowed format metadata behaves the same way.
+  uint32_t DictPtr = UINT32_C(80);
+  auto *MetadataFunc = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_metadata");
+  ASSERT_NE(MetadataFunc, nullptr);
+  auto &HostFuncMetadata = MetadataFunc->getHostFunc();
+  HostFuncMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, DictPtr},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+  ASSERT_TRUE(DictId > 0);
+
+  auto *DictFreeFunc =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_free");
+  ASSERT_NE(DictFreeFunc, nullptr);
+  auto &HostFuncDictFree = DictFreeFunc->getHostFunc();
+  HostFuncDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DictId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  // Closing the context frees codecpar and metadata exactly once.
+  auto *CloseFunc = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformat_close_input");
+  ASSERT_NE(CloseFunc, nullptr);
+  auto &HostFuncClose = dynamic_cast<
+      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatCloseInput &>(
+      CloseFunc->getHostFunc());
+  HostFuncClose.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+                    Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, ClosingContextInvalidatesBorrowedChildIds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t AVCodecParamPtr = UINT32_C(60);
+  uint32_t FormatCtxPtr = UINT32_C(24);
+  std::string FileName = "ffmpeg-assets/sample_video.mp4"; // 32 chars
+  initFFmpegStructs(UINT32_C(20), FormatCtxPtr, UINT32_C(28), FileName,
+                    AVCodecParamPtr, UINT32_C(64), UINT32_C(68), UINT32_C(72));
+
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  uint32_t CodecParamId = readUInt32(MemInst, AVCodecParamPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+  ASSERT_TRUE(CodecParamId > 0);
+
+  // Also take a borrowed metadata handle on the same context.
+  uint32_t DictPtr = UINT32_C(80);
+  auto *MetadataFunc = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_metadata");
+  ASSERT_NE(MetadataFunc, nullptr);
+  auto &HostFuncMetadata = MetadataFunc->getHostFunc();
+  HostFuncMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, DictPtr},
+      Result);
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+  ASSERT_TRUE(DictId > 0);
+
+  auto *CloseFunc = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformat_close_input");
+  ASSERT_NE(CloseFunc, nullptr);
+  auto &HostFuncClose = dynamic_cast<
+      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatCloseInput &>(
+      CloseFunc->getHostFunc());
+
+  // Both borrowed child handles resolve while the context is open.
+  auto Env = HostFuncClose.getEnv();
+  ASSERT_NE(Env->fetchData(CodecParamId), nullptr);
+  ASSERT_NE(Env->fetchData(DictId), nullptr);
+
+  HostFuncClose.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+                    Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  // Closing frees the streams and metadata the context owns, so the borrowed
+  // child ids must no longer resolve.
+  EXPECT_EQ(Env->fetchData(CodecParamId), nullptr);
+  EXPECT_EQ(Env->fetchData(DictId), nullptr);
+}
+
+TEST_F(FFmpegTest, AVCodecParametersCopyIndexOutOfRange) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t AVCodecParamPtr = UINT32_C(60);
+  uint32_t FormatCtxPtr = UINT32_C(24);
+  std::string FileName = "ffmpeg-assets/sample_video.mp4"; // 32 chars
+  initFFmpegStructs(UINT32_C(20), FormatCtxPtr, UINT32_C(28), FileName,
+                    AVCodecParamPtr, UINT32_C(64), UINT32_C(68), UINT32_C(72));
+
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  uint32_t CodecParamId = readUInt32(MemInst, AVCodecParamPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+  ASSERT_TRUE(CodecParamId > 0);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_parameters_copy");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncCopy = FuncInst->getHostFunc();
+
+  // A guest-supplied stream index past nb_streams must be rejected, not walked
+  // off the end of the streams array.
+  uint32_t OutOfRangeIdx = UINT32_C(1000000);
+  HostFuncCopy.run(CallFrame,
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       FormatCtxId, CodecParamId, OutOfRangeIdx},
+                   Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  // A null/zero format-context id must be rejected rather than dereferenced.
+  HostFuncCopy.run(CallFrame,
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       UINT32_C(0), CodecParamId, UINT32_C(0)},
+                   Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
 }
 } // namespace WasmEdgeFFmpeg
 } // namespace Host

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avCodecParameters.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avCodecParameters.cpp
@@ -2,7 +2,11 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "avcodec/avCodecParameters.h"
+#include "avcodec/avcodec_func.h"
 #include "avcodec/module.h"
+#include "avformat/avformatContext.h"
+#include "avformat/avformat_func.h"
+#include "avutil/avDictionary.h"
 
 #include "utils.h"
 
@@ -236,6 +240,156 @@ TEST_F(FFmpegTest, AVCodecParametersCopy) {
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), -1);
   }
+}
+
+TEST_F(FFmpegTest, BorrowedHandlesSurviveGuestFree) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+  ASSERT_TRUE(AVFormatMod != nullptr);
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t AVCodecParamPtr = UINT32_C(60);
+  uint32_t FormatCtxPtr = UINT32_C(24);
+  std::string FileName = "ffmpeg-assets/sample_video.mp4";
+  initFFmpegStructs(UINT32_C(20), FormatCtxPtr, UINT32_C(28), FileName,
+                    AVCodecParamPtr, UINT32_C(64), UINT32_C(68), UINT32_C(72));
+
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  uint32_t CodecParamId = readUInt32(MemInst, AVCodecParamPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+  ASSERT_TRUE(CodecParamId > 0);
+
+  auto *CodecIdFunc = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodecparam_codec_id");
+  ASSERT_NE(CodecIdFunc, nullptr);
+  auto &HostFuncCodecId = CodecIdFunc->getHostFunc();
+  HostFuncCodecId.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{CodecParamId},
+                      Result);
+  EXPECT_GT(Result[0].get<int32_t>(), 0);
+
+  auto *ParamFreeFunc = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_parameters_free");
+  ASSERT_NE(ParamFreeFunc, nullptr);
+  auto &HostFuncParamFree = ParamFreeFunc->getHostFunc();
+  HostFuncParamFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecParamId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t DictPtr = UINT32_C(80);
+  auto *MetadataFunc = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_metadata");
+  ASSERT_NE(MetadataFunc, nullptr);
+  auto &HostFuncMetadata = MetadataFunc->getHostFunc();
+  HostFuncMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, DictPtr},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+  ASSERT_TRUE(DictId > 0);
+
+  auto *DictFreeFunc =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_free");
+  ASSERT_NE(DictFreeFunc, nullptr);
+  auto &HostFuncDictFree = DictFreeFunc->getHostFunc();
+  HostFuncDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DictId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  auto *CloseFunc = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformat_close_input");
+  ASSERT_NE(CloseFunc, nullptr);
+  auto &HostFuncClose = dynamic_cast<
+      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatCloseInput &>(
+      CloseFunc->getHostFunc());
+  HostFuncClose.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+                    Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, ClosingContextInvalidatesBorrowedChildIds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t AVCodecParamPtr = UINT32_C(60);
+  uint32_t FormatCtxPtr = UINT32_C(24);
+  std::string FileName = "ffmpeg-assets/sample_video.mp4";
+  initFFmpegStructs(UINT32_C(20), FormatCtxPtr, UINT32_C(28), FileName,
+                    AVCodecParamPtr, UINT32_C(64), UINT32_C(68), UINT32_C(72));
+
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  uint32_t CodecParamId = readUInt32(MemInst, AVCodecParamPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+  ASSERT_TRUE(CodecParamId > 0);
+
+  uint32_t DictPtr = UINT32_C(80);
+  auto *MetadataFunc = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_metadata");
+  ASSERT_NE(MetadataFunc, nullptr);
+  auto &HostFuncMetadata = MetadataFunc->getHostFunc();
+  HostFuncMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, DictPtr},
+      Result);
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+  ASSERT_TRUE(DictId > 0);
+
+  auto *CloseFunc = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformat_close_input");
+  ASSERT_NE(CloseFunc, nullptr);
+  auto &HostFuncClose = dynamic_cast<
+      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatCloseInput &>(
+      CloseFunc->getHostFunc());
+
+  auto Env = HostFuncClose.getEnv();
+  ASSERT_NE(Env->fetchData(CodecParamId), nullptr);
+  ASSERT_NE(Env->fetchData(DictId), nullptr);
+
+  HostFuncClose.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+                    Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  EXPECT_EQ(Env->fetchData(CodecParamId), nullptr);
+  EXPECT_EQ(Env->fetchData(DictId), nullptr);
+}
+
+TEST_F(FFmpegTest, AVCodecParametersCopyIndexOutOfRange) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t AVCodecParamPtr = UINT32_C(60);
+  uint32_t FormatCtxPtr = UINT32_C(24);
+  std::string FileName = "ffmpeg-assets/sample_video.mp4";
+  initFFmpegStructs(UINT32_C(20), FormatCtxPtr, UINT32_C(28), FileName,
+                    AVCodecParamPtr, UINT32_C(64), UINT32_C(68), UINT32_C(72));
+
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  uint32_t CodecParamId = readUInt32(MemInst, AVCodecParamPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+  ASSERT_TRUE(CodecParamId > 0);
+
+  auto *FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_parameters_copy");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncCopy = FuncInst->getHostFunc();
+
+  uint32_t OutOfRangeIdx = UINT32_C(1000000);
+  HostFuncCopy.run(CallFrame,
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       FormatCtxId, CodecParamId, OutOfRangeIdx},
+                   Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  HostFuncCopy.run(CallFrame,
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       UINT32_C(0), CodecParamId, UINT32_C(0)},
+                   Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
 }
 } // namespace WasmEdgeFFmpeg
 } // namespace Host

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avPacket.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avPacket.cpp
@@ -290,11 +290,11 @@ TEST_F(FFmpegTest, AVPacketTest) {
   auto &HostFuncAVPacketData = FuncInst->getHostFunc();
 
   {
-    EXPECT_TRUE(HostFuncAVPacketData.run(
-        CallFrame,
-        std::initializer_list<WasmEdge::ValVariant>{PacketId, DataPtr,
-                                                    PacketDataSize},
-        Result));
+    EXPECT_TRUE(
+        HostFuncAVPacketData.run(CallFrame,
+                                 std::initializer_list<WasmEdge::ValVariant>{
+                                     PacketId, DataPtr, PacketDataSize},
+                                 Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
   }
 
@@ -327,6 +327,151 @@ TEST_F(FFmpegTest, AVPacketTest) {
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
   }
 }
+TEST_F(FFmpegTest, AVPacketDataBounds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  uint32_t PacketPtr = UINT32_C(4);
+  auto *FuncInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_alloc");
+  auto &HostFuncAVPacketAlloc = FuncInst->getHostFunc();
+  HostFuncAVPacketAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PacketPtr},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t PacketId = readUInt32(MemInst, PacketPtr);
+  ASSERT_TRUE(PacketId > 0);
+
+  FuncInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_new_packet");
+  auto &HostFuncAVNewPacket = FuncInst->getHostFunc();
+  uint32_t PacketSize = UINT32_C(40);
+  HostFuncAVNewPacket.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PacketId, PacketSize},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), 0);
+
+  FuncInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_data");
+  auto &HostFuncAVPacketData = FuncInst->getHostFunc();
+
+  // The destination is fenced with a sentinel; a guest length larger than
+  // AvPacket->size must be rejected outright, not partially copied.
+  uint32_t DataPtr = UINT32_C(200);
+  uint32_t DataLen = PacketSize + UINT32_C(24);
+  fillMemContent(MemInst, DataPtr, DataLen, UINT8_C(0xAA));
+  HostFuncAVPacketData.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PacketId, DataPtr, DataLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  char *Buf = MemInst->getPointer<char *>(DataPtr);
+  for (uint32_t I = 0; I < DataLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+  }
+
+  // A request bounded by the packet size still succeeds.
+  HostFuncAVPacketData.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               PacketId, DataPtr, PacketSize},
+                           Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+// Regression: a valid empty packet has data == null and size == 0; a
+// zero-length av_packet_data read of it must succeed and leave the
+// destination untouched.
+TEST_F(FFmpegTest, AVPacketDataEmptyPacketZeroLength) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  uint32_t PacketPtr = UINT32_C(4);
+  auto *FuncInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_alloc");
+  auto &HostFuncAVPacketAlloc = FuncInst->getHostFunc();
+  HostFuncAVPacketAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PacketPtr},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t PacketId = readUInt32(MemInst, PacketPtr);
+  ASSERT_TRUE(PacketId > 0);
+
+  // A freshly allocated packet is empty: av_packet_size reports 0.
+  FuncInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_size");
+  auto &HostFuncAVPacketSize = FuncInst->getHostFunc();
+  HostFuncAVPacketSize.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PacketId}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), 0);
+
+  FuncInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_data");
+  auto &HostFuncAVPacketData = FuncInst->getHostFunc();
+
+  // The zero-length read is a no-op success; the sentinel-filled destination
+  // stays untouched.
+  uint32_t DataPtr = UINT32_C(200);
+  uint32_t DataLen = UINT32_C(8);
+  fillMemContent(MemInst, DataPtr, DataLen, UINT8_C(0xAA));
+  HostFuncAVPacketData.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               PacketId, DataPtr, UINT32_C(0)},
+                           Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  char *Buf = MemInst->getPointer<char *>(DataPtr);
+  for (uint32_t I = 0; I < DataLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+  }
+}
+
+// av_packet_unref consumes the packet handle: id 0 and an already-consumed
+// id are no-op successes like the other free wrappers; a live id of another
+// type is rejected before any id-keyed deallocation.
+TEST_F(FFmpegTest, AVPacketUnrefNullSafeAndIdempotent) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto Run = [&](WasmEdge::Runtime::Instance::ModuleInstance *TargetMod,
+                 const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = TargetMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  EXPECT_EQ(Run(AVCodecMod.get(), "wasmedge_ffmpeg_avcodec_av_packet_unref",
+                {UINT32_C(0)}),
+            static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t PacketPtr = UINT32_C(4);
+  allocPacket(PacketPtr);
+  uint32_t PacketId = readUInt32(MemInst, PacketPtr);
+  ASSERT_TRUE(PacketId > 0);
+
+  EXPECT_EQ(Run(AVCodecMod.get(), "wasmedge_ffmpeg_avcodec_av_packet_unref",
+                {PacketId}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run(AVCodecMod.get(), "wasmedge_ffmpeg_avcodec_av_packet_unref",
+                {PacketId}),
+            static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t FramePtr = UINT32_C(8);
+  initEmptyFrame(FramePtr);
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+  EXPECT_EQ(Run(AVCodecMod.get(), "wasmedge_ffmpeg_avcodec_av_packet_unref",
+                {FrameId}),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  // The frame handle survived the rejected unref and still frees normally.
+  EXPECT_EQ(
+      Run(AVUtilMod.get(), "wasmedge_ffmpeg_avutil_av_frame_free", {FrameId}),
+      static_cast<int32_t>(ErrNo::Success));
+}
+
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avPacket.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avPacket.cpp
@@ -290,11 +290,11 @@ TEST_F(FFmpegTest, AVPacketTest) {
   auto &HostFuncAVPacketData = FuncInst->getHostFunc();
 
   {
-    EXPECT_TRUE(HostFuncAVPacketData.run(
-        CallFrame,
-        std::initializer_list<WasmEdge::ValVariant>{PacketId, DataPtr,
-                                                    PacketDataSize},
-        Result));
+    EXPECT_TRUE(
+        HostFuncAVPacketData.run(CallFrame,
+                                 std::initializer_list<WasmEdge::ValVariant>{
+                                     PacketId, DataPtr, PacketDataSize},
+                                 Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
   }
 
@@ -327,6 +327,138 @@ TEST_F(FFmpegTest, AVPacketTest) {
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
   }
 }
+TEST_F(FFmpegTest, AVPacketDataBounds) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  uint32_t PacketPtr = UINT32_C(4);
+  auto *FuncInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_alloc");
+  auto &HostFuncAVPacketAlloc = FuncInst->getHostFunc();
+  HostFuncAVPacketAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PacketPtr},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t PacketId = readUInt32(MemInst, PacketPtr);
+  ASSERT_TRUE(PacketId > 0);
+
+  FuncInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_new_packet");
+  auto &HostFuncAVNewPacket = FuncInst->getHostFunc();
+  uint32_t PacketSize = UINT32_C(40);
+  HostFuncAVNewPacket.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PacketId, PacketSize},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), 0);
+
+  FuncInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_data");
+  auto &HostFuncAVPacketData = FuncInst->getHostFunc();
+
+  uint32_t DataPtr = UINT32_C(200);
+  uint32_t DataLen = PacketSize + UINT32_C(24);
+  fillMemContent(MemInst, DataPtr, DataLen, UINT8_C(0xAA));
+  HostFuncAVPacketData.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PacketId, DataPtr, DataLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  char *Buf = MemInst->getPointer<char *>(DataPtr);
+  for (uint32_t I = 0; I < DataLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+  }
+
+  HostFuncAVPacketData.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               PacketId, DataPtr, PacketSize},
+                           Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, AVPacketDataEmptyPacketZeroLength) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  uint32_t PacketPtr = UINT32_C(4);
+  auto *FuncInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_alloc");
+  auto &HostFuncAVPacketAlloc = FuncInst->getHostFunc();
+  HostFuncAVPacketAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PacketPtr},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t PacketId = readUInt32(MemInst, PacketPtr);
+  ASSERT_TRUE(PacketId > 0);
+
+  FuncInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_size");
+  auto &HostFuncAVPacketSize = FuncInst->getHostFunc();
+  HostFuncAVPacketSize.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PacketId}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), 0);
+
+  FuncInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_data");
+  auto &HostFuncAVPacketData = FuncInst->getHostFunc();
+
+  uint32_t DataPtr = UINT32_C(200);
+  uint32_t DataLen = UINT32_C(8);
+  fillMemContent(MemInst, DataPtr, DataLen, UINT8_C(0xAA));
+  HostFuncAVPacketData.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               PacketId, DataPtr, UINT32_C(0)},
+                           Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  char *Buf = MemInst->getPointer<char *>(DataPtr);
+  for (uint32_t I = 0; I < DataLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+  }
+}
+
+TEST_F(FFmpegTest, AVPacketUnrefNullSafeAndIdempotent) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto Run = [&](WasmEdge::Runtime::Instance::ModuleInstance *TargetMod,
+                 const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = TargetMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  EXPECT_EQ(Run(AVCodecMod.get(), "wasmedge_ffmpeg_avcodec_av_packet_unref",
+                {UINT32_C(0)}),
+            static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t PacketPtr = UINT32_C(4);
+  allocPacket(PacketPtr);
+  uint32_t PacketId = readUInt32(MemInst, PacketPtr);
+  ASSERT_TRUE(PacketId > 0);
+
+  EXPECT_EQ(Run(AVCodecMod.get(), "wasmedge_ffmpeg_avcodec_av_packet_unref",
+                {PacketId}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run(AVCodecMod.get(), "wasmedge_ffmpeg_avcodec_av_packet_unref",
+                {PacketId}),
+            static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t FramePtr = UINT32_C(8);
+  initEmptyFrame(FramePtr);
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+  EXPECT_EQ(Run(AVCodecMod.get(), "wasmedge_ffmpeg_avcodec_av_packet_unref",
+                {FrameId}),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  EXPECT_EQ(
+      Run(AVUtilMod.get(), "wasmedge_ffmpeg_avutil_av_frame_free", {FrameId}),
+      static_cast<int32_t>(ErrNo::Success));
+}
+
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avcodec_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avcodec_func.cpp
@@ -538,6 +538,59 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
   }
 }
 
+// Regression: avcodec_send_packet / avcodec_send_frame read a null packet or
+// frame as an end-of-stream drain request; a nonzero id that fails the typed
+// lookup must be rejected instead of draining, and only id 0 drains.
+TEST_F(FFmpegTest, AVCodecSendRejectsUnresolvedHandles) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  uint32_t CodecCtxPtr = UINT32_C(4);
+  auto *AllocInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_alloc_context3");
+  ASSERT_NE(AllocInst, nullptr);
+  auto &HostFuncAllocCtx = AllocInst->getHostFunc();
+  EXPECT_TRUE(HostFuncAllocCtx.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0), CodecCtxPtr},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t CodecCtxId = readUInt32(MemInst, CodecCtxPtr);
+  ASSERT_TRUE(CodecCtxId > 0);
+
+  uint32_t UnresolvedId = UINT32_C(999999);
+
+  auto *SendPacketInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_send_packet");
+  ASSERT_NE(SendPacketInst, nullptr);
+  auto &HostFuncSendPacket = SendPacketInst->getHostFunc();
+  EXPECT_TRUE(HostFuncSendPacket.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecCtxId, UnresolvedId},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  auto *SendFrameInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_send_frame");
+  ASSERT_NE(SendFrameInst, nullptr);
+  auto &HostFuncSendFrame = SendFrameInst->getHostFunc();
+  EXPECT_TRUE(HostFuncSendFrame.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecCtxId, UnresolvedId},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  auto *FreeInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_free_context");
+  ASSERT_NE(FreeInst, nullptr);
+  auto &HostFuncFreeCtx = FreeInst->getHostFunc();
+  EXPECT_TRUE(HostFuncFreeCtx.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecCtxId},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avcodec_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avcodec_func.cpp
@@ -522,6 +522,56 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
   }
 }
 
+TEST_F(FFmpegTest, AVCodecSendRejectsUnresolvedHandles) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  uint32_t CodecCtxPtr = UINT32_C(4);
+  auto *AllocInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_alloc_context3");
+  ASSERT_NE(AllocInst, nullptr);
+  auto &HostFuncAllocCtx = AllocInst->getHostFunc();
+  EXPECT_TRUE(HostFuncAllocCtx.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0), CodecCtxPtr},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t CodecCtxId = readUInt32(MemInst, CodecCtxPtr);
+  ASSERT_TRUE(CodecCtxId > 0);
+
+  uint32_t UnresolvedId = UINT32_C(999999);
+
+  auto *SendPacketInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_send_packet");
+  ASSERT_NE(SendPacketInst, nullptr);
+  auto &HostFuncSendPacket = SendPacketInst->getHostFunc();
+  EXPECT_TRUE(HostFuncSendPacket.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecCtxId, UnresolvedId},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  auto *SendFrameInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_send_frame");
+  ASSERT_NE(SendFrameInst, nullptr);
+  auto &HostFuncSendFrame = SendFrameInst->getHostFunc();
+  EXPECT_TRUE(HostFuncSendFrame.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CodecCtxId, UnresolvedId},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  auto *FreeInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_free_context");
+  ASSERT_NE(FreeInst, nullptr);
+  auto &HostFuncFreeCtx = FreeInst->getHostFunc();
+  EXPECT_TRUE(HostFuncFreeCtx.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CodecCtxId},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avdevice/avDevice.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avdevice/avDevice.cpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The WasmEdge Authors
+
+#include "utils.h"
+
+#include <gtest/gtest.h>
+
+namespace WasmEdge {
+namespace Host {
+namespace WasmEdgeFFmpeg {
+
+// avdevice_free_list_devices is null-safe in FFmpeg: id 0 and an
+// already-released id are no-op successes like the other free wrappers; a
+// live id of another type is rejected before any id-keyed deallocation.
+TEST_F(FFmpegTest, AVDeviceFreeListDevicesNullSafeAndIdempotent) {
+  ASSERT_TRUE(AVDeviceMod != nullptr);
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto Run = [&](WasmEdge::Runtime::Instance::ModuleInstance *TargetMod,
+                 const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = TargetMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  EXPECT_EQ(Run(AVDeviceMod.get(),
+                "wasmedge_ffmpeg_avdevice_avdevice_free_list_devices",
+                {UINT32_C(0)}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run(AVDeviceMod.get(),
+                "wasmedge_ffmpeg_avdevice_avdevice_free_list_devices",
+                {UINT32_C(999999)}),
+            static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t FramePtr = UINT32_C(4);
+  initEmptyFrame(FramePtr);
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+  EXPECT_EQ(Run(AVDeviceMod.get(),
+                "wasmedge_ffmpeg_avdevice_avdevice_free_list_devices",
+                {FrameId}),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  // The frame handle survived the rejected free and still frees normally.
+  EXPECT_EQ(
+      Run(AVUtilMod.get(), "wasmedge_ffmpeg_avutil_av_frame_free", {FrameId}),
+      static_cast<int32_t>(ErrNo::Success));
+}
+
+} // namespace WasmEdgeFFmpeg
+} // namespace Host
+} // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avdevice/avDevice.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avdevice/avDevice.cpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The WasmEdge Authors
+
+#include "utils.h"
+
+#include <gtest/gtest.h>
+
+namespace WasmEdge {
+namespace Host {
+namespace WasmEdgeFFmpeg {
+
+TEST_F(FFmpegTest, AVDeviceFreeListDevicesNullSafeAndIdempotent) {
+  ASSERT_TRUE(AVDeviceMod != nullptr);
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto Run = [&](WasmEdge::Runtime::Instance::ModuleInstance *TargetMod,
+                 const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = TargetMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  EXPECT_EQ(Run(AVDeviceMod.get(),
+                "wasmedge_ffmpeg_avdevice_avdevice_free_list_devices",
+                {UINT32_C(0)}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run(AVDeviceMod.get(),
+                "wasmedge_ffmpeg_avdevice_avdevice_free_list_devices",
+                {UINT32_C(999999)}),
+            static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t FramePtr = UINT32_C(4);
+  initEmptyFrame(FramePtr);
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+  EXPECT_EQ(Run(AVDeviceMod.get(),
+                "wasmedge_ffmpeg_avdevice_avdevice_free_list_devices",
+                {FrameId}),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  EXPECT_EQ(
+      Run(AVUtilMod.get(), "wasmedge_ffmpeg_avutil_av_frame_free", {FrameId}),
+      static_cast<int32_t>(ErrNo::Success));
+}
+
+} // namespace WasmEdgeFFmpeg
+} // namespace Host
+} // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avfilter/avfilter.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avfilter/avfilter.cpp
@@ -271,6 +271,235 @@ TEST_F(FFmpegTest, AVFilterStructs) {
   }
 }
 
+TEST_F(FFmpegTest, AVFilterNameBounds) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  std::string InputName = std::string("abuffer");
+  uint32_t FilterPtr = UINT32_C(8);
+  uint32_t InputNamePtr = UINT32_C(100);
+  uint32_t StrPtr = UINT32_C(150);
+  fillMemContent(MemInst, InputNamePtr, InputName);
+
+  auto *FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_get_by_name");
+  auto &HostFuncAVFilterGetByName = FuncInst->getHostFunc();
+  HostFuncAVFilterGetByName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          FilterPtr, InputNamePtr, static_cast<int32_t>(InputName.length())},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t FilterId = readUInt32(MemInst, FilterPtr);
+  ASSERT_TRUE(FilterId > 0);
+
+  // The buffer is oversized and 0xAA-fenced; the copy must stop after the NUL.
+  FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_name_length");
+  auto &HostFuncNameLen = FuncInst->getHostFunc();
+  HostFuncNameLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FilterId}, Result);
+  uint32_t NameLen = Result[0].get<int32_t>();
+  ASSERT_TRUE(NameLen > 0);
+
+  FuncInst =
+      AVFilterMod->findFuncExports("wasmedge_ffmpeg_avfilter_avfilter_name");
+  auto &HostFuncName = FuncInst->getHostFunc();
+  uint32_t NameBufLen = NameLen + UINT32_C(32);
+  fillMemContent(MemInst, StrPtr, NameBufLen, UINT8_C(0xAA));
+  HostFuncName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FilterId, StrPtr, NameBufLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  {
+    char *Buf = MemInst->getPointer<char *>(StrPtr);
+    for (uint32_t I = NameLen + 1; I < NameBufLen; ++I) {
+      EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+    }
+  }
+
+  FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_description_length");
+  auto &HostFuncDescLen = FuncInst->getHostFunc();
+  HostFuncDescLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FilterId}, Result);
+  uint32_t DescLen = Result[0].get<int32_t>();
+  ASSERT_TRUE(DescLen > 0);
+
+  FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_description");
+  auto &HostFuncDesc = FuncInst->getHostFunc();
+  uint32_t DescBufLen = DescLen + UINT32_C(32);
+  fillMemContent(MemInst, StrPtr, DescBufLen, UINT8_C(0xAA));
+  HostFuncDesc.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FilterId, StrPtr, DescBufLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  {
+    char *Buf = MemInst->getPointer<char *>(StrPtr);
+    for (uint32_t I = DescLen + 1; I < DescBufLen; ++I) {
+      EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+    }
+  }
+}
+
+TEST_F(FFmpegTest, AVFilterGetByNameBounds) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  auto *FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_get_by_name");
+  auto &HostFuncAVFilterGetByName = FuncInst->getHostFunc();
+
+  // An in-bounds pointer with a length running off linear memory is rejected.
+  uint32_t FilterPtr = UINT32_C(8);
+  uint32_t OutOfBoundsStrPtr = UINT32_C(65000);
+  uint32_t OutOfBoundsStrLen = UINT32_C(2000);
+  HostFuncAVFilterGetByName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FilterPtr, OutOfBoundsStrPtr,
+                                                  OutOfBoundsStrLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::MissingMemory));
+}
+
+TEST_F(FFmpegTest, AVFilterPadGetterIndexBounds) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  uint32_t FilterPtr = UINT32_C(8);
+  uint32_t PadPtr = UINT32_C(16);
+  uint32_t NamePtr = UINT32_C(100);
+  uint32_t StrPtr = UINT32_C(200);
+
+  std::string FilterName = std::string("abuffer");
+  fillMemContent(MemInst, NamePtr, FilterName);
+
+  auto *FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_get_by_name");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncGetByName = FuncInst->getHostFunc();
+  HostFuncGetByName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          FilterPtr, NamePtr, static_cast<int32_t>(FilterName.length())},
+      Result);
+  uint32_t FilterId = readUInt32(MemInst, FilterPtr);
+  ASSERT_TRUE(FilterId > 0);
+
+  FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_get_outputs_filter_pad");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncGetOutputs = FuncInst->getHostFunc();
+  HostFuncGetOutputs.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FilterId, PadPtr},
+      Result);
+  uint32_t PadId = readUInt32(MemInst, PadPtr);
+  ASSERT_TRUE(PadId > 0);
+
+  auto *LenInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_pad_get_name_length");
+  ASSERT_NE(LenInst, nullptr);
+  auto &HostFuncLen = LenInst->getHostFunc();
+  auto *NameInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_pad_get_name");
+  ASSERT_NE(NameInst, nullptr);
+  auto &HostFuncName = NameInst->getHostFunc();
+  auto *TypeInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_pad_get_type");
+  ASSERT_NE(TypeInst, nullptr);
+  auto &HostFuncType = TypeInst->getHostFunc();
+
+  // A valid index still resolves the pad (abuffer has one output pad).
+  HostFuncLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PadId, INT32_C(0)},
+      Result);
+  EXPECT_GT(Result[0].get<int32_t>(), 0);
+
+  // FFmpeg's pad getters do not bounds-check Idx, so bad indexes report absent.
+  HostFuncLen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PadId, INT32_C(0x7FFFFFFF)},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 0);
+  HostFuncLen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PadId, INT32_C(-1)}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 0);
+
+  uint32_t BufLen = UINT32_C(64);
+  fillMemContent(MemInst, StrPtr, BufLen, UINT8_C(0xAA));
+  HostFuncName.run(CallFrame,
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       PadId, INT32_C(0x7FFFFFFF), StrPtr, BufLen},
+                   Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  HostFuncType.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PadId, INT32_C(0x7FFFFFFF)},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), -1); // AVMEDIA_TYPE_UNKNOWN
+}
+
+TEST_F(FFmpegTest, AVFilterPadViewTeardownReclaim) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  std::string FilterName = std::string("abuffer");
+  uint32_t FilterPtr = UINT32_C(8);
+  uint32_t FilterPadPtr = UINT32_C(12);
+  uint32_t NamePtr = UINT32_C(100);
+  fillMemContent(MemInst, NamePtr, FilterName);
+
+  auto *FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_get_by_name");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncGetByName = FuncInst->getHostFunc();
+  EXPECT_TRUE(HostFuncGetByName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          FilterPtr, NamePtr, static_cast<int32_t>(FilterName.length())},
+      Result));
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t FilterId = readUInt32(MemInst, FilterPtr);
+  ASSERT_TRUE(FilterId > 0);
+
+  FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_get_outputs_filter_pad");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncGetOutputs = FuncInst->getHostFunc();
+
+  // Querying pads twice through the same slot strands the first view; env
+  // teardown must reclaim it without double-freeing the one dropped below.
+  writeUInt32(MemInst, UINT32_C(0), FilterPadPtr);
+  EXPECT_TRUE(HostFuncGetOutputs.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FilterId, FilterPadPtr},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t StrandedPadId = readUInt32(MemInst, FilterPadPtr);
+  ASSERT_TRUE(StrandedPadId > 0);
+
+  EXPECT_TRUE(HostFuncGetOutputs.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FilterId, FilterPadPtr},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t DroppedPadId = readUInt32(MemInst, FilterPadPtr);
+  ASSERT_TRUE(DroppedPadId > 0);
+  EXPECT_NE(StrandedPadId, DroppedPadId);
+
+  FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_pad_drop");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncPadDrop = FuncInst->getHostFunc();
+  EXPECT_TRUE(HostFuncPadDrop.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DroppedPadId},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avfilter/avfilter.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avfilter/avfilter.cpp
@@ -271,6 +271,229 @@ TEST_F(FFmpegTest, AVFilterStructs) {
   }
 }
 
+TEST_F(FFmpegTest, AVFilterNameBounds) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  std::string InputName = std::string("abuffer");
+  uint32_t FilterPtr = UINT32_C(8);
+  uint32_t InputNamePtr = UINT32_C(100);
+  uint32_t StrPtr = UINT32_C(150);
+  fillMemContent(MemInst, InputNamePtr, InputName);
+
+  auto *FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_get_by_name");
+  auto &HostFuncAVFilterGetByName = FuncInst->getHostFunc();
+  HostFuncAVFilterGetByName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          FilterPtr, InputNamePtr, static_cast<int32_t>(InputName.length())},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t FilterId = readUInt32(MemInst, FilterPtr);
+  ASSERT_TRUE(FilterId > 0);
+
+  FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_name_length");
+  auto &HostFuncNameLen = FuncInst->getHostFunc();
+  HostFuncNameLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FilterId}, Result);
+  uint32_t NameLen = Result[0].get<int32_t>();
+  ASSERT_TRUE(NameLen > 0);
+
+  FuncInst =
+      AVFilterMod->findFuncExports("wasmedge_ffmpeg_avfilter_avfilter_name");
+  auto &HostFuncName = FuncInst->getHostFunc();
+  uint32_t NameBufLen = NameLen + UINT32_C(32);
+  fillMemContent(MemInst, StrPtr, NameBufLen, UINT8_C(0xAA));
+  HostFuncName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FilterId, StrPtr, NameBufLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  {
+    char *Buf = MemInst->getPointer<char *>(StrPtr);
+    for (uint32_t I = NameLen + 1; I < NameBufLen; ++I) {
+      EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+    }
+  }
+
+  FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_description_length");
+  auto &HostFuncDescLen = FuncInst->getHostFunc();
+  HostFuncDescLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FilterId}, Result);
+  uint32_t DescLen = Result[0].get<int32_t>();
+  ASSERT_TRUE(DescLen > 0);
+
+  FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_description");
+  auto &HostFuncDesc = FuncInst->getHostFunc();
+  uint32_t DescBufLen = DescLen + UINT32_C(32);
+  fillMemContent(MemInst, StrPtr, DescBufLen, UINT8_C(0xAA));
+  HostFuncDesc.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FilterId, StrPtr, DescBufLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  {
+    char *Buf = MemInst->getPointer<char *>(StrPtr);
+    for (uint32_t I = DescLen + 1; I < DescBufLen; ++I) {
+      EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+    }
+  }
+}
+
+TEST_F(FFmpegTest, AVFilterGetByNameBounds) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  auto *FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_get_by_name");
+  auto &HostFuncAVFilterGetByName = FuncInst->getHostFunc();
+
+  uint32_t FilterPtr = UINT32_C(8);
+  uint32_t OutOfBoundsStrPtr = UINT32_C(65000);
+  uint32_t OutOfBoundsStrLen = UINT32_C(2000);
+  HostFuncAVFilterGetByName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FilterPtr, OutOfBoundsStrPtr,
+                                                  OutOfBoundsStrLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::MissingMemory));
+}
+
+TEST_F(FFmpegTest, AVFilterPadGetterIndexBounds) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  uint32_t FilterPtr = UINT32_C(8);
+  uint32_t PadPtr = UINT32_C(16);
+  uint32_t NamePtr = UINT32_C(100);
+  uint32_t StrPtr = UINT32_C(200);
+
+  std::string FilterName = std::string("abuffer");
+  fillMemContent(MemInst, NamePtr, FilterName);
+
+  auto *FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_get_by_name");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncGetByName = FuncInst->getHostFunc();
+  HostFuncGetByName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          FilterPtr, NamePtr, static_cast<int32_t>(FilterName.length())},
+      Result);
+  uint32_t FilterId = readUInt32(MemInst, FilterPtr);
+  ASSERT_TRUE(FilterId > 0);
+
+  FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_get_outputs_filter_pad");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncGetOutputs = FuncInst->getHostFunc();
+  HostFuncGetOutputs.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FilterId, PadPtr},
+      Result);
+  uint32_t PadId = readUInt32(MemInst, PadPtr);
+  ASSERT_TRUE(PadId > 0);
+
+  auto *LenInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_pad_get_name_length");
+  ASSERT_NE(LenInst, nullptr);
+  auto &HostFuncLen = LenInst->getHostFunc();
+  auto *NameInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_pad_get_name");
+  ASSERT_NE(NameInst, nullptr);
+  auto &HostFuncName = NameInst->getHostFunc();
+  auto *TypeInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_pad_get_type");
+  ASSERT_NE(TypeInst, nullptr);
+  auto &HostFuncType = TypeInst->getHostFunc();
+
+  HostFuncLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PadId, INT32_C(0)},
+      Result);
+  EXPECT_GT(Result[0].get<int32_t>(), 0);
+
+  HostFuncLen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PadId, INT32_C(0x7FFFFFFF)},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 0);
+  HostFuncLen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PadId, INT32_C(-1)}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 0);
+
+  uint32_t BufLen = UINT32_C(64);
+  fillMemContent(MemInst, StrPtr, BufLen, UINT8_C(0xAA));
+  HostFuncName.run(CallFrame,
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       PadId, INT32_C(0x7FFFFFFF), StrPtr, BufLen},
+                   Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  HostFuncType.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PadId, INT32_C(0x7FFFFFFF)},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), -1);
+}
+
+TEST_F(FFmpegTest, AVFilterPadViewTeardownReclaim) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  std::string FilterName = std::string("abuffer");
+  uint32_t FilterPtr = UINT32_C(8);
+  uint32_t FilterPadPtr = UINT32_C(12);
+  uint32_t NamePtr = UINT32_C(100);
+  fillMemContent(MemInst, NamePtr, FilterName);
+
+  auto *FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_get_by_name");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncGetByName = FuncInst->getHostFunc();
+  EXPECT_TRUE(HostFuncGetByName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          FilterPtr, NamePtr, static_cast<int32_t>(FilterName.length())},
+      Result));
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t FilterId = readUInt32(MemInst, FilterPtr);
+  ASSERT_TRUE(FilterId > 0);
+
+  FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_get_outputs_filter_pad");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncGetOutputs = FuncInst->getHostFunc();
+
+  writeUInt32(MemInst, UINT32_C(0), FilterPadPtr);
+  EXPECT_TRUE(HostFuncGetOutputs.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FilterId, FilterPadPtr},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t StrandedPadId = readUInt32(MemInst, FilterPadPtr);
+  ASSERT_TRUE(StrandedPadId > 0);
+
+  EXPECT_TRUE(HostFuncGetOutputs.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FilterId, FilterPadPtr},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t DroppedPadId = readUInt32(MemInst, FilterPadPtr);
+  ASSERT_TRUE(DroppedPadId > 0);
+  EXPECT_NE(StrandedPadId, DroppedPadId);
+
+  FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_pad_drop");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncPadDrop = FuncInst->getHostFunc();
+  EXPECT_TRUE(HostFuncPadDrop.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DroppedPadId},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avfilter/avfilter_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avfilter/avfilter_func.cpp
@@ -348,31 +348,26 @@ TEST_F(FFmpegTest, AVFilterFunc) {
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
   }
 
-  // Crashing the program. Checked even from Rust side.
+  // avfilter_graph_parse_ptr consumed the in/out lists above and the host
+  // invalidated their handle ids, so freeing them is a safe no-op.
+  FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_inout_free");
+  EXPECT_NE(FuncInst, nullptr);
+  EXPECT_TRUE(FuncInst->isHostFunction());
 
-  //  FuncInst = AVFilterMod->findFuncExports(
-  //      "wasmedge_ffmpeg_avfilter_avfilter_inout_free");
-  //  EXPECT_NE(FuncInst, nullptr);
-  //  EXPECT_TRUE(FuncInst->isHostFunction());
-  //
-  //  auto &HostFuncAVFilterInOutFree = dynamic_cast<
-  //      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterInOutFree &>(
-  //      FuncInst->getHostFunc());
-  //
-  //  {
-  //    EXPECT_TRUE(HostFuncAVFilterInOutFree.run(
-  //        CallFrame,
-  //        std::initializer_list<WasmEdge::ValVariant>{InputInOutId}, Result));
-  //    EXPECT_EQ(Result[0].get<int32_t>(),
-  //    static_cast<int32_t>(ErrNo::Success));
-  //
-  //    EXPECT_TRUE(HostFuncAVFilterInOutFree.run(
-  //        CallFrame,
-  //        std::initializer_list<WasmEdge::ValVariant>{OutputInOutId},
-  //        Result));
-  //    EXPECT_EQ(Result[0].get<int32_t>(),
-  //    static_cast<int32_t>(ErrNo::Success));
-  //  }
+  auto &HostFuncAVFilterInOutFree = FuncInst->getHostFunc();
+
+  {
+    EXPECT_TRUE(HostFuncAVFilterInOutFree.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{InputInOutId},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+    EXPECT_TRUE(HostFuncAVFilterInOutFree.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{OutputInOutId},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  }
 
   FuncInst =
       AVFilterMod->findFuncExports("wasmedge_ffmpeg_avfilter_avfilter_version");
@@ -484,6 +479,17 @@ TEST_F(FFmpegTest, AVFilterFunc) {
         std::initializer_list<WasmEdge::ValVariant>{InputFilterCtxId, FrameId},
         Result));
     ASSERT_TRUE(Result[0].get<int32_t>());
+  }
+
+  // A zero FrameId yields a null AVFrame, which av_buffersrc_add_frame treats
+  // as an end-of-stream marker, so it must reach FFmpeg, not be rejected.
+  {
+    EXPECT_TRUE(HostFuncAVBufferSrcAddFrame.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{InputFilterCtxId,
+                                                    UINT32_C(0)},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
   }
 
   // Need to send the last frame. Then only this test will pass. Else Null
@@ -632,6 +638,517 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   // ==================================================================
   //                        End Clean Memory
   // ==================================================================
+}
+
+// Regression: a node linked into a chain via avfilter_inout_set_next is owned
+// by the chain's head: freeing it alone is a refused no-op, and freeing the
+// head releases the whole chain exactly once.
+TEST_F(FFmpegTest, AVFilterInOutChainOwnership) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  uint32_t HeadPtr = UINT32_C(4);
+  uint32_t NextPtr = UINT32_C(8);
+
+  auto *AllocInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_inout_alloc");
+  ASSERT_NE(AllocInst, nullptr);
+  auto &HostFuncInOutAlloc = AllocInst->getHostFunc();
+
+  ASSERT_TRUE(HostFuncInOutAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{HeadPtr}, Result));
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  ASSERT_TRUE(HostFuncInOutAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{NextPtr}, Result));
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t HeadId = readUInt32(MemInst, HeadPtr);
+  uint32_t NextId = readUInt32(MemInst, NextPtr);
+  ASSERT_TRUE(HeadId > 0);
+  ASSERT_TRUE(NextId > 0);
+  ASSERT_NE(HeadId, NextId);
+
+  auto *SetNextInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_inout_set_next");
+  ASSERT_NE(SetNextInst, nullptr);
+  auto &HostFuncInOutSetNext = SetNextInst->getHostFunc();
+
+  ASSERT_TRUE(HostFuncInOutSetNext.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{HeadId, NextId},
+      Result));
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  auto *FreeInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_inout_free");
+  ASSERT_NE(FreeInst, nullptr);
+  auto &HostFuncInOutFree = FreeInst->getHostFunc();
+
+  // Freeing the borrowed next node is a refused no-op: the head still owns it.
+  ASSERT_TRUE(HostFuncInOutFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{NextId}, Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  // Freeing the head releases the whole chain (head + next) exactly once.
+  ASSERT_TRUE(HostFuncInOutFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{HeadId}, Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  // The next id was dropped with the chain, so freeing it again is a no-op.
+  ASSERT_TRUE(HostFuncInOutFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{NextId}, Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+// Regression: relinking a chain head to a different next node must release the
+// previously linked node back to its own handle so it can still be freed.
+TEST_F(FFmpegTest, AVFilterInOutRelinkReleasesOldNext) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  uint32_t HeadPtr = UINT32_C(4);
+  uint32_t OldNextPtr = UINT32_C(8);
+  uint32_t NewNextPtr = UINT32_C(12);
+
+  auto *AllocInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_inout_alloc");
+  ASSERT_NE(AllocInst, nullptr);
+  auto &HostFuncInOutAlloc = AllocInst->getHostFunc();
+
+  auto Alloc = [&](uint32_t Ptr) {
+    EXPECT_TRUE(HostFuncInOutAlloc.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{Ptr}, Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    return readUInt32(MemInst, Ptr);
+  };
+  uint32_t HeadId = Alloc(HeadPtr);
+  uint32_t OldNextId = Alloc(OldNextPtr);
+  uint32_t NewNextId = Alloc(NewNextPtr);
+  ASSERT_TRUE(HeadId > 0);
+  ASSERT_TRUE(OldNextId > 0);
+  ASSERT_TRUE(NewNextId > 0);
+
+  auto *SetNextInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_inout_set_next");
+  ASSERT_NE(SetNextInst, nullptr);
+  auto &HostFuncInOutSetNext = SetNextInst->getHostFunc();
+
+  auto SetNext = [&](uint32_t Id, uint32_t NextId) {
+    EXPECT_TRUE(HostFuncInOutSetNext.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{Id, NextId},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  };
+  SetNext(HeadId, OldNextId); // OldNext is linked and becomes borrowed.
+  SetNext(HeadId, NewNextId); // Relink: OldNext detached, NewNext borrowed.
+
+  auto *FreeInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_inout_free");
+  ASSERT_NE(FreeInst, nullptr);
+  auto &HostFuncInOutFree = FreeInst->getHostFunc();
+
+  auto FreeInOut = [&](uint32_t Id) {
+    EXPECT_TRUE(HostFuncInOutFree.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{Id}, Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  };
+  // The detached old next is owned by its handle again and frees normally.
+  FreeInOut(OldNextId);
+  // Freeing the head releases head + the still-linked new next exactly once.
+  FreeInOut(HeadId);
+  // Both freed ids now resolve to no live pointer, so freeing again is a no-op.
+  FreeInOut(OldNextId);
+  FreeInOut(NewNextId);
+}
+
+// Regression: avfilter_inout_set_next must reject a link whose next node is
+// already owned by another chain (two owners would double-free it), while
+// re-linking the same edge stays idempotent.
+TEST_F(FFmpegTest, AVFilterInOutSetNextRejectsSharedNode) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  auto Run = [&](const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = AVFilterMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  uint32_t HeadOnePtr = UINT32_C(4);
+  uint32_t HeadTwoPtr = UINT32_C(8);
+  uint32_t SharedPtr = UINT32_C(12);
+
+  auto Alloc = [&](uint32_t Ptr) {
+    EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_alloc", {Ptr}),
+              static_cast<int32_t>(ErrNo::Success));
+    return readUInt32(MemInst, Ptr);
+  };
+  uint32_t HeadOneId = Alloc(HeadOnePtr);
+  uint32_t HeadTwoId = Alloc(HeadTwoPtr);
+  uint32_t SharedId = Alloc(SharedPtr);
+  ASSERT_TRUE(HeadOneId > 0);
+  ASSERT_TRUE(HeadTwoId > 0);
+  ASSERT_TRUE(SharedId > 0);
+
+  auto SetNext = [&](uint32_t Id, uint32_t NextId) {
+    return Run("wasmedge_ffmpeg_avfilter_avfilter_inout_set_next",
+               {Id, NextId});
+  };
+  auto FreeInOut = [&](uint32_t Id) {
+    return Run("wasmedge_ffmpeg_avfilter_avfilter_inout_free", {Id});
+  };
+
+  // The first link takes ownership of the shared node.
+  EXPECT_EQ(SetNext(HeadOneId, SharedId), static_cast<int32_t>(ErrNo::Success));
+  // Re-linking the same edge is idempotent, not a second owner.
+  EXPECT_EQ(SetNext(HeadOneId, SharedId), static_cast<int32_t>(ErrNo::Success));
+  // Linking the already-owned node under a second head is rejected.
+  ASSERT_EQ(SetNext(HeadTwoId, SharedId),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  // The shared node is still owned by head one, so a free is a refused no-op.
+  EXPECT_EQ(FreeInOut(SharedId), static_cast<int32_t>(ErrNo::Success));
+  // Freeing the first head releases head one plus the shared node exactly once.
+  EXPECT_EQ(FreeInOut(HeadOneId), static_cast<int32_t>(ErrNo::Success));
+  // Head two never linked the shared node, so freeing it releases only itself.
+  EXPECT_EQ(FreeInOut(HeadTwoId), static_cast<int32_t>(ErrNo::Success));
+  // The shared id was dropped with head one's chain; freeing again is a no-op.
+  EXPECT_EQ(FreeInOut(SharedId), static_cast<int32_t>(ErrNo::Success));
+}
+
+// Regression: avfilter_inout_set_next must reject a link that closes a cycle
+// (a node linked to itself, or a tail linked back to an earlier head).
+TEST_F(FFmpegTest, AVFilterInOutSetNextRejectsCyclicLink) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  auto Run = [&](const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = AVFilterMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  uint32_t HeadPtr = UINT32_C(4);
+  uint32_t TailPtr = UINT32_C(8);
+
+  auto Alloc = [&](uint32_t Ptr) {
+    EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_alloc", {Ptr}),
+              static_cast<int32_t>(ErrNo::Success));
+    return readUInt32(MemInst, Ptr);
+  };
+  uint32_t HeadId = Alloc(HeadPtr);
+  uint32_t TailId = Alloc(TailPtr);
+  ASSERT_TRUE(HeadId > 0);
+  ASSERT_TRUE(TailId > 0);
+
+  auto SetNext = [&](uint32_t Id, uint32_t NextId) {
+    return Run("wasmedge_ffmpeg_avfilter_avfilter_inout_set_next",
+               {Id, NextId});
+  };
+
+  // A node linked to itself is a one-node cycle: reject it.
+  ASSERT_EQ(SetNext(HeadId, HeadId),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  // Build head -> tail, then reject tail -> head which would close the cycle.
+  EXPECT_EQ(SetNext(HeadId, TailId), static_cast<int32_t>(ErrNo::Success));
+  ASSERT_EQ(SetNext(TailId, HeadId),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  // The rejected link left ownership intact: freeing tail is a refused no-op.
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_free", {TailId}),
+            static_cast<int32_t>(ErrNo::Success));
+  // The chain stayed acyclic, so freeing the head releases both exactly once.
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_free", {HeadId}),
+            static_cast<int32_t>(ErrNo::Success));
+  // Both ids were dropped with the chain, so a follow-up call is refused;
+  // a leaked borrowed id would still resolve here.
+  EXPECT_EQ(SetNext(HeadId, UINT32_C(0)),
+            static_cast<int32_t>(ErrNo::InternalError));
+  EXPECT_EQ(SetNext(TailId, UINT32_C(0)),
+            static_cast<int32_t>(ErrNo::InternalError));
+}
+
+// Regression: avfilter_graph_parse_ptr must reject the same AVFilterInOut id
+// passed as both the inputs and the outputs list (an aliased double-free).
+TEST_F(FFmpegTest, AVFilterGraphParsePtrRejectsAliasedInOut) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  auto Run = [&](const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = AVFilterMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  uint32_t GraphPtr = UINT32_C(4);
+  uint32_t InOutPtr = UINT32_C(8);
+  uint32_t SpecPtr = UINT32_C(100);
+  std::string Spec("anull");
+  fillMemContent(MemInst, SpecPtr, Spec);
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_graph_alloc", {GraphPtr}),
+            static_cast<int32_t>(ErrNo::Success));
+  uint32_t GraphId = readUInt32(MemInst, GraphPtr);
+  ASSERT_TRUE(GraphId > 0);
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_alloc", {InOutPtr}),
+            static_cast<int32_t>(ErrNo::Success));
+  uint32_t InOutId = readUInt32(MemInst, InOutPtr);
+  ASSERT_TRUE(InOutId > 0);
+
+  // Same id for both inputs and outputs is rejected before reaching FFmpeg.
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_graph_parse_ptr",
+                {GraphId, SpecPtr, static_cast<int32_t>(Spec.length()), InOutId,
+                 InOutId}),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  // The rejected node is still owned by its handle and frees normally.
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_free", {InOutId}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_graph_free", {GraphId}),
+            static_cast<int32_t>(ErrNo::Success));
+}
+
+// Regression: a failing avfilter_graph_parse_ptr frees every filter context
+// already in the graph, so the wrapper must drop the guest's child handle ids
+// instead of leaving them resolving to freed contexts.
+TEST_F(FFmpegTest, AVFilterGraphParsePtrDropsChildrenOnError) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  auto Run = [&](const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = AVFilterMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  uint32_t GraphPtr = UINT32_C(4);
+  uint32_t FilterPtr = UINT32_C(8);
+  uint32_t CtxPtr = UINT32_C(12);
+  uint32_t SrcNamePtr = UINT32_C(100);
+  uint32_t CtxNamePtr = UINT32_C(200);
+  uint32_t ArgsPtr = UINT32_C(300);
+  uint32_t SpecPtr = UINT32_C(500);
+
+  std::string SrcName("abuffer");
+  fillMemContent(MemInst, SrcNamePtr, SrcName);
+  std::string CtxName("in");
+  fillMemContent(MemInst, CtxNamePtr, CtxName);
+  std::string Args(
+      "time_base=1/44100:sample_rate=44100:sample_fmt=fltp:channel_layout=0x3");
+  fillMemContent(MemInst, ArgsPtr, Args);
+  std::string BadSpec("thisfilterdoesnotexist");
+  fillMemContent(MemInst, SpecPtr, BadSpec);
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_graph_alloc", {GraphPtr}),
+            static_cast<int32_t>(ErrNo::Success));
+  uint32_t GraphId = readUInt32(MemInst, GraphPtr);
+  ASSERT_TRUE(GraphId > 0);
+
+  EXPECT_EQ(
+      Run("wasmedge_ffmpeg_avfilter_avfilter_get_by_name",
+          {FilterPtr, SrcNamePtr, static_cast<int32_t>(SrcName.length())}),
+      static_cast<int32_t>(ErrNo::Success));
+  uint32_t FilterId = readUInt32(MemInst, FilterPtr);
+  ASSERT_TRUE(FilterId > 0);
+
+  ASSERT_GE(
+      Run("wasmedge_ffmpeg_avfilter_avfilter_graph_create_filter",
+          {CtxPtr, FilterId, CtxNamePtr, static_cast<int32_t>(CtxName.length()),
+           ArgsPtr, static_cast<int32_t>(Args.length()), GraphId}),
+      0);
+  uint32_t CtxId = readUInt32(MemInst, CtxPtr);
+  ASSERT_TRUE(CtxId > 0);
+
+  // Sanity: the fresh context id resolves and reports no failed requests.
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_av_buffersrc_get_nb_failed_requests",
+                {CtxId}),
+            0);
+
+  // An unknown filter name fails the parse; FFmpeg frees every graph context.
+  EXPECT_LT(Run("wasmedge_ffmpeg_avfilter_avfilter_graph_parse_ptr",
+                {GraphId, SpecPtr, static_cast<int32_t>(BadSpec.length()),
+                 UINT32_C(0), UINT32_C(0)}),
+            0);
+
+  // The child id was dropped on failure, so the call reports a missing handle.
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_av_buffersrc_get_nb_failed_requests",
+                {CtxId}),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_graph_free", {GraphId}),
+            static_cast<int32_t>(ErrNo::Success));
+}
+
+// Regression: a borrowed AVFilterInOut node (linked under a head via
+// AVFilterInOutSetNext) passed as a parse list to avfilter_graph_parse_ptr
+// must be rejected, leaving the chain intact for the head to free exactly once.
+TEST_F(FFmpegTest, AVFilterGraphParsePtrRejectsBorrowedInOut) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  auto Run = [&](const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = AVFilterMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  uint32_t GraphPtr = UINT32_C(4);
+  uint32_t HeadPtr = UINT32_C(8);
+  uint32_t TailPtr = UINT32_C(12);
+  uint32_t SpecPtr = UINT32_C(100);
+  std::string Spec("anull");
+  fillMemContent(MemInst, SpecPtr, Spec);
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_graph_alloc", {GraphPtr}),
+            static_cast<int32_t>(ErrNo::Success));
+  uint32_t GraphId = readUInt32(MemInst, GraphPtr);
+  ASSERT_TRUE(GraphId > 0);
+
+  auto Alloc = [&](uint32_t Ptr) {
+    EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_alloc", {Ptr}),
+              static_cast<int32_t>(ErrNo::Success));
+    return readUInt32(MemInst, Ptr);
+  };
+  uint32_t HeadId = Alloc(HeadPtr);
+  uint32_t TailId = Alloc(TailPtr);
+  ASSERT_TRUE(HeadId > 0);
+  ASSERT_TRUE(TailId > 0);
+
+  // Link head -> tail: the tail becomes borrowed, owned by the head's chain.
+  EXPECT_EQ(
+      Run("wasmedge_ffmpeg_avfilter_avfilter_inout_set_next", {HeadId, TailId}),
+      static_cast<int32_t>(ErrNo::Success));
+
+  auto ParsePtr = [&](uint32_t InputsId, uint32_t OutputsId) {
+    return Run("wasmedge_ffmpeg_avfilter_avfilter_graph_parse_ptr",
+               {GraphId, SpecPtr, static_cast<int32_t>(Spec.length()), InputsId,
+                OutputsId});
+  };
+
+  // The borrowed tail as the inputs head is rejected before reaching FFmpeg.
+  EXPECT_EQ(ParsePtr(TailId, UINT32_C(0)),
+            static_cast<int32_t>(ErrNo::InternalError));
+  // The same holds when it is passed as the outputs head.
+  EXPECT_EQ(ParsePtr(UINT32_C(0), TailId),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  // Rejection left ownership intact: freeing the tail is a refused no-op.
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_free", {TailId}),
+            static_cast<int32_t>(ErrNo::Success));
+  // Freeing the head releases head + tail exactly once with no dangling ->next.
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_free", {HeadId}),
+            static_cast<int32_t>(ErrNo::Success));
+  // The tail id was dropped with the chain, so freeing it again is a no-op.
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_free", {TailId}),
+            static_cast<int32_t>(ErrNo::Success));
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_graph_free", {GraphId}),
+            static_cast<int32_t>(ErrNo::Success));
+}
+
+// Regression: AVFilterGraphFree must reject an id of another handle type
+// before any deallocation, while a stale id stays an idempotent no-op.
+TEST_F(FFmpegTest, AVFilterGraphFreeRejectsWrongTypeHandle) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t FormatCtxPtr = UINT32_C(4);
+  uint32_t FilePtr = UINT32_C(100);
+  initFormatCtx(FormatCtxPtr, FilePtr,
+                std::string("ffmpeg-assets/sample_video.mp4"));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  auto *GraphFreeInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_graph_free");
+  ASSERT_NE(GraphFreeInst, nullptr);
+  auto &HostFuncGraphFree = GraphFreeInst->getHostFunc();
+  HostFuncGraphFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  // The format context handle survived the rejected free and still resolves.
+  auto *NbStreamsInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_nb_streams");
+  ASSERT_NE(NbStreamsInst, nullptr);
+  auto &HostFuncNbStreams = NbStreamsInst->getHostFunc();
+  HostFuncNbStreams.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+      Result);
+  EXPECT_TRUE(Result[0].get<uint32_t>() > 0);
+
+  // A stale graph id resolves to nothing and stays an idempotent no-op.
+  HostFuncGraphFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT32_C(999999)},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  auto *CloseInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformat_close_input");
+  ASSERT_NE(CloseInst, nullptr);
+  auto &HostFuncClose = CloseInst->getHostFunc();
+  HostFuncClose.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+                    Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+// avfilter_free_graph_str semantics: id 0 and a stale id are no-op successes,
+// while an id aliasing a live handle of another type must be rejected instead
+// of claiming the dump string was released. A live graph id keeps succeeding.
+TEST_F(FFmpegTest, AVFilterFreeGraphStrRejectsWrongTypeHandle) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto Run = [&](WasmEdge::Runtime::Instance::ModuleInstance *TargetMod,
+                 const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = TargetMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  EXPECT_EQ(Run(AVFilterMod.get(),
+                "wasmedge_ffmpeg_avfilter_avfilter_free_graph_str",
+                {UINT32_C(0)}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run(AVFilterMod.get(),
+                "wasmedge_ffmpeg_avfilter_avfilter_free_graph_str",
+                {UINT32_C(999999)}),
+            static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t FramePtr = UINT32_C(4);
+  initEmptyFrame(FramePtr);
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+  EXPECT_EQ(Run(AVFilterMod.get(),
+                "wasmedge_ffmpeg_avfilter_avfilter_free_graph_str", {FrameId}),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  // The frame handle survived the rejected call and still frees normally.
+  EXPECT_EQ(
+      Run(AVUtilMod.get(), "wasmedge_ffmpeg_avutil_av_frame_free", {FrameId}),
+      static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t GraphPtr = UINT32_C(8);
+  EXPECT_EQ(Run(AVFilterMod.get(),
+                "wasmedge_ffmpeg_avfilter_avfilter_graph_alloc", {GraphPtr}),
+            static_cast<int32_t>(ErrNo::Success));
+  uint32_t GraphId = readUInt32(MemInst, GraphPtr);
+  ASSERT_TRUE(GraphId > 0);
+  EXPECT_EQ(Run(AVFilterMod.get(),
+                "wasmedge_ffmpeg_avfilter_avfilter_free_graph_str", {GraphId}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run(AVFilterMod.get(),
+                "wasmedge_ffmpeg_avfilter_avfilter_graph_free", {GraphId}),
+            static_cast<int32_t>(ErrNo::Success));
 }
 
 } // namespace WasmEdgeFFmpeg

--- a/test/plugins/wasmedge_ffmpeg/avfilter/avfilter_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avfilter/avfilter_func.cpp
@@ -348,31 +348,24 @@ TEST_F(FFmpegTest, AVFilterFunc) {
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
   }
 
-  // Crashing the program. Checked even from Rust side.
+  FuncInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_inout_free");
+  EXPECT_NE(FuncInst, nullptr);
+  EXPECT_TRUE(FuncInst->isHostFunction());
 
-  //  FuncInst = AVFilterMod->findFuncExports(
-  //      "wasmedge_ffmpeg_avfilter_avfilter_inout_free");
-  //  EXPECT_NE(FuncInst, nullptr);
-  //  EXPECT_TRUE(FuncInst->isHostFunction());
-  //
-  //  auto &HostFuncAVFilterInOutFree = dynamic_cast<
-  //      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterInOutFree &>(
-  //      FuncInst->getHostFunc());
-  //
-  //  {
-  //    EXPECT_TRUE(HostFuncAVFilterInOutFree.run(
-  //        CallFrame,
-  //        std::initializer_list<WasmEdge::ValVariant>{InputInOutId}, Result));
-  //    EXPECT_EQ(Result[0].get<int32_t>(),
-  //    static_cast<int32_t>(ErrNo::Success));
-  //
-  //    EXPECT_TRUE(HostFuncAVFilterInOutFree.run(
-  //        CallFrame,
-  //        std::initializer_list<WasmEdge::ValVariant>{OutputInOutId},
-  //        Result));
-  //    EXPECT_EQ(Result[0].get<int32_t>(),
-  //    static_cast<int32_t>(ErrNo::Success));
-  //  }
+  auto &HostFuncAVFilterInOutFree = FuncInst->getHostFunc();
+
+  {
+    EXPECT_TRUE(HostFuncAVFilterInOutFree.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{InputInOutId},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+    EXPECT_TRUE(HostFuncAVFilterInOutFree.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{OutputInOutId},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  }
 
   FuncInst =
       AVFilterMod->findFuncExports("wasmedge_ffmpeg_avfilter_avfilter_version");
@@ -484,6 +477,15 @@ TEST_F(FFmpegTest, AVFilterFunc) {
         std::initializer_list<WasmEdge::ValVariant>{InputFilterCtxId, FrameId},
         Result));
     ASSERT_TRUE(Result[0].get<int32_t>());
+  }
+
+  {
+    EXPECT_TRUE(HostFuncAVBufferSrcAddFrame.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{InputFilterCtxId,
+                                                    UINT32_C(0)},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
   }
 
   // Need to send the last frame. Then only this test will pass. Else Null
@@ -632,6 +634,461 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   // ==================================================================
   //                        End Clean Memory
   // ==================================================================
+}
+
+TEST_F(FFmpegTest, AVFilterInOutChainOwnership) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  uint32_t HeadPtr = UINT32_C(4);
+  uint32_t NextPtr = UINT32_C(8);
+
+  auto *AllocInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_inout_alloc");
+  ASSERT_NE(AllocInst, nullptr);
+  auto &HostFuncInOutAlloc = AllocInst->getHostFunc();
+
+  ASSERT_TRUE(HostFuncInOutAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{HeadPtr}, Result));
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  ASSERT_TRUE(HostFuncInOutAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{NextPtr}, Result));
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t HeadId = readUInt32(MemInst, HeadPtr);
+  uint32_t NextId = readUInt32(MemInst, NextPtr);
+  ASSERT_TRUE(HeadId > 0);
+  ASSERT_TRUE(NextId > 0);
+  ASSERT_NE(HeadId, NextId);
+
+  auto *SetNextInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_inout_set_next");
+  ASSERT_NE(SetNextInst, nullptr);
+  auto &HostFuncInOutSetNext = SetNextInst->getHostFunc();
+
+  ASSERT_TRUE(HostFuncInOutSetNext.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{HeadId, NextId},
+      Result));
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  auto *FreeInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_inout_free");
+  ASSERT_NE(FreeInst, nullptr);
+  auto &HostFuncInOutFree = FreeInst->getHostFunc();
+
+  ASSERT_TRUE(HostFuncInOutFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{NextId}, Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  ASSERT_TRUE(HostFuncInOutFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{HeadId}, Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  ASSERT_TRUE(HostFuncInOutFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{NextId}, Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, AVFilterInOutRelinkReleasesOldNext) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  uint32_t HeadPtr = UINT32_C(4);
+  uint32_t OldNextPtr = UINT32_C(8);
+  uint32_t NewNextPtr = UINT32_C(12);
+
+  auto *AllocInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_inout_alloc");
+  ASSERT_NE(AllocInst, nullptr);
+  auto &HostFuncInOutAlloc = AllocInst->getHostFunc();
+
+  auto Alloc = [&](uint32_t Ptr) {
+    EXPECT_TRUE(HostFuncInOutAlloc.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{Ptr}, Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    return readUInt32(MemInst, Ptr);
+  };
+  uint32_t HeadId = Alloc(HeadPtr);
+  uint32_t OldNextId = Alloc(OldNextPtr);
+  uint32_t NewNextId = Alloc(NewNextPtr);
+  ASSERT_TRUE(HeadId > 0);
+  ASSERT_TRUE(OldNextId > 0);
+  ASSERT_TRUE(NewNextId > 0);
+
+  auto *SetNextInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_inout_set_next");
+  ASSERT_NE(SetNextInst, nullptr);
+  auto &HostFuncInOutSetNext = SetNextInst->getHostFunc();
+
+  auto SetNext = [&](uint32_t Id, uint32_t NextId) {
+    EXPECT_TRUE(HostFuncInOutSetNext.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{Id, NextId},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  };
+  SetNext(HeadId, OldNextId);
+  SetNext(HeadId, NewNextId);
+
+  auto *FreeInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_inout_free");
+  ASSERT_NE(FreeInst, nullptr);
+  auto &HostFuncInOutFree = FreeInst->getHostFunc();
+
+  auto FreeInOut = [&](uint32_t Id) {
+    EXPECT_TRUE(HostFuncInOutFree.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{Id}, Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  };
+  FreeInOut(OldNextId);
+  FreeInOut(HeadId);
+  FreeInOut(OldNextId);
+  FreeInOut(NewNextId);
+}
+
+TEST_F(FFmpegTest, AVFilterInOutSetNextRejectsSharedNode) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  auto Run = [&](const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = AVFilterMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  uint32_t HeadOnePtr = UINT32_C(4);
+  uint32_t HeadTwoPtr = UINT32_C(8);
+  uint32_t SharedPtr = UINT32_C(12);
+
+  auto Alloc = [&](uint32_t Ptr) {
+    EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_alloc", {Ptr}),
+              static_cast<int32_t>(ErrNo::Success));
+    return readUInt32(MemInst, Ptr);
+  };
+  uint32_t HeadOneId = Alloc(HeadOnePtr);
+  uint32_t HeadTwoId = Alloc(HeadTwoPtr);
+  uint32_t SharedId = Alloc(SharedPtr);
+  ASSERT_TRUE(HeadOneId > 0);
+  ASSERT_TRUE(HeadTwoId > 0);
+  ASSERT_TRUE(SharedId > 0);
+
+  auto SetNext = [&](uint32_t Id, uint32_t NextId) {
+    return Run("wasmedge_ffmpeg_avfilter_avfilter_inout_set_next",
+               {Id, NextId});
+  };
+  auto FreeInOut = [&](uint32_t Id) {
+    return Run("wasmedge_ffmpeg_avfilter_avfilter_inout_free", {Id});
+  };
+
+  EXPECT_EQ(SetNext(HeadOneId, SharedId), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(SetNext(HeadOneId, SharedId), static_cast<int32_t>(ErrNo::Success));
+  ASSERT_EQ(SetNext(HeadTwoId, SharedId),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  EXPECT_EQ(FreeInOut(SharedId), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(FreeInOut(HeadOneId), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(FreeInOut(HeadTwoId), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(FreeInOut(SharedId), static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, AVFilterInOutSetNextRejectsCyclicLink) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  auto Run = [&](const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = AVFilterMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  uint32_t HeadPtr = UINT32_C(4);
+  uint32_t TailPtr = UINT32_C(8);
+
+  auto Alloc = [&](uint32_t Ptr) {
+    EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_alloc", {Ptr}),
+              static_cast<int32_t>(ErrNo::Success));
+    return readUInt32(MemInst, Ptr);
+  };
+  uint32_t HeadId = Alloc(HeadPtr);
+  uint32_t TailId = Alloc(TailPtr);
+  ASSERT_TRUE(HeadId > 0);
+  ASSERT_TRUE(TailId > 0);
+
+  auto SetNext = [&](uint32_t Id, uint32_t NextId) {
+    return Run("wasmedge_ffmpeg_avfilter_avfilter_inout_set_next",
+               {Id, NextId});
+  };
+
+  ASSERT_EQ(SetNext(HeadId, HeadId),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  EXPECT_EQ(SetNext(HeadId, TailId), static_cast<int32_t>(ErrNo::Success));
+  ASSERT_EQ(SetNext(TailId, HeadId),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_free", {TailId}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_free", {HeadId}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(SetNext(HeadId, UINT32_C(0)),
+            static_cast<int32_t>(ErrNo::InternalError));
+  EXPECT_EQ(SetNext(TailId, UINT32_C(0)),
+            static_cast<int32_t>(ErrNo::InternalError));
+}
+
+TEST_F(FFmpegTest, AVFilterGraphParsePtrRejectsAliasedInOut) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  auto Run = [&](const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = AVFilterMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  uint32_t GraphPtr = UINT32_C(4);
+  uint32_t InOutPtr = UINT32_C(8);
+  uint32_t SpecPtr = UINT32_C(100);
+  std::string Spec("anull");
+  fillMemContent(MemInst, SpecPtr, Spec);
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_graph_alloc", {GraphPtr}),
+            static_cast<int32_t>(ErrNo::Success));
+  uint32_t GraphId = readUInt32(MemInst, GraphPtr);
+  ASSERT_TRUE(GraphId > 0);
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_alloc", {InOutPtr}),
+            static_cast<int32_t>(ErrNo::Success));
+  uint32_t InOutId = readUInt32(MemInst, InOutPtr);
+  ASSERT_TRUE(InOutId > 0);
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_graph_parse_ptr",
+                {GraphId, SpecPtr, static_cast<int32_t>(Spec.length()), InOutId,
+                 InOutId}),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_free", {InOutId}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_graph_free", {GraphId}),
+            static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, AVFilterGraphParsePtrDropsChildrenOnError) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  auto Run = [&](const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = AVFilterMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  uint32_t GraphPtr = UINT32_C(4);
+  uint32_t FilterPtr = UINT32_C(8);
+  uint32_t CtxPtr = UINT32_C(12);
+  uint32_t SrcNamePtr = UINT32_C(100);
+  uint32_t CtxNamePtr = UINT32_C(200);
+  uint32_t ArgsPtr = UINT32_C(300);
+  uint32_t SpecPtr = UINT32_C(500);
+
+  std::string SrcName("abuffer");
+  fillMemContent(MemInst, SrcNamePtr, SrcName);
+  std::string CtxName("in");
+  fillMemContent(MemInst, CtxNamePtr, CtxName);
+  std::string Args(
+      "time_base=1/44100:sample_rate=44100:sample_fmt=fltp:channel_layout=0x3");
+  fillMemContent(MemInst, ArgsPtr, Args);
+  std::string BadSpec("thisfilterdoesnotexist");
+  fillMemContent(MemInst, SpecPtr, BadSpec);
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_graph_alloc", {GraphPtr}),
+            static_cast<int32_t>(ErrNo::Success));
+  uint32_t GraphId = readUInt32(MemInst, GraphPtr);
+  ASSERT_TRUE(GraphId > 0);
+
+  EXPECT_EQ(
+      Run("wasmedge_ffmpeg_avfilter_avfilter_get_by_name",
+          {FilterPtr, SrcNamePtr, static_cast<int32_t>(SrcName.length())}),
+      static_cast<int32_t>(ErrNo::Success));
+  uint32_t FilterId = readUInt32(MemInst, FilterPtr);
+  ASSERT_TRUE(FilterId > 0);
+
+  ASSERT_GE(
+      Run("wasmedge_ffmpeg_avfilter_avfilter_graph_create_filter",
+          {CtxPtr, FilterId, CtxNamePtr, static_cast<int32_t>(CtxName.length()),
+           ArgsPtr, static_cast<int32_t>(Args.length()), GraphId}),
+      0);
+  uint32_t CtxId = readUInt32(MemInst, CtxPtr);
+  ASSERT_TRUE(CtxId > 0);
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_av_buffersrc_get_nb_failed_requests",
+                {CtxId}),
+            0);
+
+  EXPECT_LT(Run("wasmedge_ffmpeg_avfilter_avfilter_graph_parse_ptr",
+                {GraphId, SpecPtr, static_cast<int32_t>(BadSpec.length()),
+                 UINT32_C(0), UINT32_C(0)}),
+            0);
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_av_buffersrc_get_nb_failed_requests",
+                {CtxId}),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_graph_free", {GraphId}),
+            static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, AVFilterGraphParsePtrRejectsBorrowedInOut) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+
+  auto Run = [&](const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = AVFilterMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  uint32_t GraphPtr = UINT32_C(4);
+  uint32_t HeadPtr = UINT32_C(8);
+  uint32_t TailPtr = UINT32_C(12);
+  uint32_t SpecPtr = UINT32_C(100);
+  std::string Spec("anull");
+  fillMemContent(MemInst, SpecPtr, Spec);
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_graph_alloc", {GraphPtr}),
+            static_cast<int32_t>(ErrNo::Success));
+  uint32_t GraphId = readUInt32(MemInst, GraphPtr);
+  ASSERT_TRUE(GraphId > 0);
+
+  auto Alloc = [&](uint32_t Ptr) {
+    EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_alloc", {Ptr}),
+              static_cast<int32_t>(ErrNo::Success));
+    return readUInt32(MemInst, Ptr);
+  };
+  uint32_t HeadId = Alloc(HeadPtr);
+  uint32_t TailId = Alloc(TailPtr);
+  ASSERT_TRUE(HeadId > 0);
+  ASSERT_TRUE(TailId > 0);
+
+  EXPECT_EQ(
+      Run("wasmedge_ffmpeg_avfilter_avfilter_inout_set_next", {HeadId, TailId}),
+      static_cast<int32_t>(ErrNo::Success));
+
+  auto ParsePtr = [&](uint32_t InputsId, uint32_t OutputsId) {
+    return Run("wasmedge_ffmpeg_avfilter_avfilter_graph_parse_ptr",
+               {GraphId, SpecPtr, static_cast<int32_t>(Spec.length()), InputsId,
+                OutputsId});
+  };
+
+  EXPECT_EQ(ParsePtr(TailId, UINT32_C(0)),
+            static_cast<int32_t>(ErrNo::InternalError));
+  EXPECT_EQ(ParsePtr(UINT32_C(0), TailId),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_free", {TailId}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_free", {HeadId}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_inout_free", {TailId}),
+            static_cast<int32_t>(ErrNo::Success));
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avfilter_avfilter_graph_free", {GraphId}),
+            static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, AVFilterGraphFreeRejectsWrongTypeHandle) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t FormatCtxPtr = UINT32_C(4);
+  uint32_t FilePtr = UINT32_C(100);
+  initFormatCtx(FormatCtxPtr, FilePtr,
+                std::string("ffmpeg-assets/sample_video.mp4"));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  auto *GraphFreeInst = AVFilterMod->findFuncExports(
+      "wasmedge_ffmpeg_avfilter_avfilter_graph_free");
+  ASSERT_NE(GraphFreeInst, nullptr);
+  auto &HostFuncGraphFree = GraphFreeInst->getHostFunc();
+  HostFuncGraphFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  auto *NbStreamsInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_nb_streams");
+  ASSERT_NE(NbStreamsInst, nullptr);
+  auto &HostFuncNbStreams = NbStreamsInst->getHostFunc();
+  HostFuncNbStreams.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+      Result);
+  EXPECT_TRUE(Result[0].get<uint32_t>() > 0);
+
+  HostFuncGraphFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT32_C(999999)},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  auto *CloseInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformat_close_input");
+  ASSERT_NE(CloseInst, nullptr);
+  auto &HostFuncClose = CloseInst->getHostFunc();
+  HostFuncClose.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+                    Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, AVFilterFreeGraphStrRejectsWrongTypeHandle) {
+  ASSERT_TRUE(AVFilterMod != nullptr);
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto Run = [&](WasmEdge::Runtime::Instance::ModuleInstance *TargetMod,
+                 const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = TargetMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  EXPECT_EQ(Run(AVFilterMod.get(),
+                "wasmedge_ffmpeg_avfilter_avfilter_free_graph_str",
+                {UINT32_C(0)}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run(AVFilterMod.get(),
+                "wasmedge_ffmpeg_avfilter_avfilter_free_graph_str",
+                {UINT32_C(999999)}),
+            static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t FramePtr = UINT32_C(4);
+  initEmptyFrame(FramePtr);
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+  EXPECT_EQ(Run(AVFilterMod.get(),
+                "wasmedge_ffmpeg_avfilter_avfilter_free_graph_str", {FrameId}),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  EXPECT_EQ(
+      Run(AVUtilMod.get(), "wasmedge_ffmpeg_avutil_av_frame_free", {FrameId}),
+      static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t GraphPtr = UINT32_C(8);
+  EXPECT_EQ(Run(AVFilterMod.get(),
+                "wasmedge_ffmpeg_avfilter_avfilter_graph_alloc", {GraphPtr}),
+            static_cast<int32_t>(ErrNo::Success));
+  uint32_t GraphId = readUInt32(MemInst, GraphPtr);
+  ASSERT_TRUE(GraphId > 0);
+  EXPECT_EQ(Run(AVFilterMod.get(),
+                "wasmedge_ffmpeg_avfilter_avfilter_free_graph_str", {GraphId}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run(AVFilterMod.get(),
+                "wasmedge_ffmpeg_avfilter_avfilter_graph_free", {GraphId}),
+            static_cast<int32_t>(ErrNo::Success));
 }
 
 } // namespace WasmEdgeFFmpeg

--- a/test/plugins/wasmedge_ffmpeg/avformat/avInputOutputContext.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avInputOutputContext.cpp
@@ -192,6 +192,159 @@ TEST_F(FFmpegTest, AVInputFormat) {
   }
 }
 
+TEST_F(FFmpegTest, AVInputFormatNameBounds) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  std::string FileName = "ffmpeg-assets/sample_video.mp4"; // 32 chars
+  uint32_t FormatCtxPtr = UINT32_C(24);
+  uint32_t InputFormatPtr = UINT32_C(80);
+  uint32_t StrBuf = UINT32_C(100);
+  initFFmpegStructs(UINT32_C(20), FormatCtxPtr, UINT32_C(28), FileName,
+                    UINT32_C(60), UINT32_C(64), UINT32_C(68), UINT32_C(72));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  // Fail cleanly if the test asset could not be opened; otherwise the format
+  // context getters below would receive id 0 and report an error.
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  auto *FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_iformat");
+  auto &HostFuncIFormat = FuncInst->getHostFunc();
+  HostFuncIFormat.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, InputFormatPtr},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t InputFormatId = readUInt32(MemInst, InputFormatPtr);
+  ASSERT_TRUE(InputFormatId > 0);
+
+  // The guest buffer is larger than the host string and fenced with 0xAA; the
+  // host must copy only the string plus terminator, leaving the fence intact.
+  FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avIOFormat_name_length");
+  auto &HostFuncNameLen = FuncInst->getHostFunc();
+  HostFuncNameLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{InputFormatId, 0},
+      Result);
+  uint32_t NameLen = Result[0].get<int32_t>();
+  ASSERT_TRUE(NameLen > 0);
+
+  FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avInputFormat_name");
+  auto &HostFuncName = FuncInst->getHostFunc();
+  uint32_t NameBufLen = NameLen + UINT32_C(32);
+  fillMemContent(MemInst, StrBuf, NameBufLen, UINT8_C(0xAA));
+  HostFuncName.run(CallFrame,
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       InputFormatId, StrBuf, NameBufLen},
+                   Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  {
+    char *Buf = MemInst->getPointer<char *>(StrBuf);
+    for (uint32_t I = NameLen + 1; I < NameBufLen; ++I) {
+      EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+    }
+  }
+
+  FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avIOFormat_long_name_length");
+  auto &HostFuncLongNameLen = FuncInst->getHostFunc();
+  HostFuncLongNameLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{InputFormatId, 0},
+      Result);
+  uint32_t LongNameLen = Result[0].get<int32_t>();
+  ASSERT_TRUE(LongNameLen > 0);
+
+  FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avInputFormat_long_name");
+  auto &HostFuncLongName = FuncInst->getHostFunc();
+  uint32_t LongNameBufLen = LongNameLen + UINT32_C(32);
+  fillMemContent(MemInst, StrBuf, LongNameBufLen, UINT8_C(0xAA));
+  HostFuncLongName.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           InputFormatId, StrBuf, LongNameBufLen},
+                       Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  {
+    char *Buf = MemInst->getPointer<char *>(StrBuf);
+    for (uint32_t I = LongNameLen + 1; I < LongNameBufLen; ++I) {
+      EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+    }
+  }
+}
+
+// Regression: a live id that is neither an AVInputFormat nor an
+// AVOutputFormat must be rejected by avInputOutputFormat_free and keep
+// resolving; stale ids and id 0 stay no-ops.
+TEST_F(FFmpegTest, InputOutputFormatFreeRejectsWrongTypeHandle) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t FormatCtxPtr = UINT32_C(4);
+  uint32_t InputFormatPtr = UINT32_C(8);
+  uint32_t FilePtr = UINT32_C(100);
+  initFormatCtx(FormatCtxPtr, FilePtr,
+                std::string("ffmpeg-assets/sample_video.mp4"));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  auto *FreeInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avInputOutputFormat_free");
+  ASSERT_NE(FreeInst, nullptr);
+  auto &HostFuncFormatFree = FreeInst->getHostFunc();
+
+  // A format-context id is a live handle of another type: reject it.
+  HostFuncFormatFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  // The context handle survived the rejected free and still resolves.
+  auto *NbStreamsInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_nb_streams");
+  ASSERT_NE(NbStreamsInst, nullptr);
+  auto &HostFuncNbStreams = NbStreamsInst->getHostFunc();
+  HostFuncNbStreams.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+      Result);
+  EXPECT_TRUE(Result[0].get<uint32_t>() > 0);
+
+  // An input-format id is accepted and dropped; a stale id and id 0 are
+  // idempotent no-ops.
+  auto *IFormatInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_iformat");
+  ASSERT_NE(IFormatInst, nullptr);
+  auto &HostFuncIFormat = IFormatInst->getHostFunc();
+  HostFuncIFormat.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, InputFormatPtr},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t InputFormatId = readUInt32(MemInst, InputFormatPtr);
+  ASSERT_TRUE(InputFormatId > 0);
+
+  HostFuncFormatFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{InputFormatId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  HostFuncFormatFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{InputFormatId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  HostFuncFormatFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0)},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  auto *CloseInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformat_close_input");
+  ASSERT_NE(CloseInst, nullptr);
+  auto &HostFuncClose = CloseInst->getHostFunc();
+  HostFuncClose.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+                    Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avformat/avInputOutputContext.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avInputOutputContext.cpp
@@ -192,6 +192,148 @@ TEST_F(FFmpegTest, AVInputFormat) {
   }
 }
 
+TEST_F(FFmpegTest, AVInputFormatNameBounds) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  std::string FileName = "ffmpeg-assets/sample_video.mp4";
+  uint32_t FormatCtxPtr = UINT32_C(24);
+  uint32_t InputFormatPtr = UINT32_C(80);
+  uint32_t StrBuf = UINT32_C(100);
+  initFFmpegStructs(UINT32_C(20), FormatCtxPtr, UINT32_C(28), FileName,
+                    UINT32_C(60), UINT32_C(64), UINT32_C(68), UINT32_C(72));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  auto *FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_iformat");
+  auto &HostFuncIFormat = FuncInst->getHostFunc();
+  HostFuncIFormat.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, InputFormatPtr},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t InputFormatId = readUInt32(MemInst, InputFormatPtr);
+  ASSERT_TRUE(InputFormatId > 0);
+
+  FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avIOFormat_name_length");
+  auto &HostFuncNameLen = FuncInst->getHostFunc();
+  HostFuncNameLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{InputFormatId, 0},
+      Result);
+  uint32_t NameLen = Result[0].get<int32_t>();
+  ASSERT_TRUE(NameLen > 0);
+
+  FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avInputFormat_name");
+  auto &HostFuncName = FuncInst->getHostFunc();
+  uint32_t NameBufLen = NameLen + UINT32_C(32);
+  fillMemContent(MemInst, StrBuf, NameBufLen, UINT8_C(0xAA));
+  HostFuncName.run(CallFrame,
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       InputFormatId, StrBuf, NameBufLen},
+                   Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  {
+    char *Buf = MemInst->getPointer<char *>(StrBuf);
+    for (uint32_t I = NameLen + 1; I < NameBufLen; ++I) {
+      EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+    }
+  }
+
+  FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avIOFormat_long_name_length");
+  auto &HostFuncLongNameLen = FuncInst->getHostFunc();
+  HostFuncLongNameLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{InputFormatId, 0},
+      Result);
+  uint32_t LongNameLen = Result[0].get<int32_t>();
+  ASSERT_TRUE(LongNameLen > 0);
+
+  FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avInputFormat_long_name");
+  auto &HostFuncLongName = FuncInst->getHostFunc();
+  uint32_t LongNameBufLen = LongNameLen + UINT32_C(32);
+  fillMemContent(MemInst, StrBuf, LongNameBufLen, UINT8_C(0xAA));
+  HostFuncLongName.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           InputFormatId, StrBuf, LongNameBufLen},
+                       Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  {
+    char *Buf = MemInst->getPointer<char *>(StrBuf);
+    for (uint32_t I = LongNameLen + 1; I < LongNameBufLen; ++I) {
+      EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+    }
+  }
+}
+
+TEST_F(FFmpegTest, InputOutputFormatFreeRejectsWrongTypeHandle) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t FormatCtxPtr = UINT32_C(4);
+  uint32_t InputFormatPtr = UINT32_C(8);
+  uint32_t FilePtr = UINT32_C(100);
+  initFormatCtx(FormatCtxPtr, FilePtr,
+                std::string("ffmpeg-assets/sample_video.mp4"));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  auto *FreeInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avInputOutputFormat_free");
+  ASSERT_NE(FreeInst, nullptr);
+  auto &HostFuncFormatFree = FreeInst->getHostFunc();
+
+  HostFuncFormatFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  auto *NbStreamsInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_nb_streams");
+  ASSERT_NE(NbStreamsInst, nullptr);
+  auto &HostFuncNbStreams = NbStreamsInst->getHostFunc();
+  HostFuncNbStreams.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+      Result);
+  EXPECT_TRUE(Result[0].get<uint32_t>() > 0);
+
+  auto *IFormatInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_iformat");
+  ASSERT_NE(IFormatInst, nullptr);
+  auto &HostFuncIFormat = IFormatInst->getHostFunc();
+  HostFuncIFormat.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, InputFormatPtr},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t InputFormatId = readUInt32(MemInst, InputFormatPtr);
+  ASSERT_TRUE(InputFormatId > 0);
+
+  HostFuncFormatFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{InputFormatId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  HostFuncFormatFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{InputFormatId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  HostFuncFormatFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0)},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  auto *CloseInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformat_close_input");
+  ASSERT_NE(CloseInst, nullptr);
+  auto &HostFuncClose = CloseInst->getHostFunc();
+  HostFuncClose.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+                    Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avformat/avStream.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avStream.cpp
@@ -269,6 +269,46 @@ TEST_F(FFmpegTest, AVStreamStruct) {
   }
 }
 
+TEST_F(FFmpegTest, AVStreamIndexOutOfRange) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t FormatCtxPtr = UINT32_C(4);
+  uint32_t CodecParameterPtr = UINT32_C(8);
+  uint32_t FilePtr = UINT32_C(100);
+
+  std::string FileName = "ffmpeg-assets/sample_video.mp4"; // 32 chars
+  initFormatCtx(FormatCtxPtr, FilePtr, FileName);
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  // A guest-supplied stream index past nb_streams must be rejected, not walked
+  // off the end of the streams array.
+  uint32_t OutOfRangeIdx = UINT32_C(1000000);
+
+  auto *IdFunc =
+      AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avStream_id");
+  ASSERT_NE(IdFunc, nullptr);
+  auto &HostFuncAVStreamId = IdFunc->getHostFunc();
+  HostFuncAVStreamId.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, OutOfRangeIdx},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  auto *CodecParFunc = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avStream_codecpar");
+  ASSERT_NE(CodecParFunc, nullptr);
+  auto &HostFuncAVStreamCodecPar = CodecParFunc->getHostFunc();
+  HostFuncAVStreamCodecPar.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, OutOfRangeIdx,
+                                                  CodecParameterPtr},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+}
+
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avformat/avStream.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avStream.cpp
@@ -269,6 +269,44 @@ TEST_F(FFmpegTest, AVStreamStruct) {
   }
 }
 
+TEST_F(FFmpegTest, AVStreamIndexOutOfRange) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t FormatCtxPtr = UINT32_C(4);
+  uint32_t CodecParameterPtr = UINT32_C(8);
+  uint32_t FilePtr = UINT32_C(100);
+
+  std::string FileName = "ffmpeg-assets/sample_video.mp4";
+  initFormatCtx(FormatCtxPtr, FilePtr, FileName);
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  uint32_t OutOfRangeIdx = UINT32_C(1000000);
+
+  auto *IdFunc =
+      AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avStream_id");
+  ASSERT_NE(IdFunc, nullptr);
+  auto &HostFuncAVStreamId = IdFunc->getHostFunc();
+  HostFuncAVStreamId.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, OutOfRangeIdx},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  auto *CodecParFunc = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avStream_codecpar");
+  ASSERT_NE(CodecParFunc, nullptr);
+  auto &HostFuncAVStreamCodecPar = CodecParFunc->getHostFunc();
+  HostFuncAVStreamCodecPar.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, OutOfRangeIdx,
+                                                  CodecParameterPtr},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+}
+
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
@@ -120,17 +120,33 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
   ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatCtxNbChapters = FuncInst->getHostFunc();
   {
-    uint32_t NbChapters = 200;
+    EXPECT_TRUE(HostFuncAVFormatCtxNbChapters.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+        Result));
+    uint32_t const CurrentNbChapters = Result[0].get<uint32_t>();
+
+    // Setting the count to its current (authoritative) value is allowed.
     EXPECT_TRUE(HostFuncAVFormatCtxSetNbChapters.run(
         CallFrame,
-        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, NbChapters},
+        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId,
+                                                    CurrentNbChapters},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+    // Forging a larger count must be rejected: the chapters array is not grown
+    // here, so a raised nb_chapters would let chapterAt walk past the array.
+    EXPECT_TRUE(HostFuncAVFormatCtxSetNbChapters.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId,
+                                                    CurrentNbChapters + 200},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(),
+              static_cast<int32_t>(ErrNo::InternalError));
 
     EXPECT_TRUE(HostFuncAVFormatCtxNbChapters.run(
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
         Result));
-    EXPECT_EQ(Result[0].get<uint32_t>(), NbChapters);
+    EXPECT_EQ(Result[0].get<uint32_t>(), CurrentNbChapters);
   }
 
   FuncInst = AVFormatMod->findFuncExports(
@@ -160,6 +176,25 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
   }
+}
+
+TEST_F(FFmpegTest, AVFormatCtxMetadataNullHandle) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  auto *FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_metadata");
+  auto &HostFuncAVFormatCtxMetadata = FuncInst->getHostFunc();
+
+  // A guest id of 0 resolves to a null AVFormatContext; the getter must report
+  // InternalError instead of dereferencing it.
+  uint32_t InvalidFormatCtxId = UINT32_C(0);
+  uint32_t DictPtr = UINT32_C(4);
+  EXPECT_TRUE(HostFuncAVFormatCtxMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{InvalidFormatCtxId, DictPtr},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
 }
 
 } // namespace WasmEdgeFFmpeg

--- a/test/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
@@ -120,17 +120,30 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
   ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatCtxNbChapters = FuncInst->getHostFunc();
   {
-    uint32_t NbChapters = 200;
+    EXPECT_TRUE(HostFuncAVFormatCtxNbChapters.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+        Result));
+    uint32_t const CurrentNbChapters = Result[0].get<uint32_t>();
+
     EXPECT_TRUE(HostFuncAVFormatCtxSetNbChapters.run(
         CallFrame,
-        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, NbChapters},
+        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId,
+                                                    CurrentNbChapters},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+    EXPECT_TRUE(HostFuncAVFormatCtxSetNbChapters.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId,
+                                                    CurrentNbChapters + 200},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(),
+              static_cast<int32_t>(ErrNo::InternalError));
 
     EXPECT_TRUE(HostFuncAVFormatCtxNbChapters.run(
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
         Result));
-    EXPECT_EQ(Result[0].get<uint32_t>(), NbChapters);
+    EXPECT_EQ(Result[0].get<uint32_t>(), CurrentNbChapters);
   }
 
   FuncInst = AVFormatMod->findFuncExports(
@@ -243,6 +256,23 @@ TEST_F(FFmpegTest, AVFormatNewStream) {
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
       Result));
   EXPECT_EQ(Result[0].get<int32_t>(), NbStreamsBefore + 2);
+}
+
+TEST_F(FFmpegTest, AVFormatCtxMetadataNullHandle) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  auto *FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_metadata");
+  auto &HostFuncAVFormatCtxMetadata = FuncInst->getHostFunc();
+
+  uint32_t InvalidFormatCtxId = UINT32_C(0);
+  uint32_t DictPtr = UINT32_C(4);
+  EXPECT_TRUE(HostFuncAVFormatCtxMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{InvalidFormatCtxId, DictPtr},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
 }
 
 } // namespace WasmEdgeFFmpeg

--- a/test/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
@@ -2,7 +2,10 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "avformat/avformat_func.h"
+#include "avformat/avChapter.h"
+#include "avformat/avformatContext.h"
 #include "avformat/module.h"
+#include "avutil/avDictionary.h"
 
 #include "utils.h"
 
@@ -103,6 +106,35 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
             FormatCtxId, UINT32_C(0), INT32_C(-1), INT32_C(-1), 0, 0},
         Result));
     EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
+  }
+
+  spdlog::info("Testing AVFindBestStream rejects a nonzero decoder_ret id"sv);
+  {
+    // A live AVCodec id would pass the typed decoder_ret fetch; it must be
+    // rejected rather than written through into the static AVCodec object.
+    ASSERT_TRUE(AVCodecMod != nullptr);
+    auto *CodecFuncInst = AVCodecMod->findFuncExports(
+        "wasmedge_ffmpeg_avcodec_avcodec_find_decoder");
+    ASSERT_NE(CodecFuncInst, nullptr);
+    auto &HostFuncAVCodecFindDecoder = CodecFuncInst->getHostFunc();
+
+    uint32_t CodecDecoderPtr = UINT32_C(800);
+    ASSERT_TRUE(HostFuncAVCodecFindDecoder.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{UINT32_C(1),
+                                                    CodecDecoderPtr},
+        Result));
+    uint32_t DecoderRetId = readUInt32(MemInst, CodecDecoderPtr);
+    ASSERT_TRUE(DecoderRetId > 0);
+
+    EXPECT_TRUE(HostFuncAVFindBestStream.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, UINT32_C(0),
+                                                    INT32_C(-1), INT32_C(-1),
+                                                    DecoderRetId, 0},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(),
+              static_cast<int32_t>(ErrNo::InternalError));
   }
 
   FuncInst =
@@ -353,13 +385,16 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
         Result));
     EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
 
+    // The id stored above is an AVFormatContext, not an AVOutputFormat: the
+    // wrong-type id is rejected instead of falling back to the name lookup.
     EXPECT_TRUE(HostFuncAVFormatAllocOutputContext2.run(
         CallFrame,
         std::initializer_list<WasmEdge::ValVariant>{
             FormatCtxPtr, readUInt32(MemInst, FormatCtxPtr), FormatStart,
             FormatLen, FileStart, FileLen},
         Result));
-    EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
+    EXPECT_EQ(Result[0].get<int32_t>(),
+              static_cast<int32_t>(ErrNo::InternalError));
 
     EXPECT_TRUE(HostFuncAVFormatAllocOutputContext2.run(
         CallFrame,
@@ -542,6 +577,457 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), -22);
   }
+}
+
+TEST_F(FFmpegTest, AVIOOpenBounds) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  auto *FuncInst =
+      AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avio_open");
+  auto &HostFuncAVIOOpen = FuncInst->getHostFunc();
+
+  // The file-name pointer is in bounds but the guest-declared length runs off
+  // the end of linear memory; the host must reject it, not read past the page.
+  uint32_t AvFormatCtxId = UINT32_C(0);
+  uint32_t OutOfBoundsFileNamePtr = UINT32_C(65000);
+  uint32_t OutOfBoundsFileNameLen = UINT32_C(2000);
+  int32_t Flags = 0;
+  HostFuncAVIOOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          AvFormatCtxId, OutOfBoundsFileNamePtr, OutOfBoundsFileNameLen, Flags},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::MissingMemory));
+}
+
+TEST_F(FFmpegTest, AVChapterDynarrayAddNullContext) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t NbChaptersPtr = UINT32_C(4);
+  writeSInt32(MemInst, 0, NbChaptersPtr);
+
+  auto *FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avchapter_dynarray_add");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncDynarrayAdd = FuncInst->getHostFunc();
+
+  // A null/zero format-context id must be rejected, not dereferenced when
+  // writing through &(AvFormatContext->chapters).
+  uint32_t NullFormatCtxId = UINT32_C(0);
+  uint32_t AvChapterId = UINT32_C(0);
+  HostFuncDynarrayAdd.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              NullFormatCtxId, NbChaptersPtr, AvChapterId},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+}
+
+TEST_F(FFmpegTest, AVChapterDynarrayAddIgnoresForgedCount) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t NbChaptersPtr = UINT32_C(4);
+  uint32_t FormatCtxPtr = UINT32_C(8);
+  uint32_t ChapterPtr = UINT32_C(12);
+  uint32_t FilePtr = UINT32_C(200);
+
+  initFormatCtx(FormatCtxPtr, FilePtr,
+                std::string("ffmpeg-assets/sample_video.mp4"));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  auto *NbInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_nb_chapters");
+  ASSERT_NE(NbInst, nullptr);
+  auto &HostFuncNbChapters = NbInst->getHostFunc();
+  HostFuncNbChapters.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+      Result);
+  int32_t InitialNbChapters = static_cast<int32_t>(Result[0].get<uint32_t>());
+
+  auto *MalloczInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avchapter_mallocz");
+  ASSERT_NE(MalloczInst, nullptr);
+  auto &HostFuncMallocz = MalloczInst->getHostFunc();
+  HostFuncMallocz.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{ChapterPtr},
+                      Result);
+  uint32_t ChapterId = readUInt32(MemInst, ChapterPtr);
+  ASSERT_TRUE(ChapterId > 0);
+
+  auto *FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avchapter_dynarray_add");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncDynarrayAdd = FuncInst->getHostFunc();
+
+  // A forged large count must not make av_dynarray_add write past the array;
+  // the host appends at the authoritative index and reports the true count.
+  writeSInt32(MemInst, INT32_C(0x40000001), NbChaptersPtr);
+  HostFuncDynarrayAdd.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              FormatCtxId, NbChaptersPtr, ChapterId},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(readSInt32(MemInst, NbChaptersPtr), InitialNbChapters + 1);
+
+  HostFuncNbChapters.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+      Result);
+  EXPECT_EQ(Result[0].get<uint32_t>(),
+            static_cast<uint32_t>(InitialNbChapters + 1));
+}
+
+TEST_F(FFmpegTest, AVFreePOnContextOwnedChapter) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t NbChaptersPtr = UINT32_C(4);
+  uint32_t FormatCtxPtr = UINT32_C(8);
+  uint32_t ChapterPtr = UINT32_C(12);
+  uint32_t FilePtr = UINT32_C(200);
+
+  initFormatCtx(FormatCtxPtr, FilePtr,
+                std::string("ffmpeg-assets/sample_video.mp4"));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  auto *NbInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_nb_chapters");
+  ASSERT_NE(NbInst, nullptr);
+  auto &HostFuncNbChapters = NbInst->getHostFunc();
+  HostFuncNbChapters.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+      Result);
+  uint32_t ChapterIdx = Result[0].get<uint32_t>();
+
+  auto *MalloczInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avchapter_mallocz");
+  ASSERT_NE(MalloczInst, nullptr);
+  auto &HostFuncMallocz = MalloczInst->getHostFunc();
+  HostFuncMallocz.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{ChapterPtr},
+                      Result);
+  uint32_t ChapterId = readUInt32(MemInst, ChapterPtr);
+  ASSERT_TRUE(ChapterId > 0);
+
+  auto *AddInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avchapter_dynarray_add");
+  ASSERT_NE(AddInst, nullptr);
+  auto &HostFuncDynarrayAdd = AddInst->getHostFunc();
+  writeSInt32(MemInst, static_cast<int32_t>(ChapterIdx), NbChaptersPtr);
+  HostFuncDynarrayAdd.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              FormatCtxId, NbChaptersPtr, ChapterId},
+                          Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  // Set the context-owned chapter's id to a wild-pointer value; freeing via
+  // the handle must not treat it as a pointer nor free the owned struct.
+  auto *SetIdInst =
+      AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avChapter_set_id");
+  ASSERT_NE(SetIdInst, nullptr);
+  auto &HostFuncSetId = SetIdInst->getHostFunc();
+  int64_t const PoisonId = INT64_C(0x4141414141414141);
+  HostFuncSetId.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{
+                        FormatCtxId, ChapterIdx, PoisonId},
+                    Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  auto *FreePInst =
+      AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avformat_avfreep");
+  ASSERT_NE(FreePInst, nullptr);
+  auto &HostFuncFreeP =
+      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFreeP &>(
+          FreePInst->getHostFunc());
+  HostFuncFreeP.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{ChapterId},
+                    Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  auto Env = HostFuncFreeP.getEnv();
+  EXPECT_EQ(Env->fetchData(ChapterId), nullptr);
+}
+
+TEST_F(FFmpegTest, AVFormatCtxSetMetadataCopiesDict) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t FormatCtxPtr = UINT32_C(8);
+  uint32_t DictPtr = UINT32_C(12);
+  uint32_t MetaDictPtr = UINT32_C(16);
+  uint32_t KeyPtr = UINT32_C(200);
+  uint32_t ValuePtr = UINT32_C(220);
+  uint32_t KeyLenPtr = UINT32_C(240);
+  uint32_t ValueLenPtr = UINT32_C(244);
+  uint32_t FilePtr = UINT32_C(300);
+
+  initFormatCtx(FormatCtxPtr, FilePtr,
+                std::string("ffmpeg-assets/sample_video.mp4"));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  std::string Key = "meta_key";
+  std::string Value = "meta_val";
+  fillMemContent(MemInst, KeyPtr, Key);
+  fillMemContent(MemInst, ValuePtr, Value);
+
+  // Build an owning dictionary the guest controls.
+  auto *SetInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
+  ASSERT_NE(SetInst, nullptr);
+  auto &HostFuncDictSet = SetInst->getHostFunc();
+  HostFuncDictSet.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{
+                          DictPtr, KeyPtr, static_cast<uint32_t>(Key.length()),
+                          ValuePtr, static_cast<uint32_t>(Value.length()),
+                          INT32_C(0)},
+                      Result);
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+  ASSERT_TRUE(DictId > 0);
+
+  // Attach it to the context, then free the guest's dictionary.
+  auto *SetMetaInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_set_metadata");
+  ASSERT_NE(SetMetaInst, nullptr);
+  auto &HostFuncSetMetadata = SetMetaInst->getHostFunc();
+  HostFuncSetMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, DictId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  auto *FreeInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_free");
+  ASSERT_NE(FreeInst, nullptr);
+  auto &HostFuncDictFree = FreeInst->getHostFunc();
+  HostFuncDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DictId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  // The context kept its own copy: the entry is still readable after the guest
+  // dictionary was freed.
+  auto *MetaInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_metadata");
+  ASSERT_NE(MetaInst, nullptr);
+  auto &HostFuncMetadata = MetaInst->getHostFunc();
+  HostFuncMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, MetaDictPtr},
+      Result);
+  uint32_t MetaDictId = readUInt32(MemInst, MetaDictPtr);
+  ASSERT_TRUE(MetaDictId > 0);
+
+  auto *GetInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_get");
+  ASSERT_NE(GetInst, nullptr);
+  auto &HostFuncDictGet = GetInst->getHostFunc();
+  HostFuncDictGet.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{
+                          MetaDictId, KeyPtr,
+                          static_cast<uint32_t>(Key.length()), UINT32_C(0),
+                          INT32_C(0), KeyLenPtr, ValueLenPtr},
+                      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 1);
+
+  // Closing frees the context's copy exactly once.
+  auto *CloseInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformat_close_input");
+  ASSERT_NE(CloseInst, nullptr);
+  auto &HostFuncClose = CloseInst->getHostFunc();
+  HostFuncClose.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+                    Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+// Regression: av_write_frame and av_interleaved_write_frame read a null packet
+// as a muxer flush request, so a nonzero packet id that fails the typed lookup
+// must be rejected instead of flushing; only id 0 keeps requesting a flush.
+TEST_F(FFmpegTest, WriteFrameRejectsUnresolvedPacketHandles) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t FormatCtxPtr = UINT32_C(4);
+  uint32_t FilePtr = UINT32_C(100);
+  initFormatCtx(FormatCtxPtr, FilePtr,
+                std::string("ffmpeg-assets/sample_video.mp4"));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  uint32_t UnresolvedId = UINT32_C(999999);
+  auto Run = [&](const char *Name) {
+    auto *Inst = AVFormatMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, UnresolvedId},
+        Result));
+    return Result[0].get<int32_t>();
+  };
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avformat_av_write_frame"),
+            static_cast<int32_t>(ErrNo::InternalError));
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avformat_av_interleaved_write_frame"),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  auto *CloseInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformat_close_input");
+  ASSERT_NE(CloseInst, nullptr);
+  auto &HostFuncClose = CloseInst->getHostFunc();
+  HostFuncClose.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+                    Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+// Regression: a nonzero metadata dict id that fails the typed lookup must be
+// rejected and leave the metadata untouched; only id 0 intentionally clears.
+TEST_F(FFmpegTest, SetMetadataRejectsUnresolvedDictHandle) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t FormatCtxPtr = UINT32_C(8);
+  uint32_t DictPtr = UINT32_C(12);
+  uint32_t MetaDictPtr = UINT32_C(16);
+  uint32_t KeyPtr = UINT32_C(200);
+  uint32_t ValuePtr = UINT32_C(220);
+  uint32_t KeyLenPtr = UINT32_C(240);
+  uint32_t ValueLenPtr = UINT32_C(244);
+  uint32_t FilePtr = UINT32_C(300);
+
+  initFormatCtx(FormatCtxPtr, FilePtr,
+                std::string("ffmpeg-assets/sample_video.mp4"));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  std::string Key = "meta_key";
+  std::string Value = "meta_val";
+  fillMemContent(MemInst, KeyPtr, Key);
+  fillMemContent(MemInst, ValuePtr, Value);
+
+  auto *SetInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
+  ASSERT_NE(SetInst, nullptr);
+  auto &HostFuncDictSet = SetInst->getHostFunc();
+  HostFuncDictSet.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{
+                          DictPtr, KeyPtr, static_cast<uint32_t>(Key.length()),
+                          ValuePtr, static_cast<uint32_t>(Value.length()),
+                          INT32_C(0)},
+                      Result);
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+  ASSERT_TRUE(DictId > 0);
+
+  auto *SetMetaInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_set_metadata");
+  ASSERT_NE(SetMetaInst, nullptr);
+  auto &HostFuncSetMetadata = SetMetaInst->getHostFunc();
+  HostFuncSetMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, DictId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  // The unresolved dictionary id is rejected instead of clearing the metadata.
+  uint32_t UnresolvedId = UINT32_C(999999);
+  HostFuncSetMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, UnresolvedId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  // The entry stored before the rejected call is still present.
+  auto *MetaInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_metadata");
+  ASSERT_NE(MetaInst, nullptr);
+  auto &HostFuncMetadata = MetaInst->getHostFunc();
+  HostFuncMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, MetaDictPtr},
+      Result);
+  uint32_t MetaDictId = readUInt32(MemInst, MetaDictPtr);
+  ASSERT_TRUE(MetaDictId > 0);
+
+  auto *GetInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_get");
+  ASSERT_NE(GetInst, nullptr);
+  auto &HostFuncDictGet = GetInst->getHostFunc();
+  HostFuncDictGet.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{
+                          MetaDictId, KeyPtr,
+                          static_cast<uint32_t>(Key.length()), UINT32_C(0),
+                          INT32_C(0), KeyLenPtr, ValueLenPtr},
+                      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 1);
+
+  auto *FreeInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_free");
+  ASSERT_NE(FreeInst, nullptr);
+  auto &HostFuncDictFree = FreeInst->getHostFunc();
+  HostFuncDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DictId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  auto *CloseInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformat_close_input");
+  ASSERT_NE(CloseInst, nullptr);
+  auto &HostFuncClose = CloseInst->getHostFunc();
+  HostFuncClose.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+                    Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+// avio_close: id 0 (avio_close(NULL)) and stale ids are no-op successes; a
+// live id of another type is rejected. Closing a real context's pb nulls it,
+// so repeat close and avformat_close_input do not close the same pb twice.
+TEST_F(FFmpegTest, AVIOCloseHandleSemantics) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto Run = [&](WasmEdge::Runtime::Instance::ModuleInstance *TargetMod,
+                 const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = TargetMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  EXPECT_EQ(Run(AVFormatMod.get(), "wasmedge_ffmpeg_avformat_avio_close",
+                {UINT32_C(0)}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run(AVFormatMod.get(), "wasmedge_ffmpeg_avformat_avio_close",
+                {UINT32_C(999999)}),
+            static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t FramePtr = UINT32_C(4);
+  initEmptyFrame(FramePtr);
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+  EXPECT_EQ(
+      Run(AVFormatMod.get(), "wasmedge_ffmpeg_avformat_avio_close", {FrameId}),
+      static_cast<int32_t>(ErrNo::InternalError));
+
+  // The frame handle survived the rejected close and still frees normally.
+  EXPECT_EQ(
+      Run(AVUtilMod.get(), "wasmedge_ffmpeg_avutil_av_frame_free", {FrameId}),
+      static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t FormatCtxPtr = UINT32_C(8);
+  uint32_t FilePtr = UINT32_C(100);
+  initFormatCtx(FormatCtxPtr, FilePtr,
+                std::string("ffmpeg-assets/sample_video.mp4"));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  EXPECT_EQ(Run(AVFormatMod.get(), "wasmedge_ffmpeg_avformat_avio_close",
+                {FormatCtxId}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run(AVFormatMod.get(), "wasmedge_ffmpeg_avformat_avio_close",
+                {FormatCtxId}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run(AVFormatMod.get(),
+                "wasmedge_ffmpeg_avformat_avformat_close_input", {FormatCtxId}),
+            static_cast<int32_t>(ErrNo::Success));
 }
 
 } // namespace WasmEdgeFFmpeg

--- a/test/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
@@ -320,14 +320,14 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
   uint32_t FormatCtxPtr = UINT32_C(4);
   uint32_t DictPtr = UINT32_C(16);
   uint32_t ChapterPtr = UINT32_C(20);
-  uint32_t FramePtr = UINT32_C(24);
+  uint32_t PacketPtr = UINT32_C(24);
   uint32_t KeyPtr = UINT32_C(100);
   uint32_t ValuePtr = UINT32_C(200);
 
   initDict(DictPtr, KeyPtr, std::string("Key"), ValuePtr, std::string("Value"));
-  initEmptyFrame(FramePtr);
+  allocPacket(PacketPtr);
   uint32_t DictId = readUInt32(MemInst, DictPtr);
-  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  uint32_t PacketId = readUInt32(MemInst, PacketPtr);
 
   uint32_t FormatStart = 300;
   uint32_t FormatLen = 3;
@@ -516,12 +516,12 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
   auto &HostFuncAVWriteFrame = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVWriteFrame"sv);
-  // Passing Empty Frame, Hence giving Invalid Argument Error.
+  // Empty packet against a stream-less context, hence Invalid Argument Error.
   {
     uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
     EXPECT_TRUE(HostFuncAVWriteFrame.run(
         CallFrame,
-        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, FrameId},
+        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, PacketId},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), -22);
   }
@@ -533,12 +533,12 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
   auto &HostFuncAVInterleavedWriteFrame = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVInterleavedWriteFrame"sv);
-  // Passing Empty Frame, Hence giving Invalid Argument Error.
+  // Empty packet against a stream-less context, hence Invalid Argument Error.
   {
     uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
     EXPECT_TRUE(HostFuncAVInterleavedWriteFrame.run(
         CallFrame,
-        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, FrameId},
+        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, PacketId},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), -22);
   }

--- a/test/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
@@ -320,14 +320,14 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
   uint32_t FormatCtxPtr = UINT32_C(4);
   uint32_t DictPtr = UINT32_C(16);
   uint32_t ChapterPtr = UINT32_C(20);
-  uint32_t FramePtr = UINT32_C(24);
+  uint32_t PacketPtr = UINT32_C(24);
   uint32_t KeyPtr = UINT32_C(100);
   uint32_t ValuePtr = UINT32_C(200);
 
   initDict(DictPtr, KeyPtr, std::string("Key"), ValuePtr, std::string("Value"));
-  initEmptyFrame(FramePtr);
+  allocPacket(PacketPtr);
   uint32_t DictId = readUInt32(MemInst, DictPtr);
-  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  uint32_t PacketId = readUInt32(MemInst, PacketPtr);
 
   uint32_t FormatStart = 300;
   uint32_t FormatLen = 3;
@@ -516,12 +516,11 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
   auto &HostFuncAVWriteFrame = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVWriteFrame"sv);
-  // Passing Empty Frame, Hence giving Invalid Argument Error.
   {
     uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
     EXPECT_TRUE(HostFuncAVWriteFrame.run(
         CallFrame,
-        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, FrameId},
+        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, PacketId},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), -22);
   }
@@ -533,12 +532,11 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
   auto &HostFuncAVInterleavedWriteFrame = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVInterleavedWriteFrame"sv);
-  // Passing Empty Frame, Hence giving Invalid Argument Error.
   {
     uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
     EXPECT_TRUE(HostFuncAVInterleavedWriteFrame.run(
         CallFrame,
-        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, FrameId},
+        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, PacketId},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), -22);
   }

--- a/test/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
@@ -2,7 +2,10 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "avformat/avformat_func.h"
+#include "avformat/avChapter.h"
+#include "avformat/avformatContext.h"
 #include "avformat/module.h"
+#include "avutil/avDictionary.h"
 
 #include "utils.h"
 
@@ -103,6 +106,33 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
             FormatCtxId, UINT32_C(0), INT32_C(-1), INT32_C(-1), 0, 0},
         Result));
     EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
+  }
+
+  spdlog::info("Testing AVFindBestStream rejects a nonzero decoder_ret id"sv);
+  {
+    ASSERT_TRUE(AVCodecMod != nullptr);
+    auto *CodecFuncInst = AVCodecMod->findFuncExports(
+        "wasmedge_ffmpeg_avcodec_avcodec_find_decoder");
+    ASSERT_NE(CodecFuncInst, nullptr);
+    auto &HostFuncAVCodecFindDecoder = CodecFuncInst->getHostFunc();
+
+    uint32_t CodecDecoderPtr = UINT32_C(800);
+    ASSERT_TRUE(HostFuncAVCodecFindDecoder.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{UINT32_C(1),
+                                                    CodecDecoderPtr},
+        Result));
+    uint32_t DecoderRetId = readUInt32(MemInst, CodecDecoderPtr);
+    ASSERT_TRUE(DecoderRetId > 0);
+
+    EXPECT_TRUE(HostFuncAVFindBestStream.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, UINT32_C(0),
+                                                    INT32_C(-1), INT32_C(-1),
+                                                    DecoderRetId, 0},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(),
+              static_cast<int32_t>(ErrNo::InternalError));
   }
 
   FuncInst =
@@ -359,7 +389,8 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
             FormatCtxPtr, readUInt32(MemInst, FormatCtxPtr), FormatStart,
             FormatLen, FileStart, FileLen},
         Result));
-    EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
+    EXPECT_EQ(Result[0].get<int32_t>(),
+              static_cast<int32_t>(ErrNo::InternalError));
 
     EXPECT_TRUE(HostFuncAVFormatAllocOutputContext2.run(
         CallFrame,
@@ -540,6 +571,433 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), -22);
   }
+}
+
+TEST_F(FFmpegTest, AVIOOpenBounds) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  auto *FuncInst =
+      AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avio_open");
+  auto &HostFuncAVIOOpen = FuncInst->getHostFunc();
+
+  uint32_t AvFormatCtxId = UINT32_C(0);
+  uint32_t OutOfBoundsFileNamePtr = UINT32_C(65000);
+  uint32_t OutOfBoundsFileNameLen = UINT32_C(2000);
+  int32_t Flags = 0;
+  HostFuncAVIOOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          AvFormatCtxId, OutOfBoundsFileNamePtr, OutOfBoundsFileNameLen, Flags},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::MissingMemory));
+}
+
+TEST_F(FFmpegTest, AVChapterDynarrayAddNullContext) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t NbChaptersPtr = UINT32_C(4);
+  writeSInt32(MemInst, 0, NbChaptersPtr);
+
+  auto *FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avchapter_dynarray_add");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncDynarrayAdd = FuncInst->getHostFunc();
+
+  uint32_t NullFormatCtxId = UINT32_C(0);
+  uint32_t AvChapterId = UINT32_C(0);
+  HostFuncDynarrayAdd.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              NullFormatCtxId, NbChaptersPtr, AvChapterId},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+}
+
+TEST_F(FFmpegTest, AVChapterDynarrayAddIgnoresForgedCount) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t NbChaptersPtr = UINT32_C(4);
+  uint32_t FormatCtxPtr = UINT32_C(8);
+  uint32_t ChapterPtr = UINT32_C(12);
+  uint32_t FilePtr = UINT32_C(200);
+
+  initFormatCtx(FormatCtxPtr, FilePtr,
+                std::string("ffmpeg-assets/sample_video.mp4"));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  auto *NbInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_nb_chapters");
+  ASSERT_NE(NbInst, nullptr);
+  auto &HostFuncNbChapters = NbInst->getHostFunc();
+  HostFuncNbChapters.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+      Result);
+  int32_t InitialNbChapters = static_cast<int32_t>(Result[0].get<uint32_t>());
+
+  auto *MalloczInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avchapter_mallocz");
+  ASSERT_NE(MalloczInst, nullptr);
+  auto &HostFuncMallocz = MalloczInst->getHostFunc();
+  HostFuncMallocz.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{ChapterPtr},
+                      Result);
+  uint32_t ChapterId = readUInt32(MemInst, ChapterPtr);
+  ASSERT_TRUE(ChapterId > 0);
+
+  auto *FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avchapter_dynarray_add");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncDynarrayAdd = FuncInst->getHostFunc();
+
+  writeSInt32(MemInst, INT32_C(0x40000001), NbChaptersPtr);
+  HostFuncDynarrayAdd.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              FormatCtxId, NbChaptersPtr, ChapterId},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(readSInt32(MemInst, NbChaptersPtr), InitialNbChapters + 1);
+
+  HostFuncNbChapters.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+      Result);
+  EXPECT_EQ(Result[0].get<uint32_t>(),
+            static_cast<uint32_t>(InitialNbChapters + 1));
+}
+
+TEST_F(FFmpegTest, AVFreePOnContextOwnedChapter) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t NbChaptersPtr = UINT32_C(4);
+  uint32_t FormatCtxPtr = UINT32_C(8);
+  uint32_t ChapterPtr = UINT32_C(12);
+  uint32_t FilePtr = UINT32_C(200);
+
+  initFormatCtx(FormatCtxPtr, FilePtr,
+                std::string("ffmpeg-assets/sample_video.mp4"));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  auto *NbInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_nb_chapters");
+  ASSERT_NE(NbInst, nullptr);
+  auto &HostFuncNbChapters = NbInst->getHostFunc();
+  HostFuncNbChapters.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+      Result);
+  uint32_t ChapterIdx = Result[0].get<uint32_t>();
+
+  auto *MalloczInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avchapter_mallocz");
+  ASSERT_NE(MalloczInst, nullptr);
+  auto &HostFuncMallocz = MalloczInst->getHostFunc();
+  HostFuncMallocz.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{ChapterPtr},
+                      Result);
+  uint32_t ChapterId = readUInt32(MemInst, ChapterPtr);
+  ASSERT_TRUE(ChapterId > 0);
+
+  auto *AddInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avchapter_dynarray_add");
+  ASSERT_NE(AddInst, nullptr);
+  auto &HostFuncDynarrayAdd = AddInst->getHostFunc();
+  writeSInt32(MemInst, static_cast<int32_t>(ChapterIdx), NbChaptersPtr);
+  HostFuncDynarrayAdd.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              FormatCtxId, NbChaptersPtr, ChapterId},
+                          Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  auto *SetIdInst =
+      AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avChapter_set_id");
+  ASSERT_NE(SetIdInst, nullptr);
+  auto &HostFuncSetId = SetIdInst->getHostFunc();
+  int64_t const PoisonId = INT64_C(0x4141414141414141);
+  HostFuncSetId.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{
+                        FormatCtxId, ChapterIdx, PoisonId},
+                    Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  auto *FreePInst =
+      AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avformat_avfreep");
+  ASSERT_NE(FreePInst, nullptr);
+  auto &HostFuncFreeP =
+      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFreeP &>(
+          FreePInst->getHostFunc());
+  HostFuncFreeP.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{ChapterId},
+                    Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  auto Env = HostFuncFreeP.getEnv();
+  EXPECT_EQ(Env->fetchData(ChapterId), nullptr);
+}
+
+TEST_F(FFmpegTest, AVFormatCtxSetMetadataCopiesDict) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t FormatCtxPtr = UINT32_C(8);
+  uint32_t DictPtr = UINT32_C(12);
+  uint32_t MetaDictPtr = UINT32_C(16);
+  uint32_t KeyPtr = UINT32_C(200);
+  uint32_t ValuePtr = UINT32_C(220);
+  uint32_t KeyLenPtr = UINT32_C(240);
+  uint32_t ValueLenPtr = UINT32_C(244);
+  uint32_t FilePtr = UINT32_C(300);
+
+  initFormatCtx(FormatCtxPtr, FilePtr,
+                std::string("ffmpeg-assets/sample_video.mp4"));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  std::string Key = "meta_key";
+  std::string Value = "meta_val";
+  fillMemContent(MemInst, KeyPtr, Key);
+  fillMemContent(MemInst, ValuePtr, Value);
+
+  auto *SetInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
+  ASSERT_NE(SetInst, nullptr);
+  auto &HostFuncDictSet = SetInst->getHostFunc();
+  HostFuncDictSet.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{
+                          DictPtr, KeyPtr, static_cast<uint32_t>(Key.length()),
+                          ValuePtr, static_cast<uint32_t>(Value.length()),
+                          INT32_C(0)},
+                      Result);
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+  ASSERT_TRUE(DictId > 0);
+
+  auto *SetMetaInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_set_metadata");
+  ASSERT_NE(SetMetaInst, nullptr);
+  auto &HostFuncSetMetadata = SetMetaInst->getHostFunc();
+  HostFuncSetMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, DictId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  auto *FreeInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_free");
+  ASSERT_NE(FreeInst, nullptr);
+  auto &HostFuncDictFree = FreeInst->getHostFunc();
+  HostFuncDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DictId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  auto *MetaInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_metadata");
+  ASSERT_NE(MetaInst, nullptr);
+  auto &HostFuncMetadata = MetaInst->getHostFunc();
+  HostFuncMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, MetaDictPtr},
+      Result);
+  uint32_t MetaDictId = readUInt32(MemInst, MetaDictPtr);
+  ASSERT_TRUE(MetaDictId > 0);
+
+  auto *GetInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_get");
+  ASSERT_NE(GetInst, nullptr);
+  auto &HostFuncDictGet = GetInst->getHostFunc();
+  HostFuncDictGet.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{
+                          MetaDictId, KeyPtr,
+                          static_cast<uint32_t>(Key.length()), UINT32_C(0),
+                          INT32_C(0), KeyLenPtr, ValueLenPtr},
+                      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 1);
+
+  auto *CloseInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformat_close_input");
+  ASSERT_NE(CloseInst, nullptr);
+  auto &HostFuncClose = CloseInst->getHostFunc();
+  HostFuncClose.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+                    Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, WriteFrameRejectsUnresolvedPacketHandles) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t FormatCtxPtr = UINT32_C(4);
+  uint32_t FilePtr = UINT32_C(100);
+  initFormatCtx(FormatCtxPtr, FilePtr,
+                std::string("ffmpeg-assets/sample_video.mp4"));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  uint32_t UnresolvedId = UINT32_C(999999);
+  auto Run = [&](const char *Name) {
+    auto *Inst = AVFormatMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, UnresolvedId},
+        Result));
+    return Result[0].get<int32_t>();
+  };
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avformat_av_write_frame"),
+            static_cast<int32_t>(ErrNo::InternalError));
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avformat_av_interleaved_write_frame"),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  auto *CloseInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformat_close_input");
+  ASSERT_NE(CloseInst, nullptr);
+  auto &HostFuncClose = CloseInst->getHostFunc();
+  HostFuncClose.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+                    Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, SetMetadataRejectsUnresolvedDictHandle) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t FormatCtxPtr = UINT32_C(8);
+  uint32_t DictPtr = UINT32_C(12);
+  uint32_t MetaDictPtr = UINT32_C(16);
+  uint32_t KeyPtr = UINT32_C(200);
+  uint32_t ValuePtr = UINT32_C(220);
+  uint32_t KeyLenPtr = UINT32_C(240);
+  uint32_t ValueLenPtr = UINT32_C(244);
+  uint32_t FilePtr = UINT32_C(300);
+
+  initFormatCtx(FormatCtxPtr, FilePtr,
+                std::string("ffmpeg-assets/sample_video.mp4"));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  std::string Key = "meta_key";
+  std::string Value = "meta_val";
+  fillMemContent(MemInst, KeyPtr, Key);
+  fillMemContent(MemInst, ValuePtr, Value);
+
+  auto *SetInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
+  ASSERT_NE(SetInst, nullptr);
+  auto &HostFuncDictSet = SetInst->getHostFunc();
+  HostFuncDictSet.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{
+                          DictPtr, KeyPtr, static_cast<uint32_t>(Key.length()),
+                          ValuePtr, static_cast<uint32_t>(Value.length()),
+                          INT32_C(0)},
+                      Result);
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+  ASSERT_TRUE(DictId > 0);
+
+  auto *SetMetaInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_set_metadata");
+  ASSERT_NE(SetMetaInst, nullptr);
+  auto &HostFuncSetMetadata = SetMetaInst->getHostFunc();
+  HostFuncSetMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, DictId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t UnresolvedId = UINT32_C(999999);
+  HostFuncSetMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, UnresolvedId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  auto *MetaInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_metadata");
+  ASSERT_NE(MetaInst, nullptr);
+  auto &HostFuncMetadata = MetaInst->getHostFunc();
+  HostFuncMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, MetaDictPtr},
+      Result);
+  uint32_t MetaDictId = readUInt32(MemInst, MetaDictPtr);
+  ASSERT_TRUE(MetaDictId > 0);
+
+  auto *GetInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_get");
+  ASSERT_NE(GetInst, nullptr);
+  auto &HostFuncDictGet = GetInst->getHostFunc();
+  HostFuncDictGet.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{
+                          MetaDictId, KeyPtr,
+                          static_cast<uint32_t>(Key.length()), UINT32_C(0),
+                          INT32_C(0), KeyLenPtr, ValueLenPtr},
+                      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 1);
+
+  auto *FreeInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_free");
+  ASSERT_NE(FreeInst, nullptr);
+  auto &HostFuncDictFree = FreeInst->getHostFunc();
+  HostFuncDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DictId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  auto *CloseInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformat_close_input");
+  ASSERT_NE(CloseInst, nullptr);
+  auto &HostFuncClose = CloseInst->getHostFunc();
+  HostFuncClose.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+                    Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, AVIOCloseHandleSemantics) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto Run = [&](WasmEdge::Runtime::Instance::ModuleInstance *TargetMod,
+                 const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = TargetMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  EXPECT_EQ(Run(AVFormatMod.get(), "wasmedge_ffmpeg_avformat_avio_close",
+                {UINT32_C(0)}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run(AVFormatMod.get(), "wasmedge_ffmpeg_avformat_avio_close",
+                {UINT32_C(999999)}),
+            static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t FramePtr = UINT32_C(4);
+  initEmptyFrame(FramePtr);
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+  EXPECT_EQ(
+      Run(AVFormatMod.get(), "wasmedge_ffmpeg_avformat_avio_close", {FrameId}),
+      static_cast<int32_t>(ErrNo::InternalError));
+
+  EXPECT_EQ(
+      Run(AVUtilMod.get(), "wasmedge_ffmpeg_avutil_av_frame_free", {FrameId}),
+      static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t FormatCtxPtr = UINT32_C(8);
+  uint32_t FilePtr = UINT32_C(100);
+  initFormatCtx(FormatCtxPtr, FilePtr,
+                std::string("ffmpeg-assets/sample_video.mp4"));
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  EXPECT_EQ(Run(AVFormatMod.get(), "wasmedge_ffmpeg_avformat_avio_close",
+                {FormatCtxId}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run(AVFormatMod.get(), "wasmedge_ffmpeg_avformat_avio_close",
+                {FormatCtxId}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run(AVFormatMod.get(),
+                "wasmedge_ffmpeg_avformat_avformat_close_input", {FormatCtxId}),
+            static_cast<int32_t>(ErrNo::Success));
 }
 
 } // namespace WasmEdgeFFmpeg

--- a/test/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
@@ -146,6 +146,275 @@ TEST_F(FFmpegTest, AVDictionary) {
   }
 }
 
+TEST_F(FFmpegTest, AVDictGetKeyValueBounds) {
+  using namespace std::literals::string_view_literals;
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t KeyStart = UINT32_C(1);
+  uint32_t KeyLen = 3;
+  uint32_t ValueStart = UINT32_C(4);
+  uint32_t ValueLen = 5;
+  int32_t Flags = 0;
+  uint32_t DictPtr = UINT32_C(80);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
+  auto &HostFuncAVDictSet = FuncInst->getHostFunc();
+
+  fillMemContent(MemInst, KeyStart, KeyLen + ValueLen);
+  fillMemContent(MemInst, KeyStart, "KEY"sv);
+  fillMemContent(MemInst, ValueStart, "VALUE"sv);
+  HostFuncAVDictSet.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DictPtr, KeyStart, KeyLen,
+                                                  ValueStart, ValueLen, Flags},
+      Result);
+  ASSERT_TRUE(readUInt32(MemInst, DictPtr) > 0);
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_dict_get_key_value");
+  auto &HostFuncAVDictGetKeyValue = FuncInst->getHostFunc();
+
+  // Destination buffers are deliberately smaller than the stored key/value and
+  // fenced with a sentinel; the host must clamp the copy to the given lengths.
+  uint32_t KeyBufPtr = UINT32_C(200);
+  uint32_t ValBufPtr = UINT32_C(220);
+  uint32_t KeyBufLen = UINT32_C(1); // < strlen("KEY")
+  uint32_t ValBufLen = UINT32_C(2); // < strlen("VALUE")
+  uint32_t FenceLen = UINT32_C(16);
+  fillMemContent(MemInst, KeyBufPtr, FenceLen, UINT8_C(0xAA));
+  fillMemContent(MemInst, ValBufPtr, FenceLen, UINT8_C(0xAA));
+
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+  HostFuncAVDictGetKeyValue.run(CallFrame,
+                                std::initializer_list<WasmEdge::ValVariant>{
+                                    DictId, KeyStart, KeyLen, ValBufPtr,
+                                    ValBufLen, KeyBufPtr, KeyBufLen,
+                                    UINT32_C(0), Flags},
+                                Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 1);
+
+  char *ValBuf = MemInst->getPointer<char *>(ValBufPtr);
+  for (uint32_t I = ValBufLen; I < FenceLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(ValBuf[I]), UINT8_C(0xAA));
+  }
+  char *KeyBuf = MemInst->getPointer<char *>(KeyBufPtr);
+  for (uint32_t I = KeyBufLen; I < FenceLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(KeyBuf[I]), UINT8_C(0xAA));
+  }
+}
+
+TEST_F(FFmpegTest, AVDictGetKeyValueKeyLenBounds) {
+  using namespace std::literals::string_view_literals;
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t KeyStart = UINT32_C(1);
+  uint32_t KeyLen = 3;
+  uint32_t ValueStart = UINT32_C(4);
+  uint32_t ValueLen = 5;
+  int32_t Flags = 0;
+  uint32_t DictPtr = UINT32_C(80);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
+  auto &HostFuncAVDictSet = FuncInst->getHostFunc();
+
+  fillMemContent(MemInst, KeyStart, "KEY"sv);
+  fillMemContent(MemInst, ValueStart, "VALUE"sv);
+  HostFuncAVDictSet.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DictPtr, KeyStart, KeyLen,
+                                                  ValueStart, ValueLen, Flags},
+      Result);
+  ASSERT_TRUE(readUInt32(MemInst, DictPtr) > 0);
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_dict_get_key_value");
+  auto &HostFuncAVDictGetKeyValue = FuncInst->getHostFunc();
+
+  // The lookup-key pointer is in bounds but the guest-declared key length
+  // runs off the end of linear memory; the host must reject the call.
+  uint32_t KeyBufPtr = UINT32_C(200);
+  uint32_t ValBufPtr = UINT32_C(220);
+  uint32_t KeyBufLen = UINT32_C(8);
+  uint32_t ValBufLen = UINT32_C(8);
+  uint32_t OutOfBoundsKeyPtr = UINT32_C(65000);
+  uint32_t OutOfBoundsKeyLen = UINT32_C(2000);
+  HostFuncAVDictGetKeyValue.run(CallFrame,
+                                std::initializer_list<WasmEdge::ValVariant>{
+                                    DictId, OutOfBoundsKeyPtr,
+                                    OutOfBoundsKeyLen, ValBufPtr, ValBufLen,
+                                    KeyBufPtr, KeyBufLen, UINT32_C(0), Flags},
+                                Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::MissingMemory));
+}
+
+TEST_F(FFmpegTest, AVDictGetKeyLenBounds) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  int32_t Flags = 0;
+  uint32_t KeyLenPtr = UINT32_C(200);
+  uint32_t ValueLenPtr = UINT32_C(210);
+  uint32_t DictId = UINT32_C(0);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_get");
+  auto &HostFuncAVDictGet = FuncInst->getHostFunc();
+
+  // KeyPtr is in bounds but the guest-declared key length runs off the end of
+  // linear memory; the host must reject it, not read past the page.
+  uint32_t OutOfBoundsKeyPtr = UINT32_C(65000);
+  uint32_t OutOfBoundsKeyLen = UINT32_C(2000);
+  HostFuncAVDictGet.run(CallFrame,
+                        std::initializer_list<WasmEdge::ValVariant>{
+                            DictId, OutOfBoundsKeyPtr, OutOfBoundsKeyLen,
+                            UINT32_C(0), Flags, KeyLenPtr, ValueLenPtr},
+                        Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::MissingMemory));
+}
+
+TEST_F(FFmpegTest, AVDictSetKeyLenBounds) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  int32_t Flags = 0;
+  uint32_t ValuePtr = UINT32_C(4);
+  uint32_t ValueLen = 5;
+  uint32_t DictPtr = UINT32_C(80);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
+  auto &HostFuncAVDictSet = FuncInst->getHostFunc();
+
+  // KeyPtr is in bounds but the guest-declared key length runs off the end of
+  // linear memory; the host must reject it, not read past the page.
+  uint32_t OutOfBoundsKeyPtr = UINT32_C(65000);
+  uint32_t OutOfBoundsKeyLen = UINT32_C(2000);
+  HostFuncAVDictSet.run(CallFrame,
+                        std::initializer_list<WasmEdge::ValVariant>{
+                            DictPtr, OutOfBoundsKeyPtr, OutOfBoundsKeyLen,
+                            ValuePtr, ValueLen, Flags},
+                        Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::MissingMemory));
+}
+
+TEST_F(FFmpegTest, AVDictGetLargePrevIndexTerminates) {
+  using namespace std::literals::string_view_literals;
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t KeyStart = UINT32_C(1);
+  uint32_t KeyLen = 3;
+  uint32_t ValueStart = UINT32_C(4);
+  uint32_t ValueLen = 5;
+  int32_t Flags = 0;
+  uint32_t DictPtr = UINT32_C(80);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncAVDictSet = FuncInst->getHostFunc();
+
+  fillMemContent(MemInst, KeyStart, "KEY"sv);
+  fillMemContent(MemInst, ValueStart, "VALUE"sv);
+  HostFuncAVDictSet.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DictPtr, KeyStart, KeyLen,
+                                                  ValueStart, ValueLen, Flags},
+      Result);
+  ASSERT_TRUE(readUInt32(MemInst, DictPtr) > 0);
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_get");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncAVDictGet = FuncInst->getHostFunc();
+
+  // A previous-entry index past the matching entries must terminate with
+  // InternalError; UINT32_MAX would wrap an unbounded loop's counter forever.
+  uint32_t KeyLenPtr = UINT32_C(56);
+  uint32_t ValueLenPtr = UINT32_C(60);
+  HostFuncAVDictGet.run(CallFrame,
+                        std::initializer_list<WasmEdge::ValVariant>{
+                            DictId, KeyStart, KeyLen, UINT32_C(0xFFFFFFFF),
+                            Flags, KeyLenPtr, ValueLenPtr},
+                        Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+}
+
+TEST_F(FFmpegTest, AVDictStaleIdHandling) {
+  using namespace std::literals::string_view_literals;
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t KeyStart = UINT32_C(1);
+  uint32_t KeyLen = 3;
+  uint32_t ValueStart = UINT32_C(4);
+  uint32_t ValueLen = 5;
+  int32_t Flags = 0;
+  uint32_t DictPtr = UINT32_C(80);
+  uint32_t StaleDictId = UINT32_C(424242);
+
+  fillMemContent(MemInst, KeyStart, "KEY"sv);
+  fillMemContent(MemInst, ValueStart, "VALUE"sv);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
+  auto &HostFuncAVDictSet = FuncInst->getHostFunc();
+
+  // A nonzero id that was never allocated must be rejected instead of being
+  // handed to av_dict_set as a null map.
+  writeUInt32(MemInst, StaleDictId, DictPtr);
+  HostFuncAVDictSet.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DictPtr, KeyStart, KeyLen,
+                                                  ValueStart, ValueLen, Flags},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  writeUInt32(MemInst, UINT32_C(0), DictPtr);
+  HostFuncAVDictSet.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DictPtr, KeyStart, KeyLen,
+                                                  ValueStart, ValueLen, Flags},
+      Result);
+  ASSERT_TRUE(Result[0].get<int32_t>() >= 0);
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+  ASSERT_TRUE(DictId > 0);
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_copy");
+  auto &HostFuncAVDictCopy = FuncInst->getHostFunc();
+
+  // A stale destination id must be rejected the same way.
+  uint32_t DestDictPtr = UINT32_C(84);
+  writeUInt32(MemInst, StaleDictId, DestDictPtr);
+  HostFuncAVDictCopy.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DestDictPtr, DictId, Flags},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_free");
+  auto &HostFuncAVDictFree = FuncInst->getHostFunc();
+
+  // Freeing a stale id is a harmless no-op, and freeing a valid id twice must
+  // not turn into a null-map free on the second call.
+  HostFuncAVDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{StaleDictId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  HostFuncAVDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DictId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  HostFuncAVDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DictId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
@@ -6,6 +6,10 @@
 
 #include "utils.h"
 
+extern "C" {
+#include "libavutil/dict.h"
+}
+
 #include <gtest/gtest.h>
 
 namespace WasmEdge {
@@ -144,6 +148,65 @@ TEST_F(FFmpegTest, AVDictionary) {
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
   }
+}
+
+TEST_F(FFmpegTest, AVDictSetMasksOwnershipTransferFlags) {
+  using namespace std::literals::string_view_literals;
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t KeyStart = UINT32_C(1);
+  uint32_t KeyLen = 3;
+  uint32_t ValueStart = UINT32_C(4);
+  uint32_t ValueLen = 5;
+  uint32_t DictPtr = UINT32_C(80);
+  // The DONT_STRDUP flags ask FFmpeg to adopt key/value pointers that alias
+  // host std::string buffers; the host must strip them so the entry is copied
+  // and still round-trips after the std::strings go out of scope.
+  int32_t Flags = AV_DICT_DONT_STRDUP_KEY | AV_DICT_DONT_STRDUP_VAL;
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncAVDictSet = FuncInst->getHostFunc();
+
+  fillMemContent(MemInst, KeyStart, KeyLen + ValueLen);
+  fillMemContent(MemInst, KeyStart, "KEY"sv);
+  fillMemContent(MemInst, ValueStart, "VALUE"sv);
+
+  EXPECT_TRUE(HostFuncAVDictSet.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DictPtr, KeyStart, KeyLen,
+                                                  ValueStart, ValueLen, Flags},
+      Result));
+  EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
+  ASSERT_TRUE(readUInt32(MemInst, DictPtr) > 0);
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_dict_get_key_value");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncAVDictGetKeyValue = FuncInst->getHostFunc();
+
+  uint32_t KeyBufPtr = UINT32_C(36);
+  uint32_t ValueBufPtr = UINT32_C(40);
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+  EXPECT_TRUE(HostFuncAVDictGetKeyValue.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          DictId, KeyStart, KeyLen, ValueBufPtr, ValueLen, KeyBufPtr,
+          UINT32_C(3), UINT32_C(0), UINT32_C(0)},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), 1);
+  EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(ValueBufPtr),
+                             static_cast<size_t>(ValueLen)),
+            "VALUE"sv);
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_free");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncAVDictFree = FuncInst->getHostFunc();
+  DictId = readUInt32(MemInst, DictPtr);
+  EXPECT_TRUE(HostFuncAVDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DictId}, Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
 }
 
 TEST_F(FFmpegTest, AVDictGetKeyValueBounds) {

--- a/test/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
@@ -6,6 +6,10 @@
 
 #include "utils.h"
 
+extern "C" {
+#include "libavutil/dict.h"
+}
+
 #include <gtest/gtest.h>
 
 namespace WasmEdge {
@@ -144,6 +148,62 @@ TEST_F(FFmpegTest, AVDictionary) {
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
   }
+}
+
+TEST_F(FFmpegTest, AVDictSetMasksOwnershipTransferFlags) {
+  using namespace std::literals::string_view_literals;
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t KeyStart = UINT32_C(1);
+  uint32_t KeyLen = 3;
+  uint32_t ValueStart = UINT32_C(4);
+  uint32_t ValueLen = 5;
+  uint32_t DictPtr = UINT32_C(80);
+  int32_t Flags = AV_DICT_DONT_STRDUP_KEY | AV_DICT_DONT_STRDUP_VAL;
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncAVDictSet = FuncInst->getHostFunc();
+
+  fillMemContent(MemInst, KeyStart, KeyLen + ValueLen);
+  fillMemContent(MemInst, KeyStart, "KEY"sv);
+  fillMemContent(MemInst, ValueStart, "VALUE"sv);
+
+  EXPECT_TRUE(HostFuncAVDictSet.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DictPtr, KeyStart, KeyLen,
+                                                  ValueStart, ValueLen, Flags},
+      Result));
+  EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
+  ASSERT_TRUE(readUInt32(MemInst, DictPtr) > 0);
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_dict_get_key_value");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncAVDictGetKeyValue = FuncInst->getHostFunc();
+
+  uint32_t KeyBufPtr = UINT32_C(36);
+  uint32_t ValueBufPtr = UINT32_C(40);
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+  EXPECT_TRUE(HostFuncAVDictGetKeyValue.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          DictId, KeyStart, KeyLen, ValueBufPtr, ValueLen, KeyBufPtr,
+          UINT32_C(3), UINT32_C(0), UINT32_C(0)},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), 1);
+  EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(ValueBufPtr),
+                             static_cast<size_t>(ValueLen)),
+            "VALUE"sv);
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_free");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncAVDictFree = FuncInst->getHostFunc();
+  DictId = readUInt32(MemInst, DictPtr);
+  EXPECT_TRUE(HostFuncAVDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DictId}, Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
 }
 
 TEST_F(FFmpegTest, AVDictGetKeyValueBounds) {

--- a/test/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
@@ -146,6 +146,260 @@ TEST_F(FFmpegTest, AVDictionary) {
   }
 }
 
+TEST_F(FFmpegTest, AVDictGetKeyValueBounds) {
+  using namespace std::literals::string_view_literals;
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t KeyStart = UINT32_C(1);
+  uint32_t KeyLen = 3;
+  uint32_t ValueStart = UINT32_C(4);
+  uint32_t ValueLen = 5;
+  int32_t Flags = 0;
+  uint32_t DictPtr = UINT32_C(80);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
+  auto &HostFuncAVDictSet = FuncInst->getHostFunc();
+
+  fillMemContent(MemInst, KeyStart, KeyLen + ValueLen);
+  fillMemContent(MemInst, KeyStart, "KEY"sv);
+  fillMemContent(MemInst, ValueStart, "VALUE"sv);
+  HostFuncAVDictSet.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DictPtr, KeyStart, KeyLen,
+                                                  ValueStart, ValueLen, Flags},
+      Result);
+  ASSERT_TRUE(readUInt32(MemInst, DictPtr) > 0);
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_dict_get_key_value");
+  auto &HostFuncAVDictGetKeyValue = FuncInst->getHostFunc();
+
+  uint32_t KeyBufPtr = UINT32_C(200);
+  uint32_t ValBufPtr = UINT32_C(220);
+  uint32_t KeyBufLen = UINT32_C(1);
+  uint32_t ValBufLen = UINT32_C(2);
+  uint32_t FenceLen = UINT32_C(16);
+  fillMemContent(MemInst, KeyBufPtr, FenceLen, UINT8_C(0xAA));
+  fillMemContent(MemInst, ValBufPtr, FenceLen, UINT8_C(0xAA));
+
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+  HostFuncAVDictGetKeyValue.run(CallFrame,
+                                std::initializer_list<WasmEdge::ValVariant>{
+                                    DictId, KeyStart, KeyLen, ValBufPtr,
+                                    ValBufLen, KeyBufPtr, KeyBufLen,
+                                    UINT32_C(0), Flags},
+                                Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 1);
+
+  char *ValBuf = MemInst->getPointer<char *>(ValBufPtr);
+  for (uint32_t I = ValBufLen; I < FenceLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(ValBuf[I]), UINT8_C(0xAA));
+  }
+  char *KeyBuf = MemInst->getPointer<char *>(KeyBufPtr);
+  for (uint32_t I = KeyBufLen; I < FenceLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(KeyBuf[I]), UINT8_C(0xAA));
+  }
+}
+
+TEST_F(FFmpegTest, AVDictGetKeyValueKeyLenBounds) {
+  using namespace std::literals::string_view_literals;
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t KeyStart = UINT32_C(1);
+  uint32_t KeyLen = 3;
+  uint32_t ValueStart = UINT32_C(4);
+  uint32_t ValueLen = 5;
+  int32_t Flags = 0;
+  uint32_t DictPtr = UINT32_C(80);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
+  auto &HostFuncAVDictSet = FuncInst->getHostFunc();
+
+  fillMemContent(MemInst, KeyStart, "KEY"sv);
+  fillMemContent(MemInst, ValueStart, "VALUE"sv);
+  HostFuncAVDictSet.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DictPtr, KeyStart, KeyLen,
+                                                  ValueStart, ValueLen, Flags},
+      Result);
+  ASSERT_TRUE(readUInt32(MemInst, DictPtr) > 0);
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_dict_get_key_value");
+  auto &HostFuncAVDictGetKeyValue = FuncInst->getHostFunc();
+
+  uint32_t KeyBufPtr = UINT32_C(200);
+  uint32_t ValBufPtr = UINT32_C(220);
+  uint32_t KeyBufLen = UINT32_C(8);
+  uint32_t ValBufLen = UINT32_C(8);
+  uint32_t OutOfBoundsKeyPtr = UINT32_C(65000);
+  uint32_t OutOfBoundsKeyLen = UINT32_C(2000);
+  HostFuncAVDictGetKeyValue.run(CallFrame,
+                                std::initializer_list<WasmEdge::ValVariant>{
+                                    DictId, OutOfBoundsKeyPtr,
+                                    OutOfBoundsKeyLen, ValBufPtr, ValBufLen,
+                                    KeyBufPtr, KeyBufLen, UINT32_C(0), Flags},
+                                Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::MissingMemory));
+}
+
+TEST_F(FFmpegTest, AVDictGetKeyLenBounds) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  int32_t Flags = 0;
+  uint32_t KeyLenPtr = UINT32_C(200);
+  uint32_t ValueLenPtr = UINT32_C(210);
+  uint32_t DictId = UINT32_C(0);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_get");
+  auto &HostFuncAVDictGet = FuncInst->getHostFunc();
+
+  uint32_t OutOfBoundsKeyPtr = UINT32_C(65000);
+  uint32_t OutOfBoundsKeyLen = UINT32_C(2000);
+  HostFuncAVDictGet.run(CallFrame,
+                        std::initializer_list<WasmEdge::ValVariant>{
+                            DictId, OutOfBoundsKeyPtr, OutOfBoundsKeyLen,
+                            UINT32_C(0), Flags, KeyLenPtr, ValueLenPtr},
+                        Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::MissingMemory));
+}
+
+TEST_F(FFmpegTest, AVDictSetKeyLenBounds) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  int32_t Flags = 0;
+  uint32_t ValuePtr = UINT32_C(4);
+  uint32_t ValueLen = 5;
+  uint32_t DictPtr = UINT32_C(80);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
+  auto &HostFuncAVDictSet = FuncInst->getHostFunc();
+
+  uint32_t OutOfBoundsKeyPtr = UINT32_C(65000);
+  uint32_t OutOfBoundsKeyLen = UINT32_C(2000);
+  HostFuncAVDictSet.run(CallFrame,
+                        std::initializer_list<WasmEdge::ValVariant>{
+                            DictPtr, OutOfBoundsKeyPtr, OutOfBoundsKeyLen,
+                            ValuePtr, ValueLen, Flags},
+                        Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::MissingMemory));
+}
+
+TEST_F(FFmpegTest, AVDictGetLargePrevIndexTerminates) {
+  using namespace std::literals::string_view_literals;
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t KeyStart = UINT32_C(1);
+  uint32_t KeyLen = 3;
+  uint32_t ValueStart = UINT32_C(4);
+  uint32_t ValueLen = 5;
+  int32_t Flags = 0;
+  uint32_t DictPtr = UINT32_C(80);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncAVDictSet = FuncInst->getHostFunc();
+
+  fillMemContent(MemInst, KeyStart, "KEY"sv);
+  fillMemContent(MemInst, ValueStart, "VALUE"sv);
+  HostFuncAVDictSet.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DictPtr, KeyStart, KeyLen,
+                                                  ValueStart, ValueLen, Flags},
+      Result);
+  ASSERT_TRUE(readUInt32(MemInst, DictPtr) > 0);
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_get");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncAVDictGet = FuncInst->getHostFunc();
+
+  uint32_t KeyLenPtr = UINT32_C(56);
+  uint32_t ValueLenPtr = UINT32_C(60);
+  HostFuncAVDictGet.run(CallFrame,
+                        std::initializer_list<WasmEdge::ValVariant>{
+                            DictId, KeyStart, KeyLen, UINT32_C(0xFFFFFFFF),
+                            Flags, KeyLenPtr, ValueLenPtr},
+                        Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+}
+
+TEST_F(FFmpegTest, AVDictStaleIdHandling) {
+  using namespace std::literals::string_view_literals;
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t KeyStart = UINT32_C(1);
+  uint32_t KeyLen = 3;
+  uint32_t ValueStart = UINT32_C(4);
+  uint32_t ValueLen = 5;
+  int32_t Flags = 0;
+  uint32_t DictPtr = UINT32_C(80);
+  uint32_t StaleDictId = UINT32_C(424242);
+
+  fillMemContent(MemInst, KeyStart, "KEY"sv);
+  fillMemContent(MemInst, ValueStart, "VALUE"sv);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
+  auto &HostFuncAVDictSet = FuncInst->getHostFunc();
+
+  writeUInt32(MemInst, StaleDictId, DictPtr);
+  HostFuncAVDictSet.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DictPtr, KeyStart, KeyLen,
+                                                  ValueStart, ValueLen, Flags},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  writeUInt32(MemInst, UINT32_C(0), DictPtr);
+  HostFuncAVDictSet.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DictPtr, KeyStart, KeyLen,
+                                                  ValueStart, ValueLen, Flags},
+      Result);
+  ASSERT_TRUE(Result[0].get<int32_t>() >= 0);
+  uint32_t DictId = readUInt32(MemInst, DictPtr);
+  ASSERT_TRUE(DictId > 0);
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_copy");
+  auto &HostFuncAVDictCopy = FuncInst->getHostFunc();
+
+  uint32_t DestDictPtr = UINT32_C(84);
+  writeUInt32(MemInst, StaleDictId, DestDictPtr);
+  HostFuncAVDictCopy.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DestDictPtr, DictId, Flags},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_free");
+  auto &HostFuncAVDictFree = FuncInst->getHostFunc();
+
+  HostFuncAVDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{StaleDictId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  HostFuncAVDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DictId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  HostFuncAVDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DictId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avutil/avFrame.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avFrame.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "avutil/avFrame.h"
+#include "avutil/avDictionary.h"
 #include "avutil/module.h"
 
 #include "utils.h"
@@ -458,6 +459,15 @@ TEST_F(FFmpegTest, AVFrame) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{AVFrameId},
         Result);
     EXPECT_EQ(Result[0].get<int32_t>(), PixFormatId);
+
+    // An invalid frame id reports the signed ErrNo value, not a large
+    // positive number a negative-error check would miss.
+    HostFuncAVFrameSetVideoFormat.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0), PixFormatId},
+        Result);
+    EXPECT_EQ(Result[0].get<int32_t>(),
+              static_cast<int32_t>(ErrNo::InternalError));
   }
 
   FuncInst = AVUtilMod->findFuncExports(
@@ -751,6 +761,291 @@ TEST_F(FFmpegTest, AVFrame) {
   //  ==========================================================================
   //                            AVFrame Audio Funcs.
   //  ==========================================================================
+}
+
+TEST_F(FFmpegTest, AVFrameDataIndexBounds) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_alloc");
+  auto &HostFuncAVFrameAlloc = FuncInst->getHostFunc();
+
+  uint32_t FramePtr = UINT32_C(4);
+  HostFuncAVFrameAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FramePtr}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_data");
+  auto &HostFuncAVFrameData = FuncInst->getHostFunc();
+
+  // The destination buffer is valid but the plane index runs far past the
+  // fixed-size data[] array; the host must reject it, not read a wild pointer.
+  uint32_t BufPtr = UINT32_C(100);
+  uint32_t BufLen = UINT32_C(4);
+  uint32_t OutOfBoundsIndex = UINT32_C(100);
+  fillMemContent(MemInst, BufPtr, BufLen);
+  HostFuncAVFrameData.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              FrameId, BufPtr, BufLen, OutOfBoundsIndex},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+}
+
+TEST_F(FFmpegTest, AVFrameDataNullPlane) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_alloc");
+  auto &HostFuncAVFrameAlloc = FuncInst->getHostFunc();
+
+  uint32_t FramePtr = UINT32_C(4);
+  HostFuncAVFrameAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FramePtr}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_data");
+  auto &HostFuncAVFrameData = FuncInst->getHostFunc();
+
+  // The frame is allocated but never given a buffer, so data[0] is null; the
+  // host must reject the read instead of copying from a null plane.
+  uint32_t BufPtr = UINT32_C(100);
+  uint32_t BufLen = UINT32_C(4);
+  uint32_t Index = UINT32_C(0);
+  fillMemContent(MemInst, BufPtr, BufLen);
+  HostFuncAVFrameData.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              FrameId, BufPtr, BufLen, Index},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+}
+
+TEST_F(FFmpegTest, AVFrameDataZeroLength) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_alloc");
+  auto &HostFuncAVFrameAlloc = FuncInst->getHostFunc();
+
+  uint32_t FramePtr = UINT32_C(4);
+  HostFuncAVFrameAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FramePtr}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_data");
+  auto &HostFuncAVFrameData = FuncInst->getHostFunc();
+
+  // A zero-length read copies nothing, so it must succeed even on an unbacked
+  // plane where data[0] is null.
+  uint32_t BufPtr = UINT32_C(100);
+  uint32_t BufLen = UINT32_C(0);
+  uint32_t Index = UINT32_C(0);
+  HostFuncAVFrameData.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              FrameId, BufPtr, BufLen, Index},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, AVFrameDataRejectsOversizedRead) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_alloc");
+  auto &HostFuncAVFrameAlloc = FuncInst->getHostFunc();
+
+  uint32_t FramePtr = UINT32_C(4);
+  HostFuncAVFrameAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FramePtr}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+
+  // Build a tiny packed-audio frame: 8 samples * 1 channel * U8 gives an
+  // 8-byte data[0] plane, far smaller than the destination buffer below.
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_frame_set_audio_format");
+  auto &HostFuncAVFrameSetAudioFormat = FuncInst->getHostFunc();
+  uint32_t SampleFormatId = UINT32_C(1);
+  HostFuncAVFrameSetAudioFormat.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FrameId, SampleFormatId},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_frame_set_channel_layout");
+  auto &HostFuncAVFrameSetChannelLayout = FuncInst->getHostFunc();
+  uint64_t ChannelLayout = 1UL << 10;
+  HostFuncAVFrameSetChannelLayout.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FrameId, ChannelLayout},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_frame_set_nb_samples");
+  auto &HostFuncAVFrameSetNbSamples = FuncInst->getHostFunc();
+  int32_t NbSamples = 8;
+  HostFuncAVFrameSetNbSamples.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FrameId, NbSamples}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_get_buffer");
+  auto &HostFuncAVFrameGetBuffer = FuncInst->getHostFunc();
+  int32_t Align = 0;
+  HostFuncAVFrameGetBuffer.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FrameId, Align},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_data");
+  auto &HostFuncAVFrameData = FuncInst->getHostFunc();
+
+  // A request far beyond the backed plane must be rejected outright rather
+  // than partially copied and reported as success.
+  uint32_t BufPtr = UINT32_C(16);
+  uint32_t FrameBufLen = UINT32_C(16384);
+  uint32_t Index = UINT32_C(0);
+  uint8_t const Sentinel = UINT8_C(0xCD);
+  fillMemContent(MemInst, BufPtr, FrameBufLen, Sentinel);
+  HostFuncAVFrameData.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              FrameId, BufPtr, FrameBufLen, Index},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  const uint8_t *Buf = MemInst->getPointer<uint8_t *>(BufPtr);
+  EXPECT_EQ(Buf[0], Sentinel);
+  EXPECT_EQ(Buf[FrameBufLen / 2], Sentinel);
+  EXPECT_EQ(Buf[FrameBufLen - 1], Sentinel);
+
+  // A request within the backed plane still succeeds.
+  uint32_t SmallLen = UINT32_C(8);
+  HostFuncAVFrameData.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              FrameId, BufPtr, SmallLen, Index},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, AVFrameMetadataNullHandle) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_metadata");
+  auto &HostFuncAVFrameMetadata = FuncInst->getHostFunc();
+
+  // A guest id of 0 resolves to a null AVFrame; the getter must report
+  // InternalError instead of dereferencing it.
+  uint32_t InvalidFrameId = UINT32_C(0);
+  uint32_t DictPtr = UINT32_C(4);
+  HostFuncAVFrameMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{InvalidFrameId, DictPtr},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+}
+
+TEST_F(FFmpegTest, AVFrameMetadataLiveView) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_alloc");
+  auto &HostFuncAVFrameAlloc = FuncInst->getHostFunc();
+
+  uint32_t FramePtr = UINT32_C(4);
+  HostFuncAVFrameAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FramePtr}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+
+  uint32_t KeyPtr = UINT32_C(8);
+  uint32_t ValuePtr = UINT32_C(11);
+  uint32_t OwnedDictPtr = UINT32_C(80);
+  initDict(OwnedDictPtr, KeyPtr, "KEY", ValuePtr, "VALUE");
+  uint32_t OwnedDictId = readUInt32(MemInst, OwnedDictPtr);
+  ASSERT_TRUE(OwnedDictId > 0);
+
+  // Take a metadata handle before any metadata exists.
+  FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_metadata");
+  auto &HostFuncAVFrameMetadata = FuncInst->getHostFunc();
+  uint32_t MetaDictPtr = UINT32_C(84);
+  HostFuncAVFrameMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FrameId, MetaDictPtr},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t MetaDictId = readUInt32(MemInst, MetaDictPtr);
+  ASSERT_TRUE(MetaDictId > 0);
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_frame_set_metadata");
+  auto &HostFuncAVFrameSetMetadata = FuncInst->getHostFunc();
+  HostFuncAVFrameSetMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FrameId, OwnedDictId},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  // The handle taken before the set is a live view of the frame's metadata
+  // field, so it observes the freshly installed dictionary.
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_get");
+  auto &HostFuncAVDictGet = FuncInst->getHostFunc();
+  uint32_t KeyLenPtr = UINT32_C(100);
+  uint32_t ValueLenPtr = UINT32_C(104);
+  HostFuncAVDictGet.run(CallFrame,
+                        std::initializer_list<WasmEdge::ValVariant>{
+                            MetaDictId, KeyPtr, UINT32_C(3), UINT32_C(0),
+                            UINT32_C(0), KeyLenPtr, ValueLenPtr},
+                        Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 1);
+  EXPECT_EQ(readUInt32(MemInst, KeyLenPtr), UINT32_C(3));
+  EXPECT_EQ(readUInt32(MemInst, ValueLenPtr), UINT32_C(5));
+
+  // Freeing the borrowed handle drops only the id; the frame keeps its
+  // metadata and a fresh handle still reads it.
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_free");
+  auto &HostFuncAVDictFree = FuncInst->getHostFunc();
+  HostFuncAVDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{MetaDictId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  HostFuncAVFrameMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FrameId, MetaDictPtr},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  MetaDictId = readUInt32(MemInst, MetaDictPtr);
+  ASSERT_TRUE(MetaDictId > 0);
+
+  // The frame owns an independent copy, so freeing the source dictionary
+  // leaves the metadata readable.
+  HostFuncAVDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{OwnedDictId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  HostFuncAVDictGet.run(CallFrame,
+                        std::initializer_list<WasmEdge::ValVariant>{
+                            MetaDictId, KeyPtr, UINT32_C(3), UINT32_C(0),
+                            UINT32_C(0), KeyLenPtr, ValueLenPtr},
+                        Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 1);
 }
 
 } // namespace WasmEdgeFFmpeg

--- a/test/plugins/wasmedge_ffmpeg/avutil/avFrame.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avFrame.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "avutil/avFrame.h"
+#include "avutil/avDictionary.h"
 #include "avutil/module.h"
 
 #include "utils.h"
@@ -458,6 +459,13 @@ TEST_F(FFmpegTest, AVFrame) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{AVFrameId},
         Result);
     EXPECT_EQ(Result[0].get<int32_t>(), PixFormatId);
+
+    HostFuncAVFrameSetVideoFormat.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0), PixFormatId},
+        Result);
+    EXPECT_EQ(Result[0].get<int32_t>(),
+              static_cast<int32_t>(ErrNo::InternalError));
   }
 
   FuncInst = AVUtilMod->findFuncExports(
@@ -751,6 +759,271 @@ TEST_F(FFmpegTest, AVFrame) {
   //  ==========================================================================
   //                            AVFrame Audio Funcs.
   //  ==========================================================================
+}
+
+TEST_F(FFmpegTest, AVFrameDataIndexBounds) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_alloc");
+  auto &HostFuncAVFrameAlloc = FuncInst->getHostFunc();
+
+  uint32_t FramePtr = UINT32_C(4);
+  HostFuncAVFrameAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FramePtr}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_data");
+  auto &HostFuncAVFrameData = FuncInst->getHostFunc();
+
+  uint32_t BufPtr = UINT32_C(100);
+  uint32_t BufLen = UINT32_C(4);
+  uint32_t OutOfBoundsIndex = UINT32_C(100);
+  fillMemContent(MemInst, BufPtr, BufLen);
+  HostFuncAVFrameData.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              FrameId, BufPtr, BufLen, OutOfBoundsIndex},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+}
+
+TEST_F(FFmpegTest, AVFrameDataNullPlane) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_alloc");
+  auto &HostFuncAVFrameAlloc = FuncInst->getHostFunc();
+
+  uint32_t FramePtr = UINT32_C(4);
+  HostFuncAVFrameAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FramePtr}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_data");
+  auto &HostFuncAVFrameData = FuncInst->getHostFunc();
+
+  uint32_t BufPtr = UINT32_C(100);
+  uint32_t BufLen = UINT32_C(4);
+  uint32_t Index = UINT32_C(0);
+  fillMemContent(MemInst, BufPtr, BufLen);
+  HostFuncAVFrameData.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              FrameId, BufPtr, BufLen, Index},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+}
+
+TEST_F(FFmpegTest, AVFrameDataZeroLength) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_alloc");
+  auto &HostFuncAVFrameAlloc = FuncInst->getHostFunc();
+
+  uint32_t FramePtr = UINT32_C(4);
+  HostFuncAVFrameAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FramePtr}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_data");
+  auto &HostFuncAVFrameData = FuncInst->getHostFunc();
+
+  uint32_t BufPtr = UINT32_C(100);
+  uint32_t BufLen = UINT32_C(0);
+  uint32_t Index = UINT32_C(0);
+  HostFuncAVFrameData.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              FrameId, BufPtr, BufLen, Index},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, AVFrameDataRejectsOversizedRead) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_alloc");
+  auto &HostFuncAVFrameAlloc = FuncInst->getHostFunc();
+
+  uint32_t FramePtr = UINT32_C(4);
+  HostFuncAVFrameAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FramePtr}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_frame_set_audio_format");
+  auto &HostFuncAVFrameSetAudioFormat = FuncInst->getHostFunc();
+  uint32_t SampleFormatId = UINT32_C(1);
+  HostFuncAVFrameSetAudioFormat.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FrameId, SampleFormatId},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_frame_set_channel_layout");
+  auto &HostFuncAVFrameSetChannelLayout = FuncInst->getHostFunc();
+  uint64_t ChannelLayout = 1UL << 10;
+  HostFuncAVFrameSetChannelLayout.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FrameId, ChannelLayout},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_frame_set_nb_samples");
+  auto &HostFuncAVFrameSetNbSamples = FuncInst->getHostFunc();
+  int32_t NbSamples = 8;
+  HostFuncAVFrameSetNbSamples.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FrameId, NbSamples}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_get_buffer");
+  auto &HostFuncAVFrameGetBuffer = FuncInst->getHostFunc();
+  int32_t Align = 0;
+  HostFuncAVFrameGetBuffer.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FrameId, Align},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_data");
+  auto &HostFuncAVFrameData = FuncInst->getHostFunc();
+
+  uint32_t BufPtr = UINT32_C(16);
+  uint32_t FrameBufLen = UINT32_C(16384);
+  uint32_t Index = UINT32_C(0);
+  uint8_t const Sentinel = UINT8_C(0xCD);
+  fillMemContent(MemInst, BufPtr, FrameBufLen, Sentinel);
+  HostFuncAVFrameData.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              FrameId, BufPtr, FrameBufLen, Index},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  const uint8_t *Buf = MemInst->getPointer<uint8_t *>(BufPtr);
+  EXPECT_EQ(Buf[0], Sentinel);
+  EXPECT_EQ(Buf[FrameBufLen / 2], Sentinel);
+  EXPECT_EQ(Buf[FrameBufLen - 1], Sentinel);
+
+  uint32_t SmallLen = UINT32_C(8);
+  HostFuncAVFrameData.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              FrameId, BufPtr, SmallLen, Index},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, AVFrameMetadataNullHandle) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_metadata");
+  auto &HostFuncAVFrameMetadata = FuncInst->getHostFunc();
+
+  uint32_t InvalidFrameId = UINT32_C(0);
+  uint32_t DictPtr = UINT32_C(4);
+  HostFuncAVFrameMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{InvalidFrameId, DictPtr},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+}
+
+TEST_F(FFmpegTest, AVFrameMetadataLiveView) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_alloc");
+  auto &HostFuncAVFrameAlloc = FuncInst->getHostFunc();
+
+  uint32_t FramePtr = UINT32_C(4);
+  HostFuncAVFrameAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FramePtr}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+
+  uint32_t KeyPtr = UINT32_C(8);
+  uint32_t ValuePtr = UINT32_C(11);
+  uint32_t OwnedDictPtr = UINT32_C(80);
+  initDict(OwnedDictPtr, KeyPtr, "KEY", ValuePtr, "VALUE");
+  uint32_t OwnedDictId = readUInt32(MemInst, OwnedDictPtr);
+  ASSERT_TRUE(OwnedDictId > 0);
+
+  FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_metadata");
+  auto &HostFuncAVFrameMetadata = FuncInst->getHostFunc();
+  uint32_t MetaDictPtr = UINT32_C(84);
+  HostFuncAVFrameMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FrameId, MetaDictPtr},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t MetaDictId = readUInt32(MemInst, MetaDictPtr);
+  ASSERT_TRUE(MetaDictId > 0);
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_frame_set_metadata");
+  auto &HostFuncAVFrameSetMetadata = FuncInst->getHostFunc();
+  HostFuncAVFrameSetMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FrameId, OwnedDictId},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_get");
+  auto &HostFuncAVDictGet = FuncInst->getHostFunc();
+  uint32_t KeyLenPtr = UINT32_C(100);
+  uint32_t ValueLenPtr = UINT32_C(104);
+  HostFuncAVDictGet.run(CallFrame,
+                        std::initializer_list<WasmEdge::ValVariant>{
+                            MetaDictId, KeyPtr, UINT32_C(3), UINT32_C(0),
+                            UINT32_C(0), KeyLenPtr, ValueLenPtr},
+                        Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 1);
+  EXPECT_EQ(readUInt32(MemInst, KeyLenPtr), UINT32_C(3));
+  EXPECT_EQ(readUInt32(MemInst, ValueLenPtr), UINT32_C(5));
+
+  FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_free");
+  auto &HostFuncAVDictFree = FuncInst->getHostFunc();
+  HostFuncAVDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{MetaDictId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  HostFuncAVFrameMetadata.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FrameId, MetaDictPtr},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  MetaDictId = readUInt32(MemInst, MetaDictPtr);
+  ASSERT_TRUE(MetaDictId > 0);
+
+  HostFuncAVDictFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{OwnedDictId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  HostFuncAVDictGet.run(CallFrame,
+                        std::initializer_list<WasmEdge::ValVariant>{
+                            MetaDictId, KeyPtr, UINT32_C(3), UINT32_C(0),
+                            UINT32_C(0), KeyLenPtr, ValueLenPtr},
+                        Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 1);
 }
 
 } // namespace WasmEdgeFFmpeg

--- a/test/plugins/wasmedge_ffmpeg/avutil/avSampleFmt.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avSampleFmt.cpp
@@ -203,6 +203,132 @@ TEST_F(FFmpegTest, AVSampleFmt) {
   }
 }
 
+TEST_F(FFmpegTest, AVSampleFmtNameBounds) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_sample_fmt_name");
+  auto &HostFuncAVGetSampleFmtName = FuncInst->getHostFunc();
+
+  uint32_t NamePtr = UINT32_C(4);
+  uint32_t SampleFmtId = 1; // AV_SAMPLE_FMT_U8, name "u8".
+  // NameLen is guest-controlled and far larger than the source name.
+  uint32_t NameLen = UINT32_C(64);
+  fillMemContent(MemInst, NamePtr, NameLen, UINT8_C(0xAA));
+
+  HostFuncAVGetSampleFmtName.run(CallFrame,
+                                 std::initializer_list<WasmEdge::ValVariant>{
+                                     SampleFmtId, NamePtr, NameLen},
+                                 Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  // The host must write exactly the name and its terminator ("u8\0"); the
+  // fence past the terminator detects any over-copy of adjacent host bytes.
+  char *Buf = MemInst->getPointer<char *>(NamePtr);
+  EXPECT_STREQ(Buf, "u8");
+  uint32_t WrittenLen = 0;
+  while (WrittenLen < NameLen && Buf[WrittenLen] != '\0') {
+    ++WrittenLen;
+  }
+  for (uint32_t I = WrittenLen + 1; I < NameLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+  }
+}
+
+TEST_F(FFmpegTest, AVSampleFmtNameInvalid) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t NamePtr = UINT32_C(4);
+  uint32_t NameLen = UINT32_C(16);
+
+  auto *FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_sample_fmt_name");
+  auto &HostFuncAVGetSampleFmtName = FuncInst->getHostFunc();
+
+  // av_get_sample_fmt_name returns nullptr for AV_SAMPLE_FMT_NONE (id 0); the
+  // host writes an empty string and reports success, matching the length
+  // getter's 0.
+  fillMemContent(MemInst, NamePtr, NameLen, UINT8_C(0xFF));
+  HostFuncAVGetSampleFmtName.run(CallFrame,
+                                 std::initializer_list<WasmEdge::ValVariant>{
+                                     UINT32_C(0), NamePtr, NameLen},
+                                 Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(readUInt32(MemInst, NamePtr) & 0xFFU, UINT32_C(0));
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_sample_fmt_name_length");
+  auto &HostFuncAVGetSampleFmtNameLength = FuncInst->getHostFunc();
+
+  HostFuncAVGetSampleFmtNameLength.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0)},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 0);
+}
+
+TEST_F(FFmpegTest, AVSampleFmtGetBounds) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_get_sample_fmt");
+  auto &HostFuncAVGetSampleFmt = FuncInst->getHostFunc();
+
+  // The name pointer is in bounds but the guest-declared length runs off the
+  // end of linear memory; the host must reject it, not read past the page.
+  uint32_t OutOfBoundsStrPtr = UINT32_C(65000);
+  uint32_t OutOfBoundsStrLen = UINT32_C(2000);
+  HostFuncAVGetSampleFmt.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 OutOfBoundsStrPtr, OutOfBoundsStrLen},
+                             Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::MissingMemory));
+}
+
+// av_freep mirrors FFmpeg's null-safe free: the null handle or an already
+// released id is a no-op success, while a live handle of another type is
+// rejected before any id-keyed deallocation.
+TEST_F(FFmpegTest, AVFreepNullSafeAndIdempotent) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto Run = [&](const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = AVUtilMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avutil_av_freep", {UINT32_C(0)}),
+            static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t BufferPtr = UINT32_C(4);
+  uint32_t LinesizePtr = UINT32_C(8);
+  writeUInt32(MemInst, UINT32_C(0), BufferPtr);
+  EXPECT_GE(Run("wasmedge_ffmpeg_avutil_av_samples_alloc_array_and_samples",
+                {BufferPtr, LinesizePtr, INT32_C(1), INT32_C(5), UINT32_C(1),
+                 INT32_C(1)}),
+            0);
+  uint32_t BufferId = readUInt32(MemInst, BufferPtr);
+  ASSERT_TRUE(BufferId > 0);
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avutil_av_freep", {BufferId}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avutil_av_freep", {BufferId}),
+            static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t FramePtr = UINT32_C(12);
+  initEmptyFrame(FramePtr);
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avutil_av_freep", {FrameId}),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  // The frame handle survived the rejected free and still frees normally.
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avutil_av_frame_free", {FrameId}),
+            static_cast<int32_t>(ErrNo::Success));
+}
+
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avutil/avSampleFmt.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avSampleFmt.cpp
@@ -203,6 +203,120 @@ TEST_F(FFmpegTest, AVSampleFmt) {
   }
 }
 
+TEST_F(FFmpegTest, AVSampleFmtNameBounds) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_sample_fmt_name");
+  auto &HostFuncAVGetSampleFmtName = FuncInst->getHostFunc();
+
+  uint32_t NamePtr = UINT32_C(4);
+  uint32_t SampleFmtId = 1;
+  uint32_t NameLen = UINT32_C(64);
+  fillMemContent(MemInst, NamePtr, NameLen, UINT8_C(0xAA));
+
+  HostFuncAVGetSampleFmtName.run(CallFrame,
+                                 std::initializer_list<WasmEdge::ValVariant>{
+                                     SampleFmtId, NamePtr, NameLen},
+                                 Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  char *Buf = MemInst->getPointer<char *>(NamePtr);
+  EXPECT_STREQ(Buf, "u8");
+  uint32_t WrittenLen = 0;
+  while (WrittenLen < NameLen && Buf[WrittenLen] != '\0') {
+    ++WrittenLen;
+  }
+  for (uint32_t I = WrittenLen + 1; I < NameLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+  }
+}
+
+TEST_F(FFmpegTest, AVSampleFmtNameInvalid) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint32_t NamePtr = UINT32_C(4);
+  uint32_t NameLen = UINT32_C(16);
+
+  auto *FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_sample_fmt_name");
+  auto &HostFuncAVGetSampleFmtName = FuncInst->getHostFunc();
+
+  fillMemContent(MemInst, NamePtr, NameLen, UINT8_C(0xFF));
+  HostFuncAVGetSampleFmtName.run(CallFrame,
+                                 std::initializer_list<WasmEdge::ValVariant>{
+                                     UINT32_C(0), NamePtr, NameLen},
+                                 Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(readUInt32(MemInst, NamePtr) & 0xFFU, UINT32_C(0));
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_sample_fmt_name_length");
+  auto &HostFuncAVGetSampleFmtNameLength = FuncInst->getHostFunc();
+
+  HostFuncAVGetSampleFmtNameLength.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0)},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 0);
+}
+
+TEST_F(FFmpegTest, AVSampleFmtGetBounds) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst =
+      AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_get_sample_fmt");
+  auto &HostFuncAVGetSampleFmt = FuncInst->getHostFunc();
+
+  uint32_t OutOfBoundsStrPtr = UINT32_C(65000);
+  uint32_t OutOfBoundsStrLen = UINT32_C(2000);
+  HostFuncAVGetSampleFmt.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 OutOfBoundsStrPtr, OutOfBoundsStrLen},
+                             Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::MissingMemory));
+}
+
+TEST_F(FFmpegTest, AVFreepNullSafeAndIdempotent) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto Run = [&](const char *Name,
+                 std::initializer_list<WasmEdge::ValVariant> Args) {
+    auto *Inst = AVUtilMod->findFuncExports(Name);
+    EXPECT_NE(Inst, nullptr);
+    EXPECT_TRUE(Inst->getHostFunc().run(CallFrame, Args, Result));
+    return Result[0].get<int32_t>();
+  };
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avutil_av_freep", {UINT32_C(0)}),
+            static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t BufferPtr = UINT32_C(4);
+  uint32_t LinesizePtr = UINT32_C(8);
+  writeUInt32(MemInst, UINT32_C(0), BufferPtr);
+  EXPECT_GE(Run("wasmedge_ffmpeg_avutil_av_samples_alloc_array_and_samples",
+                {BufferPtr, LinesizePtr, INT32_C(1), INT32_C(5), UINT32_C(1),
+                 INT32_C(1)}),
+            0);
+  uint32_t BufferId = readUInt32(MemInst, BufferPtr);
+  ASSERT_TRUE(BufferId > 0);
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avutil_av_freep", {BufferId}),
+            static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avutil_av_freep", {BufferId}),
+            static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t FramePtr = UINT32_C(12);
+  initEmptyFrame(FramePtr);
+  uint32_t FrameId = readUInt32(MemInst, FramePtr);
+  ASSERT_TRUE(FrameId > 0);
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avutil_av_freep", {FrameId}),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  EXPECT_EQ(Run("wasmedge_ffmpeg_avutil_av_frame_free", {FrameId}),
+            static_cast<int32_t>(ErrNo::Success));
+}
+
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
@@ -212,6 +212,175 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   }
 }
 
+TEST_F(FFmpegTest, AVUtilChannelLayoutNameBounds) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name");
+  auto &HostFuncAVGetChannelLayoutName = FuncInst->getHostFunc();
+
+  uint32_t NamePtr = UINT32_C(4);
+  uint64_t ChannelId = 1; // FRONT_LEFT, a short name such as "FL".
+  uint32_t NameLen = UINT32_C(64);
+
+  // Pre-fill the whole destination span with a sentinel so any byte the host
+  // writes past the real channel name becomes observable.
+  fillMemContent(MemInst, NamePtr, NameLen, UINT8_C(0xAA));
+
+  HostFuncAVGetChannelLayoutName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ChannelId, NamePtr, NameLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  char *Buf = MemInst->getPointer<char *>(NamePtr);
+  uint32_t WrittenLen = 0;
+  while (WrittenLen < UINT32_C(16) && Buf[WrittenLen] != '\0') {
+    ++WrittenLen;
+  }
+  // "FL" is two characters, NUL terminated well before this scan bound.
+  EXPECT_LT(WrittenLen, UINT32_C(16));
+  // Every byte beyond the name and its terminator must be untouched.
+  for (uint32_t I = WrittenLen + 1; I < NameLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+  }
+}
+
+TEST_F(FFmpegTest, AVUtilChannelLayoutNameLowFrequency) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name");
+  auto &HostFuncAVGetChannelLayoutName = FuncInst->getHostFunc();
+
+  uint32_t NamePtr = UINT32_C(4);
+  // The SDK LOW_FREQUENCY id maps to AV_CH_LOW_FREQUENCY (bit 3), named
+  // "LFE"; an off-by-one mask>>1 would name it "BL".
+  uint64_t ChannelId = UINT64_C(1) << 3;
+  uint32_t NameLen = UINT32_C(16);
+  fillMemContent(MemInst, NamePtr, NameLen, UINT8_C(0));
+
+  HostFuncAVGetChannelLayoutName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ChannelId, NamePtr, NameLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  char *Buf = MemInst->getPointer<char *>(NamePtr);
+  EXPECT_STREQ(Buf, "LFE");
+}
+
+TEST_F(FFmpegTest, AVUtilChannelLayoutNameStereo) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  // FRONT_LEFT | FRONT_RIGHT is the stereo layout and must be named "stereo",
+  // not by its first channel alone ("FL").
+  uint64_t ChannelId = UINT64_C(0x3);
+  uint32_t NamePtr = UINT32_C(4);
+  uint32_t NameLen = UINT32_C(16);
+
+  auto *FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name_len");
+  auto &HostFuncAVGetChannelLayoutNameLen = FuncInst->getHostFunc();
+  HostFuncAVGetChannelLayoutNameLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ChannelId},
+      Result);
+  int32_t const ReportedLen = Result[0].get<int32_t>();
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name");
+  auto &HostFuncAVGetChannelLayoutName = FuncInst->getHostFunc();
+  fillMemContent(MemInst, NamePtr, NameLen, UINT8_C(0));
+  HostFuncAVGetChannelLayoutName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ChannelId, NamePtr, NameLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  char *Buf = MemInst->getPointer<char *>(NamePtr);
+  EXPECT_STREQ(Buf, "stereo");
+  // The reported length is the written name's exact length; a single-channel
+  // name such as "FL" would be shorter.
+  uint32_t WrittenLen = 0;
+  while (WrittenLen < NameLen && Buf[WrittenLen] != '\0') {
+    ++WrittenLen;
+  }
+  EXPECT_EQ(ReportedLen, static_cast<int32_t>(WrittenLen));
+}
+
+// Regression: a custom channel layout whose description exceeds the old fixed
+// 64-byte host buffer must report its true length and round-trip in full.
+TEST_F(FFmpegTest, AVUtilChannelLayoutNameLargeCustom) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  // Channels 0..17 (FL..TBR): a valid 18-channel native mask that matches no
+  // predefined layout, so FFmpeg describes it as "18 channels (FL+FR+...)",
+  // well past 63 bytes.
+  uint64_t const ChannelId = UINT64_C(0x3FFFF);
+
+  auto *LenInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name_len");
+  ASSERT_NE(LenInst, nullptr);
+  auto &HostFuncNameLen = LenInst->getHostFunc();
+  HostFuncNameLen.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{ChannelId},
+                      Result);
+  int32_t const ReportedLen = Result[0].get<int32_t>();
+  // The full description does not fit in the old 64-byte buffer.
+  EXPECT_GT(ReportedLen, 63);
+
+  auto *NameInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name");
+  ASSERT_NE(NameInst, nullptr);
+  auto &HostFuncName = NameInst->getHostFunc();
+
+  uint32_t const NamePtr = UINT32_C(4);
+  uint32_t const NameLen = static_cast<uint32_t>(ReportedLen) + 1;
+  fillMemContent(MemInst, NamePtr, NameLen, UINT8_C(0));
+  HostFuncName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ChannelId, NamePtr, NameLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  // Given a buffer of the reported size, the whole name is written untruncated:
+  // its length matches what the length getter reported.
+  char *Buf = MemInst->getPointer<char *>(NamePtr);
+  uint32_t WrittenLen = 0;
+  while (WrittenLen < NameLen && Buf[WrittenLen] != '\0') {
+    ++WrittenLen;
+  }
+  EXPECT_EQ(static_cast<int32_t>(WrittenLen), ReportedLen);
+}
+
+TEST_F(FFmpegTest, AVUtilChannelLayoutInvalidInputs) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_nb_channels");
+  auto &HostFuncNbChannels = FuncInst->getHostFunc();
+
+  // ChannelLayoutId 0 maps to mask 0, which av_channel_layout_from_mask
+  // rejects; the host must not read or uninit the then-uninitialized layout.
+  HostFuncNbChannels.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT64_C(0)},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 0);
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_default_channel_layout");
+  auto &HostFuncDefault = FuncInst->getHostFunc();
+
+  // 63 channels exceeds FFmpeg's largest native layout, so the default is a
+  // non-native layout whose union must not be reinterpreted as a mask.
+  int32_t const ChannelCountWithoutNativeDefault = 63;
+  HostFuncDefault.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{
+                          ChannelCountWithoutNativeDefault},
+                      Result);
+  EXPECT_EQ(Result[0].get<uint64_t>(), UINT64_C(0));
+}
+
 TEST_F(FFmpegTest, AVTime) {
 
   ASSERT_TRUE(AVUtilMod != nullptr);

--- a/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
@@ -320,6 +320,153 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   }
 }
 
+TEST_F(FFmpegTest, AVUtilChannelLayoutNameBounds) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name");
+  auto &HostFuncAVGetChannelLayoutName = FuncInst->getHostFunc();
+
+  uint32_t NamePtr = UINT32_C(4);
+  uint64_t ChannelId = 1;
+  uint32_t NameLen = UINT32_C(64);
+
+  fillMemContent(MemInst, NamePtr, NameLen, UINT8_C(0xAA));
+
+  HostFuncAVGetChannelLayoutName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ChannelId, NamePtr, NameLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  char *Buf = MemInst->getPointer<char *>(NamePtr);
+  uint32_t WrittenLen = 0;
+  while (WrittenLen < UINT32_C(16) && Buf[WrittenLen] != '\0') {
+    ++WrittenLen;
+  }
+  EXPECT_LT(WrittenLen, UINT32_C(16));
+  for (uint32_t I = WrittenLen + 1; I < NameLen; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+  }
+}
+
+TEST_F(FFmpegTest, AVUtilChannelLayoutNameLowFrequency) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name");
+  auto &HostFuncAVGetChannelLayoutName = FuncInst->getHostFunc();
+
+  uint32_t NamePtr = UINT32_C(4);
+  uint64_t ChannelId = UINT64_C(1) << 3;
+  uint32_t NameLen = UINT32_C(16);
+  fillMemContent(MemInst, NamePtr, NameLen, UINT8_C(0));
+
+  HostFuncAVGetChannelLayoutName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ChannelId, NamePtr, NameLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  char *Buf = MemInst->getPointer<char *>(NamePtr);
+  EXPECT_STREQ(Buf, "LFE");
+}
+
+TEST_F(FFmpegTest, AVUtilChannelLayoutNameStereo) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint64_t ChannelId = UINT64_C(0x3);
+  uint32_t NamePtr = UINT32_C(4);
+  uint32_t NameLen = UINT32_C(16);
+
+  auto *FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name_len");
+  auto &HostFuncAVGetChannelLayoutNameLen = FuncInst->getHostFunc();
+  HostFuncAVGetChannelLayoutNameLen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ChannelId},
+      Result);
+  int32_t const ReportedLen = Result[0].get<int32_t>();
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name");
+  auto &HostFuncAVGetChannelLayoutName = FuncInst->getHostFunc();
+  fillMemContent(MemInst, NamePtr, NameLen, UINT8_C(0));
+  HostFuncAVGetChannelLayoutName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ChannelId, NamePtr, NameLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  char *Buf = MemInst->getPointer<char *>(NamePtr);
+  EXPECT_STREQ(Buf, "stereo");
+  uint32_t WrittenLen = 0;
+  while (WrittenLen < NameLen && Buf[WrittenLen] != '\0') {
+    ++WrittenLen;
+  }
+  EXPECT_EQ(ReportedLen, static_cast<int32_t>(WrittenLen));
+}
+
+TEST_F(FFmpegTest, AVUtilChannelLayoutNameLargeCustom) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  uint64_t const ChannelId = UINT64_C(0x3FFFF);
+
+  auto *LenInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name_len");
+  ASSERT_NE(LenInst, nullptr);
+  auto &HostFuncNameLen = LenInst->getHostFunc();
+  HostFuncNameLen.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{ChannelId},
+                      Result);
+  int32_t const ReportedLen = Result[0].get<int32_t>();
+  EXPECT_GT(ReportedLen, 63);
+
+  auto *NameInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name");
+  ASSERT_NE(NameInst, nullptr);
+  auto &HostFuncName = NameInst->getHostFunc();
+
+  uint32_t const NamePtr = UINT32_C(4);
+  uint32_t const NameLen = static_cast<uint32_t>(ReportedLen) + 1;
+  fillMemContent(MemInst, NamePtr, NameLen, UINT8_C(0));
+  HostFuncName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ChannelId, NamePtr, NameLen},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  char *Buf = MemInst->getPointer<char *>(NamePtr);
+  uint32_t WrittenLen = 0;
+  while (WrittenLen < NameLen && Buf[WrittenLen] != '\0') {
+    ++WrittenLen;
+  }
+  EXPECT_EQ(static_cast<int32_t>(WrittenLen), ReportedLen);
+}
+
+TEST_F(FFmpegTest, AVUtilChannelLayoutInvalidInputs) {
+  ASSERT_TRUE(AVUtilMod != nullptr);
+
+  auto *FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_nb_channels");
+  auto &HostFuncNbChannels = FuncInst->getHostFunc();
+
+  HostFuncNbChannels.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT64_C(0)},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), 0);
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_default_channel_layout");
+  auto &HostFuncDefault = FuncInst->getHostFunc();
+
+  int32_t const ChannelCountWithoutNativeDefault = 63;
+  HostFuncDefault.run(CallFrame,
+                      std::initializer_list<WasmEdge::ValVariant>{
+                          ChannelCountWithoutNativeDefault},
+                      Result);
+  EXPECT_EQ(Result[0].get<uint64_t>(), UINT64_C(0));
+}
+
 TEST_F(FFmpegTest, AVTime) {
 
   ASSERT_TRUE(AVUtilMod != nullptr);

--- a/test/plugins/wasmedge_ffmpeg/swresample/swresample_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/swresample/swresample_func.cpp
@@ -100,12 +100,6 @@ TEST_F(FFmpegTest, SWResampleFunc) {
   ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwrFree = FuncInst->getHostFunc();
 
-  {
-    EXPECT_TRUE(HostFuncSwrFree.run(
-        CallFrame, std::initializer_list<WasmEdge::ValVariant>{SwrId}, Result));
-    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
-  }
-
   FuncInst =
       SWResampleMod->findFuncExports("wasmedge_ffmpeg_swresample_swr_init");
   ASSERT_NE(FuncInst, nullptr);
@@ -237,6 +231,279 @@ TEST_F(FFmpegTest, SWResampleFunc) {
                   .find("--"),
               std::string_view::npos);
   }
+
+  // Free once every operation is done: freeing invalidates all ids aliasing the
+  // same SwrContext, so an earlier free would strand the reconfigured alias.
+  {
+    SwrId = readUInt32(MemInst, SWResamplePtr);
+    EXPECT_TRUE(HostFuncSwrFree.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{SwrId}, Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  }
+}
+
+TEST_F(FFmpegTest, SWRAllocSetOptsFailureInvalidatesAliases) {
+  ASSERT_TRUE(SWResampleMod != nullptr);
+
+  auto *FuncInst = SWResampleMod->findFuncExports(
+      "wasmedge_ffmpeg_swresample_swr_alloc_set_opts");
+  auto &HostFuncSwrAllocSetOpts = dynamic_cast<
+      WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWRAllocSetOpts &>(
+      FuncInst->getHostFunc());
+
+  uint32_t SWResamplePtr = UINT32_C(4);
+  uint64_t OutChLayoutId = UINT64_C(1) << 1; // Front Right
+  uint32_t OutSampleFmtId = 2;               // AV_SAMPLE_FMT_S16
+  uint64_t InChLayoutId = UINT64_C(1) << 2;  // Front Center
+  uint32_t InSampleFmtId = 3;                // AV_SAMPLE_FMT_S32
+  int32_t InSampleRate = 40;
+  int32_t LogOffset = 1;
+
+  auto AllocSetOpts = [&](uint32_t ExistingId, int32_t OutSampleRate) {
+    HostFuncSwrAllocSetOpts.run(CallFrame,
+                                std::initializer_list<WasmEdge::ValVariant>{
+                                    SWResamplePtr, ExistingId, OutChLayoutId,
+                                    OutSampleFmtId, OutSampleRate, InChLayoutId,
+                                    InSampleFmtId, InSampleRate, LogOffset},
+                                Result);
+    return Result[0].get<int32_t>();
+  };
+
+  writeUInt32(MemInst, UINT32_C(0), SWResamplePtr);
+
+  // Allocate a context, then reconfigure it. Reconfiguring mints a second id
+  // that aliases the same SwrContext (the established contract).
+  ASSERT_EQ(AllocSetOpts(UINT32_C(0), 30),
+            static_cast<int32_t>(ErrNo::Success));
+  uint32_t FirstId = readUInt32(MemInst, SWResamplePtr);
+  ASSERT_TRUE(FirstId > 0);
+
+  ASSERT_EQ(AllocSetOpts(FirstId, 30), static_cast<int32_t>(ErrNo::Success));
+  uint32_t SecondId = readUInt32(MemInst, SWResamplePtr);
+  ASSERT_TRUE(SecondId > 0);
+  ASSERT_NE(SecondId, FirstId);
+
+  auto Env = HostFuncSwrAllocSetOpts.getEnv();
+  ASSERT_NE(Env->fetchData(FirstId), nullptr);
+  ASSERT_EQ(Env->fetchData(FirstId), Env->fetchData(SecondId));
+
+  // A failing reconfigure frees the underlying SwrContext, so every id
+  // aliasing it -- not just the one passed in -- must be invalidated.
+  EXPECT_EQ(AllocSetOpts(FirstId, -1),
+            static_cast<int32_t>(ErrNo::InternalError));
+  EXPECT_EQ(Env->fetchData(FirstId), nullptr);
+  EXPECT_EQ(Env->fetchData(SecondId), nullptr);
+}
+
+// Regression: an invalid channel-layout id fails before swr_alloc_set_opts2
+// touches the existing SwrContext, so the guest's output handle (which may be
+// its only copy of the id) must be left intact rather than cleared.
+TEST_F(FFmpegTest, SWRAllocSetOptsPreservesHandleOnInvalidLayout) {
+  ASSERT_TRUE(SWResampleMod != nullptr);
+
+  auto *FuncInst = SWResampleMod->findFuncExports(
+      "wasmedge_ffmpeg_swresample_swr_alloc_set_opts");
+  auto &HostFuncSwrAllocSetOpts = dynamic_cast<
+      WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWRAllocSetOpts &>(
+      FuncInst->getHostFunc());
+
+  uint32_t SWResamplePtr = UINT32_C(4);
+  uint64_t OutChLayoutId = UINT64_C(1) << 1; // Front Right
+  uint32_t OutSampleFmtId = 2;               // AV_SAMPLE_FMT_S16
+  uint64_t InChLayoutId = UINT64_C(1) << 2;  // Front Center
+  uint32_t InSampleFmtId = 3;                // AV_SAMPLE_FMT_S32
+  int32_t OutSampleRate = 30;
+  int32_t InSampleRate = 40;
+  int32_t LogOffset = 1;
+
+  auto AllocSetOpts = [&](uint32_t ExistingId, uint64_t OutLayout,
+                          uint64_t InLayout) {
+    HostFuncSwrAllocSetOpts.run(CallFrame,
+                                std::initializer_list<WasmEdge::ValVariant>{
+                                    SWResamplePtr, ExistingId, OutLayout,
+                                    OutSampleFmtId, OutSampleRate, InLayout,
+                                    InSampleFmtId, InSampleRate, LogOffset},
+                                Result);
+    return Result[0].get<int32_t>();
+  };
+
+  writeUInt32(MemInst, UINT32_C(0), SWResamplePtr);
+
+  // Allocate a valid context; the guest keeps its id in the same slot it passes
+  // as the output pointer.
+  ASSERT_EQ(AllocSetOpts(UINT32_C(0), OutChLayoutId, InChLayoutId),
+            static_cast<int32_t>(ErrNo::Success));
+  uint32_t FirstId = readUInt32(MemInst, SWResamplePtr);
+  ASSERT_TRUE(FirstId > 0);
+
+  auto Env = HostFuncSwrAllocSetOpts.getEnv();
+  ASSERT_NE(Env->fetchData(FirstId), nullptr);
+
+  // An invalid output channel-layout id (0 -> empty mask) fails; the output
+  // slot must still hold the live handle rather than being cleared to 0.
+  EXPECT_EQ(AllocSetOpts(FirstId, UINT64_C(0), InChLayoutId),
+            static_cast<int32_t>(ErrNo::InternalError));
+  EXPECT_EQ(readUInt32(MemInst, SWResamplePtr), FirstId);
+  EXPECT_NE(Env->fetchData(FirstId), nullptr);
+
+  // The same holds when the input channel-layout id is the invalid one.
+  EXPECT_EQ(AllocSetOpts(FirstId, OutChLayoutId, UINT64_C(0)),
+            static_cast<int32_t>(ErrNo::InternalError));
+  EXPECT_EQ(readUInt32(MemInst, SWResamplePtr), FirstId);
+  EXPECT_NE(Env->fetchData(FirstId), nullptr);
+
+  // The preserved handle still works: a valid reconfigure succeeds.
+  EXPECT_EQ(AllocSetOpts(FirstId, OutChLayoutId, InChLayoutId),
+            static_cast<int32_t>(ErrNo::Success));
+}
+
+// Regression: a nonzero SWRContextId that does not resolve to a SwrContext
+// (forged, stale, or wrong-type) is rejected before any allocation, and the
+// guest's output slot must be left untouched rather than cleared.
+TEST_F(FFmpegTest, SWRAllocSetOptsPreservesSlotOnUnresolvedId) {
+  ASSERT_TRUE(SWResampleMod != nullptr);
+
+  auto *FuncInst = SWResampleMod->findFuncExports(
+      "wasmedge_ffmpeg_swresample_swr_alloc_set_opts");
+  auto &HostFuncSwrAllocSetOpts = dynamic_cast<
+      WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWRAllocSetOpts &>(
+      FuncInst->getHostFunc());
+
+  uint32_t SWResamplePtr = UINT32_C(4);
+  uint64_t OutChLayoutId = UINT64_C(1) << 1; // Front Right
+  uint32_t OutSampleFmtId = 2;               // AV_SAMPLE_FMT_S16
+  uint64_t InChLayoutId = UINT64_C(1) << 2;  // Front Center
+  uint32_t InSampleFmtId = 3;                // AV_SAMPLE_FMT_S32
+  int32_t OutSampleRate = 30;
+  int32_t InSampleRate = 40;
+  int32_t LogOffset = 1;
+
+  // A nonzero id that was never allocated cannot resolve. The guest keeps it in
+  // the same slot it passes as the output pointer (in-place reconfigure idiom).
+  uint32_t UnresolvedId = UINT32_C(0xDEADBEEF);
+  writeUInt32(MemInst, UnresolvedId, SWResamplePtr);
+
+  HostFuncSwrAllocSetOpts.run(CallFrame,
+                              std::initializer_list<WasmEdge::ValVariant>{
+                                  SWResamplePtr, UnresolvedId, OutChLayoutId,
+                                  OutSampleFmtId, OutSampleRate, InChLayoutId,
+                                  InSampleFmtId, InSampleRate, LogOffset},
+                              Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+  EXPECT_EQ(readUInt32(MemInst, SWResamplePtr), UnresolvedId);
+}
+
+TEST_F(FFmpegTest, SWRFreeInvalidatesAliases) {
+  ASSERT_TRUE(SWResampleMod != nullptr);
+
+  auto *FuncInst = SWResampleMod->findFuncExports(
+      "wasmedge_ffmpeg_swresample_swr_alloc_set_opts");
+  auto &HostFuncSwrAllocSetOpts = dynamic_cast<
+      WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWRAllocSetOpts &>(
+      FuncInst->getHostFunc());
+
+  uint32_t SWResamplePtr = UINT32_C(4);
+  uint64_t OutChLayoutId = UINT64_C(1) << 1; // Front Right
+  uint32_t OutSampleFmtId = 2;               // AV_SAMPLE_FMT_S16
+  uint64_t InChLayoutId = UINT64_C(1) << 2;  // Front Center
+  uint32_t InSampleFmtId = 3;                // AV_SAMPLE_FMT_S32
+  int32_t InSampleRate = 40;
+  int32_t LogOffset = 1;
+
+  auto AllocSetOpts = [&](uint32_t ExistingId, int32_t OutSampleRate) {
+    HostFuncSwrAllocSetOpts.run(CallFrame,
+                                std::initializer_list<WasmEdge::ValVariant>{
+                                    SWResamplePtr, ExistingId, OutChLayoutId,
+                                    OutSampleFmtId, OutSampleRate, InChLayoutId,
+                                    InSampleFmtId, InSampleRate, LogOffset},
+                                Result);
+    return Result[0].get<int32_t>();
+  };
+
+  writeUInt32(MemInst, UINT32_C(0), SWResamplePtr);
+
+  // Allocate a context, then reconfigure it. Reconfiguring mints a second id
+  // that aliases the same SwrContext (the established contract).
+  ASSERT_EQ(AllocSetOpts(UINT32_C(0), 30),
+            static_cast<int32_t>(ErrNo::Success));
+  uint32_t FirstId = readUInt32(MemInst, SWResamplePtr);
+  ASSERT_TRUE(FirstId > 0);
+
+  ASSERT_EQ(AllocSetOpts(FirstId, 30), static_cast<int32_t>(ErrNo::Success));
+  uint32_t SecondId = readUInt32(MemInst, SWResamplePtr);
+  ASSERT_TRUE(SecondId > 0);
+  ASSERT_NE(SecondId, FirstId);
+
+  auto Env = HostFuncSwrAllocSetOpts.getEnv();
+  ASSERT_NE(Env->fetchData(FirstId), nullptr);
+  ASSERT_EQ(Env->fetchData(FirstId), Env->fetchData(SecondId));
+
+  // Freeing via one id frees the underlying SwrContext, so every id aliasing
+  // it -- not just the one passed in -- must be invalidated.
+  FuncInst =
+      SWResampleMod->findFuncExports("wasmedge_ffmpeg_swresample_swr_free");
+  auto &HostFuncSwrFree = FuncInst->getHostFunc();
+  HostFuncSwrFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FirstId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Env->fetchData(FirstId), nullptr);
+  EXPECT_EQ(Env->fetchData(SecondId), nullptr);
+}
+
+// Regression: swr_convert_frame treats a null input as a drain request and a
+// null output as a buffered-samples query, so an unresolved nonzero frame id
+// must be rejected; only id 0 selects the intentional null-frame behavior.
+TEST_F(FFmpegTest, SWRConvertFrameRejectsUnresolvedFrameHandles) {
+  ASSERT_TRUE(SWResampleMod != nullptr);
+
+  auto *AllocInst = SWResampleMod->findFuncExports(
+      "wasmedge_ffmpeg_swresample_swr_alloc_set_opts");
+  ASSERT_NE(AllocInst, nullptr);
+  auto &HostFuncSwrAllocSetOpts = AllocInst->getHostFunc();
+
+  uint32_t SWResamplePtr = UINT32_C(4);
+  uint64_t OutChLayoutId = UINT64_C(1) << 1;
+  uint32_t OutSampleFmtId = 2;
+  uint64_t InChLayoutId = UINT64_C(1) << 2;
+  uint32_t InSampleFmtId = 3;
+  writeUInt32(MemInst, UINT32_C(0), SWResamplePtr);
+  HostFuncSwrAllocSetOpts.run(CallFrame,
+                              std::initializer_list<WasmEdge::ValVariant>{
+                                  SWResamplePtr, UINT32_C(0), OutChLayoutId,
+                                  OutSampleFmtId, INT32_C(30), InChLayoutId,
+                                  InSampleFmtId, INT32_C(40), INT32_C(1)},
+                              Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t SwrId = readUInt32(MemInst, SWResamplePtr);
+  ASSERT_TRUE(SwrId > 0);
+
+  auto *ConvertInst = SWResampleMod->findFuncExports(
+      "wasmedge_ffmpeg_swresample_swr_convert_frame");
+  ASSERT_NE(ConvertInst, nullptr);
+  auto &HostFuncConvertFrame = ConvertInst->getHostFunc();
+
+  uint32_t UnresolvedId = UINT32_C(999999);
+  HostFuncConvertFrame.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               SwrId, UnresolvedId, UINT32_C(0)},
+                           Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+  HostFuncConvertFrame.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               SwrId, UINT32_C(0), UnresolvedId},
+                           Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  auto *FreeInst =
+      SWResampleMod->findFuncExports("wasmedge_ffmpeg_swresample_swr_free");
+  ASSERT_NE(FreeInst, nullptr);
+  auto &HostFuncSwrFree = FreeInst->getHostFunc();
+  HostFuncSwrFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{SwrId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
 }
 
 } // namespace WasmEdgeFFmpeg

--- a/test/plugins/wasmedge_ffmpeg/swresample/swresample_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/swresample/swresample_func.cpp
@@ -100,12 +100,6 @@ TEST_F(FFmpegTest, SWResampleFunc) {
   ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwrFree = FuncInst->getHostFunc();
 
-  {
-    EXPECT_TRUE(HostFuncSwrFree.run(
-        CallFrame, std::initializer_list<WasmEdge::ValVariant>{SwrId}, Result));
-    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
-  }
-
   FuncInst =
       SWResampleMod->findFuncExports("wasmedge_ffmpeg_swresample_swr_init");
   ASSERT_NE(FuncInst, nullptr);
@@ -237,6 +231,252 @@ TEST_F(FFmpegTest, SWResampleFunc) {
                   .find("--"),
               std::string_view::npos);
   }
+
+  {
+    SwrId = readUInt32(MemInst, SWResamplePtr);
+    EXPECT_TRUE(HostFuncSwrFree.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{SwrId}, Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  }
+}
+
+TEST_F(FFmpegTest, SWRAllocSetOptsFailureInvalidatesAliases) {
+  ASSERT_TRUE(SWResampleMod != nullptr);
+
+  auto *FuncInst = SWResampleMod->findFuncExports(
+      "wasmedge_ffmpeg_swresample_swr_alloc_set_opts");
+  auto &HostFuncSwrAllocSetOpts = dynamic_cast<
+      WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWRAllocSetOpts &>(
+      FuncInst->getHostFunc());
+
+  uint32_t SWResamplePtr = UINT32_C(4);
+  uint64_t OutChLayoutId = UINT64_C(1) << 1;
+  uint32_t OutSampleFmtId = 2;
+  uint64_t InChLayoutId = UINT64_C(1) << 2;
+  uint32_t InSampleFmtId = 3;
+  int32_t InSampleRate = 40;
+  int32_t LogOffset = 1;
+
+  auto AllocSetOpts = [&](uint32_t ExistingId, int32_t OutSampleRate) {
+    HostFuncSwrAllocSetOpts.run(CallFrame,
+                                std::initializer_list<WasmEdge::ValVariant>{
+                                    SWResamplePtr, ExistingId, OutChLayoutId,
+                                    OutSampleFmtId, OutSampleRate, InChLayoutId,
+                                    InSampleFmtId, InSampleRate, LogOffset},
+                                Result);
+    return Result[0].get<int32_t>();
+  };
+
+  writeUInt32(MemInst, UINT32_C(0), SWResamplePtr);
+
+  ASSERT_EQ(AllocSetOpts(UINT32_C(0), 30),
+            static_cast<int32_t>(ErrNo::Success));
+  uint32_t FirstId = readUInt32(MemInst, SWResamplePtr);
+  ASSERT_TRUE(FirstId > 0);
+
+  ASSERT_EQ(AllocSetOpts(FirstId, 30), static_cast<int32_t>(ErrNo::Success));
+  uint32_t SecondId = readUInt32(MemInst, SWResamplePtr);
+  ASSERT_TRUE(SecondId > 0);
+  ASSERT_NE(SecondId, FirstId);
+
+  auto Env = HostFuncSwrAllocSetOpts.getEnv();
+  ASSERT_NE(Env->fetchData(FirstId), nullptr);
+  ASSERT_EQ(Env->fetchData(FirstId), Env->fetchData(SecondId));
+
+  EXPECT_EQ(AllocSetOpts(FirstId, -1),
+            static_cast<int32_t>(ErrNo::InternalError));
+  EXPECT_EQ(Env->fetchData(FirstId), nullptr);
+  EXPECT_EQ(Env->fetchData(SecondId), nullptr);
+}
+
+TEST_F(FFmpegTest, SWRAllocSetOptsPreservesHandleOnInvalidLayout) {
+  ASSERT_TRUE(SWResampleMod != nullptr);
+
+  auto *FuncInst = SWResampleMod->findFuncExports(
+      "wasmedge_ffmpeg_swresample_swr_alloc_set_opts");
+  auto &HostFuncSwrAllocSetOpts = dynamic_cast<
+      WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWRAllocSetOpts &>(
+      FuncInst->getHostFunc());
+
+  uint32_t SWResamplePtr = UINT32_C(4);
+  uint64_t OutChLayoutId = UINT64_C(1) << 1;
+  uint32_t OutSampleFmtId = 2;
+  uint64_t InChLayoutId = UINT64_C(1) << 2;
+  uint32_t InSampleFmtId = 3;
+  int32_t OutSampleRate = 30;
+  int32_t InSampleRate = 40;
+  int32_t LogOffset = 1;
+
+  auto AllocSetOpts = [&](uint32_t ExistingId, uint64_t OutLayout,
+                          uint64_t InLayout) {
+    HostFuncSwrAllocSetOpts.run(CallFrame,
+                                std::initializer_list<WasmEdge::ValVariant>{
+                                    SWResamplePtr, ExistingId, OutLayout,
+                                    OutSampleFmtId, OutSampleRate, InLayout,
+                                    InSampleFmtId, InSampleRate, LogOffset},
+                                Result);
+    return Result[0].get<int32_t>();
+  };
+
+  writeUInt32(MemInst, UINT32_C(0), SWResamplePtr);
+
+  ASSERT_EQ(AllocSetOpts(UINT32_C(0), OutChLayoutId, InChLayoutId),
+            static_cast<int32_t>(ErrNo::Success));
+  uint32_t FirstId = readUInt32(MemInst, SWResamplePtr);
+  ASSERT_TRUE(FirstId > 0);
+
+  auto Env = HostFuncSwrAllocSetOpts.getEnv();
+  ASSERT_NE(Env->fetchData(FirstId), nullptr);
+
+  EXPECT_EQ(AllocSetOpts(FirstId, UINT64_C(0), InChLayoutId),
+            static_cast<int32_t>(ErrNo::InternalError));
+  EXPECT_EQ(readUInt32(MemInst, SWResamplePtr), FirstId);
+  EXPECT_NE(Env->fetchData(FirstId), nullptr);
+
+  EXPECT_EQ(AllocSetOpts(FirstId, OutChLayoutId, UINT64_C(0)),
+            static_cast<int32_t>(ErrNo::InternalError));
+  EXPECT_EQ(readUInt32(MemInst, SWResamplePtr), FirstId);
+  EXPECT_NE(Env->fetchData(FirstId), nullptr);
+
+  EXPECT_EQ(AllocSetOpts(FirstId, OutChLayoutId, InChLayoutId),
+            static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, SWRAllocSetOptsPreservesSlotOnUnresolvedId) {
+  ASSERT_TRUE(SWResampleMod != nullptr);
+
+  auto *FuncInst = SWResampleMod->findFuncExports(
+      "wasmedge_ffmpeg_swresample_swr_alloc_set_opts");
+  auto &HostFuncSwrAllocSetOpts = dynamic_cast<
+      WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWRAllocSetOpts &>(
+      FuncInst->getHostFunc());
+
+  uint32_t SWResamplePtr = UINT32_C(4);
+  uint64_t OutChLayoutId = UINT64_C(1) << 1;
+  uint32_t OutSampleFmtId = 2;
+  uint64_t InChLayoutId = UINT64_C(1) << 2;
+  uint32_t InSampleFmtId = 3;
+  int32_t OutSampleRate = 30;
+  int32_t InSampleRate = 40;
+  int32_t LogOffset = 1;
+
+  uint32_t UnresolvedId = UINT32_C(0xDEADBEEF);
+  writeUInt32(MemInst, UnresolvedId, SWResamplePtr);
+
+  HostFuncSwrAllocSetOpts.run(CallFrame,
+                              std::initializer_list<WasmEdge::ValVariant>{
+                                  SWResamplePtr, UnresolvedId, OutChLayoutId,
+                                  OutSampleFmtId, OutSampleRate, InChLayoutId,
+                                  InSampleFmtId, InSampleRate, LogOffset},
+                              Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+  EXPECT_EQ(readUInt32(MemInst, SWResamplePtr), UnresolvedId);
+}
+
+TEST_F(FFmpegTest, SWRFreeInvalidatesAliases) {
+  ASSERT_TRUE(SWResampleMod != nullptr);
+
+  auto *FuncInst = SWResampleMod->findFuncExports(
+      "wasmedge_ffmpeg_swresample_swr_alloc_set_opts");
+  auto &HostFuncSwrAllocSetOpts = dynamic_cast<
+      WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWRAllocSetOpts &>(
+      FuncInst->getHostFunc());
+
+  uint32_t SWResamplePtr = UINT32_C(4);
+  uint64_t OutChLayoutId = UINT64_C(1) << 1;
+  uint32_t OutSampleFmtId = 2;
+  uint64_t InChLayoutId = UINT64_C(1) << 2;
+  uint32_t InSampleFmtId = 3;
+  int32_t InSampleRate = 40;
+  int32_t LogOffset = 1;
+
+  auto AllocSetOpts = [&](uint32_t ExistingId, int32_t OutSampleRate) {
+    HostFuncSwrAllocSetOpts.run(CallFrame,
+                                std::initializer_list<WasmEdge::ValVariant>{
+                                    SWResamplePtr, ExistingId, OutChLayoutId,
+                                    OutSampleFmtId, OutSampleRate, InChLayoutId,
+                                    InSampleFmtId, InSampleRate, LogOffset},
+                                Result);
+    return Result[0].get<int32_t>();
+  };
+
+  writeUInt32(MemInst, UINT32_C(0), SWResamplePtr);
+
+  ASSERT_EQ(AllocSetOpts(UINT32_C(0), 30),
+            static_cast<int32_t>(ErrNo::Success));
+  uint32_t FirstId = readUInt32(MemInst, SWResamplePtr);
+  ASSERT_TRUE(FirstId > 0);
+
+  ASSERT_EQ(AllocSetOpts(FirstId, 30), static_cast<int32_t>(ErrNo::Success));
+  uint32_t SecondId = readUInt32(MemInst, SWResamplePtr);
+  ASSERT_TRUE(SecondId > 0);
+  ASSERT_NE(SecondId, FirstId);
+
+  auto Env = HostFuncSwrAllocSetOpts.getEnv();
+  ASSERT_NE(Env->fetchData(FirstId), nullptr);
+  ASSERT_EQ(Env->fetchData(FirstId), Env->fetchData(SecondId));
+
+  FuncInst =
+      SWResampleMod->findFuncExports("wasmedge_ffmpeg_swresample_swr_free");
+  auto &HostFuncSwrFree = FuncInst->getHostFunc();
+  HostFuncSwrFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FirstId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Env->fetchData(FirstId), nullptr);
+  EXPECT_EQ(Env->fetchData(SecondId), nullptr);
+}
+
+TEST_F(FFmpegTest, SWRConvertFrameRejectsUnresolvedFrameHandles) {
+  ASSERT_TRUE(SWResampleMod != nullptr);
+
+  auto *AllocInst = SWResampleMod->findFuncExports(
+      "wasmedge_ffmpeg_swresample_swr_alloc_set_opts");
+  ASSERT_NE(AllocInst, nullptr);
+  auto &HostFuncSwrAllocSetOpts = AllocInst->getHostFunc();
+
+  uint32_t SWResamplePtr = UINT32_C(4);
+  uint64_t OutChLayoutId = UINT64_C(1) << 1;
+  uint32_t OutSampleFmtId = 2;
+  uint64_t InChLayoutId = UINT64_C(1) << 2;
+  uint32_t InSampleFmtId = 3;
+  writeUInt32(MemInst, UINT32_C(0), SWResamplePtr);
+  HostFuncSwrAllocSetOpts.run(CallFrame,
+                              std::initializer_list<WasmEdge::ValVariant>{
+                                  SWResamplePtr, UINT32_C(0), OutChLayoutId,
+                                  OutSampleFmtId, INT32_C(30), InChLayoutId,
+                                  InSampleFmtId, INT32_C(40), INT32_C(1)},
+                              Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t SwrId = readUInt32(MemInst, SWResamplePtr);
+  ASSERT_TRUE(SwrId > 0);
+
+  auto *ConvertInst = SWResampleMod->findFuncExports(
+      "wasmedge_ffmpeg_swresample_swr_convert_frame");
+  ASSERT_NE(ConvertInst, nullptr);
+  auto &HostFuncConvertFrame = ConvertInst->getHostFunc();
+
+  uint32_t UnresolvedId = UINT32_C(999999);
+  HostFuncConvertFrame.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               SwrId, UnresolvedId, UINT32_C(0)},
+                           Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+  HostFuncConvertFrame.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               SwrId, UINT32_C(0), UnresolvedId},
+                           Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  auto *FreeInst =
+      SWResampleMod->findFuncExports("wasmedge_ffmpeg_swresample_swr_free");
+  ASSERT_NE(FreeInst, nullptr);
+  auto &HostFuncSwrFree = FreeInst->getHostFunc();
+  HostFuncSwrFree.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{SwrId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
 }
 
 } // namespace WasmEdgeFFmpeg

--- a/test/plugins/wasmedge_ffmpeg/swscale/swscale_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/swscale/swscale_func.cpp
@@ -516,6 +516,275 @@ TEST_F(FFmpegTest, SWScaleVersion) {
   }
 }
 
+TEST_F(FFmpegTest, SwsGetCachedContextFailureInvalidatesAliases) {
+  ASSERT_TRUE(SWScaleMod != nullptr);
+
+  uint32_t SwsCtxPtr = UINT32_C(4);
+  uint32_t SwsCachedCtxPtr = UINT32_C(8);
+  uint32_t YUV420PId = 1;
+  uint32_t RGB24Id = 3;
+  uint32_t SrcWidth = 100;
+  uint32_t SrcHeight = 100;
+  uint32_t DestWidth = 200;
+  uint32_t DestHeight = 200;
+  int32_t Flags = 8;
+  uint32_t SrcFilterId = 0;
+  uint32_t DestFilterId = 0;
+
+  auto *FuncInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getContext");
+  auto &HostFuncSwsGetContext =
+      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsGetContext &>(
+          FuncInst->getHostFunc());
+  HostFuncSwsGetContext.run(CallFrame,
+                            std::initializer_list<WasmEdge::ValVariant>{
+                                SwsCtxPtr, SrcWidth, SrcHeight, YUV420PId,
+                                DestWidth, DestHeight, RGB24Id, Flags,
+                                SrcFilterId, DestFilterId},
+                            Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t SwsCtxId = readUInt32(MemInst, SwsCtxPtr);
+  ASSERT_TRUE(SwsCtxId > 0);
+
+  auto Env = HostFuncSwsGetContext.getEnv();
+  ASSERT_NE(Env->fetchData(SwsCtxId), nullptr);
+
+  FuncInst = SWScaleMod->findFuncExports(
+      "wasmedge_ffmpeg_swscale_sws_getCachedContext");
+  auto &HostFuncSwsGetCachedContext = FuncInst->getHostFunc();
+
+  // A zero source size makes sws_getCachedContext free the passed context and
+  // fail, so the id passed in -- now dangling -- must be invalidated.
+  writeUInt32(MemInst, UINT32_C(0), SwsCachedCtxPtr);
+  HostFuncSwsGetCachedContext.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          SwsCachedCtxPtr, SwsCtxId, UINT32_C(0), UINT32_C(0), YUV420PId,
+          DestWidth, DestHeight, RGB24Id, Flags, SrcFilterId, DestFilterId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+  EXPECT_EQ(Env->fetchData(SwsCtxId), nullptr);
+}
+
+TEST_F(FFmpegTest, SwsFreeContextInvalidatesAliases) {
+  ASSERT_TRUE(SWScaleMod != nullptr);
+
+  uint32_t SwsCtxPtr = UINT32_C(4);
+  uint32_t SwsCachedCtxPtr = UINT32_C(8);
+  uint32_t YUV420PId = 1;
+  uint32_t RGB24Id = 3;
+  uint32_t SrcWidth = 100;
+  uint32_t SrcHeight = 100;
+  uint32_t DestWidth = 200;
+  uint32_t DestHeight = 200;
+  int32_t Flags = 8;
+  uint32_t SrcFilterId = 0;
+  uint32_t DestFilterId = 0;
+
+  auto *FuncInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getContext");
+  auto &HostFuncSwsGetContext =
+      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsGetContext &>(
+          FuncInst->getHostFunc());
+  HostFuncSwsGetContext.run(CallFrame,
+                            std::initializer_list<WasmEdge::ValVariant>{
+                                SwsCtxPtr, SrcWidth, SrcHeight, YUV420PId,
+                                DestWidth, DestHeight, RGB24Id, Flags,
+                                SrcFilterId, DestFilterId},
+                            Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t FirstId = readUInt32(MemInst, SwsCtxPtr);
+  ASSERT_TRUE(FirstId > 0);
+
+  // Reconfiguring with identical parameters makes sws_getCachedContext reuse
+  // the same SwsContext, so the minted id aliases the same pointer.
+  FuncInst = SWScaleMod->findFuncExports(
+      "wasmedge_ffmpeg_swscale_sws_getCachedContext");
+  auto &HostFuncSwsGetCachedContext = FuncInst->getHostFunc();
+  writeUInt32(MemInst, UINT32_C(0), SwsCachedCtxPtr);
+  HostFuncSwsGetCachedContext.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          SwsCachedCtxPtr, FirstId, SrcWidth, SrcHeight, YUV420PId, DestWidth,
+          DestHeight, RGB24Id, Flags, SrcFilterId, DestFilterId},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t SecondId = readUInt32(MemInst, SwsCachedCtxPtr);
+  ASSERT_TRUE(SecondId > 0);
+  ASSERT_NE(SecondId, FirstId);
+
+  auto Env = HostFuncSwsGetContext.getEnv();
+  ASSERT_NE(Env->fetchData(FirstId), nullptr);
+  ASSERT_EQ(Env->fetchData(FirstId), Env->fetchData(SecondId));
+
+  // Freeing via one id frees the underlying SwsContext, so every id aliasing
+  // it -- not just the one passed in -- must be invalidated.
+  FuncInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_freeContext");
+  auto &HostFuncSwsFreeContext = FuncInst->getHostFunc();
+  HostFuncSwsFreeContext.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FirstId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Env->fetchData(FirstId), nullptr);
+  EXPECT_EQ(Env->fetchData(SecondId), nullptr);
+}
+
+TEST_F(FFmpegTest, SwsGetCoeffBounds) {
+  ASSERT_TRUE(SWScaleMod != nullptr);
+
+  uint32_t SwsVectorPtr = UINT32_C(4);
+  int32_t VecLength = 5;
+  auto *FuncInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_allocVec");
+  auto &HostFuncSwsAllocVec = FuncInst->getHostFunc();
+  writeUInt32(MemInst, UINT32_C(0), SwsVectorPtr);
+  HostFuncSwsAllocVec.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{SwsVectorPtr, VecLength},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t SwsVecId = readUInt32(MemInst, SwsVectorPtr);
+  ASSERT_TRUE(SwsVecId > 0);
+
+  FuncInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getCoeff");
+  auto &HostFuncSwsGetCoeff = FuncInst->getHostFunc();
+
+  // A guest length beyond the coeff array must be rejected outright rather
+  // than partially copied and reported as success.
+  uint32_t Available = static_cast<uint32_t>(VecLength) * sizeof(double);
+  uint32_t CoeffPtr = UINT32_C(200);
+  uint32_t Len = Available + UINT32_C(24);
+  fillMemContent(MemInst, CoeffPtr, Len, UINT8_C(0xAA));
+  HostFuncSwsGetCoeff.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{SwsVecId, CoeffPtr, Len},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  char *Buf = MemInst->getPointer<char *>(CoeffPtr);
+  for (uint32_t I = 0; I < Len; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+  }
+
+  // A request bounded by the coefficient array still succeeds.
+  HostFuncSwsGetCoeff.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              SwsVecId, CoeffPtr, Available},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+// Regression: sws_getCachedContext treats a null context as a fresh-allocation
+// request, so an unresolved nonzero id must be rejected before reaching
+// FFmpeg; freeing a wrong-type live id is rejected, a stale id is a no-op.
+TEST_F(FFmpegTest, SwsCachedContextRejectsUnresolvedAndWrongTypeIds) {
+  ASSERT_TRUE(SWScaleMod != nullptr);
+
+  uint32_t CachedPtr = UINT32_C(4);
+  uint32_t UnresolvedId = UINT32_C(999999);
+  writeUInt32(MemInst, UINT32_C(0), CachedPtr);
+
+  auto *CachedInst = SWScaleMod->findFuncExports(
+      "wasmedge_ffmpeg_swscale_sws_getCachedContext");
+  ASSERT_NE(CachedInst, nullptr);
+  auto &HostFuncGetCachedContext = CachedInst->getHostFunc();
+  HostFuncGetCachedContext.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   CachedPtr, UnresolvedId, UINT32_C(100),
+                                   UINT32_C(100), UINT32_C(1), UINT32_C(50),
+                                   UINT32_C(50), UINT32_C(1), INT32_C(0),
+                                   UINT32_C(0), UINT32_C(0)},
+                               Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  // Freeing a stale context id has nothing left to release: idempotent no-op.
+  auto *FreeCtxInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_freeContext");
+  ASSERT_NE(FreeCtxInst, nullptr);
+  auto &HostFuncFreeContext = FreeCtxInst->getHostFunc();
+  HostFuncFreeContext.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{UnresolvedId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  // A live id of another type must not be erased by an id-keyed free:
+  // sws_freeContext rejects the vector id and the vector stays freeable.
+  uint32_t VecPtr = UINT32_C(8);
+  auto *AllocVecInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_allocVec");
+  ASSERT_NE(AllocVecInst, nullptr);
+  auto &HostFuncAllocVec = AllocVecInst->getHostFunc();
+  writeUInt32(MemInst, UINT32_C(0), VecPtr);
+  HostFuncAllocVec.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{VecPtr, INT32_C(4)}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t VecId = readUInt32(MemInst, VecPtr);
+  ASSERT_TRUE(VecId > 0);
+
+  HostFuncFreeContext.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{VecId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  auto *FreeVecInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_freeVec");
+  ASSERT_NE(FreeVecInst, nullptr);
+  auto &HostFuncFreeVec = FreeVecInst->getHostFunc();
+  HostFuncFreeVec.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{VecId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+// Regression: sws_allocVec returns NULL for length <= 0; the wrapper must
+// report the reserved null id 0 instead of minting a handle for the null
+// result, and a later valid allocation must still yield a freeable handle.
+TEST_F(FFmpegTest, SwsAllocVecFailureDoesNotLeakHandle) {
+  ASSERT_TRUE(SWScaleMod != nullptr);
+
+  uint32_t SwsVectorPtr = UINT32_C(4);
+  auto *FuncInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_allocVec");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncSwsAllocVec =
+      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsAllocVec &>(
+          FuncInst->getHostFunc());
+  auto Env = HostFuncSwsAllocVec.getEnv();
+
+  for (int I = 0; I < 8; ++I) {
+    writeUInt32(MemInst, UINT32_C(0xABCD), SwsVectorPtr);
+    EXPECT_TRUE(HostFuncSwsAllocVec.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{SwsVectorPtr, INT32_C(-1)},
+        Result));
+    EXPECT_EQ(readUInt32(MemInst, SwsVectorPtr), UINT32_C(0));
+  }
+
+  writeUInt32(MemInst, UINT32_C(0), SwsVectorPtr);
+  EXPECT_TRUE(HostFuncSwsAllocVec.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{SwsVectorPtr, INT32_C(4)},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t VecId = readUInt32(MemInst, SwsVectorPtr);
+  ASSERT_TRUE(VecId > 0);
+  ASSERT_NE(Env->fetchData(VecId), nullptr);
+
+  auto *FreeVecInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_freeVec");
+  ASSERT_NE(FreeVecInst, nullptr);
+  auto &HostFuncSwsFreeVec = FreeVecInst->getHostFunc();
+  EXPECT_TRUE(HostFuncSwsFreeVec.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{VecId}, Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Env->fetchData(VecId), nullptr);
+}
+
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/swscale/swscale_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/swscale/swscale_func.cpp
@@ -516,6 +516,257 @@ TEST_F(FFmpegTest, SWScaleVersion) {
   }
 }
 
+TEST_F(FFmpegTest, SwsGetCachedContextFailureInvalidatesAliases) {
+  ASSERT_TRUE(SWScaleMod != nullptr);
+
+  uint32_t SwsCtxPtr = UINT32_C(4);
+  uint32_t SwsCachedCtxPtr = UINT32_C(8);
+  uint32_t YUV420PId = 1;
+  uint32_t RGB24Id = 3;
+  uint32_t SrcWidth = 100;
+  uint32_t SrcHeight = 100;
+  uint32_t DestWidth = 200;
+  uint32_t DestHeight = 200;
+  int32_t Flags = 8;
+  uint32_t SrcFilterId = 0;
+  uint32_t DestFilterId = 0;
+
+  auto *FuncInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getContext");
+  auto &HostFuncSwsGetContext =
+      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsGetContext &>(
+          FuncInst->getHostFunc());
+  HostFuncSwsGetContext.run(CallFrame,
+                            std::initializer_list<WasmEdge::ValVariant>{
+                                SwsCtxPtr, SrcWidth, SrcHeight, YUV420PId,
+                                DestWidth, DestHeight, RGB24Id, Flags,
+                                SrcFilterId, DestFilterId},
+                            Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t SwsCtxId = readUInt32(MemInst, SwsCtxPtr);
+  ASSERT_TRUE(SwsCtxId > 0);
+
+  auto Env = HostFuncSwsGetContext.getEnv();
+  ASSERT_NE(Env->fetchData(SwsCtxId), nullptr);
+
+  FuncInst = SWScaleMod->findFuncExports(
+      "wasmedge_ffmpeg_swscale_sws_getCachedContext");
+  auto &HostFuncSwsGetCachedContext = FuncInst->getHostFunc();
+
+  writeUInt32(MemInst, UINT32_C(0), SwsCachedCtxPtr);
+  HostFuncSwsGetCachedContext.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          SwsCachedCtxPtr, SwsCtxId, UINT32_C(0), UINT32_C(0), YUV420PId,
+          DestWidth, DestHeight, RGB24Id, Flags, SrcFilterId, DestFilterId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+  EXPECT_EQ(Env->fetchData(SwsCtxId), nullptr);
+}
+
+TEST_F(FFmpegTest, SwsFreeContextInvalidatesAliases) {
+  ASSERT_TRUE(SWScaleMod != nullptr);
+
+  uint32_t SwsCtxPtr = UINT32_C(4);
+  uint32_t SwsCachedCtxPtr = UINT32_C(8);
+  uint32_t YUV420PId = 1;
+  uint32_t RGB24Id = 3;
+  uint32_t SrcWidth = 100;
+  uint32_t SrcHeight = 100;
+  uint32_t DestWidth = 200;
+  uint32_t DestHeight = 200;
+  int32_t Flags = 8;
+  uint32_t SrcFilterId = 0;
+  uint32_t DestFilterId = 0;
+
+  auto *FuncInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getContext");
+  auto &HostFuncSwsGetContext =
+      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsGetContext &>(
+          FuncInst->getHostFunc());
+  HostFuncSwsGetContext.run(CallFrame,
+                            std::initializer_list<WasmEdge::ValVariant>{
+                                SwsCtxPtr, SrcWidth, SrcHeight, YUV420PId,
+                                DestWidth, DestHeight, RGB24Id, Flags,
+                                SrcFilterId, DestFilterId},
+                            Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t FirstId = readUInt32(MemInst, SwsCtxPtr);
+  ASSERT_TRUE(FirstId > 0);
+
+  FuncInst = SWScaleMod->findFuncExports(
+      "wasmedge_ffmpeg_swscale_sws_getCachedContext");
+  auto &HostFuncSwsGetCachedContext = FuncInst->getHostFunc();
+  writeUInt32(MemInst, UINT32_C(0), SwsCachedCtxPtr);
+  HostFuncSwsGetCachedContext.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          SwsCachedCtxPtr, FirstId, SrcWidth, SrcHeight, YUV420PId, DestWidth,
+          DestHeight, RGB24Id, Flags, SrcFilterId, DestFilterId},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t SecondId = readUInt32(MemInst, SwsCachedCtxPtr);
+  ASSERT_TRUE(SecondId > 0);
+  ASSERT_NE(SecondId, FirstId);
+
+  auto Env = HostFuncSwsGetContext.getEnv();
+  ASSERT_NE(Env->fetchData(FirstId), nullptr);
+  ASSERT_EQ(Env->fetchData(FirstId), Env->fetchData(SecondId));
+
+  FuncInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_freeContext");
+  auto &HostFuncSwsFreeContext = FuncInst->getHostFunc();
+  HostFuncSwsFreeContext.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FirstId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Env->fetchData(FirstId), nullptr);
+  EXPECT_EQ(Env->fetchData(SecondId), nullptr);
+}
+
+TEST_F(FFmpegTest, SwsGetCoeffBounds) {
+  ASSERT_TRUE(SWScaleMod != nullptr);
+
+  uint32_t SwsVectorPtr = UINT32_C(4);
+  int32_t VecLength = 5;
+  auto *FuncInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_allocVec");
+  auto &HostFuncSwsAllocVec = FuncInst->getHostFunc();
+  writeUInt32(MemInst, UINT32_C(0), SwsVectorPtr);
+  HostFuncSwsAllocVec.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{SwsVectorPtr, VecLength},
+      Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t SwsVecId = readUInt32(MemInst, SwsVectorPtr);
+  ASSERT_TRUE(SwsVecId > 0);
+
+  FuncInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getCoeff");
+  auto &HostFuncSwsGetCoeff = FuncInst->getHostFunc();
+
+  uint32_t Available = static_cast<uint32_t>(VecLength) * sizeof(double);
+  uint32_t CoeffPtr = UINT32_C(200);
+  uint32_t Len = Available + UINT32_C(24);
+  fillMemContent(MemInst, CoeffPtr, Len, UINT8_C(0xAA));
+  HostFuncSwsGetCoeff.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{SwsVecId, CoeffPtr, Len},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  char *Buf = MemInst->getPointer<char *>(CoeffPtr);
+  for (uint32_t I = 0; I < Len; ++I) {
+    EXPECT_EQ(static_cast<uint8_t>(Buf[I]), UINT8_C(0xAA));
+  }
+
+  HostFuncSwsGetCoeff.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              SwsVecId, CoeffPtr, Available},
+                          Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, SwsCachedContextRejectsUnresolvedAndWrongTypeIds) {
+  ASSERT_TRUE(SWScaleMod != nullptr);
+
+  uint32_t CachedPtr = UINT32_C(4);
+  uint32_t UnresolvedId = UINT32_C(999999);
+  writeUInt32(MemInst, UINT32_C(0), CachedPtr);
+
+  auto *CachedInst = SWScaleMod->findFuncExports(
+      "wasmedge_ffmpeg_swscale_sws_getCachedContext");
+  ASSERT_NE(CachedInst, nullptr);
+  auto &HostFuncGetCachedContext = CachedInst->getHostFunc();
+  HostFuncGetCachedContext.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   CachedPtr, UnresolvedId, UINT32_C(100),
+                                   UINT32_C(100), UINT32_C(1), UINT32_C(50),
+                                   UINT32_C(50), UINT32_C(1), INT32_C(0),
+                                   UINT32_C(0), UINT32_C(0)},
+                               Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  auto *FreeCtxInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_freeContext");
+  ASSERT_NE(FreeCtxInst, nullptr);
+  auto &HostFuncFreeContext = FreeCtxInst->getHostFunc();
+  HostFuncFreeContext.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{UnresolvedId},
+      Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+  uint32_t VecPtr = UINT32_C(8);
+  auto *AllocVecInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_allocVec");
+  ASSERT_NE(AllocVecInst, nullptr);
+  auto &HostFuncAllocVec = AllocVecInst->getHostFunc();
+  writeUInt32(MemInst, UINT32_C(0), VecPtr);
+  HostFuncAllocVec.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{VecPtr, INT32_C(4)}, Result);
+  ASSERT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t VecId = readUInt32(MemInst, VecPtr);
+  ASSERT_TRUE(VecId > 0);
+
+  HostFuncFreeContext.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{VecId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(),
+            static_cast<int32_t>(ErrNo::InternalError));
+
+  auto *FreeVecInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_freeVec");
+  ASSERT_NE(FreeVecInst, nullptr);
+  auto &HostFuncFreeVec = FreeVecInst->getHostFunc();
+  HostFuncFreeVec.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{VecId}, Result);
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+}
+
+TEST_F(FFmpegTest, SwsAllocVecFailureDoesNotLeakHandle) {
+  ASSERT_TRUE(SWScaleMod != nullptr);
+
+  uint32_t SwsVectorPtr = UINT32_C(4);
+  auto *FuncInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_allocVec");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncSwsAllocVec =
+      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsAllocVec &>(
+          FuncInst->getHostFunc());
+  auto Env = HostFuncSwsAllocVec.getEnv();
+
+  for (int I = 0; I < 8; ++I) {
+    writeUInt32(MemInst, UINT32_C(0xABCD), SwsVectorPtr);
+    EXPECT_TRUE(HostFuncSwsAllocVec.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{SwsVectorPtr, INT32_C(-1)},
+        Result));
+    EXPECT_EQ(readUInt32(MemInst, SwsVectorPtr), UINT32_C(0));
+  }
+
+  writeUInt32(MemInst, UINT32_C(0), SwsVectorPtr);
+  EXPECT_TRUE(HostFuncSwsAllocVec.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{SwsVectorPtr, INT32_C(4)},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t VecId = readUInt32(MemInst, SwsVectorPtr);
+  ASSERT_TRUE(VecId > 0);
+  ASSERT_NE(Env->fetchData(VecId), nullptr);
+
+  auto *FreeVecInst =
+      SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_freeVec");
+  ASSERT_NE(FreeVecInst, nullptr);
+  auto &HostFuncSwsFreeVec = FreeVecInst->getHostFunc();
+  EXPECT_TRUE(HostFuncSwsFreeVec.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{VecId}, Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  EXPECT_EQ(Env->fetchData(VecId), nullptr);
+}
+
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/utils.h
+++ b/test/plugins/wasmedge_ffmpeg/utils.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "avcodec/module.h"
+#include "avdevice/module.h"
 #include "avfilter/module.h"
 #include "avformat/module.h"
 #include "avutil/module.h"
@@ -121,6 +122,13 @@ public:
                                    WasmEdgeFFmpegAVFilterModule>(
                 Module->create());
       }
+      if (const auto *Module =
+              Plugin->findModule("wasmedge_ffmpeg_avdevice"sv)) {
+        AVDeviceMod =
+            dynamicPointerCast<WasmEdge::Host::WasmEdgeFFmpeg::AVDevice::
+                                   WasmEdgeFFmpegAVDeviceModule>(
+                Module->create());
+      }
     }
   }
 
@@ -165,6 +173,9 @@ protected:
   std::unique_ptr<
       WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::WasmEdgeFFmpegAVFilterModule>
       AVFilterMod;
+  std::unique_ptr<
+      WasmEdge::Host::WasmEdgeFFmpeg::AVDevice::WasmEdgeFFmpegAVDeviceModule>
+      AVDeviceMod;
 };
 
 } // namespace WasmEdgeFFmpeg


### PR DESCRIPTION
## Description

Hardens the guest-facing host calls in the `wasmedge_ffmpeg` plugin. Every
host call now validates guest-supplied lengths, indices, and handle ids
before touching host memory:

- Bound every string copy with a shared helper (`copyCStringToBuffer`),
  fixing host-memory over-reads such as the channel-layout name copy.
- Tag each stored handle with its pointer type and fail any fetch whose tag
  does not match, so a mistyped guest id can no longer reinterpret a live
  pointer (e.g. running C++ `delete` on an `av_malloc`'d AVFrame).
- Look up handle ids with `find` instead of `operator[]`, so probing unknown
  ids no longer grows the handle table without bound.
- Bounds-check guest indices into FFmpeg-owned arrays (streams, chapters,
  filter pads, frame planes, scaler coefficients) via `checkedArraySlot`,
  and reject a forged `nb_chapters`.
- Track handle ownership (borrowed ids, parent-owned children, alias
  invalidation) so freeing a guest id never double-frees or dangles
  (`codecpar`, chapters, metadata dictionaries, `SwsContext`, `SwrContext`).
- Close the guest-triggerable use-after-free, double-free, and leak paths in
  the `AVFilterInOut` chain helpers and the `avfilter_graph_parse_ptr`
  wrapper, which consumes the guest-supplied in/out lists.
- Report the full channel-layout name length: `av_channel_name` and
  `av_channel_layout_describe` follow snprintf semantics, so describing into
  a fixed 64-byte buffer and returning `strlen` under-reported long custom
  layouts and made the full name unreachable; query the required length
  first and size the buffer to it.
- Require native channel layouts before reading `ch_layout.u.mask`, which
  aliases a host pointer for custom layouts.
- Null-check FFmpeg getters (names, descriptions, metadata) before use.

Adds 57 regression tests covering the bounded copies, out-of-range indices,
freed, aliased, and mistyped handles, filter-graph ownership, and truncated
or invalid channel layouts.

> This contribution was developed with assistance from Claude (Anthropic).

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

`wasmedgeFFmpegTests` on macOS arm64 (27 pre-existing + 57 new cases):

```text
[----------] 84 tests from FFmpegTest (557 ms total)

[----------] Global test environment tear-down
[==========] 84 tests from 1 test suite ran. (557 ms total)
[  PASSED  ] 84 tests.
```

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
