### PR TITLE
fix: fix lookup error while vm unregister module

### DIFF
--- a/lib/vm/vm.cpp
+++ b/lib/vm/vm.cpp
@@ -345,19 +345,19 @@ VM::unsafeRegisterModule(std::string_view Name,
 }
 
 Expect<void> VM::unsafeUnregisterModule(std::string_view Name) {
-  auto RegMapIt = RegModMap.find(std::string(Name));
-  if (RegMapIt != RegModMap.end()) {
-    size_t ModInstIdx = RegMapIt->second[1];
+  auto InstIt = std::find_if(
+      RegModInsts.begin(), RegModInsts.end(),
+      [&Name](const std::unique_ptr<Runtime::Instance::ModuleInstance> &Inst) {
+        return Inst && Inst->getModuleName() == Name;
+      });
+  if (InstIt != RegModInsts.end()) {
+    auto ModId = (*InstIt)->getID();
+    auto *ModInst = (*InstIt).release();
 
-    if (ModInstIdx < RegModInsts.size()) {
-      auto *ModInst = RegModInsts[ModInstIdx].release();
-      if (ModInst) {
-        ModInst->terminate();
-      }
+    if (ModInst) {
+      ModInst->terminate();
     }
-
-    RegModMap.erase(RegMapIt);
-
+    RegModMap.erase(ModId);
     return {};
   }
   for (auto It = BuiltInModInsts.begin(); It != BuiltInModInsts.end(); ++It) {


### PR DESCRIPTION
## Description

This PR fixes a key mismatch bug in `unsafeUnregisterModule` where it incorrectly attempts to look up `RegModMap` using the registered module `Name` (alias) instead of its internal `Module.getID()`.

During module registration, `RegModMap` is populated using `Module.getID()` as the key. However, `unsafeUnregisterModule` receives the registered `Name` (alias) and previously called `RegModMap.find(std::string(Name))`. This caused a lookup failure since the alias does not match the internal module ID.

As a temporary solution to unblock development while we reconsider the overall data structure design (as discussed), this PR introduces a `std::find_if` traversal over `RegModInsts` to locate the target `ModuleInstance` by matching `getModuleName() == Name`.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence

<img width="702" height="1023" alt="image" src="https://github.com/user-attachments/assets/d848228f-db80-483d-82d4-7cb052bca6d6" />