### PR TITLE
feat(statistics): add machine-readable JSON output for CLI stats

### DIFF
--- a/include/common/configure.h
+++ b/include/common/configure.h
@@ -174,7 +174,8 @@ public:
   StatisticsConfigure(const StatisticsConfigure &RHS) noexcept
       : InstrCounting(RHS.InstrCounting.load(std::memory_order_relaxed)),
         CostMeasuring(RHS.CostMeasuring.load(std::memory_order_relaxed)),
-        TimeMeasuring(RHS.TimeMeasuring.load(std::memory_order_relaxed)) {}
+        TimeMeasuring(RHS.TimeMeasuring.load(std::memory_order_relaxed)),
+        StatsOutputJSON(RHS.StatsOutputJSON.load(std::memory_order_relaxed)) {}
 
   void setInstructionCounting(bool IsCount) noexcept {
     InstrCounting.store(IsCount, std::memory_order_relaxed);
@@ -200,6 +201,14 @@ public:
     return TimeMeasuring.load(std::memory_order_relaxed);
   }
 
+  void setStatsOutputJSON(bool IsJSON) noexcept {
+    StatsOutputJSON.store(IsJSON, std::memory_order_relaxed);
+  }
+
+  bool isStatsOutputJSON() const noexcept {
+    return StatsOutputJSON.load(std::memory_order_relaxed);
+  }
+
   void setCostLimit(uint64_t Cost) noexcept {
     CostLimit.store(Cost, std::memory_order_relaxed);
   }
@@ -212,6 +221,7 @@ private:
   std::atomic<bool> InstrCounting = false;
   std::atomic<bool> CostMeasuring = false;
   std::atomic<bool> TimeMeasuring = false;
+  std::atomic<bool> StatsOutputJSON = false;
 
   std::atomic<uint64_t> CostLimit = std::numeric_limits<uint64_t>::max();
 };

--- a/include/common/statistics.h
+++ b/include/common/statistics.h
@@ -19,6 +19,7 @@
 #include "common/span.h"
 #include "common/spdlog.h"
 #include "common/timer.h"
+#include <fmt/format.h>
 
 #include <atomic>
 #include <vector>
@@ -157,33 +158,56 @@ public:
       return std::chrono::nanoseconds(Duration).count();
     };
     const auto &StatConf = Conf.getStatisticsConfigure();
-    if (StatConf.isTimeMeasuring() || StatConf.isInstructionCounting() ||
-        StatConf.isCostMeasuring()) {
-      spdlog::info("====================  Statistics  ===================="sv);
-    }
-    if (StatConf.isTimeMeasuring()) {
-      spdlog::info(" Total execution time: {} ns"sv, Nano(getTotalExecTime()));
-      spdlog::info(" Wasm instructions execution time: {} ns"sv,
-                   Nano(getWasmExecTime()));
-      spdlog::info(" Host functions execution time: {} ns"sv,
-                   Nano(getHostFuncExecTime()));
-    }
-    if (StatConf.isInstructionCounting()) {
-      spdlog::info(" Executed wasm instructions count: {}"sv, getInstrCount());
-    }
-    if (StatConf.isCostMeasuring()) {
-      spdlog::info(" Gas costs: {}"sv, getTotalCost());
-    }
-    if (StatConf.isInstructionCounting() && StatConf.isTimeMeasuring()) {
-      const double IPS = getInstrPerSecond();
-      spdlog::info(" Instructions per second: {}"sv,
-                   likely(!std::isnan(IPS))
-                       ? static_cast<uint64_t>(IPS)
-                       : std::numeric_limits<uint64_t>::max());
-    }
-    if (StatConf.isTimeMeasuring() || StatConf.isInstructionCounting() ||
-        StatConf.isCostMeasuring()) {
-      spdlog::info("=======================   End   ======================"sv);
+    if (StatConf.isStatsOutputJSON()) {
+      double IPS = getInstrPerSecond();
+      uint64_t IPS_val = likely(!std::isnan(IPS))
+                         ? static_cast<uint64_t>(IPS)
+                         : std::numeric_limits<uint64_t>::max();
+      fmt::print(
+          "{{\n"
+          "  \"total_execution_time_ns\": {},\n"
+          "  \"wasm_instruction_time_ns\": {},\n"
+          "  \"host_function_time_ns\": {},\n"
+          "  \"instruction_count\": {},\n"
+          "  \"gas_used\": {},\n"
+          "  \"instructions_per_second\": {}\n"
+          "}}\n"sv,
+          Nano(getTotalExecTime()),
+          Nano(getWasmExecTime()),
+          Nano(getHostFuncExecTime()),
+          getInstrCount(),
+          getTotalCost(),
+          IPS_val
+      );
+    } else {
+      if (StatConf.isTimeMeasuring() || StatConf.isInstructionCounting() ||
+          StatConf.isCostMeasuring()) {
+        spdlog::info("====================  Statistics  ===================="sv);
+      }
+      if (StatConf.isTimeMeasuring()) {
+        spdlog::info(" Total execution time: {} ns"sv, Nano(getTotalExecTime()));
+        spdlog::info(" Wasm instructions execution time: {} ns"sv,
+                     Nano(getWasmExecTime()));
+        spdlog::info(" Host functions execution time: {} ns"sv,
+                     Nano(getHostFuncExecTime()));
+      }
+      if (StatConf.isInstructionCounting()) {
+        spdlog::info(" Executed wasm instructions count: {}"sv, getInstrCount());
+      }
+      if (StatConf.isCostMeasuring()) {
+        spdlog::info(" Gas costs: {}"sv, getTotalCost());
+      }
+      if (StatConf.isInstructionCounting() && StatConf.isTimeMeasuring()) {
+        const double IPS = getInstrPerSecond();
+        spdlog::info(" Instructions per second: {}"sv,
+                     likely(!std::isnan(IPS))
+                         ? static_cast<uint64_t>(IPS)
+                         : std::numeric_limits<uint64_t>::max());
+      }
+      if (StatConf.isTimeMeasuring() || StatConf.isInstructionCounting() ||
+          StatConf.isCostMeasuring()) {
+        spdlog::info("=======================   End   ======================"sv);
+      }
     }
   }
 

--- a/include/driver/tool.h
+++ b/include/driver/tool.h
@@ -62,6 +62,8 @@ struct DriverToolOptions : public DriverProposalOptions {
         ConfEnableAllStatistics(PO::Description(
             "Enable generating code for all statistics options include "
             "instruction counting, gas measuring, and execution time"sv)),
+        ConfStatsOutputJSON(PO::Description(
+            "Enable structured JSON output for statistics"sv)),
         ConfEnableJIT(
             PO::Description("Enable Just-In-Time compiler for running WASM"sv)),
         ConfEnableCoredump(PO::Description(
@@ -117,6 +119,7 @@ struct DriverToolOptions : public DriverProposalOptions {
   PO::Option<PO::Toggle> ConfEnableGasMeasuring;
   PO::Option<PO::Toggle> ConfEnableTimeMeasuring;
   PO::Option<PO::Toggle> ConfEnableAllStatistics;
+  PO::Option<PO::Toggle> ConfStatsOutputJSON;
   PO::Option<PO::Toggle> ConfEnableJIT;
   PO::Option<PO::Toggle> ConfEnableCoredump;
   PO::Option<PO::Toggle> ConfCoredumpWasmgdb;
@@ -168,6 +171,7 @@ public:
         .add_option("enable-gas-measuring"sv, ConfEnableGasMeasuring)
         .add_option("enable-time-measuring"sv, ConfEnableTimeMeasuring)
         .add_option("enable-all-statistics"sv, ConfEnableAllStatistics)
+        .add_option("stats-output-json"sv, ConfStatsOutputJSON)
         .add_option("enable-jit"sv, ConfEnableJIT)
         .add_option("enable-coredump"sv, ConfEnableCoredump)
         .add_option("coredump-for-wasmgdb"sv, ConfCoredumpWasmgdb)

--- a/lib/driver/runtimeTool.cpp
+++ b/lib/driver/runtimeTool.cpp
@@ -392,6 +392,9 @@ int Tool(struct DriverToolOptions &Opt) noexcept {
       Conf.getStatisticsConfigure().setTimeMeasuring(true);
     }
   }
+  if (Opt.ConfStatsOutputJSON.value()) {
+    Conf.getStatisticsConfigure().setStatsOutputJSON(true);
+  }
   // Determine the effective run mode.
   // Precedence: --run-mode > deprecated --enable-jit / --force-interpreter.
   RunMode RunModeFromFlag = RunMode::Interpreter;


### PR DESCRIPTION
Description

This PR adds a machine-readable JSON output mode for WasmEdge CLI statistics via the new:

`--stats-output-json`

flag.

Currently, when `--enable-all-statistics` is used, WasmEdge emits human-readable `[info]` log lines. While useful for interactive inspection, this format is difficult to consume programmatically in CI pipelines, benchmarking workflows, dashboards, and scripts (e.g. using `jq`).

This change introduces a structured JSON output mode while preserving the existing human-readable statistics output for backward compatibility.

Changes

1. Add `--stats-output-json` CLI flag
2. Add internal `StatsOutputJSON` option to `StatisticsConfigure`
3. Wire CLI flag parsing into runtime configuration
4. Emit structured JSON statistics inside `dumpToLog` when enabled
5. Preserve existing human-readable statistics logging behavior when the flag is absent

Example

```bash
wasmedge --enable-all-statistics --stats-output-json app.wasm
```

Example output:

```json
{
  "total_execution_time_ns": 268266,
  "wasm_instruction_time_ns": 251610,
  "host_function_time_ns": 16656,
  "instruction_count": 20425,
  "gas_used": 20425,
  "instructions_per_second": 81177218
}
```

Resolves #4879

Test Evidence

Locally verified :- 

1. `--stats-output-json` works with `--enable-all-statistics`
2. JSON output is machine-readable and parseable
3. Existing human-readable statistics output remains unchanged

Example verification:

```bash
wasmedge --enable-all-statistics --stats-output-json app.wasm | jq
```
