### PR TITLE
fix: update component import exports

### DIFF
--- a/include/runtime/instance/component/component.h
+++ b/include/runtime/instance/component/component.h
@@ -42,43 +42,43 @@ public:
   // Export a named component func to this import manager.
   void exportFunction(std::string_view Name,
                       Component::FunctionInstance *Inst) noexcept {
-    NamedFunc.emplace(Name, Inst);
+    NamedFunc.insert_or_assign(std::string(Name), Inst);
   }
 
   // Export a named component instance to this import manager.
   void exportComponentInstance(std::string_view Name,
                                const ComponentInstance *Inst) noexcept {
-    NamedCompInst.emplace(Name, Inst);
+    NamedCompInst.insert_or_assign(std::string(Name), Inst);
   }
 
   // Export a named core function instance to this import manager.
   void exportCoreFunctionInstance(std::string_view Name,
                                   FunctionInstance *Inst) noexcept {
-    NamedCoreFunc.emplace(Name, Inst);
+    NamedCoreFunc.insert_or_assign(std::string(Name), Inst);
   }
 
   // Export a named core table instance to this import manager.
   void exportCoreTableInstance(std::string_view Name,
                                TableInstance *Inst) noexcept {
-    NamedCoreTable.emplace(Name, Inst);
+    NamedCoreTable.insert_or_assign(std::string(Name), Inst);
   }
 
   // Export a named core memory instance to this import manager.
   void exportCoreMemoryInstance(std::string_view Name,
                                 MemoryInstance *Inst) noexcept {
-    NamedCoreMemory.emplace(Name, Inst);
+    NamedCoreMemory.insert_or_assign(std::string(Name), Inst);
   }
 
   // Export a named core global instance to this import manager.
   void exportCoreGlobalInstance(std::string_view Name,
                                 GlobalInstance *Inst) noexcept {
-    NamedCoreGlobal.emplace(Name, Inst);
+    NamedCoreGlobal.insert_or_assign(std::string(Name), Inst);
   }
 
   // Export a named core module instance to this import manager.
   void exportCoreModuleInstance(std::string_view Name,
                                 const ModuleInstance *Inst) noexcept {
-    NamedCoreModInst.emplace(Name, Inst);
+    NamedCoreModInst.insert_or_assign(std::string(Name), Inst);
   }
 
   // Find component func by name.


### PR DESCRIPTION
## Description
- update ComponentImportManager export methods to replace existing entries on duplicate names
- align behavior with ComponentInstance::exportFunction
- fixes stale exports when re-registering the same name

Fixes #4907 

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [ ] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
CMake Tools build (WASMEDGE_USE_LLVM=OFF): success
