### PR TITLE
fix(test/plugins/image): remove concrete types to fix devirtualization

### DIFF
--- a/test/plugins/wasmedge_image/wasmedge_image.cpp
+++ b/test/plugins/wasmedge_image/wasmedge_image.cpp
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: 2019-2024 Second State INC
 
 #include "common/defines.h"
-#include "image_func.h"
 #include "image_module.h"
+#include "runtime/callingframe.h"
 #include "runtime/instance/module.h"
 
 #include <algorithm>
@@ -179,8 +179,7 @@ TEST(WasmEdgeImageTest, LoadJPG) {
   auto *FuncInst = ImgMod->findFuncExports("load_jpg");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncInst = dynamic_cast<WasmEdge::Host::WasmEdgeImage::LoadJPG &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Test: Load JPG and resize into 50x60 RGB u8 format.
   // Clear the memory[0, 32768].
@@ -320,8 +319,7 @@ TEST(WasmEdgeImageTest, LoadPNG) {
   auto *FuncInst = ImgMod->findFuncExports("load_png");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncInst = dynamic_cast<WasmEdge::Host::WasmEdgeImage::LoadPNG &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Test: Load PNG and resize into 50x60 RGB u8 format.
   // Clear the memory[0, 32768].
@@ -459,8 +457,7 @@ TEST(WasmEdgeImageTest, LoadImage) {
   auto *FuncInst = ImgMod->findFuncExports("load_image");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncInst = dynamic_cast<WasmEdge::Host::WasmEdgeImage::LoadImage &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Test: Load JPG and resize into 50x60 BGR u8 format.
   // Clear the memory[0, 32768].


### PR DESCRIPTION
## Description
This was breaking the build because of undefined references to LoadJPG::body, LoadPNG::body, LoadImage::body. I have removed `dynamic_cast<concrete_type>` and the inclusion of the concrete Load* types from `image_func.h`

This fixes the build as can be seen here:
```
 build $ cmake -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_PLUGIN_IMAGE=ON .. && make -j 2
-- spdlog found
-- Downloading stb_image source
-- Downloading stb_image source -- done
-- Checking SIMDJSON from system
-- Downloading SIMDJSON source
-- Adding -Og to compile flag
-- Downloading SIMDJSON source -- done
-- Downloading the WASM spec test suite
-- Downloading the WASM spec test suite -- done
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-1.0
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-1.0 -- done
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-2.0
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-2.0 -- done
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-3.0
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-3.0 -- done
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-3.0-bulk-memory
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-3.0-bulk-memory -- done
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-3.0-exceptions
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-3.0-exceptions -- done
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-3.0-gc
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-3.0-gc -- done
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-3.0-memory64
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-3.0-memory64 -- done
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-3.0-multi-memory
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-3.0-multi-memory -- done
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-3.0-relaxed-simd
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-3.0-relaxed-simd -- done
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-3.0-simd
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/wasm-3.0-simd -- done
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/threads
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/threads -- done
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/component-model
-- Copying test suite to /home/pranjal/Projects/WasmEdge/build/test/spec/testSuites/component-model -- done
-- Configuring done (2.9s)
-- Generating done (0.3s)
-- Build files have been written to: /home/pranjal/Projects/WasmEdge/build
[  4%] Built target utilBlake3
[  6%] Built target wasmedgeCommon
[  7%] Built target simdjson
[ 12%] Built target expectedTests
[ 12%] Built target spanTests
[ 13%] Built target wasmedgeErrinfoTests
[ 16%] Built target wasmedgeSystem
[ 17%] Built target wasmedgePluginWasiLogging
[ 18%] Built target wasmedgePO
[ 20%] Built target wasmedgeValidator
[ 23%] Built target wasmedgeHostModuleWasi
[ 35%] Built target wasmedgeExecutor
[ 35%] Built target wasmedgeTestSpec
[ 37%] Built target wasmedgeCommonTests
[ 39%] Built target wasiTests
[ 41%] Built target poTests
[ 42%] Built target wasmedgeAOT
[ 44%] Built target wasmedgeLLVM
[ 46%] Built target wasmedgeLoaderFileMgr
[ 47%] Built target wasmedgeAOTCacheTests
[ 48%] Built target wasmedgeAOTBlake3Tests
[ 48%] Built target wasmedgeLoaderFileMgrTests
[ 49%] Built target wasmedgePlugin
[ 61%] Built target wasmedgeLoader
[ 62%] Built target wasmedgeVM
[ 65%] Built target wasmedgeLoaderASTTests
[ 67%] Built target wasmedgeExecutorCoreTests
[ 70%] Built target wasmedgeLoaderSerializerTests
[ 72%] Built target wasmedgeExecutorRegressionTests
[ 72%] Built target wasmedgeValidatorRegressionTests
[ 72%] Built target wasmedgeComponentFuzzTest
[ 74%] Built target wasmedgeComponentRegressionTests
[ 75%] Built target wasmedgeThreadTests
[ 75%] Built target wasiSocketTests
[ 76%] Built target wasmedgeHostMockTests
[ 77%] Built target wasmedgeMemInstanceTests
[ 78%] Built target wasmedgeLLVMCoreTests
[ 82%] Built target wasmedgeDriver
[ 83%] Built target wasmedgeLazyJITTests
[ 83%] Built target wasmedgeMixcallTests
[ 84%] Built target wasmedgeDriverToolTests
[ 84%] Built target wasmedgeCAPI
[ 85%] Built target wasmedge_shared
[ 86%] Built target wasmedgec
[ 88%] Built target wasmedgePluginWasmEdgeImage
[ 89%] Built target wasmedge
[ 90%] Built target wasmedgeAPITestHelpers
[ 91%] Built target wasmedgeExternrefTests
[ 92%] Built target wasiLoggingTests
[ 93%] Built target wasmedgeImageTests
[ 94%] Built target wasmedgePluginTestModuleC
[ 95%] Built target wasmedgePluginTestModuleCPP
[ 95%] Built target wasmedgePluginUnittestsC
[ 96%] Built target wasmedgePluginUnittestsCPP
[ 97%] Built target wasmedgeAPIUnitTests
[ 98%] Built target wasmedgeAPIVMCoreTests
[ 99%] Built target wasmedgeAPIStepsCoreTests
[100%] Built target wasmedgeAPIAOTCoreTests
[100%] Built target wasmedgeAPIAOTNestedVMTests
```

The same issue affects WasiNNTests as well. The build fails with the command `cmake -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=ggml .. && make -j 2`. I have not looked into the other plugins but I suspect that they have this issue as well. I will fix these in future PRs.

## Checklist

Before submitting this PR, please ensure the following:

- [X] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [X] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [X] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->
```
Test project /home/pranjal/Projects/WasmEdge/build
      Start  1: wasmedgeAOTCacheTests
 1/33 Test  #1: wasmedgeAOTCacheTests ..............   Passed    0.01 sec
      Start  2: wasmedgeAOTBlake3Tests
 2/33 Test  #2: wasmedgeAOTBlake3Tests .............   Passed    0.01 sec
      Start  3: wasmedgeLLVMCoreTests
 3/33 Test  #3: wasmedgeLLVMCoreTests ..............   Passed   98.89 sec
      Start  4: wasmedgeLazyJITTests
 4/33 Test  #4: wasmedgeLazyJITTests ...............   Passed    0.10 sec
      Start  5: wasmedgeMixcallTests
 5/33 Test  #5: wasmedgeMixcallTests ...............   Passed    0.04 sec
      Start  6: wasmedgeCommonTests
 6/33 Test  #6: wasmedgeCommonTests ................   Passed    0.00 sec
      Start  7: wasmedgeLoaderFileMgrTests
 7/33 Test  #7: wasmedgeLoaderFileMgrTests .........   Passed    0.01 sec
      Start  8: wasmedgeLoaderASTTests
 8/33 Test  #8: wasmedgeLoaderASTTests .............   Passed    0.01 sec
      Start  9: wasmedgeLoaderSerializerTests
 9/33 Test  #9: wasmedgeLoaderSerializerTests ......   Passed    0.00 sec
      Start 10: wasmedgeExecutorCoreTests
10/33 Test #10: wasmedgeExecutorCoreTests ..........   Passed    1.78 sec
      Start 11: wasmedgeExecutorRegressionTests
11/33 Test #11: wasmedgeExecutorRegressionTests ....   Passed    0.03 sec
      Start 12: wasmedgeValidatorRegressionTests
12/33 Test #12: wasmedgeValidatorRegressionTests ...   Passed    0.02 sec
      Start 13: wasmedgeComponentRegressionTests
13/33 Test #13: wasmedgeComponentRegressionTests ...   Passed    0.03 sec
      Start 14: wasmedgeThreadTests
14/33 Test #14: wasmedgeThreadTests ................   Passed    1.03 sec
      Start 15: wasmedgeAPIUnitTests
15/33 Test #15: wasmedgeAPIUnitTests ...............   Passed    0.14 sec
      Start 16: wasmedgeAPIVMCoreTests
16/33 Test #16: wasmedgeAPIVMCoreTests .............   Passed    1.88 sec
      Start 17: wasmedgeAPIStepsCoreTests
17/33 Test #17: wasmedgeAPIStepsCoreTests ..........   Passed    1.77 sec
      Start 18: wasmedgeAPIAOTCoreTests
18/33 Test #18: wasmedgeAPIAOTCoreTests ............   Passed   15.28 sec
      Start 19: wasmedgeAPIAOTNestedVMTests
19/33 Test #19: wasmedgeAPIAOTNestedVMTests ........   Passed    0.03 sec
      Start 20: wasmedgeDriverToolTests
20/33 Test #20: wasmedgeDriverToolTests ............   Passed    0.13 sec
      Start 21: wasmedgeExternrefTests
21/33 Test #21: wasmedgeExternrefTests .............   Passed    0.02 sec
      Start 22: wasiLoggingTests
22/33 Test #22: wasiLoggingTests ...................   Passed    0.02 sec
      Start 23: wasmedgeImageTests
23/33 Test #23: wasmedgeImageTests .................   Passed    0.02 sec
      Start 24: wasmedgePluginUnittestsC
24/33 Test #24: wasmedgePluginUnittestsC ...........   Passed    0.02 sec
      Start 25: wasmedgePluginUnittestsCPP
25/33 Test #25: wasmedgePluginUnittestsCPP .........   Passed    0.01 sec
      Start 26: wasiSocketTests
26/33 Test #26: wasiSocketTests ....................   Passed    0.06 sec
      Start 27: wasiTests
27/33 Test #27: wasiTests ..........................   Passed    7.09 sec
      Start 28: wasmedgeHostMockTests
28/33 Test #28: wasmedgeHostMockTests ..............   Passed    0.03 sec
      Start 29: expectedTests
29/33 Test #29: expectedTests ......................   Passed    0.01 sec
      Start 30: spanTests
30/33 Test #30: spanTests ..........................   Passed    0.01 sec
      Start 31: poTests
31/33 Test #31: poTests ............................   Passed    0.01 sec
      Start 32: wasmedgeMemInstanceTests
32/33 Test #32: wasmedgeMemInstanceTests ...........   Passed    0.03 sec
      Start 33: wasmedgeErrinfoTests
33/33 Test #33: wasmedgeErrinfoTests ...............   Passed    0.01 sec

100% tests passed, 0 tests failed out of 33

Total Test time (real) = 128.57 sec
```

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
