### PR TITLE
fix(test/plugins/zlib): remove concrete types to fix devirtualization

### DIFF
--- a/test/plugins/wasmedge_zlib/wasmedge_zlib.cpp
+++ b/test/plugins/wasmedge_zlib/wasmedge_zlib.cpp
@@ -84,38 +84,32 @@ TEST(WasmEdgeZlibTest, DeflateInflateCycle) {
   auto *FuncInst = ZlibMod->findFuncExports("deflateInit_");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &DeflateInit_ = dynamic_cast<WasmEdge::Host::WasmEdgeZlibDeflateInit_ &>(
-      FuncInst->getHostFunc());
+  auto &DeflateInit_ = FuncInst->getHostFunc();
 
   FuncInst = ZlibMod->findFuncExports("deflate");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &Deflate = dynamic_cast<WasmEdge::Host::WasmEdgeZlibDeflate &>(
-      FuncInst->getHostFunc());
+  auto &Deflate = FuncInst->getHostFunc();
 
   FuncInst = ZlibMod->findFuncExports("deflateEnd");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &DeflateEnd = dynamic_cast<WasmEdge::Host::WasmEdgeZlibDeflateEnd &>(
-      FuncInst->getHostFunc());
+  auto &DeflateEnd = FuncInst->getHostFunc();
 
   FuncInst = ZlibMod->findFuncExports("inflateInit_");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &InflateInit_ = dynamic_cast<WasmEdge::Host::WasmEdgeZlibInflateInit_ &>(
-      FuncInst->getHostFunc());
+  auto &InflateInit_ = FuncInst->getHostFunc();
 
   FuncInst = ZlibMod->findFuncExports("inflate");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &Inflate = dynamic_cast<WasmEdge::Host::WasmEdgeZlibInflate &>(
-      FuncInst->getHostFunc());
+  auto &Inflate = FuncInst->getHostFunc();
 
   FuncInst = ZlibMod->findFuncExports("inflateEnd");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &InflateEnd = dynamic_cast<WasmEdge::Host::WasmEdgeZlibInflateEnd &>(
-      FuncInst->getHostFunc());
+  auto &InflateEnd = FuncInst->getHostFunc();
 
   std::array<WasmEdge::ValVariant, 1> RetVal;
 


### PR DESCRIPTION
## Description
<!-- Describe your changes here -->
Similar to #4910, tests for the Zlib plugin were breaking the build. Here are the failing build logs before this change:
```
build $ cmake -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_PLUGIN_ZLIB=ON .. && make -j 2
/usr/bin/ld: /tmp/ccEhMzob.ltrans0.ltrans.o: in function `WasmEdge::Runtime::HostFunction<WasmEdge::Host::WasmEdgeZlibDeflateInit_>::run(WasmEdge::Runtime::CallingFrame const&, cxx20::span<WasmEdge::Variant<unsigned int, int, unsigned long, long, float, double, unsigned __int128, __int128, unsigned long __vector(2), long __vector(2), unsigned int __vector(4), int __vector(4), unsigned short __vector(8), short __vector(8), unsigned char __vector(16), signed char __vector(16), float __vector(4), double __vector(2), WasmEdge::RefVariant> const, 18446744073709551615ul>, cxx20::span<WasmEdge::Variant<unsigned int, int, unsigned long, long, float, double, unsigned __int128, __int128, unsigned long __vector(2), long __vector(2), unsigned int __vector(4), int __vector(4), unsigned short __vector(8), short __vector(8), unsigned char __vector(16), signed char __vector(16), float __vector(4), double __vector(2), WasmEdge::RefVariant>, 18446744073709551615ul>)':
/usr/include/c++/16.1.1/bits/invoke.h:69:(.text+0x6f3): undefined reference to `WasmEdge::Host::WasmEdgeZlibDeflateInit_::body(WasmEdge::Runtime::CallingFrame const&, unsigned int, int, unsigned int, int)'
/usr/bin/ld: /tmp/ccEhMzob.ltrans0.ltrans.o: in function `WasmEdge::Runtime::HostFunction<WasmEdge::Host::WasmEdgeZlibDeflate>::run(WasmEdge::Runtime::CallingFrame const&, cxx20::span<WasmEdge::Variant<unsigned int, int, unsigned long, long, float, double, unsigned __int128, __int128, unsigned long __vector(2), long __vector(2), unsigned int __vector(4), int __vector(4), unsigned short __vector(8), short __vector(8), unsigned char __vector(16), signed char __vector(16), float __vector(4), double __vector(2), WasmEdge::RefVariant> const, 18446744073709551615ul>, cxx20::span<WasmEdge::Variant<unsigned int, int, unsigned long, long, float, double, unsigned __int128, __int128, unsigned long __vector(2), long __vector(2), unsigned int __vector(4), int __vector(4), unsigned short __vector(8), short __vector(8), unsigned char __vector(16), signed char __vector(16), float __vector(4), double __vector(2), WasmEdge::RefVariant>, 18446744073709551615ul>)':
/usr/include/c++/16.1.1/bits/invoke.h:69:(.text+0x7a5): undefined reference to `WasmEdge::Host::WasmEdgeZlibDeflate::body(WasmEdge::Runtime::CallingFrame const&, unsigned int, int)'
/usr/bin/ld: /tmp/ccEhMzob.ltrans0.ltrans.o: in function `WasmEdge::Runtime::HostFunction<WasmEdge::Host::WasmEdgeZlibDeflateEnd>::run(WasmEdge::Runtime::CallingFrame const&, cxx20::span<WasmEdge::Variant<unsigned int, int, unsigned long, long, float, double, unsigned __int128, __int128, unsigned long __vector(2), long __vector(2), unsigned int __vector(4), int __vector(4), unsigned short __vector(8), short __vector(8), unsigned char __vector(16), signed char __vector(16), float __vector(4), double __vector(2), WasmEdge::RefVariant> const, 18446744073709551615ul>, cxx20::span<WasmEdge::Variant<unsigned int, int, unsigned long, long, float, double, unsigned __int128, __int128, unsigned long __vector(2), long __vector(2), unsigned int __vector(4), int __vector(4), unsigned short __vector(8), short __vector(8), unsigned char __vector(16), signed char __vector(16), float __vector(4), double __vector(2), WasmEdge::RefVariant>, 18446744073709551615ul>)':
/usr/include/c++/16.1.1/bits/invoke.h:69:(.text+0x84f): undefined reference to `WasmEdge::Host::WasmEdgeZlibDeflateEnd::body(WasmEdge::Runtime::CallingFrame const&, unsigned int)'
/usr/bin/ld: /tmp/ccEhMzob.ltrans0.ltrans.o: in function `WasmEdge::Runtime::HostFunction<WasmEdge::Host::WasmEdgeZlibInflateInit_>::run(WasmEdge::Runtime::CallingFrame const&, cxx20::span<WasmEdge::Variant<unsigned int, int, unsigned long, long, float, double, unsigned __int128, __int128, unsigned long __vector(2), long __vector(2), unsigned int __vector(4), int __vector(4), unsigned short __vector(8), short __vector(8), unsigned char __vector(16), signed char __vector(16), float __vector(4), double __vector(2), WasmEdge::RefVariant> const, 18446744073709551615ul>, cxx20::span<WasmEdge::Variant<unsigned int, int, unsigned long, long, float, double, unsigned __int128, __int128, unsigned long __vector(2), long __vector(2), unsigned int __vector(4), int __vector(4), unsigned short __vector(8), short __vector(8), unsigned char __vector(16), signed char __vector(16), float __vector(4), double __vector(2), WasmEdge::RefVariant>, 18446744073709551615ul>)':
/usr/include/c++/16.1.1/bits/invoke.h:69:(.text+0x8f9): undefined reference to `WasmEdge::Host::WasmEdgeZlibInflateInit_::body(WasmEdge::Runtime::CallingFrame const&, unsigned int, unsigned int, int)'
/usr/bin/ld: /tmp/ccEhMzob.ltrans0.ltrans.o: in function `WasmEdge::Runtime::HostFunction<WasmEdge::Host::WasmEdgeZlibInflate>::run(WasmEdge::Runtime::CallingFrame const&, cxx20::span<WasmEdge::Variant<unsigned int, int, unsigned long, long, float, double, unsigned __int128, __int128, unsigned long __vector(2), long __vector(2), unsigned int __vector(4), int __vector(4), unsigned short __vector(8), short __vector(8), unsigned char __vector(16), signed char __vector(16), float __vector(4), double __vector(2), WasmEdge::RefVariant> const, 18446744073709551615ul>, cxx20::span<WasmEdge::Variant<unsigned int, int, unsigned long, long, float, double, unsigned __int128, __int128, unsigned long __vector(2), long __vector(2), unsigned int __vector(4), int __vector(4), unsigned short __vector(8), short __vector(8), unsigned char __vector(16), signed char __vector(16), float __vector(4), double __vector(2), WasmEdge::RefVariant>, 18446744073709551615ul>)':
/usr/include/c++/16.1.1/bits/invoke.h:69:(.text+0x9a5): undefined reference to `WasmEdge::Host::WasmEdgeZlibInflate::body(WasmEdge::Runtime::CallingFrame const&, unsigned int, int)'
/usr/bin/ld: /tmp/ccEhMzob.ltrans0.ltrans.o: in function `WasmEdge::Runtime::HostFunction<WasmEdge::Host::WasmEdgeZlibInflateEnd>::run(WasmEdge::Runtime::CallingFrame const&, cxx20::span<WasmEdge::Variant<unsigned int, int, unsigned long, long, float, double, unsigned __int128, __int128, unsigned long __vector(2), long __vector(2), unsigned int __vector(4), int __vector(4), unsigned short __vector(8), short __vector(8), unsigned char __vector(16), signed char __vector(16), float __vector(4), double __vector(2), WasmEdge::RefVariant> const, 18446744073709551615ul>, cxx20::span<WasmEdge::Variant<unsigned int, int, unsigned long, long, float, double, unsigned __int128, __int128, unsigned long __vector(2), long __vector(2), unsigned int __vector(4), int __vector(4), unsigned short __vector(8), short __vector(8), unsigned char __vector(16), signed char __vector(16), float __vector(4), double __vector(2), WasmEdge::RefVariant>, 18446744073709551615ul>)':
/usr/include/c++/16.1.1/bits/invoke.h:69:(.text+0xa4f): undefined reference to `WasmEdge::Host::WasmEdgeZlibInflateEnd::body(WasmEdge::Runtime::CallingFrame const&, unsigned int)'
/usr/bin/ld: /tmp/ccEhMzob.ltrans0.ltrans.o: in function `WasmEdgeZlibTest_DeflateInflateCycle_Test::TestBody()':
/usr/include/c++/16.1.1/bits/invoke.h:69:(.text+0x78f5): undefined reference to `WasmEdge::Host::WasmEdgeZlibDeflateInit_::body(WasmEdge::Runtime::CallingFrame const&, unsigned int, int, unsigned int, int)'
/usr/bin/ld: /usr/include/c++/16.1.1/bits/invoke.h:69:(.text+0x7a0d): undefined reference to `WasmEdge::Host::WasmEdgeZlibDeflateInit_::body(WasmEdge::Runtime::CallingFrame const&, unsigned int, int, unsigned int, int)'
/usr/bin/ld: /usr/include/c++/16.1.1/bits/invoke.h:69:(.text+0x7b15): undefined reference to `WasmEdge::Host::WasmEdgeZlibDeflateInit_::body(WasmEdge::Runtime::CallingFrame const&, unsigned int, int, unsigned int, int)'
/usr/bin/ld: /usr/include/c++/16.1.1/bits/invoke.h:69:(.text+0x7c2a): undefined reference to `WasmEdge::Host::WasmEdgeZlibDeflate::body(WasmEdge::Runtime::CallingFrame const&, unsigned int, int)'
/usr/bin/ld: /usr/include/c++/16.1.1/bits/invoke.h:69:(.text+0x7f99): undefined reference to `WasmEdge::Host::WasmEdgeZlibDeflateEnd::body(WasmEdge::Runtime::CallingFrame const&, unsigned int)'
/usr/bin/ld: /usr/include/c++/16.1.1/bits/invoke.h:69:(.text+0x80e6): undefined reference to `WasmEdge::Host::WasmEdgeZlibInflateInit_::body(WasmEdge::Runtime::CallingFrame const&, unsigned int, unsigned int, int)'
/usr/bin/ld: /usr/include/c++/16.1.1/bits/invoke.h:69:(.text+0x81d5): undefined reference to `WasmEdge::Host::WasmEdgeZlibInflateInit_::body(WasmEdge::Runtime::CallingFrame const&, unsigned int, unsigned int, int)'
/usr/bin/ld: /usr/include/c++/16.1.1/bits/invoke.h:69:(.text+0x82c4): undefined reference to `WasmEdge::Host::WasmEdgeZlibInflateInit_::body(WasmEdge::Runtime::CallingFrame const&, unsigned int, unsigned int, int)'
/usr/bin/ld: /usr/include/c++/16.1.1/bits/invoke.h:69:(.text+0x83f1): undefined reference to `WasmEdge::Host::WasmEdgeZlibInflate::body(WasmEdge::Runtime::CallingFrame const&, unsigned int, int)'
/usr/bin/ld: /usr/include/c++/16.1.1/bits/invoke.h:69:(.text+0x86b9): undefined reference to `WasmEdge::Host::WasmEdgeZlibInflateEnd::body(WasmEdge::Runtime::CallingFrame const&, unsigned int)'
collect2: error: ld returned 1 exit status
make[2]: *** [test/plugins/wasmedge_zlib/CMakeFiles/wasmedgeZlibTests.dir/build.make:124: test/plugins/wasmedge_zlib/wasmedgeZlibTests] Error 1
make[1]: *** [CMakeFiles/Makefile2:4229: test/plugins/wasmedge_zlib/CMakeFiles/wasmedgeZlibTests.dir/all] Error 2
make: *** [Makefile:166: all] Error 2
```

## Checklist

Before submitting this PR, please ensure the following:

- [X] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [X] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [X] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->
```
Test project /home/pranjal/Projects/WasmEdge/build
      Start  1: wasmedgeAOTCacheTests
 1/33 Test  #1: wasmedgeAOTCacheTests ..............   Passed    0.01 sec
      Start  2: wasmedgeAOTBlake3Tests
 2/33 Test  #2: wasmedgeAOTBlake3Tests .............   Passed    0.01 sec
      Start  3: wasmedgeLLVMCoreTests
 3/33 Test  #3: wasmedgeLLVMCoreTests ..............   Passed  103.08 sec
      Start  4: wasmedgeLazyJITTests
 4/33 Test  #4: wasmedgeLazyJITTests ...............   Passed    0.11 sec
      Start  5: wasmedgeMixcallTests
 5/33 Test  #5: wasmedgeMixcallTests ...............   Passed    0.04 sec
      Start  6: wasmedgeCommonTests
 6/33 Test  #6: wasmedgeCommonTests ................   Passed    0.00 sec
      Start  7: wasmedgeLoaderFileMgrTests
 7/33 Test  #7: wasmedgeLoaderFileMgrTests .........   Passed    0.01 sec
      Start  8: wasmedgeLoaderASTTests
 8/33 Test  #8: wasmedgeLoaderASTTests .............   Passed    0.01 sec
      Start  9: wasmedgeLoaderSerializerTests
 9/33 Test  #9: wasmedgeLoaderSerializerTests ......   Passed    0.00 sec
      Start 10: wasmedgeExecutorCoreTests
10/33 Test #10: wasmedgeExecutorCoreTests ..........   Passed    4.39 sec
      Start 11: wasmedgeExecutorRegressionTests
11/33 Test #11: wasmedgeExecutorRegressionTests ....   Passed    0.04 sec
      Start 12: wasmedgeValidatorRegressionTests
12/33 Test #12: wasmedgeValidatorRegressionTests ...   Passed    0.03 sec
      Start 13: wasmedgeComponentRegressionTests
13/33 Test #13: wasmedgeComponentRegressionTests ...   Passed    0.04 sec
      Start 14: wasmedgeThreadTests
14/33 Test #14: wasmedgeThreadTests ................   Passed    2.24 sec
      Start 15: wasmedgeAPIUnitTests
15/33 Test #15: wasmedgeAPIUnitTests ...............   Passed    0.26 sec
      Start 16: wasmedgeAPIVMCoreTests
16/33 Test #16: wasmedgeAPIVMCoreTests .............   Passed    2.42 sec
      Start 17: wasmedgeAPIStepsCoreTests
17/33 Test #17: wasmedgeAPIStepsCoreTests ..........   Passed    1.83 sec
      Start 18: wasmedgeAPIAOTCoreTests
18/33 Test #18: wasmedgeAPIAOTCoreTests ............   Passed   15.87 sec
      Start 19: wasmedgeAPIAOTNestedVMTests
19/33 Test #19: wasmedgeAPIAOTNestedVMTests ........   Passed    0.02 sec
      Start 20: wasmedgeDriverToolTests
20/33 Test #20: wasmedgeDriverToolTests ............   Passed    0.12 sec
      Start 21: wasmedgeExternrefTests
21/33 Test #21: wasmedgeExternrefTests .............   Passed    0.02 sec
      Start 22: wasiLoggingTests
22/33 Test #22: wasiLoggingTests ...................   Passed    0.02 sec
      Start 23: wasmedgeZlibTests
23/33 Test #23: wasmedgeZlibTests ..................   Passed    0.05 sec
      Start 24: wasmedgePluginUnittestsC
24/33 Test #24: wasmedgePluginUnittestsC ...........   Passed    0.01 sec
      Start 25: wasmedgePluginUnittestsCPP
25/33 Test #25: wasmedgePluginUnittestsCPP .........   Passed    0.01 sec
      Start 26: wasiSocketTests
26/33 Test #26: wasiSocketTests ....................   Passed    0.04 sec
      Start 27: wasiTests
27/33 Test #27: wasiTests ..........................   Passed    6.64 sec
      Start 28: wasmedgeHostMockTests
28/33 Test #28: wasmedgeHostMockTests ..............   Passed    0.02 sec
      Start 29: expectedTests
29/33 Test #29: expectedTests ......................   Passed    0.01 sec
      Start 30: spanTests
30/33 Test #30: spanTests ..........................   Passed    0.00 sec
      Start 31: poTests
31/33 Test #31: poTests ............................   Passed    0.01 sec
      Start 32: wasmedgeMemInstanceTests
32/33 Test #32: wasmedgeMemInstanceTests ...........   Passed    0.03 sec
      Start 33: wasmedgeErrinfoTests
33/33 Test #33: wasmedgeErrinfoTests ...............   Passed    0.01 sec

100% tests passed, 0 tests failed out of 33

Total Test time (real) = 137.47 sec
```
---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
