### PR TITLE
fix(plugin/image): compute output buffer size in 64-bit in decodeImgToSize

### DIFF
--- a/plugins/wasmedge_image/image_func.cpp
+++ b/plugins/wasmedge_image/image_func.cpp
@@ -62,12 +62,12 @@ bool decodeImgToSize(Span<const uint8_t> Buf, uint32_t W, uint32_t H,
   }
 
   // Resize.
-  if (unlikely(DstBuf.size() <
-               W * H * 3 * (IsU8 ? sizeof(uint8_t) : sizeof(float)))) {
+  const uint64_t NeededSize = static_cast<uint64_t>(W) * H * 3 *
+                              (IsU8 ? sizeof(uint8_t) : sizeof(float));
+  if (unlikely(DstBuf.size() < NeededSize)) {
     spdlog::error("[WasmEdge-Image] Output buffer size {} not enough. "sv
                   "At least need {} bytes."sv,
-                  DstBuf.size(),
-                  W * H * 3 * (IsU8 ? sizeof(uint8_t) : sizeof(float)));
+                  DstBuf.size(), NeededSize);
     return false;
   }
   if (IsU8) {

--- a/plugins/wasmedge_image/image_func.cpp
+++ b/plugins/wasmedge_image/image_func.cpp
@@ -62,12 +62,12 @@ bool decodeImgToSize(Span<const uint8_t> Buf, uint32_t W, uint32_t H,
   }
 
   // Resize.
-  const uint64_t NeededSize = static_cast<uint64_t>(W) * H * 3 *
-                              (IsU8 ? sizeof(uint8_t) : sizeof(float));
-  if (unlikely(DstBuf.size() < NeededSize)) {
+  const uint64_t BytesPerPixel = 3 * (IsU8 ? sizeof(uint8_t) : sizeof(float));
+  const uint64_t NumPixels = static_cast<uint64_t>(W) * H;
+  if (unlikely(DstBuf.size() / BytesPerPixel < NumPixels)) {
     spdlog::error("[WasmEdge-Image] Output buffer size {} not enough. "sv
-                  "At least need {} bytes."sv,
-                  DstBuf.size(), NeededSize);
+                  "At least need {}x{}x{} bytes."sv,
+                  DstBuf.size(), W, H, BytesPerPixel);
     return false;
   }
   if (IsU8) {


### PR DESCRIPTION
In the image plugin, decodeImgToSize checks DstBuf against W * H * 3 * sizeof(...) computed in 32-bit, but W and H come straight from the guest, so the product wraps (e.g. W=2^30, H=4 gives 0) and the check passes even for a zero-length output buffer before stbir_resize_ writes the real multi-GB image. Rework the check to compare DstBuf.size() / BytesPerPixel against the 64-bit pixel count, so no multiplication of guest-controlled values can overflow (a plain 64-bit product can still wrap, e.g. W=H=2^31 with RGB32F gives 2^62 * 12 = 3 * 2^64 = 0).