### PR TITLE
feat(validator/component): enumerate exports of imported/aliased modules

### DIFF
--- a/include/validator/component_context.h
+++ b/include/validator/component_context.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <variant>
 #include <vector>
 
 namespace WasmEdge {
@@ -32,7 +33,11 @@ public:
     const Context *Parent;
 
     // --- Core sort index spaces ---
-    std::vector<const AST::Module *> CoreModules; // core:module
+    // The export source of a core:module index: inline AST (defined here),
+    // declared core:moduletype (imported/aliased), or monostate (opaque).
+    using CoreModuleEntry = std::variant<std::monostate, const AST::Module *,
+                                         const AST::Component::CoreDefType *>;
+    std::vector<CoreModuleEntry> CoreModules; // core:module
     std::vector<std::unordered_map<std::string, ExternalType>>
         CoreInstances;                                 // core:instance
     std::vector<const AST::SubType *> CoreTypes;       // core:type
@@ -43,7 +48,12 @@ public:
     uint32_t CoreTagCount = 0;                         // core:tag
 
     // --- Component sort index spaces ---
-    std::vector<const AST::Component::Component *> Components; // component
+    // Component analogue of CoreModuleEntry: inline AST, declared
+    // componenttype, or monostate (opaque).
+    using ComponentEntry =
+        std::variant<std::monostate, const AST::Component::Component *,
+                     const AST::Component::ComponentType *>;
+    std::vector<ComponentEntry> Components; // component
     // Instance exports: name → {sort, optional resolved InstanceType,
     // optional nested instance idx} so alias-export and ascription subtype
     // checks can follow chains without re-deriving from ExternDesc.
@@ -64,6 +74,11 @@ public:
         InstanceTypes;
     std::unordered_map<uint32_t, const AST::Component::ResourceType *>
         ResourceTypes;
+    // Moduletype bodies, keyed by core:type index (rec types live in
+    // CoreTypes). Lets an imported `(core module (type i))` recover its
+    // exports.
+    std::unordered_map<uint32_t, const AST::Component::CoreDefType *>
+        CoreModuleTypeDefs;
 
     // Type indices that refer to locally-defined resources (not imported / not
     // aliased from an outer scope). Required by canon resource.new /
@@ -146,22 +161,41 @@ public:
   // core:module
   // ==========================================================================
 
-  uint32_t addCoreModule(const AST::Module &M) noexcept {
+  // Add a core:module index entry from each possible export source.
+  uint32_t addInlineCoreModule(const AST::Module &M) noexcept {
     auto &V = getCurrentContext().CoreModules;
     uint32_t Idx = static_cast<uint32_t>(V.size());
-    V.push_back(&M);
+    V.emplace_back(&M);
+    return Idx;
+  }
+  uint32_t
+  addDeclaredCoreModule(const AST::Component::CoreDefType &MT) noexcept {
+    assuming(MT.isModuleType());
+    auto &V = getCurrentContext().CoreModules;
+    uint32_t Idx = static_cast<uint32_t>(V.size());
+    V.emplace_back(&MT);
+    return Idx;
+  }
+  uint32_t addOpaqueCoreModule() noexcept {
+    auto &V = getCurrentContext().CoreModules;
+    uint32_t Idx = static_cast<uint32_t>(V.size());
+    V.emplace_back();
     return Idx;
   }
 
-  uint32_t addCoreModule() noexcept {
-    auto &V = getCurrentContext().CoreModules;
-    uint32_t Idx = static_cast<uint32_t>(V.size());
-    V.push_back(nullptr);
-    return Idx;
-  }
-
+  // Inline module AST, or nullptr if the entry is a moduletype or opaque.
   const AST::Module *getCoreModule(uint32_t Idx) const noexcept {
-    return getCurrentContext().CoreModules.at(Idx);
+    const auto &E = getCurrentContext().CoreModules.at(Idx);
+    const auto *P = std::get_if<const AST::Module *>(&E);
+    return P != nullptr ? *P : nullptr;
+  }
+
+  // Declared moduletype, or nullptr if the entry is a raw AST or opaque.
+  const AST::Component::CoreDefType *
+  getCoreModuleType(uint32_t Idx) const noexcept {
+    const auto &E = getCurrentContext().CoreModules.at(Idx);
+    const auto *P = std::get_if<const AST::Component::CoreDefType *>(&E);
+    return P != nullptr ? *P : nullptr;
   }
 
   // ==========================================================================
@@ -194,6 +228,22 @@ public:
     uint32_t Idx = static_cast<uint32_t>(V.size());
     V.push_back(ST);
     return Idx;
+  }
+
+  // Tag the core:type at CoreTypeIdx as a moduletype (keyed by core:type
+  // index, unlike getCoreModuleType which is keyed by core:module index).
+  void recordCoreModuleTypeDef(uint32_t CoreTypeIdx,
+                               const AST::Component::CoreDefType &MT) noexcept {
+    assuming(MT.isModuleType());
+    getCurrentContext().CoreModuleTypeDefs[CoreTypeIdx] = &MT;
+  }
+
+  // Moduletype at a core:type index, or nullptr if that index isn't one.
+  const AST::Component::CoreDefType *
+  getCoreModuleTypeDef(uint32_t CoreTypeIdx) const noexcept {
+    const auto &M = getCurrentContext().CoreModuleTypeDefs;
+    auto It = M.find(CoreTypeIdx);
+    return It != M.end() ? It->second : nullptr;
   }
   uint32_t addCoreFunc(const AST::SubType *ST = nullptr) noexcept {
     auto &V = getCurrentContext().CoreFuncs;
@@ -230,22 +280,74 @@ public:
   // component
   // ==========================================================================
 
-  uint32_t addComponent(const AST::Component::Component &C) noexcept {
+  // Add a component index entry from each possible export source.
+  uint32_t addInlineComponent(const AST::Component::Component &C) noexcept {
     auto &V = getCurrentContext().Components;
     uint32_t Idx = static_cast<uint32_t>(V.size());
-    V.push_back(&C);
+    V.emplace_back(&C);
+    return Idx;
+  }
+  uint32_t
+  addDeclaredComponent(const AST::Component::ComponentType &CT) noexcept {
+    auto &V = getCurrentContext().Components;
+    uint32_t Idx = static_cast<uint32_t>(V.size());
+    V.emplace_back(&CT);
+    return Idx;
+  }
+  uint32_t addOpaqueComponent() noexcept {
+    auto &V = getCurrentContext().Components;
+    uint32_t Idx = static_cast<uint32_t>(V.size());
+    V.emplace_back();
     return Idx;
   }
 
-  uint32_t addComponent() noexcept {
-    auto &V = getCurrentContext().Components;
-    uint32_t Idx = static_cast<uint32_t>(V.size());
-    V.push_back(nullptr);
-    return Idx;
-  }
-
+  // Inline component AST, or nullptr if the entry is a componenttype or
+  // opaque.
   const AST::Component::Component *getComponent(uint32_t Idx) const noexcept {
-    return getCurrentContext().Components.at(Idx);
+    const auto &E = getCurrentContext().Components.at(Idx);
+    const auto *P = std::get_if<const AST::Component::Component *>(&E);
+    return P != nullptr ? *P : nullptr;
+  }
+
+  // Declared componenttype, or nullptr if the entry is a raw AST or opaque.
+  const AST::Component::ComponentType *
+  getComponentType(uint32_t Idx) const noexcept {
+    const auto &E = getCurrentContext().Components.at(Idx);
+    const auto *P = std::get_if<const AST::Component::ComponentType *>(&E);
+    return P != nullptr ? *P : nullptr;
+  }
+
+  // The scope an outer alias targets: Ct parent hops up. nullptr if Ct
+  // exceeds the enclosing depth.
+  const Context *resolveOuterContext(uint32_t Ct) const noexcept {
+    uint32_t Hops = 0;
+    const Context *T = &getCurrentContext();
+    while (Ct > Hops && T != nullptr) {
+      T = T->Parent;
+      ++Hops;
+    }
+    return T;
+  }
+
+  // Reproduce an outer-aliased core module's export source into the alias's
+  // slot DstIdx, so its exports stay enumerable when the alias is instantiated.
+  void carryOuterCoreModule(uint32_t DstIdx, uint32_t Ct,
+                            uint32_t SrcIdx) noexcept {
+    const Context *O = resolveOuterContext(Ct);
+    auto &Dst = getCurrentContext().CoreModules;
+    if (O != nullptr && SrcIdx < O->CoreModules.size() && DstIdx < Dst.size()) {
+      Dst[DstIdx] = O->CoreModules[SrcIdx];
+    }
+  }
+
+  // Component analogue of carryOuterCoreModule.
+  void carryOuterComponent(uint32_t DstIdx, uint32_t Ct,
+                           uint32_t SrcIdx) noexcept {
+    const Context *O = resolveOuterContext(Ct);
+    auto &Dst = getCurrentContext().Components;
+    if (O != nullptr && SrcIdx < O->Components.size() && DstIdx < Dst.size()) {
+      Dst[DstIdx] = O->Components[SrcIdx];
+    }
   }
 
   // ==========================================================================

--- a/lib/validator/component_context.cpp
+++ b/lib/validator/component_context.cpp
@@ -56,7 +56,7 @@ uint32_t ComponentContext::incSortIndexSize(Sort::SortType ST) noexcept {
   case Sort::SortType::Type:
     return addType();
   case Sort::SortType::Component:
-    return addComponent();
+    return addOpaqueComponent();
   case Sort::SortType::Instance:
     return addInstance();
   default:
@@ -80,7 +80,7 @@ ComponentContext::incCoreSortIndexSize(Sort::CoreSortType ST) noexcept {
   case Sort::CoreSortType::Type:
     return addCoreType();
   case Sort::CoreSortType::Module:
-    return addCoreModule();
+    return addOpaqueCoreModule();
   case Sort::CoreSortType::Instance:
     return addCoreInstance();
   default:

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -119,6 +119,62 @@ void populateInstanceFromType(ComponentContext &Ctx, uint32_t InstIdx,
   }
 }
 
+// Populate a core:instance from a moduletype's exportdecls (name to
+// ExternalType), for instantiating an imported/aliased core module.
+void populateCoreInstanceFromModuleType(ComponentContext &Ctx, uint32_t InstIdx,
+                                        const AST::Component::CoreDefType &MT) {
+  for (const auto &Decl : MT.getModuleType()) {
+    if (!Decl.isExport()) {
+      continue;
+    }
+    const auto &Exp = Decl.getExport();
+    const auto ImpDesc = Exp.getImportDesc();
+    ExternalType ET;
+    if (ImpDesc.isFunc()) {
+      ET = ExternalType::Function;
+    } else if (ImpDesc.isTable()) {
+      ET = ExternalType::Table;
+    } else if (ImpDesc.isMemory()) {
+      ET = ExternalType::Memory;
+    } else if (ImpDesc.isGlobal()) {
+      ET = ExternalType::Global;
+    } else if (ImpDesc.isTag()) {
+      ET = ExternalType::Tag;
+    } else {
+      continue;
+    }
+    Ctx.addCoreInstanceExport(InstIdx, Exp.getName(), ET);
+  }
+}
+
+// Populate an instance from a componenttype's exportdecls (name to sort), for
+// instantiating an imported/aliased component. Like populateInstanceFromType,
+// but a componenttype's exports arrive as `instancedecl`s holding an
+// `exportdecl`.
+void populateInstanceFromComponentType(
+    ComponentContext &Ctx, uint32_t InstIdx,
+    const AST::Component::ComponentType &CT) {
+  for (const auto &CDecl : CT.getDecl()) {
+    if (!CDecl.isInstanceDecl()) {
+      continue;
+    }
+    const auto &IDecl = CDecl.getInstance();
+    if (!IDecl.isExportDecl()) {
+      continue;
+    }
+    const auto &Exp = IDecl.getExport();
+    auto ST = descTypeToSortType(Exp.getExternDesc().getDescType());
+    if (!ST.has_value()) {
+      // `(core module)` export: InstanceExport::ST is component-side only.
+      // Skip symmetrically with populateInstanceFromType.
+      continue;
+    }
+    // TODO(B): resolve a nested InstanceType for instance-typed exports so
+    // multi-level alias-export can chase through it; single-level works now.
+    Ctx.addInstanceExport(InstIdx, Exp.getName(), *ST, /*IT=*/nullptr);
+  }
+}
+
 // Returns the first export in `RequiredIT` missing from the instance at
 // `ProvidedInstIdx`, or whose stored SortType doesn't match the required
 // sort kind. nullopt ⇒ Provided is a sort-kind subtype of RequiredIT.
@@ -277,7 +333,7 @@ Validator::validate(const AST::Component::CoreModuleSection &ModSec) noexcept {
     return E;
   }));
   const_cast<AST::Module &>(ModSec.getContent()).setIsValidated();
-  CompCtx.addCoreModule(ModSec.getContent());
+  CompCtx.addInlineCoreModule(ModSec.getContent());
   return {};
 }
 
@@ -309,7 +365,7 @@ Validator::validate(const AST::Component::ComponentSection &CompSec) noexcept {
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Sec_Component));
     return E;
   }));
-  CompCtx.addComponent(CompSec.getContent());
+  CompCtx.addInlineComponent(CompSec.getContent());
   return {};
 }
 
@@ -332,10 +388,26 @@ Validator::validate(const AST::Component::AliasSection &AliasSec) noexcept {
       return E;
     }));
     const auto &Sort = Alias.getSort();
+    const bool IsOuter =
+        Alias.getTargetType() == AST::Component::Alias::TargetType::Outer;
     if (Sort.isCore()) {
-      CompCtx.incCoreSortIndexSize(Sort.getCoreSortType());
+      uint32_t NewCoreIdx =
+          CompCtx.incCoreSortIndexSize(Sort.getCoreSortType());
+      // Carry the outer-aliased module's export source so the alias stays
+      // enumerable when instantiated.
+      if (IsOuter && Sort.getCoreSortType() ==
+                         AST::Component::Sort::CoreSortType::Module) {
+        CompCtx.carryOuterCoreModule(NewCoreIdx, Alias.getOuter().first,
+                                     Alias.getOuter().second);
+      }
     } else {
       uint32_t NewIdx = CompCtx.incSortIndexSize(Sort.getSortType());
+      if (IsOuter &&
+          Sort.getSortType() == AST::Component::Sort::SortType::Component) {
+        // Component analogue of the outer core-module carry above.
+        CompCtx.carryOuterComponent(NewIdx, Alias.getOuter().first,
+                                    Alias.getOuter().second);
+      }
       // If the alias creates a new instance entry out of an `alias export`
       // on another instance, propagate the source instance's export table
       // into the new slot so a subsequent `alias export` on this slot can
@@ -498,7 +570,14 @@ Validator::validate(const AST::Component::CoreInstance &Inst) noexcept {
         CompCtx.addCoreInstanceExport(InstanceIdx, ExportDesc.getExternalName(),
                                       ExportDesc.getExternalType());
       }
+    } else if (const auto *MT = CompCtx.getCoreModuleType(ModIdx)) {
+      // Imported / aliased core module: bind exports from its moduletype.
+      // TODO(B): arg-check against MT's importdecls (only inline modules are
+      // arg-checked above).
+      uint32_t InstanceIdx = CompCtx.addCoreInstance();
+      populateCoreInstanceFromModuleType(CompCtx, InstanceIdx, *MT);
     } else {
+      // Opaque module: exports not enumerable; leave the instance empty.
       CompCtx.addCoreInstance();
     }
   } else if (Inst.isInlineExport()) {
@@ -721,6 +800,11 @@ Validator::validate(const AST::Component::Instance &Inst) noexcept {
                                     ExpSort.getSortType(), IT);
         }
       }
+    } else if (const auto *CT = CompCtx.getComponentType(CompIdx)) {
+      // Imported / aliased component: bind exports from its componenttype.
+      // TODO(B): arg-check against CT's importdecls (only inline components are
+      // arg-checked above).
+      populateInstanceFromComponentType(CompCtx, InstanceIdx, *CT);
     }
   } else if (Inst.isInlineExport()) {
     // Allocate the instance first so exports can be registered on it.
@@ -792,17 +876,12 @@ Expect<void> Validator::validate(const AST::Component::CoreAlias &A) noexcept {
   uint32_t Ct = A.getComponentJump();
   uint32_t Idx = A.getIndex();
 
-  uint32_t OutLinkCompCnt = 0;
-  const auto *TargetCtx = &CompCtx.getCurrentContext();
-  while (Ct > OutLinkCompCnt && TargetCtx != nullptr) {
-    TargetCtx = TargetCtx->Parent;
-    OutLinkCompCnt++;
-  }
+  const auto *TargetCtx = CompCtx.resolveOuterContext(Ct);
   if (TargetCtx == nullptr) {
     spdlog::error(ErrCode::Value::InvalidIndex);
     spdlog::error(
-        "    CoreAlias: outer count {} exceeds enclosing component count {}"sv,
-        Ct, OutLinkCompCnt);
+        "    CoreAlias: outer count {} exceeds enclosing component count"sv,
+        Ct);
     return Unexpect(ErrCode::Value::InvalidIndex);
   }
 
@@ -929,17 +1008,12 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
     const auto Ct = Alias.getOuter().first;
     const auto Idx = Alias.getOuter().second;
 
-    uint32_t OutLinkCompCnt = 0;
-    const auto *TargetCtx = &CompCtx.getCurrentContext();
-    while (Ct > OutLinkCompCnt && TargetCtx != nullptr) {
-      TargetCtx = TargetCtx->Parent;
-      OutLinkCompCnt++;
-    }
+    const auto *TargetCtx = CompCtx.resolveOuterContext(Ct);
     if (TargetCtx == nullptr) {
       spdlog::error(ErrCode::Value::InvalidIndex);
       spdlog::error(
-          "    Alias outer: Component out-link count {} is exceeding the enclosing component count {}"sv,
-          Ct, OutLinkCompCnt);
+          "    Alias outer: Component out-link count {} is exceeding the enclosing component count"sv,
+          Ct);
       return Unexpect(ErrCode::Value::InvalidIndex);
     }
 
@@ -1020,8 +1094,10 @@ Validator::validate(const AST::Component::CoreDefType &DType) noexcept {
       }));
     }
     CompCtx.exitComponent();
-    // Module type also gets an entry in core:type (nullptr — not a SubType).
-    CompCtx.addCoreType();
+    // Module type takes a core:type slot (nullptr — not a SubType) and is
+    // recorded so an imported `(core module (type i))` can recover its exports.
+    uint32_t TIdx = CompCtx.addCoreType();
+    CompCtx.recordCoreModuleTypeDef(TIdx, DType);
   } else {
     assumingUnreachable();
   }
@@ -1636,8 +1712,13 @@ Validator::validate(const AST::Component::ExternDesc &Desc) noexcept {
   switch (Desc.getDescType()) {
   case AST::Component::ExternDesc::DescType::CoreType:
     // The CoreType externdesc is `(core module (type i))`, so it introduces
-    // a new core module index, not a core type.
-    CompCtx.addCoreModule();
+    // a new core module index, not a core type. Carry the referenced
+    // moduletype so instance definitions can enumerate the module's exports.
+    if (const auto *MT = CompCtx.getCoreModuleTypeDef(Desc.getTypeIndex())) {
+      CompCtx.addDeclaredCoreModule(*MT);
+    } else {
+      CompCtx.addOpaqueCoreModule();
+    }
     break;
   case AST::Component::ExternDesc::DescType::FuncType:
     CompCtx.addFunc();
@@ -1669,7 +1750,14 @@ Validator::validate(const AST::Component::ExternDesc &Desc) noexcept {
     }
     break;
   case AST::Component::ExternDesc::DescType::ComponentType:
-    CompCtx.addComponent();
+    // Carry the referenced componenttype so instance definitions that
+    // instantiate this imported component can enumerate its exports.
+    if (const auto *DT = CompCtx.getDefType(Desc.getTypeIndex());
+        DT != nullptr && DT->isComponentType()) {
+      CompCtx.addDeclaredComponent(DT->getComponentType());
+    } else {
+      CompCtx.addOpaqueComponent();
+    }
     break;
   case AST::Component::ExternDesc::DescType::InstanceType: {
     uint32_t InstIdx = CompCtx.addInstance();
@@ -1817,7 +1905,9 @@ Validator::validate(const AST::Component::ExportDecl &Decl) noexcept {
   case AST::Component::ExternDesc::DescType::CoreType:
     // The CoreType externdesc is `(core module (type i))`, so it introduces
     // a new core module index, not a core type.
-    CompCtx.addCoreModule();
+    // TODO(B): carry the moduletype (like the top-level import path) once
+    // type-body type-index scoping is resolved; opaque for now.
+    CompCtx.addOpaqueCoreModule();
     break;
   case AST::Component::ExternDesc::DescType::FuncType:
     CompCtx.addFunc();
@@ -1842,7 +1932,9 @@ Validator::validate(const AST::Component::ExportDecl &Decl) noexcept {
     break;
   }
   case AST::Component::ExternDesc::DescType::ComponentType:
-    CompCtx.addComponent();
+    // TODO(B): carry the componenttype (like the top-level import path) once
+    // type-body type-index scoping is resolved; opaque for now.
+    CompCtx.addOpaqueComponent();
     break;
   case AST::Component::ExternDesc::DescType::InstanceType: {
     // Populate the new instance slot with the referenced InstanceType's

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -318,7 +318,7 @@ std::map<std::string, ComponentModelSupport> ComponentModelFolders = {
     // Test table: the testing status of load, validate, instantiate, and execute.
     {"adapt",                   {true, false, false, false}},
     {"alias",                   {true, false, false, false}},
-    {"big",                     {true, false, false, false}},
+    {"big",                     {true, true,  false, false}},
     {"definedtypes",            {true, true,  true,  false}},
     {"empty",                   {true, true,  true,  false}},
     {"example",                 {true, true,  true,  false}},
@@ -327,7 +327,7 @@ std::map<std::string, ComponentModelSupport> ComponentModelFolders = {
     {"export-introduces-alias", {true, true,  true,  false}},
     {"func",                    {true, false, false, false}},
     {"import",                  {true, false, false, false}},
-    {"imports-exports",         {true, false, false, false}},
+    {"imports-exports",         {true, true,  false, false}},
     {"inline-exports",          {true, true,  true,  false}},
     {"instance-types",          {true, true,  true,  false}},
     {"instantiate",             {true, false, false, false}},
@@ -336,7 +336,7 @@ std::map<std::string, ComponentModelSupport> ComponentModelFolders = {
     {"lots-of-aliases",         {true, true,  true,  false}},
     {"lower",                   {true, false, false, false}},
     {"memory64",                {true, false, false, false}},
-    {"module-link",             {true, false, false, false}},
+    {"module-link",             {true, true,  false, false}},
     {"more-flags",              {true, true,  true,  false}},
     {"naming",                  {true, false, false, false}},
     {"nested-modules",          {true, false, false, false}},
@@ -345,7 +345,7 @@ std::map<std::string, ComponentModelSupport> ComponentModelFolders = {
     {"type-export-restrictions",{true, false, false, false}},
     {"types",                   {true, false, false, false}},
     {"very-nested",             {true, false, false, false}},
-    {"virtualize",              {true, false, false, false}},
+    {"virtualize",              {true, true,  false, false}},
 };
 // clang-format on
 


### PR DESCRIPTION
Component instance definitions could not resolve an alias-export into an instance produced by instantiating an imported, declared, or outer-aliased core module / component. The validator only derived instance exports from a locally-defined module/component's inline AST, so every other case got an empty export table and failed validation with "export not found".

Carry an export source on each core:module and component index entry as a variant (inline AST | declared moduletype/componenttype | opaque), keeping the entry's AST and type index-aligned and the "exactly one source" invariant unrepresentable-otherwise. Exports then stay enumerable however the module/component entered the index space:

- record an imported `(core module (type i))` / `(component (type i))`'s declared type at registration, and populate the instance's exports from it at instantiation;
- reproduce an outer-aliased module/component's export source into the aliasing scope's closure.

Enables the validate phase for the big, imports-exports, module-link, and virtualize component-model spec tests. Argument type-compatibility against the declared import types and nested instance-typed export resolution remain follow-ups (marked TODO(B)).

## Description

Fix the corner case about export from instance in spec test.

## Checklist

Before submitting this PR, please ensure the following:

- [ ] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [ ] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
