### PR TITLE
fix: reject non-funcref tables/refs in call_indirect and call_ref

### DIFF
--- a/include/common/types.h
+++ b/include/common/types.h
@@ -689,6 +689,9 @@ inline ValVariant ValueFromType(ValType Type) noexcept {
 
 inline const Runtime::Instance::FunctionInstance *
 retrieveFuncRef(const RefVariant &Val) {
+  if (!Val.getType().isFuncRefType()) {
+    return nullptr;
+  }
   return Val.getPtr<Runtime::Instance::FunctionInstance>();
 }
 

--- a/lib/executor/engine/controlInstr.cpp
+++ b/lib/executor/engine/controlInstr.cpp
@@ -172,7 +172,8 @@ Expect<void> Executor::runCallRefOp(Runtime::StackManager &StackMgr,
                                     AST::InstrView::iterator &PC,
                                     bool IsTailCall) noexcept {
   const auto Ref = StackMgr.pop().get<RefVariant>();
-  if (Ref.isNull()) {
+  const auto *FuncInst = retrieveFuncRef(Ref);
+  if (FuncInst == nullptr) {
     spdlog::error(ErrCode::Value::AccessNullFunc);
     spdlog::error(
         ErrInfo::InfoInstruction(Instr.getOpCode(), Instr.getOffset()));
@@ -180,7 +181,6 @@ Expect<void> Executor::runCallRefOp(Runtime::StackManager &StackMgr,
   }
 
   // Get Function address.
-  const auto *FuncInst = retrieveFuncRef(Ref);
   EXPECTED_TRY(auto NextPC,
                enterFunction(StackMgr, *FuncInst, PC + 1, IsTailCall));
   PC = NextPC - 1;
@@ -213,7 +213,8 @@ Expect<void> Executor::runCallIndirectOp(Runtime::StackManager &StackMgr,
 
   // Get function address. The bound is guaranteed.
   RefVariant Ref = *TabInst->getRefAddr(Idx);
-  if (Ref.isNull()) {
+  const auto *FuncInst = retrieveFuncRef(Ref);
+  if (FuncInst == nullptr) {
     spdlog::error(ErrCode::Value::UninitializedElement);
     spdlog::error(ErrInfo::InfoInstruction(Instr.getOpCode(), Instr.getOffset(),
                                            {Idx},
@@ -222,7 +223,6 @@ Expect<void> Executor::runCallIndirectOp(Runtime::StackManager &StackMgr,
   }
 
   // Check function type.
-  const auto *FuncInst = retrieveFuncRef(Ref);
   bool IsMatch = false;
   if (FuncInst->getModule()) {
     IsMatch = AST::TypeMatcher::matchType(

--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -628,7 +628,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
     auto T = Instr.getSourceIndex();
     // Check source table index.
     EXPECTED_TRY(checkTableIdx(T));
-    if (unlikely(!Tables[T].second.isFuncRefType())) {
+    if (!AST::TypeMatcher::matchType(Types, TypeCode::FuncRef,
+                                     Tables[T].second)) {
       spdlog::error(ErrCode::Value::TypeCheckFailed);
       spdlog::error(ErrInfo::InfoMismatch(TypeCode::FuncRef, Tables[T].second));
       return Unexpect(ErrCode::Value::TypeCheckFailed);
@@ -661,7 +662,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
     auto T = Instr.getSourceIndex();
     // Check source table index.
     EXPECTED_TRY(checkTableIdx(T));
-    if (unlikely(!Tables[T].second.isFuncRefType())) {
+    if (!AST::TypeMatcher::matchType(Types, TypeCode::FuncRef,
+                                     Tables[T].second)) {
       spdlog::error(ErrCode::Value::TypeCheckFailed);
       spdlog::error(ErrInfo::InfoMismatch(TypeCode::FuncRef, Tables[T].second));
       return Unexpect(ErrCode::Value::TypeCheckFailed);

--- a/test/executor/ExecutorRegressionTest.cpp
+++ b/test/executor/ExecutorRegressionTest.cpp
@@ -482,6 +482,39 @@ std::array<WasmEdge::Byte, 134> ThrowRefMultiParamWasm{
     0x00, 0x03, 0x65, 0x78, 0x6e, 0x03, 0x0b, 0x01, 0x00, 0x02, 0x00, 0x02,
     0x68, 0x31, 0x02, 0x02, 0x68, 0x32, 0x0b, 0x06, 0x01, 0x00, 0x03, 0x65,
     0x72, 0x72};
+
+/// Binary Wasm module: call_indirect on a table whose element type is a
+/// concrete struct reference, not a funcref subtype.
+///
+/// The table is `(ref null $s)` where `$s` is a struct type, so it is NOT a
+/// subtype of funcref and call_indirect on it must be rejected at validation.
+/// The old check used `ValType::isFuncRefType()`, which reported *any* concrete
+/// type index as a funcref. The module therefore validated, and at runtime the
+/// struct reference was reinterpreted as a `FunctionInstance *` -- a type
+/// confusion in which the attacker-controlled v128 field bytes (here 0x41.. /
+/// 0x49) stand in for function metadata. The fix validates the table type with
+/// `TypeMatcher::matchType(.., FuncRef, ..)`, which resolves the concrete type
+/// index and rejects the struct-typed table.
+///
+/// (module
+///   (type $f (func))
+///   (type $s (struct (field v128)))
+///   (table 1 (ref null $s))
+///   (func (export "_start")
+///     i32.const 0
+///     v128.const i32x4 0x41414141 0x41414141 0x41414149 0x41414141
+///     struct.new $s
+///     table.set 0
+///     i32.const 0
+///     call_indirect (type $f)))
+std::array<WasmEdge::Byte, 77> CallIndirectStructTableWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x60,
+    0x00, 0x00, 0x5f, 0x01, 0x7b, 0x00, 0x03, 0x02, 0x01, 0x00, 0x04, 0x05,
+    0x01, 0x63, 0x01, 0x00, 0x01, 0x07, 0x0a, 0x01, 0x06, 0x5f, 0x73, 0x74,
+    0x61, 0x72, 0x74, 0x00, 0x00, 0x0a, 0x22, 0x01, 0x20, 0x00, 0x41, 0x00,
+    0xfd, 0x0c, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x49, 0x41,
+    0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0xfb, 0x00, 0x01, 0x26, 0x00, 0x41,
+    0x00, 0x11, 0x00, 0x00, 0x0b};
 // clang-format on
 
 /// Regression test for ref.test on externalized nullable references.
@@ -936,6 +969,27 @@ TEST(ExecutorRegression, ThrowRefPreservesPayload) {
     ASSERT_EQ((*Result).size(), 1U);
     EXPECT_EQ((*Result)[0].first.get<uint32_t>(), 1007U);
   }
+}
+
+/// Regression test for call_indirect on a non-funcref table (type confusion).
+///
+/// A table whose element type is a concrete struct reference is not a funcref
+/// subtype, so call_indirect on it must be rejected by validation. Before the
+/// fix, ValType::isFuncRefType() accepted any concrete type index, so the
+/// module passed validation and the executor reinterpreted the struct
+/// reference as a FunctionInstance pointer -- with the v128 struct field bytes
+/// acting as a forged function pointer. The validator now resolves the
+/// concrete type via TypeMatcher and rejects the module before it can run.
+TEST(ExecutorRegression, CallIndirectNonFuncTable) {
+  Configure Conf;
+  VM::VM VM(Conf);
+  // The module is well-formed and loads successfully...
+  ASSERT_TRUE(VM.loadWasm(CallIndirectStructTableWasm));
+  // ... but validation must reject call_indirect on the (ref null $s) table
+  // instead of letting the struct reference reach the executor as a function.
+  auto Result = VM.validate();
+  ASSERT_FALSE(Result);
+  EXPECT_EQ(Result.error(), ErrCode::Value::TypeCheckFailed);
 }
 
 } // namespace


### PR DESCRIPTION
## Description

A table whose element type is a concrete non-funcref reference (e.g. `(ref null $s)` for a struct type) passed validation because the checks used `ValType::isFuncRefType()`, which treats any concrete type index as a funcref. Such a module would then reinterpret the struct reference as a `FunctionInstance *` at runtime -- a type confusion where attacker- controlled field bytes stand in for function metadata.

Resolve the concrete type via `TypeMatcher::matchType(.., FuncRef, ..)` in the table.set/call_indirect validator path, and harden the executor so `retrieveFuncRef` returns nullptr for non-funcref references, making `call_ref`/`call_indirect` raise a null-function trap instead of dereferencing a forged pointer.

Add a regression test covering call_indirect on a struct-typed table.

## Checklist

Before submitting this PR, please ensure the following:

- [ ] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [ ] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
