### PR TITLE
fix(test/llvm): drop redundant libs from wasmedgeLazyJITTests

### DIFF
--- a/test/llvm/CMakeLists.txt
+++ b/test/llvm/CMakeLists.txt
@@ -21,9 +21,6 @@ add_test(wasmedgeLazyJITTests wasmedgeLazyJITTests)
 
 target_link_libraries(wasmedgeLazyJITTests
   PRIVATE
-  wasmedgeCommon
-  wasmedgeLoader
-  wasmedgeValidator
   wasmedgeVM
   GTest::gtest
 )


### PR DESCRIPTION
wasmedgeVM already PUBLIC-links wasmedgeCommon, wasmedgeLoader and wasmedgeValidator, so listing them again on wasmedgeLazyJITTests put each archive on the link line twice and produced the macOS linker warning "ld: warning: ignoring duplicate libraries". Link wasmedgeVM alone, matching every other wasmedgeVM-consuming target in the tree.

## Checklist

Before submitting this PR, please ensure the following:

- [ ] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [ ] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
