### PR TITLE
fix(plugins/opencvmini): bound-check guest buffer length in host funcs

### DIFF
--- a/plugins/wasmedge_opencvmini/opencvmini_func.cpp
+++ b/plugins/wasmedge_opencvmini/opencvmini_func.cpp
@@ -24,9 +24,12 @@ WasmEdgeOpenCVMiniImdecode::body(const Runtime::CallingFrame &Frame,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  char *Buf = MemInst->getPointer<char *>(BufPtr);
+  auto Buf = MemInst->getSpan<char>(BufPtr, BufLen);
+  if (unlikely(Buf.size() != BufLen)) {
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
 
-  std::vector<char> Content(Buf, Buf + BufLen);
+  std::vector<char> Content(Buf.begin(), Buf.end());
   cv::Mat Img = cv::imdecode(cv::InputArray(Content), cv::IMREAD_COLOR);
 
   return Env.insertMat(Img);
@@ -44,8 +47,11 @@ Expect<void> WasmEdgeOpenCVMiniImshow::body(const Runtime::CallingFrame &Frame,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  char *Buf = MemInst->getPointer<char *>(WindowNamePtr);
-  std::copy_n(Buf, WindowNameLen, std::back_inserter(WindowName));
+  auto Buf = MemInst->getSpan<char>(WindowNamePtr, WindowNameLen);
+  if (unlikely(Buf.size() != WindowNameLen)) {
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
+  std::copy_n(Buf.data(), WindowNameLen, std::back_inserter(WindowName));
 
   if (auto Img = Env.getMat(MatKey); Img) {
     cv::imshow(WindowName.c_str(), *Img);
@@ -186,8 +192,12 @@ Expect<void> WasmEdgeOpenCVMiniImwrite::body(const Runtime::CallingFrame &Frame,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  char *Buf = MemInst->getPointer<char *>(TargetFileNamePtr);
-  std::copy_n(Buf, TargetFileNameLen, std::back_inserter(TargetFileName));
+  auto Buf = MemInst->getSpan<char>(TargetFileNamePtr, TargetFileNameLen);
+  if (unlikely(Buf.size() != TargetFileNameLen)) {
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
+  std::copy_n(Buf.data(), TargetFileNameLen,
+              std::back_inserter(TargetFileName));
 
   if (auto Img = Env.getMat(MatKey); Img) {
     cv::imwrite(TargetFileName.c_str(), *Img);
@@ -203,8 +213,11 @@ Expect<void> WasmEdgeOpenCVMiniImencode::body(
 
   auto *MemInst = Frame.getMemoryByIndex(0);
 
-  char *Buf = MemInst->getPointer<char *>(ExtPtr);
-  std::copy_n(Buf, ExtLen, std::back_inserter(Ext));
+  auto Buf = MemInst->getSpan<char>(ExtPtr, ExtLen);
+  if (unlikely(Buf.size() != ExtLen)) {
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
+  std::copy_n(Buf.data(), ExtLen, std::back_inserter(Ext));
 
   auto Img = Env.getMat(MatKey);
   if (!Img) {


### PR DESCRIPTION
## Description

The `wasmedge_opencvmini` host functions `imdecode`, `imshow`, `imwrite` and `imencode` fetched the guest input buffer with `MemInst->getPointer<char *>(Ptr)`. That call only bounds-checks one byte at `Ptr`, then the code read a fully guest-controlled length (`BufLen` / `WindowNameLen` / `TargetFileNameLen` / `ExtLen`) starting from that pointer.

A length larger than the guest allocation reads past the end of the WebAssembly linear memory into adjacent host process memory, i.e. an out-of-bounds read / information leak.

Fixed at all four sites by fetching the input with `getSpan<char>(Ptr, Len)` and returning `HostFuncError` when the returned span size does not equal the requested length. This mirrors the output-buffer `getSpan` check that already exists in `imencode`.

## Checklist

- [x] **DCO Signed-off**: the commit carries a `Signed-off-by` line, DCO check is green.
- [x] **Commit Messages**: `commitlint` passes on the commit (conventional commit, `fix(plugins/opencvmini): ...`).
- [x] **Local Tests Passed**: lint/format checks run clean locally, logs below.

## Test Evidence

`clang-format-20` dry-run on the changed file (this was the failing linter):

```
$ clang-format-20 -style=file -Werror --dry-run plugins/wasmedge_opencvmini/opencvmini_func.cpp
$ echo $?
0
```

`commitlint` on the commit message:

```
$ git log -1 --format=%B | npx commitlint --verbose
⧗   input: fix(plugins/opencvmini): bound-check guest buffer length in host funcs
✔   found 0 problems, 0 warnings
```

The plugin needs OpenCV to compile, so the full functional build is left to CI.
