### PR TITLE
feat(wasi_crypto): implement EdDSA public key verification

### DIFF
--- a/plugins/wasi_crypto/signatures/eddsa.cpp
+++ b/plugins/wasi_crypto/signatures/eddsa.cpp
@@ -35,7 +35,15 @@ Eddsa::PublicKey::import(Span<const uint8_t> Encoded,
 }
 
 WasiCryptoExpect<void> Eddsa::PublicKey::verify() const noexcept {
-  return WasiCryptoUnexpect(__WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
+  EvpPkeyCtxPtr CheckCtx{EVP_PKEY_CTX_new(Ctx.get(), nullptr)};
+  ensureOrReturn(CheckCtx, __WASI_CRYPTO_ERRNO_ALGORITHM_FAILURE);
+  // EVP_PKEY_public_check() returns 1 for a valid key and 0 for an invalid
+  // one. A negative value means the check is unsupported for this key type
+  // (e.g. Ed25519 on OpenSSL 1.1.1), so only an explicit 0 is treated as
+  // invalid.
+  ensureOrReturn(EVP_PKEY_public_check(CheckCtx.get()) != 0,
+                 __WASI_CRYPTO_ERRNO_INVALID_KEY);
+  return {};
 }
 
 WasiCryptoExpect<std::vector<uint8_t>> Eddsa::PublicKey::exportData(

--- a/test/plugins/wasi_crypto/signatures.cpp
+++ b/test/plugins/wasi_crypto/signatures.cpp
@@ -52,6 +52,27 @@ TEST_F(WasiCryptoTest, Signatures) {
   SigTest(__WASI_ALGORITHM_TYPE_SIGNATURES, "RSA_PSS_3072_SHA512"sv);
   SigTest(__WASI_ALGORITHM_TYPE_SIGNATURES, "RSA_PSS_4096_SHA512"sv);
 
+  // Verify that a generated public key is well-formed.
+  auto PublicKeyVerifyTest = [this](__wasi_algorithm_type_e_t AlgType,
+                                    std::string_view Alg) {
+    SCOPED_TRACE(Alg);
+    WASI_CRYPTO_EXPECT_SUCCESS(KpHandle,
+                               keypairGenerate(AlgType, Alg, std::nullopt));
+    WASI_CRYPTO_EXPECT_SUCCESS(PkHandle, keypairPublickey(KpHandle));
+    WASI_CRYPTO_EXPECT_TRUE(publickeyVerify(PkHandle));
+  };
+  PublicKeyVerifyTest(__WASI_ALGORITHM_TYPE_SIGNATURES, "Ed25519"sv);
+
+  // A raw public key with an invalid length is rejected on import.
+  auto PublicKeyImportInvalidTest = [this](__wasi_algorithm_type_e_t AlgType,
+                                           std::string_view Alg) {
+    SCOPED_TRACE(Alg);
+    WASI_CRYPTO_EXPECT_FAILURE(
+        publickeyImport(AlgType, Alg, "00"_u8v, __WASI_PUBLICKEY_ENCODING_RAW),
+        __WASI_CRYPTO_ERRNO_INVALID_KEY);
+  };
+  PublicKeyImportInvalidTest(__WASI_ALGORITHM_TYPE_SIGNATURES, "Ed25519"sv);
+
   auto SigEncodingTest =
       [this](
           std::string_view Alg,


### PR DESCRIPTION
## Description
Implements `Eddsa::PublicKey::verify()`, which previously returned `NOT_IMPLEMENTED`.
Uses `EVP_PKEY_public_check`, consistent with the existing RSA implementation. Part of #2669.

## Checklist
- [x] DCO Signed-off
- [x] Commit Messages follow Conventional Commits
- [x] Local Tests Passed

## Test Evidence
<img width="1469" height="147" alt="image" src="https://github.com/user-attachments/assets/95f5503b-bd9b-4222-b74d-16cf35d4df4a" />

