### PR TITLE
ci(linter): bump to clang-format-20

### DIFF
--- a/.github/workflows/reusable-call-linter.yml
+++ b/.github/workflows/reusable-call-linter.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install clang-format
         run: |
           sudo apt update
-          sudo apt install clang-format
+          sudo apt install -y clang-format-20
       - name: Run clang-format
         run: |
-          bash ./.github/scripts/clang-format.sh `which clang-format`
+          bash ./.github/scripts/clang-format.sh `which clang-format-20`

--- a/lib/system/fault.cpp
+++ b/lib/system/fault.cpp
@@ -47,7 +47,7 @@ void signalHandler(int Signal, siginfo_t *Siginfo, void *) {
 }
 
 void enableHandler() noexcept {
-  struct sigaction Action {};
+  struct sigaction Action{};
   Action.sa_sigaction = &signalHandler;
   Action.sa_flags = SA_SIGINFO;
   sigaction(SIGFPE, &Action, nullptr);

--- a/plugins/wasi_crypto/asymmetric_common/keypair.cpp
+++ b/plugins/wasi_crypto/asymmetric_common/keypair.cpp
@@ -42,7 +42,7 @@ generateKp(AsymmetricCommon::Algorithm Alg,
         return transposeOptionalRef(
                    OptOptions,
                    [](auto &&Options) noexcept
-                   -> WasiCryptoExpect<OptionalRef<RequiredOptionsType>> {
+                       -> WasiCryptoExpect<OptionalRef<RequiredOptionsType>> {
                      using InOptionsType = std::decay_t<decltype(Options)>;
                      if constexpr (std::is_same_v<InOptionsType,
                                                   RequiredOptionsType>) {

--- a/plugins/wasi_crypto/symmetric/ctx.cpp
+++ b/plugins/wasi_crypto/symmetric/ctx.cpp
@@ -202,7 +202,7 @@ Context::symmetricKeyGenerate(Symmetric::Algorithm Alg,
   auto OptSymmetricOptionsResult = transposeOptionalToRef(
       *OptOptionsResult,
       [](const auto &Options) noexcept
-      -> WasiCryptoExpect<OptionalRef<const Symmetric::Options>> {
+          -> WasiCryptoExpect<OptionalRef<const Symmetric::Options>> {
         auto *SymmetricOptions = std::get_if<Symmetric::Options>(&Options);
         if (!SymmetricOptions) {
           return WasiCryptoUnexpect(__WASI_CRYPTO_ERRNO_INVALID_HANDLE);
@@ -228,7 +228,7 @@ Context::symmetricStateOpen(Symmetric::Algorithm Alg,
   auto OptKeyResult =
       mapAndTransposeOptional(OptKeyHandle,
                               [this](__wasi_symmetric_key_t KeyHandle) noexcept
-                              -> WasiCryptoExpect<Symmetric::KeyVariant> {
+                                  -> WasiCryptoExpect<Symmetric::KeyVariant> {
                                 return SymmetricKeyManager.get(KeyHandle);
                               });
   if (!OptKeyResult) {
@@ -248,7 +248,7 @@ Context::symmetricStateOpen(Symmetric::Algorithm Alg,
   auto OptSymmetricOptionsResult = transposeOptionalToRef(
       *OptOptionsResult,
       [](const auto &Options) noexcept
-      -> WasiCryptoExpect<OptionalRef<const Symmetric::Options>> {
+          -> WasiCryptoExpect<OptionalRef<const Symmetric::Options>> {
         auto *SymmetricOptions = std::get_if<Symmetric::Options>(&Options);
         if (!SymmetricOptions) {
           return WasiCryptoUnexpect(__WASI_CRYPTO_ERRNO_INVALID_HANDLE);

--- a/plugins/wasi_crypto/symmetric/state.cpp
+++ b/plugins/wasi_crypto/symmetric/state.cpp
@@ -161,7 +161,7 @@ WasiCryptoExpect<size_t> stateEncrypt(StateVariant &StateVariant,
               return checkedAdd(DataSize, TagLen);
             })
             .and_then([Out, Data, &State](size_t ActualDataLen) noexcept
-                      -> WasiCryptoExpect<size_t> {
+                          -> WasiCryptoExpect<size_t> {
               ensureOrReturn(Out.size() == ActualDataLen,
                              __WASI_CRYPTO_ERRNO_INVALID_LENGTH);
               return State.encrypt(Out, Data);
@@ -189,7 +189,7 @@ WasiCryptoExpect<size_t> stateDecrypt(StateVariant &StateVariant,
               return checkedAdd(OutSize, TagLen);
             })
             .and_then([Out, Data, &State](size_t ActualOutLen) noexcept
-                      -> WasiCryptoExpect<size_t> {
+                          -> WasiCryptoExpect<size_t> {
               ensureOrReturn(Data.size() == ActualOutLen,
                              __WASI_CRYPTO_ERRNO_INVALID_LENGTH);
               return State.decrypt(Out, Data);


### PR DESCRIPTION
## Description

Ensure that the CI uses a pinned clang-format version, 20.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.
