### PR TITLE
fix: implement EdDSA public key verification

### DIFF
--- a/plugins/wasi_crypto/signatures/eddsa.cpp
+++ b/plugins/wasi_crypto/signatures/eddsa.cpp
@@ -35,7 +35,11 @@ Eddsa::PublicKey::import(Span<const uint8_t> Encoded,
 }
 
 WasiCryptoExpect<void> Eddsa::PublicKey::verify() const noexcept {
-  return WasiCryptoUnexpect(__WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
+  EvpPkeyCtxPtr PkCtx(EVP_PKEY_CTX_new(Ctx.get(), nullptr));
+  opensslCheck(PkCtx);
+  ensureOrReturn(EVP_PKEY_public_check(PkCtx.get()),
+                  __WASI_CRYPTO_ERRNO_INVALID_KEY);
+  return {};
 }
 
 WasiCryptoExpect<std::vector<uint8_t>> Eddsa::PublicKey::exportData(


### PR DESCRIPTION
## Description
1.) Added EVP_PKEY_public_check() to validate the public component provided by the parameter\
2.) Added opensslCheck for checking if openssl calls have succeeded, following the pattern of generate function in the same file
3.) Made sure the verification followed a consistent pattern with rsa public key verification.
4.) Added EVP_PKEY_CTX_new for memory management and type conversion.

Links with: #2669

## Checklist

I have ensured that:

- [X] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [X] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [X] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<img width="909" height="181" alt="image" src="https://github.com/user-attachments/assets/2dcb7ca5-e83b-4503-a252-5fc1751276e8" />