### PR TITLE
feat(wasi_crypto): implement ECDSA public key verification

### DIFF
--- a/plugins/wasi_crypto/asymmetric_common/ecdsa.h
+++ b/plugins/wasi_crypto/asymmetric_common/ecdsa.h
@@ -82,7 +82,14 @@ public:
     }
 
     WasiCryptoExpect<void> verify() const noexcept {
-      return WasiCryptoUnexpect(__WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
+      EvpPkeyCtxPtr CheckCtx{EVP_PKEY_CTX_new(Ctx.get(), nullptr)};
+      ensureOrReturn(CheckCtx, __WASI_CRYPTO_ERRNO_ALGORITHM_FAILURE);
+      // EVP_PKEY_public_check() returns 1 for a valid key and 0 for an invalid
+      // one. A negative value means the check is unsupported for this key type
+      // (e.g. on OpenSSL 1.1.1), so only an explicit 0 is treated as invalid.
+      ensureOrReturn(EVP_PKEY_public_check(CheckCtx.get()) != 0,
+                     __WASI_CRYPTO_ERRNO_INVALID_KEY);
+      return {};
     }
 
   protected:

--- a/test/plugins/wasi_crypto/signatures.cpp
+++ b/test/plugins/wasi_crypto/signatures.cpp
@@ -62,6 +62,9 @@ TEST_F(WasiCryptoTest, Signatures) {
     WASI_CRYPTO_EXPECT_TRUE(publickeyVerify(PkHandle));
   };
   PublicKeyVerifyTest(__WASI_ALGORITHM_TYPE_SIGNATURES, "Ed25519"sv);
+  PublicKeyVerifyTest(__WASI_ALGORITHM_TYPE_SIGNATURES, "ECDSA_P256_SHA256"sv);
+  PublicKeyVerifyTest(__WASI_ALGORITHM_TYPE_SIGNATURES, "ECDSA_K256_SHA256"sv);
+  PublicKeyVerifyTest(__WASI_ALGORITHM_TYPE_SIGNATURES, "ECDSA_P384_SHA384"sv);
 
   // A raw public key with an invalid length is rejected on import.
   auto PublicKeyImportInvalidTest = [this](__wasi_algorithm_type_e_t AlgType,
@@ -72,6 +75,21 @@ TEST_F(WasiCryptoTest, Signatures) {
         __WASI_CRYPTO_ERRNO_INVALID_KEY);
   };
   PublicKeyImportInvalidTest(__WASI_ALGORITHM_TYPE_SIGNATURES, "Ed25519"sv);
+
+  // A SEC1 public key whose point is not on the curve is rejected on import.
+  auto PublicKeyImportInvalidSecTest = [this](__wasi_algorithm_type_e_t AlgType,
+                                              std::string_view Alg) {
+    SCOPED_TRACE(Alg);
+    WASI_CRYPTO_EXPECT_FAILURE(
+        publickeyImport(
+            AlgType, Alg,
+            "04ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"_u8v,
+            __WASI_PUBLICKEY_ENCODING_SEC),
+        __WASI_CRYPTO_ERRNO_INVALID_KEY);
+  };
+  PublicKeyImportInvalidSecTest(__WASI_ALGORITHM_TYPE_SIGNATURES,
+                                "ECDSA_P256_SHA256"sv);
 
   auto SigEncodingTest =
       [this](


### PR DESCRIPTION
## Description
Implements `Ecdsa::PublicKey::verify()`, which previously returned `NOT_IMPLEMENTED`.
Uses `EVP_PKEY_public_check`, consistent with the EdDSA (#4927) and RSA implementations. Part of #2669.

Note: the `PublickeyVerifyTest` test helper overlaps with #4927; whichever merges first
establishes it, and I'll rebase the other.

## Checklist
- [x] DCO Signed-off
- [x] Commit Messages follow Conventional Commits
- [x] Local Tests Passed

## Test Evidence
<img width="1394" height="256" alt="image" src="https://github.com/user-attachments/assets/7e480320-1c47-4d58-827d-c6614c76bc8b" />

