### PR TITLE
Fix dangling sd_image_t buffers in readControlImage and readMaskImage

### DIFF
--- a/plugins/wasmedge_stablediffusion/sd_func.cpp
+++ b/plugins/wasmedge_stablediffusion/sd_func.cpp
@@ -104,8 +104,9 @@ sd_image_t *readControlImage(Span<uint8_t> ControlImage, int Width, int Height,
     ControlImg->data =
         preprocess_canny(ControlImg->data, ControlImg->width,
                          ControlImg->height, 0.08f, 0.08f, 0.8f, 1.0f, false);
+    // preprocess_canny returns a fresh buffer, so the decoded one is now unused.
+    free(ControlImageBuffer);
   }
-  free(ControlImageBuffer);
   return ControlImg;
 }
 
@@ -120,8 +121,10 @@ sd_image_t readMaskImage(Span<uint8_t> MaskImage, int Width, int Height) {
     MaskImageBuffer = stbi_load_from_memory(MaskImage.data(), MaskImage.size(),
                                             &Width, &Height, &Channel, 3);
   } else {
-    std::vector<uint8_t> Arr(Width * Height, 255);
-    MaskImageBuffer = Arr.data();
+    MaskImageBuffer = static_cast<uint8_t *>(malloc(Width * Height));
+    if (MaskImageBuffer != nullptr) {
+      std::fill_n(MaskImageBuffer, Width * Height, static_cast<uint8_t>(255));
+    }
   }
   return {static_cast<uint32_t>(Width), static_cast<uint32_t>(Height), 1,
           MaskImageBuffer};


### PR DESCRIPTION
Spotted this reading through the stable-diffusion image readers. Two of them hand back an sd_image_t whose data pointer is already dead.

readControlImage frees the decoded buffer unconditionally:

    ControlImg->data = ControlImageBuffer;   // CannyPreprocess == false
    free(ControlImageBuffer);                // frees the buffer it returns
    return ControlImg;                        // ->data now dangles

img2img and txt2img then read ControlImage->data. readMaskImage is the same shape in its empty-mask branch: it returns Arr.data() of a std::vector local to the function, so the buffer is gone the moment it returns.

A quick clobber after each reader confirms it: the default mask reads 0xAB instead of 255, and the control buffer reads back garbage once the freed chunk is reused.

Free the decoded buffer only when preprocess_canny actually replaced it, and malloc the default mask so it outlives the reader.