### PR TITLE
fix(wasi): reject symlink targets that resolve outside the preopen root

### DIFF
--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -846,10 +846,13 @@ public:
     if (!VINode::isPathValid(NewPath)) {
       return WasiUnexpect(__WASI_ERRNO_INVAL);
     }
-    // forbid absolute path
+    // Forbid an absolute target. A target escaping the base directory is "not
+    // permitted", matching resolvePath and the `..` check in pathSymlink.
     if (!OldPath.empty() && OldPath[0] == '/') {
-      return WasiUnexpect(__WASI_ERRNO_INVAL);
+      return WasiUnexpect(__WASI_ERRNO_PERM);
     }
+    // Relative targets escaping via `..` are rejected in VINode::pathSymlink,
+    // where the link's depth is known.
     auto NewNode = getNodeOrNull(New);
     if (unlikely(!NewNode)) {
       return WasiUnexpect(__WASI_ERRNO_BADF);

--- a/include/host/wasi/vinode.h
+++ b/include/host/wasi/vinode.h
@@ -47,6 +47,35 @@ public:
     return Path.find('\0') == std::string_view::npos;
   }
 
+  /// Check whether a relative symlink target would resolve outside the base
+  /// directory. Each component descends a level and each `..` ascends one; it
+  /// escapes if the level ever drops below the base.
+  /// @param[in] Target Symlink target (link contents).
+  /// @param[in] Depth The link directory's depth below the base fd.
+  /// @return Whether the target escapes the base directory.
+  static bool isSymlinkTargetEscaping(std::string_view Target,
+                                      uint32_t Depth) noexcept {
+    int64_t Level = static_cast<int64_t>(Depth);
+    std::string_view Path = Target;
+    while (!Path.empty()) {
+      const auto Slash = Path.find('/');
+      const auto Part = Path.substr(0, Slash);
+      Path = (Slash == std::string_view::npos) ? std::string_view()
+                                               : Path.substr(Slash + 1);
+      if (Part.empty() || (Part.size() == 1 && Part[0] == '.')) {
+        continue;
+      }
+      if (Part.size() == 2 && Part[0] == '.' && Part[1] == '.') {
+        if (--Level < 0) {
+          return true;
+        }
+        continue;
+      }
+      ++Level;
+    }
+    return false;
+  }
+
   static std::shared_ptr<VINode> stdIn(__wasi_rights_t FRB,
                                        __wasi_rights_t FRI);
   static std::shared_ptr<VINode> stdOut(__wasi_rights_t FRB,
@@ -724,12 +753,14 @@ private:
   /// @param[in] LinkCount Counting symbolic link lookup times.
   /// @param[in] FollowTrailingSlashes If Path ends with slash, open it and set
   /// Path to ".".
+  /// @param[out] ResolvedDepth If not null, set to the parent's depth below
+  /// `Fd`. Left untouched on error paths.
   /// @return Allocated buffer, or WASI error.
   static WasiExpect<std::vector<char>> resolvePath(
       std::shared_ptr<VINode> &Fd, std::string_view &Path,
       __wasi_lookupflags_t LookupFlags = __WASI_LOOKUPFLAGS_SYMLINK_FOLLOW,
       VFS::Flags VFSFlags = static_cast<VFS::Flags>(0), uint8_t LinkCount = 0,
-      bool FollowTrailingSlashes = true);
+      bool FollowTrailingSlashes = true, uint32_t *ResolvedDepth = nullptr);
 
   /// Proxy function for `resolvePath`.
   /// @param[in,out] Fd Fd. Return parent of last part if found.

--- a/lib/host/wasi/vinode.cpp
+++ b/lib/host/wasi/vinode.cpp
@@ -256,8 +256,19 @@ WasiExpect<void> VINode::pathSymlink(std::string_view OldPath,
   if (!New->can(__WASI_RIGHTS_PATH_SYMLINK)) {
     return WasiUnexpect(__WASI_ERRNO_NOTCAPABLE);
   }
-  EXPECTED_TRY(auto NewBuffer, resolvePath(New, NewPath));
+  // Resolve the new path without following its trailing component (an existing
+  // link must not be followed, so creating over it fails with EEXIST), and
+  // capture the link directory's depth below the fd.
+  uint32_t ParentDepth = 0;
+  EXPECTED_TRY(auto NewBuffer,
+               resolvePath(New, NewPath, static_cast<__wasi_lookupflags_t>(0),
+                           static_cast<VFS::Flags>(0), 0, true, &ParentDepth));
 
+  // Reject relative targets that resolve outside the preopen root; store
+  // in-bounds targets as-is.
+  if (isSymlinkTargetEscaping(OldPath, ParentDepth)) {
+    return WasiUnexpect(__WASI_ERRNO_PERM);
+  }
   return New->Node.pathSymlink(std::string(OldPath), std::string(NewPath));
 }
 
@@ -328,7 +339,8 @@ VINode::directOpen(std::string_view Path, __wasi_oflags_t OpenFlags,
 WasiExpect<std::vector<char>>
 VINode::resolvePath(std::shared_ptr<VINode> &Fd, std::string_view &Path,
                     __wasi_lookupflags_t LookupFlags, VFS::Flags VFSFlags,
-                    uint8_t LinkCount, bool FollowTrailingSlashes) {
+                    uint8_t LinkCount, bool FollowTrailingSlashes,
+                    uint32_t *ResolvedDepth) {
   std::vector<std::shared_ptr<VINode>> PartFds;
   std::vector<char> Buffer;
   do {
@@ -368,6 +380,9 @@ VINode::resolvePath(std::shared_ptr<VINode> &Fd, std::string_view &Path,
       if (!Part.empty() && Part[0] == '.') {
         if (Part.size() == 1) {
           if (LastPart) {
+            if (ResolvedDepth) {
+              *ResolvedDepth = static_cast<uint32_t>(PartFds.size());
+            }
             return Buffer;
           }
           Path = Remain;
@@ -382,6 +397,9 @@ VINode::resolvePath(std::shared_ptr<VINode> &Fd, std::string_view &Path,
           Path = Remain;
           if (LastPart) {
             Path = "."sv;
+            if (ResolvedDepth) {
+              *ResolvedDepth = static_cast<uint32_t>(PartFds.size());
+            }
             return Buffer;
           }
           continue;
@@ -390,6 +408,9 @@ VINode::resolvePath(std::shared_ptr<VINode> &Fd, std::string_view &Path,
 
       if (LastPart && !(LookupFlags & __WASI_LOOKUPFLAGS_SYMLINK_FOLLOW)) {
         Path = Part;
+        if (ResolvedDepth) {
+          *ResolvedDepth = static_cast<uint32_t>(PartFds.size());
+        }
         return Buffer;
       }
 
@@ -398,6 +419,9 @@ VINode::resolvePath(std::shared_ptr<VINode> &Fd, std::string_view &Path,
           unlikely(!Res)) {
         if (LastPart) {
           Path = Part;
+          if (ResolvedDepth) {
+            *ResolvedDepth = static_cast<uint32_t>(PartFds.size());
+          }
           return Buffer;
         }
         return WasiUnexpect(Res);
@@ -428,6 +452,9 @@ VINode::resolvePath(std::shared_ptr<VINode> &Fd, std::string_view &Path,
 
       if (LastPart) {
         Path = Part;
+        if (ResolvedDepth) {
+          *ResolvedDepth = static_cast<uint32_t>(PartFds.size());
+        }
         return Buffer;
       }
 
@@ -445,6 +472,9 @@ VINode::resolvePath(std::shared_ptr<VINode> &Fd, std::string_view &Path,
       Path = Remain;
       if (Path.empty()) {
         Path = "."sv;
+        if (ResolvedDepth) {
+          *ResolvedDepth = static_cast<uint32_t>(PartFds.size());
+        }
         return {};
       }
       continue;

--- a/test/host/wasi/wasi.cpp
+++ b/test/host/wasi/wasi.cpp
@@ -4003,6 +4003,9 @@ TEST(WasiTest, SymbolicLink) {
   WasmEdge::Host::WasiPathSymlink WasiPathSymlink(Env);
   WasmEdge::Host::WasiPathUnlinkFile WasiPathUnlinkFile(Env);
   WasmEdge::Host::WasiPathFilestatGet WasiPathFilestatGet(Env);
+  WasmEdge::Host::WasiPathCreateDirectory WasiPathCreateDirectory(Env);
+  WasmEdge::Host::WasiPathReadLink WasiPathReadLink(Env);
+  WasmEdge::Host::WasiPathRemoveDirectory WasiPathRemoveDirectory(Env);
   std::array<WasmEdge::ValVariant, 1> Errno = {UINT32_C(0)};
 
   const uint32_t Fd = 3;
@@ -4126,6 +4129,129 @@ TEST(WasiTest, SymbolicLink) {
                                    Fd, NewPathPtr, NewPathSize},
                                Errno));
     EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    Env.fini();
+  }
+
+  // Symlink targets resolving outside the preopen root are rejected; in-bounds
+  // targets are stored verbatim. Use spaced buffers so the targets and link
+  // names do not overlap in guest memory.
+  OldPathPtr = 0;
+  NewPathPtr = 64;
+  const auto makeSymlink = [&](std::string_view OldPath,
+                               std::string_view NewPath) {
+    writeString(MemInst, OldPath, OldPathPtr);
+    writeString(MemInst, NewPath, NewPathPtr);
+    EXPECT_TRUE(WasiPathSymlink.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            OldPathPtr, static_cast<uint32_t>(OldPath.size()), Fd, NewPathPtr,
+            static_cast<uint32_t>(NewPath.size())},
+        Errno));
+    return Errno[0].get<int32_t>();
+  };
+  // Read back the verbatim stored target of a link.
+  const uint32_t LinkBufPtr = 256;
+  const uint32_t NReadPtr = 600;
+  const auto readSymlink = [&](std::string_view NewPath) {
+    writeString(MemInst, NewPath, NewPathPtr);
+    EXPECT_TRUE(WasiPathReadLink.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            Fd, NewPathPtr, static_cast<uint32_t>(NewPath.size()), LinkBufPtr,
+            UINT32_C(256), NReadPtr},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    const auto NRead = *MemInst.getPointer<const uint32_t *>(NReadPtr);
+    return std::string(MemInst.getPointer<const char *>(LinkBufPtr), NRead);
+  };
+  const auto removeSymlink = [&](std::string_view NewPath) {
+    writeString(MemInst, NewPath, NewPathPtr);
+    EXPECT_TRUE(WasiPathUnlinkFile.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            Fd, NewPathPtr, static_cast<uint32_t>(NewPath.size())},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+  };
+
+  // absolute target rejected (control)
+  {
+    Env.init({"/:."s}, "test"s, {}, {});
+    EXPECT_EQ(makeSymlink("/etc/passwd"sv, "planted_abs_symlink"sv),
+              __WASI_ERRNO_PERM);
+    Env.fini();
+  }
+
+  // `..` targets at the preopen root escape and are rejected
+  {
+    Env.init({"/:."s}, "test"s, {}, {});
+    EXPECT_EQ(makeSymlink("../../etc/passwd"sv, "escape_a"sv),
+              __WASI_ERRNO_PERM);
+    EXPECT_EQ(makeSymlink("foo/../../etc/passwd"sv, "escape_b"sv),
+              __WASI_ERRNO_PERM);
+    EXPECT_EQ(makeSymlink(".."sv, "escape_c"sv), __WASI_ERRNO_PERM);
+    Env.fini();
+  }
+
+  // depth-1 link: in-bounds `..` accepted, deeper escape rejected
+  {
+    Env.init({"/:."s}, "test"s, {}, {});
+    writeString(MemInst, "sub"sv, NewPathPtr);
+    EXPECT_TRUE(
+        WasiPathCreateDirectory.run(CallFrame,
+                                    std::initializer_list<WasmEdge::ValVariant>{
+                                        Fd, NewPathPtr, UINT32_C(3)},
+                                    Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    // single `..` stays in bounds
+    EXPECT_EQ(makeSymlink("../sibling"sv, "sub/keep"sv), __WASI_ERRNO_SUCCESS);
+    EXPECT_EQ(readSymlink("sub/keep"sv), "../sibling");
+    // deeper `..` escapes, rejected
+    EXPECT_EQ(makeSymlink("../../../etc/passwd"sv, "sub/escape"sv),
+              __WASI_ERRNO_PERM);
+    removeSymlink("sub/keep"sv);
+    writeString(MemInst, "sub"sv, NewPathPtr);
+    EXPECT_TRUE(
+        WasiPathRemoveDirectory.run(CallFrame,
+                                    std::initializer_list<WasmEdge::ValVariant>{
+                                        Fd, NewPathPtr, UINT32_C(3)},
+                                    Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    Env.fini();
+  }
+
+  // in-bounds targets stored verbatim
+  {
+    Env.init({"/:."s}, "test"s, {}, {});
+    EXPECT_EQ(makeSymlink("sibling_file"sv, "safe_same_dir"sv),
+              __WASI_ERRNO_SUCCESS);
+    EXPECT_EQ(readSymlink("safe_same_dir"sv), "sibling_file");
+    EXPECT_EQ(makeSymlink("a/../sibling_file"sv, "safe_normalized"sv),
+              __WASI_ERRNO_SUCCESS);
+    EXPECT_EQ(readSymlink("safe_normalized"sv), "a/../sibling_file");
+    removeSymlink("safe_same_dir"sv);
+    removeSymlink("safe_normalized"sv);
+    Env.fini();
+  }
+
+  // the new path's trailing component is not followed: creating a link where
+  // one already exists fails with EEXIST instead of being created at the
+  // existing link's target
+  {
+    Env.init({"/:."s}, "test"s, {}, {});
+    EXPECT_EQ(makeSymlink("target_x"sv, "existing_link"sv),
+              __WASI_ERRNO_SUCCESS);
+    EXPECT_EQ(makeSymlink("target_y"sv, "existing_link"sv), __WASI_ERRNO_EXIST);
+    // the original link is untouched and no link named after its target exists
+    EXPECT_EQ(readSymlink("existing_link"sv), "target_x");
+    writeString(MemInst, "target_x"sv, NewPathPtr);
+    EXPECT_TRUE(WasiPathReadLink.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            Fd, NewPathPtr, UINT32_C(8), LinkBufPtr, UINT32_C(256), NReadPtr},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_NOENT);
+    removeSymlink("existing_link"sv);
     Env.fini();
   }
 }


### PR DESCRIPTION
`path_symlink` rejected absolute targets but accepted relative targets containing `..` that ascend above the preopen root, storing them verbatim. This aligns symlink-target handling with the RESOLVE_BENEATH path resolution WASI enforces: a target that would resolve outside the base (preopened) directory is rejected.

- `VINode::pathSymlink` gets the link directory's depth below the fd (via a new optional `ResolvedDepth` out-param on `resolvePath`) and returns `__WASI_ERRNO_PERM` via `VINode::isSymlinkTargetEscaping` when a relative target's `..` chain would step above that root. In-bounds targets such as `../sibling` from a sub-directory are stored verbatim, so `path_readlink` round-trips.
- The absolute-target check now returns `__WASI_ERRNO_PERM` (was `__WASI_ERRNO_INVAL`) for consistency with `resolvePath` and the WASI filesystem spec.

Adds regression tests in `test/host/wasi/wasi.cpp` covering absolute, root-level-escaping, deeper-escaping, in-bounds `../sibling`, and plain in-bounds targets, asserting both the errno and the stored target via `path_readlink`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)