### PR TITLE
fix(wasi_crypto): validate RSA public keys with EVP_PKEY_public_check

### DIFF
--- a/plugins/wasi_crypto/signatures/rsa.cpp
+++ b/plugins/wasi_crypto/signatures/rsa.cpp
@@ -52,7 +52,9 @@ Rsa<PadMode, KeyBits, ShaNid>::PublicKey::checkValid(EvpPkeyPtr Ctx) noexcept {
 template <int PadMode, int KeyBits, int ShaNid>
 WasiCryptoExpect<void>
 Rsa<PadMode, KeyBits, ShaNid>::PublicKey::verify() const noexcept {
-  ensureOrReturn(RSA_check_key(EVP_PKEY_get0_RSA(Ctx.get())),
+  EvpPkeyCtxPtr CheckCtx{EVP_PKEY_CTX_new(Ctx.get(), nullptr)};
+  ensureOrReturn(CheckCtx, __WASI_CRYPTO_ERRNO_INVALID_KEY);
+  ensureOrReturn(EVP_PKEY_public_check(CheckCtx.get()),
                  __WASI_CRYPTO_ERRNO_INVALID_KEY);
   return {};
 }

--- a/plugins/wasi_crypto/signatures/rsa.cpp
+++ b/plugins/wasi_crypto/signatures/rsa.cpp
@@ -53,17 +53,21 @@ template <int PadMode, int KeyBits, int ShaNid>
 WasiCryptoExpect<void>
 Rsa<PadMode, KeyBits, ShaNid>::PublicKey::verify() const noexcept {
   EvpPkeyCtxPtr CheckCtx{EVP_PKEY_CTX_new(Ctx.get(), nullptr)};
-  ensureOrReturn(CheckCtx, __WASI_CRYPTO_ERRNO_INVALID_KEY);
+  ensureOrReturn(CheckCtx, __WASI_CRYPTO_ERRNO_ALGORITHM_FAILURE);
   int Ret = EVP_PKEY_public_check(CheckCtx.get());
   if (Ret == -2) {
-    // Fallback for older OpenSSL versions where public_check is not supported for RSA
+    // Fallback for older OpenSSL versions where public_check is not supported
+    // for RSA
     const RSA *RsaKey = EVP_PKEY_get0_RSA(Ctx.get());
     ensureOrReturn(RsaKey, __WASI_CRYPTO_ERRNO_INVALID_KEY);
-    const BIGNUM *N, *E, *D;
-    RSA_get0_key(RsaKey, &N, &E, &D);
-    ensureOrReturn(N != nullptr && E != nullptr, __WASI_CRYPTO_ERRNO_INVALID_KEY);
+    const BIGNUM *N, *E;
+    RSA_get0_key(RsaKey, &N, &E, nullptr);
+    ensureOrReturn(N != nullptr && E != nullptr,
+                   __WASI_CRYPTO_ERRNO_INVALID_KEY);
+  } else if (Ret == 0) {
+    return WasiCryptoUnexpect(__WASI_CRYPTO_ERRNO_INVALID_KEY);
   } else {
-    ensureOrReturn(Ret == 1, __WASI_CRYPTO_ERRNO_INVALID_KEY);
+    ensureOrReturn(Ret == 1, __WASI_CRYPTO_ERRNO_ALGORITHM_FAILURE);
   }
   return {};
 }

--- a/plugins/wasi_crypto/signatures/rsa.cpp
+++ b/plugins/wasi_crypto/signatures/rsa.cpp
@@ -54,8 +54,17 @@ WasiCryptoExpect<void>
 Rsa<PadMode, KeyBits, ShaNid>::PublicKey::verify() const noexcept {
   EvpPkeyCtxPtr CheckCtx{EVP_PKEY_CTX_new(Ctx.get(), nullptr)};
   ensureOrReturn(CheckCtx, __WASI_CRYPTO_ERRNO_INVALID_KEY);
-  ensureOrReturn(EVP_PKEY_public_check(CheckCtx.get()) == 1,
-                 __WASI_CRYPTO_ERRNO_INVALID_KEY);
+  int Ret = EVP_PKEY_public_check(CheckCtx.get());
+  if (Ret == -2) {
+    // Fallback for older OpenSSL versions where public_check is not supported for RSA
+    const RSA *RsaKey = EVP_PKEY_get0_RSA(Ctx.get());
+    ensureOrReturn(RsaKey, __WASI_CRYPTO_ERRNO_INVALID_KEY);
+    const BIGNUM *N, *E, *D;
+    RSA_get0_key(RsaKey, &N, &E, &D);
+    ensureOrReturn(N != nullptr && E != nullptr, __WASI_CRYPTO_ERRNO_INVALID_KEY);
+  } else {
+    ensureOrReturn(Ret == 1, __WASI_CRYPTO_ERRNO_INVALID_KEY);
+  }
   return {};
 }
 

--- a/plugins/wasi_crypto/signatures/rsa.cpp
+++ b/plugins/wasi_crypto/signatures/rsa.cpp
@@ -54,7 +54,7 @@ WasiCryptoExpect<void>
 Rsa<PadMode, KeyBits, ShaNid>::PublicKey::verify() const noexcept {
   EvpPkeyCtxPtr CheckCtx{EVP_PKEY_CTX_new(Ctx.get(), nullptr)};
   ensureOrReturn(CheckCtx, __WASI_CRYPTO_ERRNO_INVALID_KEY);
-  ensureOrReturn(EVP_PKEY_public_check(CheckCtx.get()),
+  ensureOrReturn(EVP_PKEY_public_check(CheckCtx.get()) == 1,
                  __WASI_CRYPTO_ERRNO_INVALID_KEY);
   return {};
 }

--- a/plugins/wasi_crypto/signatures/rsa.cpp
+++ b/plugins/wasi_crypto/signatures/rsa.cpp
@@ -5,6 +5,11 @@
 
 #include <mutex>
 
+#include <openssl/opensslv.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/core_names.h>
+#endif
+
 namespace WasmEdge {
 namespace Host {
 namespace WasiCrypto {
@@ -58,12 +63,26 @@ Rsa<PadMode, KeyBits, ShaNid>::PublicKey::verify() const noexcept {
   if (Ret == -2) {
     // Fallback for older OpenSSL versions where public_check is not supported
     // for RSA
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    BIGNUM *N = nullptr;
+    BIGNUM *E = nullptr;
+    int RetN = EVP_PKEY_get_bn_param(Ctx.get(), OSSL_PKEY_PARAM_RSA_N, &N);
+    int RetE = EVP_PKEY_get_bn_param(Ctx.get(), OSSL_PKEY_PARAM_RSA_E, &E);
+    if (N != nullptr) {
+      BN_free(N);
+    }
+    if (E != nullptr) {
+      BN_free(E);
+    }
+    ensureOrReturn(RetN > 0 && RetE > 0, __WASI_CRYPTO_ERRNO_INVALID_KEY);
+#else
     const RSA *RsaKey = EVP_PKEY_get0_RSA(Ctx.get());
     ensureOrReturn(RsaKey, __WASI_CRYPTO_ERRNO_INVALID_KEY);
     const BIGNUM *N, *E;
     RSA_get0_key(RsaKey, &N, &E, nullptr);
     ensureOrReturn(N != nullptr && E != nullptr,
                    __WASI_CRYPTO_ERRNO_INVALID_KEY);
+#endif
   } else if (Ret == 0) {
     return WasiCryptoUnexpect(__WASI_CRYPTO_ERRNO_INVALID_KEY);
   } else {

--- a/test/plugins/wasi_crypto/signatures.cpp
+++ b/test/plugins/wasi_crypto/signatures.cpp
@@ -176,10 +176,12 @@ TEST_F(WasiCryptoTest, Signatures) {
     WASI_CRYPTO_EXPECT_SUCCESS(ExportSize, arrayOutputLen(ExportHandle));
     std::vector<uint8_t> ExportedPk(ExportSize);
     WASI_CRYPTO_EXPECT_TRUE(arrayOutputPull(ExportHandle, ExportedPk));
-    EXPECT_GT(ExportedPk.size(), 16);
+    ASSERT_GT(ExportedPk.size(), 16);
     ExportedPk.resize(ExportedPk.size() - 16);
-    EXPECT_FALSE(publickeyImport(AlgType, Alg, ExportedPk,
-                                 __WASI_PUBLICKEY_ENCODING_PKCS8));
+    WASI_CRYPTO_EXPECT_FAILURE(
+        publickeyImport(AlgType, Alg, ExportedPk,
+                        __WASI_PUBLICKEY_ENCODING_PKCS8),
+        __WASI_CRYPTO_ERRNO_INVALID_KEY);
     WASI_CRYPTO_EXPECT_TRUE(publickeyClose(PkHandle));
     WASI_CRYPTO_EXPECT_TRUE(keypairClose(KpHandle));
   };

--- a/test/plugins/wasi_crypto/signatures.cpp
+++ b/test/plugins/wasi_crypto/signatures.cpp
@@ -148,7 +148,8 @@ TEST_F(WasiCryptoTest, Signatures) {
                                keypairGenerate(AlgType, Alg, std::nullopt));
     WASI_CRYPTO_EXPECT_SUCCESS(PkHandle, keypairPublickey(KpHandle));
     WASI_CRYPTO_EXPECT_SUCCESS(
-        ExportHandle, publickeyExport(PkHandle, __WASI_PUBLICKEY_ENCODING_PKCS8));
+        ExportHandle,
+        publickeyExport(PkHandle, __WASI_PUBLICKEY_ENCODING_PKCS8));
     WASI_CRYPTO_EXPECT_SUCCESS(ExportSize, arrayOutputLen(ExportHandle));
     std::vector<uint8_t> ExportedPk(ExportSize);
     WASI_CRYPTO_EXPECT_TRUE(arrayOutputPull(ExportHandle, ExportedPk));

--- a/test/plugins/wasi_crypto/signatures.cpp
+++ b/test/plugins/wasi_crypto/signatures.cpp
@@ -140,6 +140,52 @@ TEST_F(WasiCryptoTest, Signatures) {
         "8613ecd5ecfc3b40a1d02f40891ca43695cd4c088b05a8054c89c595a47e2748"
         "16f35384226f74459ee63e25a1bfc03c360490552ec38343f8ace502f065303b"
         "00bc0ec320711b211fde92e57feb9013c3609342495ec0d7cabdec21e54acc38"_u8v}});
+
+  auto PkVerifyTest = [this](__wasi_algorithm_type_e_t AlgType,
+                             std::string_view Alg) {
+    SCOPED_TRACE(Alg);
+    WASI_CRYPTO_EXPECT_SUCCESS(KpHandle,
+                               keypairGenerate(AlgType, Alg, std::nullopt));
+    WASI_CRYPTO_EXPECT_SUCCESS(PkHandle, keypairPublickey(KpHandle));
+    WASI_CRYPTO_EXPECT_SUCCESS(
+        ExportHandle, publickeyExport(PkHandle, __WASI_PUBLICKEY_ENCODING_PKCS8));
+    WASI_CRYPTO_EXPECT_SUCCESS(ExportSize, arrayOutputLen(ExportHandle));
+    std::vector<uint8_t> ExportedPk(ExportSize);
+    WASI_CRYPTO_EXPECT_TRUE(arrayOutputPull(ExportHandle, ExportedPk));
+    WASI_CRYPTO_EXPECT_SUCCESS(
+        ReimportedPkHandle,
+        publickeyImport(AlgType, Alg, ExportedPk,
+                        __WASI_PUBLICKEY_ENCODING_PKCS8));
+    WASI_CRYPTO_EXPECT_TRUE(publickeyVerify(ReimportedPkHandle));
+    WASI_CRYPTO_EXPECT_TRUE(publickeyClose(ReimportedPkHandle));
+    WASI_CRYPTO_EXPECT_TRUE(publickeyClose(PkHandle));
+    WASI_CRYPTO_EXPECT_TRUE(keypairClose(KpHandle));
+  };
+  PkVerifyTest(__WASI_ALGORITHM_TYPE_SIGNATURES, "RSA_PKCS1_2048_SHA256"sv);
+  PkVerifyTest(__WASI_ALGORITHM_TYPE_SIGNATURES, "RSA_PSS_2048_SHA256"sv);
+
+  auto PkVerifyNegativeTest = [this](__wasi_algorithm_type_e_t AlgType,
+                                     std::string_view Alg) {
+    SCOPED_TRACE(Alg);
+    WASI_CRYPTO_EXPECT_SUCCESS(KpHandle,
+                               keypairGenerate(AlgType, Alg, std::nullopt));
+    WASI_CRYPTO_EXPECT_SUCCESS(PkHandle, keypairPublickey(KpHandle));
+    WASI_CRYPTO_EXPECT_SUCCESS(
+        ExportHandle,
+        publickeyExport(PkHandle, __WASI_PUBLICKEY_ENCODING_PKCS8));
+    WASI_CRYPTO_EXPECT_SUCCESS(ExportSize, arrayOutputLen(ExportHandle));
+    std::vector<uint8_t> ExportedPk(ExportSize);
+    WASI_CRYPTO_EXPECT_TRUE(arrayOutputPull(ExportHandle, ExportedPk));
+    ExportedPk.resize(ExportedPk.size() - 16);
+    EXPECT_FALSE(publickeyImport(AlgType, Alg, ExportedPk,
+                                 __WASI_PUBLICKEY_ENCODING_PKCS8));
+    WASI_CRYPTO_EXPECT_TRUE(publickeyClose(PkHandle));
+    WASI_CRYPTO_EXPECT_TRUE(keypairClose(KpHandle));
+  };
+  PkVerifyNegativeTest(__WASI_ALGORITHM_TYPE_SIGNATURES,
+                       "RSA_PKCS1_2048_SHA256"sv);
+  PkVerifyNegativeTest(__WASI_ALGORITHM_TYPE_SIGNATURES,
+                       "RSA_PSS_2048_SHA256"sv);
 }
 
 } // namespace WasiCrypto

--- a/test/plugins/wasi_crypto/signatures.cpp
+++ b/test/plugins/wasi_crypto/signatures.cpp
@@ -176,6 +176,7 @@ TEST_F(WasiCryptoTest, Signatures) {
     WASI_CRYPTO_EXPECT_SUCCESS(ExportSize, arrayOutputLen(ExportHandle));
     std::vector<uint8_t> ExportedPk(ExportSize);
     WASI_CRYPTO_EXPECT_TRUE(arrayOutputPull(ExportHandle, ExportedPk));
+    EXPECT_GT(ExportedPk.size(), 16);
     ExportedPk.resize(ExportedPk.size() - 16);
     EXPECT_FALSE(publickeyImport(AlgType, Alg, ExportedPk,
                                  __WASI_PUBLICKEY_ENCODING_PKCS8));


### PR DESCRIPTION
Fixes the RSA public key validation path in the WASI-Crypto plugin.
`Rsa::PublicKey::verify()` previously used `RSA_check_key()` to validate a public key. `RSA_check_key()` is meant to validate an RSA *private* key by checking that `p` and `q` are prime. Because a public key only carries the modulus and public exponent, those private components are absent, causing `RSA_check_key()` to fail. As a result, valid imported RSA public keys were rejected with `__WASI_CRYPTO_ERRNO_INVALID_KEY`.
Both `RSA_check_key()` and `EVP_PKEY_get0_RSA()` are also deprecated since OpenSSL 3.0.
This PR:
1. Switches to `EVP_PKEY_public_check()`, which is the correct API for validating the public component of a key.
2. Adds positive regression tests to `test/plugins/wasi_crypto/signatures.cpp` covering both RSA PKCS1 and PSS padding modes.
3. Adds a negative test that exports the public key, truncates the DER encoding by 16 bytes, and attempts to re-import it. This safely verifies that the import fails without accidentally triggering the expensive mathematical OpenSSL composite-number check on corrupted moduli (protecting against DoS/CVE-2023-6237).

Closes #4881

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence

<img width="1410" height="210" alt="image" src="https://github.com/user-attachments/assets/9891f373-faef-489a-a626-8407826f1499" />

