### PR TITLE
fix(plugin/wasi_nn): clamp get_output copy to guest buffer size

### DIFF
--- a/plugins/wasi_nn/GGML/core/output_generator.cpp
+++ b/plugins/wasi_nn/GGML/core/output_generator.cpp
@@ -27,7 +27,9 @@ Expect<ErrNo> getOutputSingle(WasiNNEnvironment &Env, uint32_t ContextId,
   // Use index 1 for output metadata.
   if (Index == 1) {
     std::string Metadata = buildOutputMetadata(CxtRef);
-    std::copy_n(Metadata.data(), Metadata.length(), OutBuffer.data());
+    const size_t BytesToCopy =
+        std::min(static_cast<size_t>(OutBuffer.size()), Metadata.length());
+    std::copy_n(Metadata.data(), BytesToCopy, OutBuffer.data());
     BytesWritten = static_cast<uint32_t>(Metadata.length());
     LOG_DEBUG(GraphRef.EnableDebugLog,
               "getOutputSingle: with Index {} a.k.a Metadata...Done"sv, Index)
@@ -36,7 +38,9 @@ Expect<ErrNo> getOutputSingle(WasiNNEnvironment &Env, uint32_t ContextId,
 
   std::string LastToken = common_token_to_piece(
       GraphRef.LlamaContext.get(), CxtRef.LlamaOutputTokens.back());
-  std::copy_n(LastToken.data(), LastToken.length(), OutBuffer.data());
+  const size_t BytesToCopy =
+      std::min(static_cast<size_t>(OutBuffer.size()), LastToken.length());
+  std::copy_n(LastToken.data(), BytesToCopy, OutBuffer.data());
   BytesWritten = EndianValue(static_cast<uint32_t>(LastToken.length())).le();
   LOG_DEBUG(GraphRef.EnableDebugLog, "getOutputSingle: with Index {}...Done"sv,
             Index)
@@ -53,15 +57,18 @@ Expect<ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
   // Use index 1 for output metadata.
   if (Index == 1) {
     std::string Metadata = buildOutputMetadata(CxtRef);
-    std::copy_n(Metadata.data(), Metadata.length(), OutBuffer.data());
+    const size_t BytesToCopy =
+        std::min(static_cast<size_t>(OutBuffer.size()), Metadata.length());
+    std::copy_n(Metadata.data(), BytesToCopy, OutBuffer.data());
     BytesWritten = static_cast<uint32_t>(Metadata.length());
     LOG_DEBUG(GraphRef.EnableDebugLog,
               "getOutput: with Index {} a.k.a Metadata ...Done"sv, Index)
     return ErrNo::Success;
   }
 
-  std::copy_n(CxtRef.LlamaOutputs.data(), CxtRef.LlamaOutputs.size(),
-              OutBuffer.data());
+  const size_t BytesToCopy = std::min(static_cast<size_t>(OutBuffer.size()),
+                                      CxtRef.LlamaOutputs.size());
+  std::copy_n(CxtRef.LlamaOutputs.data(), BytesToCopy, OutBuffer.data());
   BytesWritten =
       EndianValue(static_cast<uint32_t>(CxtRef.LlamaOutputs.size())).le();
   LOG_DEBUG(GraphRef.EnableDebugLog, "getOutput: with Index {}...Done"sv, Index)

--- a/plugins/wasi_nn/wasinn_chattts.cpp
+++ b/plugins/wasi_nn/wasinn_chattts.cpp
@@ -236,7 +236,9 @@ Expect<WASINN::ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
     spdlog::info("[WASI-NN] ChatTTS backend: getOutput"sv);
   }
   if (Index == 0) {
-    std::copy_n(CxtRef.Outputs.data(), CxtRef.Outputs.size(), OutBuffer.data());
+    const size_t BytesToCopy =
+        std::min(static_cast<size_t>(OutBuffer.size()), CxtRef.Outputs.size());
+    std::copy_n(CxtRef.Outputs.data(), BytesToCopy, OutBuffer.data());
     BytesWritten = CxtRef.Outputs.size();
     return WASINN::ErrNo::Success;
   }

--- a/plugins/wasi_nn/wasinn_mlx.cpp
+++ b/plugins/wasi_nn/wasinn_mlx.cpp
@@ -551,8 +551,9 @@ Expect<WASINN::ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
   if (GraphRef.ModelArch == "llm") {
     auto *Output = std::get_if<LLMOutput>(&CxtRef.Outputs);
     if (Output != nullptr) {
-      std::copy_n(Output->Answer.data(), Output->Answer.length(),
-                  OutBuffer.data());
+      const size_t BytesToCopy = std::min(static_cast<size_t>(OutBuffer.size()),
+                                          Output->Answer.length());
+      std::copy_n(Output->Answer.data(), BytesToCopy, OutBuffer.data());
       BytesWritten = Output->Answer.length();
     } else {
       spdlog::error("[WASI-NN] MLX backend: No output found."sv);
@@ -562,7 +563,9 @@ Expect<WASINN::ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
     auto *Output = std::get_if<VLMOutput>(&CxtRef.Outputs);
     if (Output != nullptr) {
       auto OutputBytes = toBytes(Output->Answer);
-      std::copy_n(OutputBytes.data(), OutputBytes.size(), OutBuffer.data());
+      const size_t BytesToCopy =
+          std::min(static_cast<size_t>(OutBuffer.size()), OutputBytes.size());
+      std::copy_n(OutputBytes.data(), BytesToCopy, OutBuffer.data());
       BytesWritten = OutputBytes.size();
     } else {
       spdlog::error("[WASI-NN] MLX backend: No output found."sv);
@@ -572,7 +575,9 @@ Expect<WASINN::ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
     auto *Output = std::get_if<whisper::TranscribeResult>(&CxtRef.Outputs);
     if (Output != nullptr) {
       std::string Text = Output->Text;
-      std::copy_n(Text.data(), Text.length(), OutBuffer.data());
+      const size_t BytesToCopy =
+          std::min(static_cast<size_t>(OutBuffer.size()), Text.length());
+      std::copy_n(Text.data(), BytesToCopy, OutBuffer.data());
       BytesWritten = Text.length();
     } else {
       spdlog::error("[WASI-NN] MLX backend: No output found."sv);

--- a/plugins/wasi_nn/wasinn_openvino.cpp
+++ b/plugins/wasi_nn/wasinn_openvino.cpp
@@ -160,7 +160,9 @@ Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
     const ov::Tensor &OutputTensor =
         CxtRef.OpenVINOInferRequest.get_output_tensor(Index);
     BytesWritten = OutputTensor.get_byte_size();
-    std::copy_n(static_cast<const uint8_t *>(OutputTensor.data()), BytesWritten,
+    const size_t BytesToCopy = std::min(static_cast<size_t>(OutBuffer.size()),
+                                        static_cast<size_t>(BytesWritten));
+    std::copy_n(static_cast<const uint8_t *>(OutputTensor.data()), BytesToCopy,
                 OutBuffer.data());
   } catch (const std::exception &EX) {
     spdlog::error("[WASI-NN] Get Output Exception: {}"sv, EX.what());

--- a/plugins/wasi_nn/wasinn_openvino_genai.cpp
+++ b/plugins/wasi_nn/wasinn_openvino_genai.cpp
@@ -94,8 +94,10 @@ LLMPipelineBackend::GetContextOutput(Context &CxtRef, uint32_t Index,
 
   try {
     BytesWritten = CxtRef.StringOutput.size();
+    const size_t BytesToCopy = std::min(static_cast<size_t>(OutBuffer.size()),
+                                        static_cast<size_t>(BytesWritten));
     std::copy_n(reinterpret_cast<const uint8_t *>(CxtRef.StringOutput.data()),
-                BytesWritten, OutBuffer.data());
+                BytesToCopy, OutBuffer.data());
   } catch (const std::exception &EX) {
     spdlog::error("[WASI-NN] Get Output Exception: {}"sv, EX.what());
     return WASINN::ErrNo::RuntimeError;


### PR DESCRIPTION
## Description

Found this while reading the wasi-nn `get_output` / `get_output_single` path. The output buffer reaches each backend as a `Span<uint8_t>` whose size is the guest-supplied `OutBufferMaxSize`. Most backends clamp the copy to that size, a few do not.

1. `get_output` hands the backend `OutBuffer`, sized to the guest's `OutBufferMaxSize`.
2. GGML, MLX, ChatTTS, OpenVINO and OpenVINOGenAI pass the source length to `std::copy_n` (LlamaOutputs, output metadata, the MLX answer/text bytes, the OpenVINO output tensor, the OpenVINOGenAI string output) rather than `OutBuffer.size()`.
3. A guest that hands over a buffer smaller than the produced output gets a write past the span, off the end of the linear memory into adjacent host memory.

Observation: the RPC branch in `wasinnfunc.cpp` and the bitnet/whisper/piper/torch/tfl backends already guard this with `std::min(OutBuffer.size(), ...)`. These five were the ones left unclamped, so this brings them in line.

`BytesWritten` still reports the full output length so a caller can spot the truncation, resize and read again.

## Checklist

- [x] **DCO Signed-off**: commit is signed off.
- [x] **Commit Messages**: conventional-commit subject, checked with commitlint.
- [x] **Local Tests Passed**: see below.

## Test Evidence

Reduced the construct to the same shape (4-byte destination span, 4096-byte source) to confirm the overrun and the clamp:

```
OutBuffer.size()=4 ModelOutput.size()=4096
buggy copy_n count=4096 -> writes 4092 bytes past the span
clamped copy_n count=4 -> in bounds
```
