### PR TITLE
fix(wasi_nn): reuse validated tensor data in RPC set_input

### DIFF
--- a/plugins/wasi_nn/wasinnfunc.cpp
+++ b/plugins/wasi_nn/wasinnfunc.cpp
@@ -356,8 +356,8 @@ WasiNNSetInput::bodyImpl(const Runtime::CallingFrame &Frame, uint32_t ContextId,
     RPCTensor.mutable_dimensions()->Add(Tensor.Dimension.begin(),
                                         Tensor.Dimension.end());
     RPCTensor.set_ty(wasi_ephemeral_nn::TensorType(Tensor.RType));
-    RPCTensor.set_data(MemInst->getPointer<char *>(WasiTensor->TensorPtr),
-                       WasiTensor->TensorLen);
+    RPCTensor.set_data(reinterpret_cast<const char *>(Tensor.Tensor.data()),
+                       Tensor.Tensor.size());
     *Req.mutable_tensor() = RPCTensor;
     google::protobuf::Empty Res;
     auto Status = Stub->SetInput(&ClientContext, Req, &Res);


### PR DESCRIPTION
## Summary

WasiNNSetInput already retrieves the tensor data through `Tensor.Tensor` before constructing the RPC request.

This change reuses that existing span when calling `RPCTensor.set_data()` instead of retrieving the pointer and length again from `WasiTensor`.

The behavior for valid inputs remains unchanged.

## Testing

- Built successfully with WASI-NN RPC enabled.