### PR TITLE
docs: add secure configuration guidelines for users

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,3 +49,12 @@ Information regarding supported versions of WasmEdge are in the below table:
 | ------- | --------- |
 | 0.15.0  | :white_check_mark: |
 | 0.14.1  | :white_check_mark: |
+
+## Secure Configuration Guidelines
+
+WasmEdge executes WebAssembly bytecode programs within a well-defined execution sandbox. By default, WebAssembly programs run with no access to host OS resources.
+
+When deploying WasmEdge in production, please adhere to the following secure defaults:
+* **Isolation:** JIT mode, core dumps, and debug features are completely disabled by default. Do not enable them unless explicitly required.
+* **Capabilities:** WASM modules have no access to the file system, sockets, or environment variables unless explicitly granted by the host application.
+* **Host Functions:** Be aware that WASI host function implementations and third-party plug-in interfaces bypass the WebAssembly sandbox. They run natively and form the security boundary between the sandbox and the host OS. Only load trusted plugins.


### PR DESCRIPTION
Motivation

Closes #4240.

The CNCF TAG Security Joint Assessment identified a need for clearer user-facing documentation describing WasmEdge's security model and secure deployment considerations.

To address this requirement with minimal repository impact, this PR expands the existing `SECURITY.md` document with a concise set of secure configuration guidelines.

Summary of Changes

Added a `Secure Configuration Guidelines` section to `SECURITY.md`.
Documented WasmEdge's default sandbox isolation model.
Clarified the capability-based access model for host resources.
Added guidance regarding the security boundary between WebAssembly code and native host functions/plugins.

Details

The new section highlights the following security concepts:

WebAssembly modules execute in an isolated sandbox by default.
Access to host resources is not granted unless explicitly provided by the host environment.
JIT mode, core dumps, and debug features are disabled by default.
Native host functions and third-party plugins operate outside the WebAssembly sandbox and therefore represent the primary boundary between sandboxed code and the host operating system.

Why This Change

Issue #4240 requests improved security documentation for users as part of the CNCF security assessment recommendations.

Rather than introducing new documentation files, this change enhances the existing security policy document and keeps the guidance close to other security-related information already maintained by the project.

Testing

Documentation-only change.

Validation performed by reviewing existing security and assessment documentation, including:

`docs/technical-review.md`
Existing security policy documentation

No runtime behavior, APIs, build configuration, or security mechanisms were modified.
