### PR TITLE
fix(wasi_nn): validate tensor field lengths in MLX fromBytes

### DIFF
--- a/plugins/wasi_nn/wasinn_mlx.cpp
+++ b/plugins/wasi_nn/wasinn_mlx.cpp
@@ -44,17 +44,63 @@ mx::array fromBytes(const Span<uint8_t> &Bytes) {
   std::memcpy(&DimBufLen, &Bytes[Offset], 4);
   Offset += 4;
 
+  // Each dimension is four bytes; the dimension block plus the following
+  // four-byte data-length field must lie within the input.
+  if (DimBufLen % 4 != 0 || DimBufLen > Bytes.size() - 9) {
+    spdlog::error(
+        "[WASI-NN] MLX backend: Tensor dimension length {} is out of range."sv,
+        DimBufLen);
+    return mx::array({0.0f});
+  }
+
   std::vector<int> Shape;
+  uint64_t ElemCnt = 1;
   for (size_t I = 0; I < DimBufLen; I += 4) {
     uint32_t Dim;
     std::memcpy(&Dim, &Bytes[Offset + I], 4);
     Shape.push_back(static_cast<int>(Dim));
+    ElemCnt =
+        (Dim != 0 && ElemCnt > UINT64_MAX / Dim) ? UINT64_MAX : ElemCnt * Dim;
   }
   Offset += DimBufLen;
 
   uint32_t DataBufLen;
   std::memcpy(&DataBufLen, &Bytes[Offset], 4);
   Offset += 4;
+
+  // Bytes consumed per element of the declared type.
+  size_t ElemSize;
+  switch (RtypeValue) {
+  case 0:
+    ElemSize = 2; // F16
+    break;
+  case 1:
+    ElemSize = 4; // F32
+    break;
+  case 2:
+    ElemSize = 8; // F64
+    break;
+  case 3:
+    ElemSize = 1; // U8
+    break;
+  case 4:
+    ElemSize = 4; // I32
+    break;
+  case 5:
+    ElemSize = 8; // I64
+    break;
+  default:
+    spdlog::error("[WASI-NN] MLX backend: Unsupported rtype: {}", RtypeValue);
+    return mx::array({0.0f});
+  }
+
+  // The element data described by the shape must fit in the remaining input.
+  if (ElemCnt > (Bytes.size() - Offset) / ElemSize) {
+    spdlog::error(
+        "[WASI-NN] MLX backend: Tensor data of {} elements does not fit the {}-byte input."sv,
+        ElemCnt, Bytes.size());
+    return mx::array({0.0f});
+  }
 
   const void *DataPtr = &Bytes[Offset];
   switch (RtypeValue) {

--- a/plugins/wasi_nn/wasinn_mlx.cpp
+++ b/plugins/wasi_nn/wasinn_mlx.cpp
@@ -46,7 +46,9 @@ mx::array fromBytes(const Span<uint8_t> &Bytes) {
 
   // Each dimension is four bytes; the dimension block plus the following
   // four-byte data-length field must lie within the input.
-  if (DimBufLen % 4 != 0 || DimBufLen > Bytes.size() - 9) {
+  if (DimBufLen % 4 != 0 ||
+      Offset + static_cast<size_t>(DimBufLen) + sizeof(uint32_t) >
+          Bytes.size()) {
     spdlog::error(
         "[WASI-NN] MLX backend: Tensor dimension length {} is out of range."sv,
         DimBufLen);
@@ -105,7 +107,7 @@ mx::array fromBytes(const Span<uint8_t> &Bytes) {
     ElemSize = 8; // I64
     break;
   default:
-    spdlog::error("[WASI-NN] MLX backend: Unsupported rtype: {}", RtypeValue);
+    spdlog::error("[WASI-NN] MLX backend: Unsupported rtype: {}"sv, RtypeValue);
     return mx::array({0.0f});
   }
 

--- a/plugins/wasi_nn/wasinn_mlx.cpp
+++ b/plugins/wasi_nn/wasinn_mlx.cpp
@@ -58,6 +58,13 @@ mx::array fromBytes(const Span<uint8_t> &Bytes) {
   for (size_t I = 0; I < DimBufLen; I += 4) {
     uint32_t Dim;
     std::memcpy(&Dim, &Bytes[Offset + I], 4);
+    // Shape is a vector of int; a dimension past INT32_MAX would narrow to a
+    // negative value.
+    if (Dim > static_cast<uint32_t>(INT32_MAX)) {
+      spdlog::error(
+          "[WASI-NN] MLX backend: Tensor dimension {} is out of range."sv, Dim);
+      return mx::array({0.0f});
+    }
     Shape.push_back(static_cast<int>(Dim));
     ElemCnt =
         (Dim != 0 && ElemCnt > UINT64_MAX / Dim) ? UINT64_MAX : ElemCnt * Dim;
@@ -67,6 +74,14 @@ mx::array fromBytes(const Span<uint8_t> &Bytes) {
   uint32_t DataBufLen;
   std::memcpy(&DataBufLen, &Bytes[Offset], 4);
   Offset += 4;
+
+  // The declared data section must lie within the input.
+  if (DataBufLen > Bytes.size() - Offset) {
+    spdlog::error(
+        "[WASI-NN] MLX backend: Tensor data length {} is out of range."sv,
+        DataBufLen);
+    return mx::array({0.0f});
+  }
 
   // Bytes consumed per element of the declared type.
   size_t ElemSize;
@@ -94,11 +109,12 @@ mx::array fromBytes(const Span<uint8_t> &Bytes) {
     return mx::array({0.0f});
   }
 
-  // The element data described by the shape must fit in the remaining input.
-  if (ElemCnt > (Bytes.size() - Offset) / ElemSize) {
+  // The element data described by the shape must fit in the declared data
+  // section, which in turn lies within the input.
+  if (ElemCnt > DataBufLen / ElemSize) {
     spdlog::error(
-        "[WASI-NN] MLX backend: Tensor data of {} elements does not fit the {}-byte input."sv,
-        ElemCnt, Bytes.size());
+        "[WASI-NN] MLX backend: Tensor data of {} elements does not fit the {}-byte data section."sv,
+        ElemCnt, DataBufLen);
     return mx::array({0.0f});
   }
 


### PR DESCRIPTION
setInput passes the guest tensor bytes to fromBytes in the MLX backend, and only the leading 9-byte size is checked. walked it under asan:

1. DimBufLen is read from the blob and then used as both the dimension-loop bound and an Offset increment, with no check against the buffer size. a 9-byte tensor declaring DimBufLen=64 reads 64 bytes past the end.
2. the dimension values become the array shape, also unchecked, so a single large dim makes mx::array read well past the data section.

bounded the dimension block and the trailing data-length field against the input, and rejected any tensor whose element count would not fit the remaining bytes. malformed tensors return the error array as before.