### PR TITLE
feat: enable -Wshadow and -Wshadow-field warnings

### DIFF
--- a/cmake/Helper.cmake
+++ b/cmake/Helper.cmake
@@ -35,6 +35,10 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     /wd4611 # interaction between '_setjmp' and C++ object destruction is non-portable
     /bigobj # for large object files
   )
+  # /W4 already enables the C4456-C4459 shadow warnings, so no extra enables
+  # are needed; pair them with suppression flags to keep third-party targets
+  # exempt on MSVC as well.
+  set(WASMEDGE_SHADOW_SUPPRESS_FLAGS /wd4456 /wd4457 /wd4458 /wd4459)
 else()
   list(APPEND WASMEDGE_CFLAGS
     -Wall
@@ -68,7 +72,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     -Wno-documentation-unknown-command
     -Wno-error=nested-anon-types
     -Wno-error=old-style-cast
-    -Wno-error=shadow
     -Wno-error=unused-command-line-argument
     -Wno-error=unknown-warning-option
     -Wno-ctad-maybe-unsupported
@@ -76,11 +79,21 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     -Wno-keyword-macro
     -Wno-language-extension-token
     -Wno-newline-eof
-    -Wno-shadow-field-in-constructor
     -Wno-signed-enum-bitfield
     -Wno-switch-enum
     -Wno-undefined-func-template
   )
+
+  # -Wshadow does not enable -Wshadow-field-in-constructor, so the Name(Name)
+  # constructor idiom stays accepted; it does enable the narrower
+  # -Wshadow-field-in-constructor-modified check. -Wshadow-field is not part
+  # of -Wshadow either; it is enabled explicitly to catch declarations that
+  # shadow members inherited from a base class.
+  list(APPEND WASMEDGE_CFLAGS
+    -Wshadow
+    -Wshadow-field
+  )
+  set(WASMEDGE_SHADOW_SUPPRESS_FLAGS -Wno-shadow -Wno-shadow-field)
 
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 17.0.0)
     list(APPEND WASMEDGE_CFLAGS
@@ -100,11 +113,17 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     )
   elseif(NOT CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     list(APPEND WASMEDGE_CFLAGS
-      -Wno-error=shadow-field
       -Wno-reserved-identifier
     )
   endif()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  # GCC's -Wshadow, unlike Clang's, flags the Name(Name) constructor idiom
+  # and offers no subgroup to exempt it; =local checks local shadowing only.
+  list(APPEND WASMEDGE_CFLAGS
+    -Wshadow=local
+  )
+  # -Wno-shadow disables the whole -Wshadow family, including =local.
+  set(WASMEDGE_SHADOW_SUPPRESS_FLAGS -Wno-shadow)
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 13)
     list(APPEND WASMEDGE_CFLAGS
       -Wno-error=dangling-reference
@@ -183,6 +202,17 @@ function(wasmedge_setup_target target)
       -fsanitize=fuzzer,address
     )
   endif()
+endfunction()
+
+# Third-party targets built with WASMEDGE_CFLAGS are not ours to fix; undo the
+# shadow warning enables on them.
+function(wasmedge_suppress_shadow_warnings)
+  if(NOT WASMEDGE_SHADOW_SUPPRESS_FLAGS)
+    return()
+  endif()
+  foreach(target IN LISTS ARGN)
+    target_compile_options(${target} PRIVATE ${WASMEDGE_SHADOW_SUPPRESS_FLAGS})
+  endforeach()
 endfunction()
 
 function(wasmedge_add_library target)
@@ -359,6 +389,7 @@ function(wasmedge_setup_simdjson)
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4505> # unreferenced local function has been removed
       )
     endif()
+    wasmedge_suppress_shadow_warnings(simdjson)
   endif()
 endfunction()
 
@@ -391,6 +422,7 @@ function(wasmedge_setup_spdlog)
         -Wno-sign-conversion
       )
     endif()
+    wasmedge_suppress_shadow_warnings(fmt)
     if (WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       target_compile_options(fmt
         PUBLIC
@@ -413,6 +445,7 @@ function(wasmedge_setup_spdlog)
     FetchContent_MakeAvailable(spdlog)
     message(STATUS "Downloading spdlog source -- done")
     wasmedge_setup_target(spdlog)
+    wasmedge_suppress_shadow_warnings(spdlog)
     if (WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       target_compile_options(spdlog
         PUBLIC

--- a/cmake/Helper.cmake
+++ b/cmake/Helper.cmake
@@ -84,14 +84,18 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     -Wno-undefined-func-template
   )
 
-  # -Wshadow does not enable -Wshadow-field-in-constructor, so the Name(Name)
-  # constructor idiom stays accepted; it does enable the narrower
-  # -Wshadow-field-in-constructor-modified check. -Wshadow-field is not part
-  # of -Wshadow either; it is enabled explicitly to catch declarations that
-  # shadow members inherited from a base class.
+  # -Wshadow is not documented to enable -Wshadow-field-in-constructor, so
+  # the Name(Name) constructor idiom should stay accepted, but clang-cl 21 on
+  # Windows fires it under these flags anyway; disable it explicitly and
+  # re-enable the narrower -Wshadow-field-in-constructor-modified check that
+  # -Wshadow intends. -Wshadow-field is not part of -Wshadow either; it is
+  # enabled explicitly to catch declarations that shadow members inherited
+  # from a base class.
   list(APPEND WASMEDGE_CFLAGS
     -Wshadow
     -Wshadow-field
+    -Wno-shadow-field-in-constructor
+    -Wshadow-field-in-constructor-modified
   )
   set(WASMEDGE_SHADOW_SUPPRESS_FLAGS -Wno-shadow -Wno-shadow-field)
 
@@ -122,8 +126,8 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   list(APPEND WASMEDGE_CFLAGS
     -Wshadow=local
   )
-  # -Wno-shadow disables the whole -Wshadow family, including =local.
-  set(WASMEDGE_SHADOW_SUPPRESS_FLAGS -Wno-shadow)
+  # Match the enabled subgroup so third-party targets drop -Wshadow=local.
+  set(WASMEDGE_SHADOW_SUPPRESS_FLAGS -Wno-shadow=local)
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 13)
     list(APPEND WASMEDGE_CFLAGS
       -Wno-error=dangling-reference
@@ -210,8 +214,12 @@ function(wasmedge_suppress_shadow_warnings)
   if(NOT WASMEDGE_SHADOW_SUPPRESS_FLAGS)
     return()
   endif()
+  set(SHADOW_SUPPRESS_OPTIONS)
+  foreach(flag IN LISTS WASMEDGE_SHADOW_SUPPRESS_FLAGS)
+    list(APPEND SHADOW_SUPPRESS_OPTIONS "$<$<COMPILE_LANGUAGE:C,CXX>:${flag}>")
+  endforeach()
   foreach(target IN LISTS ARGN)
-    target_compile_options(${target} PRIVATE ${WASMEDGE_SHADOW_SUPPRESS_FLAGS})
+    target_compile_options(${target} PRIVATE ${SHADOW_SUPPRESS_OPTIONS})
   endforeach()
 endfunction()
 

--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -1252,15 +1252,15 @@ public:
 
   /// Concurrently poll for a ready-to-read event.
   ///
-  /// @param[in] Fd The file descriptor on which to wait for it to become ready
-  /// for reading.
+  /// @param[in] WasiFd The file descriptor on which to wait for it to become
+  /// ready for reading.
   /// @param[in] Trigger Specifying whether the notification is level-trigger or
   /// edge-trigger.
   /// @param[in] UserData User-provided value that may be attached to objects
   /// that is retained when extracted from the implementation.
-  void read(__wasi_fd_t Fd, TriggerType Trigger,
+  void read(__wasi_fd_t WasiFd, TriggerType Trigger,
             __wasi_userdata_t UserData) noexcept {
-    if (auto Node = env().getNodeOrNull(Fd); unlikely(!Node)) {
+    if (auto Node = env().getNodeOrNull(WasiFd); unlikely(!Node)) {
       VPoller::error(UserData, __WASI_ERRNO_BADF, __WASI_EVENTTYPE_FD_READ);
     } else {
       VPoller::read(Node, Trigger, UserData);
@@ -1269,15 +1269,15 @@ public:
 
   /// Concurrently poll for a ready-to-write event.
   ///
-  /// @param[in] Fd The file descriptor on which to wait for it to become ready
-  /// for writing.
+  /// @param[in] WasiFd The file descriptor on which to wait for it to become
+  /// ready for writing.
   /// @param[in] Trigger Specifying whether the notification is level-trigger or
   /// edge-trigger.
   /// @param[in] UserData User-provided value that may be attached to objects
   /// that is retained when extracted from the implementation.
-  void write(__wasi_fd_t Fd, TriggerType Trigger,
+  void write(__wasi_fd_t WasiFd, TriggerType Trigger,
              __wasi_userdata_t UserData) noexcept {
-    if (auto Node = env().getNodeOrNull(Fd); unlikely(!Node)) {
+    if (auto Node = env().getNodeOrNull(WasiFd); unlikely(!Node)) {
       VPoller::error(UserData, __WASI_ERRNO_BADF, __WASI_EVENTTYPE_FD_WRITE);
     } else {
       VPoller::write(Node, Trigger, UserData);

--- a/include/host/wasi/inode.h
+++ b/include/host/wasi/inode.h
@@ -347,7 +347,7 @@ public:
 
   static INode stdErr() noexcept;
 
-  static WasiExpect<INode> fromFd(int32_t Fd);
+  static WasiExpect<INode> fromFd(int32_t FdNum);
 
   /// Open a file or directory.
   ///

--- a/include/host/wasi/vinode.h
+++ b/include/host/wasi/vinode.h
@@ -788,29 +788,31 @@ public:
   using Poller::result;
   using Poller::wait;
 
-  void read(std::shared_ptr<VINode> Fd, TriggerType Trigger,
+  void read(std::shared_ptr<VINode> Node, TriggerType Trigger,
             __wasi_userdata_t UserData) noexcept {
-    if (!Fd->can(__WASI_RIGHTS_POLL_FD_READWRITE) &&
-        !Fd->can(__WASI_RIGHTS_FD_READ)) {
+    if (!Node->can(__WASI_RIGHTS_POLL_FD_READWRITE) &&
+        !Node->can(__WASI_RIGHTS_FD_READ)) {
       Poller::error(UserData, __WASI_ERRNO_NOTCAPABLE,
                     __WASI_EVENTTYPE_FD_READ);
     } else {
-      Poller::read(Fd->Node, Trigger, UserData);
+      Poller::read(Node->Node, Trigger, UserData);
     }
   }
 
-  void write(std::shared_ptr<VINode> Fd, TriggerType Trigger,
+  void write(std::shared_ptr<VINode> Node, TriggerType Trigger,
              __wasi_userdata_t UserData) noexcept {
-    if (!Fd->can(__WASI_RIGHTS_POLL_FD_READWRITE) &&
-        !Fd->can(__WASI_RIGHTS_FD_WRITE)) {
+    if (!Node->can(__WASI_RIGHTS_POLL_FD_READWRITE) &&
+        !Node->can(__WASI_RIGHTS_FD_WRITE)) {
       Poller::error(UserData, __WASI_ERRNO_NOTCAPABLE,
                     __WASI_EVENTTYPE_FD_WRITE);
     } else {
-      Poller::write(Fd->Node, Trigger, UserData);
+      Poller::write(Node->Node, Trigger, UserData);
     }
   }
 
-  void close(std::shared_ptr<VINode> Fd) noexcept { Poller::close(Fd->Node); }
+  void close(std::shared_ptr<VINode> Node) noexcept {
+    Poller::close(Node->Node);
+  }
 };
 
 } // namespace WASI

--- a/include/llvm/compiler.h
+++ b/include/llvm/compiler.h
@@ -39,7 +39,7 @@ public:
 
   struct CompileContext;
   struct CompileContextDeleter {
-    void operator()(CompileContext *Context) const noexcept;
+    void operator()(CompileContext *ContextPtr) const noexcept;
   };
 
   /// Compile only the infrastructure (types, imports, globals, etc.) without

--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -182,7 +182,7 @@ INode INode::stdOut() noexcept { return INode(STDOUT_FILENO); }
 
 INode INode::stdErr() noexcept { return INode(STDERR_FILENO); }
 
-WasiExpect<INode> INode::fromFd(int32_t Fd) { return createStdNode(Fd); }
+WasiExpect<INode> INode::fromFd(int32_t FdNum) { return createStdNode(FdNum); }
 
 WasiExpect<INode> INode::open(std::string Path, __wasi_oflags_t OpenFlags,
                               __wasi_fdflags_t FdFlags,

--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -152,7 +152,7 @@ INode INode::stdOut() noexcept { return INode(STDOUT_FILENO); }
 
 INode INode::stdErr() noexcept { return INode(STDERR_FILENO); }
 
-WasiExpect<INode> INode::fromFd(int32_t Fd) { return createStdNode(Fd); }
+WasiExpect<INode> INode::fromFd(int32_t FdNum) { return createStdNode(FdNum); }
 
 WasiExpect<INode> INode::open(std::string Path, __wasi_oflags_t OpenFlags,
                               __wasi_fdflags_t FdFlags,
@@ -197,7 +197,7 @@ WasiExpect<void> INode::fdAllocate(__wasi_filesize_t Offset,
   if (auto Res = ::fcntl(Fd, F_PREALLOCATE, &Store); unlikely(Res < 0)) {
     // Try to allocate sparse space.
     Store.fst_flags = F_ALLOCATEALL;
-    if (auto Res = ::fcntl(Fd, F_PREALLOCATE, &Store); unlikely(Res < 0)) {
+    if (auto Res2 = ::fcntl(Fd, F_PREALLOCATE, &Store); unlikely(Res2 < 0)) {
       return WasiUnexpect(fromErrNo(errno));
     }
   }

--- a/lib/host/wasi/inode-win.cpp
+++ b/lib/host/wasi/inode-win.cpp
@@ -679,8 +679,8 @@ INode INode::stdErr() noexcept {
   return INode(GetStdHandle(STD_ERROR_HANDLE_), true);
 }
 
-WasiExpect<INode> INode::fromFd(int32_t Fd) {
-  EXPECTED_TRY(auto Handle, getWindowsHandle(Fd));
+WasiExpect<INode> INode::fromFd(int32_t FdNum) {
+  EXPECTED_TRY(auto Handle, getWindowsHandle(FdNum));
   return INode(Handle, true);
 }
 

--- a/lib/llvm/compiler.cpp
+++ b/lib/llvm/compiler.cpp
@@ -31,9 +31,9 @@ using namespace std::literals;
 namespace {
 
 struct RAIICleanup {
-  RAIICleanup(LLVM::Compiler::CompileContext *&Context,
+  RAIICleanup(LLVM::Compiler::CompileContext *&ContextRef,
               LLVM::Compiler::CompileContext *NewContext)
-      : Context(Context) {
+      : Context(ContextRef) {
     Context = NewContext;
   }
   ~RAIICleanup() { Context = nullptr; }
@@ -6717,8 +6717,8 @@ Compiler::compileFunctions(Data &&LLData, CompileContext *NewContext,
 }
 
 void LLVM::Compiler::CompileContextDeleter::operator()(
-    CompileContext *Context) const noexcept {
-  delete Context;
+    CompileContext *ContextPtr) const noexcept {
+  delete ContextPtr;
 }
 } // namespace LLVM
 } // namespace WasmEdge

--- a/lib/system/stacktrace.cpp
+++ b/lib/system/stacktrace.cpp
@@ -58,11 +58,11 @@ Span<void *const> stackTrace(Span<void *> Buffer) noexcept {
   BacktraceState State{Buffer, 0};
   _Unwind_Backtrace(
       [](struct _Unwind_Context *Ctx, void *Arg) noexcept {
-        auto &State = *static_cast<BacktraceState *>(Arg);
-        if (State.Index >= State.Buffer.size()) {
+        auto &BTState = *static_cast<BacktraceState *>(Arg);
+        if (BTState.Index >= BTState.Buffer.size()) {
           return _URC_END_OF_STACK;
         }
-        State.Buffer[State.Index++] =
+        BTState.Buffer[BTState.Index++] =
             reinterpret_cast<void *>(_Unwind_GetIP(Ctx));
         return _URC_NO_REASON;
       },

--- a/plugins/wasi_nn/MLX/mlx/base.cpp
+++ b/plugins/wasi_nn/MLX/mlx/base.cpp
@@ -9,26 +9,26 @@
 namespace WasmEdge::Host::WASINN::MLX {
 namespace mlx::core::nn {
 
-mx::array &Module::registerParameter(std::string Name, mx::array &&W) {
-  Parameters.insert({Name, W});
-  return Parameters.at(Name);
+mx::array &Module::registerParameter(std::string ParamName, mx::array &&W) {
+  Parameters.insert({ParamName, W});
+  return Parameters.at(ParamName);
 }
 
-void Module::update(std::unordered_map<std::string, mx::array> Parameters) {
-  for (auto &[K, V] : Parameters) {
+void Module::update(std::unordered_map<std::string, mx::array> NewParameters) {
+  for (auto &[K, V] : NewParameters) {
     apply(K, V);
   }
 }
 
 std::shared_ptr<nn::Module> Module::toQuantized(
     int GroupSize, int Bits, const std::string &Prefix,
-    const std::unordered_map<std::string, mx::array> &Parameters) {
+    const std::unordered_map<std::string, mx::array> &LoadedWeights) {
   auto NewPrefix = Prefix + Name + (Prefix.empty() && Name.empty() ? "" : ".");
   for (auto &[K, V] : Submodules) {
     if (V->hasQuantize()) {
       auto Weights = V->Parameters.find("weight");
-      if (Weights != V->Parameters.end() && !Parameters.empty()) {
-        if (Parameters.count(NewPrefix + V->Name + ".scales") == 0) {
+      if (Weights != V->Parameters.end() && !LoadedWeights.empty()) {
+        if (LoadedWeights.count(NewPrefix + V->Name + ".scales") == 0) {
           continue;
         }
       }
@@ -38,7 +38,8 @@ std::shared_ptr<nn::Module> Module::toQuantized(
       }
     }
     V = V->toQuantized(GroupSize, Bits,
-                       Prefix + Name + (Name.empty() ? "" : "."), Parameters);
+                       Prefix + Name + (Name.empty() ? "" : "."),
+                       LoadedWeights);
   }
   return shared_from_this();
 }

--- a/plugins/wasi_nn/MLX/mlx/base.h
+++ b/plugins/wasi_nn/MLX/mlx/base.h
@@ -31,20 +31,20 @@ public:
 
   virtual ~Module() = default;
 
-  mx::array &registerParameter(std::string Name, mx::array &&W);
+  mx::array &registerParameter(std::string ParamName, mx::array &&W);
 
   std::unordered_map<std::string, mx::array>
   getWeigts(const std::string &Prefix = "model");
 
   virtual std::shared_ptr<nn::Module> toQuantized(
       int GroupSize = 64, int Bits = 4, const std::string &Prefix = "",
-      const std::unordered_map<std::string, mx::array> &Parameters = {});
+      const std::unordered_map<std::string, mx::array> &LoadedWeights = {});
 
   virtual bool hasQuantize() { return false; }
 
-  void update(std::unordered_map<std::string, mx::array> Parameters);
+  void update(std::unordered_map<std::string, mx::array> NewParameters);
 
-  void apply(std::string Key, mx::array Parameters);
+  void apply(std::string Key, mx::array Value);
 
   template <typename T>
   void registerModule(std::string ModuleName, std::shared_ptr<T> M) {

--- a/plugins/wasi_nn/MLX/mlx/embedding.h
+++ b/plugins/wasi_nn/MLX/mlx/embedding.h
@@ -30,8 +30,8 @@ public:
 
   std::shared_ptr<nn::Module>
   toQuantized(int GroupSize = 64, int Bits = 4, const std::string &Prefix = "",
-              const std::unordered_map<std::string, mx::array> &Parameters = {})
-      override;
+              const std::unordered_map<std::string, mx::array> &LoadedWeights =
+                  {}) override;
 
   virtual bool hasQuantize() override { return true; }
 };

--- a/plugins/wasi_nn/MLX/mlx/linear.h
+++ b/plugins/wasi_nn/MLX/mlx/linear.h
@@ -36,8 +36,8 @@ public:
   virtual mx::array forward(mx::array Input);
   std::shared_ptr<nn::Module>
   toQuantized(int GroupSize = 64, int Bits = 4, const std::string &Prefix = "",
-              const std::unordered_map<std::string, mx::array> &Parameters = {})
-      override;
+              const std::unordered_map<std::string, mx::array> &LoadedWeights =
+                  {}) override;
 
   virtual bool hasQuantize() override { return true; }
 };

--- a/plugins/wasi_nn/MLX/mlx/pooling.cpp
+++ b/plugins/wasi_nn/MLX/mlx/pooling.cpp
@@ -151,30 +151,31 @@ mx::array Pool::forward(const mx::array &X) {
 
 Pool2d::Pool2d(
     const std::function<mx::array(const mx::array &, const std::vector<int> &)>
-        &PoolingFunction,
-    int PaddingValue, const std::vector<int> &KernelSize,
+        &PoolingFn,
+    int PadValue, const std::vector<int> &KernelSizes,
     const std::optional<std::vector<int>> &StrideOpt,
     const std::optional<std::vector<int>> &PaddingOpt)
-    : Pool(PoolingFunction,
-           KernelSize.size() == 1 ? valueOrList(KernelSize[0], 2) : KernelSize,
+    : Pool(PoolingFn,
+           KernelSizes.size() == 1 ? valueOrList(KernelSizes[0], 2)
+                                   : KernelSizes,
            (StrideOpt.has_value()
                 ? (StrideOpt.value().size() == 1
                        ? valueOrList(StrideOpt.value()[0], 2)
                        : StrideOpt.value())
-                : (KernelSize.size() == 1 ? valueOrList(KernelSize[0], 2)
-                                          : KernelSize)),
+                : (KernelSizes.size() == 1 ? valueOrList(KernelSizes[0], 2)
+                                           : KernelSizes)),
            makePaddingPairs(PaddingOpt.has_value() ? PaddingOpt.value()
                                                    : valueOrList(0, 2)),
-           PaddingValue) {}
+           PadValue) {}
 
-AvgPool2d::AvgPool2d(const std::vector<int> &KernelSize,
-                     const std::optional<std::vector<int>> &Stride,
-                     const std::optional<std::vector<int>> &Padding)
+AvgPool2d::AvgPool2d(const std::vector<int> &KernelSizes,
+                     const std::optional<std::vector<int>> &StrideOpt,
+                     const std::optional<std::vector<int>> &PaddingOpt)
     : Pool2d(
           [](const mx::array &A, const std::vector<int> &Axis) -> mx::array {
             return mx::mean(A, Axis, false);
           },
-          0, KernelSize, Stride, Padding) {}
+          0, KernelSizes, StrideOpt, PaddingOpt) {}
 
 } // namespace mlx::core::nn
 } // namespace WasmEdge::Host::WASINN::MLX

--- a/plugins/wasi_nn/MLX/mlx/pooling.h
+++ b/plugins/wasi_nn/MLX/mlx/pooling.h
@@ -27,18 +27,18 @@ protected:
 
 class Pool2d : public Pool {
 public:
-  Pool2d(const std::function<mx::array(
-             const mx::array &, const std::vector<int> &)> &PoolingFunction,
-         int PaddingValue, const std::vector<int> &KernelSize,
-         const std::optional<std::vector<int>> &Stride,
-         const std::optional<std::vector<int>> &Padding);
+  Pool2d(const std::function<mx::array(const mx::array &,
+                                       const std::vector<int> &)> &PoolingFn,
+         int PadValue, const std::vector<int> &KernelSizes,
+         const std::optional<std::vector<int>> &StrideOpt,
+         const std::optional<std::vector<int>> &PaddingOpt);
 };
 
 class AvgPool2d : public Pool2d {
 public:
-  AvgPool2d(const std::vector<int> &KernelSize,
-            const std::optional<std::vector<int>> &Stride = std::nullopt,
-            const std::optional<std::vector<int>> &Padding = std::nullopt);
+  AvgPool2d(const std::vector<int> &KernelSizes,
+            const std::optional<std::vector<int>> &StrideOpt = std::nullopt,
+            const std::optional<std::vector<int>> &PaddingOpt = std::nullopt);
 };
 
 } // namespace mlx::core::nn

--- a/plugins/wasi_nn/MLX/model/vlm_base.cpp
+++ b/plugins/wasi_nn/MLX/model/vlm_base.cpp
@@ -131,8 +131,8 @@ int KVCache::trim(int N) {
 }
 
 // RotatingKVCache implementation
-RotatingKVCache::RotatingKVCache(int MaxSize, int Keep, int Step)
-    : KVCache(0, 0, Step), Keep(Keep), MaxSize(MaxSize), Idx(0) {}
+RotatingKVCache::RotatingKVCache(int MaxSize, int Keep, int StepSize)
+    : KVCache(0, 0, StepSize), Keep(Keep), MaxSize(MaxSize), Idx(0) {}
 
 mx::array RotatingKVCache::trim(int TrimSize, const mx::array &V,
                                 std::optional<mx::array> Append) {

--- a/plugins/wasi_nn/MLX/model/vlm_base.h
+++ b/plugins/wasi_nn/MLX/model/vlm_base.h
@@ -67,7 +67,7 @@ public:
   int MaxSize;
   int Idx;
 
-  RotatingKVCache(int MaxSize = -1, int Keep = 0, int Step = 256);
+  RotatingKVCache(int MaxSize = -1, int Keep = 0, int StepSize = 256);
 
   std::tuple<mx::array, mx::array>
   updateAndFetch(const mx::array &NewKeys, const mx::array &NewValues) override;

--- a/plugins/wasi_nn/MLX/model/whisper/decoding.cpp
+++ b/plugins/wasi_nn/MLX/model/whisper/decoding.cpp
@@ -468,8 +468,9 @@ DecodingTask::DecodingTask(std::shared_ptr<Whisper> Model,
   }
 }
 
-DecodingOptions DecodingTask::verifyOptions(const DecodingOptions &Options) {
-  DecodingOptions Result = Options;
+DecodingOptions
+DecodingTask::verifyOptions(const DecodingOptions &InputOptions) {
+  DecodingOptions Result = InputOptions;
 
   // Check beam_size and best_of conflicts
   if (Result.BeamSize && Result.BestOf) {

--- a/plugins/wasi_nn/MLX/model/whisper/decoding.h
+++ b/plugins/wasi_nn/MLX/model/whisper/decoding.h
@@ -163,7 +163,7 @@ public:
   std::vector<DecodingResult> run(const mx::array &Mel);
 
 private:
-  DecodingOptions verifyOptions(const DecodingOptions &Options);
+  DecodingOptions verifyOptions(const DecodingOptions &InputOptions);
   std::vector<int> getInitialTokens();
   std::vector<int> getSuppressTokens();
   mx::array getAudioFeatures(const mx::array &Mel);

--- a/plugins/wasi_nn/MLX/model/whisper/tokenizer.cpp
+++ b/plugins/wasi_nn/MLX/model/whisper/tokenizer.cpp
@@ -451,13 +451,14 @@ int Tokenizer::languageToken() const {
   return toLanguageToken(Language.value());
 }
 
-int Tokenizer::toLanguageToken(const std::string &Language) const {
-  std::string TokenName = "<|" + Language + "|>";
+int Tokenizer::toLanguageToken(const std::string &LanguageCode) const {
+  std::string TokenName = "<|" + LanguageCode + "|>";
   auto It = SpecialTokens.find(TokenName);
   if (It != SpecialTokens.end()) {
     return It->second;
   }
-  throw std::runtime_error("Language " + Language + " not found in tokenizer.");
+  throw std::runtime_error("Language " + LanguageCode +
+                           " not found in tokenizer.");
 }
 
 std::vector<int> Tokenizer::getAllLanguageTokens() const {
@@ -703,7 +704,7 @@ std::unique_ptr<Encoding> getEncoding(const std::string &Name,
   std::vector<std::string> Specials = {"<|endoftext|>",
                                        "<|startoftranscript|>"};
 
-  for (const auto &[Code, Name] : LANGUAGES) {
+  for (const auto &[Code, LanguageName] : LANGUAGES) {
     Specials.push_back("<|" + Code + "|>");
     if (static_cast<int>(Specials.size()) >= NumLanguages + 2)
       break;

--- a/plugins/wasi_nn/MLX/model/whisper/tokenizer.h
+++ b/plugins/wasi_nn/MLX/model/whisper/tokenizer.h
@@ -63,7 +63,7 @@ public:
   int getNoTimestamps() const;
   int getTimestampBegin() const;
   int languageToken() const;
-  int toLanguageToken(const std::string &Language) const;
+  int toLanguageToken(const std::string &LanguageCode) const;
   std::vector<int> getAllLanguageTokens() const;
   std::vector<std::string> getAllLanguageCodes() const;
   std::vector<int> getSotSequenceIncludingNotimestamps() const;

--- a/plugins/wasmedge_llmc/llmc_base.h
+++ b/plugins/wasmedge_llmc/llmc_base.h
@@ -14,7 +14,7 @@ namespace WasmEdgeLLMC {
 
 template <typename T> class HostFunction : public Runtime::HostFunction<T> {
 public:
-  HostFunction(LLMCEnv &E) : Runtime::HostFunction<T>(0), Env(E) {}
+  HostFunction(LLMCEnv &HostEnv) : Runtime::HostFunction<T>(0), Env(HostEnv) {}
 
 protected:
   static constexpr uint32_t castErrNo(ErrNo E) noexcept {

--- a/plugins/wasmedge_llmc/llmc_func.h
+++ b/plugins/wasmedge_llmc/llmc_func.h
@@ -16,7 +16,7 @@ namespace WasmEdgeLLMC {
 
 class ModelCreate : public HostFunction<ModelCreate> {
 public:
-  explicit ModelCreate(LLMCEnv &Env) : HostFunction(Env) {}
+  explicit ModelCreate(LLMCEnv &HostEnv) : HostFunction(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame,
                         uint32_t CheckPointPath, uint32_t CheckPointPathLen,
@@ -33,7 +33,7 @@ private:
 
 class DataLoaderCreate : public HostFunction<DataLoaderCreate> {
 public:
-  explicit DataLoaderCreate(LLMCEnv &Env) : HostFunction(Env) {}
+  explicit DataLoaderCreate(LLMCEnv &HostEnv) : HostFunction(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t DataPath,
                         uint32_t DataPathLen, uint32_t B, uint32_t T,
@@ -53,7 +53,7 @@ private:
 
 class TokenizerCreate : public HostFunction<TokenizerCreate> {
 public:
-  explicit TokenizerCreate(LLMCEnv &Env) : HostFunction(Env) {}
+  explicit TokenizerCreate(LLMCEnv &HostEnv) : HostFunction(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t FilePath,
                         uint32_t FilePathLen, uint32_t TokenizerIdPtr) {
@@ -68,7 +68,7 @@ private:
 
 class ModelTrain : public HostFunction<ModelTrain> {
 public:
-  explicit ModelTrain(LLMCEnv &Env) : HostFunction(Env) {}
+  explicit ModelTrain(LLMCEnv &HostEnv) : HostFunction(HostEnv) {}
 
   Expect<uint32_t> body(const Runtime::CallingFrame &Frame, uint32_t ModelId,
                         uint32_t TrainDataLoaderId, uint32_t ValDataLoaderId,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,6 +53,7 @@ else()
   endif()
 
   FetchContent_MakeAvailable(GTest)
+  wasmedge_suppress_shadow_warnings(gtest gtest_main)
   set(GTEST_BOTH_LIBRARIES "gtest_main")
 endif()
 

--- a/thirdparty/blake3/CMakeLists.txt
+++ b/thirdparty/blake3/CMakeLists.txt
@@ -27,6 +27,7 @@ wasmedge_add_library(utilBlake3
   blake3_dispatch.c
   blake3_portable.c
 )
+wasmedge_suppress_shadow_warnings(utilBlake3)
 
 # optional SIMD sources
 macro(BLAKE3_DISABLE_SIMD)


### PR DESCRIPTION
## Description

Re-implementation of #3055 on the current tree. Variable/field shadowing silently
hides an outer declaration and is a recurring source of latent bugs, so this turns
on shadowing warnings across the supported compilers and fixes every diagnostic
they surface.

### Enable the warnings — `cmake/Helper.cmake`

- **Clang family (Clang / AppleClang / clang-cl)**: add `-Wshadow` and
  `-Wshadow-field`, dropping the previous `-Wno-error=shadow` /
  `-Wno-error=shadow-field` escape hatches, so both are enforced as errors
  everywhere through the existing `-Werror`. `-Wshadow-field` is not part of
  `-Wshadow`, so it is enabled explicitly to catch declarations that shadow
  members inherited from a base class.
- Keep the idiomatic `Foo(x) : x(x)` constructor accepted: clang-cl 21 fires
  `-Wshadow-field-in-constructor` under these flags even though it is not
  documented as part of either group, so it is disabled explicitly while
  re-enabling the narrower `-Wshadow-field-in-constructor-modified` check that
  `-Wshadow` intends.
- **GCC**: enable `-Wshadow=local`. GCC's full `-Wshadow`, unlike Clang's, flags
  the constructor idiom (pervasive in this repo) and offers no subgroup to
  exempt it, so only local shadowing is checked there.
- **MSVC**: `/W4` already enables the C4456–C4459 shadow warnings; no new
  enables are needed.
- Add a `wasmedge_suppress_shadow_warnings()` helper and apply it to the
  third-party targets built with our flags (fmt, spdlog, gtest, simdjson, and
  the vendored blake3) — they are not ours to fix.

### Fix the reported diagnostics

Resolved by renaming the shadowing identifiers, following the existing codebase
convention (the base `Poller` methods already use `Node` for this reason):

| Location | Change | Diagnostic |
| --- | --- | --- |
| `inode.h`, `inode-{macos,linux,win}.cpp` | `fromFd(Fd)` → `fromFd(FdNum)` | `-Wshadow-field` |
| `environ.h` | poller `read`/`write(Fd)` → `(WasiFd)` | `-Wshadow-field` |
| `vinode.h` | poller `read`/`write`/`close(Fd)` → `(Vinode)` | `-Wshadow-field` |
| `inode-macos.cpp` | nested `Res` → `Res2` | `-Wshadow` |
| `compiler.cpp` | `CompileContextDeleter(Context)` → `(Cxt)` | `-Wshadow` |
| `compiler.cpp` | `RAIICleanup(Context)` → `(Ctx)` | `-Wshadow-field-in-constructor-modified` |
| `stacktrace.cpp` | backtrace lambda `State` → `BTState` | `-Wshadow` (local) |
| `wasmedge_llmc` | host function ctor `Env` params → `HostEnv` | `-Wshadow-field` |
| `wasi_nn` MLX backend | params/locals shadowing members, types, and outer bindings | `-Wshadow` / `-Wshadow-field` |

The `RAIICleanup` case was a genuine latent bug — the constructor body assigned the
shadowing *parameter* instead of the member reference, exactly the mistake these
warnings exist to catch.

### Scope / platform notes

- Shadow warnings are enforced as **errors on all platforms** via the
  pre-existing `-Werror` / `/WX`; no `-Wno-error=shadow*` escape hatches remain.
  AppleClang was verified locally, and Linux GCC/Clang plus Windows clang-cl and
  MSVC are verified by the full CI matrix on this PR.
- `-Wshadow-field` is Clang-only; GCC is covered by `-Wshadow=local` and MSVC by
  the C4456–C4459 checks already in `/W4`.

> This contribution was developed with assistance from Claude (Anthropic).

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence

Built on macOS / AppleClang 21 with the new flags enforced (`-Werror -Wshadow -Wshadow-field`):

```
$ cmake -G Ninja -DWASMEDGE_USE_LLVM=ON -DWASMEDGE_BUILD_TESTS=ON \
        -DWASMEDGE_BUILD_TOOLS=ON -DWASMEDGE_BUILD_PLUGINS=ON -B build
$ ninja -C build
...
[107/107] Linking CXX executable test/meminstance/wasmedgeMemInstanceTests
ninja: build complete.   # 0 -Wshadow/-Wshadow-field diagnostics, 0 errors
```

- Full build of libraries + tools + tests + plugins compiles and links cleanly
  under the enforced flags: **0 shadow diagnostics, 0 errors**.
- All **35 test executables** build successfully.
- The PR CI matrix builds green with the warnings enforced as errors on Linux
  GCC/Clang, Windows clang-cl/MSVC, and macOS AppleClang.
