### PR TITLE
feat(api): version C ABI symbols for the 0.16 -> 0.17 limit change

### DIFF
--- a/.github/scripts/SYMBOL_CHECKING.md
+++ b/.github/scripts/SYMBOL_CHECKING.md
@@ -38,3 +38,61 @@ When adding new public API functions:
 1. Add the function to `include/api/wasmedge/wasmedge.h` with `WASMEDGE_CAPI_EXPORT`
 2. Add the symbol name to `whitelist.symbols` (keep alphabetical order)
 3. Commit both changes together
+
+## C API symbol versioning
+
+On Linux/Android the exported C symbols are grouped into versioned nodes by the
+linker version script `lib/api/libwasmedge.lds` (e.g. `WASMEDGE_0.16`,
+`WASMEDGE_0.17`). This lets a single `libwasmedge.so.0` keep serving an older
+ABI alongside the current one, so a signature-only break does not force every
+dynamically linked consumer to rebuild and does not, by itself, require a
+SONAME (`WASMEDGE_CAPI_SOVERSION`) bump.
+
+When a release breaks the signature of an existing C API function (changed
+parameters/return type or a changed by-value struct layout):
+
+1. Add a new version node to `lib/api/libwasmedge.lds` named after the release
+   that introduces the break (inheriting the previous node), and list the
+   changed symbols under its `global:` section. The literal names take
+   precedence over the `WasmEdge*` wildcard, so the current implementations
+   become the new node's default (`@@`) symbols automatically.
+2. Keep the previous behaviour available by adding a backward-compatible shim in
+   `lib/api/wasmedge_compat.cpp` (guarded by `#if defined(__ELF__) &&
+   (defined(__linux__) || defined(__ANDROID__))`) named
+   `WasmEdge_<Name>_Compat_<old>`, and bind it to the old version with
+   `__asm__(".symver WasmEdge_<Name>_Compat_<old>, WasmEdge_<Name>@WASMEDGE_<old>")`.
+   The shim lives in its own translation unit (compiled only into the shared
+   library) so that this `.symver` module-level asm does not collide with the
+   in-IR definition of `WasmEdge_<Name>` under ThinLTO.
+   Mark the shim `__attribute__((used, visibility("default")))`. The
+   `visibility("default")` is required: the project builds with
+   `-fvisibility=hidden`, and a hidden source symbol does not produce an exported
+   `.symver` alias (the compat symbol silently disappears). Because that default
+   visibility plus the `WasmEdge_*` name would otherwise export the shim's own
+   name, add its exact name to the `local:` section of the base node in
+   `lib/api/libwasmedge.lds` (an exact match outranks the `WasmEdge*` wildcard),
+   so only the `@WASMEDGE_<old>` alias is exported.
+3. `check_symbols.sh` strips the `@<version>` suffix before matching, so the
+   `whitelist.symbols` entries stay the bare function names — no whitelist
+   changes are needed for versioning.
+
+The limit struct -> limit context change (0.16 -> 0.17) is the worked example:
+`WasmEdge_LimitIsEqual`, `WasmEdge_MemoryTypeCreate`, `WasmEdge_MemoryTypeGetLimit`,
+`WasmEdge_TableTypeCreate`, and `WasmEdge_TableTypeGetLimit` carry both a
+`@@WASMEDGE_0.17` default and a `@WASMEDGE_0.16` compatibility symbol.
+
+> Note: this mechanism is ELF-only; macOS and Windows export the symbols
+> unversioned. A subtle but important runtime rule: an *unversioned* reference
+> (from a consumer built against a pre-versioning library — i.e. 0.16.x or the
+> released 0.17.0) binds to the **oldest** matching version definition, here
+> `@WASMEDGE_0.16` (the struct shim), **not** to the default `@@` symbol. The
+> `@@` default only selects what *newly linked* code records (it gets a
+> versioned `@WASMEDGE_0.17` reference). Consequences:
+>
+> - Consumers built against **0.16.x keep working without a rebuild** — their
+>   unversioned references land on the matching `@WASMEDGE_0.16` struct shim.
+> - Consumers built against the (also unversioned) **0.17.0 must be rebuilt** —
+>   their unversioned references also land on the `@WASMEDGE_0.16` struct shim,
+>   which mismatches the pointer/context ABI they were compiled for.
+> - Consumers built against this versioned library resolve to `@WASMEDGE_0.17`
+>   and are correct.

--- a/.github/scripts/check_symbols.sh
+++ b/.github/scripts/check_symbols.sh
@@ -131,9 +131,12 @@ else
         exit 1
     fi
 
+    # Strip the version suffix (e.g. WasmEdge_Foo@@WASMEDGE_0.17 or
+    # WasmEdge_Foo@WASMEDGE_0.16) so versioned symbols match the whitelist,
+    # then de-duplicate the default and compat aliases of the same name.
     nm -D --defined-only "$LIB_PATH" 2>/dev/null | \
-        awk '/^[0-9a-fA-F]+ [TBDW] / {print $3}' | \
-        grep -E "^WasmEdge" | sort > "$TEMP_DIR/extracted.symbols"
+        awk '/^[0-9a-fA-F]+ [TBDW] / {sub(/@.*/, "", $3); print $3}' | \
+        grep -E "^WasmEdge" | sort -u > "$TEMP_DIR/extracted.symbols"
 fi
 
 if [ ! -s "$TEMP_DIR/extracted.symbols" ]; then

--- a/lib/api/CMakeLists.txt
+++ b/lib/api/CMakeLists.txt
@@ -128,6 +128,13 @@ if(WASMEDGE_BUILD_SHARED_LIB)
       PRIVATE
       "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libwasmedge.lds"
     )
+
+    # The 0.16 `@WASMEDGE_0.16` compat shims rely on the version script, so they
+    # belong only to the shared library, not the static one (see wasmedge_compat.cpp).
+    target_sources(wasmedge_shared
+      PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/wasmedge_compat.cpp
+    )
   endif()
 
   target_link_libraries(wasmedge_shared

--- a/lib/api/libwasmedge.lds
+++ b/lib/api/libwasmedge.lds
@@ -1,4 +1,4 @@
-{
+WASMEDGE_0.16 {
   global:
     WasmEdge*;
     extern "C++" {
@@ -6,5 +6,24 @@
     };
 
   local:
+    # Internal names of the 0.16 backward-compat shims (see
+    # lib/api/wasmedge_compat.cpp).
+    # They need default visibility so `.symver` can export their `@WASMEDGE_0.16`
+    # aliases, but their own names match the `WasmEdge*` pattern above; listing
+    # them here (an exact match outranks the wildcard) keeps them unexported.
+    WasmEdge_LimitIsEqual_Compat_016;
+    WasmEdge_MemoryTypeCreate_Compat_016;
+    WasmEdge_MemoryTypeGetLimit_Compat_016;
+    WasmEdge_TableTypeCreate_Compat_016;
+    WasmEdge_TableTypeGetLimit_Compat_016;
     *;
 };
+
+WASMEDGE_0.17 {
+  global:
+    WasmEdge_LimitIsEqual;
+    WasmEdge_MemoryTypeCreate;
+    WasmEdge_MemoryTypeGetLimit;
+    WasmEdge_TableTypeCreate;
+    WasmEdge_TableTypeGetLimit;
+} WASMEDGE_0.16;

--- a/lib/api/wasmedge_compat.cpp
+++ b/lib/api/wasmedge_compat.cpp
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+// >>>>>>>> WasmEdge 0.16 compat ABI shims >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+//
+// The 0.16 -> 0.17 transition changed five C API functions from the by-value
+// `WasmEdge_Limit` struct to the opaque `WasmEdge_LimitContext` handle. These
+// shims provide the old `@WASMEDGE_0.16` symbols (bound with `.symver`) while
+// `wasmedge.cpp` keeps the default `@@WASMEDGE_0.17` ones; they are a frozen
+// copy of the 0.16.4-rc.1 implementations so the old ABI stays pinned.
+//
+// Compiled only into the shared library on Linux/Android (see CMakeLists.txt).
+// Kept in a separate TU because under ThinLTO the module-level `.symver` asm
+// would otherwise collide with the in-IR definition of the same public symbol.
+
+#include "wasmedge/wasmedge.h"
+
+#include "ast/type.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+
+#if defined(__ELF__) && (defined(__linux__) || defined(__ANDROID__))
+
+namespace {
+using namespace WasmEdge;
+
+// Local copies of the `wasmedge.cpp` helpers, kept here to stay self-contained.
+inline ValType genValType(const WasmEdge_ValType &T) noexcept {
+  std::array<uint8_t, 8> R;
+  std::copy_n(T.Data, 8, R.begin());
+  return ValType(R);
+}
+inline auto *toTabTypeCxt(AST::TableType *Cxt) noexcept {
+  return reinterpret_cast<WasmEdge_TableTypeContext *>(Cxt);
+}
+inline const auto *
+fromTabTypeCxt(const WasmEdge_TableTypeContext *Cxt) noexcept {
+  return reinterpret_cast<const AST::TableType *>(Cxt);
+}
+inline auto *toMemTypeCxt(AST::MemoryType *Cxt) noexcept {
+  return reinterpret_cast<WasmEdge_MemoryTypeContext *>(Cxt);
+}
+inline const auto *
+fromMemTypeCxt(const WasmEdge_MemoryTypeContext *Cxt) noexcept {
+  return reinterpret_cast<const AST::MemoryType *>(Cxt);
+}
+} // namespace
+
+extern "C" {
+
+// Layout-compatible revival of the 0.16 `WasmEdge_Limit` struct. `Min`/`Max`
+// are `uint32_t` (Memory64 widened them to 64-bit only in 0.17), keeping the
+// by-value ABI bit-for-bit identical to what 0.16 consumers were built against.
+typedef struct WasmEdge_Limit_0_16 {
+  bool HasMax;
+  bool Shared;
+  uint32_t Min;
+  uint32_t Max;
+} WasmEdge_Limit_0_16;
+
+__attribute__((used, visibility("default"))) bool
+WasmEdge_LimitIsEqual_Compat_016(const WasmEdge_Limit_0_16 Lim1,
+                                 const WasmEdge_Limit_0_16 Lim2) {
+  return Lim1.HasMax == Lim2.HasMax && Lim1.Shared == Lim2.Shared &&
+         Lim1.Min == Lim2.Min && Lim1.Max == Lim2.Max;
+}
+
+__attribute__((used, visibility("default"))) WasmEdge_TableTypeContext *
+WasmEdge_TableTypeCreate_Compat_016(const WasmEdge_ValType RefType,
+                                    const WasmEdge_Limit_0_16 Limit) {
+  WasmEdge::ValType RT = genValType(RefType);
+  if (!RT.isRefType()) {
+    return nullptr;
+  }
+  if (Limit.HasMax) {
+    return toTabTypeCxt(new WasmEdge::AST::TableType(RT, Limit.Min, Limit.Max));
+  } else {
+    return toTabTypeCxt(new WasmEdge::AST::TableType(RT, Limit.Min));
+  }
+}
+
+__attribute__((used, visibility("default"))) WasmEdge_Limit_0_16
+WasmEdge_TableTypeGetLimit_Compat_016(const WasmEdge_TableTypeContext *Cxt) {
+  if (Cxt) {
+    const auto &Lim = fromTabTypeCxt(Cxt)->getLimit();
+    return WasmEdge_Limit_0_16{/* HasMax */ Lim.hasMax(),
+                               /* Shared */ Lim.isShared(),
+                               /* Min */ static_cast<uint32_t>(Lim.getMin()),
+                               /* Max */ static_cast<uint32_t>(Lim.getMax())};
+  }
+  return WasmEdge_Limit_0_16{/* HasMax */ false, /* Shared */ false,
+                             /* Min */ 0, /* Max */ 0};
+}
+
+__attribute__((used, visibility("default"))) WasmEdge_MemoryTypeContext *
+WasmEdge_MemoryTypeCreate_Compat_016(const WasmEdge_Limit_0_16 Limit) {
+  if (Limit.Shared) {
+    return toMemTypeCxt(
+        new WasmEdge::AST::MemoryType(Limit.Min, Limit.Max, true));
+  } else if (Limit.HasMax) {
+    return toMemTypeCxt(new WasmEdge::AST::MemoryType(Limit.Min, Limit.Max));
+  } else {
+    return toMemTypeCxt(new WasmEdge::AST::MemoryType(Limit.Min));
+  }
+}
+
+__attribute__((used, visibility("default"))) WasmEdge_Limit_0_16
+WasmEdge_MemoryTypeGetLimit_Compat_016(const WasmEdge_MemoryTypeContext *Cxt) {
+  if (Cxt) {
+    const auto &Lim = fromMemTypeCxt(Cxt)->getLimit();
+    return WasmEdge_Limit_0_16{/* HasMax */ Lim.hasMax(),
+                               /* Shared */ Lim.isShared(),
+                               /* Min */ static_cast<uint32_t>(Lim.getMin()),
+                               /* Max */ static_cast<uint32_t>(Lim.getMax())};
+  }
+  return WasmEdge_Limit_0_16{/* HasMax */ false, /* Shared */ false,
+                             /* Min */ 0, /* Max */ 0};
+}
+
+} // extern "C"
+
+// Bind each shim to its historical `@WASMEDGE_0.16` symbol name. The shims need
+// default visibility for `.symver` to export the alias; their own
+// `WasmEdge_*_Compat_016` names are hidden via the `local:` list in
+// `lib/api/libwasmedge.lds` so only the `@WASMEDGE_0.16` aliases are exported.
+__asm__(".symver WasmEdge_LimitIsEqual_Compat_016, "
+        "WasmEdge_LimitIsEqual@WASMEDGE_0.16");
+__asm__(".symver WasmEdge_TableTypeCreate_Compat_016, "
+        "WasmEdge_TableTypeCreate@WASMEDGE_0.16");
+__asm__(".symver WasmEdge_TableTypeGetLimit_Compat_016, "
+        "WasmEdge_TableTypeGetLimit@WASMEDGE_0.16");
+__asm__(".symver WasmEdge_MemoryTypeCreate_Compat_016, "
+        "WasmEdge_MemoryTypeCreate@WASMEDGE_0.16");
+__asm__(".symver WasmEdge_MemoryTypeGetLimit_Compat_016, "
+        "WasmEdge_MemoryTypeGetLimit@WASMEDGE_0.16");
+
+#endif // __ELF__ && (__linux__ || __ANDROID__)
+
+// <<<<<<<< WasmEdge 0.16 compat ABI shims <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<


### PR DESCRIPTION
The 0.16 -> 0.17 transition replaced the by-value WasmEdge_Limit struct with the opaque WasmEdge_LimitContext handle, breaking the signatures of five C API functions while keeping their names. Use ELF symbol versioning so a single libwasmedge.so.0 keeps serving both ABIs instead of bumping the SONAME.

- lib/api/libwasmedge.lds: split the script into WASMEDGE_0.16 and WASMEDGE_0.17 version nodes; the changed symbols become the default @@WASMEDGE_0.17, and the compat shim names are pinned to local: so only their @WASMEDGE_0.16 aliases are exported.
- lib/api/wasmedge.cpp: add struct-based @WASMEDGE_0.16 compat shims (ELF/Linux/Android only), bound via .symver, with default visibility required under -fvisibility=hidden.
- check_symbols.sh: strip the @<version> suffix and de-duplicate so versioned symbols still match the bare whitelist names.
- SYMBOL_CHECKING.md: document the versioning mechanism and the unversioned-reference binding rule.

Assisted-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

## Checklist

Before submitting this PR, please ensure the following:

- [ ] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [ ] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
