### PR TITLE
fix(wasi_nn): prevent OOB read in load_by_name and OOB write in GGML get_output

### DIFF
--- a/plugins/wasi_nn/GGML/core/output_generator.cpp
+++ b/plugins/wasi_nn/GGML/core/output_generator.cpp
@@ -3,6 +3,8 @@
 
 #include "ggml_core.h"
 
+#include <algorithm>
+
 namespace WasmEdge::Host::WASINN::GGML {
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
 namespace {
@@ -27,8 +29,11 @@ Expect<ErrNo> getOutputSingle(WasiNNEnvironment &Env, uint32_t ContextId,
   // Use index 1 for output metadata.
   if (Index == 1) {
     std::string Metadata = buildOutputMetadata(CxtRef);
-    std::copy_n(Metadata.data(), Metadata.length(), OutBuffer.data());
-    BytesWritten = static_cast<uint32_t>(Metadata.length());
+    uint32_t BytesToCopy =
+        std::min(static_cast<uint32_t>(Metadata.length()),
+                 static_cast<uint32_t>(OutBuffer.size()));
+    std::copy_n(Metadata.data(), BytesToCopy, OutBuffer.data());
+    BytesWritten = BytesToCopy;
     LOG_DEBUG(GraphRef.EnableDebugLog,
               "getOutputSingle: with Index {} a.k.a Metadata...Done"sv, Index)
     return ErrNo::Success;
@@ -36,8 +41,10 @@ Expect<ErrNo> getOutputSingle(WasiNNEnvironment &Env, uint32_t ContextId,
 
   std::string LastToken = common_token_to_piece(
       GraphRef.LlamaContext.get(), CxtRef.LlamaOutputTokens.back());
-  std::copy_n(LastToken.data(), LastToken.length(), OutBuffer.data());
-  BytesWritten = EndianValue(static_cast<uint32_t>(LastToken.length())).le();
+  uint32_t BytesToCopy = std::min(static_cast<uint32_t>(LastToken.length()),
+                                   static_cast<uint32_t>(OutBuffer.size()));
+  std::copy_n(LastToken.data(), BytesToCopy, OutBuffer.data());
+  BytesWritten = EndianValue(BytesToCopy).le();
   LOG_DEBUG(GraphRef.EnableDebugLog, "getOutputSingle: with Index {}...Done"sv,
             Index)
   return ErrNo::Success;
@@ -53,17 +60,21 @@ Expect<ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
   // Use index 1 for output metadata.
   if (Index == 1) {
     std::string Metadata = buildOutputMetadata(CxtRef);
-    std::copy_n(Metadata.data(), Metadata.length(), OutBuffer.data());
-    BytesWritten = static_cast<uint32_t>(Metadata.length());
+    uint32_t BytesToCopy =
+        std::min(static_cast<uint32_t>(Metadata.length()),
+                 static_cast<uint32_t>(OutBuffer.size()));
+    std::copy_n(Metadata.data(), BytesToCopy, OutBuffer.data());
+    BytesWritten = BytesToCopy;
     LOG_DEBUG(GraphRef.EnableDebugLog,
               "getOutput: with Index {} a.k.a Metadata ...Done"sv, Index)
     return ErrNo::Success;
   }
 
-  std::copy_n(CxtRef.LlamaOutputs.data(), CxtRef.LlamaOutputs.size(),
-              OutBuffer.data());
-  BytesWritten =
-      EndianValue(static_cast<uint32_t>(CxtRef.LlamaOutputs.size())).le();
+  uint32_t BytesToCopy =
+      std::min(static_cast<uint32_t>(CxtRef.LlamaOutputs.size()),
+               static_cast<uint32_t>(OutBuffer.size()));
+  std::copy_n(CxtRef.LlamaOutputs.data(), BytesToCopy, OutBuffer.data());
+  BytesWritten = EndianValue(BytesToCopy).le();
   LOG_DEBUG(GraphRef.EnableDebugLog, "getOutput: with Index {}...Done"sv, Index)
   return ErrNo::Success;
 }

--- a/plugins/wasi_nn/wasinnfunc.cpp
+++ b/plugins/wasi_nn/wasinnfunc.cpp
@@ -133,19 +133,16 @@ WasiNNLoadByName::bodyImpl(const Runtime::CallingFrame &Frame, uint32_t NamePtr,
     return WASINN::ErrNo::InvalidArgument;
   }
 
-  // Get the model name.
-  auto Name = MemInst->getPointer<const uint32_t *>(NamePtr);
-  if (unlikely(Name == nullptr)) {
-    spdlog::error("[WASI-NN] Failed when accessing the return Name memory."sv);
-    return WASINN::ErrNo::InvalidArgument;
-  }
-
 #ifdef WASMEDGE_BUILD_WASI_NN_RPC
   if (Env.NNRPCChannel != nullptr) {
     auto Stub = wasi_ephemeral_nn::Graph::NewStub(Env.NNRPCChannel);
     grpc::ClientContext ClientContext;
     wasi_ephemeral_nn::LoadByNameRequest Req;
     auto NameStrView = MemInst->getStringView(NamePtr, NameLen);
+    if (unlikely(NameStrView.size() != NameLen)) {
+      spdlog::error("[WASI-NN] Failed when accessing the Name memory."sv);
+      return WASINN::ErrNo::InvalidArgument;
+    }
     Req.set_name(NameStrView.data(), NameStrView.size());
     wasi_ephemeral_nn::LoadByNameResult Res;
     auto Status = Stub->LoadByName(&ClientContext, Req, &Res);
@@ -158,8 +155,13 @@ WasiNNLoadByName::bodyImpl(const Runtime::CallingFrame &Frame, uint32_t NamePtr,
   }
 #endif // ifdef WASMEDGE_BUILD_WASI_NN_RPC
 
-  // Get the model.
-  std::string ModelName(reinterpret_cast<const char *>(Name), NameLen);
+  // Get the model name.
+  auto NameStrView = MemInst->getStringView(NamePtr, NameLen);
+  if (unlikely(NameStrView.size() != NameLen)) {
+    spdlog::error("[WASI-NN] Failed when accessing the Name memory."sv);
+    return WASINN::ErrNo::InvalidArgument;
+  }
+  std::string ModelName(NameStrView);
   if (Env.mdGet(ModelName, *GraphId)) {
     return WASINN::ErrNo::Success;
   } else {
@@ -183,21 +185,6 @@ Expect<WASINN::ErrNo> WasiNNLoadByNameWithConfig::bodyImpl(
     return WASINN::ErrNo::InvalidArgument;
   }
 
-  // Get the model name.
-  auto Name = MemInst->getPointer<const uint32_t *>(NamePtr);
-  if (unlikely(Name == nullptr)) {
-    spdlog::error("[WASI-NN] Failed when accessing the return Name memory."sv);
-    return WASINN::ErrNo::InvalidArgument;
-  }
-
-  // Get the model config.
-  auto Config = MemInst->getPointer<const uint32_t *>(ConfigPtr);
-  if (unlikely(Config == nullptr)) {
-    spdlog::error(
-        "[WASI-NN] Failed when accessing the return Config memory."sv);
-    return WASINN::ErrNo::InvalidArgument;
-  }
-
 #ifdef WASMEDGE_BUILD_WASI_NN_RPC
   if (Env.NNRPCChannel != nullptr) {
     auto Stub = wasi_ephemeral_nn::Graph::NewStub(Env.NNRPCChannel);
@@ -205,6 +192,14 @@ Expect<WASINN::ErrNo> WasiNNLoadByNameWithConfig::bodyImpl(
     wasi_ephemeral_nn::LoadByNameWithConfigRequest Req;
     auto NameStrView = MemInst->getStringView(NamePtr, NameLen);
     auto ConfigStrView = MemInst->getStringView(ConfigPtr, ConfigLen);
+    if (unlikely(NameStrView.size() != NameLen)) {
+      spdlog::error("[WASI-NN] Failed when accessing the Name memory."sv);
+      return WASINN::ErrNo::InvalidArgument;
+    }
+    if (unlikely(ConfigStrView.size() != ConfigLen)) {
+      spdlog::error("[WASI-NN] Failed when accessing the Config memory."sv);
+      return WASINN::ErrNo::InvalidArgument;
+    }
     Req.set_name(NameStrView.data(), NameStrView.size());
     Req.set_config(ConfigStrView.data(), ConfigStrView.size());
     wasi_ephemeral_nn::LoadByNameWithConfigResult Res;
@@ -218,11 +213,19 @@ Expect<WASINN::ErrNo> WasiNNLoadByNameWithConfig::bodyImpl(
   }
 #endif // ifdef WASMEDGE_BUILD_WASI_NN_RPC
 
-  // Get the model.
-  std::string ModelName(reinterpret_cast<const char *>(Name), NameLen);
-  std::vector<uint8_t> ModelConfig(reinterpret_cast<const uint8_t *>(Config),
-                                   reinterpret_cast<const uint8_t *>(Config) +
-                                       ConfigLen);
+  // Get the model name and config.
+  auto NameStrView = MemInst->getStringView(NamePtr, NameLen);
+  if (unlikely(NameStrView.size() != NameLen)) {
+    spdlog::error("[WASI-NN] Failed when accessing the Name memory."sv);
+    return WASINN::ErrNo::InvalidArgument;
+  }
+  auto ConfigSpan = MemInst->getSpan<const uint8_t>(ConfigPtr, ConfigLen);
+  if (unlikely(ConfigSpan.size() != ConfigLen)) {
+    spdlog::error("[WASI-NN] Failed when accessing the Config memory."sv);
+    return WASINN::ErrNo::InvalidArgument;
+  }
+  std::string ModelName(NameStrView);
+  std::vector<uint8_t> ModelConfig(ConfigSpan.begin(), ConfigSpan.end());
   if (Env.mdGet(ModelName, *GraphId)) {
     return WASINN::ErrNo::Success;
   } else {

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -1571,6 +1571,88 @@ TEST(WasiNNTest, GGMLBackend) {
     EXPECT_GE(BytesWritten, 50);
   }
 }
+
+// Regression test for the get_output OOB write through the real
+// WasiNNGetOutput::bodyImpl -> MemoryInstance::getSpan ->
+// GGML::getOutput -> std::copy_n path, without requiring model loading
+// or inference. A Ready Graph/Context pair is created directly via the
+// environment, LlamaOutputs is populated with a 256-byte payload, and
+// get_output is invoked with OutBufferMaxSize=8. The output must be
+// truncated to fit OutBuffer, leaving the guard region untouched.
+TEST(WasiNNTest, GGMLGetOutputTruncatesToBuffer) {
+  auto NNMod = createModule();
+  ASSERT_TRUE(NNMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_TRUE(MemInstPtr != nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+
+  auto &Env = NNMod->getEnv();
+
+  // Create a minimal Ready graph + context without loading any model.
+  uint32_t GraphId = Env.newGraph(WasmEdge::Host::WASINN::Backend::GGML);
+  auto &G = Env.NNGraph[GraphId];
+  G.setReady();
+  uint32_t ContextId = Env.newContext(GraphId, G);
+  Env.NNContext[ContextId].setReady();
+
+  // Populate LlamaOutputs with a 256-byte sentinel payload, simulating a
+  // long model generation.
+  auto &CxtRef =
+      Env.NNContext[ContextId].get<WasmEdge::Host::WASINN::GGML::Context>();
+  CxtRef.LlamaOutputs.assign(256, 0xABU);
+
+  // Layout in linear memory:
+  //   [0, 8)   -> OutBuffer (OutBufferMaxSize = 8)
+  //   [8, 72)  -> guard region, pre-filled with sentinel 0xCD
+  //   [4096,)  -> BytesWritten output
+  const uint32_t OutBufferPtr = 0;
+  const uint32_t OutBufferMaxSize = 8;
+  const uint32_t GuardPtr = OutBufferPtr + OutBufferMaxSize;
+  const uint32_t GuardLen = 64;
+  const uint32_t BytesWrittenPtr = 4096;
+
+  for (uint32_t I = 0; I < GuardLen; ++I) {
+    *MemInst.getPointer<uint8_t *>(GuardPtr + I) = 0xCDU;
+  }
+
+  // Get the "get_output" host function.
+  auto *FuncInst = NNMod->findFuncExports("get_output");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncGetOutput =
+      dynamic_cast<WasmEdge::Host::WasiNNGetOutput &>(FuncInst->getHostFunc());
+
+  std::array<WasmEdge::ValVariant, 1> Errno = {UINT32_C(0)};
+  EXPECT_TRUE(HostFuncGetOutput.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          ContextId, UINT32_C(0), OutBufferPtr, OutBufferMaxSize,
+          BytesWrittenPtr},
+      Errno));
+
+  // BytesWritten must be truncated to the buffer size, not the full
+  // 256-byte LlamaOutputs payload.
+  uint32_t BytesWritten = *MemInst.getPointer<uint32_t *>(BytesWrittenPtr);
+  EXPECT_EQ(BytesWritten, OutBufferMaxSize);
+
+  // The copy must not spill past OutBuffer into the guard region.
+  for (uint32_t I = 0; I < GuardLen; ++I) {
+    EXPECT_EQ(*MemInst.getPointer<uint8_t *>(GuardPtr + I), 0xCDU)
+        << "Guard byte at offset " << I << " was overwritten";
+  }
+
+  // OutBuffer should contain the first OutBufferMaxSize bytes of
+  // LlamaOutputs.
+  for (uint32_t I = 0; I < OutBufferMaxSize; ++I) {
+    EXPECT_EQ(*MemInst.getPointer<uint8_t *>(OutBufferPtr + I), 0xABU);
+  }
+}
+
 #ifdef WASMEDGE_BUILD_WASI_NN_RPC
 TEST(WasiNNTest, GGMLBackendWithRPC) {
   // wasi_nn_rpcserver has to be started outside this test,

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -23,15 +23,6 @@ using WasmEdge::Host::WASINN::Device;
 using WasmEdge::Host::WASINN::ErrNo;
 using WasmEdge::Host::WASINN::TensorType;
 
-#if defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_OPENVINO) ||                       \
-    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_TORCH) ||                          \
-    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_TFLITE) ||                         \
-    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML) ||                           \
-    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_PIPER) ||                          \
-    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_WHISPER) ||                        \
-    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_CHATTTS) ||                        \
-    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_MLX) ||                            \
-    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_BITNET)
 namespace {
 
 template <typename T, typename U>
@@ -61,6 +52,19 @@ createModule(std::string_view NNRPCURI = "") {
   }
   return {};
 }
+
+} // namespace
+
+#if defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_OPENVINO) ||                       \
+    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_TORCH) ||                          \
+    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_TFLITE) ||                         \
+    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML) ||                           \
+    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_PIPER) ||                          \
+    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_WHISPER) ||                        \
+    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_CHATTTS) ||                        \
+    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_MLX) ||                            \
+    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_BITNET)
+namespace {
 
 inline std::vector<uint8_t> readEntireFile
     [[maybe_unused]] (const std::string &Path) {
@@ -3463,3 +3467,92 @@ TEST(WasiNNTest, BitNetBackend) {
   }
 }
 #endif // WASMEDGE_PLUGIN_WASI_NN_BACKEND_BITNET
+
+// Regression tests: OOB read in load_by_name / load_by_name_with_config.
+// NameLen (or ConfigLen) extending past the end of linear memory must return
+// InvalidArgument, not read into guard pages.
+TEST(WasiNNTest, LoadByNameOOBRead) {
+  auto NNMod = createModule();
+  if (!NNMod) {
+    GTEST_SKIP() << "wasi_nn plugin not found";
+  }
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory",
+      std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+          WasmEdge::AST::MemoryType(1)));
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+
+  auto *FuncInst = NNMod->findFuncExports("load_by_name");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncLoadByName =
+      dynamic_cast<WasmEdge::Host::WasiNNLoadByName &>(FuncInst->getHostFunc());
+
+  std::array<WasmEdge::ValVariant, 1> Errno = {UINT32_C(0)};
+
+  // NamePtr=65532, NameLen=100: name extends 96 bytes past the 1-page boundary.
+  EXPECT_TRUE(HostFuncLoadByName.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          UINT32_C(65532), // NamePtr
+          UINT32_C(100),   // NameLen
+          UINT32_C(0)      // GraphIdPtr
+      },
+      Errno));
+  EXPECT_EQ(Errno[0].get<uint32_t>(),
+            static_cast<uint32_t>(ErrNo::InvalidArgument));
+}
+
+// Regression test: OOB read in load_by_name_with_config covers both NameLen
+// and ConfigLen extending past the end of linear memory.
+TEST(WasiNNTest, LoadByNameWithConfigOOBRead) {
+  auto NNMod = createModule();
+  if (!NNMod) {
+    GTEST_SKIP() << "wasi_nn plugin not found";
+  }
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory",
+      std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+          WasmEdge::AST::MemoryType(1)));
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+
+  auto *FuncInst = NNMod->findFuncExports("load_by_name_with_config");
+  ASSERT_NE(FuncInst, nullptr);
+  auto &HostFuncLoadByNameWithConfig =
+      dynamic_cast<WasmEdge::Host::WasiNNLoadByNameWithConfig &>(
+          FuncInst->getHostFunc());
+
+  std::array<WasmEdge::ValVariant, 1> Errno = {UINT32_C(0)};
+
+  // NamePtr OOB: name extends 96 bytes past the 1-page boundary.
+  EXPECT_TRUE(HostFuncLoadByNameWithConfig.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          UINT32_C(65532), // NamePtr
+          UINT32_C(100),   // NameLen (extends past end)
+          UINT32_C(0),     // ConfigPtr
+          UINT32_C(8),     // ConfigLen (valid)
+          UINT32_C(0)      // GraphIdPtr
+      },
+      Errno));
+  EXPECT_EQ(Errno[0].get<uint32_t>(),
+            static_cast<uint32_t>(ErrNo::InvalidArgument));
+
+  // ConfigPtr OOB: name is valid, config extends 96 bytes past the boundary.
+  Errno[0] = UINT32_C(0);
+  EXPECT_TRUE(HostFuncLoadByNameWithConfig.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          UINT32_C(0),     // NamePtr
+          UINT32_C(8),     // NameLen (valid)
+          UINT32_C(65532), // ConfigPtr
+          UINT32_C(100),   // ConfigLen (extends past end)
+          UINT32_C(0)      // GraphIdPtr
+      },
+      Errno));
+  EXPECT_EQ(Errno[0].get<uint32_t>(),
+            static_cast<uint32_t>(ErrNo::InvalidArgument));
+}

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -3486,6 +3486,7 @@ TEST(WasiNNTest, LoadByNameOOBRead) {
 
   auto *FuncInst = NNMod->findFuncExports("load_by_name");
   ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncLoadByName =
       dynamic_cast<WasmEdge::Host::WasiNNLoadByName &>(FuncInst->getHostFunc());
 
@@ -3521,6 +3522,7 @@ TEST(WasiNNTest, LoadByNameWithConfigOOBRead) {
 
   auto *FuncInst = NNMod->findFuncExports("load_by_name_with_config");
   ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncLoadByNameWithConfig =
       dynamic_cast<WasmEdge::Host::WasiNNLoadByNameWithConfig &>(
           FuncInst->getHostFunc());


### PR DESCRIPTION
## Summary

### 1. OOB read in `load_by_name` / `load_by_name_with_config`

`wasi_nn_load_by_name` and `wasi_nn_load_by_name_with_config` used
`getPointer<const uint32_t *>(NamePtr)` to obtain the name pointer, which validates only 4 bytes at `NamePtr`. The subsequent `std::string(ptr, NameLen)` and `std::vector<uint8_t>(ptr, ptr + ConfigLen)` then consume `NameLen` / `ConfigLen` bytes with no further bounds check.

A Wasm guest that passes a valid `NamePtr` near the end of its linear memory page with an oversized `NameLen` causes:
- **mmap-backed allocator (aarch64 / x86_64):** `SIGBUS` / `SIGSEGV` - host process crash.
- **fallback allocator (`std::malloc`):** silent heap read past the
  allocation boundary — detected as `heap-buffer-overflow` by ASan.

**Fix:** Replace `getPointer` with `getStringView(NamePtr, NameLen)` and
`getSpan<uint8_t>(ConfigPtr, ConfigLen)` in the non-RPC path, and add the same size guard to the RPC path for consistency. Both functions validate the full requested extent before returning.

The `set_input` RPC OOB fix was already merged as #4942 and is not repeated here.

### 2. OOB write in GGML `get_output` / `get_output_single`

`GGML::getOutput` and `GGML::getOutputSingle` copied the output metadata, last token, or full `LlamaOutputs` buffer into the caller-supplied `OutBuffer` via `std::copy_n` using the *source* length, never checking against `OutBuffer.size()` (derived from `OutBufferMaxSize`).

A Wasm guest that passes a small `OutBufferMaxSize` while the model has produced a larger output causes an OOB heap write past `OutBuffer`.

**Fix:** Clamp each copy to `std::min(source size, OutBuffer.size())` and report the truncated byte count via `BytesWritten`, matching the pattern already used by the RPC path in `WasiNNGetOutput::bodyImpl`.

## Test plan

- [ ] `LoadByNameOOBRead`: `NamePtr=65532`, `NameLen=100` on a 1-page memory instance; expects `InvalidArgument`.
- [ ] `LoadByNameWithConfigOOBRead` (NamePtr OOB): `NamePtr=65532`,
  `NameLen=100`, valid `ConfigPtr`; expects `InvalidArgument`.
- [ ] `LoadByNameWithConfigOOBRead` (ConfigPtr OOB): valid `NamePtr`,
  `ConfigPtr=65532`, `ConfigLen=100`; expects `InvalidArgument`.
- [ ] `GGMLGetOutputTruncatesToBuffer`: `OutBufferMaxSize=8` with a 256-byte `LlamaOutputs` payload; expects `BytesWritten == 8`, no write past `OutBuffer`, and correct truncated content.
- [ ] Tests skip automatically when the plugin DSO is absent (no-backend CI builds unaffected).
- [ ] Confirmed: load_by_name tests exhibit `AddressSanitizer: BUS` crash on upstream/master and pass with fix applied.
