### PR TITLE
fix: resolve sed crash in uninstall.sh due to multiple env entries

### DIFF
--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -162,20 +162,20 @@ jobs:
         bash utils/install.sh -D
         # Add dummy content to verify it is preserved
         echo "export DUMMY_VAR=1" >> ~/.bashrc
-        echo ". \"\$HOME/.wasmedge/env\"" >> ~/.bashrc
+        echo ". \"${HOME}/.wasmedge/env\"" >> ~/.bashrc
         echo "alias dummy=ls" >> ~/.bashrc
-        echo ". \"\$HOME/.wasmedge/env\"" >> ~/.bashrc
+        echo ". \"${HOME}/.wasmedge/env\"" >> ~/.bashrc
         
         bash utils/uninstall.sh -q -V
         
         # Verify the duplicate entries are removed
-        if grep -q ". \"\$HOME/.wasmedge/env\"" ~/.bashrc; then
+        if grep -qF ". \"${HOME}/.wasmedge/env\"" ~/.bashrc; then
           echo "[FAIL] Duplicate entries were not removed"
           exit 1
         fi
         
         # Verify the expected unrelated content is preserved
-        if ! grep -q "export DUMMY_VAR=1" ~/.bashrc || ! grep -q "alias dummy=ls" ~/.bashrc; then
+        if ! grep -qF "export DUMMY_VAR=1" ~/.bashrc || ! grep -qF "alias dummy=ls" ~/.bashrc; then
           echo "[FAIL] Unrelated content in .bashrc was corrupted or removed"
           exit 1
         fi

--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -157,6 +157,31 @@ jobs:
         verify_plugin "libwasmedgePluginWasiNN.so"
         bash utils/uninstall.sh -q -V
 
+        # Test uninstallation with duplicate env entries
+        printf "\n=== Test 4: Uninstall with duplicate env entries ===\n"
+        bash utils/install.sh -D
+        # Add dummy content to verify it is preserved
+        echo "export DUMMY_VAR=1" >> ~/.bashrc
+        echo ". \"\$HOME/.wasmedge/env\"" >> ~/.bashrc
+        echo "alias dummy=ls" >> ~/.bashrc
+        echo ". \"\$HOME/.wasmedge/env\"" >> ~/.bashrc
+        
+        bash utils/uninstall.sh -q -V
+        
+        # Verify the duplicate entries are removed
+        if grep -q ". \"\$HOME/.wasmedge/env\"" ~/.bashrc; then
+          echo "[FAIL] Duplicate entries were not removed"
+          exit 1
+        fi
+        
+        # Verify the expected unrelated content is preserved
+        if ! grep -q "export DUMMY_VAR=1" ~/.bashrc || ! grep -q "alias dummy=ls" ~/.bashrc; then
+          echo "[FAIL] Unrelated content in .bashrc was corrupted or removed"
+          exit 1
+        fi
+        
+        echo "[PASS] Duplicate entries removed and unrelated content preserved successfully"
+
   # Test install.sh on macOS
   test-install-sh-macos:
     needs: get-latest-version

--- a/utils/uninstall.sh
+++ b/utils/uninstall.sh
@@ -263,7 +263,7 @@ main() {
       if grep -qF ". \"${IPATH}/env\"" "$file"; then
         real_file="$(resolve_path "$file")"
         cp "$real_file" "$real_file.bak"
-        grep -Fv ". \"${IPATH}/env\"" "$real_file.bak" > "$real_file"
+        grep -Fv ". \"${IPATH}/env\"" "$real_file.bak" > "$real_file" || [ $? -eq 1 ]
         rm -f "$real_file.bak"
       fi
     done

--- a/utils/uninstall.sh
+++ b/utils/uninstall.sh
@@ -260,12 +260,12 @@ main() {
 
     for file in "${__HOME__}/${_shell_rc}" "${__HOME__}/.profile" "${__HOME__}/.bash_profile"; do
       [[ -f "$file" ]] || continue
-      line_num="$(grep -n ". \"${IPATH}/env\"" "$file" | cut -d : -f 1)"
-      [[ -n "$line_num" ]] || continue
-      real_file="$(resolve_path "$file")"
-      cp "$real_file" "$real_file.bak"
-      sed "${line_num}d" "$real_file.bak" > "$real_file"
-      rm -f "$real_file.bak"
+      if grep -qF ". \"${IPATH}/env\"" "$file"; then
+        real_file="$(resolve_path "$file")"
+        cp "$real_file" "$real_file.bak"
+        grep -Fv ". \"${IPATH}/env\"" "$real_file.bak" > "$real_file"
+        rm -f "$real_file.bak"
+      fi
     done
 
     exit 0


### PR DESCRIPTION
## Description
<!-- Describe your changes here -->
Fixes #4958 

While looking at the installer side-effects discussed in #4955, I noticed a fragile edge case on the reverse side in `uninstall.sh`.

If a user ends up with duplicate WasmEdge `env` entries in their `~/.bashrc` (which easily happens if the installer is run multiple times or manually tweaked), the uninstaller completely crashes.

The script currently uses `grep -n` to grab the line number to feed to `sed`:
`line_num="$(grep -n ". \"${IPATH}/env\"" "$file" | cut -d : -f 1)"`

When there are multiple duplicate entries, `line_num` evaluates to a newline-separated list (e.g. `10\n11`). Passing this to `sed` produces an invalid command (`sed "10\n11d"`), instantly breaking the uninstallation process with a syntax error.

I swapped out the line-number deletion logic for a much safer `grep -Fv` filter. This guarantees all identical occurrences are cleanly removed without relying on `sed`'s line-deletion syntax, making the script fully robust against duplicate entries.




## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

 *I'm exploring more and more into the WasmEdge codebase to prepare for the upcoming LFX Mentorship Term 3 — happy to adjust anything here if needed!*