### PR TITLE
fix(loader): resolve incorrect 0x00 attribute byte injection in Tag ExportDesc serialization

### DIFF
--- a/lib/loader/serialize/serial_description.cpp
+++ b/lib/loader/serialize/serial_description.cpp
@@ -68,7 +68,6 @@ Serializer::serializeDesc(const AST::ExportDesc &Desc,
       return logNeedProposal(ErrCode::Value::MalformedExportKind,
                              Proposal::ExceptionHandling, ASTNodeAttr::Module);
     }
-    return serializeType(Desc.getExternalIndex(), OutVec);
   }
   serializeU32(Desc.getExternalIndex(), OutVec);
   return {};

--- a/test/loader/serializeDescriptionTest.cpp
+++ b/test/loader/serializeDescriptionTest.cpp
@@ -236,11 +236,11 @@ TEST(SerializeDescriptionTest, SerializeExportDesc) {
   EXPECT_TRUE(Ser.serializeSection(createExportSec(Desc), Output));
   Expected = {
       0x07U,                                           // Export section
-      0x0BU,                                           // Content size = 10
+      0x0AU,                                           // Content size = 10
       0x01U,                                           // Vector length = 1
       0x06U, 0x4CU, 0x6FU, 0x61U, 0x64U, 0x65U, 0x72U, // External name: Loader
       0x04U,                                           // Tag type
-      0x00U, 0x02U                                     // TypeIdx value
+      0x02U                                            // TypeIdx value
   };
   EXPECT_EQ(Expected, Output);
 


### PR DESCRIPTION

### What does this PR do?
Fixes a subtle serialization bug where an invalid `0x00` attribute byte was being erroneously injected into `Tag` exports.

fixes #4961 

**The cause:**
In `serial_description.cpp`, when serializing an `AST::ExportDesc` of type `Tag`, the code called `return serializeType(Desc.getExternalIndex(), OutVec);`. Since `getExternalIndex()` returns a `uint32_t`, C++ implicitly constructed an `AST::TagType` from the integer and dispatched to the `serializeType(const AST::TagType &)` overload. 

While injecting an `0x00` attribute byte is strictly correct for an `importdesc` Tag signature, the Wasm exception handling spec dictates that an `exportdesc` for a Tag must *only* contain `0x04 tagidx` (a raw `u32` with no attribute byte). The implicit conversion caused the serializer to output malformed binaries for Tag exports.

**The fix:**
Removed the `serializeType()` call entirely for Tag exports, allowing the switch to fall through to `serializeU32()`, which outputs the raw index directly. I've also updated the unit test in `serializeDescriptionTest.cpp` because it was historically enforcing the buggy behavior.


## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.


