### PR TITLE
refactor(llvm): move lazy JIT orchestration into a dedicated engine

### DIFF
--- a/include/ast/module.h
+++ b/include/ast/module.h
@@ -78,10 +78,6 @@ public:
   bool getIsValidated() const noexcept { return IsValidated; }
   void setIsValidated(bool V = true) noexcept { IsValidated = V; }
 
-  /// Getter and setter of ID.
-  const std::string &getID() const noexcept { return ID; }
-  void setID(std::string_view NewID) noexcept { ID = NewID; }
-
 private:
   /// \name Data of Module node.
   /// @{
@@ -116,11 +112,6 @@ private:
   /// \name Validated flag.
   /// @{
   bool IsValidated = false;
-  /// @}
-
-  /// \name ID.
-  /// @{
-  std::string ID;
   /// @}
 };
 

--- a/include/ast/module.h
+++ b/include/ast/module.h
@@ -79,6 +79,11 @@ public:
     return Count;
   }
 
+  /// Get the number of defined (non-imported) functions.
+  uint32_t getDefinedFuncCount() const noexcept {
+    return static_cast<uint32_t>(CodeSec.getContent().size());
+  }
+
   /// Getter and setter for compiled symbol.
   const auto &getSymbol() const noexcept { return IntrSymbol; }
   void setSymbol(Symbol<const Executable::IntrinsicsTable *> S) noexcept {

--- a/include/ast/module.h
+++ b/include/ast/module.h
@@ -68,6 +68,17 @@ public:
   const AOTSection &getAOTSection() const { return AOTSec; }
   AOTSection &getAOTSection() { return AOTSec; }
 
+  /// Get the number of imported functions.
+  uint32_t getImportFuncCount() const noexcept {
+    uint32_t Count = 0;
+    for (const auto &ImpDesc : ImportSec.getContent()) {
+      if (ImpDesc.getExternalType() == ExternalType::Function) {
+        ++Count;
+      }
+    }
+    return Count;
+  }
+
   /// Getter and setter for compiled symbol.
   const auto &getSymbol() const noexcept { return IntrSymbol; }
   void setSymbol(Symbol<const Executable::IntrinsicsTable *> S) noexcept {

--- a/include/common/executable.h
+++ b/include/common/executable.h
@@ -90,8 +90,7 @@ public:
   virtual std::vector<Symbol<void>> getCodes(size_t Offset,
                                              size_t Size) noexcept = 0;
 
-  virtual bool isLazy() const noexcept { return false; }
-
+protected:
   template <typename T> Symbol<T> createSymbol(T *Pointer) const noexcept {
     return Symbol<T>(shared_from_this(), Pointer);
   }

--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -1157,7 +1157,8 @@ private:
   /// unsafeUpgradeToCompiled on the same FuncInst could result in a race
   /// condition if checking FuncInst->isCompiledFunction() directly here. As a
   /// temporary workaround, checks for compilation state are deferred to the
-  /// LazyCompilationHandler, which executes under the lazy JIT engine lock.
+  /// LazyCompilationHandler, which must serialize them against compiled-state
+  /// upgrades (the lazy JIT engine does so under its internal lock).
   Expect<void> checkLazyCompilation(
       const Runtime::Instance::FunctionInstance *FuncInst) const noexcept {
     if (unlikely(LazyCompilationHandler != nullptr)) {

--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -204,7 +204,7 @@ public:
 
   /// Register a callback for lazy function compilation
   void registerLazyCompilationCallback(
-      std::function<Expect<void>(const std::string &, const uint32_t)>
+      std::function<Expect<void>(const Runtime::Instance::FunctionInstance *)>
           Callback) {
     LazyCompilationHandler = std::move(Callback);
   }
@@ -1149,7 +1149,7 @@ private:
   /// Executor Host Function Handler
   HostFuncHandler HostFuncHelper = {};
   /// Callback for lazy function compilation
-  std::function<Expect<void>(const std::string &, const uint32_t)>
+  std::function<Expect<void>(const Runtime::Instance::FunctionInstance *)>
       LazyCompilationHandler;
 
   /// Helper function for triggering lazy compilation.
@@ -1157,20 +1157,11 @@ private:
   /// unsafeUpgradeToCompiled on the same FuncInst could result in a race
   /// condition if checking FuncInst->isCompiledFunction() directly here. As a
   /// temporary workaround, checks for compilation state are deferred to the
-  /// LazyCompilationHandler (VM::lazyCompileFunctions), which executes
-  /// under a global JIT compilation lock.
+  /// LazyCompilationHandler, which executes under the lazy JIT engine lock.
   Expect<void> checkLazyCompilation(
       const Runtime::Instance::FunctionInstance *FuncInst) const noexcept {
-    if (LazyCompilationHandler) {
-      if (const auto *TargetModInst = FuncInst->getModule()) {
-        if (auto Res = TargetModInst->getFuncIdx(FuncInst)) {
-          uint32_t TargetFuncIdx = *Res;
-          const std::string ID = TargetModInst->getID();
-          if (!ID.empty()) {
-            return LazyCompilationHandler(ID, TargetFuncIdx);
-          }
-        }
-      }
+    if (unlikely(LazyCompilationHandler != nullptr)) {
+      return LazyCompilationHandler(FuncInst);
     }
     return {};
   }

--- a/include/llvm/compiler.h
+++ b/include/llvm/compiler.h
@@ -38,19 +38,13 @@ public:
   Expect<Data> compile(const AST::Module &Module) noexcept;
 
   struct CompileContext;
-  struct CompileContextDeleter {
-    void operator()(CompileContext *ContextPtr) const noexcept;
-  };
 
   /// Compile only the infrastructure (types, imports, globals, etc.) without
   /// function bodies.
-  Expect<
-      std::pair<Data, std::unique_ptr<CompileContext, CompileContextDeleter>>>
-  compileInfrastructure(const AST::Module &Module) noexcept;
+  Expect<Data> compileInfrastructure(const AST::Module &Module) noexcept;
   /// Compile multiple function bodies in one LLVM module for lazy JIT.
   /// \p LocalFuncIndices are indices of defined functions (not imports).
-  Expect<Data> compileFunctions(Data &&LLData, CompileContext *Context,
-                                const AST::Module &Module,
+  Expect<Data> compileFunctions(Data &&LLData, const AST::Module &Module,
                                 Span<const uint32_t> LocalFuncIndices) noexcept;
 
 private:
@@ -63,9 +57,12 @@ private:
                const AST::DataSection &DataSection) noexcept;
   void compile(const AST::TableSection &TableSection,
                const AST::ElementSection &ElementSection) noexcept;
-  Expect<void> compile(const AST::FunctionSection &FunctionSection,
-                       const AST::CodeSection &CodeSection) noexcept;
 
+  /// Compile all sections and create the function declarations. When
+  /// \p DeclarationsOnly is set, the type wrappers are emitted as external
+  /// declarations resolved against another module in the same JIT session.
+  void compileSections(const AST::Module &Module,
+                       bool DeclarationsOnly) noexcept;
   void compileFunctionDeclarations(const AST::FunctionSection &FunctionSec,
                                    const AST::CodeSection &CodeSec) noexcept;
   Expect<void> compileFunctionBody(uint32_t LocalFuncIndex) noexcept;

--- a/include/llvm/compiler.h
+++ b/include/llvm/compiler.h
@@ -46,8 +46,7 @@ public:
   /// function bodies.
   Expect<
       std::pair<Data, std::unique_ptr<CompileContext, CompileContextDeleter>>>
-  compileInfrastructure(const AST::Module &Module,
-                        std::string Prefix = "") noexcept;
+  compileInfrastructure(const AST::Module &Module) noexcept;
   /// Compile multiple function bodies in one LLVM module for lazy JIT.
   /// \p LocalFuncIndices are indices of defined functions (not imports).
   Expect<Data> compileFunctions(Data &&LLData, CompileContext *Context,

--- a/include/llvm/data.h
+++ b/include/llvm/data.h
@@ -33,9 +33,6 @@ public:
   Data(Data &&) noexcept;
   Data &operator=(Data &&) noexcept;
   DataContext &extract() noexcept { return *Context; }
-  bool isValid() const noexcept { return static_cast<bool>(Context); }
-  bool hasModule() const noexcept;
-  void resetModule() noexcept;
 
 private:
   std::unique_ptr<DataContext> Context;

--- a/include/llvm/data.h
+++ b/include/llvm/data.h
@@ -36,8 +36,6 @@ public:
   bool isValid() const noexcept { return static_cast<bool>(Context); }
   bool hasModule() const noexcept;
   void resetModule() noexcept;
-  void setPrefix(std::string_view P) noexcept;
-  std::string_view getPrefix() const noexcept;
 
 private:
   std::unique_ptr<DataContext> Context;

--- a/include/llvm/data.h
+++ b/include/llvm/data.h
@@ -35,7 +35,6 @@ public:
 
 private:
   std::unique_ptr<DataContext> Context;
-  const Configure Conf;
 };
 
 } // namespace WasmEdge::LLVM

--- a/include/llvm/data.h
+++ b/include/llvm/data.h
@@ -22,7 +22,6 @@
 #include <mutex>
 
 namespace WasmEdge::LLVM {
-class OrcThreadSafeContext;
 
 /// Holds llvm-relative runtime data, like llvm::Context, llvm::Module, etc.
 class Data {

--- a/include/llvm/jit.h
+++ b/include/llvm/jit.h
@@ -16,22 +16,14 @@
 #include "ast/module.h"
 #include "common/configure.h"
 #include "common/errcode.h"
+#include "common/executable.h"
 #include "common/span.h"
-#include "llvm/compiler.h"
 #include "llvm/data.h"
 #include <memory>
-#include <mutex>
 #include <string_view>
-#include <unordered_set>
 #include <vector>
 
-namespace llvm {
-class Module;
-}
-
 namespace WasmEdge::LLVM {
-
-class Module;
 
 /// Address of JIT- or AOT-generated machine code for a wasm function. Not a
 /// typed C++ function pointer; wasm signatures vary and calls go through the
@@ -80,20 +72,6 @@ public:
 
 private:
   const Configure Conf;
-};
-
-struct LazyJITState {
-  /// Track which functions have been lazy-compiled.
-  std::unordered_set<uint32_t> LazyCompiledFuncs;
-  /// Number of import functions (offset for local function indices).
-  uint32_t ImportFuncCount = 0;
-  /// Store compiled JIT library to keep it alive
-  std::shared_ptr<JITLibrary> JITLib;
-  /// Per-module JIT data and context
-  Data LLData;
-  /// Pointer to the LLVM context.
-  std::unique_ptr<Compiler::CompileContext, Compiler::CompileContextDeleter>
-      LLContext;
 };
 
 } // namespace WasmEdge::LLVM

--- a/include/llvm/jit.h
+++ b/include/llvm/jit.h
@@ -20,7 +20,6 @@
 #include "common/span.h"
 #include "llvm/data.h"
 #include <memory>
-#include <string_view>
 #include <vector>
 
 namespace WasmEdge::LLVM {
@@ -43,7 +42,11 @@ public:
 
   std::vector<Symbol<void>> getCodes(size_t Offset,
                                      size_t Size) noexcept override;
-  bool isLazy() const noexcept override { return IsLazy; }
+
+  /// Create a symbol for lazily compiled machine code owned by this library.
+  Symbol<void> createCodeSymbol(void *Address) const noexcept {
+    return createSymbol<void>(Address);
+  }
 
 private:
   std::shared_ptr<OrcLLJIT> J;
@@ -54,8 +57,11 @@ private:
 class JIT {
 public:
   JIT(const Configure &Conf) noexcept : Conf(Conf) {}
-  Expect<std::shared_ptr<Executable>> load(Data &D,
-                                           bool IsLazy = false) noexcept;
+  Expect<std::shared_ptr<Executable>> load(Data D) noexcept;
+
+  /// Load for lazy JIT. The data is kept alive by the caller so following
+  /// batches can reuse its thread-safe context.
+  Expect<std::shared_ptr<Executable>> loadLazy(Data &D) noexcept;
 
   /// Adds one LLVM IR module and resolves many wasm function symbols.
   Expect<std::vector<WasmFunctionCodeAddress>>
@@ -63,6 +69,8 @@ public:
       Span<const uint32_t> GlobalFuncIndices) noexcept;
 
 private:
+  Expect<std::shared_ptr<Executable>> loadImpl(Data &D, bool IsLazy) noexcept;
+
   const Configure Conf;
 };
 

--- a/include/llvm/jit.h
+++ b/include/llvm/jit.h
@@ -34,8 +34,7 @@ class OrcLLJIT;
 
 class JITLibrary : public Executable {
 public:
-  JITLibrary(std::shared_ptr<OrcLLJIT> JIT, std::string Prefix = "",
-             bool IsLazy = false) noexcept;
+  JITLibrary(std::shared_ptr<OrcLLJIT> JIT, bool IsLazy = false) noexcept;
   ~JITLibrary() noexcept override;
 
   Symbol<const IntrinsicsTable *> getIntrinsics() noexcept override;
@@ -48,7 +47,6 @@ public:
 
 private:
   std::shared_ptr<OrcLLJIT> J;
-  std::string Prefix;
   bool IsLazy;
   friend class JIT;
 };
@@ -63,12 +61,6 @@ public:
   Expect<std::vector<WasmFunctionCodeAddress>>
   add(JITLibrary &Lib, Data &D,
       Span<const uint32_t> GlobalFuncIndices) noexcept;
-
-  /// Look up already-loaded symbols (no IR add). Same index convention as
-  /// \c add .
-  Expect<std::vector<WasmFunctionCodeAddress>>
-  lookupWasmFunctionSymbols(JITLibrary &Lib, std::string_view Prefix,
-                            Span<const uint32_t> GlobalFuncIndices) noexcept;
 
 private:
   const Configure Conf;

--- a/include/llvm/lazyjit.h
+++ b/include/llvm/lazyjit.h
@@ -46,11 +46,13 @@ namespace LLVM {
 ///    dedicated ORC LLJIT instance and returns the executable so the caller
 ///    can hook it into the AST module via \c Loader::loadExecutable .
 /// 2. \c registerInstance binds the instantiated module instance to the
-///    prepared state. The engine shares ownership of the AST module for
-///    later on-demand compilation.
+///    prepared state.
 /// 3. \c compileOnDemand compiles the requested function together with its
 ///    not-yet-compiled callees and upgrades the bound function instances to
 ///    compiled mode.
+/// 4. \c unregisterInstance drops the per-instance bindings but keeps the
+///    module-level JIT state, so re-instantiating the same AST module
+///    rebinds it and previously compiled functions stay compiled.
 class LazyJITEngine {
 public:
   LazyJITEngine(const Configure &Conf) noexcept;
@@ -58,15 +60,20 @@ public:
   LazyJITEngine(const LazyJITEngine &) = delete;
   LazyJITEngine &operator=(const LazyJITEngine &) = delete;
 
-  /// Compile the module infrastructure and create the per-module JIT.
-  Expect<std::shared_ptr<Executable>> prepare(const AST::Module &Module);
+  /// Compile the module infrastructure and create the per-module JIT. The
+  /// engine shares ownership of the AST module from this point on, so the
+  /// prepared state can never outlive (and dangle on) its module.
+  Expect<std::shared_ptr<Executable>>
+  prepare(std::shared_ptr<const AST::Module> Module);
 
   /// Bind an instantiated module instance to its prepared AST module. No-op
   /// when the AST module has not been prepared.
   void registerInstance(const Runtime::Instance::ModuleInstance &ModInst,
                         std::shared_ptr<const AST::Module> Module) noexcept;
 
-  /// Drop the state bound to a module instance.
+  /// Drop the per-instance bindings of a module instance. The module-level
+  /// JIT state is kept so a later instantiation of the same AST module can
+  /// rebind it.
   void
   unregisterInstance(const Runtime::Instance::ModuleInstance &ModInst) noexcept;
 

--- a/include/llvm/lazyjit.h
+++ b/include/llvm/lazyjit.h
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2026 Second State INC
+
+//===-- wasmedge/llvm/lazyjit.h - Lazy JIT engine class definition --------===//
+//
+// Part of the WasmEdge Project.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the LazyJITEngine class, which owns
+/// all per-module state and orchestration for lazy (per-function) JIT
+/// compilation. The VM only forwards thin hooks to this engine.
+///
+//===----------------------------------------------------------------------===//
+#pragma once
+
+#include "common/configure.h"
+#include "common/errcode.h"
+
+#include <cstdint>
+#include <memory>
+
+namespace WasmEdge {
+
+class Executable;
+
+namespace AST {
+class Module;
+} // namespace AST
+
+namespace Runtime {
+namespace Instance {
+class ModuleInstance;
+class FunctionInstance;
+} // namespace Instance
+} // namespace Runtime
+
+namespace LLVM {
+
+/// Engine driving lazy (per-function) JIT compilation.
+///
+/// Lifecycle per wasm module:
+/// 1. \c prepare compiles the module infrastructure (types, imports, globals,
+///    tables, memories, and function declarations without bodies) into a
+///    dedicated ORC LLJIT instance and returns the executable so the caller
+///    can hook it into the AST module via \c Loader::loadExecutable .
+/// 2. \c registerInstance binds the instantiated module instance to the
+///    prepared state. The engine shares ownership of the AST module for
+///    later on-demand compilation.
+/// 3. \c compileOnDemand compiles the requested function together with its
+///    not-yet-compiled callees and upgrades the bound function instances to
+///    compiled mode.
+class LazyJITEngine {
+public:
+  LazyJITEngine(const Configure &Conf) noexcept;
+  ~LazyJITEngine() noexcept;
+  LazyJITEngine(const LazyJITEngine &) = delete;
+  LazyJITEngine &operator=(const LazyJITEngine &) = delete;
+
+  /// Compile the module infrastructure and create the per-module JIT.
+  Expect<std::shared_ptr<Executable>> prepare(const AST::Module &Module);
+
+  /// Bind an instantiated module instance to its prepared AST module. No-op
+  /// when the AST module has not been prepared.
+  void registerInstance(const Runtime::Instance::ModuleInstance &ModInst,
+                        std::shared_ptr<const AST::Module> Module) noexcept;
+
+  /// Drop the state bound to a module instance.
+  void
+  unregisterInstance(const Runtime::Instance::ModuleInstance &ModInst) noexcept;
+
+  /// Compile the function and its reachable callees on demand. No-op for
+  /// functions which are not bound to this engine or already compiled.
+  Expect<void>
+  compileOnDemand(const Runtime::Instance::FunctionInstance *FuncInst);
+
+  /// Get the total number of lazily compiled functions.
+  uint32_t compiledFunctionCount() const noexcept;
+
+  /// Drop all states.
+  void clear() noexcept;
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> PImpl;
+};
+
+} // namespace LLVM
+} // namespace WasmEdge

--- a/include/runtime/instance/module.h
+++ b/include/runtime/instance/module.h
@@ -37,7 +37,6 @@
 #include <shared_mutex>
 #include <string>
 #include <type_traits>
-#include <unordered_map>
 #include <vector>
 
 namespace WasmEdge {
@@ -97,16 +96,6 @@ public:
   std::string_view getModuleName() const noexcept {
     std::shared_lock Lock(Mutex);
     return ModName;
-  }
-
-  std::string getID() const noexcept {
-    std::shared_lock Lock(Mutex);
-    return ID;
-  }
-
-  void setID(std::string_view NewID) noexcept {
-    std::unique_lock Lock(Mutex);
-    ID = NewID;
   }
 
   void *getHostData() const noexcept { return HostData; }
@@ -243,22 +232,6 @@ public:
   auto getGlobalExports(CallbackT &&CallBack) const noexcept {
     std::shared_lock Lock(Mutex);
     return std::forward<CallbackT>(CallBack)(ExpGlobals);
-  }
-
-  Expect<uint32_t> getFuncIdx(const FunctionInstance *FuncInst) const noexcept {
-    std::shared_lock Lock(Mutex);
-    if (auto It = FuncInstMap.find(FuncInst); It != FuncInstMap.end()) {
-      return It->second;
-    }
-    return Unexpect(ErrCode::Value::WrongInstanceAddress);
-  }
-
-  Expect<FunctionInstance *> getFuncInst(uint32_t Idx) const noexcept {
-    std::shared_lock Lock(Mutex);
-    if (Idx >= FuncInsts.size()) {
-      return Unexpect(ErrCode::Value::WrongInstanceIndex);
-    }
-    return FuncInsts[Idx];
   }
 
 protected:
@@ -499,9 +472,6 @@ protected:
   std::enable_if_t<IsEntityV<T>, void>
   unsafeImportInstance(std::vector<T *> &Vec, T *Ptr) {
     Vec.push_back(Ptr);
-    if constexpr (std::is_same_v<T, FunctionInstance>) {
-      FuncInstMap[Ptr] = static_cast<uint32_t>(Vec.size()) - 1;
-    }
   }
 
   /// Unsafely import a defined type from a host function into this module.
@@ -518,9 +488,6 @@ protected:
                     std::vector<T *> &InstsVec, Args &&...Values) {
     OwnedInstsVec.push_back(std::make_unique<T>(std::forward<Args>(Values)...));
     InstsVec.push_back(OwnedInstsVec.back().get());
-    if constexpr (std::is_same_v<T, FunctionInstance>) {
-      FuncInstMap[InstsVec.back()] = static_cast<uint32_t>(InstsVec.size()) - 1;
-    }
   }
 
   /// Unsafely add and export the existing instance to this module.
@@ -534,9 +501,6 @@ protected:
     OwnedInstsVec.push_back(std::move(Inst));
     InstsVec.push_back(OwnedInstsVec.back().get());
     InstsMap.insert_or_assign(std::string(Name), InstsVec.back());
-    if constexpr (std::is_same_v<T, FunctionInstance>) {
-      FuncInstMap[InstsVec.back()] = static_cast<uint32_t>(InstsVec.size()) - 1;
-    }
   }
 
   /// Unsafely find and get the exported instance by name.
@@ -629,9 +593,6 @@ protected:
   /// Module name.
   const std::string ModName;
 
-  /// Module ID.
-  std::string ID;
-
   /// Defined types.
   std::vector<const AST::SubType *> Types;
   std::vector<std::unique_ptr<const AST::SubType>> OwnedTypes;
@@ -656,7 +617,6 @@ protected:
   std::vector<GlobalInstance *> GlobInsts;
   std::vector<ElementInstance *> ElemInsts;
   std::vector<DataInstance *> DataInsts;
-  std::unordered_map<const FunctionInstance *, uint32_t> FuncInstMap;
 
   /// Imported instance counts.
   uint32_t ImpGlobalNum = 0;

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -447,6 +447,12 @@ private:
   /// @{
   Loader::Loader LoaderEngine;
   Validator::Validator ValidatorEngine;
+#ifdef WASMEDGE_USE_LLVM
+  /// Lazy JIT engine. Created only when the run mode is LazyJIT. Declared
+  /// before the executor so it outlives the executor-registered lazy
+  /// compilation callback that references it.
+  std::unique_ptr<LLVM::LazyJITEngine> LazyEngine;
+#endif
   Executor::Executor ExecutorEngine;
   /// @}
 
@@ -473,10 +479,6 @@ private:
   std::unique_ptr<Runtime::StoreManager> Store;
   /// Reference to the store.
   Runtime::StoreManager &StoreRef;
-#ifdef WASMEDGE_USE_LLVM
-  /// Lazy JIT engine. Created only when the run mode is LazyJIT.
-  std::unique_ptr<LLVM::LazyJITEngine> LazyEngine;
-#endif
   /// @}
 };
 

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -27,19 +27,15 @@
 #include "runtime/storemgr.h"
 
 #ifdef WASMEDGE_USE_LLVM
-#include "llvm/compiler.h"
-#include "llvm/data.h"
-#include "llvm/jit.h"
+#include "llvm/lazyjit.h"
 #endif
 
 #include <cstdint>
 #include <memory>
-#include <mutex>
 #include <shared_mutex>
 #include <string>
 #include <string_view>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -306,13 +302,9 @@ public:
   Statistics::Statistics &getStatistics() noexcept { return Stat; }
 
 #ifdef WASMEDGE_USE_LLVM
+  /// Getter for the number of lazily compiled functions.
   uint32_t getLazyCompiledFuncCount() const noexcept {
-    std::shared_lock Lock(LazyJITMutex);
-    uint32_t Count = 0;
-    for (const auto &Pair : LazyJITStates) {
-      Count += static_cast<uint32_t>(Pair.second.LazyCompiledFuncs.size());
-    }
-    return Count;
+    return LazyEngine ? LazyEngine->compiledFunctionCount() : 0;
   }
 #endif
 
@@ -358,6 +350,8 @@ private:
                                     Span<const Byte> Code);
   Expect<void> unsafeRegisterModule(std::string_view Name,
                                     const AST::Module &Module);
+  Expect<void> unsafeRegisterModule(std::string_view Name,
+                                    std::shared_ptr<AST::Module> Module);
   Expect<void>
   unsafeRegisterModule(std::string_view Name,
                        const Runtime::Instance::ModuleInstance &ModInst);
@@ -447,7 +441,6 @@ private:
   Statistics::Statistics Stat;
   VMStage Stage;
   mutable std::shared_mutex Mutex;
-  mutable std::shared_mutex LazyJITMutex;
   /// @}
 
   /// \name VM components.
@@ -460,17 +453,13 @@ private:
   /// \name VM Storage.
   /// @{
   /// Loaded AST module.
-  std::unique_ptr<AST::Module> Mod;
+  std::shared_ptr<AST::Module> Mod;
   std::unique_ptr<AST::Component::Component> Comp;
   /// Active module instance.
   std::unique_ptr<Runtime::Instance::ModuleInstance> ActiveModInst;
   std::unique_ptr<Runtime::Instance::ComponentInstance> ActiveCompInst;
-  /// Registered AST modules.
-  std::vector<std::shared_ptr<const AST::Module>> RegASTModules;
   /// Registered module instances by user.
   std::vector<std::unique_ptr<Runtime::Instance::ModuleInstance>> RegModInsts;
-  /// Map from ID to the index in RegASTModules and RegModInsts.
-  std::unordered_map<std::string, std::array<size_t, 2>> RegModMap;
   /// Built-in module instances mapped to the configurations. For WASI.
   std::unordered_map<HostRegistration,
                      std::unique_ptr<Runtime::Instance::ModuleInstance>>
@@ -484,23 +473,11 @@ private:
   std::unique_ptr<Runtime::StoreManager> Store;
   /// Reference to the store.
   Runtime::StoreManager &StoreRef;
-  /// @}
-
 #ifdef WASMEDGE_USE_LLVM
-  /// \name Lazy JIT.
-  /// @{
-  /// Prepare Lazy JIT infrastructure for a module.
-  Expect<WasmEdge::LLVM::LazyJITState> prepareLazyJIT(AST::Module &Module);
-
-  /// Lazy compile a function if lazy JIT mode is enabled and function not yet
-  /// compiled.
-  Expect<void> lazyCompileFunctions(const std::string &ID, uint32_t FuncIdx);
-
-  /// Map from module ID to its lazy JIT state
-  std::unordered_map<std::string, WasmEdge::LLVM::LazyJITState> LazyJITStates;
-
-  /// @}
+  /// Lazy JIT engine. Created only when the run mode is LazyJIT.
+  std::unique_ptr<LLVM::LazyJITEngine> LazyEngine;
 #endif
+  /// @}
 };
 
 } // namespace VM

--- a/lib/executor/instantiate/module.cpp
+++ b/lib/executor/instantiate/module.cpp
@@ -44,8 +44,6 @@ Executor::instantiate(Runtime::StoreManager &StoreMgr, const AST::Module &Mod,
     ModInst = std::make_unique<Runtime::Instance::ModuleInstance>("");
   }
 
-  ModInst->setID(Mod.getID());
-
   // Instantiate Function Types in Module Instance. (TypeSec)
   for (auto &SubType : Mod.getTypeSection().getContent()) {
     // Copy defined types to module instance.

--- a/lib/llvm/CMakeLists.txt
+++ b/lib/llvm/CMakeLists.txt
@@ -20,6 +20,7 @@ if(WASMEDGE_LINK_LLVM_STATIC)
     codegen.cpp
     data.cpp
     jit.cpp
+    lazyjit.cpp
   )
 
   target_link_libraries(wasmedgeLLVM
@@ -56,6 +57,7 @@ else()
     codegen.cpp
     data.cpp
     jit.cpp
+    lazyjit.cpp
     LINK_LIBS
     wasmedgeCommon
     wasmedgeSystem

--- a/lib/llvm/compiler.cpp
+++ b/lib/llvm/compiler.cpp
@@ -6147,8 +6147,7 @@ Expect<Data> Compiler::compile(const AST::Module &Module) noexcept {
   // Compile all sections and the function declarations.
   compileSections(Module, false);
   // Compile all function bodies.
-  const auto DefinedCount =
-      static_cast<uint32_t>(Module.getCodeSection().getContent().size());
+  const auto DefinedCount = Module.getDefinedFuncCount();
   for (uint32_t I = 0; I < DefinedCount; ++I) {
     EXPECTED_TRY(compileFunctionBody(I));
   }

--- a/lib/llvm/compiler.cpp
+++ b/lib/llvm/compiler.cpp
@@ -273,9 +273,9 @@ struct LLVM::Compiler::CompileContext {
             Int8Ty.getPointerTo(),
             static_cast<uint32_t>(Executable::Intrinsics::kIntrinsicMax))),
         IntrinsicsTablePtrTy(IntrinsicsTableTy.getPointerTo()),
-        IntrinsicsTable(LLModule.get().addGlobal(
-            IntrinsicsTablePtrTy, true, LLVMExternalLinkage, LLVM::Value(),
-            "intrinsics")) {
+        IntrinsicsTable(LLModule.get().addGlobal(IntrinsicsTablePtrTy, true,
+                                                 LLVMExternalLinkage,
+                                                 LLVM::Value(), "intrinsics")) {
     Trap.Ty = LLVM::Type::getFunctionType(VoidTy, {Int32Ty});
     Trap.Fn = LLModule.get().addFunction(Trap.Ty, LLVMPrivateLinkage, "trap");
     Trap.Fn.setDSOLocal(true);
@@ -414,9 +414,9 @@ struct LLVM::Compiler::CompileContext {
       Table.setInitializer(LLVM::Value::getConstNull(Table.getType()));
       Table.setGlobalConstant(false);
     } else {
-      LLModule.get().addGlobal(
-          IntrinsicsTablePtrTy, false, LLVMExternalLinkage,
-          LLVM::Value::getConstNull(IntrinsicsTablePtrTy), "intrinsics");
+      LLModule.get().addGlobal(IntrinsicsTablePtrTy, false, LLVMExternalLinkage,
+                               LLVM::Value::getConstNull(IntrinsicsTablePtrTy),
+                               "intrinsics");
     }
   }
   std::pair<std::vector<ValType>, std::vector<ValType>>
@@ -6191,8 +6191,7 @@ void Compiler::compile(const AST::TypeSection &TypeSec,
   // Iterate and compile types.
   for (size_t I = 0; I < Size; ++I) {
     const auto &CompType = SubTypes[I].getCompositeType();
-    const auto Name =
-        fmt::format("t{}"sv, Context->CompositeTypes.size());
+    const auto Name = fmt::format("t{}"sv, Context->CompositeTypes.size());
     if (CompType.isFunc()) {
       // Check that the function type is unique.
       {
@@ -6315,10 +6314,10 @@ void Compiler::compile(const AST::ImportSection &ImportSec) noexcept {
       auto FTy =
           toLLVMType(Context->LLContext, Context->ExecCtxPtrTy, FuncType);
       auto RTy = FTy.getReturnType();
-      auto F = LLVM::FunctionCallee{
-          FTy, Context->LLModule.get().addFunction(
-                   FTy, LLVMInternalLinkage,
-                   fmt::format("f{}"sv, FuncID).c_str())};
+      auto F =
+          LLVM::FunctionCallee{FTy, Context->LLModule.get().addFunction(
+                                        FTy, LLVMInternalLinkage,
+                                        fmt::format("f{}"sv, FuncID).c_str())};
       F.Fn.setDSOLocal(true);
       F.Fn.addFnAttr(Context->NoStackArgProbe);
       F.Fn.addFnAttr(Context->StrictFP);
@@ -6465,10 +6464,9 @@ void Compiler::compileFunctionDeclarations(
     const auto &FuncType = Context->CompositeTypes[TypeIdx]->getFuncType();
     const auto FuncID = Context->Functions.size();
     auto FTy = toLLVMType(Context->LLContext, Context->ExecCtxPtrTy, FuncType);
-    LLVM::FunctionCallee F = {
-        FTy, Context->LLModule.get().addFunction(
-                 FTy, LLVMExternalLinkage,
-                 fmt::format("f{}"sv, FuncID).c_str())};
+    LLVM::FunctionCallee F = {FTy, Context->LLModule.get().addFunction(
+                                       FTy, LLVMExternalLinkage,
+                                       fmt::format("f{}"sv, FuncID).c_str())};
     F.Fn.setVisibility(LLVMProtectedVisibility);
     F.Fn.setDSOLocal(true);
     F.Fn.setDLLStorageClass(LLVMDLLExportStorageClass);

--- a/lib/llvm/compiler.cpp
+++ b/lib/llvm/compiler.cpp
@@ -6587,11 +6587,11 @@ Compiler::compileFunctions(Data &&LLData, const AST::Module &Module,
   spdlog::debug("[lazy-jit]: compile functions batch ({}) start"sv,
                 Sorted.size());
 
-  // The previous batch module was consumed by the JIT, so start the next
-  // batch from a fresh module sharing the same thread-safe context.
-  if (!LLData.extract().LLModule) {
-    LLData.extract().resetModule();
-  }
+  // Each batch starts from a fresh module sharing the same thread-safe
+  // context: on success the previous batch module was consumed by the JIT,
+  // and after a failed batch the leftover module must be discarded so its
+  // declarations are not re-added on top of themselves.
+  LLData.extract().resetModule();
   auto LLContext = initLLVMModule(LLData);
   auto &LLModule = LLData.extract().LLModule;
 

--- a/lib/llvm/compiler.cpp
+++ b/lib/llvm/compiler.cpp
@@ -286,10 +286,6 @@ struct LLVM::Compiler::CompileContext {
     Trap.Fn.addFnAttr(Cold);
     Trap.Fn.addFnAttr(NoInline);
 
-    LLModule.get().addGlobal(
-        Int32Ty, true, LLVMExternalLinkage,
-        LLVM::Value::getConstInt(Int32Ty, AOT::kBinaryVersion), "version");
-
     if (!IsGenericBinary) {
       SubtargetFeatures = LLVM::getHostCPUFeatures();
       auto Features = SubtargetFeatures.string_view();
@@ -407,6 +403,21 @@ struct LLVM::Compiler::CompileContext {
         {Trap.Fn.getFirstParam()});
     CallTrap.addCallSiteAttribute(NoReturn);
     Builder.createUnreachable();
+  }
+  void addVersionGlobal() noexcept {
+    LLModule.get().addGlobal(
+        Int32Ty, true, LLVMExternalLinkage,
+        LLVM::Value::getConstInt(Int32Ty, AOT::kBinaryVersion), "version");
+  }
+  void finalizeIntrinsicsTable() noexcept {
+    if (auto Table = LLModule.get().getNamedGlobal("intrinsics")) {
+      Table.setInitializer(LLVM::Value::getConstNull(Table.getType()));
+      Table.setGlobalConstant(false);
+    } else {
+      LLModule.get().addGlobal(
+          IntrinsicsTablePtrTy, false, LLVMExternalLinkage,
+          LLVM::Value::getConstNull(IntrinsicsTablePtrTy), "intrinsics");
+    }
   }
   std::pair<std::vector<ValType>, std::vector<ValType>>
   resolveBlockType(const BlockType &BType) const noexcept {
@@ -6123,19 +6134,16 @@ Expect<Data> Compiler::compile(const AST::Module &Module) noexcept {
   CompileContext NewContext(LLContext, LLModule,
                             Conf.getCompilerConfigure().isGenericBinary());
   RAIICleanup Cleanup(Context, &NewContext);
+  Context->addVersionGlobal();
 
-  // Compile Function Types
-  compile(Module.getTypeSection());
-  // Compile ImportSection
-  compile(Module.getImportSection());
-  // Compile GlobalSection
-  compile(Module.getGlobalSection());
-  // Compile MemorySection (MemorySec, DataSec)
-  compile(Module.getMemorySection(), Module.getDataSection());
-  // Compile TableSection (TableSec, ElemSec)
-  compile(Module.getTableSection(), Module.getElementSection());
-  // Compile functions in the module. (FunctionSec, CodeSec)
-  EXPECTED_TRY(compile(Module.getFunctionSection(), Module.getCodeSection()));
+  // Compile all sections and the function declarations.
+  compileSections(Module, false);
+  // Compile all function bodies.
+  const auto DefinedCount =
+      static_cast<uint32_t>(Module.getCodeSection().getContent().size());
+  for (uint32_t I = 0; I < DefinedCount; ++I) {
+    EXPECTED_TRY(compileFunctionBody(I));
+  }
   // Compile ExportSection.
   compile(Module.getExportSection());
   // StartSection is not required for compilation.
@@ -6147,18 +6155,7 @@ Expect<Data> Compiler::compile(const AST::Module &Module) noexcept {
   EXPECTED_TRY(optimize(LLModule, TM));
 
   // Set initializer for constant value
-  if (auto IntrinsicsTable = LLModule.getNamedGlobal("intrinsics")) {
-    IntrinsicsTable.setInitializer(
-        LLVM::Value::getConstNull(IntrinsicsTable.getType()));
-    IntrinsicsTable.setGlobalConstant(false);
-  } else {
-    auto IntrinsicsTableTy = LLVM::Type::getArrayType(
-        LLContext.getInt8Ty().getPointerTo(),
-        static_cast<uint32_t>(Executable::Intrinsics::kIntrinsicMax));
-    LLModule.addGlobal(
-        IntrinsicsTableTy.getPointerTo(), false, LLVMExternalLinkage,
-        LLVM::Value::getConstNull(IntrinsicsTableTy), "intrinsics");
-  }
+  Context->finalizeIntrinsicsTable();
   return Expect<Data>{std::move(D)};
 }
 
@@ -6435,57 +6432,22 @@ void Compiler::compile(const AST::TableSection &TableSec,
   }
 }
 
-Expect<void> Compiler::compile(const AST::FunctionSection &FuncSec,
-                               const AST::CodeSection &CodeSec) noexcept {
-  const auto &TypeIdxs = FuncSec.getContent();
-  const auto &CodeSegs = CodeSec.getContent();
-  assuming(TypeIdxs.size() == CodeSegs.size());
-
-  for (size_t I = 0; I < CodeSegs.size(); ++I) {
-    const auto &TypeIdx = TypeIdxs[I];
-    const auto &Code = CodeSegs[I];
-    assuming(TypeIdx < Context->CompositeTypes.size());
-    assuming(Context->CompositeTypes[TypeIdx]->isFunc());
-    const auto &FuncType = Context->CompositeTypes[TypeIdx]->getFuncType();
-    const auto FuncID = Context->Functions.size();
-    auto FTy = toLLVMType(Context->LLContext, Context->ExecCtxPtrTy, FuncType);
-    LLVM::FunctionCallee F = {
-        FTy, Context->LLModule.get().addFunction(
-                 FTy, LLVMExternalLinkage,
-                 fmt::format("f{}"sv, FuncID).c_str())};
-    F.Fn.setVisibility(LLVMProtectedVisibility);
-    F.Fn.setDSOLocal(true);
-    F.Fn.setDLLStorageClass(LLVMDLLExportStorageClass);
-    F.Fn.addFnAttr(Context->NoStackArgProbe);
-    F.Fn.addFnAttr(Context->StrictFP);
-    F.Fn.addFnAttr(Context->UWTable);
-    F.Fn.addParamAttr(0, Context->ReadOnly);
-    F.Fn.addParamAttr(0, Context->NoAlias);
-
-    Context->Functions.emplace_back(TypeIdx, F, &Code);
-  }
-
-  for (auto [T, F, Code] : Context->Functions) {
-    if (!Code) {
-      continue;
-    }
-
-    std::vector<ValType> Locals;
-    for (const auto &Local : Code->getLocals()) {
-      for (unsigned I = 0; I < Local.first; ++I) {
-        Locals.push_back(Local.second);
-      }
-    }
-    FunctionCompiler FC(
-        *Context, F, Locals, Conf.getCompilerConfigure().isInterruptible(),
-        Conf.getStatisticsConfigure().isInstructionCounting(),
-        Conf.getStatisticsConfigure().isCostMeasuring(),
-        Conf.getRuntimeConfigure().getRunMode() == RunMode::LazyJIT);
-    auto Type = Context->resolveBlockType(T);
-    EXPECTED_TRY(FC.compile(*Code, std::move(Type)));
-    F.Fn.eliminateUnreachableBlocks();
-  }
-  return {};
+void Compiler::compileSections(const AST::Module &Module,
+                               bool DeclarationsOnly) noexcept {
+  // Compile Function Types
+  compile(Module.getTypeSection(), DeclarationsOnly);
+  // Compile ImportSection
+  compile(Module.getImportSection());
+  // Compile GlobalSection
+  compile(Module.getGlobalSection());
+  // Compile MemorySection (MemorySec, DataSec)
+  compile(Module.getMemorySection(), Module.getDataSection());
+  // Compile TableSection (TableSec, ElemSec)
+  compile(Module.getTableSection(), Module.getElementSection());
+  // Create function declarations without compiling bodies. (FunctionSec,
+  // CodeSec)
+  compileFunctionDeclarations(Module.getFunctionSection(),
+                              Module.getCodeSection());
 }
 
 void Compiler::compileFunctionDeclarations(
@@ -6564,11 +6526,8 @@ Expect<void> Compiler::compileFunctionBody(uint32_t LocalFuncIndex) noexcept {
   return {};
 }
 
-Expect<std::pair<LLVM::Data,
-                 std::unique_ptr<LLVM::Compiler::CompileContext,
-                                 LLVM::Compiler::CompileContextDeleter>>>
+Expect<LLVM::Data>
 LLVM::Compiler::compileInfrastructure(const AST::Module &Module) noexcept {
-  Data D;
   // Check the module is validated.
   if (unlikely(!Module.getIsValidated())) {
     spdlog::error(ErrCode::Value::NotValidated);
@@ -6578,59 +6537,34 @@ LLVM::Compiler::compileInfrastructure(const AST::Module &Module) noexcept {
   std::unique_lock Lock(Mutex);
   spdlog::info("[lazy-jit]: compile infrastructure start"sv);
 
+  Data D;
   auto LLContext = D.extract().getLLContext();
   LLVM::Core::init(LLContext.unwrap());
   auto &LLModule = D.extract().LLModule;
   LLModule.setTarget(LLVM::getDefaultTargetTriple().unwrap());
   LLModule.addFlag(LLVMModuleFlagBehaviorError, "PIC Level"sv, 2);
 
-  std::unique_ptr<CompileContext, CompileContextDeleter> NewContext(
-      new CompileContext(LLContext, LLModule,
-                         Conf.getCompilerConfigure().isGenericBinary()));
-  RAIICleanup Cleanup(this->Context, NewContext.get());
+  CompileContext NewContext(LLContext, LLModule,
+                            Conf.getCompilerConfigure().isGenericBinary());
+  RAIICleanup Cleanup(Context, &NewContext);
+  Context->addVersionGlobal();
 
-  // Compile Function Types
-  compile(Module.getTypeSection());
-  // Compile ImportSection
-  compile(Module.getImportSection());
-  // Compile GlobalSection
-  compile(Module.getGlobalSection());
-  // Compile MemorySection (MemorySec, DataSec)
-  compile(Module.getMemorySection(), Module.getDataSection());
-  // Compile TableSection (TableSec, ElemSec)
-  compile(Module.getTableSection(), Module.getElementSection());
-  // Create function declarations without compiling bodies
-  compileFunctionDeclarations(Module.getFunctionSection(),
-                              Module.getCodeSection());
+  // Compile all sections and the function declarations without bodies.
+  compileSections(Module, false);
   // Compile ExportSection
   compile(Module.getExportSection());
 
   // Set initializer for constant value
-  if (auto IntrinsicsTable = LLModule.getNamedGlobal("intrinsics")) {
-    IntrinsicsTable.setInitializer(
-        LLVM::Value::getConstNull(IntrinsicsTable.getType()));
-    IntrinsicsTable.setGlobalConstant(false);
-  } else {
-    auto IntrinsicsTableTy = LLVM::Type::getArrayType(
-        LLContext.getInt8Ty().getPointerTo(),
-        static_cast<uint32_t>(Executable::Intrinsics::kIntrinsicMax));
-    LLModule.addGlobal(
-        IntrinsicsTableTy.getPointerTo(), false, LLVMExternalLinkage,
-        LLVM::Value::getConstNull(IntrinsicsTableTy), "intrinsics");
-  }
+  Context->finalizeIntrinsicsTable();
   LLModule.verify(LLVMPrintMessageAction);
 
   spdlog::info("[lazy-jit]: infrastructure compilation done"sv);
 
-  return Expect<
-      std::pair<Data, std::unique_ptr<CompileContext, CompileContextDeleter>>>{
-      std::pair<Data, std::unique_ptr<CompileContext, CompileContextDeleter>>{
-          std::move(D), std::move(NewContext)}};
+  return Expect<Data>{std::move(D)};
 }
 
 Expect<LLVM::Data>
-Compiler::compileFunctions(Data &&LLData, CompileContext *NewContext,
-                           const AST::Module &Module,
+Compiler::compileFunctions(Data &&LLData, const AST::Module &Module,
                            Span<const uint32_t> LocalFuncIndices) noexcept {
   if (unlikely(!Module.getIsValidated())) {
     spdlog::error(ErrCode::Value::NotValidated);
@@ -6650,49 +6584,25 @@ Compiler::compileFunctions(Data &&LLData, CompileContext *NewContext,
   spdlog::debug("[lazy-jit]: compile functions batch ({}) start"sv,
                 Sorted.size());
 
+  // The previous batch module was consumed by the JIT, so start the next
+  // batch from a fresh module sharing the same thread-safe context.
+  if (!LLData.extract().LLModule) {
+    LLData.extract().resetModule();
+  }
   auto LLContext = LLData.extract().getLLContext();
   LLVM::Core::init(LLContext.unwrap());
   auto &LLModule = LLData.extract().LLModule;
   LLModule.setTarget(LLVM::getDefaultTargetTriple().unwrap());
   LLModule.addFlag(LLVMModuleFlagBehaviorError, "PIC Level"sv, 2);
 
-  RAIICleanup Cleanup(this->Context, NewContext);
-  Context->LLModule = LLModule;
+  CompileContext NewContext(LLContext, LLModule,
+                            Conf.getCompilerConfigure().isGenericBinary());
+  RAIICleanup Cleanup(Context, &NewContext);
 
-  Context->CompositeTypes.clear();
-  Context->FunctionWrappers.clear();
-  Context->Functions.clear();
-  Context->LazyJITCacheVars.clear();
-  Context->ImportCount = 0;
-  Context->MemoryAddrTypes.clear();
-  Context->TableAddrTypes.clear();
-  Context->Globals.clear();
-
-  Context->IntrinsicsTable = LLModule.addGlobal(
-      Context->IntrinsicsTablePtrTy, true, LLVMExternalLinkage, LLVM::Value(),
-      "intrinsics");
-  Context->IntrinsicsTable.setInitializer(LLVM::Value());
-  Context->Trap.Ty =
-      LLVM::Type::getFunctionType(Context->VoidTy, {Context->Int32Ty});
-  Context->Trap.Fn =
-      LLModule.addFunction(Context->Trap.Ty, LLVMPrivateLinkage, "trap");
-  Context->Trap.Fn.setDSOLocal(true);
-  Context->Trap.Fn.addFnAttr(Context->NoStackArgProbe);
-  Context->Trap.Fn.addFnAttr(Context->StrictFP);
-  Context->Trap.Fn.addFnAttr(Context->UWTable);
-  Context->Trap.Fn.addFnAttr(Context->NoReturn);
-  Context->Trap.Fn.addFnAttr(Context->Cold);
-  Context->Trap.Fn.addFnAttr(Context->NoInline);
-  Context->compileTrap();
-
-  compile(Module.getTypeSection(), true);
-  compile(Module.getImportSection());
-  compile(Module.getGlobalSection());
-  compile(Module.getMemorySection(), Module.getDataSection());
-  compile(Module.getTableSection(), Module.getElementSection());
-
-  compileFunctionDeclarations(Module.getFunctionSection(),
-                              Module.getCodeSection());
+  // Emit the type wrappers as external declarations resolved against the
+  // infrastructure module, then declare the functions and compile the
+  // requested bodies.
+  compileSections(Module, true);
 
   for (uint32_t FuncIndex : Sorted) {
     EXPECTED_TRY(compileFunctionBody(FuncIndex));
@@ -6710,9 +6620,5 @@ Compiler::compileFunctions(Data &&LLData, CompileContext *NewContext,
   return Expect<Data>{std::move(LLData)};
 }
 
-void LLVM::Compiler::CompileContextDeleter::operator()(
-    CompileContext *ContextPtr) const noexcept {
-  delete ContextPtr;
-}
 } // namespace LLVM
 } // namespace WasmEdge

--- a/lib/llvm/compiler.cpp
+++ b/lib/llvm/compiler.cpp
@@ -6114,6 +6114,17 @@ Expect<void> Compiler::optimize(LLVM::Module &LLModule,
   return {};
 }
 
+// Initialize the LLVM module held by the data for compilation: set the
+// target triple and the PIC level, and return the LLVM context.
+static LLVM::Context initLLVMModule(LLVM::Data &D) noexcept {
+  auto LLContext = D.extract().getLLContext();
+  LLVM::Core::init(LLContext.unwrap());
+  auto &LLModule = D.extract().LLModule;
+  LLModule.setTarget(LLVM::getDefaultTargetTriple().unwrap());
+  LLModule.addFlag(LLVMModuleFlagBehaviorError, "PIC Level"sv, 2);
+  return LLContext;
+}
+
 Expect<Data> Compiler::compile(const AST::Module &Module) noexcept {
   // Check that the module is validated.
   if (unlikely(!Module.getIsValidated())) {
@@ -6125,11 +6136,8 @@ Expect<Data> Compiler::compile(const AST::Module &Module) noexcept {
   spdlog::info("compile start"sv);
 
   LLVM::Data D;
-  auto LLContext = D.extract().getLLContext();
-  LLVM::Core::init(LLContext.unwrap());
+  auto LLContext = initLLVMModule(D);
   auto &LLModule = D.extract().LLModule;
-  LLModule.setTarget(LLVM::getDefaultTargetTriple().unwrap());
-  LLModule.addFlag(LLVMModuleFlagBehaviorError, "PIC Level"sv, 2);
 
   CompileContext NewContext(LLContext, LLModule,
                             Conf.getCompilerConfigure().isGenericBinary());
@@ -6536,11 +6544,8 @@ LLVM::Compiler::compileInfrastructure(const AST::Module &Module) noexcept {
   spdlog::info("[lazy-jit]: compile infrastructure start"sv);
 
   Data D;
-  auto LLContext = D.extract().getLLContext();
-  LLVM::Core::init(LLContext.unwrap());
+  auto LLContext = initLLVMModule(D);
   auto &LLModule = D.extract().LLModule;
-  LLModule.setTarget(LLVM::getDefaultTargetTriple().unwrap());
-  LLModule.addFlag(LLVMModuleFlagBehaviorError, "PIC Level"sv, 2);
 
   CompileContext NewContext(LLContext, LLModule,
                             Conf.getCompilerConfigure().isGenericBinary());
@@ -6587,11 +6592,8 @@ Compiler::compileFunctions(Data &&LLData, const AST::Module &Module,
   if (!LLData.extract().LLModule) {
     LLData.extract().resetModule();
   }
-  auto LLContext = LLData.extract().getLLContext();
-  LLVM::Core::init(LLContext.unwrap());
+  auto LLContext = initLLVMModule(LLData);
   auto &LLModule = LLData.extract().LLModule;
-  LLModule.setTarget(LLVM::getDefaultTargetTriple().unwrap());
-  LLModule.addFlag(LLVMModuleFlagBehaviorError, "PIC Level"sv, 2);
 
   CompileContext NewContext(LLContext, LLModule,
                             Conf.getCompilerConfigure().isGenericBinary());

--- a/lib/llvm/compiler.cpp
+++ b/lib/llvm/compiler.cpp
@@ -219,11 +219,10 @@ struct LLVM::Compiler::CompileContext {
   std::vector<LLVM::Type> MemoryAddrTypes;
   std::vector<LLVM::Type> TableAddrTypes;
   std::vector<LLVM::Type> Globals;
-  std::string Prefix;
   LLVM::Value IntrinsicsTable;
   LLVM::FunctionCallee Trap;
-  CompileContext(LLVM::Context C, LLVM::Module &M, bool IsGenericBinary,
-                 std::string_view P = ""sv) noexcept
+  CompileContext(LLVM::Context C, LLVM::Module &M,
+                 bool IsGenericBinary) noexcept
       : LLContext(C), LLModule(M),
         Cold(LLVM::Attribute::createEnum(C, LLVM::Core::Cold, 0)),
         NoAlias(LLVM::Attribute::createEnum(C, LLVM::Core::NoAlias, 0)),
@@ -273,10 +272,10 @@ struct LLVM::Compiler::CompileContext {
         IntrinsicsTableTy(LLVM::Type::getArrayType(
             Int8Ty.getPointerTo(),
             static_cast<uint32_t>(Executable::Intrinsics::kIntrinsicMax))),
-        IntrinsicsTablePtrTy(IntrinsicsTableTy.getPointerTo()), Prefix(P),
+        IntrinsicsTablePtrTy(IntrinsicsTableTy.getPointerTo()),
         IntrinsicsTable(LLModule.get().addGlobal(
             IntrinsicsTablePtrTy, true, LLVMExternalLinkage, LLVM::Value(),
-            fmt::format("{}intrinsics"sv, Prefix).c_str())) {
+            "intrinsics")) {
     Trap.Ty = LLVM::Type::getFunctionType(VoidTy, {Int32Ty});
     Trap.Fn = LLModule.get().addFunction(Trap.Ty, LLVMPrivateLinkage, "trap");
     Trap.Fn.setDSOLocal(true);
@@ -289,8 +288,7 @@ struct LLVM::Compiler::CompileContext {
 
     LLModule.get().addGlobal(
         Int32Ty, true, LLVMExternalLinkage,
-        LLVM::Value::getConstInt(Int32Ty, AOT::kBinaryVersion),
-        fmt::format("{}version"sv, Prefix).c_str());
+        LLVM::Value::getConstInt(Int32Ty, AOT::kBinaryVersion), "version");
 
     if (!IsGenericBinary) {
       SubtargetFeatures = LLVM::getHostCPUFeatures();
@@ -6197,7 +6195,7 @@ void Compiler::compile(const AST::TypeSection &TypeSec,
   for (size_t I = 0; I < Size; ++I) {
     const auto &CompType = SubTypes[I].getCompositeType();
     const auto Name =
-        fmt::format("{}t{}"sv, Context->Prefix, Context->CompositeTypes.size());
+        fmt::format("t{}"sv, Context->CompositeTypes.size());
     if (CompType.isFunc()) {
       // Check that the function type is unique.
       {
@@ -6323,7 +6321,7 @@ void Compiler::compile(const AST::ImportSection &ImportSec) noexcept {
       auto F = LLVM::FunctionCallee{
           FTy, Context->LLModule.get().addFunction(
                    FTy, LLVMInternalLinkage,
-                   fmt::format("{}f{}"sv, Context->Prefix, FuncID).c_str())};
+                   fmt::format("f{}"sv, FuncID).c_str())};
       F.Fn.setDSOLocal(true);
       F.Fn.addFnAttr(Context->NoStackArgProbe);
       F.Fn.addFnAttr(Context->StrictFP);
@@ -6454,7 +6452,7 @@ Expect<void> Compiler::compile(const AST::FunctionSection &FuncSec,
     LLVM::FunctionCallee F = {
         FTy, Context->LLModule.get().addFunction(
                  FTy, LLVMExternalLinkage,
-                 fmt::format("{}f{}"sv, Context->Prefix, FuncID).c_str())};
+                 fmt::format("f{}"sv, FuncID).c_str())};
     F.Fn.setVisibility(LLVMProtectedVisibility);
     F.Fn.setDSOLocal(true);
     F.Fn.setDLLStorageClass(LLVMDLLExportStorageClass);
@@ -6508,7 +6506,7 @@ void Compiler::compileFunctionDeclarations(
     LLVM::FunctionCallee F = {
         FTy, Context->LLModule.get().addFunction(
                  FTy, LLVMExternalLinkage,
-                 fmt::format("{}f{}"sv, Context->Prefix, FuncID).c_str())};
+                 fmt::format("f{}"sv, FuncID).c_str())};
     F.Fn.setVisibility(LLVMProtectedVisibility);
     F.Fn.setDSOLocal(true);
     F.Fn.setDLLStorageClass(LLVMDLLExportStorageClass);
@@ -6569,10 +6567,8 @@ Expect<void> Compiler::compileFunctionBody(uint32_t LocalFuncIndex) noexcept {
 Expect<std::pair<LLVM::Data,
                  std::unique_ptr<LLVM::Compiler::CompileContext,
                                  LLVM::Compiler::CompileContextDeleter>>>
-LLVM::Compiler::compileInfrastructure(const AST::Module &Module,
-                                      std::string Prefix) noexcept {
+LLVM::Compiler::compileInfrastructure(const AST::Module &Module) noexcept {
   Data D;
-  D.setPrefix(Prefix);
   // Check the module is validated.
   if (unlikely(!Module.getIsValidated())) {
     spdlog::error(ErrCode::Value::NotValidated);
@@ -6590,8 +6586,7 @@ LLVM::Compiler::compileInfrastructure(const AST::Module &Module,
 
   std::unique_ptr<CompileContext, CompileContextDeleter> NewContext(
       new CompileContext(LLContext, LLModule,
-                         Conf.getCompilerConfigure().isGenericBinary(),
-                         D.getPrefix()));
+                         Conf.getCompilerConfigure().isGenericBinary()));
   RAIICleanup Cleanup(this->Context, NewContext.get());
 
   // Compile Function Types
@@ -6611,8 +6606,7 @@ LLVM::Compiler::compileInfrastructure(const AST::Module &Module,
   compile(Module.getExportSection());
 
   // Set initializer for constant value
-  auto IntrinsicsName = fmt::format("{}intrinsics"sv, D.getPrefix());
-  if (auto IntrinsicsTable = LLModule.getNamedGlobal(IntrinsicsName.c_str())) {
+  if (auto IntrinsicsTable = LLModule.getNamedGlobal("intrinsics")) {
     IntrinsicsTable.setInitializer(
         LLVM::Value::getConstNull(IntrinsicsTable.getType()));
     IntrinsicsTable.setGlobalConstant(false);
@@ -6622,7 +6616,7 @@ LLVM::Compiler::compileInfrastructure(const AST::Module &Module,
         static_cast<uint32_t>(Executable::Intrinsics::kIntrinsicMax));
     LLModule.addGlobal(
         IntrinsicsTableTy.getPointerTo(), false, LLVMExternalLinkage,
-        LLVM::Value::getConstNull(IntrinsicsTableTy), IntrinsicsName.c_str());
+        LLVM::Value::getConstNull(IntrinsicsTableTy), "intrinsics");
   }
   LLModule.verify(LLVMPrintMessageAction);
 
@@ -6676,7 +6670,7 @@ Compiler::compileFunctions(Data &&LLData, CompileContext *NewContext,
 
   Context->IntrinsicsTable = LLModule.addGlobal(
       Context->IntrinsicsTablePtrTy, true, LLVMExternalLinkage, LLVM::Value(),
-      fmt::format("{}intrinsics"sv, Context->Prefix).c_str());
+      "intrinsics");
   Context->IntrinsicsTable.setInitializer(LLVM::Value());
   Context->Trap.Ty =
       LLVM::Type::getFunctionType(Context->VoidTy, {Context->Int32Ty});

--- a/lib/llvm/data.cpp
+++ b/lib/llvm/data.cpp
@@ -17,7 +17,3 @@ LLVM::Data &LLVM::Data::operator=(LLVM::Data &&RHS) noexcept {
   swap(Context, RHS.Context);
   return *this;
 }
-bool LLVM::Data::hasModule() const noexcept {
-  return static_cast<bool>(Context->LLModule);
-}
-void LLVM::Data::resetModule() noexcept { Context->resetModule(); }

--- a/lib/llvm/data.cpp
+++ b/lib/llvm/data.cpp
@@ -21,9 +21,3 @@ bool LLVM::Data::hasModule() const noexcept {
   return static_cast<bool>(Context->LLModule);
 }
 void LLVM::Data::resetModule() noexcept { Context->resetModule(); }
-void LLVM::Data::setPrefix(std::string_view P) noexcept {
-  Context->Prefix = std::string(P);
-}
-std::string_view LLVM::Data::getPrefix() const noexcept {
-  return Context->Prefix;
-}

--- a/lib/llvm/data.h
+++ b/lib/llvm/data.h
@@ -18,7 +18,6 @@ struct WasmEdge::LLVM::Data::DataContext {
 #endif
   LLVM::Module LLModule;
   LLVM::TargetMachine TM;
-  std::string Prefix;
   DataContext() noexcept : LLModule(getLLContext(), "wasm") {}
   void resetModule() noexcept {
     LLModule = LLVM::Module(getLLContext(), "wasm");

--- a/lib/llvm/jit.cpp
+++ b/lib/llvm/jit.cpp
@@ -78,19 +78,18 @@ static WasmEdge::Expect<LLVM::OrcLLJIT> createTunedLazyLLJIT() noexcept {
 
 namespace WasmEdge::LLVM {
 
-JITLibrary::JITLibrary(std::shared_ptr<LLVM::OrcLLJIT> JIT, std::string P,
+JITLibrary::JITLibrary(std::shared_ptr<LLVM::OrcLLJIT> JIT,
                        bool IsLazy) noexcept
-    : J(std::move(JIT)), Prefix(std::move(P)), IsLazy(IsLazy) {}
+    : J(std::move(JIT)), IsLazy(IsLazy) {}
 
 JITLibrary::~JITLibrary() noexcept {}
 
 Symbol<const Executable::IntrinsicsTable *>
 JITLibrary::getIntrinsics() noexcept {
-  if (auto Symbol = J->lookup<const IntrinsicsTable *>(
-          fmt::format("{}intrinsics"sv, Prefix).c_str())) {
+  if (auto Symbol = J->lookup<const IntrinsicsTable *>("intrinsics")) {
     return createSymbol<const IntrinsicsTable *>(*Symbol);
   } else {
-    spdlog::error("[lazy-jit]: failed to lookup intrinsics symbol: {}"sv,
+    spdlog::error("failed to lookup intrinsics symbol: {}"sv,
                   errorToString(std::move(Symbol.error())));
     return {};
   }
@@ -101,11 +100,11 @@ JITLibrary::getTypes(size_t Size) noexcept {
   std::vector<Symbol<Wrapper>> Result;
   Result.reserve(Size);
   for (size_t I = 0; I < Size; ++I) {
-    const std::string Name = fmt::format("{}t{}"sv, Prefix, I);
+    const std::string Name = fmt::format("t{}"sv, I);
     if (auto Symbol = J->lookup<Wrapper>(Name.c_str())) {
       Result.push_back(createSymbol<Wrapper>(*Symbol));
     } else {
-      spdlog::error("[lazy-jit]: failed to lookup table symbol {}: {}"sv, Name,
+      spdlog::error("failed to lookup table symbol {}: {}"sv, Name,
                     errorToString(std::move(Symbol.error())));
       Result.emplace_back();
     }
@@ -119,7 +118,7 @@ std::vector<Symbol<void>> JITLibrary::getCodes(size_t Offset,
   std::vector<Symbol<void>> Result;
   Result.reserve(Size);
   for (size_t I = 0; I < Size; ++I) {
-    const std::string Name = fmt::format("{}f{}"sv, Prefix, I + Offset);
+    const std::string Name = fmt::format("f{}"sv, I + Offset);
     void *Addr = nullptr;
     auto AddrOrErr = J->lookup<void *>(Name.c_str());
     if (AddrOrErr) {
@@ -128,8 +127,8 @@ std::vector<Symbol<void>> JITLibrary::getCodes(size_t Offset,
       auto ErrMsg = errorToString(std::move(AddrOrErr.error()));
       // consuming only symbol not found errors for lazy-jit
       if (!IsLazy || ErrMsg.find("Symbols not found"sv) == std::string::npos) {
-        spdlog::error("[lazy-jit]: failed to lookup function symbol {}: {}"sv,
-                      Name, ErrMsg);
+        spdlog::error("failed to lookup function symbol {}: {}"sv, Name,
+                      ErrMsg);
       }
     }
     if (Addr) {
@@ -183,8 +182,7 @@ Expect<std::shared_ptr<Executable>> JIT::load(Data &D, bool IsLazy) noexcept {
   }
 
   return std::make_shared<JITLibrary>(
-      std::make_shared<OrcLLJIT>(std::move(LLJITInstance)),
-      std::string(D.getPrefix()), IsLazy);
+      std::make_shared<OrcLLJIT>(std::move(LLJITInstance)), IsLazy);
 }
 
 Expect<std::vector<WasmFunctionCodeAddress>>
@@ -215,8 +213,7 @@ JIT::add(JITLibrary &Lib, Data &D,
   std::vector<WasmFunctionCodeAddress> Addresses;
   Addresses.reserve(GlobalFuncIndices.size());
   for (uint32_t GlobalFuncIndex : GlobalFuncIndices) {
-    const std::string SymName =
-        fmt::format("{}f{}"sv, D.getPrefix(), GlobalFuncIndex);
+    const std::string SymName = fmt::format("f{}"sv, GlobalFuncIndex);
     auto AddrOrErr = Lib.J->lookup<void *>(SymName.c_str());
     if (!AddrOrErr) {
       spdlog::error("[lazy-jit]: failed to lookup function symbol {}: {}"sv,
@@ -226,24 +223,6 @@ JIT::add(JITLibrary &Lib, Data &D,
             "[lazy-jit]: failed to remove failed module from tracker: {}"sv,
             RemoveErr.message().string_view());
       }
-      return Unexpect(ErrCode::Value::LazyCompilationError);
-    }
-    Addresses.push_back(*AddrOrErr);
-  }
-  return Addresses;
-}
-
-Expect<std::vector<WasmFunctionCodeAddress>> JIT::lookupWasmFunctionSymbols(
-    JITLibrary &Lib, std::string_view Prefix,
-    Span<const uint32_t> GlobalFuncIndices) noexcept {
-  std::vector<WasmFunctionCodeAddress> Addresses;
-  Addresses.reserve(GlobalFuncIndices.size());
-  for (uint32_t GlobalFuncIndex : GlobalFuncIndices) {
-    const std::string SymName = fmt::format("{}f{}"sv, Prefix, GlobalFuncIndex);
-    auto AddrOrErr = Lib.J->lookup<void *>(SymName.c_str());
-    if (!AddrOrErr) {
-      spdlog::error("[lazy-jit]: failed to lookup function symbol {}: {}"sv,
-                    SymName, errorToString(std::move(AddrOrErr.error())));
       return Unexpect(ErrCode::Value::LazyCompilationError);
     }
     Addresses.push_back(*AddrOrErr);

--- a/lib/llvm/jit.cpp
+++ b/lib/llvm/jit.cpp
@@ -144,7 +144,16 @@ std::vector<Symbol<void>> JITLibrary::getCodes(size_t Offset,
   return Result;
 }
 
-Expect<std::shared_ptr<Executable>> JIT::load(Data &D, bool IsLazy) noexcept {
+Expect<std::shared_ptr<Executable>> JIT::load(Data D) noexcept {
+  return loadImpl(D, false);
+}
+
+Expect<std::shared_ptr<Executable>> JIT::loadLazy(Data &D) noexcept {
+  return loadImpl(D, true);
+}
+
+Expect<std::shared_ptr<Executable>> JIT::loadImpl(Data &D,
+                                                  bool IsLazy) noexcept {
   OrcLLJIT LLJITInstance;
   if (IsLazy) {
     auto R = createTunedLazyLLJIT();

--- a/lib/llvm/lazyjit.cpp
+++ b/lib/llvm/lazyjit.cpp
@@ -37,9 +37,9 @@ std::vector<uint32_t> collectCallGraphBatch(
   const auto &CodeSec = Module.getCodeSection().getContent();
   const uint32_t DefinedCount = static_cast<uint32_t>(CodeSec.size());
 
-  if (LocalSeed >= DefinedCount || Compiled.count(LocalSeed) > 0) {
-    return SortedLocals;
-  }
+  // The caller's findPendingCompile guarantees a valid, not-yet-compiled
+  // seed.
+  assuming(LocalSeed < DefinedCount && Compiled.count(LocalSeed) == 0);
 
   std::vector<uint8_t> Visited(DefinedCount, 0);
   std::vector<uint32_t> Stack;
@@ -226,9 +226,9 @@ void LazyJITEngine::registerInstance(
   // earlier instantiations from their persisted code addresses.
   for (const auto &[LocalFuncIdx, Address] : State.CompiledCode) {
     const size_t GlobalFuncIdx = size_t{State.ImportFuncCount} + LocalFuncIdx;
-    if (GlobalFuncIdx >= FuncInsts.size()) {
-      continue;
-    }
+    // A fully instantiated instance of the same AST module covers every
+    // persisted local function index.
+    assuming(GlobalFuncIdx < FuncInsts.size());
     // The function instances are owned mutable by the module instance; the
     // accessor only adds constness. Upgrading them to compiled mode is the
     // purpose of this engine.
@@ -346,11 +346,9 @@ Expect<void> LazyJITEngine::compileOnDemand(
   const auto FuncInsts = ModInst->getFunctionInstances();
   for (size_t I = 0; I < BatchLocals.size(); ++I) {
     const uint32_t GlobalFuncIdx = BatchGlobal[I];
-    if (GlobalFuncIdx >= FuncInsts.size()) {
-      spdlog::error("[lazy-jit]: function index {} out of instance range"sv,
-                    GlobalFuncIdx);
-      return Unexpect(ErrCode::Value::WrongInstanceAddress);
-    }
+    // A fully instantiated instance of the same AST module covers every
+    // batch function index.
+    assuming(GlobalFuncIdx < FuncInsts.size());
     // The function instances are owned mutable by the module instance; the
     // accessor only adds constness. Upgrading them to compiled mode is the
     // purpose of this engine.

--- a/lib/llvm/lazyjit.cpp
+++ b/lib/llvm/lazyjit.cpp
@@ -133,7 +133,7 @@ LazyJITEngine::prepare(const AST::Module &Module) {
   EXPECTED_TRY(State.LLData, InfraCompiler.compileInfrastructure(Module));
 
   JIT JITEngine(PImpl->Conf);
-  EXPECTED_TRY(auto Exec, JITEngine.load(State.LLData, true));
+  EXPECTED_TRY(auto Exec, JITEngine.loadLazy(State.LLData));
   State.JITLib = std::static_pointer_cast<JITLibrary>(Exec);
 
   State.ImportFuncCount = countImportFunctions(Module);
@@ -273,9 +273,7 @@ Expect<void> LazyJITEngine::compileOnDemand(
     }
     auto *BatchFuncInst = State.FuncInsts[GlobalFuncIdx];
     if (BatchFuncInst->isWasmFunction()) {
-      auto CompiledSym = State.JITLib->createSymbol(
-          reinterpret_cast<Runtime::Instance::FunctionInstance::CompiledFunction
-                               *>(ResolvedAddresses[I]));
+      auto CompiledSym = State.JITLib->createCodeSymbol(ResolvedAddresses[I]);
       BatchFuncInst->unsafeUpgradeToCompiled(std::move(CompiledSym));
     }
   }

--- a/lib/llvm/lazyjit.cpp
+++ b/lib/llvm/lazyjit.cpp
@@ -75,6 +75,25 @@ std::vector<uint32_t> collectCallGraphBatch(
   return SortedLocals;
 }
 
+// Upgrade the function instance at GlobalFuncIdx of a bound module instance
+// to run the compiled code at Address. Shared by the fresh-batch path and the
+// re-instantiation restore path.
+void upgradeToCompiled(
+    Span<const Runtime::Instance::FunctionInstance *const> FuncInsts,
+    size_t GlobalFuncIdx, JITLibrary &JITLib,
+    WasmFunctionCodeAddress Address) noexcept {
+  // A fully instantiated instance of the same AST module covers every
+  // compiled local function index.
+  assuming(GlobalFuncIdx < FuncInsts.size());
+  // The function instances are owned mutable by the module instance; the
+  // accessor only adds constness. Upgrading them to compiled mode is the
+  // purpose of this engine. Non-wasm functions are declined by
+  // unsafeUpgradeToCompiled itself.
+  auto *FuncInst = const_cast<Runtime::Instance::FunctionInstance *>(
+      FuncInsts[GlobalFuncIdx]);
+  FuncInst->unsafeUpgradeToCompiled(JITLib.createCodeSymbol(Address));
+}
+
 } // namespace
 
 struct LazyJITEngine::Impl {
@@ -215,19 +234,8 @@ void LazyJITEngine::registerInstance(
   // in interpreter mode, so restore the functions already compiled in
   // earlier instantiations from their persisted code addresses.
   for (const auto &[LocalFuncIdx, Address] : State.CompiledCode) {
-    const size_t GlobalFuncIdx = size_t{State.ImportFuncCount} + LocalFuncIdx;
-    // A fully instantiated instance of the same AST module covers every
-    // persisted local function index.
-    assuming(GlobalFuncIdx < FuncInsts.size());
-    // The function instances are owned mutable by the module instance; the
-    // accessor only adds constness. Upgrading them to compiled mode is the
-    // purpose of this engine.
-    auto *FuncInst = const_cast<Runtime::Instance::FunctionInstance *>(
-        FuncInsts[GlobalFuncIdx]);
-    if (!FuncInst->isWasmFunction()) {
-      continue;
-    }
-    FuncInst->unsafeUpgradeToCompiled(State.JITLib->createCodeSymbol(Address));
+    upgradeToCompiled(FuncInsts, size_t{State.ImportFuncCount} + LocalFuncIdx,
+                      *State.JITLib, Address);
   }
 
   PImpl->States.insert_or_assign(&ModInst, std::move(State));
@@ -335,19 +343,8 @@ Expect<void> LazyJITEngine::compileOnDemand(
 
   const auto FuncInsts = ModInst->getFunctionInstances();
   for (size_t I = 0; I < BatchLocals.size(); ++I) {
-    const uint32_t GlobalFuncIdx = BatchGlobal[I];
-    // A fully instantiated instance of the same AST module covers every
-    // batch function index.
-    assuming(GlobalFuncIdx < FuncInsts.size());
-    // The function instances are owned mutable by the module instance; the
-    // accessor only adds constness. Upgrading them to compiled mode is the
-    // purpose of this engine.
-    auto *BatchFuncInst = const_cast<Runtime::Instance::FunctionInstance *>(
-        FuncInsts[GlobalFuncIdx]);
-    if (BatchFuncInst->isWasmFunction()) {
-      BatchFuncInst->unsafeUpgradeToCompiled(
-          State.JITLib->createCodeSymbol(ResolvedAddresses[I]));
-    }
+    upgradeToCompiled(FuncInsts, BatchGlobal[I], *State.JITLib,
+                      ResolvedAddresses[I]);
   }
 
   spdlog::debug(

--- a/lib/llvm/lazyjit.cpp
+++ b/lib/llvm/lazyjit.cpp
@@ -296,9 +296,6 @@ Expect<void> LazyJITEngine::compileOnDemand(
 
   auto BatchLocals = collectCallGraphBatch(
       LocalFuncIdx, *State.Module, State.ImportFuncCount, State.CompiledCode);
-  if (BatchLocals.empty()) {
-    return {};
-  }
 
   spdlog::debug(
       "[lazy-jit]: lazy compiling batch ({} local funcs) for entry local {}"sv,

--- a/lib/llvm/lazyjit.cpp
+++ b/lib/llvm/lazyjit.cpp
@@ -12,7 +12,6 @@
 #include "runtime/instance/module.h"
 
 #include <algorithm>
-#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -134,11 +133,7 @@ LazyJITEngine::prepare(const AST::Module &Module) {
   Compiler InfraCompiler(PImpl->Conf);
   EXPECTED_TRY(InfraCompiler.checkConfigure());
 
-  static std::atomic<uint64_t> NextModuleIndex{0};
-  auto Prefix = fmt::format(
-      "m{}_"sv, NextModuleIndex.fetch_add(1, std::memory_order_relaxed));
-  EXPECTED_TRY(auto Infra,
-               InfraCompiler.compileInfrastructure(Module, Prefix));
+  EXPECTED_TRY(auto Infra, InfraCompiler.compileInfrastructure(Module));
   State.LLData = std::move(Infra.first);
   State.LLContext = std::move(Infra.second);
 

--- a/lib/llvm/lazyjit.cpp
+++ b/lib/llvm/lazyjit.cpp
@@ -185,6 +185,17 @@ LazyJITEngine::prepare(std::shared_ptr<const AST::Module> Module) {
   State.ImportFuncCount = countImportFunctions(*State.Module);
 
   std::unique_lock Lock(PImpl->Mutex);
+  // Prune pending states whose AST module nobody outside the engine holds
+  // anymore: they can never be re-instantiated, so keeping them would leak
+  // their JIT and compiled code for the lifetime of the engine.
+  for (auto It = PImpl->PendingStates.begin();
+       It != PImpl->PendingStates.end();) {
+    if (It->second.Module.use_count() > 1) {
+      ++It;
+    } else {
+      It = PImpl->PendingStates.erase(It);
+    }
+  }
   const auto *Key = State.Module.get();
   PImpl->PendingStates.insert_or_assign(Key, std::move(State));
   return Exec;
@@ -254,7 +265,11 @@ void LazyJITEngine::unregisterInstance(
   PImpl->States.erase(It);
   State.FuncInsts.clear();
   State.FuncIndices.clear();
-  if (const auto *Key = State.Module.get(); Key != nullptr) {
+  // Keep the state only while someone outside the engine still holds the
+  // AST module and could re-instantiate it; otherwise it can never be
+  // rebound, so drop it instead of leaking the JIT and its compiled code.
+  if (const auto *Key = State.Module.get();
+      Key != nullptr && State.Module.use_count() > 1) {
     PImpl->PendingStates.insert_or_assign(Key, std::move(State));
   }
 }

--- a/lib/llvm/lazyjit.cpp
+++ b/lib/llvm/lazyjit.cpp
@@ -18,7 +18,6 @@
 #include <shared_mutex>
 #include <string_view>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -31,15 +30,14 @@ using namespace std::literals;
 // Collect the not-yet-compiled local functions reachable from the seed
 // function through direct calls and function references, so one lazy
 // compilation batch covers the whole call graph of the entry.
-std::vector<uint32_t>
-collectCallGraphBatch(uint32_t LocalSeed, const AST::Module &Module,
-                      uint32_t ImportFuncCount,
-                      const std::unordered_set<uint32_t> &LazyCompiled) {
+std::vector<uint32_t> collectCallGraphBatch(
+    uint32_t LocalSeed, const AST::Module &Module, uint32_t ImportFuncCount,
+    const std::unordered_map<uint32_t, WasmFunctionCodeAddress> &Compiled) {
   std::vector<uint32_t> SortedLocals;
   const auto &CodeSec = Module.getCodeSection().getContent();
   const uint32_t DefinedCount = static_cast<uint32_t>(CodeSec.size());
 
-  if (LocalSeed >= DefinedCount || LazyCompiled.count(LocalSeed) > 0) {
+  if (LocalSeed >= DefinedCount || Compiled.count(LocalSeed) > 0) {
     return SortedLocals;
   }
 
@@ -63,7 +61,7 @@ collectCallGraphBatch(uint32_t LocalSeed, const AST::Module &Module,
         if (Target >= ImportFuncCount) {
           const uint32_t LocalIdx = Target - ImportFuncCount;
           if (LocalIdx < DefinedCount && !Visited[LocalIdx] &&
-              LazyCompiled.count(LocalIdx) == 0) {
+              Compiled.count(LocalIdx) == 0) {
             Visited[LocalIdx] = 1;
             Stack.push_back(LocalIdx);
             SortedLocals.push_back(LocalIdx);
@@ -99,10 +97,10 @@ struct LazyJITEngine::Impl {
     Data LLData;
     /// Per-module ORC LLJIT holding the generated code.
     std::shared_ptr<JITLibrary> JITLib;
-    /// Local indices of functions already lazily compiled.
-    std::unordered_set<uint32_t> LazyCompiledFuncs;
-    /// Function instances of the bound module instance by function index.
-    std::vector<Runtime::Instance::FunctionInstance *> FuncInsts;
+    /// Resolved machine code addresses of lazily compiled functions, keyed
+    /// by local function index. Survives re-instantiations, so rebinding
+    /// restores compiled functions without further JIT symbol lookups.
+    std::unordered_map<uint32_t, WasmFunctionCodeAddress> CompiledCode;
     /// Reverse lookup from function instance to function index.
     std::unordered_map<const Runtime::Instance::FunctionInstance *, uint32_t>
         FuncIndices;
@@ -119,6 +117,14 @@ struct LazyJITEngine::Impl {
   std::pair<ModuleState *, uint32_t>
   findPendingCompile(const Runtime::Instance::ModuleInstance *ModInst,
                      const Runtime::Instance::FunctionInstance *FuncInst) {
+    // Already compiled or not a wasm function: nothing to do. Checked first
+    // because it needs no map lookup, so the steady state where every call
+    // probes an already-compiled function short-circuits here. The check is
+    // done under the engine mutex to avoid racing with the upgrade in
+    // compileOnDemand.
+    if (!FuncInst->isWasmFunction() || FuncInst->isCompiledFunction()) {
+      return {nullptr, 0};
+    }
     auto StateIt = States.find(ModInst);
     if (StateIt == States.end()) {
       return {nullptr, 0};
@@ -137,13 +143,7 @@ struct LazyJITEngine::Impl {
       return {nullptr, 0};
     }
     const uint32_t LocalFuncIdx = FuncIdx - State.ImportFuncCount;
-    // Already compiled or not a wasm function: nothing to do. This check is
-    // done under the engine mutex to avoid racing with the upgrade in
-    // compileOnDemand.
-    if (!FuncInst->isWasmFunction() || FuncInst->isCompiledFunction()) {
-      return {nullptr, 0};
-    }
-    if (State.LazyCompiledFuncs.count(LocalFuncIdx) > 0) {
+    if (State.CompiledCode.count(LocalFuncIdx) > 0) {
       return {nullptr, 0};
     }
     return {&State, LocalFuncIdx};
@@ -216,35 +216,28 @@ void LazyJITEngine::registerInstance(
   PImpl->PendingStates.erase(It);
 
   const auto FuncInsts = ModInst.getFunctionInstances();
-  State.FuncInsts.reserve(FuncInsts.size());
+  State.FuncIndices.reserve(FuncInsts.size());
   for (uint32_t I = 0; I < FuncInsts.size(); ++I) {
+    State.FuncIndices.emplace(FuncInsts[I], I);
+  }
+
+  // Rebinding after a re-instantiation: the fresh function instances start
+  // in interpreter mode, so restore the functions already compiled in
+  // earlier instantiations from their persisted code addresses.
+  for (const auto &[LocalFuncIdx, Address] : State.CompiledCode) {
+    const size_t GlobalFuncIdx = size_t{State.ImportFuncCount} + LocalFuncIdx;
+    if (GlobalFuncIdx >= FuncInsts.size()) {
+      continue;
+    }
     // The function instances are owned mutable by the module instance; the
     // accessor only adds constness. Upgrading them to compiled mode is the
     // purpose of this engine.
-    auto *FuncInst =
-        const_cast<Runtime::Instance::FunctionInstance *>(FuncInsts[I]);
-    State.FuncInsts.push_back(FuncInst);
-    State.FuncIndices.emplace(FuncInst, I);
-  }
-
-  if (!State.LazyCompiledFuncs.empty() && State.JITLib) {
-    // Rebinding after a re-instantiation: the fresh function instances start
-    // in interpreter mode, so restore the functions already compiled in
-    // earlier instantiations from the persisted JIT.
-    for (uint32_t L : State.LazyCompiledFuncs) {
-      const size_t GlobalFuncIdx = size_t{State.ImportFuncCount} + L;
-      if (GlobalFuncIdx >= State.FuncInsts.size()) {
-        continue;
-      }
-      auto *FuncInst = State.FuncInsts[GlobalFuncIdx];
-      if (!FuncInst->isWasmFunction()) {
-        continue;
-      }
-      auto Codes = State.JITLib->getCodes(GlobalFuncIdx, 1);
-      if (!Codes.empty() && Codes[0]) {
-        FuncInst->unsafeUpgradeToCompiled(std::move(Codes[0]));
-      }
+    auto *FuncInst = const_cast<Runtime::Instance::FunctionInstance *>(
+        FuncInsts[GlobalFuncIdx]);
+    if (!FuncInst->isWasmFunction()) {
+      continue;
     }
+    FuncInst->unsafeUpgradeToCompiled(State.JITLib->createCodeSymbol(Address));
   }
 
   PImpl->States.insert_or_assign(&ModInst, std::move(State));
@@ -263,7 +256,6 @@ void LazyJITEngine::unregisterInstance(
   // it instead of silently losing lazy compilation.
   auto State = std::move(It->second);
   PImpl->States.erase(It);
-  State.FuncInsts.clear();
   State.FuncIndices.clear();
   // Keep the state only while someone outside the engine still holds the
   // AST module and could re-instantiate it; otherwise it can never be
@@ -304,9 +296,8 @@ Expect<void> LazyJITEngine::compileOnDemand(
   }
   auto &State = *StatePtr;
 
-  auto BatchLocals =
-      collectCallGraphBatch(LocalFuncIdx, *State.Module, State.ImportFuncCount,
-                            State.LazyCompiledFuncs);
+  auto BatchLocals = collectCallGraphBatch(
+      LocalFuncIdx, *State.Module, State.ImportFuncCount, State.CompiledCode);
   if (BatchLocals.empty()) {
     return {};
   }
@@ -333,42 +324,48 @@ Expect<void> LazyJITEngine::compileOnDemand(
           .map_error(LogError("lazy JIT function compilation"sv)));
   State.LLData = std::move(CompiledData);
 
-  if (!State.JITLib) {
-    spdlog::error("[lazy-jit]: missing JIT library for lazy compilation"sv);
-    return Unexpect(ErrCode::Value::LazyCompilationError);
-  }
-
   std::vector<uint32_t> BatchGlobal;
   BatchGlobal.reserve(BatchLocals.size());
   for (uint32_t L : BatchLocals) {
     BatchGlobal.push_back(State.ImportFuncCount + L);
   }
 
+  // The JIT library is created in prepare() and lives as long as the state.
+  assuming(State.JITLib);
   JIT JITEngine(PImpl->Conf);
   EXPECTED_TRY(auto ResolvedAddresses,
                JITEngine.add(*State.JITLib, State.LLData, BatchGlobal)
                    .map_error(LogError("lazy JIT add"sv)));
 
+  // The machine code now lives in the persisted JIT regardless of the
+  // instance bindings, so record the batch before upgrading the instances.
+  for (size_t I = 0; I < BatchLocals.size(); ++I) {
+    State.CompiledCode.emplace(BatchLocals[I], ResolvedAddresses[I]);
+  }
+
+  const auto FuncInsts = ModInst->getFunctionInstances();
   for (size_t I = 0; I < BatchLocals.size(); ++I) {
     const uint32_t GlobalFuncIdx = BatchGlobal[I];
-    if (GlobalFuncIdx >= State.FuncInsts.size()) {
+    if (GlobalFuncIdx >= FuncInsts.size()) {
       spdlog::error("[lazy-jit]: function index {} out of instance range"sv,
                     GlobalFuncIdx);
       return Unexpect(ErrCode::Value::WrongInstanceAddress);
     }
-    auto *BatchFuncInst = State.FuncInsts[GlobalFuncIdx];
+    // The function instances are owned mutable by the module instance; the
+    // accessor only adds constness. Upgrading them to compiled mode is the
+    // purpose of this engine.
+    auto *BatchFuncInst = const_cast<Runtime::Instance::FunctionInstance *>(
+        FuncInsts[GlobalFuncIdx]);
     if (BatchFuncInst->isWasmFunction()) {
-      auto CompiledSym = State.JITLib->createCodeSymbol(ResolvedAddresses[I]);
-      BatchFuncInst->unsafeUpgradeToCompiled(std::move(CompiledSym));
+      BatchFuncInst->unsafeUpgradeToCompiled(
+          State.JITLib->createCodeSymbol(ResolvedAddresses[I]));
     }
   }
-
-  State.LazyCompiledFuncs.insert(BatchLocals.begin(), BatchLocals.end());
 
   spdlog::debug(
       "[lazy-jit]: lazy compilation completed for batch of {} functions, "
       "total compiled: {}"sv,
-      BatchLocals.size(), State.LazyCompiledFuncs.size());
+      BatchLocals.size(), State.CompiledCode.size());
 
   return {};
 }
@@ -377,7 +374,11 @@ uint32_t LazyJITEngine::compiledFunctionCount() const noexcept {
   std::shared_lock Lock(PImpl->Mutex);
   uint32_t Count = 0;
   for (const auto &Pair : PImpl->States) {
-    Count += static_cast<uint32_t>(Pair.second.LazyCompiledFuncs.size());
+    Count += static_cast<uint32_t>(Pair.second.CompiledCode.size());
+  }
+  // Pending states of unbound modules still hold live compiled code.
+  for (const auto &Pair : PImpl->PendingStates) {
+    Count += static_cast<uint32_t>(Pair.second.CompiledCode.size());
   }
   return Count;
 }

--- a/lib/llvm/lazyjit.cpp
+++ b/lib/llvm/lazyjit.cpp
@@ -6,10 +6,10 @@
 #include "ast/instruction.h"
 #include "ast/module.h"
 #include "common/spdlog.h"
+#include "runtime/instance/module.h"
 #include "llvm/compiler.h"
 #include "llvm/data.h"
 #include "llvm/jit.h"
-#include "runtime/instance/module.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -234,8 +234,7 @@ Expect<void> LazyJITEngine::compileOnDemand(
   EXPECTED_TRY(
       auto CompiledData,
       BatchCompiler
-          .compileFunctions(std::move(State.LLData), *State.Module,
-                            BatchLocals)
+          .compileFunctions(std::move(State.LLData), *State.Module, BatchLocals)
           .map_error([](auto Err) {
             spdlog::error(
                 "[lazy-jit]: lazy JIT function compilation failed: {}"sv, Err);
@@ -266,9 +265,8 @@ Expect<void> LazyJITEngine::compileOnDemand(
   for (size_t I = 0; I < BatchLocals.size(); ++I) {
     const uint32_t GlobalFuncIdx = State.ImportFuncCount + BatchLocals[I];
     if (GlobalFuncIdx >= State.FuncInsts.size()) {
-      spdlog::error(
-          "[lazy-jit]: function index {} out of instance range"sv,
-          GlobalFuncIdx);
+      spdlog::error("[lazy-jit]: function index {} out of instance range"sv,
+                    GlobalFuncIdx);
       return Unexpect(ErrCode::Value::WrongInstanceAddress);
     }
     auto *BatchFuncInst = State.FuncInsts[GlobalFuncIdx];

--- a/lib/llvm/lazyjit.cpp
+++ b/lib/llvm/lazyjit.cpp
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2026 Second State INC
+
+#include "llvm/lazyjit.h"
+
+#include "ast/instruction.h"
+#include "ast/module.h"
+#include "common/spdlog.h"
+#include "llvm/compiler.h"
+#include "llvm/data.h"
+#include "llvm/jit.h"
+#include "runtime/instance/module.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace WasmEdge::LLVM {
+
+namespace {
+
+using namespace std::literals;
+
+// Collect the not-yet-compiled local functions reachable from the seed
+// function through direct calls and function references, so one lazy
+// compilation batch covers the whole call graph of the entry.
+std::vector<uint32_t>
+collectCallGraphBatch(uint32_t LocalSeed, const AST::Module &Module,
+                      uint32_t ImportFuncCount,
+                      const std::unordered_set<uint32_t> &LazyCompiled) {
+  std::vector<uint32_t> SortedLocals;
+  const auto &CodeSec = Module.getCodeSection().getContent();
+  const uint32_t DefinedCount = static_cast<uint32_t>(CodeSec.size());
+
+  if (LocalSeed >= DefinedCount || LazyCompiled.count(LocalSeed) > 0) {
+    return SortedLocals;
+  }
+
+  std::vector<uint8_t> Visited(DefinedCount, 0);
+  std::vector<uint32_t> Stack;
+  Stack.reserve(64);
+
+  Visited[LocalSeed] = 1;
+  Stack.push_back(LocalSeed);
+  SortedLocals.push_back(LocalSeed);
+
+  while (!Stack.empty()) {
+    const uint32_t L = Stack.back();
+    Stack.pop_back();
+
+    for (const auto &Instr : CodeSec[L].getExpr().getInstrs()) {
+      const auto Op = Instr.getOpCode();
+      if (Op == OpCode::Call || Op == OpCode::Return_call ||
+          Op == OpCode::Ref__func) {
+        const uint32_t Target = Instr.getTargetIndex();
+        if (Target >= ImportFuncCount) {
+          const uint32_t LocalIdx = Target - ImportFuncCount;
+          if (LocalIdx < DefinedCount && !Visited[LocalIdx] &&
+              LazyCompiled.count(LocalIdx) == 0) {
+            Visited[LocalIdx] = 1;
+            Stack.push_back(LocalIdx);
+            SortedLocals.push_back(LocalIdx);
+          }
+        }
+      }
+    }
+  }
+
+  std::sort(SortedLocals.begin(), SortedLocals.end());
+  return SortedLocals;
+}
+
+uint32_t countImportFunctions(const AST::Module &Module) noexcept {
+  uint32_t Count = 0;
+  for (const auto &ImpDesc : Module.getImportSection().getContent()) {
+    if (ImpDesc.getExternalType() == ExternalType::Function) {
+      ++Count;
+    }
+  }
+  return Count;
+}
+
+} // namespace
+
+struct LazyJITEngine::Impl {
+  struct ModuleState {
+    /// Shared ownership of the AST module for on-demand compilation.
+    std::shared_ptr<const AST::Module> Module;
+    /// Per-module LLVM data holding the thread-safe context.
+    Data LLData;
+    /// Compilation context reused across batches.
+    std::unique_ptr<Compiler::CompileContext, Compiler::CompileContextDeleter>
+        LLContext;
+    /// Per-module ORC LLJIT holding the generated code.
+    std::shared_ptr<JITLibrary> JITLib;
+    /// Local indices of functions already lazily compiled.
+    std::unordered_set<uint32_t> LazyCompiledFuncs;
+    /// Function instances of the bound module instance by function index.
+    std::vector<Runtime::Instance::FunctionInstance *> FuncInsts;
+    /// Reverse lookup from function instance to function index.
+    std::unordered_map<const Runtime::Instance::FunctionInstance *, uint32_t>
+        FuncIndices;
+    /// Number of imported functions of the module.
+    uint32_t ImportFuncCount = 0;
+  };
+
+  Impl(const Configure &C) noexcept : Conf(C) {}
+
+  const Configure Conf;
+  mutable std::shared_mutex Mutex;
+  /// States prepared but not yet bound to a module instance.
+  std::unordered_map<const AST::Module *, ModuleState> PendingStates;
+  /// States bound to instantiated module instances.
+  std::unordered_map<const Runtime::Instance::ModuleInstance *, ModuleState>
+      States;
+};
+
+LazyJITEngine::LazyJITEngine(const Configure &Conf) noexcept
+    : PImpl(std::make_unique<Impl>(Conf)) {}
+
+LazyJITEngine::~LazyJITEngine() noexcept = default;
+
+Expect<std::shared_ptr<Executable>>
+LazyJITEngine::prepare(const AST::Module &Module) {
+  Impl::ModuleState State;
+
+  Compiler InfraCompiler(PImpl->Conf);
+  EXPECTED_TRY(InfraCompiler.checkConfigure());
+
+  static std::atomic<uint64_t> NextModuleIndex{0};
+  auto Prefix = fmt::format(
+      "m{}_"sv, NextModuleIndex.fetch_add(1, std::memory_order_relaxed));
+  EXPECTED_TRY(auto Infra,
+               InfraCompiler.compileInfrastructure(Module, Prefix));
+  State.LLData = std::move(Infra.first);
+  State.LLContext = std::move(Infra.second);
+
+  JIT JITEngine(PImpl->Conf);
+  EXPECTED_TRY(auto Exec, JITEngine.load(State.LLData, true));
+  State.JITLib = std::static_pointer_cast<JITLibrary>(Exec);
+
+  State.ImportFuncCount = countImportFunctions(Module);
+
+  std::unique_lock Lock(PImpl->Mutex);
+  PImpl->PendingStates.insert_or_assign(&Module, std::move(State));
+  return Exec;
+}
+
+void LazyJITEngine::registerInstance(
+    const Runtime::Instance::ModuleInstance &ModInst,
+    std::shared_ptr<const AST::Module> Module) noexcept {
+  if (!Module) {
+    return;
+  }
+  std::unique_lock Lock(PImpl->Mutex);
+  auto It = PImpl->PendingStates.find(Module.get());
+  if (It == PImpl->PendingStates.end()) {
+    return;
+  }
+  auto State = std::move(It->second);
+  PImpl->PendingStates.erase(It);
+  State.Module = std::move(Module);
+
+  const auto FuncInsts = ModInst.getFunctionInstances();
+  State.FuncInsts.reserve(FuncInsts.size());
+  for (uint32_t I = 0; I < FuncInsts.size(); ++I) {
+    // The function instances are owned mutable by the module instance; the
+    // accessor only adds constness. Upgrading them to compiled mode is the
+    // purpose of this engine.
+    auto *FuncInst =
+        const_cast<Runtime::Instance::FunctionInstance *>(FuncInsts[I]);
+    State.FuncInsts.push_back(FuncInst);
+    State.FuncIndices.emplace(FuncInst, I);
+  }
+  PImpl->States.insert_or_assign(&ModInst, std::move(State));
+}
+
+void LazyJITEngine::unregisterInstance(
+    const Runtime::Instance::ModuleInstance &ModInst) noexcept {
+  std::unique_lock Lock(PImpl->Mutex);
+  PImpl->States.erase(&ModInst);
+}
+
+Expect<void> LazyJITEngine::compileOnDemand(
+    const Runtime::Instance::FunctionInstance *FuncInst) {
+  if (FuncInst == nullptr) {
+    return {};
+  }
+  const auto *ModInst = FuncInst->getModule();
+  if (ModInst == nullptr) {
+    return {};
+  }
+
+  std::unique_lock Lock(PImpl->Mutex);
+  auto StateIt = PImpl->States.find(ModInst);
+  if (StateIt == PImpl->States.end()) {
+    return {};
+  }
+  auto &State = StateIt->second;
+
+  auto IdxIt = State.FuncIndices.find(FuncInst);
+  if (IdxIt == State.FuncIndices.end()) {
+    return {};
+  }
+  const uint32_t FuncIdx = IdxIt->second;
+  if (FuncIdx < State.ImportFuncCount) {
+    return {};
+  }
+  const uint32_t LocalFuncIdx = FuncIdx - State.ImportFuncCount;
+
+  // Already compiled or not a wasm function: nothing to do. This check is
+  // done under the engine lock to avoid racing with the upgrade below.
+  if (!FuncInst->isWasmFunction() || FuncInst->isCompiledFunction()) {
+    return {};
+  }
+  if (State.LazyCompiledFuncs.count(LocalFuncIdx) > 0) {
+    return {};
+  }
+
+  auto BatchLocals =
+      collectCallGraphBatch(LocalFuncIdx, *State.Module, State.ImportFuncCount,
+                            State.LazyCompiledFuncs);
+  if (BatchLocals.empty()) {
+    return {};
+  }
+
+  spdlog::debug(
+      "[lazy-jit]: lazy compiling batch ({} local funcs) for entry local {}"sv,
+      BatchLocals.size(), LocalFuncIdx);
+
+  Compiler BatchCompiler(PImpl->Conf);
+  EXPECTED_TRY(BatchCompiler.checkConfigure().map_error([](auto Err) {
+    spdlog::error("[lazy-jit]: lazy JIT compiler config failed: {}"sv, Err);
+    return Err;
+  }));
+
+  if (!State.LLData.hasModule()) {
+    State.LLData.resetModule();
+  }
+  EXPECTED_TRY(
+      auto CompiledData,
+      BatchCompiler
+          .compileFunctions(std::move(State.LLData), State.LLContext.get(),
+                            *State.Module, BatchLocals)
+          .map_error([](auto Err) {
+            spdlog::error(
+                "[lazy-jit]: lazy JIT function compilation failed: {}"sv, Err);
+            return Err;
+          }));
+  State.LLData = std::move(CompiledData);
+
+  if (!State.JITLib) {
+    spdlog::error("[lazy-jit]: missing JIT library for lazy compilation"sv);
+    return Unexpect(ErrCode::Value::LazyCompilationError);
+  }
+
+  std::vector<uint32_t> BatchGlobal;
+  BatchGlobal.reserve(BatchLocals.size());
+  for (uint32_t L : BatchLocals) {
+    BatchGlobal.push_back(State.ImportFuncCount + L);
+  }
+
+  JIT JITEngine(PImpl->Conf);
+  EXPECTED_TRY(auto ResolvedAddresses,
+               JITEngine.add(*State.JITLib, State.LLData, BatchGlobal)
+                   .map_error([](auto Err) {
+                     spdlog::error("[lazy-jit]: lazy JIT add failed: {}"sv,
+                                   Err);
+                     return Err;
+                   }));
+
+  for (size_t I = 0; I < BatchLocals.size(); ++I) {
+    const uint32_t GlobalFuncIdx = State.ImportFuncCount + BatchLocals[I];
+    if (GlobalFuncIdx >= State.FuncInsts.size()) {
+      spdlog::error(
+          "[lazy-jit]: function index {} out of instance range"sv,
+          GlobalFuncIdx);
+      return Unexpect(ErrCode::Value::WrongInstanceAddress);
+    }
+    auto *BatchFuncInst = State.FuncInsts[GlobalFuncIdx];
+    if (BatchFuncInst->isWasmFunction()) {
+      auto CompiledSym = State.JITLib->createSymbol(
+          reinterpret_cast<Runtime::Instance::FunctionInstance::CompiledFunction
+                               *>(ResolvedAddresses[I]));
+      BatchFuncInst->unsafeUpgradeToCompiled(std::move(CompiledSym));
+    }
+  }
+
+  State.LazyCompiledFuncs.insert(BatchLocals.begin(), BatchLocals.end());
+
+  spdlog::debug(
+      "[lazy-jit]: lazy compilation completed for batch of {} functions, "
+      "total compiled: {}"sv,
+      BatchLocals.size(), State.LazyCompiledFuncs.size());
+
+  return {};
+}
+
+uint32_t LazyJITEngine::compiledFunctionCount() const noexcept {
+  std::shared_lock Lock(PImpl->Mutex);
+  uint32_t Count = 0;
+  for (const auto &Pair : PImpl->States) {
+    Count += static_cast<uint32_t>(Pair.second.LazyCompiledFuncs.size());
+  }
+  return Count;
+}
+
+void LazyJITEngine::clear() noexcept {
+  std::unique_lock Lock(PImpl->Mutex);
+  PImpl->PendingStates.clear();
+  PImpl->States.clear();
+}
+
+} // namespace WasmEdge::LLVM

--- a/lib/llvm/lazyjit.cpp
+++ b/lib/llvm/lazyjit.cpp
@@ -35,7 +35,7 @@ std::vector<uint32_t> collectCallGraphBatch(
     const std::unordered_map<uint32_t, WasmFunctionCodeAddress> &Compiled) {
   std::vector<uint32_t> SortedLocals;
   const auto &CodeSec = Module.getCodeSection().getContent();
-  const uint32_t DefinedCount = static_cast<uint32_t>(CodeSec.size());
+  const uint32_t DefinedCount = Module.getDefinedFuncCount();
 
   // The caller's findPendingCompile guarantees a valid, not-yet-compiled
   // seed.

--- a/lib/llvm/lazyjit.cpp
+++ b/lib/llvm/lazyjit.cpp
@@ -337,13 +337,10 @@ Expect<void> LazyJITEngine::compileOnDemand(
                    .map_error(LogError("lazy JIT add"sv)));
 
   // The machine code now lives in the persisted JIT regardless of the
-  // instance bindings, so record the batch before upgrading the instances.
-  for (size_t I = 0; I < BatchLocals.size(); ++I) {
-    State.CompiledCode.emplace(BatchLocals[I], ResolvedAddresses[I]);
-  }
-
+  // instance bindings, so record each address before upgrading its instance.
   const auto FuncInsts = ModInst->getFunctionInstances();
   for (size_t I = 0; I < BatchLocals.size(); ++I) {
+    State.CompiledCode.emplace(BatchLocals[I], ResolvedAddresses[I]);
     upgradeToCompiled(FuncInsts, BatchGlobal[I], *State.JITLib,
                       ResolvedAddresses[I]);
   }

--- a/lib/llvm/lazyjit.cpp
+++ b/lib/llvm/lazyjit.cpp
@@ -94,9 +94,6 @@ struct LazyJITEngine::Impl {
     std::shared_ptr<const AST::Module> Module;
     /// Per-module LLVM data holding the thread-safe context.
     Data LLData;
-    /// Compilation context reused across batches.
-    std::unique_ptr<Compiler::CompileContext, Compiler::CompileContextDeleter>
-        LLContext;
     /// Per-module ORC LLJIT holding the generated code.
     std::shared_ptr<JITLibrary> JITLib;
     /// Local indices of functions already lazily compiled.
@@ -133,9 +130,7 @@ LazyJITEngine::prepare(const AST::Module &Module) {
   Compiler InfraCompiler(PImpl->Conf);
   EXPECTED_TRY(InfraCompiler.checkConfigure());
 
-  EXPECTED_TRY(auto Infra, InfraCompiler.compileInfrastructure(Module));
-  State.LLData = std::move(Infra.first);
-  State.LLContext = std::move(Infra.second);
+  EXPECTED_TRY(State.LLData, InfraCompiler.compileInfrastructure(Module));
 
   JIT JITEngine(PImpl->Conf);
   EXPECTED_TRY(auto Exec, JITEngine.load(State.LLData, true));
@@ -236,14 +231,11 @@ Expect<void> LazyJITEngine::compileOnDemand(
     return Err;
   }));
 
-  if (!State.LLData.hasModule()) {
-    State.LLData.resetModule();
-  }
   EXPECTED_TRY(
       auto CompiledData,
       BatchCompiler
-          .compileFunctions(std::move(State.LLData), State.LLContext.get(),
-                            *State.Module, BatchLocals)
+          .compileFunctions(std::move(State.LLData), *State.Module,
+                            BatchLocals)
           .map_error([](auto Err) {
             spdlog::error(
                 "[lazy-jit]: lazy JIT function compilation failed: {}"sv, Err);

--- a/lib/llvm/lazyjit.cpp
+++ b/lib/llvm/lazyjit.cpp
@@ -94,6 +94,14 @@ void upgradeToCompiled(
   FuncInst->unsafeUpgradeToCompiled(JITLib.createCodeSymbol(Address));
 }
 
+// True while someone outside the engine still holds the AST module and could
+// re-instantiate it; a state failing this can never be rebound, so keeping it
+// would leak its JIT and compiled code for the lifetime of the engine.
+bool isReinstantiable(
+    const std::shared_ptr<const AST::Module> &Module) noexcept {
+  return Module != nullptr && Module.use_count() > 1;
+}
+
 } // namespace
 
 struct LazyJITEngine::Impl {
@@ -194,12 +202,10 @@ LazyJITEngine::prepare(std::shared_ptr<const AST::Module> Module) {
   State.ImportFuncCount = State.Module->getImportFuncCount();
 
   std::unique_lock Lock(PImpl->Mutex);
-  // Prune pending states whose AST module nobody outside the engine holds
-  // anymore: they can never be re-instantiated, so keeping them would leak
-  // their JIT and compiled code for the lifetime of the engine.
+  // Prune pending states nobody can re-instantiate anymore.
   for (auto It = PImpl->PendingStates.begin();
        It != PImpl->PendingStates.end();) {
-    if (It->second.Module.use_count() > 1) {
+    if (isReinstantiable(It->second.Module)) {
       ++It;
     } else {
       It = PImpl->PendingStates.erase(It);
@@ -255,11 +261,9 @@ void LazyJITEngine::unregisterInstance(
   auto State = std::move(It->second);
   PImpl->States.erase(It);
   State.FuncIndices.clear();
-  // Keep the state only while someone outside the engine still holds the
-  // AST module and could re-instantiate it; otherwise it can never be
-  // rebound, so drop it instead of leaking the JIT and its compiled code.
-  if (const auto *Key = State.Module.get();
-      Key != nullptr && State.Module.use_count() > 1) {
+  // Keep the state only while it can be rebound; otherwise drop it instead
+  // of leaking the JIT and its compiled code.
+  if (const auto *Key = State.Module.get(); isReinstantiable(State.Module)) {
     PImpl->PendingStates.insert_or_assign(Key, std::move(State));
   }
 }

--- a/lib/llvm/lazyjit.cpp
+++ b/lib/llvm/lazyjit.cpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -90,7 +91,9 @@ uint32_t countImportFunctions(const AST::Module &Module) noexcept {
 
 struct LazyJITEngine::Impl {
   struct ModuleState {
-    /// Shared ownership of the AST module for on-demand compilation.
+    /// Shared ownership of the AST module for on-demand compilation. Held
+    /// from prepare time on, so the AST module pointers used as map keys
+    /// below can never dangle or be reused by another allocation.
     std::shared_ptr<const AST::Module> Module;
     /// Per-module LLVM data holding the thread-safe context.
     Data LLData;
@@ -109,9 +112,47 @@ struct LazyJITEngine::Impl {
 
   Impl(const Configure &C) noexcept : Conf(C) {}
 
+  /// Locate the bound state and the local function index when the function
+  /// still needs lazy compilation. Returns {nullptr, 0} when there is
+  /// nothing to do. The caller must hold Mutex (shared or exclusive); all
+  /// writers hold it exclusively, so shared-locked reads are race-free.
+  std::pair<ModuleState *, uint32_t>
+  findPendingCompile(const Runtime::Instance::ModuleInstance *ModInst,
+                     const Runtime::Instance::FunctionInstance *FuncInst) {
+    auto StateIt = States.find(ModInst);
+    if (StateIt == States.end()) {
+      return {nullptr, 0};
+    }
+    auto &State = StateIt->second;
+    auto IdxIt = State.FuncIndices.find(FuncInst);
+    if (IdxIt == State.FuncIndices.end()) {
+      // A bound module knows all of its function instances; reaching here
+      // indicates a foreign or stale instance.
+      spdlog::debug(
+          "[lazy-jit]: function instance not bound to its module state"sv);
+      return {nullptr, 0};
+    }
+    const uint32_t FuncIdx = IdxIt->second;
+    if (FuncIdx < State.ImportFuncCount) {
+      return {nullptr, 0};
+    }
+    const uint32_t LocalFuncIdx = FuncIdx - State.ImportFuncCount;
+    // Already compiled or not a wasm function: nothing to do. This check is
+    // done under the engine mutex to avoid racing with the upgrade in
+    // compileOnDemand.
+    if (!FuncInst->isWasmFunction() || FuncInst->isCompiledFunction()) {
+      return {nullptr, 0};
+    }
+    if (State.LazyCompiledFuncs.count(LocalFuncIdx) > 0) {
+      return {nullptr, 0};
+    }
+    return {&State, LocalFuncIdx};
+  }
+
   const Configure Conf;
   mutable std::shared_mutex Mutex;
-  /// States prepared but not yet bound to a module instance.
+  /// States prepared but not yet bound to a module instance, keyed by the
+  /// AST module owned by the state itself.
   std::unordered_map<const AST::Module *, ModuleState> PendingStates;
   /// States bound to instantiated module instances.
   std::unordered_map<const Runtime::Instance::ModuleInstance *, ModuleState>
@@ -124,22 +165,28 @@ LazyJITEngine::LazyJITEngine(const Configure &Conf) noexcept
 LazyJITEngine::~LazyJITEngine() noexcept = default;
 
 Expect<std::shared_ptr<Executable>>
-LazyJITEngine::prepare(const AST::Module &Module) {
+LazyJITEngine::prepare(std::shared_ptr<const AST::Module> Module) {
+  if (!Module) {
+    return Unexpect(ErrCode::Value::WrongVMWorkflow);
+  }
   Impl::ModuleState State;
+  State.Module = std::move(Module);
 
   Compiler InfraCompiler(PImpl->Conf);
   EXPECTED_TRY(InfraCompiler.checkConfigure());
 
-  EXPECTED_TRY(State.LLData, InfraCompiler.compileInfrastructure(Module));
+  EXPECTED_TRY(State.LLData,
+               InfraCompiler.compileInfrastructure(*State.Module));
 
   JIT JITEngine(PImpl->Conf);
   EXPECTED_TRY(auto Exec, JITEngine.loadLazy(State.LLData));
   State.JITLib = std::static_pointer_cast<JITLibrary>(Exec);
 
-  State.ImportFuncCount = countImportFunctions(Module);
+  State.ImportFuncCount = countImportFunctions(*State.Module);
 
   std::unique_lock Lock(PImpl->Mutex);
-  PImpl->PendingStates.insert_or_assign(&Module, std::move(State));
+  const auto *Key = State.Module.get();
+  PImpl->PendingStates.insert_or_assign(Key, std::move(State));
   return Exec;
 }
 
@@ -156,7 +203,6 @@ void LazyJITEngine::registerInstance(
   }
   auto State = std::move(It->second);
   PImpl->PendingStates.erase(It);
-  State.Module = std::move(Module);
 
   const auto FuncInsts = ModInst.getFunctionInstances();
   State.FuncInsts.reserve(FuncInsts.size());
@@ -169,13 +215,48 @@ void LazyJITEngine::registerInstance(
     State.FuncInsts.push_back(FuncInst);
     State.FuncIndices.emplace(FuncInst, I);
   }
+
+  if (!State.LazyCompiledFuncs.empty() && State.JITLib) {
+    // Rebinding after a re-instantiation: the fresh function instances start
+    // in interpreter mode, so restore the functions already compiled in
+    // earlier instantiations from the persisted JIT.
+    for (uint32_t L : State.LazyCompiledFuncs) {
+      const size_t GlobalFuncIdx = size_t{State.ImportFuncCount} + L;
+      if (GlobalFuncIdx >= State.FuncInsts.size()) {
+        continue;
+      }
+      auto *FuncInst = State.FuncInsts[GlobalFuncIdx];
+      if (!FuncInst->isWasmFunction()) {
+        continue;
+      }
+      auto Codes = State.JITLib->getCodes(GlobalFuncIdx, 1);
+      if (!Codes.empty() && Codes[0]) {
+        FuncInst->unsafeUpgradeToCompiled(std::move(Codes[0]));
+      }
+    }
+  }
+
   PImpl->States.insert_or_assign(&ModInst, std::move(State));
 }
 
 void LazyJITEngine::unregisterInstance(
     const Runtime::Instance::ModuleInstance &ModInst) noexcept {
   std::unique_lock Lock(PImpl->Mutex);
-  PImpl->States.erase(&ModInst);
+  auto It = PImpl->States.find(&ModInst);
+  if (It == PImpl->States.end()) {
+    return;
+  }
+  // Drop only the per-instance bindings; the module-level JIT state moves
+  // back to the pending map so a later instantiation of the same AST module
+  // (which skips prepare because its executable is already hooked) rebinds
+  // it instead of silently losing lazy compilation.
+  auto State = std::move(It->second);
+  PImpl->States.erase(It);
+  State.FuncInsts.clear();
+  State.FuncIndices.clear();
+  if (const auto *Key = State.Module.get(); Key != nullptr) {
+    PImpl->PendingStates.insert_or_assign(Key, std::move(State));
+  }
 }
 
 Expect<void> LazyJITEngine::compileOnDemand(
@@ -188,31 +269,25 @@ Expect<void> LazyJITEngine::compileOnDemand(
     return {};
   }
 
+  // Fast path: the common no-work cases (unbound module, host function,
+  // already compiled) need only read access. All writers hold the exclusive
+  // lock on the same mutex, so the shared lock keeps this race-free without
+  // serializing concurrent callers.
+  {
+    std::shared_lock SharedLock(PImpl->Mutex);
+    if (PImpl->findPendingCompile(ModInst, FuncInst).first == nullptr) {
+      return {};
+    }
+  }
+
   std::unique_lock Lock(PImpl->Mutex);
-  auto StateIt = PImpl->States.find(ModInst);
-  if (StateIt == PImpl->States.end()) {
+  // Re-locate under the exclusive lock; the state may have changed between
+  // the two locks.
+  auto [StatePtr, LocalFuncIdx] = PImpl->findPendingCompile(ModInst, FuncInst);
+  if (StatePtr == nullptr) {
     return {};
   }
-  auto &State = StateIt->second;
-
-  auto IdxIt = State.FuncIndices.find(FuncInst);
-  if (IdxIt == State.FuncIndices.end()) {
-    return {};
-  }
-  const uint32_t FuncIdx = IdxIt->second;
-  if (FuncIdx < State.ImportFuncCount) {
-    return {};
-  }
-  const uint32_t LocalFuncIdx = FuncIdx - State.ImportFuncCount;
-
-  // Already compiled or not a wasm function: nothing to do. This check is
-  // done under the engine lock to avoid racing with the upgrade below.
-  if (!FuncInst->isWasmFunction() || FuncInst->isCompiledFunction()) {
-    return {};
-  }
-  if (State.LazyCompiledFuncs.count(LocalFuncIdx) > 0) {
-    return {};
-  }
+  auto &State = *StatePtr;
 
   auto BatchLocals =
       collectCallGraphBatch(LocalFuncIdx, *State.Module, State.ImportFuncCount,
@@ -225,21 +300,22 @@ Expect<void> LazyJITEngine::compileOnDemand(
       "[lazy-jit]: lazy compiling batch ({} local funcs) for entry local {}"sv,
       BatchLocals.size(), LocalFuncIdx);
 
+  const auto LogError = [](std::string_view Stage) {
+    return [Stage](auto Err) {
+      spdlog::error("[lazy-jit]: {} failed: {}"sv, Stage, Err);
+      return Err;
+    };
+  };
+
   Compiler BatchCompiler(PImpl->Conf);
-  EXPECTED_TRY(BatchCompiler.checkConfigure().map_error([](auto Err) {
-    spdlog::error("[lazy-jit]: lazy JIT compiler config failed: {}"sv, Err);
-    return Err;
-  }));
+  EXPECTED_TRY(BatchCompiler.checkConfigure().map_error(
+      LogError("lazy JIT compiler config"sv)));
 
   EXPECTED_TRY(
       auto CompiledData,
       BatchCompiler
           .compileFunctions(std::move(State.LLData), *State.Module, BatchLocals)
-          .map_error([](auto Err) {
-            spdlog::error(
-                "[lazy-jit]: lazy JIT function compilation failed: {}"sv, Err);
-            return Err;
-          }));
+          .map_error(LogError("lazy JIT function compilation"sv)));
   State.LLData = std::move(CompiledData);
 
   if (!State.JITLib) {
@@ -256,14 +332,10 @@ Expect<void> LazyJITEngine::compileOnDemand(
   JIT JITEngine(PImpl->Conf);
   EXPECTED_TRY(auto ResolvedAddresses,
                JITEngine.add(*State.JITLib, State.LLData, BatchGlobal)
-                   .map_error([](auto Err) {
-                     spdlog::error("[lazy-jit]: lazy JIT add failed: {}"sv,
-                                   Err);
-                     return Err;
-                   }));
+                   .map_error(LogError("lazy JIT add"sv)));
 
   for (size_t I = 0; I < BatchLocals.size(); ++I) {
-    const uint32_t GlobalFuncIdx = State.ImportFuncCount + BatchLocals[I];
+    const uint32_t GlobalFuncIdx = BatchGlobal[I];
     if (GlobalFuncIdx >= State.FuncInsts.size()) {
       spdlog::error("[lazy-jit]: function index {} out of instance range"sv,
                     GlobalFuncIdx);

--- a/lib/llvm/lazyjit.cpp
+++ b/lib/llvm/lazyjit.cpp
@@ -312,10 +312,10 @@ Expect<void> LazyJITEngine::compileOnDemand(
     };
   };
 
+  // The configure was already validated by checkConfigure() in prepare(),
+  // and a state only exists after a successful prepare, so re-validating
+  // here would only repeat its per-proposal warnings once per batch.
   Compiler BatchCompiler(PImpl->Conf);
-  EXPECTED_TRY(BatchCompiler.checkConfigure().map_error(
-      LogError("lazy JIT compiler config"sv)));
-
   EXPECTED_TRY(
       auto CompiledData,
       BatchCompiler

--- a/lib/llvm/lazyjit.cpp
+++ b/lib/llvm/lazyjit.cpp
@@ -75,16 +75,6 @@ std::vector<uint32_t> collectCallGraphBatch(
   return SortedLocals;
 }
 
-uint32_t countImportFunctions(const AST::Module &Module) noexcept {
-  uint32_t Count = 0;
-  for (const auto &ImpDesc : Module.getImportSection().getContent()) {
-    if (ImpDesc.getExternalType() == ExternalType::Function) {
-      ++Count;
-    }
-  }
-  return Count;
-}
-
 } // namespace
 
 struct LazyJITEngine::Impl {
@@ -182,7 +172,7 @@ LazyJITEngine::prepare(std::shared_ptr<const AST::Module> Module) {
   EXPECTED_TRY(auto Exec, JITEngine.loadLazy(State.LLData));
   State.JITLib = std::static_pointer_cast<JITLibrary>(Exec);
 
-  State.ImportFuncCount = countImportFunctions(*State.Module);
+  State.ImportFuncCount = State.Module->getImportFuncCount();
 
   std::unique_lock Lock(PImpl->Mutex);
   // Prune pending states whose AST module nobody outside the engine holds

--- a/lib/loader/ast/module.cpp
+++ b/lib/loader/ast/module.cpp
@@ -157,12 +157,7 @@ Expect<void> Loader::loadModule(AST::Module &Mod,
 Expect<void> Loader::loadExecutable(AST::Module &Mod,
                                     std::shared_ptr<Executable> Exec) {
   auto &SubTypes = Mod.getTypeSection().getContent();
-  size_t Offset = 0;
-  for (const auto &ImpDesc : Mod.getImportSection().getContent()) {
-    if (ImpDesc.getExternalType() == ExternalType::Function) {
-      ++Offset;
-    }
-  }
+  const size_t Offset = Mod.getImportFuncCount();
   auto &CodeSegs = Mod.getCodeSection().getContent();
 
   // Check the symbols.

--- a/lib/loader/loader.cpp
+++ b/lib/loader/loader.cpp
@@ -10,29 +10,11 @@
 #include <fstream>
 #include <limits>
 #include <memory>
-#include <random>
 #include <system_error>
 #include <utility>
 #include <variant>
 
 using namespace std::literals;
-
-namespace {
-std::string generateID() {
-  static const std::string Characters =
-      "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-  static std::mutex M;
-  static std::mt19937 Gen{std::random_device{}()};
-  std::uniform_int_distribution<size_t> Dist(0, Characters.size() - 1);
-  std::lock_guard L(M);
-
-  std::string Result(10, '\0');
-  for (char &C : Result) {
-    C = Characters[Dist(Gen)];
-  }
-  return Result;
-}
-} // namespace
 
 namespace WasmEdge {
 namespace Loader {
@@ -211,9 +193,6 @@ Loader::loadUnit() {
     auto Mod = std::make_unique<AST::Module>();
     Mod->getMagic() = WasmMagic;
     Mod->getVersion() = Ver;
-    if (Conf.getRuntimeConfigure().getRunMode() == RunMode::LazyJIT) {
-      Mod->setID(generateID());
-    }
     if (Conf.getRuntimeConfigure().getRunMode() == RunMode::AOT) {
       EXPECTED_TRY(loadModuleAOT(Mod->getAOTSection()));
     }

--- a/lib/vm/CMakeLists.txt
+++ b/lib/vm/CMakeLists.txt
@@ -25,12 +25,6 @@ if(WASMEDGE_USE_LLVM)
     PUBLIC
     wasmedgeLLVM
   )
-  target_include_directories(wasmedgeVM
-    SYSTEM
-    PRIVATE
-    ${LLVM_INCLUDE_DIR}
-    ${LLD_INCLUDE_DIRS}
-  )
 endif()
 
 if(MSVC)

--- a/lib/vm/vm.cpp
+++ b/lib/vm/vm.cpp
@@ -145,8 +145,24 @@ void VM::unsafeInitVM() {
     spdlog::warn(
         "Lazy JIT is an alpha and experimental feature, which is not ready for production use."sv);
     ExecutorEngine.registerLazyCompilationCallback(
-        [this](const std::string &ID, const uint32_t FuncIdx) -> Expect<void> {
-          return lazyCompileFunctions(ID, FuncIdx);
+        [this](const Runtime::Instance::FunctionInstance *FuncInst)
+            -> Expect<void> {
+          if (FuncInst == nullptr) {
+            return {};
+          }
+          const auto *TargetModInst = FuncInst->getModule();
+          if (TargetModInst == nullptr) {
+            return {};
+          }
+          auto Res = TargetModInst->getFuncIdx(FuncInst);
+          if (!Res) {
+            return {};
+          }
+          const std::string ID = TargetModInst->getID();
+          if (ID.empty()) {
+            return {};
+          }
+          return lazyCompileFunctions(ID, *Res);
         });
   }
 #endif

--- a/lib/vm/vm.cpp
+++ b/lib/vm/vm.cpp
@@ -387,16 +387,21 @@ VM::unsafeRunWasmFile(const AST::Module &Module, std::string_view Func,
   EXPECTED_TRY(ValidatorEngine.validate(Module));
 #ifdef WASMEDGE_USE_LLVM
   if (LazyEngine) {
-    if (ActiveModInst) {
-      LazyEngine->unregisterInstance(*ActiveModInst);
-    }
     // This one-shot path takes no shared ownership of the module, so it is
     // not bound to the lazy JIT engine and executes in the interpreter.
     spdlog::debug("[lazy-jit]: runWasmFile executes in interpreter mode"sv);
   }
 #endif
-  EXPECTED_TRY(ActiveModInst,
+  EXPECTED_TRY(auto NewModInst,
                ExecutorEngine.instantiateModule(StoreRef, Module));
+#ifdef WASMEDGE_USE_LLVM
+  // Drop the lazy binding of the replaced instance only after the new
+  // instantiation succeeds, so a failed run keeps the current instance bound.
+  if (LazyEngine && ActiveModInst) {
+    LazyEngine->unregisterInstance(*ActiveModInst);
+  }
+#endif
+  ActiveModInst = std::move(NewModInst);
 
   // Get module instance.
   if (ActiveModInst) {
@@ -579,20 +584,20 @@ Expect<void> VM::unsafeInstantiate() {
 #endif
     }
 
-#ifdef WASMEDGE_USE_LLVM
-    if (LazyEngine && ActiveModInst) {
-      LazyEngine->unregisterInstance(*ActiveModInst);
-    }
-#endif
-
-    EXPECTED_TRY(ActiveModInst,
+    EXPECTED_TRY(auto NewModInst,
                  ExecutorEngine.instantiateModule(StoreRef, *Mod));
 
 #ifdef WASMEDGE_USE_LLVM
     if (LazyEngine) {
-      LazyEngine->registerInstance(*ActiveModInst, Mod);
+      // Rebind the lazy JIT state only after instantiation succeeds, so a
+      // failed re-instantiation keeps the current instance bound.
+      if (ActiveModInst) {
+        LazyEngine->unregisterInstance(*ActiveModInst);
+      }
+      LazyEngine->registerInstance(*NewModInst, Mod);
     }
 #endif
+    ActiveModInst = std::move(NewModInst);
 
     Stage = VMStage::Instantiated;
     return {};

--- a/lib/vm/vm.cpp
+++ b/lib/vm/vm.cpp
@@ -546,7 +546,7 @@ Expect<void> VM::unsafeInstantiate() {
             })
             .and_then([&](auto LLModule) {
               LLVM::JIT JIT(Conf);
-              return JIT.load(LLModule);
+              return JIT.load(std::move(LLModule));
             })
             .map_error([](uint32_t Err) {
               if (Err != ErrCode::Value::Success) {

--- a/lib/vm/vm.cpp
+++ b/lib/vm/vm.cpp
@@ -238,7 +238,7 @@ Expect<void> VM::unsafeRegisterModule(std::string_view Name,
 
 #ifdef WASMEDGE_USE_LLVM
   if (LazyEngine && !Module->getSymbol()) {
-    EXPECTED_TRY(auto Exec, LazyEngine->prepare(*Module));
+    EXPECTED_TRY(auto Exec, LazyEngine->prepare(Module));
     EXPECTED_TRY(LoaderEngine.loadExecutable(*Module, std::move(Exec)));
   }
 #endif
@@ -386,8 +386,13 @@ VM::unsafeRunWasmFile(const AST::Module &Module, std::string_view Func,
   }
   EXPECTED_TRY(ValidatorEngine.validate(Module));
 #ifdef WASMEDGE_USE_LLVM
-  if (LazyEngine && ActiveModInst) {
-    LazyEngine->unregisterInstance(*ActiveModInst);
+  if (LazyEngine) {
+    if (ActiveModInst) {
+      LazyEngine->unregisterInstance(*ActiveModInst);
+    }
+    // This one-shot path takes no shared ownership of the module, so it is
+    // not bound to the lazy JIT engine and executes in the interpreter.
+    spdlog::debug("[lazy-jit]: runWasmFile executes in interpreter mode"sv);
   }
 #endif
   EXPECTED_TRY(ActiveModInst,
@@ -522,7 +527,7 @@ Expect<void> VM::unsafeInstantiate() {
         !Mod->getSymbol()) {
 #ifdef WASMEDGE_USE_LLVM
       if (LazyEngine) {
-        EXPECTED_TRY(auto Exec, LazyEngine->prepare(*Mod));
+        EXPECTED_TRY(auto Exec, LazyEngine->prepare(Mod));
         EXPECTED_TRY(LoaderEngine.loadExecutable(*Mod, std::move(Exec)));
       } else {
         LLVM::Compiler Compiler(Conf);

--- a/lib/vm/vm.cpp
+++ b/lib/vm/vm.cpp
@@ -3,9 +3,7 @@
 
 #include "vm/vm.h"
 
-#include "ast/instruction.h"
 #include "ast/module.h"
-#include "common/enum_errcode.hpp"
 #include "common/errcode.h"
 #include "common/types.h"
 #include "host/wasi/wasimodule.h"
@@ -22,70 +20,13 @@
 #include "host/mock/wasmedge_tensorflow_module.h"
 #include "host/mock/wasmedge_tensorflowlite_module.h"
 #include "validator/validator.h"
-#include <algorithm>
-#include <cstddef>
 #include <memory>
 #include <variant>
-#include <vector>
-
-#ifdef WASMEDGE_USE_LLVM
-#include <llvm/IR/Module.h>
-#endif
 
 namespace WasmEdge {
 namespace VM {
 
 namespace {
-
-#ifdef WASMEDGE_USE_LLVM
-void collectLazyCallGraphBatch(uint32_t LocalSeed, const AST::Module *ModulePtr,
-                               uint32_t ImportFuncCount,
-                               const std::unordered_set<uint32_t> &LazyCompiled,
-                               std::vector<uint32_t> &OutSortedLocals) {
-  OutSortedLocals.clear();
-  if (!ModulePtr) {
-    return;
-  }
-  const auto &CodeSec = ModulePtr->getCodeSection().getContent();
-  const uint32_t DefinedCount = static_cast<uint32_t>(CodeSec.size());
-
-  if (LocalSeed >= DefinedCount || LazyCompiled.count(LocalSeed)) {
-    return;
-  }
-
-  std::vector<uint8_t> Visited(DefinedCount, 0);
-  std::vector<uint32_t> Stack;
-  Stack.reserve(64);
-
-  Visited[LocalSeed] = 1;
-  Stack.push_back(LocalSeed);
-  OutSortedLocals.push_back(LocalSeed);
-
-  while (!Stack.empty()) {
-    const uint32_t L = Stack.back();
-    Stack.pop_back();
-
-    for (const auto &Instr : CodeSec[L].getExpr().getInstrs()) {
-      const auto Op = Instr.getOpCode();
-      if (Op == OpCode::Call || Op == OpCode::Return_call ||
-          Op == OpCode::Ref__func) {
-        const uint32_t Target = Instr.getTargetIndex();
-        if (Target >= ImportFuncCount) {
-          const uint32_t LocalIdx = Target - ImportFuncCount;
-          if (LocalIdx < DefinedCount && !Visited[LocalIdx] &&
-              !LazyCompiled.count(LocalIdx)) {
-            Visited[LocalIdx] = 1;
-            Stack.push_back(LocalIdx);
-            OutSortedLocals.push_back(LocalIdx);
-          }
-        }
-      }
-    }
-  }
-
-  std::sort(OutSortedLocals.begin(), OutSortedLocals.end());
-}
-#endif
 
 template <typename T> struct VisitUnit {
   using MT = std::function<T(std::unique_ptr<AST::Module> &)>;
@@ -139,31 +80,15 @@ void VM::unsafeInitVM() {
   unsafeLoadBuiltInHosts();
   unsafeLoadPlugInHosts();
 
-  // Register the lazy compilation callback if lazy JIT mode is enabled.
+  // Set up the lazy JIT engine if lazy JIT mode is enabled.
 #ifdef WASMEDGE_USE_LLVM
   if (Conf.getRuntimeConfigure().getRunMode() == RunMode::LazyJIT) {
     spdlog::warn(
         "Lazy JIT is an alpha and experimental feature, which is not ready for production use."sv);
+    LazyEngine = std::make_unique<LLVM::LazyJITEngine>(Conf);
     ExecutorEngine.registerLazyCompilationCallback(
         [this](const Runtime::Instance::FunctionInstance *FuncInst)
-            -> Expect<void> {
-          if (FuncInst == nullptr) {
-            return {};
-          }
-          const auto *TargetModInst = FuncInst->getModule();
-          if (TargetModInst == nullptr) {
-            return {};
-          }
-          auto Res = TargetModInst->getFuncIdx(FuncInst);
-          if (!Res) {
-            return {};
-          }
-          const std::string ID = TargetModInst->getID();
-          if (ID.empty()) {
-            return {};
-          }
-          return lazyCompileFunctions(ID, *Res);
-        });
+            -> Expect<void> { return LazyEngine->compileOnDemand(FuncInst); });
   }
 #endif
 
@@ -263,46 +188,30 @@ void VM::unsafeRegisterPlugInHosts() {
 
 Expect<void> VM::unsafeRegisterModule(std::string_view Name,
                                       const std::filesystem::path &Path) {
-  if (Stage == VMStage::Instantiated) {
-    // When registering a module, the instantiated module in the store will be
-    // reset. Therefore the instantiation should restart.
-    Stage = VMStage::Validated;
-  }
   // Load module.
   EXPECTED_TRY(std::shared_ptr<AST::Module> Module,
                LoaderEngine.parseModule(Path));
-
-  EXPECTED_TRY(unsafeRegisterModule(Name, *Module));
-
-  if (!RegASTModules.empty()) {
-    RegASTModules.back() = Module;
-  }
-
-  return {};
+  return unsafeRegisterModule(Name, std::move(Module));
 }
 
 Expect<void> VM::unsafeRegisterModule(std::string_view Name,
                                       Span<const Byte> Code) {
-  if (Stage == VMStage::Instantiated) {
-    // When registering a module, the instantiated module in the store will be
-    // reset. Therefore the instantiation should restart.
-    Stage = VMStage::Validated;
-  }
   // Load module.
   EXPECTED_TRY(std::shared_ptr<AST::Module> Module,
                LoaderEngine.parseModule(Code));
-
-  EXPECTED_TRY(unsafeRegisterModule(Name, *Module));
-
-  if (!RegASTModules.empty()) {
-    RegASTModules.back() = Module;
-  }
-
-  return {};
+  return unsafeRegisterModule(Name, std::move(Module));
 }
 
 Expect<void> VM::unsafeRegisterModule(std::string_view Name,
                                       const AST::Module &Module) {
+#ifdef WASMEDGE_USE_LLVM
+  if (LazyEngine) {
+    // The lazy JIT engine needs to own the AST module and hook the compiled
+    // executable into it, so register an owned copy instead of mutating the
+    // caller's module.
+    return unsafeRegisterModule(Name, std::make_shared<AST::Module>(Module));
+  }
+#endif
   if (Stage == VMStage::Instantiated) {
     // When registering a module, the instantiated module in the store will be
     // reset. Therefore the instantiation should restart.
@@ -310,42 +219,41 @@ Expect<void> VM::unsafeRegisterModule(std::string_view Name,
   }
   // Validate module.
   EXPECTED_TRY(ValidatorEngine.validate(Module));
+  // Instantiate and register module.
+  EXPECTED_TRY(auto ModInst,
+               ExecutorEngine.registerModule(StoreRef, Module, Name));
+  RegModInsts.push_back(std::move(ModInst));
+  return {};
+}
 
-  std::string ID = Module.getID();
+Expect<void> VM::unsafeRegisterModule(std::string_view Name,
+                                      std::shared_ptr<AST::Module> Module) {
+  if (Stage == VMStage::Instantiated) {
+    // When registering a module, the instantiated module in the store will be
+    // reset. Therefore the instantiation should restart.
+    Stage = VMStage::Validated;
+  }
+  // Validate module.
+  EXPECTED_TRY(ValidatorEngine.validate(*Module));
 
 #ifdef WASMEDGE_USE_LLVM
-  std::optional<WasmEdge::LLVM::LazyJITState> State;
-  if (Conf.getRuntimeConfigure().getRunMode() == RunMode::LazyJIT &&
-      !Module.getSymbol()) {
-    EXPECTED_TRY(State, prepareLazyJIT(const_cast<AST::Module &>(Module)));
+  if (LazyEngine && !Module->getSymbol()) {
+    EXPECTED_TRY(auto Exec, LazyEngine->prepare(*Module));
+    EXPECTED_TRY(LoaderEngine.loadExecutable(*Module, std::move(Exec)));
   }
 #endif
 
   // Instantiate and register module.
   EXPECTED_TRY(auto ModInst,
-               ExecutorEngine.registerModule(StoreRef, Module, Name));
+               ExecutorEngine.registerModule(StoreRef, *Module, Name));
+
+#ifdef WASMEDGE_USE_LLVM
+  if (LazyEngine) {
+    LazyEngine->registerInstance(*ModInst, std::move(Module));
+  }
+#endif
+
   RegModInsts.push_back(std::move(ModInst));
-
-#ifdef WASMEDGE_USE_LLVM
-  if (State) {
-    std::unique_lock Lock(LazyJITMutex);
-    LazyJITStates.insert({ID, std::move(*State)});
-  }
-#endif
-
-#ifdef WASMEDGE_USE_LLVM
-  size_t InstIdx = RegModInsts.size() - 1;
-  if (Conf.getRuntimeConfigure().getRunMode() == RunMode::LazyJIT) {
-    auto It = RegModMap.find(ID);
-    if (It != RegModMap.end()) {
-      It->second[1] = InstIdx;
-    } else {
-      RegASTModules.push_back(std::make_shared<const AST::Module>(Module));
-      RegModMap[ID] = {RegASTModules.size() - 1, InstIdx};
-    }
-  }
-#endif
-
   return {};
 }
 
@@ -367,13 +275,16 @@ Expect<void> VM::unsafeUnregisterModule(std::string_view Name) {
         return Inst && Inst->getModuleName() == Name;
       });
   if (InstIt != RegModInsts.end()) {
-    auto ModId = (*InstIt)->getID();
     auto *ModInst = (*InstIt).release();
 
     if (ModInst) {
+#ifdef WASMEDGE_USE_LLVM
+      if (LazyEngine) {
+        LazyEngine->unregisterInstance(*ModInst);
+      }
+#endif
       ModInst->terminate();
     }
-    RegModMap.erase(ModId);
     return {};
   }
   for (auto It = BuiltInModInsts.begin(); It != BuiltInModInsts.end(); ++It) {
@@ -474,6 +385,11 @@ VM::unsafeRunWasmFile(const AST::Module &Module, std::string_view Func,
     Stage = VMStage::Validated;
   }
   EXPECTED_TRY(ValidatorEngine.validate(Module));
+#ifdef WASMEDGE_USE_LLVM
+  if (LazyEngine && ActiveModInst) {
+    LazyEngine->unregisterInstance(*ActiveModInst);
+  }
+#endif
   EXPECTED_TRY(ActiveModInst,
                ExecutorEngine.instantiateModule(StoreRef, Module));
 
@@ -555,7 +471,7 @@ Expect<void> VM::unsafeLoadWasm(Span<const Byte> Code) {
 }
 
 Expect<void> VM::unsafeLoadWasm(const AST::Module &Module) {
-  Mod = std::make_unique<AST::Module>(Module);
+  Mod = std::make_shared<AST::Module>(Module);
   Stage = VMStage::Loaded;
   return {};
 }
@@ -601,16 +517,13 @@ Expect<void> VM::unsafeInstantiate() {
     return Unexpect(ErrCode::Value::WrongVMWorkflow);
   }
   if (Mod) {
-    std::string ID = Mod->getID();
-
     if ((Conf.getRuntimeConfigure().getRunMode() == RunMode::JIT ||
          Conf.getRuntimeConfigure().getRunMode() == RunMode::LazyJIT) &&
         !Mod->getSymbol()) {
 #ifdef WASMEDGE_USE_LLVM
-      if (Conf.getRuntimeConfigure().getRunMode() == RunMode::LazyJIT) {
-        EXPECTED_TRY(auto State, prepareLazyJIT(*Mod));
-        std::unique_lock Lock(LazyJITMutex);
-        LazyJITStates[ID] = std::move(State);
+      if (LazyEngine) {
+        EXPECTED_TRY(auto Exec, LazyEngine->prepare(*Mod));
+        EXPECTED_TRY(LoaderEngine.loadExecutable(*Mod, std::move(Exec)));
       } else {
         LLVM::Compiler Compiler(Conf);
         Compiler.checkConfigure()
@@ -662,25 +575,19 @@ Expect<void> VM::unsafeInstantiate() {
     }
 
 #ifdef WASMEDGE_USE_LLVM
-    if (Conf.getRuntimeConfigure().getRunMode() == RunMode::LazyJIT) {
-      std::unique_lock Lock(LazyJITMutex);
-      auto StateIt = LazyJITStates.find(ID);
-      if (StateIt != LazyJITStates.end()) {
-        size_t ImportFuncCount = 0;
-        for (const auto &ImpDesc : Mod->getImportSection().getContent()) {
-          if (ImpDesc.getExternalType() == ExternalType::Function) {
-            ++ImportFuncCount;
-          }
-        }
-        StateIt->second.ImportFuncCount =
-            static_cast<uint32_t>(ImportFuncCount);
-        StateIt->second.LazyCompiledFuncs.clear();
-      }
+    if (LazyEngine && ActiveModInst) {
+      LazyEngine->unregisterInstance(*ActiveModInst);
     }
 #endif
 
     EXPECTED_TRY(ActiveModInst,
                  ExecutorEngine.instantiateModule(StoreRef, *Mod));
+
+#ifdef WASMEDGE_USE_LLVM
+    if (LazyEngine) {
+      LazyEngine->registerInstance(*ActiveModInst, Mod);
+    }
+#endif
 
     Stage = VMStage::Instantiated;
     return {};
@@ -758,25 +665,9 @@ VM::unsafeExecute(const Runtime::Instance::ModuleInstance *ModInst,
       ModInst->findFuncExports(Func);
 
 #ifdef WASMEDGE_USE_LLVM
-  // lazy JIT: compile function on-demand if needed.
-  if (Conf.getRuntimeConfigure().getRunMode() == RunMode::LazyJIT && FuncInst) {
-    bool NeedsCompile = false;
-    uint32_t FuncIdx = UINT32_MAX;
-    {
-      std::shared_lock Lock(LazyJITMutex);
-      if (FuncInst->isWasmFunction()) {
-        NeedsCompile = true;
-        if (auto Res = ModInst->getFuncIdx(FuncInst)) {
-          FuncIdx = *Res;
-        }
-      }
-    }
-    if (NeedsCompile && FuncIdx != UINT32_MAX) {
-      if (auto Result = lazyCompileFunctions(ModInst->getID(), FuncIdx);
-          !Result) {
-        return Unexpect(Result.error());
-      }
-    }
+  // Lazy JIT: compile the function on-demand if needed.
+  if (LazyEngine) {
+    EXPECTED_TRY(LazyEngine->compileOnDemand(FuncInst));
   }
 #endif
 
@@ -882,8 +773,6 @@ void VM::unsafeCleanup() {
   }
   StoreRef.reset();
   cleanupModInstContainer(RegModInsts);
-  RegASTModules.clear();
-  RegModMap.clear();
   Stat.clear();
   unsafeLoadBuiltInHosts();
   unsafeLoadPlugInHosts();
@@ -892,9 +781,9 @@ void VM::unsafeCleanup() {
   LoaderEngine.reset();
   Stage = VMStage::Inited;
 #ifdef WASMEDGE_USE_LLVM
-  // LazyJITStates.clear() will automatically clean up all unique_ptr
-  // LLContexts.
-  LazyJITStates.clear();
+  if (LazyEngine) {
+    LazyEngine->clear();
+  }
 #endif
 }
 
@@ -942,237 +831,6 @@ const Runtime::Instance::ModuleInstance *VM::unsafeGetActiveModule() const {
   }
   return nullptr;
 };
-
-#ifdef WASMEDGE_USE_LLVM
-Expect<void> VM::lazyCompileFunctions(const std::string &ID, uint32_t FuncIdx) {
-  std::unique_lock Lock(LazyJITMutex);
-  uint32_t ImportFuncCount = 0;
-  const AST::Module *ModulePtr = nullptr;
-  LLVM::Data *LLDataPtr = nullptr;
-  std::unique_ptr<LLVM::Compiler::CompileContext,
-                  LLVM::Compiler::CompileContextDeleter> *LLContextPtr =
-      nullptr;
-  LLVM::LazyJITState *StatePtr = nullptr;
-  const Runtime::Instance::ModuleInstance *ModInst = nullptr;
-
-  if (ActiveModInst && ActiveModInst->getID() == ID) {
-    ModInst = ActiveModInst.get();
-    ModulePtr = Mod.get();
-  } else {
-    auto ItMap = RegModMap.find(ID);
-    if (ItMap != RegModMap.end()) {
-      ModInst = RegModInsts[ItMap->second[1]].get();
-      ModulePtr = RegASTModules[ItMap->second[0]].get();
-    }
-  }
-
-  if (!ModInst || !ModulePtr) {
-    return {};
-  }
-
-  auto It = LazyJITStates.find(ID);
-  if (It != LazyJITStates.end()) {
-    StatePtr = &It->second;
-    ImportFuncCount = StatePtr->ImportFuncCount;
-    LLDataPtr = &StatePtr->LLData;
-    LLContextPtr = &StatePtr->LLContext;
-  } else {
-    spdlog::error("[lazy-jit]: failed to find JIT state for ID: {}"sv, ID);
-    return Unexpect(ErrCode::Value::WrongInstanceAddress);
-  }
-
-  if (FuncIdx < ImportFuncCount) {
-    return {};
-  }
-
-  uint32_t LocalFuncIdx = FuncIdx - ImportFuncCount;
-
-  auto FuncResult = ModInst->getFuncInst(FuncIdx);
-  if (!FuncResult) {
-    spdlog::error(
-        "[lazy-jit]: failed to get function instance for index {}, module ID: {}"sv,
-        FuncIdx, ID);
-    return Unexpect(FuncResult.error());
-  }
-  auto *FuncInst = *FuncResult;
-
-  // If already compiled or not a Wasm function, nothing to do.
-  if (!FuncInst->isWasmFunction() || FuncInst->isCompiledFunction()) {
-    return {};
-  }
-
-  if (StatePtr && StatePtr->LazyCompiledFuncs.count(LocalFuncIdx) > 0) {
-    return {};
-  }
-
-  const std::unordered_set<uint32_t> EmptyCompiledSet;
-  const std::unordered_set<uint32_t> &CompiledSet =
-      StatePtr ? StatePtr->LazyCompiledFuncs : EmptyCompiledSet;
-
-  std::vector<uint32_t> BatchLocals;
-  collectLazyCallGraphBatch(LocalFuncIdx, ModulePtr, ImportFuncCount,
-                            CompiledSet, BatchLocals);
-  if (BatchLocals.empty()) {
-    return {};
-  }
-
-  spdlog::debug("[lazy-jit]: Lazy compiling batch ({} local funcs) for wasm "
-                "entry local "
-                "{}, module ID: {}"sv,
-                BatchLocals.size(), LocalFuncIdx, ID);
-
-  LLVM::Compiler Compiler(Conf);
-  auto ConfigResult = Compiler.checkConfigure();
-  if (!ConfigResult) {
-    spdlog::error(
-        "[lazy-jit]: Lazy JIT compiler config failed: {}, module ID: {}"sv,
-        ConfigResult.error(), ID);
-    return Unexpect(ConfigResult.error());
-  }
-
-  if (!LLDataPtr->hasModule()) {
-    LLDataPtr->resetModule();
-  }
-  auto CompileResult = Compiler.compileFunctions(
-      std::move(*LLDataPtr),
-      static_cast<LLVM::Compiler::CompileContext *>(LLContextPtr->get()),
-      *ModulePtr,
-      WasmEdge::Span<const uint32_t>(BatchLocals.data(), BatchLocals.size()));
-  if (!CompileResult) {
-    spdlog::error(
-        "[lazy-jit]: Lazy JIT function compilation failed: {}, module ID: {}"sv,
-        CompileResult.error(), ID);
-    return Unexpect(CompileResult.error());
-  }
-
-  *LLDataPtr = std::move(*CompileResult);
-  LLVM::JIT JIT(Conf);
-  std::shared_ptr<LLVM::JITLibrary> JITLib;
-  if (StatePtr && StatePtr->JITLib) {
-    JITLib = StatePtr->JITLib;
-  }
-
-  std::vector<uint32_t> BatchGlobal;
-  BatchGlobal.reserve(BatchLocals.size());
-  for (uint32_t L : BatchLocals) {
-    BatchGlobal.push_back(ImportFuncCount + L);
-  }
-
-  std::vector<LLVM::WasmFunctionCodeAddress> ResolvedAddresses;
-  if (JITLib) {
-    auto AddrRes = JIT.add(
-        *JITLib, *LLDataPtr,
-        WasmEdge::Span<const uint32_t>(BatchGlobal.data(), BatchGlobal.size()));
-    if (!AddrRes) {
-      spdlog::error("[lazy-jit]: Lazy JIT add failed: {}, module ID: {}"sv,
-                    AddrRes.error(), ID);
-      return Unexpect(AddrRes.error());
-    }
-    ResolvedAddresses = std::move(*AddrRes);
-  } else {
-    auto LoadResult = JIT.load(*LLDataPtr, true);
-    if (!LoadResult) {
-      spdlog::error("[lazy-jit]: Lazy JIT load failed: {}, module ID: {}"sv,
-                    LoadResult.error(), ID);
-      return Unexpect(LoadResult.error());
-    }
-    JITLib = std::static_pointer_cast<LLVM::JITLibrary>(*LoadResult);
-    if (StatePtr) {
-      StatePtr->JITLib = JITLib;
-    }
-    auto LkRes = JIT.lookupWasmFunctionSymbols(
-        *JITLib, LLDataPtr->getPrefix(),
-        WasmEdge::Span<const uint32_t>(BatchGlobal.data(), BatchGlobal.size()));
-    if (!LkRes) {
-      spdlog::error(
-          "[lazy-jit]: Lazy JIT symbol resolution failed: {}, module ID: {}"sv,
-          LkRes.error(), ID);
-      return Unexpect(LkRes.error());
-    }
-    ResolvedAddresses = std::move(*LkRes);
-  }
-
-  if (ResolvedAddresses.size() != BatchLocals.size()) {
-    spdlog::error(
-        "[lazy-jit]: Lazy JIT address count mismatch, module ID: {}"sv, ID);
-    return Unexpect(ErrCode::Value::LazyCompilationError);
-  }
-
-  if (auto IntrinsicsSymbol = JITLib->getIntrinsics()) {
-    *IntrinsicsSymbol = &Executor::Executor::Intrinsics;
-  } else {
-    spdlog::error(
-        "[lazy-jit]: failed to get intrinsics symbol, module ID: {}"sv, ID);
-    return Unexpect(ErrCode::Value::LazyCompilationError);
-  }
-
-  for (size_t I = 0; I < BatchLocals.size(); ++I) {
-    const uint32_t L = BatchLocals[I];
-    const uint32_t WasmFuncIdx = ImportFuncCount + L;
-    LLVM::WasmFunctionCodeAddress CompiledCodePtr = ResolvedAddresses[I];
-    auto BatchFuncResult = ModInst->getFuncInst(WasmFuncIdx);
-    if (!BatchFuncResult) {
-      spdlog::error(
-          "[lazy-jit]: failed to get function instance for index {}, module ID: {}"sv,
-          WasmFuncIdx, ID);
-      return Unexpect(ErrCode::Value::WrongInstanceAddress);
-    }
-
-    auto *BatchFuncInst = *BatchFuncResult;
-    if (BatchFuncInst->isWasmFunction()) {
-      auto CompiledSym = JITLib->createSymbol(
-          reinterpret_cast<Runtime::Instance::FunctionInstance::CompiledFunction
-                               *>(CompiledCodePtr));
-      BatchFuncInst->unsafeUpgradeToCompiled(std::move(CompiledSym));
-    }
-  }
-
-  if (StatePtr) {
-    for (uint32_t L : BatchLocals) {
-      StatePtr->LazyCompiledFuncs.insert(L);
-    }
-  }
-
-  spdlog::debug(
-      "Lazy compilation completed for batch of {} functions, total compiled: "
-      "{}, module ID: {}"sv,
-      BatchLocals.size(),
-      StatePtr ? StatePtr->LazyCompiledFuncs.size() : BatchLocals.size(), ID);
-
-  return {};
-}
-#endif
-
-#ifdef WASMEDGE_USE_LLVM
-Expect<WasmEdge::LLVM::LazyJITState> VM::prepareLazyJIT(AST::Module &Module) {
-  WasmEdge::LLVM::LazyJITState State;
-  LLVM::Compiler Compiler(Conf);
-  EXPECTED_TRY(
-      Compiler.checkConfigure().map_error([](uint32_t Err) { return Err; }));
-
-  auto Prefix = fmt::format("m{}_"sv, Module.getID());
-  EXPECTED_TRY(auto LLModule, Compiler.compileInfrastructure(Module, Prefix));
-
-  State.LLData = std::move(LLModule.first);
-  State.LLContext = std::move(LLModule.second);
-
-  LLVM::JIT JIT(Conf);
-  EXPECTED_TRY(auto Exec, JIT.load(State.LLData, true));
-  State.JITLib = std::static_pointer_cast<LLVM::JITLibrary>(Exec);
-
-  EXPECTED_TRY(LoaderEngine.loadExecutable(Module, State.JITLib));
-
-  size_t ImportFuncCount = 0;
-  for (const auto &ImpDesc : Module.getImportSection().getContent()) {
-    if (ImpDesc.getExternalType() == ExternalType::Function) {
-      ++ImportFuncCount;
-    }
-  }
-  State.ImportFuncCount = static_cast<uint32_t>(ImportFuncCount);
-
-  return State;
-}
-#endif
 
 } // namespace VM
 } // namespace WasmEdge

--- a/test/llvm/LazyJITTest.cpp
+++ b/test/llvm/LazyJITTest.cpp
@@ -585,8 +585,7 @@ TEST_F(LazyJITTest, JITAddLookupFailure) {
   auto CompileRes = Compiler.compileInfrastructure(*Module);
   ASSERT_TRUE(CompileRes);
 
-  auto &LLData = CompileRes->first;
-  auto &CompileCtx = CompileRes->second;
+  auto &LLData = *CompileRes;
 
   LLVM::JIT JIT(Conf);
   auto ExecRes = JIT.load(LLData, true);
@@ -595,11 +594,8 @@ TEST_F(LazyJITTest, JITAddLookupFailure) {
   auto JITLib = std::static_pointer_cast<LLVM::JITLibrary>(*ExecRes);
 
   std::vector<uint32_t> CompileLocals = {0};
-  if (!LLData.hasModule()) {
-    LLData.resetModule();
-  }
-  auto FuncCompileRes = Compiler.compileFunctions(
-      std::move(LLData), CompileCtx.get(), *Module, CompileLocals);
+  auto FuncCompileRes =
+      Compiler.compileFunctions(std::move(LLData), *Module, CompileLocals);
   ASSERT_TRUE(FuncCompileRes);
 
   std::vector<uint32_t> InvalidIndices = {999};

--- a/test/llvm/LazyJITTest.cpp
+++ b/test/llvm/LazyJITTest.cpp
@@ -96,6 +96,18 @@ std::vector<uint8_t> MathConsumerWasm = {
     0x10, 0x00, 0x10, 0x01, 0x0b, 0x10, 0x00, 0x20, 0x00, 0x20, 0x00,
     0x10, 0x01, 0x20, 0x01, 0x20, 0x01, 0x10, 0x01, 0x10, 0x00, 0x0b};
 
+// Module exercising the runtime intrinsics table from lazily compiled code:
+//   (memory 1)
+//   export "trap" -> unreachable   (reaches the trap intrinsic)
+//   export "grow" -> memory.grow   (reaches the memory-grow intrinsic)
+std::vector<uint8_t> IntrinsicsWasm = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0a, 0x02,
+    0x60, 0x00, 0x01, 0x7f, 0x60, 0x01, 0x7f, 0x01, 0x7f, 0x03, 0x03,
+    0x02, 0x00, 0x01, 0x05, 0x03, 0x01, 0x00, 0x01, 0x07, 0x0f, 0x02,
+    0x04, 0x74, 0x72, 0x61, 0x70, 0x00, 0x00, 0x04, 0x67, 0x72, 0x6f,
+    0x77, 0x00, 0x01, 0x0a, 0x0c, 0x02, 0x03, 0x00, 0x00, 0x0b, 0x06,
+    0x00, 0x20, 0x00, 0x40, 0x00, 0x0b};
+
 class HostAdd : public Runtime::HostFunction<HostAdd> {
 public:
   Expect<uint32_t> body(const Runtime::CallingFrame &, uint32_t A, uint32_t B) {
@@ -642,6 +654,31 @@ TEST_F(LazyJITTest, JITAddLookupFailure) {
   auto AddResult = JIT.add(*JITLib, *FuncCompileRes, InvalidIndices);
   EXPECT_FALSE(AddResult);
   EXPECT_EQ(AddResult.error(), ErrCode::Value::LazyCompilationError);
+}
+
+TEST_F(LazyJITTest, LazyJITIntrinsicsReachableFromCompiledCode) {
+  // Batch modules only declare the "intrinsics" global; it resolves against
+  // the infrastructure module's definition patched at prepare time. Run two
+  // operations that call back into the runtime through that table — an
+  // unresolved or null table pointer would crash instead.
+  auto VM = createLazyJITVM();
+
+  ASSERT_TRUE(VM->loadWasm(IntrinsicsWasm));
+  ASSERT_TRUE(VM->validate());
+  ASSERT_TRUE(VM->instantiate());
+
+  std::vector<ValVariant> GrowParams = {1U};
+  std::vector<ValType> GrowTypes = {ValType(TypeCode::I32)};
+  auto GrowRes = VM->execute("grow", GrowParams, GrowTypes);
+  ASSERT_TRUE(GrowRes);
+  // memory.grow returns the previous size in pages.
+  EXPECT_EQ((*GrowRes)[0].first.get<uint32_t>(), 1U);
+
+  auto TrapRes = VM->execute("trap");
+  ASSERT_FALSE(TrapRes);
+  EXPECT_EQ(TrapRes.error(), ErrCode::Value::Unreachable);
+
+  EXPECT_EQ(VM->getLazyCompiledFuncCount(), 2U);
 }
 
 TEST_F(LazyJITTest, LazyJITConcurrentSameFunction) {

--- a/test/llvm/LazyJITTest.cpp
+++ b/test/llvm/LazyJITTest.cpp
@@ -582,8 +582,7 @@ TEST_F(LazyJITTest, JITAddLookupFailure) {
   LLVM::Compiler Compiler(Conf);
   ASSERT_TRUE(Compiler.checkConfigure());
 
-  auto Prefix = "test_prefix_";
-  auto CompileRes = Compiler.compileInfrastructure(*Module, Prefix);
+  auto CompileRes = Compiler.compileInfrastructure(*Module);
   ASSERT_TRUE(CompileRes);
 
   auto &LLData = CompileRes->first;
@@ -608,44 +607,6 @@ TEST_F(LazyJITTest, JITAddLookupFailure) {
   auto AddResult = JIT.add(*JITLib, *FuncCompileRes, InvalidIndices);
   EXPECT_FALSE(AddResult);
   EXPECT_EQ(AddResult.error(), ErrCode::Value::LazyCompilationError);
-}
-
-TEST_F(LazyJITTest, JITLookupWasmFunctionSymbolsFailure) {
-  Configure Conf;
-  Conf.getRuntimeConfigure().setRunMode(RunMode::LazyJIT);
-  Conf.getCompilerConfigure().setOptimizationLevel(
-      CompilerConfigure::OptimizationLevel::O1);
-
-  Loader::Loader LoaderEngine(Conf);
-  auto ModOrErr = LoaderEngine.parseWasmUnit(SimpleWasm);
-  ASSERT_TRUE(ModOrErr);
-  auto &Module = std::get<std::unique_ptr<AST::Module>>(*ModOrErr);
-
-  Validator::Validator ValidatorEngine(Conf);
-  auto ValRes = ValidatorEngine.validate(*Module);
-  ASSERT_TRUE(ValRes);
-
-  LLVM::Compiler Compiler(Conf);
-  ASSERT_TRUE(Compiler.checkConfigure());
-
-  auto Prefix = "test_prefix_";
-  auto CompileRes = Compiler.compileInfrastructure(*Module, Prefix);
-  ASSERT_TRUE(CompileRes);
-
-  auto &LLData = CompileRes->first;
-
-  LLVM::JIT JIT(Conf);
-  auto ExecRes = JIT.load(LLData, true);
-  ASSERT_TRUE(ExecRes);
-
-  auto JITLib = std::static_pointer_cast<LLVM::JITLibrary>(*ExecRes);
-
-  std::vector<uint32_t> InvalidIndices = {999};
-
-  auto LookupRes =
-      JIT.lookupWasmFunctionSymbols(*JITLib, Prefix, InvalidIndices);
-  EXPECT_FALSE(LookupRes);
-  EXPECT_EQ(LookupRes.error(), ErrCode::Value::LazyCompilationError);
 }
 
 TEST_F(LazyJITTest, LazyJITConcurrentSameFunction) {

--- a/test/llvm/LazyJITTest.cpp
+++ b/test/llvm/LazyJITTest.cpp
@@ -366,6 +366,45 @@ TEST_F(LazyJITTest, LazyJITMultipleInstantiations) {
   }
 }
 
+TEST_F(LazyJITTest, LazyJITReinstantiateSameVM) {
+  auto VM = createLazyJITVM();
+
+  ASSERT_TRUE(VM->loadWasm(SimpleWasm));
+  ASSERT_TRUE(VM->validate());
+  ASSERT_TRUE(VM->instantiate());
+
+  std::vector<ValVariant> Params = {static_cast<uint32_t>(2),
+                                    static_cast<uint32_t>(3)};
+  std::vector<ValType> Types = {ValType(TypeCode::I32), ValType(TypeCode::I32)};
+
+  // Compile "add" lazily on the first instance.
+  auto Result = VM->execute("add", Params, Types);
+  ASSERT_TRUE(Result);
+  EXPECT_EQ((*Result)[0].first.get<uint32_t>(), 5U);
+  const auto CompiledBefore = VM->getLazyCompiledFuncCount();
+  EXPECT_GT(CompiledBefore, 0U);
+
+  // Re-instantiate the same loaded module on the same VM. The engine must
+  // rebind the persisted JIT state to the new module instance.
+  ASSERT_TRUE(VM->instantiate());
+
+  // The previously compiled function is restored to compiled mode...
+  auto *AddFunc = VM->getActiveModule()->findFuncExports("add");
+  ASSERT_NE(AddFunc, nullptr);
+  EXPECT_TRUE(AddFunc->isCompiledFunction());
+
+  // ...still executes correctly...
+  Result = VM->execute("add", Params, Types);
+  ASSERT_TRUE(Result);
+  EXPECT_EQ((*Result)[0].first.get<uint32_t>(), 5U);
+
+  // ...and lazy compilation keeps working for functions not yet compiled.
+  Result = VM->execute("mul", Params, Types);
+  ASSERT_TRUE(Result);
+  EXPECT_EQ((*Result)[0].first.get<uint32_t>(), 6U);
+  EXPECT_GT(VM->getLazyCompiledFuncCount(), CompiledBefore);
+}
+
 TEST_F(LazyJITTest, LazyJITOnlySomeFunctionsCalled) {
   auto VM = createLazyJITVM();
 

--- a/test/llvm/LazyJITTest.cpp
+++ b/test/llvm/LazyJITTest.cpp
@@ -588,7 +588,7 @@ TEST_F(LazyJITTest, JITAddLookupFailure) {
   auto &LLData = *CompileRes;
 
   LLVM::JIT JIT(Conf);
-  auto ExecRes = JIT.load(LLData, true);
+  auto ExecRes = JIT.loadLazy(LLData);
   ASSERT_TRUE(ExecRes);
 
   auto JITLib = std::static_pointer_cast<LLVM::JITLibrary>(*ExecRes);

--- a/test/llvm/LazyJITTest.cpp
+++ b/test/llvm/LazyJITTest.cpp
@@ -22,6 +22,7 @@
 #include "runtime/callingframe.h"
 #include "runtime/instance/module.h"
 #include "vm/vm.h"
+#include "llvm/compiler.h"
 #include "llvm/jit.h"
 #include <gtest/gtest.h>
 #include <thread>


### PR DESCRIPTION
## Description

Move lazy JIT orchestration out of the VM and into `LLVM::LazyJITEngine`, which now owns per-module lazy JIT state, infrastructure preparation, call-graph batch compilation, instance rebinding, and compiled-function upgrades.

This also removes the random module-ID/function-map plumbing, simplifies the compiler/JIT public surfaces for lazy loading, preserves lazy JIT state across re-instantiation, restores already compiled functions from persisted code addresses, and prunes states that can no longer be rebound.

Additional regression coverage exercises same-VM re-instantiation and runtime intrinsics reached from lazily compiled code.

This contribution was developed with assistance from Claude Fable 5 (Anthropic) and GitHub Copilot CLI.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence

```text
Test project /Users/hydai/workspace/vibe/copilot-worktrees/WasmEdge/lazy-jit/build
    Start 4: wasmedgeLazyJITTests
1/1 Test #4: wasmedgeLazyJITTests .............   Passed    0.19 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.20 sec
```

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.