### PR TITLE
feat(validator): enable component-model naming spec tests

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1120,6 +1120,16 @@ E(InvalidExportName, 0x02B3, "not a valid export name")
 E(InvalidExternName, 0x02B4, "not a valid extern name")
 // Core tag referenced by a core-export alias or inline-export does not exist
 E(UnknownCoreTag, 0x02B5, "unknown tag")
+// Component name label is not in kebab case
+E(ComponentNameNotKebab, 0x02B6, "not in kebab case")
+// Component package name/namespace is not lowercase
+E(ComponentPackageNameNotLowercase, 0x02B7,
+  "not lowercase in package name/namespace")
+// Component import name conflicts with a previous import name
+E(ComponentImportNameConflict, 0x02B8,
+  "import name conflicts with previous name")
+// Component alias references an export the instance does not provide
+E(ComponentUnknownExport, 0x02B9, "unknown export")
 // @}
 
 // Instantiation phase

--- a/lib/validator/component_name.cpp
+++ b/lib/validator/component_name.cpp
@@ -316,16 +316,24 @@ Expect<PkgPath> parsePkgPath(std::string_view &Next,
   std::string_view Namespace;
   if (!readUntil(Next, ':', Namespace))
     return reportError("expected ':' in namespace"sv);
-  if (!isLowercaseKebabString(Namespace))
-    return reportError("invalid namespace"sv);
+  if (!isLowercaseKebabString(Namespace)) {
+    spdlog::error(ErrCode::Value::ComponentPackageNameNotLowercase);
+    spdlog::error("    Component name: namespace '{}' is not lowercase"sv,
+                  Namespace);
+    return Unexpect(ErrCode::Value::ComponentPackageNameNotLowercase);
+  }
 
   size_t PkgEnd = Next.find_first_of(StopChars);
   if (PkgEnd == Next.npos)
     return reportError("unterminated package name"sv);
   std::string_view Package = Next.substr(0, PkgEnd);
   Next.remove_prefix(PkgEnd);
-  if (!isLowercaseKebabString(Package))
-    return reportError("invalid package name"sv);
+  if (!isLowercaseKebabString(Package)) {
+    spdlog::error(ErrCode::Value::ComponentPackageNameNotLowercase);
+    spdlog::error("    Component name: package '{}' is not lowercase"sv,
+                  Package);
+    return Unexpect(ErrCode::Value::ComponentPackageNameNotLowercase);
+  }
 
   return PkgPath{Namespace, Package};
 }
@@ -570,7 +578,10 @@ Expect<ComponentName> ComponentName::parse(std::string_view Name) {
     while (readUntil(Next, ':', Namespace)) {
       Counter++;
       if (!isLowercaseKebabString(Namespace)) {
-        return reportError("invalid namespace in interface name"sv);
+        spdlog::error(ErrCode::Value::ComponentPackageNameNotLowercase);
+        spdlog::error("    Component name: namespace '{}' is not lowercase"sv,
+                      Namespace);
+        return Unexpect(ErrCode::Value::ComponentPackageNameNotLowercase);
       }
     }
     if (Counter == 0) {
@@ -583,7 +594,10 @@ Expect<ComponentName> ComponentName::parse(std::string_view Name) {
 
     // interfacename ::= <namespace> <words> <projection> ...
     if (!tryReadKebab(Next, Package) || !isLowercaseKebabString(Package)) {
-      return reportError("invalid package in interface name"sv);
+      spdlog::error(ErrCode::Value::ComponentPackageNameNotLowercase);
+      spdlog::error("    Component name: package '{}' is not lowercase"sv,
+                    Package);
+      return Unexpect(ErrCode::Value::ComponentPackageNameNotLowercase);
     }
 
     Counter = 0;
@@ -618,7 +632,10 @@ Expect<ComponentName> ComponentName::parse(std::string_view Name) {
 
 ParseLabel:
   if (!isKebabString(Next)) {
-    return reportError("invalid label"sv);
+    spdlog::error(ErrCode::Value::ComponentNameNotKebab);
+    spdlog::error("    Component name: label '{}' is not in kebab case"sv,
+                  Next);
+    return Unexpect(ErrCode::Value::ComponentNameNotKebab);
   }
   Result.Detail.emplace<LabelDetail>();
   Result.Kind = ComponentNameKind::Label;

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -937,6 +937,11 @@ Validator::validate(const AST::Component::Instance &Inst) noexcept {
     // Inline-export names on a component instance must be strongly-unique.
     std::unordered_set<std::string_view> SeenExports;
     for (const auto &Export : Inst.getInlineExports()) {
+      // Inline-export names must be valid component export names.
+      if (auto Res = validateExportName(Export.getName()); !Res) {
+        spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Instance));
+        return Unexpect(Res.error());
+      }
       if (!SeenExports.insert(Export.getName()).second) {
         spdlog::error(ErrCode::Value::ComponentDuplicateName);
         spdlog::error("    Instance: Duplicate inline-export name '{}'"sv,
@@ -1055,11 +1060,11 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
     const auto &InstExports = CompCtx.getInstance(Idx).Exports;
     auto It = InstExports.find(std::string(Name));
     if (It == InstExports.cend()) {
-      spdlog::error(ErrCode::Value::ExportNotFound);
+      spdlog::error(ErrCode::Value::ComponentUnknownExport);
       spdlog::error(
           "    Alias export: No matching export '{}' found in component instance index {}"sv,
           Name, Idx);
-      return Unexpect(ErrCode::Value::ExportNotFound);
+      return Unexpect(ErrCode::Value::ComponentUnknownExport);
     }
 
     if (It->second.ST != Sort.getSortType()) {
@@ -1735,10 +1740,10 @@ Expect<void> Validator::validate(const AST::Component::Import &Im) noexcept {
   }
 
   if (!CompCtx.addImportedName(CName)) {
-    spdlog::error(ErrCode::Value::ComponentDuplicateName);
+    spdlog::error(ErrCode::Value::ComponentImportNameConflict);
     spdlog::error("    Import: Duplicate import name"sv);
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Import));
-    return Unexpect(ErrCode::Value::ComponentDuplicateName);
+    return Unexpect(ErrCode::Value::ComponentImportNameConflict);
   }
 
   // If this import introduced a TypeBound resource with a label name,
@@ -2077,10 +2082,10 @@ Validator::validate(const AST::Component::ImportDecl &Decl) noexcept {
 
   // Check import name uniqueness.
   if (!CompCtx.addImportedName(CName)) {
-    spdlog::error(ErrCode::Value::ComponentDuplicateName);
+    spdlog::error(ErrCode::Value::ComponentImportNameConflict);
     spdlog::error("    ImportDecl: Duplicate import name"sv);
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Decl_Import));
-    return Unexpect(ErrCode::Value::ComponentDuplicateName);
+    return Unexpect(ErrCode::Value::ComponentImportNameConflict);
   }
 
   return {};
@@ -2267,11 +2272,11 @@ Validator::validate(const AST::Component::DefValType &DVT) noexcept {
         return Unexpect(ErrCode::Value::NameCannotBeEmpty);
       }
       if (!isKebabString(LT.getLabel())) {
-        spdlog::error(ErrCode::Value::ComponentInvalidName);
+        spdlog::error(ErrCode::Value::ComponentNameNotKebab);
         spdlog::error(
             "    DefValType: record field '{}' is not valid kebab-case"sv,
             LT.getLabel());
-        return Unexpect(ErrCode::Value::ComponentInvalidName);
+        return Unexpect(ErrCode::Value::ComponentNameNotKebab);
       }
       if (!Seen.insert(toLowerStr(LT.getLabel())).second) {
         spdlog::error(ErrCode::Value::RecordFieldNameConflicts);
@@ -2294,11 +2299,11 @@ Validator::validate(const AST::Component::DefValType &DVT) noexcept {
         return Unexpect(ErrCode::Value::NameCannotBeEmpty);
       }
       if (!isKebabString(C.first)) {
-        spdlog::error(ErrCode::Value::ComponentInvalidName);
+        spdlog::error(ErrCode::Value::ComponentNameNotKebab);
         spdlog::error(
             "    DefValType: variant case '{}' is not valid kebab-case"sv,
             C.first);
-        return Unexpect(ErrCode::Value::ComponentInvalidName);
+        return Unexpect(ErrCode::Value::ComponentNameNotKebab);
       }
       if (!Seen.insert(toLowerStr(C.first)).second) {
         spdlog::error(ErrCode::Value::VariantCaseNameConflicts);
@@ -2348,10 +2353,10 @@ Validator::validate(const AST::Component::DefValType &DVT) noexcept {
         return Unexpect(ErrCode::Value::NameCannotBeEmpty);
       }
       if (!isKebabString(L)) {
-        spdlog::error(ErrCode::Value::ComponentInvalidName);
+        spdlog::error(ErrCode::Value::ComponentNameNotKebab);
         spdlog::error(
             "    DefValType: flags label '{}' is not valid kebab-case"sv, L);
-        return Unexpect(ErrCode::Value::ComponentInvalidName);
+        return Unexpect(ErrCode::Value::ComponentNameNotKebab);
       }
       if (!Seen.insert(toLowerStr(L)).second) {
         spdlog::error(ErrCode::Value::FlagNameConflicts);
@@ -2373,10 +2378,10 @@ Validator::validate(const AST::Component::DefValType &DVT) noexcept {
         return Unexpect(ErrCode::Value::NameCannotBeEmpty);
       }
       if (!isKebabString(L)) {
-        spdlog::error(ErrCode::Value::ComponentInvalidName);
+        spdlog::error(ErrCode::Value::ComponentNameNotKebab);
         spdlog::error(
             "    DefValType: enum label '{}' is not valid kebab-case"sv, L);
-        return Unexpect(ErrCode::Value::ComponentInvalidName);
+        return Unexpect(ErrCode::Value::ComponentNameNotKebab);
       }
       if (!Seen.insert(toLowerStr(L)).second) {
         spdlog::error(ErrCode::Value::EnumTagNameConflicts);
@@ -2402,11 +2407,11 @@ Expect<void> Validator::validate(const AST::Component::FuncType &FT) noexcept {
   for (const auto &P : FT.getParamList()) {
     if (!P.getLabel().empty()) {
       if (!isKebabString(P.getLabel())) {
-        spdlog::error(ErrCode::Value::ComponentInvalidName);
+        spdlog::error(ErrCode::Value::ComponentNameNotKebab);
         spdlog::error(
             "    FuncType: parameter name '{}' is not valid kebab-case"sv,
             P.getLabel());
-        return Unexpect(ErrCode::Value::ComponentInvalidName);
+        return Unexpect(ErrCode::Value::ComponentNameNotKebab);
       }
       if (!ParamNames.insert(P.getLabel()).second) {
         spdlog::error(ErrCode::Value::ComponentDuplicateName);

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -338,7 +338,7 @@ std::map<std::string, ComponentModelSupport> ComponentModelFolders = {
     {"memory64",                {true, false, false, false}},
     {"module-link",             {true, true,  false, false}},
     {"more-flags",              {true, true,  true,  false}},
-    {"naming",                  {true, false, false, false}},
+    {"naming",                  {true, true,  false, false}},
     {"nested-modules",          {true, false, false, false}},
     {"resources",               {true, false, false, false}},
     {"tags",                    {true, true,  false, false}},


### PR DESCRIPTION
This enables the `naming` folder of the component-model spec tests (#4441).

While digging into why it was disabled, I found that WasmEdge was already rejecting 14 of the 15 invalid cases it just reported generic error codes ("invalid component name", "duplicate name in component", "export not found") whose text didn't line up with what the spec tests expect. The harness matches the expected message as a prefix of our ErrCodeStr, so those cases failed even though validation itself was correct.

So most of this PR is making the diagnostics specific. I added four error codes:

  - ComponentNameNotKebab            -> "not in kebab case"
  - ComponentPackageNameNotLowercase -> "not lowercase in package name/namespace"
  - ComponentImportNameConflict      -> "import name conflicts with previous name"
  - ComponentUnknownExport           -> "unknown export"

and routed the label / interface-name / package / import-uniqueness / alias-export validation sites to them.

There was also one real bug: instance inline-export names weren't being validated at all, so an invalid name like "1" was accepted. I added a validateExportName() check in the component-instance inline-export loop, which
is what naming.1 exercises.

Testing:
  - the `naming` spec test passes now
  - the full spec test suite still passes (525 tests), including every other
    component-model folder, so no regression
  - clang-format (20) is clean

I kept the scope to load+validate for this folder; instantiate/execute stay off.

Part of #4441.
