### PR TITLE
chore: cherry-pick for 0.17.1-rc.1 version

### DIFF
--- a/.CurrentChangelog.md
+++ b/.CurrentChangelog.md
@@ -1,198 +1,27 @@
-### 0.17.0 (2026-05-18)
+### 0.17.1-rc.1 (2026-06-16)
 
 Features:
 
-* [Version]: Bump the version of the WasmEdge shared library.
-  * Due to the breaking change of API, bump the `SOVERSION` to `0.1.1`.
-  * Due to the breaking change of API, bump the plug-in `API_VERSION` to `5`.
-* [Memory64]
-  * feat: support wasm memory64 proposal in interpreter and AOT/JIT
-  * feat(api): introduce limit context to replace limit struct
 * [CAPI]
-  * feat(api): add registerModule with alias name across API layers
-* [Component Model]
-  * feat(loader): complete the loader implementation of canonical
-  * feat(validator): implement ComponentName parsing and validation with full spec coverage
-  * feat(component,validator): validate component value types, func types, and type imports
-  * feat(component,validator): populate instance exports and support alias-export chains
-  * feat(component,validator): export ascription sort-kind subtype check
-  * feat(component,loader): align functype binary grammar with current spec
-  * feat(component,loader): support i64 resource rep under memory64 proposal
-  * feat(component,validator): validate declaration types in component model (#4797)
-  * feat(component,validator): reject duplicate names on instance exprs (#4811)
-  * feat(component,validator): validate canonical built-ins (#4842)
-* [WASI-NN]
-  * feat(wasi-nn,piper): update the WASI-NN Piper plugin due to upstream changes (#4443)
-  * feat(wasi-nn,ggml): support HIP backend for llama.cpp (#4552)
-  * feat(wasi-nn,ggml): upgrade llama.cpp version to b8757
-  * feat(wasi-nn,ggml): redirect multi model log (#4801)
-* [Tools]
-  * feat(cli): add CLI option to control logging level (#4525)
-  * feat(loader,vm): gate AOT/JIT behaviour on RunMode and tighten dlopen scope
-* [Misc]
-  * feat(hash): upgrade rapidhash to v3 Nano variant (#4734)
-  * feat(android): remove gradle-wrapper.jar and bootstrap wrapper (#4505)
-  * feat(android): move app from utils to examples (#4499)
-  * feat(docker): add libpiper to plugin-deps image
+  * feat(api): version C ABI symbols for the 0.16 -> 0.17 limit change (#4951)
 
 Fixed issues:
 
-* [CAPI]
-  * fix(api): add noexcept to all C API functions
-  * fix(api): add exception handlers at C API boundary
-  * fix(api): guard WasmEdge_StringCopy against null Buf (#4686)
-  * fix(api): typo and grammar error in WasmEdge C API docs (#4763)
-  * fix(api): correct parameter order of VM RegisterModuleFromImportWithAlias
-  * fix(api): handle null paths in C APIs (#4835)
-* [Component Model]
-  * fix(component): use ValVariant for argument types in ToolOnComponent (#4704, #4716)
-  * fix(component,loader): missed set data in loading core deftype
-  * fix(component,validator): enforce lowercase package name per spec PR #630
-  * fix(component,validator): route core module externdesc and stop export double-count
-  * fix(component): pass correct alignment to realloc in canonical lifting (#4730)
 * [Validator]
-  * fix(validator): wrong jump end offset of try_table
-  * fix(validator): handle unreachable type in ref.test/ref.cast validation (#4669)
-  * fix(validator): use matchType for active element segment reftype (#4814)
-* [Loader]
-  * fix(loader): handle try_table catch flag syntax (#4676)
-  * fix(loader,component): support component inline export names and core tag sort in loader (#4745)
-  * fix(loader): reject non-canonical multi-byte SLEB128 blocktype (#4817)
-* [Executor]
-  * fix(executor): move WaiterMap from Executor to MemoryInstance
-  * fix(executor): preserve nullability for externalized refs in ref.test/ref.cast (#4679)
-  * fix(executor): use memmove semantics for same-memory memory.copy (#4671)
-  * fix(executor): preserve heap type when externalizing references (#4536)
-  * fix(executor): synchronize HostFuncHandler callback invocation (#4508)
-  * fix(executor): correct memory.init error log logic (#4582)
-  * fix(executor): only memory address apply the uint64_t, the indices of memories still are uint32_t
-  * fix(executor): ref type for uninit values in table (#4764)
-  * fix(executor): normalize null ref types for locals and AOT (#4772)
-  * fix(executor): prevent silent override of error code in registerModule() & registerComponent() (#4777)
-  * fix(executor): reject insufficient argument count in component invoke
-  * fix(executor): correct WASI socket v2 fallback matching (#4832)
-  * fix(executor): preserve exnref payload across throw_ref
-* [Runtime]
-  * fix(runtime): use unique_lock in StoreManager::reset() to prevent data race (#4771)
-* [AOT]
-  * fix(llvm): serialize LLD linker invocations with mutex
-  * fix(compiler): error on LLVM-22 (#4696)
-  * fix(aot): align the NaN propagation order in {f32x4,f64x2}.max/min with the interpreter mode (#4522)
-* [Tools]
-  * fix(cli): handle invalid numeric arguments gracefully (#4602)
-  * fix(tools): handle exported function not found case in reactor mode (#4647)
-  * fix(tools): default logging level not passing (#4765)
-  * fix(po): reject numeric option values with trailing garbage
-  * fix(cli): reject insufficient arguments for invoked function
+  * fix: reject non-funcref tables/refs in call_indirect and call_ref (#4920)
 * [WASI]
-  * fix(wasi): resolve 100% CPU usage on macOS due to clock mismatch (#4470)
-  * fix(wasi): return ERRNO BADF error when try to sync a directory (#4572)
-  * fix(wasi): refactor Poller context handling to use pointer instead of wrapper (#4509)
-  * fix(wasi): initialize Filestat to silence MSVC C4701 warning (#4852)
-* [WASI-NN]
-  * fix(wasi-nn,bitnet): out-of-bounds array access in unload() function (#4531)
-  * fix(wasi-nn): disable shallow clone for BitNet dependency (#4638)
-  * fix(wasi-nn): install espeak-ng-data for Piper backend tests in CI (#4634)
-* [Plugin]
-  * fix(plugin,process): correct timeout unit conversion (#4678)
-  * fix(plugin,ffmpeg): clamp guest-provided lengths when copying FFmpeg C strings (#4478)
-  * fix(plugin,zlib): standardize missing memory instance handling (#4506)
-  * fix(plugin,ffmpeg): remove duplicate directory creation check (#4484)
-* [Docker]
-  * fix(docker): build libpiper statically (#4565)
-  * fix(docker): build libpiper statically in install script (#4535)
-  * fix(docker): manually link espeak-ng and ucd static libs for Piper backend (#4622)
-* [Examples]
-  * fix(example): update PluginDescriptor in getstring example (#4798)
-* [Misc]
-  * fix(common): correct uint128 output for fmt on Windows
-  * fix(common): remove invalid specialization for uint128 (#4796)
-  * fix(misc): resolve warnings on Windows clang-cl
-  * fix(typo): some typo in comments (#4810)
-
-Tests:
-
-* test(spec): add thread and wait command support in spec tests
-* test: add C-API boundary test for empty strings
-* test(spec): combine component model spec tests into core spec test infrastructure
-* test: support component-model spec test
-* test(spec): update spec test suite to 2026/03/01
-* test: apply the spec tests for memory64 proposal
-* test: add component model fuzz testing (#4657)
-* test(component,validator): split component tests and add type validation tests
-* test(component,validator): add regression tests for validator fixes
-* test(component): enable func spec test and drop wrong-order entry
-* fix(test): split poll socket tests to isolate flaky cycle 2 (#4747)
-* fix(test): disable LTO in tensorflow plugin tests of manylinux (#4766)
-* test(component): fix GCC -Wdangling-reference and gate Clang-only flags (#4813)
-* test: cover RunMode behaviours and opt JIT/AOT spec tests into explicit modes
-* test(executor): regression tests for exnref payload preservation
-
-Refactored:
-
-* refactor(loader): trick for deducing the instruction class size
-* refactor(runtime): adjust the boundary printing logic for error logging
-* refactor(installer): handle shell login config by OS and distro (#4453)
-* refactor(WASI-Crypto): deduplicate factory functions and OpenSSL BIO helpers (#4545)
-* refactor(validator): introduce typed index spaces and fix section validation
-* refactor(api): introduce RunMode and the --run-mode CLI flag
-* refactor(component): move AST::Component::Canonical enums to enums.inc (#4875)
-
-Misc:
-
-* docs: explain why ErrCode does not support parameterized messages (#4666)
-* docs(roadmap): update roadmap for Q1/2026 (#4583)
-* docs: add WasmEdge mentorship policy (#4519)
-* docs: update CONTRIBUTING and PR template for the basic checks (#4538)
-* chore(AI): provide AGENTS.md for the AI co-working toolchains (#4521)
-* chore: add mentorship policy into the issue template (#4520)
-* chore: add missing gitvote update from previous maintainer onboarding (#4493)
-* docs: create technical review document for WasmEdge
-* docs: update the technical-review.md for the latest changes
-* docs(roadmap): update roadmap for Q2/2026 (#4800)
-* chore: fix comment grammar sweep (#4850)
+  * fix(wasi): reject symlink targets that resolve outside the preopen root (#4938)
+* [WASI-Logging]
+  * fix(plugin/wasi-logging): keep the default logger alive across instances
 
 CI:
 
 * [dependabot]
-  * ci(dependabot): bump github/codeql-action from 4.31.9 to 4.35.4
-  * ci(dependabot): bump codecov/codecov-action from 5.5.2 to 6.0.0 (#4750)
-  * ci(dependabot): bump actions/cache from 5.0.1 to 5.0.5
-  * ci(dependabot): bump cachix/install-nix-action from 31.9.0 to 31.10.6
-  * ci(dependabot): bump vedantmgoyal9/winget-releaser (#4721)
-  * ci(dependabot): bump dorny/paths-filter from 3.0.2 to 4.0.1 (#4718)
-  * ci(dependabot): bump actions/download-artifact from 8.0.0 to 8.0.1 (#4717)
-  * ci(dependabot): bump step-security/harden-runner from 2.14.0 to 2.19.1
-  * ci(dependabot): bump the docker group with 3 updates (#4697)
-  * ci(dependabot): bump docker/login-action from 3.6.0 to 4.1.0 in the docker group (#4760)
-  * ci(dependabot): bump docker/bake-action from 7.0.0 to 7.1.0 in the docker group (#4780)
-  * ci(dependabot): bump the upload-and-download-artifact group with 2 updates (#4689)
-  * ci(dependabot): bump actions/upload-artifact from 7.0.0 to 7.0.1
-  * ci(dependabot): bump crazy-max/ghaction-chocolatey from 3.4.0 to 4.0.0 (#4652)
-  * ci(dependabot): bump actions/setup-python from 6.1.0 to 6.2.0 (#4555)
-  * ci(dependabot): bump actions/checkout from 6.0.1 to 6.0.2 (#4556)
-  * ci(dependabot): bump actions/github-script from 8.0.0 to 9.0.0 (#4783)
-  * ci(dependabot): bump actions/labeler from 6.0.1 to 6.1.0 (#4869)
-  * ci(dependabot): bump GuillaumeFalourd/setup-windows10-sdk-action from 2.4 to 2.5 (#4868)
-* [Runner]
-  * ci(riscv): enable RISC-V cross-compilation CI (#4542)
-  * ci: guard reusable workflows and jobs to avoid empty matrix jobs (#4668)
-  * ci: optimize s390x workflow with apt cache and Ninja (#4645)
-  * ci: cache homebrew deps, lld (#4600)
-  * ci(windows): cache LLVM and remove redundant CMake configure for WASI-NN GGML (#4580)
-  * ci: fix Windows GGML performance by forcing Release build (#4578)
-  * ci: bump lineguard to 0.1.7 (#4627)
-  * ci: symbol exposure checking
-  * ci: update labeler.yml for some new categories (#4584)
-  * refactor(ci): optimize workflows (#4544)
-  * fix(ci): cache lld pre-built on macOS workflow (#4753)
-  * fix(ci): new content for wasi-testsuite (#4751)
-  * fix(ci): update SOVERSION for openwrt build (#4792)
-  * fix(ci): bump Fedora IWYU toolchain to llvm19 + IWYU 0.23 (#4827)
-  * fix(ci): backward support for old tap in older brew LLVM version (#4845)
+  * ci(dependabot): bump codecov/codecov-action from 6.0.1 to 7.0.0 (#4943)
+  * ci(dependabot): bump github/codeql-action from 4.36.1 to 4.36.2 (#4944)
 
 Thank all the contributors who made this release possible!
 
-Abdelrahman Emad, alabulei1, Asish Kumar, Asmit Kumar Rai, Barry, Digo, Divyansh Khatri, Han-Wen Tsao, harukiki97, hydai, Kajal Jotwani, Karan Lokchandani, Khushi-Singh, LuaLighter, Lîm Tsú-thuàn, Meet Jain, Mrinal Chaturvedi, Parship Chowdhury, Piyush Kumar, Pranjal Kole, Samarth Jain, SANCHIT KUMAR, Sankalp Jha, Shen-Ta Hsieh(BestSteve), Siddhartha Mondal, Sourav Kumar, SriramB, Tushar Gupta, Vikas_pal8923, Vishal Malyan, Wang-Yang Li, Yi Liu, Yi-Ying He
+Shen-Ta Hsieh(BestSteve), Yi-Ying He
 
-If you want to build from source, please use WasmEdge-0.17.0-src.tar.gz instead of the zip or tarball provided by GitHub directly.
+If you want to build from source, please use WasmEdge-0.17.1-rc.1-src.tar.gz instead of the zip or tarball provided by GitHub directly.

--- a/.github/scripts/SYMBOL_CHECKING.md
+++ b/.github/scripts/SYMBOL_CHECKING.md
@@ -38,3 +38,61 @@ When adding new public API functions:
 1. Add the function to `include/api/wasmedge/wasmedge.h` with `WASMEDGE_CAPI_EXPORT`
 2. Add the symbol name to `whitelist.symbols` (keep alphabetical order)
 3. Commit both changes together
+
+## C API symbol versioning
+
+On Linux/Android the exported C symbols are grouped into versioned nodes by the
+linker version script `lib/api/libwasmedge.lds` (e.g. `WASMEDGE_0.16`,
+`WASMEDGE_0.17`). This lets a single `libwasmedge.so.0` keep serving an older
+ABI alongside the current one, so a signature-only break does not force every
+dynamically linked consumer to rebuild and does not, by itself, require a
+SONAME (`WASMEDGE_CAPI_SOVERSION`) bump.
+
+When a release breaks the signature of an existing C API function (changed
+parameters/return type or a changed by-value struct layout):
+
+1. Add a new version node to `lib/api/libwasmedge.lds` named after the release
+   that introduces the break (inheriting the previous node), and list the
+   changed symbols under its `global:` section. The literal names take
+   precedence over the `WasmEdge*` wildcard, so the current implementations
+   become the new node's default (`@@`) symbols automatically.
+2. Keep the previous behaviour available by adding a backward-compatible shim in
+   `lib/api/wasmedge_compat.cpp` (guarded by `#if defined(__ELF__) &&
+   (defined(__linux__) || defined(__ANDROID__))`) named
+   `WasmEdge_<Name>_Compat_<old>`, and bind it to the old version with
+   `__asm__(".symver WasmEdge_<Name>_Compat_<old>, WasmEdge_<Name>@WASMEDGE_<old>")`.
+   The shim lives in its own translation unit (compiled only into the shared
+   library) so that this `.symver` module-level asm does not collide with the
+   in-IR definition of `WasmEdge_<Name>` under ThinLTO.
+   Mark the shim `__attribute__((used, visibility("default")))`. The
+   `visibility("default")` is required: the project builds with
+   `-fvisibility=hidden`, and a hidden source symbol does not produce an exported
+   `.symver` alias (the compat symbol silently disappears). Because that default
+   visibility plus the `WasmEdge_*` name would otherwise export the shim's own
+   name, add its exact name to the `local:` section of the base node in
+   `lib/api/libwasmedge.lds` (an exact match outranks the `WasmEdge*` wildcard),
+   so only the `@WASMEDGE_<old>` alias is exported.
+3. `check_symbols.sh` strips the `@<version>` suffix before matching, so the
+   `whitelist.symbols` entries stay the bare function names — no whitelist
+   changes are needed for versioning.
+
+The limit struct -> limit context change (0.16 -> 0.17) is the worked example:
+`WasmEdge_LimitIsEqual`, `WasmEdge_MemoryTypeCreate`, `WasmEdge_MemoryTypeGetLimit`,
+`WasmEdge_TableTypeCreate`, and `WasmEdge_TableTypeGetLimit` carry both a
+`@@WASMEDGE_0.17` default and a `@WASMEDGE_0.16` compatibility symbol.
+
+> Note: this mechanism is ELF-only; macOS and Windows export the symbols
+> unversioned. A subtle but important runtime rule: an *unversioned* reference
+> (from a consumer built against a pre-versioning library — i.e. 0.16.x or the
+> released 0.17.0) binds to the **oldest** matching version definition, here
+> `@WASMEDGE_0.16` (the struct shim), **not** to the default `@@` symbol. The
+> `@@` default only selects what *newly linked* code records (it gets a
+> versioned `@WASMEDGE_0.17` reference). Consequences:
+>
+> - Consumers built against **0.16.x keep working without a rebuild** — their
+>   unversioned references land on the matching `@WASMEDGE_0.16` struct shim.
+> - Consumers built against the (also unversioned) **0.17.0 must be rebuilt** —
+>   their unversioned references also land on the `@WASMEDGE_0.16` struct shim,
+>   which mismatches the pointer/context ABI they were compiled for.
+> - Consumers built against this versioned library resolve to `@WASMEDGE_0.17`
+>   and are correct.

--- a/.github/scripts/check_symbols.sh
+++ b/.github/scripts/check_symbols.sh
@@ -131,9 +131,12 @@ else
         exit 1
     fi
 
+    # Strip the version suffix (e.g. WasmEdge_Foo@@WASMEDGE_0.17 or
+    # WasmEdge_Foo@WASMEDGE_0.16) so versioned symbols match the whitelist,
+    # then de-duplicate the default and compat aliases of the same name.
     nm -D --defined-only "$LIB_PATH" 2>/dev/null | \
-        awk '/^[0-9a-fA-F]+ [TBDW] / {print $3}' | \
-        grep -E "^WasmEdge" | sort > "$TEMP_DIR/extracted.symbols"
+        awk '/^[0-9a-fA-F]+ [TBDW] / {sub(/@.*/, "", $3); print $3}' | \
+        grep -E "^WasmEdge" | sort -u > "$TEMP_DIR/extracted.symbols"
 fi
 
 if [ ! -s "$TEMP_DIR/extracted.symbols" ]; then

--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - master
+      - "[0-9]+.[0-9]+.x"
     paths:
       - ".github/extensions.paths-filter.yml"
       - ".github/workflows/build-extensions.yml"
@@ -24,6 +25,7 @@ on:
     branches:
       - master
       - "proposal/**"
+      - "[0-9]+.[0-9]+.x"
     paths:
       - ".github/extensions.paths-filter.yml"
       - ".github/workflows/build-extensions.yml"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - master
+      - "[0-9]+.[0-9]+.x"
     paths:
       - ".github/workflows/build.yml"
       - ".github/workflows/reusable-build-on-**"
@@ -26,6 +27,7 @@ on:
     branches:
       - master
       - "proposal/**"
+      - "[0-9]+.[0-9]+.x"
     paths:
       - ".github/workflows/build.yml"
       - ".github/workflows/reusable-build-on-**"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -81,7 +81,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         languages: ${{ matrix.language }}
 
@@ -93,4 +93,4 @@ jobs:
         cmake --build build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/reusable-build-on-ubuntu.yml
+++ b/.github/workflows/reusable-build-on-ubuntu.yml
@@ -123,7 +123,7 @@ jobs:
           gh release upload ${{ inputs.version }} WasmEdge-${{ inputs.version }}-ubuntu20.04_${{ matrix.arch }}.tar.gz --clobber
       - name: Create and upload coverage report to Codecov
         if: ${{ matrix.coverage }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./build/codecov.xml

--- a/Changelog.md
+++ b/Changelog.md
@@ -403,6 +403,21 @@ Han-Wen Tsao, Karan Lokchandani, Khush Agrawal, Minimega12121, Sankalp Jha, Shen
 
 If you want to build from source, please use WasmEdge-0.16.0-src.tar.gz instead of the zip or tarball provided by GitHub directly.
 
+### 0.15.1 (2026-01-08)
+
+This is the hot fix for 0.15.x versions.
+
+Fixed issues:
+
+* feat(aot): add support for llvm 21
+* [CVE-2025-69261] fix(runtime): overflow issue of getting memory over 32-bit offset
+
+Thank all the contributors who made this release possible!
+
+Shen-Ta Hsieh, Yi-Ying He
+
+If you want to build from source, please use WasmEdge-0.15.1-src.tar.gz instead of the zip or tarball provided by GitHub directly.
+
 ### 0.15.0 (2025-08-04)
 
 Features:

--- a/Changelog.md
+++ b/Changelog.md
@@ -197,6 +197,25 @@ Abdelrahman Emad, alabulei1, Asish Kumar, Asmit Kumar Rai, Barry, Digo, Divyansh
 
 If you want to build from source, please use WasmEdge-0.17.0-src.tar.gz instead of the zip or tarball provided by GitHub directly.
 
+### 0.16.4 (2026-06-12)
+
+This is the bug fix for the 0.16.x versions.
+
+Fixed issues:
+
+* fix: reject non-funcref tables/refs in call_indirect and call_ref (#4920)
+* fix(wasi): reject symlink targets that resolve outside the preopen root (#4938)
+
+CI:
+
+* Bumped CI dependencies
+
+Thank all the contributors who made this release possible!
+
+Shen-Ta Hsieh(BestSteve), Yi-Ying He
+
+If you want to build from source, please use WasmEdge-0.16.4-src.tar.gz instead of the zip or tarball provided by GitHub directly.
+
 ### 0.16.3 (2026-05-04)
 
 This is the bug fix for the 0.16.x versions.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,31 @@
+### 0.17.1-rc.1 (2026-06-16)
+
+Features:
+
+* [CAPI]
+  * feat(api): version C ABI symbols for the 0.16 -> 0.17 limit change (#4951)
+
+Fixed issues:
+
+* [Validator]
+  * fix: reject non-funcref tables/refs in call_indirect and call_ref (#4920)
+* [WASI]
+  * fix(wasi): reject symlink targets that resolve outside the preopen root (#4938)
+* [WASI-Logging]
+  * fix(plugin/wasi-logging): keep the default logger alive across instances
+
+CI:
+
+* [dependabot]
+  * ci(dependabot): bump codecov/codecov-action from 6.0.1 to 7.0.0 (#4943)
+  * ci(dependabot): bump github/codeql-action from 4.36.1 to 4.36.2 (#4944)
+
+Thank all the contributors who made this release possible!
+
+Shen-Ta Hsieh(BestSteve), Yi-Ying He
+
+If you want to build from source, please use WasmEdge-0.17.1-rc.1-src.tar.gz instead of the zip or tarball provided by GitHub directly.
+
 ### 0.17.0 (2026-05-18)
 
 Features:

--- a/include/common/types.h
+++ b/include/common/types.h
@@ -689,6 +689,9 @@ inline ValVariant ValueFromType(ValType Type) noexcept {
 
 inline const Runtime::Instance::FunctionInstance *
 retrieveFuncRef(const RefVariant &Val) {
+  if (!Val.getType().isFuncRefType()) {
+    return nullptr;
+  }
   return Val.getPtr<Runtime::Instance::FunctionInstance>();
 }
 

--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -846,10 +846,13 @@ public:
     if (!VINode::isPathValid(NewPath)) {
       return WasiUnexpect(__WASI_ERRNO_INVAL);
     }
-    // forbid absolute path
+    // Forbid an absolute target. A target escaping the base directory is "not
+    // permitted", matching resolvePath and the `..` check in pathSymlink.
     if (!OldPath.empty() && OldPath[0] == '/') {
-      return WasiUnexpect(__WASI_ERRNO_INVAL);
+      return WasiUnexpect(__WASI_ERRNO_PERM);
     }
+    // Relative targets escaping via `..` are rejected in VINode::pathSymlink,
+    // where the link's depth is known.
     auto NewNode = getNodeOrNull(New);
     if (unlikely(!NewNode)) {
       return WasiUnexpect(__WASI_ERRNO_BADF);

--- a/include/host/wasi/vinode.h
+++ b/include/host/wasi/vinode.h
@@ -47,6 +47,35 @@ public:
     return Path.find('\0') == std::string_view::npos;
   }
 
+  /// Check whether a relative symlink target would resolve outside the base
+  /// directory. Each component descends a level and each `..` ascends one; it
+  /// escapes if the level ever drops below the base.
+  /// @param[in] Target Symlink target (link contents).
+  /// @param[in] Depth The link directory's depth below the base fd.
+  /// @return Whether the target escapes the base directory.
+  static bool isSymlinkTargetEscaping(std::string_view Target,
+                                      uint32_t Depth) noexcept {
+    int64_t Level = static_cast<int64_t>(Depth);
+    std::string_view Path = Target;
+    while (!Path.empty()) {
+      const auto Slash = Path.find('/');
+      const auto Part = Path.substr(0, Slash);
+      Path = (Slash == std::string_view::npos) ? std::string_view()
+                                               : Path.substr(Slash + 1);
+      if (Part.empty() || (Part.size() == 1 && Part[0] == '.')) {
+        continue;
+      }
+      if (Part.size() == 2 && Part[0] == '.' && Part[1] == '.') {
+        if (--Level < 0) {
+          return true;
+        }
+        continue;
+      }
+      ++Level;
+    }
+    return false;
+  }
+
   static std::shared_ptr<VINode> stdIn(__wasi_rights_t FRB,
                                        __wasi_rights_t FRI);
   static std::shared_ptr<VINode> stdOut(__wasi_rights_t FRB,
@@ -724,12 +753,14 @@ private:
   /// @param[in] LinkCount Counting symbolic link lookup times.
   /// @param[in] FollowTrailingSlashes If Path ends with slash, open it and set
   /// Path to ".".
+  /// @param[out] ResolvedDepth If not null, set to the parent's depth below
+  /// `Fd`. Left untouched on error paths.
   /// @return Allocated buffer, or WASI error.
   static WasiExpect<std::vector<char>> resolvePath(
       std::shared_ptr<VINode> &Fd, std::string_view &Path,
       __wasi_lookupflags_t LookupFlags = __WASI_LOOKUPFLAGS_SYMLINK_FOLLOW,
       VFS::Flags VFSFlags = static_cast<VFS::Flags>(0), uint8_t LinkCount = 0,
-      bool FollowTrailingSlashes = true);
+      bool FollowTrailingSlashes = true, uint32_t *ResolvedDepth = nullptr);
 
   /// Proxy function for `resolvePath`.
   /// @param[in,out] Fd Fd. Return parent of last part if found.

--- a/include/plugin/wasi_logging/env.h
+++ b/include/plugin/wasi_logging/env.h
@@ -58,7 +58,11 @@ public:
 
   ~LogEnv() noexcept {
     std::unique_lock Lock(Mutex);
-    spdlog::drop(LogFileName);
+    // Drop the file logger by its registered name; never LogFileName, which is
+    // empty until a file is set and would reset the unnamed default logger.
+    if (FileLogger) {
+      spdlog::drop(LogRegName);
+    }
     RegisteredID.erase(InstanceID);
   }
 

--- a/lib/api/CMakeLists.txt
+++ b/lib/api/CMakeLists.txt
@@ -128,6 +128,13 @@ if(WASMEDGE_BUILD_SHARED_LIB)
       PRIVATE
       "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libwasmedge.lds"
     )
+
+    # The 0.16 `@WASMEDGE_0.16` compat shims rely on the version script, so they
+    # belong only to the shared library, not the static one (see wasmedge_compat.cpp).
+    target_sources(wasmedge_shared
+      PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/wasmedge_compat.cpp
+    )
   endif()
 
   target_link_libraries(wasmedge_shared

--- a/lib/api/libwasmedge.lds
+++ b/lib/api/libwasmedge.lds
@@ -1,4 +1,4 @@
-{
+WASMEDGE_0.16 {
   global:
     WasmEdge*;
     extern "C++" {
@@ -6,5 +6,24 @@
     };
 
   local:
+    # Internal names of the 0.16 backward-compat shims (see
+    # lib/api/wasmedge_compat.cpp).
+    # They need default visibility so `.symver` can export their `@WASMEDGE_0.16`
+    # aliases, but their own names match the `WasmEdge*` pattern above; listing
+    # them here (an exact match outranks the wildcard) keeps them unexported.
+    WasmEdge_LimitIsEqual_Compat_016;
+    WasmEdge_MemoryTypeCreate_Compat_016;
+    WasmEdge_MemoryTypeGetLimit_Compat_016;
+    WasmEdge_TableTypeCreate_Compat_016;
+    WasmEdge_TableTypeGetLimit_Compat_016;
     *;
 };
+
+WASMEDGE_0.17 {
+  global:
+    WasmEdge_LimitIsEqual;
+    WasmEdge_MemoryTypeCreate;
+    WasmEdge_MemoryTypeGetLimit;
+    WasmEdge_TableTypeCreate;
+    WasmEdge_TableTypeGetLimit;
+} WASMEDGE_0.16;

--- a/lib/api/wasmedge_compat.cpp
+++ b/lib/api/wasmedge_compat.cpp
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+// >>>>>>>> WasmEdge 0.16 compat ABI shims >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+//
+// The 0.16 -> 0.17 transition changed five C API functions from the by-value
+// `WasmEdge_Limit` struct to the opaque `WasmEdge_LimitContext` handle. These
+// shims provide the old `@WASMEDGE_0.16` symbols (bound with `.symver`) while
+// `wasmedge.cpp` keeps the default `@@WASMEDGE_0.17` ones; they are a frozen
+// copy of the 0.16.4-rc.1 implementations so the old ABI stays pinned.
+//
+// Compiled only into the shared library on Linux/Android (see CMakeLists.txt).
+// Kept in a separate TU because under ThinLTO the module-level `.symver` asm
+// would otherwise collide with the in-IR definition of the same public symbol.
+
+#include "wasmedge/wasmedge.h"
+
+#include "ast/type.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+
+#if defined(__ELF__) && (defined(__linux__) || defined(__ANDROID__))
+
+namespace {
+using namespace WasmEdge;
+
+// Local copies of the `wasmedge.cpp` helpers, kept here to stay self-contained.
+inline ValType genValType(const WasmEdge_ValType &T) noexcept {
+  std::array<uint8_t, 8> R;
+  std::copy_n(T.Data, 8, R.begin());
+  return ValType(R);
+}
+inline auto *toTabTypeCxt(AST::TableType *Cxt) noexcept {
+  return reinterpret_cast<WasmEdge_TableTypeContext *>(Cxt);
+}
+inline const auto *
+fromTabTypeCxt(const WasmEdge_TableTypeContext *Cxt) noexcept {
+  return reinterpret_cast<const AST::TableType *>(Cxt);
+}
+inline auto *toMemTypeCxt(AST::MemoryType *Cxt) noexcept {
+  return reinterpret_cast<WasmEdge_MemoryTypeContext *>(Cxt);
+}
+inline const auto *
+fromMemTypeCxt(const WasmEdge_MemoryTypeContext *Cxt) noexcept {
+  return reinterpret_cast<const AST::MemoryType *>(Cxt);
+}
+} // namespace
+
+extern "C" {
+
+// Layout-compatible revival of the 0.16 `WasmEdge_Limit` struct. `Min`/`Max`
+// are `uint32_t` (Memory64 widened them to 64-bit only in 0.17), keeping the
+// by-value ABI bit-for-bit identical to what 0.16 consumers were built against.
+typedef struct WasmEdge_Limit_0_16 {
+  bool HasMax;
+  bool Shared;
+  uint32_t Min;
+  uint32_t Max;
+} WasmEdge_Limit_0_16;
+
+__attribute__((used, visibility("default"))) bool
+WasmEdge_LimitIsEqual_Compat_016(const WasmEdge_Limit_0_16 Lim1,
+                                 const WasmEdge_Limit_0_16 Lim2) {
+  return Lim1.HasMax == Lim2.HasMax && Lim1.Shared == Lim2.Shared &&
+         Lim1.Min == Lim2.Min && Lim1.Max == Lim2.Max;
+}
+
+__attribute__((used, visibility("default"))) WasmEdge_TableTypeContext *
+WasmEdge_TableTypeCreate_Compat_016(const WasmEdge_ValType RefType,
+                                    const WasmEdge_Limit_0_16 Limit) {
+  WasmEdge::ValType RT = genValType(RefType);
+  if (!RT.isRefType()) {
+    return nullptr;
+  }
+  if (Limit.HasMax) {
+    return toTabTypeCxt(new WasmEdge::AST::TableType(RT, Limit.Min, Limit.Max));
+  } else {
+    return toTabTypeCxt(new WasmEdge::AST::TableType(RT, Limit.Min));
+  }
+}
+
+__attribute__((used, visibility("default"))) WasmEdge_Limit_0_16
+WasmEdge_TableTypeGetLimit_Compat_016(const WasmEdge_TableTypeContext *Cxt) {
+  if (Cxt) {
+    const auto &Lim = fromTabTypeCxt(Cxt)->getLimit();
+    return WasmEdge_Limit_0_16{/* HasMax */ Lim.hasMax(),
+                               /* Shared */ Lim.isShared(),
+                               /* Min */ static_cast<uint32_t>(Lim.getMin()),
+                               /* Max */ static_cast<uint32_t>(Lim.getMax())};
+  }
+  return WasmEdge_Limit_0_16{/* HasMax */ false, /* Shared */ false,
+                             /* Min */ 0, /* Max */ 0};
+}
+
+__attribute__((used, visibility("default"))) WasmEdge_MemoryTypeContext *
+WasmEdge_MemoryTypeCreate_Compat_016(const WasmEdge_Limit_0_16 Limit) {
+  if (Limit.Shared) {
+    return toMemTypeCxt(
+        new WasmEdge::AST::MemoryType(Limit.Min, Limit.Max, true));
+  } else if (Limit.HasMax) {
+    return toMemTypeCxt(new WasmEdge::AST::MemoryType(Limit.Min, Limit.Max));
+  } else {
+    return toMemTypeCxt(new WasmEdge::AST::MemoryType(Limit.Min));
+  }
+}
+
+__attribute__((used, visibility("default"))) WasmEdge_Limit_0_16
+WasmEdge_MemoryTypeGetLimit_Compat_016(const WasmEdge_MemoryTypeContext *Cxt) {
+  if (Cxt) {
+    const auto &Lim = fromMemTypeCxt(Cxt)->getLimit();
+    return WasmEdge_Limit_0_16{/* HasMax */ Lim.hasMax(),
+                               /* Shared */ Lim.isShared(),
+                               /* Min */ static_cast<uint32_t>(Lim.getMin()),
+                               /* Max */ static_cast<uint32_t>(Lim.getMax())};
+  }
+  return WasmEdge_Limit_0_16{/* HasMax */ false, /* Shared */ false,
+                             /* Min */ 0, /* Max */ 0};
+}
+
+} // extern "C"
+
+// Bind each shim to its historical `@WASMEDGE_0.16` symbol name. The shims need
+// default visibility for `.symver` to export the alias; their own
+// `WasmEdge_*_Compat_016` names are hidden via the `local:` list in
+// `lib/api/libwasmedge.lds` so only the `@WASMEDGE_0.16` aliases are exported.
+__asm__(".symver WasmEdge_LimitIsEqual_Compat_016, "
+        "WasmEdge_LimitIsEqual@WASMEDGE_0.16");
+__asm__(".symver WasmEdge_TableTypeCreate_Compat_016, "
+        "WasmEdge_TableTypeCreate@WASMEDGE_0.16");
+__asm__(".symver WasmEdge_TableTypeGetLimit_Compat_016, "
+        "WasmEdge_TableTypeGetLimit@WASMEDGE_0.16");
+__asm__(".symver WasmEdge_MemoryTypeCreate_Compat_016, "
+        "WasmEdge_MemoryTypeCreate@WASMEDGE_0.16");
+__asm__(".symver WasmEdge_MemoryTypeGetLimit_Compat_016, "
+        "WasmEdge_MemoryTypeGetLimit@WASMEDGE_0.16");
+
+#endif // __ELF__ && (__linux__ || __ANDROID__)
+
+// <<<<<<<< WasmEdge 0.16 compat ABI shims <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

--- a/lib/common/spdlog.cpp
+++ b/lib/common/spdlog.cpp
@@ -81,7 +81,7 @@ void setLoggingCallback(
         std::make_shared<spdlog::logger>("WasmEdge"s, Callback_sink));
   } else {
     spdlog::set_default_logger(std::make_shared<spdlog::logger>(
-        ""s, std::make_shared<color_sink_t>()));
+        "WasmEdge"s, std::make_shared<color_sink_t>()));
   }
 }
 

--- a/lib/executor/engine/controlInstr.cpp
+++ b/lib/executor/engine/controlInstr.cpp
@@ -172,7 +172,8 @@ Expect<void> Executor::runCallRefOp(Runtime::StackManager &StackMgr,
                                     AST::InstrView::iterator &PC,
                                     bool IsTailCall) noexcept {
   const auto Ref = StackMgr.pop().get<RefVariant>();
-  if (Ref.isNull()) {
+  const auto *FuncInst = retrieveFuncRef(Ref);
+  if (FuncInst == nullptr) {
     spdlog::error(ErrCode::Value::AccessNullFunc);
     spdlog::error(
         ErrInfo::InfoInstruction(Instr.getOpCode(), Instr.getOffset()));
@@ -180,7 +181,6 @@ Expect<void> Executor::runCallRefOp(Runtime::StackManager &StackMgr,
   }
 
   // Get Function address.
-  const auto *FuncInst = retrieveFuncRef(Ref);
   EXPECTED_TRY(auto NextPC,
                enterFunction(StackMgr, *FuncInst, PC + 1, IsTailCall));
   PC = NextPC - 1;
@@ -213,7 +213,8 @@ Expect<void> Executor::runCallIndirectOp(Runtime::StackManager &StackMgr,
 
   // Get function address. The bound is guaranteed.
   RefVariant Ref = *TabInst->getRefAddr(Idx);
-  if (Ref.isNull()) {
+  const auto *FuncInst = retrieveFuncRef(Ref);
+  if (FuncInst == nullptr) {
     spdlog::error(ErrCode::Value::UninitializedElement);
     spdlog::error(ErrInfo::InfoInstruction(Instr.getOpCode(), Instr.getOffset(),
                                            {Idx},
@@ -222,7 +223,6 @@ Expect<void> Executor::runCallIndirectOp(Runtime::StackManager &StackMgr,
   }
 
   // Check function type.
-  const auto *FuncInst = retrieveFuncRef(Ref);
   bool IsMatch = false;
   if (FuncInst->getModule()) {
     IsMatch = AST::TypeMatcher::matchType(

--- a/lib/host/wasi/vinode.cpp
+++ b/lib/host/wasi/vinode.cpp
@@ -256,8 +256,19 @@ WasiExpect<void> VINode::pathSymlink(std::string_view OldPath,
   if (!New->can(__WASI_RIGHTS_PATH_SYMLINK)) {
     return WasiUnexpect(__WASI_ERRNO_NOTCAPABLE);
   }
-  EXPECTED_TRY(auto NewBuffer, resolvePath(New, NewPath));
+  // Resolve the new path without following its trailing component (an existing
+  // link must not be followed, so creating over it fails with EEXIST), and
+  // capture the link directory's depth below the fd.
+  uint32_t ParentDepth = 0;
+  EXPECTED_TRY(auto NewBuffer,
+               resolvePath(New, NewPath, static_cast<__wasi_lookupflags_t>(0),
+                           static_cast<VFS::Flags>(0), 0, true, &ParentDepth));
 
+  // Reject relative targets that resolve outside the preopen root; store
+  // in-bounds targets as-is.
+  if (isSymlinkTargetEscaping(OldPath, ParentDepth)) {
+    return WasiUnexpect(__WASI_ERRNO_PERM);
+  }
   return New->Node.pathSymlink(std::string(OldPath), std::string(NewPath));
 }
 
@@ -328,7 +339,8 @@ VINode::directOpen(std::string_view Path, __wasi_oflags_t OpenFlags,
 WasiExpect<std::vector<char>>
 VINode::resolvePath(std::shared_ptr<VINode> &Fd, std::string_view &Path,
                     __wasi_lookupflags_t LookupFlags, VFS::Flags VFSFlags,
-                    uint8_t LinkCount, bool FollowTrailingSlashes) {
+                    uint8_t LinkCount, bool FollowTrailingSlashes,
+                    uint32_t *ResolvedDepth) {
   std::vector<std::shared_ptr<VINode>> PartFds;
   std::vector<char> Buffer;
   do {
@@ -368,6 +380,9 @@ VINode::resolvePath(std::shared_ptr<VINode> &Fd, std::string_view &Path,
       if (!Part.empty() && Part[0] == '.') {
         if (Part.size() == 1) {
           if (LastPart) {
+            if (ResolvedDepth) {
+              *ResolvedDepth = static_cast<uint32_t>(PartFds.size());
+            }
             return Buffer;
           }
           Path = Remain;
@@ -382,6 +397,9 @@ VINode::resolvePath(std::shared_ptr<VINode> &Fd, std::string_view &Path,
           Path = Remain;
           if (LastPart) {
             Path = "."sv;
+            if (ResolvedDepth) {
+              *ResolvedDepth = static_cast<uint32_t>(PartFds.size());
+            }
             return Buffer;
           }
           continue;
@@ -390,6 +408,9 @@ VINode::resolvePath(std::shared_ptr<VINode> &Fd, std::string_view &Path,
 
       if (LastPart && !(LookupFlags & __WASI_LOOKUPFLAGS_SYMLINK_FOLLOW)) {
         Path = Part;
+        if (ResolvedDepth) {
+          *ResolvedDepth = static_cast<uint32_t>(PartFds.size());
+        }
         return Buffer;
       }
 
@@ -398,6 +419,9 @@ VINode::resolvePath(std::shared_ptr<VINode> &Fd, std::string_view &Path,
           unlikely(!Res)) {
         if (LastPart) {
           Path = Part;
+          if (ResolvedDepth) {
+            *ResolvedDepth = static_cast<uint32_t>(PartFds.size());
+          }
           return Buffer;
         }
         return WasiUnexpect(Res);
@@ -428,6 +452,9 @@ VINode::resolvePath(std::shared_ptr<VINode> &Fd, std::string_view &Path,
 
       if (LastPart) {
         Path = Part;
+        if (ResolvedDepth) {
+          *ResolvedDepth = static_cast<uint32_t>(PartFds.size());
+        }
         return Buffer;
       }
 
@@ -445,6 +472,9 @@ VINode::resolvePath(std::shared_ptr<VINode> &Fd, std::string_view &Path,
       Path = Remain;
       if (Path.empty()) {
         Path = "."sv;
+        if (ResolvedDepth) {
+          *ResolvedDepth = static_cast<uint32_t>(PartFds.size());
+        }
         return {};
       }
       continue;

--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -628,7 +628,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
     auto T = Instr.getSourceIndex();
     // Check source table index.
     EXPECTED_TRY(checkTableIdx(T));
-    if (unlikely(!Tables[T].second.isFuncRefType())) {
+    if (!AST::TypeMatcher::matchType(Types, TypeCode::FuncRef,
+                                     Tables[T].second)) {
       spdlog::error(ErrCode::Value::TypeCheckFailed);
       spdlog::error(ErrInfo::InfoMismatch(TypeCode::FuncRef, Tables[T].second));
       return Unexpect(ErrCode::Value::TypeCheckFailed);
@@ -661,7 +662,8 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
     auto T = Instr.getSourceIndex();
     // Check source table index.
     EXPECTED_TRY(checkTableIdx(T));
-    if (unlikely(!Tables[T].second.isFuncRefType())) {
+    if (!AST::TypeMatcher::matchType(Types, TypeCode::FuncRef,
+                                     Tables[T].second)) {
       spdlog::error(ErrCode::Value::TypeCheckFailed);
       spdlog::error(ErrInfo::InfoMismatch(TypeCode::FuncRef, Tables[T].second));
       return Unexpect(ErrCode::Value::TypeCheckFailed);

--- a/test/executor/ExecutorRegressionTest.cpp
+++ b/test/executor/ExecutorRegressionTest.cpp
@@ -482,6 +482,39 @@ std::array<WasmEdge::Byte, 134> ThrowRefMultiParamWasm{
     0x00, 0x03, 0x65, 0x78, 0x6e, 0x03, 0x0b, 0x01, 0x00, 0x02, 0x00, 0x02,
     0x68, 0x31, 0x02, 0x02, 0x68, 0x32, 0x0b, 0x06, 0x01, 0x00, 0x03, 0x65,
     0x72, 0x72};
+
+/// Binary Wasm module: call_indirect on a table whose element type is a
+/// concrete struct reference, not a funcref subtype.
+///
+/// The table is `(ref null $s)` where `$s` is a struct type, so it is NOT a
+/// subtype of funcref and call_indirect on it must be rejected at validation.
+/// The old check used `ValType::isFuncRefType()`, which reported *any* concrete
+/// type index as a funcref. The module therefore validated, and at runtime the
+/// struct reference was reinterpreted as a `FunctionInstance *` -- a type
+/// confusion in which the attacker-controlled v128 field bytes (here 0x41.. /
+/// 0x49) stand in for function metadata. The fix validates the table type with
+/// `TypeMatcher::matchType(.., FuncRef, ..)`, which resolves the concrete type
+/// index and rejects the struct-typed table.
+///
+/// (module
+///   (type $f (func))
+///   (type $s (struct (field v128)))
+///   (table 1 (ref null $s))
+///   (func (export "_start")
+///     i32.const 0
+///     v128.const i32x4 0x41414141 0x41414141 0x41414149 0x41414141
+///     struct.new $s
+///     table.set 0
+///     i32.const 0
+///     call_indirect (type $f)))
+std::array<WasmEdge::Byte, 77> CallIndirectStructTableWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x60,
+    0x00, 0x00, 0x5f, 0x01, 0x7b, 0x00, 0x03, 0x02, 0x01, 0x00, 0x04, 0x05,
+    0x01, 0x63, 0x01, 0x00, 0x01, 0x07, 0x0a, 0x01, 0x06, 0x5f, 0x73, 0x74,
+    0x61, 0x72, 0x74, 0x00, 0x00, 0x0a, 0x22, 0x01, 0x20, 0x00, 0x41, 0x00,
+    0xfd, 0x0c, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x49, 0x41,
+    0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0xfb, 0x00, 0x01, 0x26, 0x00, 0x41,
+    0x00, 0x11, 0x00, 0x00, 0x0b};
 // clang-format on
 
 /// Regression test for ref.test on externalized nullable references.
@@ -936,6 +969,27 @@ TEST(ExecutorRegression, ThrowRefPreservesPayload) {
     ASSERT_EQ((*Result).size(), 1U);
     EXPECT_EQ((*Result)[0].first.get<uint32_t>(), 1007U);
   }
+}
+
+/// Regression test for call_indirect on a non-funcref table (type confusion).
+///
+/// A table whose element type is a concrete struct reference is not a funcref
+/// subtype, so call_indirect on it must be rejected by validation. Before the
+/// fix, ValType::isFuncRefType() accepted any concrete type index, so the
+/// module passed validation and the executor reinterpreted the struct
+/// reference as a FunctionInstance pointer -- with the v128 struct field bytes
+/// acting as a forged function pointer. The validator now resolves the
+/// concrete type via TypeMatcher and rejects the module before it can run.
+TEST(ExecutorRegression, CallIndirectNonFuncTable) {
+  Configure Conf;
+  VM::VM VM(Conf);
+  // The module is well-formed and loads successfully...
+  ASSERT_TRUE(VM.loadWasm(CallIndirectStructTableWasm));
+  // ... but validation must reject call_indirect on the (ref null $s) table
+  // instead of letting the struct reference reach the executor as a function.
+  auto Result = VM.validate();
+  ASSERT_FALSE(Result);
+  EXPECT_EQ(Result.error(), ErrCode::Value::TypeCheckFailed);
 }
 
 } // namespace

--- a/test/host/wasi/wasi.cpp
+++ b/test/host/wasi/wasi.cpp
@@ -4003,6 +4003,9 @@ TEST(WasiTest, SymbolicLink) {
   WasmEdge::Host::WasiPathSymlink WasiPathSymlink(Env);
   WasmEdge::Host::WasiPathUnlinkFile WasiPathUnlinkFile(Env);
   WasmEdge::Host::WasiPathFilestatGet WasiPathFilestatGet(Env);
+  WasmEdge::Host::WasiPathCreateDirectory WasiPathCreateDirectory(Env);
+  WasmEdge::Host::WasiPathReadLink WasiPathReadLink(Env);
+  WasmEdge::Host::WasiPathRemoveDirectory WasiPathRemoveDirectory(Env);
   std::array<WasmEdge::ValVariant, 1> Errno = {UINT32_C(0)};
 
   const uint32_t Fd = 3;
@@ -4126,6 +4129,129 @@ TEST(WasiTest, SymbolicLink) {
                                    Fd, NewPathPtr, NewPathSize},
                                Errno));
     EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    Env.fini();
+  }
+
+  // Symlink targets resolving outside the preopen root are rejected; in-bounds
+  // targets are stored verbatim. Use spaced buffers so the targets and link
+  // names do not overlap in guest memory.
+  OldPathPtr = 0;
+  NewPathPtr = 64;
+  const auto makeSymlink = [&](std::string_view OldPath,
+                               std::string_view NewPath) {
+    writeString(MemInst, OldPath, OldPathPtr);
+    writeString(MemInst, NewPath, NewPathPtr);
+    EXPECT_TRUE(WasiPathSymlink.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            OldPathPtr, static_cast<uint32_t>(OldPath.size()), Fd, NewPathPtr,
+            static_cast<uint32_t>(NewPath.size())},
+        Errno));
+    return Errno[0].get<int32_t>();
+  };
+  // Read back the verbatim stored target of a link.
+  const uint32_t LinkBufPtr = 256;
+  const uint32_t NReadPtr = 600;
+  const auto readSymlink = [&](std::string_view NewPath) {
+    writeString(MemInst, NewPath, NewPathPtr);
+    EXPECT_TRUE(WasiPathReadLink.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            Fd, NewPathPtr, static_cast<uint32_t>(NewPath.size()), LinkBufPtr,
+            UINT32_C(256), NReadPtr},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    const auto NRead = *MemInst.getPointer<const uint32_t *>(NReadPtr);
+    return std::string(MemInst.getPointer<const char *>(LinkBufPtr), NRead);
+  };
+  const auto removeSymlink = [&](std::string_view NewPath) {
+    writeString(MemInst, NewPath, NewPathPtr);
+    EXPECT_TRUE(WasiPathUnlinkFile.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            Fd, NewPathPtr, static_cast<uint32_t>(NewPath.size())},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+  };
+
+  // absolute target rejected (control)
+  {
+    Env.init({"/:."s}, "test"s, {}, {});
+    EXPECT_EQ(makeSymlink("/etc/passwd"sv, "planted_abs_symlink"sv),
+              __WASI_ERRNO_PERM);
+    Env.fini();
+  }
+
+  // `..` targets at the preopen root escape and are rejected
+  {
+    Env.init({"/:."s}, "test"s, {}, {});
+    EXPECT_EQ(makeSymlink("../../etc/passwd"sv, "escape_a"sv),
+              __WASI_ERRNO_PERM);
+    EXPECT_EQ(makeSymlink("foo/../../etc/passwd"sv, "escape_b"sv),
+              __WASI_ERRNO_PERM);
+    EXPECT_EQ(makeSymlink(".."sv, "escape_c"sv), __WASI_ERRNO_PERM);
+    Env.fini();
+  }
+
+  // depth-1 link: in-bounds `..` accepted, deeper escape rejected
+  {
+    Env.init({"/:."s}, "test"s, {}, {});
+    writeString(MemInst, "sub"sv, NewPathPtr);
+    EXPECT_TRUE(
+        WasiPathCreateDirectory.run(CallFrame,
+                                    std::initializer_list<WasmEdge::ValVariant>{
+                                        Fd, NewPathPtr, UINT32_C(3)},
+                                    Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    // single `..` stays in bounds
+    EXPECT_EQ(makeSymlink("../sibling"sv, "sub/keep"sv), __WASI_ERRNO_SUCCESS);
+    EXPECT_EQ(readSymlink("sub/keep"sv), "../sibling");
+    // deeper `..` escapes, rejected
+    EXPECT_EQ(makeSymlink("../../../etc/passwd"sv, "sub/escape"sv),
+              __WASI_ERRNO_PERM);
+    removeSymlink("sub/keep"sv);
+    writeString(MemInst, "sub"sv, NewPathPtr);
+    EXPECT_TRUE(
+        WasiPathRemoveDirectory.run(CallFrame,
+                                    std::initializer_list<WasmEdge::ValVariant>{
+                                        Fd, NewPathPtr, UINT32_C(3)},
+                                    Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_SUCCESS);
+    Env.fini();
+  }
+
+  // in-bounds targets stored verbatim
+  {
+    Env.init({"/:."s}, "test"s, {}, {});
+    EXPECT_EQ(makeSymlink("sibling_file"sv, "safe_same_dir"sv),
+              __WASI_ERRNO_SUCCESS);
+    EXPECT_EQ(readSymlink("safe_same_dir"sv), "sibling_file");
+    EXPECT_EQ(makeSymlink("a/../sibling_file"sv, "safe_normalized"sv),
+              __WASI_ERRNO_SUCCESS);
+    EXPECT_EQ(readSymlink("safe_normalized"sv), "a/../sibling_file");
+    removeSymlink("safe_same_dir"sv);
+    removeSymlink("safe_normalized"sv);
+    Env.fini();
+  }
+
+  // the new path's trailing component is not followed: creating a link where
+  // one already exists fails with EEXIST instead of being created at the
+  // existing link's target
+  {
+    Env.init({"/:."s}, "test"s, {}, {});
+    EXPECT_EQ(makeSymlink("target_x"sv, "existing_link"sv),
+              __WASI_ERRNO_SUCCESS);
+    EXPECT_EQ(makeSymlink("target_y"sv, "existing_link"sv), __WASI_ERRNO_EXIST);
+    // the original link is untouched and no link named after its target exists
+    EXPECT_EQ(readSymlink("existing_link"sv), "target_x");
+    writeString(MemInst, "target_x"sv, NewPathPtr);
+    EXPECT_TRUE(WasiPathReadLink.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            Fd, NewPathPtr, UINT32_C(8), LinkBufPtr, UINT32_C(256), NReadPtr},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_NOENT);
+    removeSymlink("existing_link"sv);
     Env.fini();
   }
 }


### PR DESCRIPTION
## Description

Features:

* [CAPI]
  * feat(api): version C ABI symbols for the 0.16 -> 0.17 limit change (#4951)

Fixed issues:

* [Validator]
  * fix: reject non-funcref tables/refs in call_indirect and call_ref (#4920)
* [WASI]
  * fix(wasi): reject symlink targets that resolve outside the preopen root (#4938)
* [WASI-Logging]
  * fix(plugin/wasi-logging): keep the default logger alive across instances

## Checklist

Before submitting this PR, please ensure the following:

- [ ] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [ ] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
