### PR TITLE
feat(validator): enable component-model invalid spec tests

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1130,6 +1130,8 @@ E(ComponentImportNameConflict, 0x02B8,
   "import name conflicts with previous name")
 // Component alias references an export the instance does not provide
 E(ComponentUnknownExport, 0x02B9, "unknown export")
+// Core type index referenced in a component core:moduledecl is out of bounds
+E(CoreTypeIndexOutOfBounds, 0x02BA, "type index out of bounds")
 // @}
 
 // Instantiation phase

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -1998,10 +1998,10 @@ Validator::validate(const AST::Component::CoreImportDesc &Desc) noexcept {
     uint32_t TypeIdx = Desc.getTypeIndex();
     if (TypeIdx >= CompCtx.getCoreSortIndexSize(
                        AST::Component::Sort::CoreSortType::Type)) {
-      spdlog::error(ErrCode::Value::InvalidIndex);
+      spdlog::error(ErrCode::Value::CoreTypeIndexOutOfBounds);
       spdlog::error("    CoreImportDesc: func type index {} out of bounds"sv,
                     TypeIdx);
-      return Unexpect(ErrCode::Value::InvalidIndex);
+      return Unexpect(ErrCode::Value::CoreTypeIndexOutOfBounds);
     }
     CompCtx.addCoreFunc();
   } else if (Desc.isTable()) {

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -331,7 +331,7 @@ std::map<std::string, ComponentModelSupport> ComponentModelFolders = {
     {"inline-exports",          {true, true,  true,  false}},
     {"instance-types",          {true, true,  true,  false}},
     {"instantiate",             {true, false, false, false}},
-    {"invalid",                 {true, false, false, false}},
+    {"invalid",                 {true, true,  false, false}},
     {"link",                    {true, true,  true,  false}},
     {"lots-of-aliases",         {true, true,  true,  false}},
     {"lower",                   {true, false, false, false}},


### PR DESCRIPTION
A core:moduledecl import that references an out-of-range core type index now reports "type index out of bounds" instead of the generic "invalid index", matching the spec diagnostic. Flip the invalid folder to validate=true.
This enables the `invalid` folder of the component-model spec tests (targeting dev/component).

The folder was already almost there  WasmEdge rejects all the invalid cases correctly. The only mismatch was one diagnostic: when a core:moduledecl import references a core type index that's out of range, e.g.

    (core type (module (import "" "" (func (type 1)))))   ;; no type 1 exists

WasmEdge reported the generic "invalid index", but the spec test expects "type index out of bounds".

So I added a CoreTypeIndexOutOfBounds error code and used it at that check in the CoreImportDesc validation, then flipped the invalid folder to validate=true.

Testing:
  - the invalid spec test passes
  - the full spec test suite still passes (525 tests), no regression
  - clang-format (20) clean

Signed-off-by: Parth Dagia <parth.24bcs10414@sst.scaler.com>
