### PR TITLE
feat(validator): enable component-model memory64 spec tests

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1130,6 +1130,12 @@ E(ComponentImportNameConflict, 0x02B8,
   "import name conflicts with previous name")
 // Component alias references an export the instance does not provide
 E(ComponentUnknownExport, 0x02B9, "unknown export")
+// Core instance arg memory index type does not match the import (i32 vs i64)
+E(ComponentMemoryIndexTypeMismatch, 0x02BA,
+  "mismatch in index type used for memories")
+// Canonical option `memory` must reference a 32-bit linear memory
+E(ComponentCanonMemoryNot32Bit, 0x02BB,
+  "canonical ABI memory is not a 32-bit linear memory")
 // @}
 
 // Instantiation phase

--- a/include/validator/component_context.h
+++ b/include/validator/component_context.h
@@ -74,6 +74,13 @@ public:
       // True for validate(DefType) in this scope. Gates resource.new/.rep.
       bool LocallyDefined = false;
     };
+    // Export of a core:instance. Kind is always set; Mem is populated for
+    // memory exports so instantiation can subtype-check the index type
+    // (GAP-CI-1).
+    struct CoreInstanceExport {
+      ExternalType Kind;
+      const AST::MemoryType *Mem = nullptr;
+    };
 
     // ---- Scope identity ----
     const AST::Component::Component *Component;
@@ -81,7 +88,7 @@ public:
 
     // ---- Core sort index spaces ----
     std::vector<CoreModuleSlot> CoreModules; // core:module
-    std::vector<std::unordered_map<std::string, ExternalType>>
+    std::vector<std::unordered_map<std::string, CoreInstanceExport>>
         CoreInstances;                                 // core:instance
     std::vector<const AST::SubType *> CoreTypes;       // core:type
     std::vector<const AST::SubType *> CoreFuncs;       // core:func
@@ -243,14 +250,16 @@ public:
     return Idx;
   }
 
-  const std::unordered_map<std::string, ExternalType> &
+  const std::unordered_map<std::string, Context::CoreInstanceExport> &
   getCoreInstance(uint32_t Idx) const noexcept {
     return getCurrentContext().CoreInstances.at(Idx);
   }
 
   void addCoreInstanceExport(uint32_t InstIdx, std::string_view Name,
-                             ExternalType ET) {
-    getCurrentContext().CoreInstances.at(InstIdx)[std::string(Name)] = ET;
+                             ExternalType ET,
+                             const AST::MemoryType *Mem = nullptr) {
+    getCurrentContext().CoreInstances.at(InstIdx)[std::string(Name)] =
+        Context::CoreInstanceExport{ET, Mem};
   }
 
   // ==========================================================================
@@ -285,6 +294,10 @@ public:
     uint32_t Idx = static_cast<uint32_t>(V.size());
     V.push_back(MT);
     return Idx;
+  }
+  const AST::MemoryType *getCoreMemory(uint32_t Idx) const noexcept {
+    const auto &V = getCurrentContext().CoreMemories;
+    return Idx < V.size() ? V[Idx] : nullptr;
   }
   uint32_t addCoreGlobal(const AST::GlobalType *GT = nullptr) noexcept {
     auto &V = getCurrentContext().CoreGlobals;

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -405,8 +405,28 @@ Validator::validate(const AST::Component::AliasSection &AliasSec) noexcept {
     const bool IsOuter =
         Alias.getTargetType() == AST::Component::Alias::TargetType::Outer;
     if (Sort.isCore()) {
-      uint32_t NewCoreIdx =
-          CompCtx.incCoreSortIndexSize(Sort.getCoreSortType());
+      uint32_t NewCoreIdx;
+      // For an `alias core export` of a memory, carry the source memory's type
+      // into the core-memory sort space so canonical options can subtype-check
+      // its index type later (GAP-CI-1).
+      if (Alias.getTargetType() ==
+              AST::Component::Alias::TargetType::CoreExport &&
+          Sort.getCoreSortType() ==
+              AST::Component::Sort::CoreSortType::Memory) {
+        const AST::MemoryType *SrcMem = nullptr;
+        const auto SrcIdx = Alias.getExport().first;
+        if (SrcIdx < CompCtx.getCoreSortIndexSize(
+                         AST::Component::Sort::CoreSortType::Instance)) {
+          const auto &Exports = CompCtx.getCoreInstance(SrcIdx);
+          const auto It = Exports.find(std::string(Alias.getExport().second));
+          if (It != Exports.end()) {
+            SrcMem = It->second.Mem;
+          }
+        }
+        NewCoreIdx = CompCtx.addCoreMemory(SrcMem);
+      } else {
+        NewCoreIdx = CompCtx.incCoreSortIndexSize(Sort.getCoreSortType());
+      }
       // Carry the outer-aliased module's slot so the alias stays enumerable
       // when instantiated.
       if (IsOuter && Sort.getCoreSortType() ==
@@ -654,12 +674,73 @@ Validator::validate(const AST::Component::CoreInstance &Inst) noexcept {
       }
     }
 
+    // GAP-CI-1: the index type (i32/i64) of each provided memory must match
+    // the corresponding memory import of the instantiated module.
+    if (Mod != nullptr) {
+      const uint32_t InstCount = CompCtx.getCoreSortIndexSize(
+          AST::Component::Sort::CoreSortType::Instance);
+      for (const auto &Import : Mod->getImportSection().getContent()) {
+        if (Import.getExternalType() != ExternalType::Memory) {
+          continue;
+        }
+        const auto ArgIt =
+            std::find_if(Args.begin(), Args.end(), [&](const auto &Arg) {
+              return Arg.getName() == Import.getModuleName();
+            });
+        if (ArgIt == Args.end() || ArgIt->getIndex() >= InstCount) {
+          continue;
+        }
+        const auto &ProvExports = CompCtx.getCoreInstance(ArgIt->getIndex());
+        const auto ExpIt =
+            ProvExports.find(std::string(Import.getExternalName()));
+        if (ExpIt == ProvExports.end() ||
+            ExpIt->second.Kind != ExternalType::Memory ||
+            ExpIt->second.Mem == nullptr) {
+          continue;
+        }
+        if (Import.getExternalMemoryType().getLimit().is64() !=
+            ExpIt->second.Mem->getLimit().is64()) {
+          spdlog::error(ErrCode::Value::ComponentMemoryIndexTypeMismatch);
+          spdlog::error(
+              "    CoreInstance: memory import '{}'.'{}' index type does not "
+              "match the provided memory"sv,
+              Import.getModuleName(), Import.getExternalName());
+          spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_CoreInstance));
+          return Unexpect(ErrCode::Value::ComponentMemoryIndexTypeMismatch);
+        }
+      }
+    }
+
     // Allocate the core:instance and bind exports to it.
     uint32_t InstanceIdx = CompCtx.addCoreInstance();
     if (Mod != nullptr) {
       for (const auto &ExportDesc : Mod->getExportSection().getContent()) {
+        // Resolve the memory type so re-exports carry their index type for
+        // later instantiation subtype checks (GAP-CI-1).
+        const AST::MemoryType *MemTy = nullptr;
+        if (ExportDesc.getExternalType() == ExternalType::Memory) {
+          const uint32_t Target = ExportDesc.getExternalIndex();
+          uint32_t MemImpCount = 0;
+          for (const auto &Imp : Mod->getImportSection().getContent()) {
+            if (Imp.getExternalType() != ExternalType::Memory) {
+              continue;
+            }
+            if (MemImpCount == Target) {
+              MemTy = &Imp.getExternalMemoryType();
+              break;
+            }
+            ++MemImpCount;
+          }
+          if (MemTy == nullptr) {
+            const auto Mems = Mod->getMemorySection().getContent();
+            const uint32_t Local = Target - MemImpCount;
+            if (Local < Mems.size()) {
+              MemTy = &Mems[Local];
+            }
+          }
+        }
         CompCtx.addCoreInstanceExport(InstanceIdx, ExportDesc.getExternalName(),
-                                      ExportDesc.getExternalType());
+                                      ExportDesc.getExternalType(), MemTy);
       }
     } else if (ModTy != nullptr && ModTy->isModuleType()) {
       for (const auto &Decl : ModTy->getModuleType()) {
@@ -1108,7 +1189,7 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
       return Unexpect(ErrCode::Value::ExportNotFound);
     }
 
-    const auto ExternTy = It->second;
+    const auto ExternTy = It->second.Kind;
     AST::Component::Sort::CoreSortType ST;
     switch (ExternTy) {
     case ExternalType::Function:
@@ -1442,6 +1523,19 @@ Expect<void> Validator::validateCanonOptions(
         MemoryIdx);
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
     return Unexpect(ErrCode::Value::InvalidIndex);
+  }
+  // The canonical ABI requires a 32-bit linear memory (GAP-CI-1).
+  if (HasMemory) {
+    const auto *Mem = CompCtx.getCoreMemory(MemoryIdx);
+    if (Mem != nullptr && Mem->getLimit().is64()) {
+      spdlog::error(ErrCode::Value::ComponentCanonMemoryNot32Bit);
+      spdlog::error(
+          "    canonical option 'memory': core memory {} is not a 32-bit "
+          "linear memory"sv,
+          MemoryIdx);
+      spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+      return Unexpect(ErrCode::Value::ComponentCanonMemoryNot32Bit);
+    }
   }
   const uint32_t CoreFuncSpaceSize =
       CompCtx.getCoreSortIndexSize(AST::Component::Sort::CoreSortType::Func);

--- a/test/component/ComponentValidatorTest.cpp
+++ b/test/component/ComponentValidatorTest.cpp
@@ -2031,4 +2031,76 @@ TEST(ComponentValidatorTest, InstantiateImportedComponentMissingArgRejected) {
   ASSERT_FALSE(V.validate(Comp));
 }
 
+// =============================================================================
+// Core instance memory index-type checking on instantiation (GAP-CI-1)
+// =============================================================================
+
+namespace {
+// Builds:
+//   (core module $A (import "" "" (memory 1)))   ;; imports a 32-bit memory
+//   (core module $B (memory (export "") <mem>))  ;; exports `Mem`
+//   (core instance $b (instantiate $B))
+//   (core instance $a (instantiate $A (with "" (instance $b))))
+// so the provided memory's index type is checked against $A's import.
+AST::Component::Component buildMemoryLinkComponent(const AST::MemoryType &Mem) {
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CoreModuleSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CoreModuleSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CoreInstanceSection>();
+
+  // Module 0 ($A): import a 32-bit memory.
+  auto &ModA =
+      std::get<AST::Component::CoreModuleSection>(Comp.getSections()[0])
+          .getContent();
+  AST::ImportDesc ImpA;
+  ImpA.setModuleName("");
+  ImpA.setExternalName("");
+  ImpA.setExternalType(ExternalType::Memory);
+  ImpA.getExternalMemoryType() = AST::MemoryType(AST::Limit(1));
+  ModA.getImportSection().getContent().push_back(std::move(ImpA));
+
+  // Module 1 ($B): define and export `Mem`.
+  auto &ModB =
+      std::get<AST::Component::CoreModuleSection>(Comp.getSections()[1])
+          .getContent();
+  ModB.getMemorySection().getContent().push_back(Mem);
+  AST::ExportDesc EDB;
+  EDB.setExternalName("");
+  EDB.setExternalType(ExternalType::Memory);
+  EDB.setExternalIndex(0);
+  ModB.getExportSection().getContent().push_back(std::move(EDB));
+
+  // Core instance 0: instantiate module 1 ($B).
+  auto &CoreInstSec =
+      std::get<AST::Component::CoreInstanceSection>(Comp.getSections()[2]);
+  CoreInstSec.getContent().emplace_back();
+  CoreInstSec.getContent().back().setInstantiateArgs(
+      1U, AST::Component::CoreInstance::InstantiateArgs{});
+  // Core instance 1: instantiate module 0 ($A) with instance 0 as arg "".
+  AST::Component::InstantiateArg<uint32_t> Arg;
+  Arg.getName() = "";
+  Arg.getIndex() = 0U;
+  CoreInstSec.getContent().emplace_back();
+  CoreInstSec.getContent().back().setInstantiateArgs(0U, {Arg});
+  return Comp;
+}
+} // namespace
+
+TEST(ComponentValidatorTest, CoreInstanceMemoryIndexTypeMismatchRejected) {
+  // Provide a 64-bit memory where a 32-bit memory is imported -> reject.
+  auto Comp = buildMemoryLinkComponent(AST::MemoryType(AST::Limit(1, true)));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CoreInstanceMemoryIndexTypeMatchAccepted) {
+  // Provide a 32-bit memory matching the 32-bit import -> accept.
+  auto Comp = buildMemoryLinkComponent(AST::MemoryType(AST::Limit(1)));
+  Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
 } // namespace

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -335,7 +335,7 @@ std::map<std::string, ComponentModelSupport> ComponentModelFolders = {
     {"link",                    {true, true,  true,  false}},
     {"lots-of-aliases",         {true, true,  true,  false}},
     {"lower",                   {true, false, false, false}},
-    {"memory64",                {true, false, false, false}},
+    {"memory64",                {true, true,  false, false}},
     {"module-link",             {true, true,  false, false}},
     {"more-flags",              {true, true,  true,  false}},
     {"naming",                  {true, true,  false, false}},


### PR DESCRIPTION
The validator tracked core export kinds but not types, so it ignored core memory index types (i32 vs i64). Check that each provided memory matches its import on instantiation, reject a non-32-bit canonical memory option, and carry memory types through core:instance exports and alias core export to support both. Flip memory64 to validate=true.

This enables the memory64 folder of the component-model spec tests (targeting dev/component).

These cases check that the validator respects core memory index types (i32 vs i64), which it currently ignores it tracks core export kinds but not their types, so:

  - instantiating a module that imports an i32 memory with a provider exporting an i64 memory (or vice versa) was wrongly accepted, and
  - a canon lift/lower could point its `memory` option at a 64-bit memory.

To fix it I carry a bit of the type info that GAP-CI-1 leaves out today:
  - core:instance exports now record the MemoryType for memory exports (not just the kind),
  - `alias core export` of a memory carries that type into the core-memory sort space,
  - core-module instantiation subtype-checks each provided memory against the import, and
  - validateCanonOptions rejects a non-32-bit canonical memory.

Scoped to memories (what memory64 exercises); the same plumbing is the natural place to extend to full func/table/global instance subtyping later.

Testing:
  - the memory64 spec test passes
  - the full spec test suite still passes (525 tests), no regression
  - clang-format (20) clean



