### PR TITLE
feat(wasi_crypto): implement EdDSA toKeyPair

### DIFF
--- a/test/plugins/wasi_crypto/signatures.cpp
+++ b/test/plugins/wasi_crypto/signatures.cpp
@@ -91,6 +91,52 @@ TEST_F(WasiCryptoTest, Signatures) {
   PublicKeyImportInvalidSecTest(__WASI_ALGORITHM_TYPE_SIGNATURES,
                                 "ECDSA_P256_SHA256"sv);
 
+  auto KeypairFromPkAndSkTest = [this](__wasi_algorithm_type_e_t AlgType,
+                                       std::string_view Alg) {
+    SCOPED_TRACE(Alg);
+    WASI_CRYPTO_EXPECT_SUCCESS(KpHandle,
+                               keypairGenerate(AlgType, Alg, std::nullopt));
+    WASI_CRYPTO_EXPECT_SUCCESS(PkHandle, keypairPublickey(KpHandle));
+    WASI_CRYPTO_EXPECT_SUCCESS(SkHandle, keypairSecretkey(KpHandle));
+
+    WASI_CRYPTO_EXPECT_SUCCESS(NewKpHandle,
+                               keypairFromPkAndSk(PkHandle, SkHandle));
+
+    // Verify it works by signing and verifying.
+    WASI_CRYPTO_EXPECT_SUCCESS(StateHandle, signatureStateOpen(NewKpHandle));
+    WASI_CRYPTO_EXPECT_TRUE(signatureStateUpdate(StateHandle, "test"_u8));
+    WASI_CRYPTO_EXPECT_SUCCESS(SigHandle, signatureStateSign(StateHandle));
+    WASI_CRYPTO_EXPECT_TRUE(signatureStateClose(StateHandle));
+
+    WASI_CRYPTO_EXPECT_SUCCESS(VerifictionStateHandle,
+                               signatureVerificationStateOpen(PkHandle));
+    WASI_CRYPTO_EXPECT_TRUE(
+        signatureVerificationStateUpdate(VerifictionStateHandle, "test"_u8));
+    WASI_CRYPTO_EXPECT_TRUE(
+        signatureVerificationStateVerify(VerifictionStateHandle, SigHandle));
+    WASI_CRYPTO_EXPECT_TRUE(
+        signatureVerificationStateClose(VerifictionStateHandle));
+
+    WASI_CRYPTO_EXPECT_TRUE(keypairClose(NewKpHandle));
+  };
+  KeypairFromPkAndSkTest(__WASI_ALGORITHM_TYPE_SIGNATURES, "Ed25519"sv);
+
+  auto KeypairFromPkAndSkMismatchTest = [this](__wasi_algorithm_type_e_t AlgType,
+                                               std::string_view Alg) {
+    SCOPED_TRACE(Alg);
+    WASI_CRYPTO_EXPECT_SUCCESS(KpHandle1,
+                               keypairGenerate(AlgType, Alg, std::nullopt));
+    WASI_CRYPTO_EXPECT_SUCCESS(PkHandle1, keypairPublickey(KpHandle1));
+    
+    WASI_CRYPTO_EXPECT_SUCCESS(KpHandle2,
+                               keypairGenerate(AlgType, Alg, std::nullopt));
+    WASI_CRYPTO_EXPECT_SUCCESS(SkHandle2, keypairSecretkey(KpHandle2));
+
+    WASI_CRYPTO_EXPECT_FAILURE(keypairFromPkAndSk(PkHandle1, SkHandle2),
+                               __WASI_CRYPTO_ERRNO_INVALID_KEY);
+  };
+  KeypairFromPkAndSkMismatchTest(__WASI_ALGORITHM_TYPE_SIGNATURES, "Ed25519"sv);
+
   auto SigEncodingTest =
       [this](
           std::string_view Alg,

--- a/test/plugins/wasi_crypto/signatures.cpp
+++ b/test/plugins/wasi_crypto/signatures.cpp
@@ -127,7 +127,7 @@ TEST_F(WasiCryptoTest, Signatures) {
     WASI_CRYPTO_EXPECT_SUCCESS(KpHandle1,
                                keypairGenerate(AlgType, Alg, std::nullopt));
     WASI_CRYPTO_EXPECT_SUCCESS(PkHandle1, keypairPublickey(KpHandle1));
-    
+
     WASI_CRYPTO_EXPECT_SUCCESS(KpHandle2,
                                keypairGenerate(AlgType, Alg, std::nullopt));
     WASI_CRYPTO_EXPECT_SUCCESS(SkHandle2, keypairSecretkey(KpHandle2));

--- a/test/plugins/wasi_crypto/signatures.cpp
+++ b/test/plugins/wasi_crypto/signatures.cpp
@@ -133,7 +133,7 @@ TEST_F(WasiCryptoTest, Signatures) {
     WASI_CRYPTO_EXPECT_SUCCESS(SkHandle2, keypairSecretkey(KpHandle2));
 
     WASI_CRYPTO_EXPECT_FAILURE(keypairFromPkAndSk(PkHandle1, SkHandle2),
-                               __WASI_CRYPTO_ERRNO_INVALID_KEY);
+                               __WASI_CRYPTO_ERRNO_INCOMPATIBLE_KEYS);
   };
   KeypairFromPkAndSkMismatchTest(__WASI_ALGORITHM_TYPE_SIGNATURES, "Ed25519"sv);
 


### PR DESCRIPTION
## Description
<!-- Describe your changes here -->
This PR adds tests `KeypairFromPkAndSkTest` and `KeypairFromPkAndSkMismatchTest` for the function `EdDSA::SecretKey::toKeyPair` implemented in #4985
Part of https://github.com/WasmEdge/WasmEdge/issues/2669
## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->
<img width="927" height="328" alt="Screenshot_20260619_134051" src="https://github.com/user-attachments/assets/927fa4c6-c9c7-4fce-86d6-f0cde8d22527" />


