### PR TITLE
feat(validator): check core global/table types on component instantiation

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1138,6 +1138,12 @@ E(ComponentMemoryIndexTypeMismatch, 0x02BB,
 // Canonical option `memory` must reference a 32-bit linear memory
 E(ComponentCanonMemoryNot32Bit, 0x02BC,
   "canonical ABI memory is not a 32-bit linear memory")
+// Core instance arg global type does not match the import
+E(ComponentGlobalTypeMismatch, 0x02BD, "type mismatch in global type")
+// Core instance arg table limits do not match the import
+E(ComponentTableLimitsMismatch, 0x02BE, "mismatch in table limits")
+// Core instance arg table element type does not match the import
+E(ComponentTableElemTypeMismatch, 0x02BF, "type mismatch in table element type")
 // @}
 
 // Instantiation phase

--- a/include/validator/component_context.h
+++ b/include/validator/component_context.h
@@ -81,7 +81,30 @@ public:
     // (GAP-CI-1).
     struct CoreInstanceExport {
       ExternalType Kind;
-      const AST::MemoryType *Mem = nullptr;
+      // Stored by value (not pointer): the module-type descriptor getter
+      // returns a temporary, so a pointer into it would dangle. Each optional
+      // is populated only for its matching Kind, for instantiation subtype
+      // checks (GAP-CI-1).
+      std::optional<AST::MemoryType> Mem;
+      std::optional<AST::TableType> Tab;
+      std::optional<AST::GlobalType> Glob;
+
+      CoreInstanceExport() noexcept = default;
+      // Copies whichever core extern type is provided (the others stay empty).
+      CoreInstanceExport(ExternalType K, const AST::MemoryType *M,
+                         const AST::TableType *T,
+                         const AST::GlobalType *G) noexcept
+          : Kind(K) {
+        if (M != nullptr) {
+          Mem = *M;
+        }
+        if (T != nullptr) {
+          Tab = *T;
+        }
+        if (G != nullptr) {
+          Glob = *G;
+        }
+      }
     };
 
     // ---- Scope identity ----
@@ -259,9 +282,11 @@ public:
 
   void addCoreInstanceExport(uint32_t InstIdx, std::string_view Name,
                              ExternalType ET,
-                             const AST::MemoryType *Mem = nullptr) {
+                             const AST::MemoryType *Mem = nullptr,
+                             const AST::TableType *Tab = nullptr,
+                             const AST::GlobalType *Glob = nullptr) {
     getCurrentContext().CoreInstances.at(InstIdx)[std::string(Name)] =
-        Context::CoreInstanceExport{ET, Mem};
+        Context::CoreInstanceExport{ET, Mem, Tab, Glob};
   }
 
   // ==========================================================================

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -421,8 +421,8 @@ Validator::validate(const AST::Component::AliasSection &AliasSec) noexcept {
                          AST::Component::Sort::CoreSortType::Instance)) {
           const auto &Exports = CompCtx.getCoreInstance(SrcIdx);
           const auto It = Exports.find(std::string(Alias.getExport().second));
-          if (It != Exports.end()) {
-            SrcMem = It->second.Mem;
+          if (It != Exports.end() && It->second.Mem.has_value()) {
+            SrcMem = &*It->second.Mem;
           }
         }
         NewCoreIdx = CompCtx.addCoreMemory(SrcMem);
@@ -697,7 +697,7 @@ Validator::validate(const AST::Component::CoreInstance &Inst) noexcept {
             ProvExports.find(std::string(Import.getExternalName()));
         if (ExpIt == ProvExports.end() ||
             ExpIt->second.Kind != ExternalType::Memory ||
-            ExpIt->second.Mem == nullptr) {
+            !ExpIt->second.Mem.has_value()) {
           continue;
         }
         if (Import.getExternalMemoryType().getLimit().is64() !=
@@ -709,6 +709,82 @@ Validator::validate(const AST::Component::CoreInstance &Inst) noexcept {
               Import.getModuleName(), Import.getExternalName());
           spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_CoreInstance));
           return Unexpect(ErrCode::Value::ComponentMemoryIndexTypeMismatch);
+        }
+      }
+    }
+
+    // GAP-CI-1 (cont.): for an imported core module type, subtype-check each
+    // provided core extern (memory / table / global) against the import.
+    if (ModTy != nullptr && ModTy->isModuleType()) {
+      const uint32_t InstCount = CompCtx.getCoreSortIndexSize(
+          AST::Component::Sort::CoreSortType::Instance);
+      for (const auto &Decl : ModTy->getModuleType()) {
+        if (!Decl.isImport()) {
+          continue;
+        }
+        const auto &Imp = Decl.getImport();
+        const auto Desc = Imp.getImportDesc();
+        if (!Desc.isMemory() && !Desc.isTable() && !Desc.isGlobal()) {
+          continue;
+        }
+        const auto ArgIt =
+            std::find_if(Args.begin(), Args.end(), [&](const auto &Arg) {
+              return Arg.getName() == Imp.getModuleName();
+            });
+        if (ArgIt == Args.end() || ArgIt->getIndex() >= InstCount) {
+          continue;
+        }
+        const auto &ProvExports = CompCtx.getCoreInstance(ArgIt->getIndex());
+        const auto ExpIt = ProvExports.find(std::string(Imp.getName()));
+        if (ExpIt == ProvExports.end()) {
+          continue;
+        }
+        const auto &Got = ExpIt->second;
+        auto reportMismatch =
+            [&](ErrCode::Value Code,
+                std::string_view What) -> Unexpected<ErrCode> {
+          spdlog::error(Code);
+          spdlog::error("    CoreInstance: import '{}'.'{}' {}"sv,
+                        Imp.getModuleName(), Imp.getName(), What);
+          spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_CoreInstance));
+          return Unexpect(Code);
+        };
+        if (Desc.isMemory() && Got.Kind == ExternalType::Memory &&
+            Got.Mem.has_value()) {
+          const auto &W = Desc.getMemoryType().getLimit();
+          const auto &G = Got.Mem->getLimit();
+          if (W.is64() != G.is64()) {
+            return reportMismatch(
+                ErrCode::Value::ComponentMemoryIndexTypeMismatch,
+                "memory index type mismatch");
+          }
+        } else if (Desc.isTable() && Got.Kind == ExternalType::Table &&
+                   Got.Tab.has_value()) {
+          const auto &W = Desc.getTableType();
+          const auto &G = *Got.Tab;
+          if (!(W.getRefType() == G.getRefType())) {
+            return reportMismatch(
+                ErrCode::Value::ComponentTableElemTypeMismatch,
+                "table element type mismatch");
+          }
+          const auto &WL = W.getLimit();
+          const auto &GL = G.getLimit();
+          const bool LimitsOk =
+              GL.is64() == WL.is64() && GL.getMin() >= WL.getMin() &&
+              (!WL.hasMax() || (GL.hasMax() && GL.getMax() <= WL.getMax()));
+          if (!LimitsOk) {
+            return reportMismatch(ErrCode::Value::ComponentTableLimitsMismatch,
+                                  "table limits mismatch");
+          }
+        } else if (Desc.isGlobal() && Got.Kind == ExternalType::Global &&
+                   Got.Glob.has_value()) {
+          const auto &W = Desc.getGlobalType();
+          const auto &G = *Got.Glob;
+          if (!(W.getValType() == G.getValType()) ||
+              W.getValMut() != G.getValMut()) {
+            return reportMismatch(ErrCode::Value::ComponentGlobalTypeMismatch,
+                                  "global type mismatch");
+          }
         }
       }
     }
@@ -765,7 +841,17 @@ Validator::validate(const AST::Component::CoreInstance &Inst) noexcept {
         } else {
           continue;
         }
-        CompCtx.addCoreInstanceExport(InstanceIdx, Exp.getName(), ET);
+        // Carry the core extern type so a later instantiation can subtype-check
+        // it (GAP-CI-1). Pointers are copied into the export entry immediately,
+        // so pointing into the temporary descriptor is safe here.
+        const AST::MemoryType *MemTy =
+            ImpDesc.isMemory() ? &ImpDesc.getMemoryType() : nullptr;
+        const AST::TableType *TabTy =
+            ImpDesc.isTable() ? &ImpDesc.getTableType() : nullptr;
+        const AST::GlobalType *GlobTy =
+            ImpDesc.isGlobal() ? &ImpDesc.getGlobalType() : nullptr;
+        CompCtx.addCoreInstanceExport(InstanceIdx, Exp.getName(), ET, MemTy,
+                                      TabTy, GlobTy);
       }
     }
   } else if (Inst.isInlineExport()) {

--- a/test/component/ComponentValidatorTest.cpp
+++ b/test/component/ComponentValidatorTest.cpp
@@ -2295,4 +2295,168 @@ TEST(ComponentValidatorTest, EndToEnd_CanonLift_NoReallocRejected) {
   EXPECT_FALSE(VM.validate());
 }
 
+// =============================================================================
+// Core instance global/table/memory checking via an imported core MODULE TYPE
+// (GAP-CI-1). Unlike the raw-module tests above, these drive the imported
+// module-type subtype path: the instantiated module's core externs come from a
+// CoreModuleType (not an inline AST::Module).
+// =============================================================================
+
+namespace {
+// Builds a component that links two imported core modules by type:
+//   (core type (module (export "g" <ExpDesc>)))      ;; core:type 0 (provider)
+//   (core type (module (import "provider" "g" <ImpDesc>)))  ;; core:type 1
+//   (import "provider-mod" (core module (type 0)))    ;; core:module 0
+//   (import "consumer-mod" (core module (type 1)))    ;; core:module 1
+//   (core instance (instantiate 0))                   ;; core instance 0
+//   (core instance (instantiate 1 (with "provider" (instance 0))))
+// so the provider's exported core extern is subtype-checked against the
+// consumer's import on instantiation.
+AST::Component::Component
+buildCoreModuleLinkComponent(AST::Component::CoreImportDesc ExpDesc,
+                             AST::Component::CoreImportDesc ImpDesc) {
+  AST::Component::Component Comp;
+
+  // CoreTypeSection with the two module types.
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CoreTypeSection>();
+  auto &CoreTypeSec =
+      std::get<AST::Component::CoreTypeSection>(Comp.getSections().back());
+
+  // core:type 0 (provider): (module (export "g" <ExpDesc>))
+  std::vector<AST::Component::CoreModuleDecl> Decls0;
+  AST::Component::CoreExportDecl CExp;
+  CExp.getName() = "g";
+  CExp.getImportDesc() = std::move(ExpDesc);
+  AST::Component::CoreModuleDecl DE;
+  DE.setExport(std::move(CExp));
+  Decls0.push_back(std::move(DE));
+  CoreTypeSec.getContent().emplace_back();
+  CoreTypeSec.getContent().back().setModuleType(std::move(Decls0));
+
+  // core:type 1 (consumer): (module (import "provider" "g" <ImpDesc>))
+  std::vector<AST::Component::CoreModuleDecl> Decls1;
+  AST::Component::CoreImportDecl CImp;
+  CImp.getModuleName() = "provider";
+  CImp.getName() = "g";
+  CImp.getImportDesc() = std::move(ImpDesc);
+  AST::Component::CoreModuleDecl DI;
+  DI.setImport(std::move(CImp));
+  Decls1.push_back(std::move(DI));
+  CoreTypeSec.getContent().emplace_back();
+  CoreTypeSec.getContent().back().setModuleType(std::move(Decls1));
+
+  // ImportSection: import the two core modules ascribed to those types.
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+  auto &ImpSec =
+      std::get<AST::Component::ImportSection>(Comp.getSections().back());
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "provider-mod";
+  ImpSec.getContent().back().getDesc().setCoreTypeIdx(0);
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "consumer-mod";
+  ImpSec.getContent().back().getDesc().setCoreTypeIdx(1);
+
+  // CoreInstanceSection: instantiate provider then consumer.
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CoreInstanceSection>();
+  auto &CoreInstSec =
+      std::get<AST::Component::CoreInstanceSection>(Comp.getSections().back());
+  // Core instance 0: instantiate core module 0 (provider), no args.
+  CoreInstSec.getContent().emplace_back();
+  CoreInstSec.getContent().back().setInstantiateArgs(
+      0U, AST::Component::CoreInstance::InstantiateArgs{});
+  // Core instance 1: instantiate core module 1 (consumer) with the provider.
+  AST::Component::InstantiateArg<uint32_t> Arg;
+  Arg.getName() = "provider";
+  Arg.getIndex() = 0U;
+  CoreInstSec.getContent().emplace_back();
+  CoreInstSec.getContent().back().setInstantiateArgs(1U, {Arg});
+  return Comp;
+}
+
+// Helper: build a CoreImportDesc carrying a global type.
+AST::Component::CoreImportDesc mkGlobalDesc(ValType VT, ValMut Mut) {
+  AST::Component::CoreImportDesc D;
+  D.setGlobalType(AST::GlobalType(VT, Mut));
+  return D;
+}
+
+// Helper: build a CoreImportDesc carrying a table type.
+AST::Component::CoreImportDesc mkTableDesc(ValType RefT, uint64_t Min) {
+  AST::Component::CoreImportDesc D;
+  D.setTableType(AST::TableType(RefT, Min));
+  return D;
+}
+
+// Helper: build a CoreImportDesc carrying a memory type.
+AST::Component::CoreImportDesc mkMemoryDesc(const AST::Limit &L) {
+  AST::Component::CoreImportDesc D;
+  D.setMemoryType(AST::MemoryType(L));
+  return D;
+}
+} // namespace
+
+TEST(ComponentValidatorTest, CoreInstanceImportGlobalTypeMismatchRejected) {
+  // Provider exports (global (mut i64)); consumer imports (global (mut i32)).
+  auto Comp =
+      buildCoreModuleLinkComponent(mkGlobalDesc(TypeCode::I64, ValMut::Var),
+                                   mkGlobalDesc(TypeCode::I32, ValMut::Var));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest,
+     CoreInstanceImportGlobalMutabilityMismatchRejected) {
+  // Same value type but mutability differs (var vs const) -> reject.
+  auto Comp =
+      buildCoreModuleLinkComponent(mkGlobalDesc(TypeCode::I32, ValMut::Const),
+                                   mkGlobalDesc(TypeCode::I32, ValMut::Var));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CoreInstanceImportGlobalTypeMatchAccepted) {
+  // Provider and consumer agree on (global (mut i64)) -> accept.
+  auto Comp =
+      buildCoreModuleLinkComponent(mkGlobalDesc(TypeCode::I64, ValMut::Var),
+                                   mkGlobalDesc(TypeCode::I64, ValMut::Var));
+  Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CoreInstanceImportTableElemTypeMismatchRejected) {
+  // Provider exports a funcref table; consumer imports an externref table.
+  auto Comp = buildCoreModuleLinkComponent(mkTableDesc(TypeCode::FuncRef, 1),
+                                           mkTableDesc(TypeCode::ExternRef, 1));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CoreInstanceImportTableLimitsMismatchRejected) {
+  // Consumer requires min 5; provider only offers min 1 -> reject.
+  auto Comp = buildCoreModuleLinkComponent(mkTableDesc(TypeCode::FuncRef, 1),
+                                           mkTableDesc(TypeCode::FuncRef, 5));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CoreInstanceImportTableTypeMatchAccepted) {
+  // Provider offers min 5 where consumer requires min 1 -> accept.
+  auto Comp = buildCoreModuleLinkComponent(mkTableDesc(TypeCode::FuncRef, 5),
+                                           mkTableDesc(TypeCode::FuncRef, 1));
+  Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest,
+     CoreInstanceImportMemoryIndexTypeMismatchRejected) {
+  // Provider exports a 32-bit memory; consumer imports a 64-bit memory.
+  auto Comp = buildCoreModuleLinkComponent(mkMemoryDesc(AST::Limit(1)),
+                                           mkMemoryDesc(AST::Limit(1, true)));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
 } // namespace


### PR DESCRIPTION
Extends the core-instance instantiation subtype checking (GAP-CI-1) from memory (added in #4987) to **global** and **table** for imported core module types:

  - global: reject if the provided global's value type or mutability differs from the import
  - table:  reject if the provided table's element type or limits don't satisfy the import

To do this, core:instance exports now carry the global/table type (stored by value the module-type descriptor getter returns a temporary, so a pointer would dangle).

Verified against the component-model `instantiate` spec tests these cases now pass: "type mismatch in global type", "mismatch in table limits", "type mismatch in table element type".

Notes:
- **Stacked on #4987** (memory64). Until that merges, this PR's diff includes #4987's commit;  I'll rebase once it lands so only this change remains.
- This does **not** flip the `instantiate` spec folder yet that folder also needs the component value-type subtyping (variant/record/tuple/flags/result), which is the larger GAP-CI-1 work. A focused unit test + the folder-enable will follow with that.
- Full spec suite still passes (525 tests); clang-format clean.
