### PR TITLE
fix(serializer): emit 0x04 flag for memory64 limits

### DIFF
--- a/lib/loader/serialize/serial_type.cpp
+++ b/lib/loader/serialize/serial_type.cpp
@@ -136,23 +136,32 @@ Serializer::serializeLimit(const AST::Limit &Lim,
   //
   // we encode all of them in u64
   uint8_t Flag = 0;
+  if (Lim.is64()) {
+    Flag |= 0x04U;
+  }
   if (Lim.isShared()) {
     Flag |= 0x02U;
   }
   if (Lim.hasMax()) {
     Flag |= 0x01U;
   }
-  if (static_cast<AST::Limit::LimitType>(Flag) >=
-      AST::Limit::LimitType::SharedNoMax) {
-    if (Conf.hasProposal(Proposal::Threads)) {
-      if (unlikely(!Lim.hasMax())) {
-        return logSerializeError(ErrCode::Value::SharedMemoryNoMax,
-                                 ASTNodeAttr::Type_Limit);
-      }
+
+  if (Lim.isShared() && !Conf.hasProposal(Proposal::Threads)) {
+    if (Conf.hasProposal(Proposal::Memory64)) {
+      return logSerializeError(ErrCode::Value::MalformedLimitFlags,
+                               ASTNodeAttr::Type_Limit);
     } else {
       return logSerializeError(ErrCode::Value::IntegerTooLarge,
                                ASTNodeAttr::Type_Limit);
     }
+  }
+  if (Lim.is64() && !Conf.hasProposal(Proposal::Memory64)) {
+    return logSerializeError(ErrCode::Value::IntegerTooLarge,
+                             ASTNodeAttr::Type_Limit);
+  }
+  if (Lim.isShared() && unlikely(!Lim.hasMax())) {
+    return logSerializeError(ErrCode::Value::SharedMemoryNoMax,
+                             ASTNodeAttr::Type_Limit);
   }
   OutVec.push_back(Flag);
   serializeU64(Lim.getMin(), OutVec);

--- a/test/loader/serializeTypeTest.cpp
+++ b/test/loader/serializeTypeTest.cpp
@@ -240,6 +240,48 @@ TEST(serializeTypeTest, SerializeMemoryType) {
       0xFFU, 0xFFU, 0xFFU, 0xFFU, 0x0FU  // Max = 4294967295
   };
   EXPECT_EQ(Output, Expected);
+
+  // 3.  Serialize limit with is64 (Memory64).
+  WasmEdge::Configure ConfMem64;
+  ConfMem64.addProposal(WasmEdge::Proposal::Memory64);
+  WasmEdge::Loader::Serializer SerMem64(ConfMem64);
+
+  MemoryType.getLimit().setMin(4294967295);
+  MemoryType.getLimit().setType(WasmEdge::AST::Limit::LimitType::I64HasMin);
+
+  Output = {};
+  EXPECT_TRUE(SerMem64.serializeSection(createMemorySec(MemoryType), Output));
+  Expected = {
+      0x05U,                            // Memory section
+      0x07U,                            // Content size = 7
+      0x01U,                            // Vector length = 1
+      0x04U,                            // Has min and is64
+      0xFFU, 0xFFU, 0xFFU, 0xFFU, 0x0FU // Min = 4294967295
+  };
+  EXPECT_EQ(Output, Expected);
+
+  MemoryType.getLimit().setMin(4294967281);
+  MemoryType.getLimit().setMax(4294967295);
+  MemoryType.getLimit().setType(WasmEdge::AST::Limit::LimitType::I64HasMinMax);
+
+  Output = {};
+  EXPECT_TRUE(SerMem64.serializeSection(createMemorySec(MemoryType), Output));
+  Expected = {
+      0x05U,                             // Memory section
+      0x0CU,                             // Content size = 12
+      0x01U,                             // Vector length = 1
+      0x05U,                             // Has min and max and is64
+      0xF1U, 0xFFU, 0xFFU, 0xFFU, 0x0FU, // Min = 4294967281
+      0xFFU, 0xFFU, 0xFFU, 0xFFU, 0x0FU  // Max = 4294967295
+  };
+  EXPECT_EQ(Output, Expected);
+
+  // Negative test: memory64 is missing
+  WasmEdge::Configure ConfNoMem64;
+  ConfNoMem64.removeProposal(WasmEdge::Proposal::Memory64);
+  WasmEdge::Loader::Serializer SerNoMem64(ConfNoMem64);
+  Output = {};
+  EXPECT_FALSE(SerNoMem64.serializeSection(createMemorySec(MemoryType), Output));
 }
 
 TEST(serializeTypeTest, SerializeGlobalType) {


### PR DESCRIPTION

## Description
<!-- Describe your changes here -->
This PR fixes the missing `0x04` Memory64 limit flag serialization bug in the WasmEdge serializer, addressing a subpart of the serializer tracking issue #4992 

**Changes:**
- Updated `Serializer::serializeLimit` to correctly detect `Lim.is64()` and append `Flag |= 0x04U`.
- Refactored the `Threads` and `Memory64` proposal validation logic to explicitly use `Lim.isShared()` and `Lim.is64()`. This aligns the serializer's error-throwing behavior perfectly with the `loadLimit` deserializer, resolving the bug where `0x04` and `0x05` flags were mistakenly blocked by the `Threads` validation gate.
- Added comprehensive unit tests for `0x04`, `0x05`, `0x06`, and `0x07` limit flags in `serializeTypeTest.cpp` to close the test coverage gap. 

### Related Issues
- Resolves #4993 
- Addresses subpart of #4992


## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

