### PR TITLE
fix(serializer): correct element segment proposal gate logic

### DIFF
--- a/lib/loader/serialize/serial_segment.cpp
+++ b/lib/loader/serialize/serial_segment.cpp
@@ -51,7 +51,7 @@ Serializer::serializeSegment(const AST::ElementSegment &Seg,
   // vec(u32) + vec(expr)
   if (!Conf.hasProposal(Proposal::BulkMemoryOperations) &&
       !Conf.hasProposal(Proposal::ReferenceTypes) &&
-      (Seg.getMode() != AST::ElementSegment::ElemMode::Passive ||
+      (Seg.getMode() != AST::ElementSegment::ElemMode::Active ||
        Seg.getIdx() != 0)) {
     return logNeedProposal(ErrCode::Value::ExpectedZeroByte,
                            Proposal::BulkMemoryOperations,

--- a/test/loader/serializeSegmentTest.cpp
+++ b/test/loader/serializeSegmentTest.cpp
@@ -305,6 +305,16 @@ TEST(SerializeSegmentTest, SerializeElementSegment) {
   };
   EXPECT_EQ(Output, Expected);
 
+  ElementSeg.setMode(WasmEdge::AST::ElementSegment::ElemMode::Passive);
+  ElementSeg.setIdx(0x00U);
+  ElementSeg.getExpr().getInstrs().clear();
+  ElementSec.getContent() = {ElementSeg};
+  EXPECT_FALSE(SerWASM1.serializeSection(ElementSec, Output));
+
+  ElementSeg.setMode(WasmEdge::AST::ElementSegment::ElemMode::Declarative);
+  ElementSeg.setIdx(0x00U);
+  ElementSeg.getExpr().getInstrs().clear();
+  ElementSec.getContent() = {ElementSeg};
   EXPECT_FALSE(SerWASM1.serializeSection(ElementSec, Output));
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes here -->
This PR fixes an inverted logic gate in the element segment serializer. Previously, the serializer checked `getMode() != ElemMode::Passive`, which incorrectly allowed `Declarative` and `Passive` segments to bypass the Bulk Memory Operations and Reference Types proposal gates. 
The condition has been corrected to `getMode() != ElemMode::Active`, properly restricting older Wasm configurations to only `Active` segments at table `0`.

Unit tests have been added to `test/loader/serializeSegmentTest.cpp` to verify that `WASM_1` configurations correctly reject both `Passive` and `Declarative` segment serialization.

fixes #4997 
Subpart of #4992 

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.


