### PR TITLE
fix(serializer): prevent element segment table 0 active downgrade

### DIFF
--- a/lib/loader/serialize/serial_segment.cpp
+++ b/lib/loader/serialize/serial_segment.cpp
@@ -77,8 +77,26 @@ Serializer::serializeSegment(const AST::ElementSegment &Seg,
     return E;
   };
 
+  // Distinguish between FuncIdx and Expr.
+  auto IsInitExpr = false;
+  if (Seg.getInitExprs().size() != 0) {
+    for (auto &Expr : Seg.getInitExprs()) {
+      if (Expr.getInstrs().size() != 2 ||
+          Expr.getInstrs()[0].getOpCode() != OpCode::Ref__func ||
+          Expr.getInstrs()[1].getOpCode() != OpCode::End) {
+        IsInitExpr = true;
+        break;
+      }
+    }
+  }
+  if (Seg.getRefType() != TypeCode::FuncRef) {
+    IsInitExpr = true;
+  }
+
   // Serialize idx.
-  if (Seg.getIdx() != 0) {
+  if (Seg.getIdx() != 0 ||
+      (Seg.getMode() == AST::ElementSegment::ElemMode::Active &&
+       Seg.getRefType() != TypeCode::FuncRef)) {
     Mode |= 0x02;
     serializeU32(Seg.getIdx(), OutVec);
   }
@@ -89,20 +107,8 @@ Serializer::serializeSegment(const AST::ElementSegment &Seg,
         serializeExpression(Seg.getExpr(), OutVec).map_error(ReportError));
   }
 
-  // Distinguish between FuncIdx and Expr.
-  if (Seg.getInitExprs().size() != 0) {
-    auto IsInitExpr = false;
-    for (auto &Expr : Seg.getInitExprs()) {
-      if (Expr.getInstrs().size() != 2 ||
-          Expr.getInstrs()[0].getOpCode() != OpCode::Ref__func ||
-          Expr.getInstrs()[1].getOpCode() != OpCode::End) {
-        IsInitExpr = true;
-        break;
-      }
-    }
-    if (IsInitExpr) {
-      Mode |= 0x04;
-    }
+  if (IsInitExpr) {
+    Mode |= 0x04;
   }
 
   // Serialize ElemKind or RefType.

--- a/test/loader/serializeSegmentTest.cpp
+++ b/test/loader/serializeSegmentTest.cpp
@@ -234,6 +234,7 @@ TEST(SerializeSegmentTest, SerializeElementSegment) {
   ElementSeg.getInitExprs().clear();
   ElementSeg.getInitExprs().emplace_back();
   ElementSeg.getInitExprs().back().getInstrs() = {I32Eqz, I32Eq, I32Ne, End};
+  ElementSeg.setRefType(WasmEdge::TypeCode::FuncRef); // Explicitly FuncRef for mode 4
   ElementSec.getContent() = {ElementSeg};
 
   Output = {};
@@ -244,6 +245,31 @@ TEST(SerializeSegmentTest, SerializeElementSegment) {
       0x01U,                      // Vector length = 1
       0x04U,                      // Prefix checking byte
       0x45U, 0x46U, 0x47U, 0x0BU, // Offset expression
+      0x01U,                      // Vector length = 1
+      0x45U, 0x46U, 0x47U, 0x0BU, // Vec[0]
+  };
+  EXPECT_EQ(Output, Expected);
+
+  // Bug 3 test: Active segment, idx = 0, but RefType is ExternRef. Should be mode 6.
+  ElementSeg.setMode(WasmEdge::AST::ElementSegment::ElemMode::Active);
+  ElementSeg.setIdx(0x00U);
+  ElementSeg.setRefType(WasmEdge::TypeCode::ExternRef);
+  ElementSeg.getExpr().getInstrs() = {I32Eqz, I32Eq, I32Ne, End};
+  ElementSeg.getInitExprs().clear();
+  ElementSeg.getInitExprs().emplace_back();
+  ElementSeg.getInitExprs().back().getInstrs() = {I32Eqz, I32Eq, I32Ne, End};
+  ElementSec.getContent() = {ElementSeg};
+
+  Output = {};
+  EXPECT_TRUE(Ser.serializeSection(ElementSec, Output));
+  Expected = {
+      0x09U,                      // Element section
+      0x0DU,                      // Content size = 13
+      0x01U,                      // Vector length = 1
+      0x06U,                      // Prefix checking byte
+      0x00U,                      // TableIdx
+      0x45U, 0x46U, 0x47U, 0x0BU, // Offset Expression
+      0x6FU,                      // RefType
       0x01U,                      // Vector length = 1
       0x45U, 0x46U, 0x47U, 0x0BU, // Vec[0]
   };


### PR DESCRIPTION
## Description
<!-- Describe your changes here -->
This PR prevents the WasmEdge serializer from improperly downgrading active element segments at Table 0 to the `funcref`-specific `0x04` mode when they contain non-funcref reference types (such as `externref`). 
In `lib/loader/serialize/serial_segment.cpp`, checks have been added to ensure that the segment's `RefType` is evaluated. If the type is not `FuncRef`, the logic now safely forces the segment to use Mode `0x06` (by treating it similarly to segments with `IsInitExpr = true`), preserving both the Table index and the explicit reference type byte.
Unit tests have been added to `test/loader/serializeSegmentTest.cpp` to explicitly verify that an active `ExternRef` segment at index `0` correctly serializes using Mode `0x06`.

fixes #4999 
Sub-part of #4992 

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

