### PR TITLE
test(serializer): add comprehensive serializer test coverage for instructions, segments, and modules

### DIFF
--- a/test/loader/serializeInstructionTest.cpp
+++ b/test/loader/serializeInstructionTest.cpp
@@ -1763,4 +1763,350 @@ TEST(SerializeInstructionTest, SerializeDotProductInstruction) {
   Output = {};
   EXPECT_FALSE(Ser.serializeSection(createCodeSec(Instructions), Output));
 }
+
+TEST(SerializeInstructionTest, SerializeSIMDMemoryInstruction) {
+  std::vector<uint8_t> Expected;
+  std::vector<uint8_t> Output;
+  std::vector<WasmEdge::AST::Instruction> Instructions;
+
+  // 20. Test base SIMD memory instructions.
+  //
+  //   1.  Serialize v128_load instruction with memarg.
+  //   2.  Serialize v128_store instruction with memarg.
+
+  WasmEdge::AST::Instruction V128Load(WasmEdge::OpCode::V128__load);
+  WasmEdge::AST::Instruction V128Store(WasmEdge::OpCode::V128__store);
+  WasmEdge::AST::Instruction End(WasmEdge::OpCode::End);
+
+  V128Load.getMemoryAlign() = 0x04U;
+  V128Load.getMemoryOffset() = 0x10U;
+  Instructions = {V128Load, End};
+  Output = {};
+  EXPECT_TRUE(Ser.serializeSection(createCodeSec(Instructions), Output));
+  Expected = {
+      0x0AU,        // Code section
+      0x08U,        // Content size = 8
+      0x01U,        // Vector length = 1
+      0x06U,        // Code segment size = 6
+      0x00U,        // Local vec(0)
+      0xFDU, 0x00U, // OpCode V128__load.
+      0x04U,        // Align.
+      0x10U,        // Offset.
+      0x0BU         // Expression End.
+  };
+  EXPECT_EQ(Output, Expected);
+
+  V128Store.getMemoryAlign() = 0x04U;
+  V128Store.getMemoryOffset() = 0x10U;
+  Instructions = {V128Store, End};
+  Output = {};
+  EXPECT_TRUE(Ser.serializeSection(createCodeSec(Instructions), Output));
+  Expected = {
+      0x0AU,        // Code section
+      0x08U,        // Content size = 8
+      0x01U,        // Vector length = 1
+      0x06U,        // Code segment size = 6
+      0x00U,        // Local vec(0)
+      0xFDU, 0x0BU, // OpCode V128__store.
+      0x04U,        // Align.
+      0x10U,        // Offset.
+      0x0BU         // Expression End.
+  };
+  EXPECT_EQ(Output, Expected);
+}
+
+TEST(SerializeInstructionTest, SerializeSIMDLaneAndNumericInstruction) {
+  std::vector<uint8_t> Expected;
+  std::vector<uint8_t> Output;
+  std::vector<WasmEdge::AST::Instruction> Instructions;
+
+  // 21. Test base SIMD lane and numeric instructions.
+  //
+  //   1.  Serialize i8x16_splat instruction.
+  //   2.  Serialize i8x16_add instruction.
+  //   3.  Serialize i32x4_mul instruction (two-byte LEB128 opcode suffix).
+  //   4.  Serialize f32x4_add instruction (two-byte LEB128 opcode suffix).
+  //   5.  Serialize i8x16_extract_lane_s instruction with lane immediate.
+  //   6.  Serialize i8x16_replace_lane instruction with lane immediate.
+
+  WasmEdge::AST::Instruction I8x16Splat(WasmEdge::OpCode::I8x16__splat);
+  WasmEdge::AST::Instruction I8x16Add(WasmEdge::OpCode::I8x16__add);
+  WasmEdge::AST::Instruction I32x4Mul(WasmEdge::OpCode::I32x4__mul);
+  WasmEdge::AST::Instruction F32x4Add(WasmEdge::OpCode::F32x4__add);
+  WasmEdge::AST::Instruction I8x16ExtractLaneS(
+      WasmEdge::OpCode::I8x16__extract_lane_s);
+  WasmEdge::AST::Instruction I8x16ReplaceLane(
+      WasmEdge::OpCode::I8x16__replace_lane);
+  WasmEdge::AST::Instruction End(WasmEdge::OpCode::End);
+
+  Instructions = {I8x16Splat, End};
+  Output = {};
+  EXPECT_TRUE(Ser.serializeSection(createCodeSec(Instructions), Output));
+  Expected = {
+      0x0AU,        // Code section
+      0x06U,        // Content size = 6
+      0x01U,        // Vector length = 1
+      0x04U,        // Code segment size = 4
+      0x00U,        // Local vec(0)
+      0xFDU, 0x0FU, // OpCode I8x16__splat.
+      0x0BU         // Expression End.
+  };
+  EXPECT_EQ(Output, Expected);
+
+  Instructions = {I8x16Add, End};
+  Output = {};
+  EXPECT_TRUE(Ser.serializeSection(createCodeSec(Instructions), Output));
+  Expected = {
+      0x0AU,        // Code section
+      0x06U,        // Content size = 6
+      0x01U,        // Vector length = 1
+      0x04U,        // Code segment size = 4
+      0x00U,        // Local vec(0)
+      0xFDU, 0x6EU, // OpCode I8x16__add.
+      0x0BU         // Expression End.
+  };
+  EXPECT_EQ(Output, Expected);
+
+  Instructions = {I32x4Mul, End};
+  Output = {};
+  EXPECT_TRUE(Ser.serializeSection(createCodeSec(Instructions), Output));
+  Expected = {
+      0x0AU,               // Code section
+      0x07U,               // Content size = 7
+      0x01U,               // Vector length = 1
+      0x05U,               // Code segment size = 5
+      0x00U,               // Local vec(0)
+      0xFDU, 0xB5U, 0x01U, // OpCode I32x4__mul.
+      0x0BU                // Expression End.
+  };
+  EXPECT_EQ(Output, Expected);
+
+  Instructions = {F32x4Add, End};
+  Output = {};
+  EXPECT_TRUE(Ser.serializeSection(createCodeSec(Instructions), Output));
+  Expected = {
+      0x0AU,               // Code section
+      0x07U,               // Content size = 7
+      0x01U,               // Vector length = 1
+      0x05U,               // Code segment size = 5
+      0x00U,               // Local vec(0)
+      0xFDU, 0xE4U, 0x01U, // OpCode F32x4__add.
+      0x0BU                // Expression End.
+  };
+  EXPECT_EQ(Output, Expected);
+
+  I8x16ExtractLaneS.getMemoryLane() = 0x05U;
+  Instructions = {I8x16ExtractLaneS, End};
+  Output = {};
+  EXPECT_TRUE(Ser.serializeSection(createCodeSec(Instructions), Output));
+  Expected = {
+      0x0AU,        // Code section
+      0x07U,        // Content size = 7
+      0x01U,        // Vector length = 1
+      0x05U,        // Code segment size = 5
+      0x00U,        // Local vec(0)
+      0xFDU, 0x15U, // OpCode I8x16__extract_lane_s.
+      0x05U,        // Lane index.
+      0x0BU         // Expression End.
+  };
+  EXPECT_EQ(Output, Expected);
+
+  I8x16ReplaceLane.getMemoryLane() = 0x05U;
+  Instructions = {I8x16ReplaceLane, End};
+  Output = {};
+  EXPECT_TRUE(Ser.serializeSection(createCodeSec(Instructions), Output));
+  Expected = {
+      0x0AU,        // Code section
+      0x07U,        // Content size = 7
+      0x01U,        // Vector length = 1
+      0x05U,        // Code segment size = 5
+      0x00U,        // Local vec(0)
+      0xFDU, 0x17U, // OpCode I8x16__replace_lane.
+      0x05U,        // Lane index.
+      0x0BU         // Expression End.
+  };
+  EXPECT_EQ(Output, Expected);
+}
+
+TEST(SerializeInstructionTest, SerializeAtomicInstruction) {
+  WasmEdge::Configure ConfThreads;
+  ConfThreads.addProposal(WasmEdge::Proposal::Threads);
+  WasmEdge::Loader::Serializer SerThreads(ConfThreads);
+
+  std::vector<uint8_t> Expected;
+  std::vector<uint8_t> Output;
+  std::vector<WasmEdge::AST::Instruction> Instructions;
+
+  // 22. Test atomic instructions.
+  //
+  //   1.  Serialize memory_atomic_notify instruction with memarg.
+  //   2.  Serialize memory_atomic_wait32 instruction with memarg.
+  //   3.  Serialize i32_atomic_load instruction with memarg.
+  //   4.  Serialize i32_atomic_store instruction with memarg.
+  //   5.  Serialize i32_atomic_rmw_add instruction with memarg.
+  //
+  // memory.atomic.* instructions are not Threads-gated; i32.atomic.* requires
+  // the Threads proposal.
+
+  WasmEdge::AST::Instruction MemoryAtomicNotify(
+      WasmEdge::OpCode::Memory__atomic__notify);
+  WasmEdge::AST::Instruction MemoryAtomicWait32(
+      WasmEdge::OpCode::Memory__atomic__wait32);
+  WasmEdge::AST::Instruction I32AtomicLoad(
+      WasmEdge::OpCode::I32__atomic__load);
+  WasmEdge::AST::Instruction I32AtomicStore(
+      WasmEdge::OpCode::I32__atomic__store);
+  WasmEdge::AST::Instruction I32AtomicRmwAdd(
+      WasmEdge::OpCode::I32__atomic__rmw__add);
+  WasmEdge::AST::Instruction End(WasmEdge::OpCode::End);
+
+  MemoryAtomicNotify.getMemoryAlign() = 0x02U;
+  MemoryAtomicNotify.getMemoryOffset() = 0x08U;
+  Instructions = {MemoryAtomicNotify, End};
+  Output = {};
+  EXPECT_TRUE(Ser.serializeSection(createCodeSec(Instructions), Output));
+  Expected = {
+      0x0AU,        // Code section
+      0x08U,        // Content size = 8
+      0x01U,        // Vector length = 1
+      0x06U,        // Code segment size = 6
+      0x00U,        // Local vec(0)
+      0xFEU, 0x00U, // OpCode Memory__atomic__notify.
+      0x02U,        // Align.
+      0x08U,        // Offset.
+      0x0BU         // Expression End.
+  };
+  EXPECT_EQ(Output, Expected);
+
+  MemoryAtomicWait32.getMemoryAlign() = 0x02U;
+  MemoryAtomicWait32.getMemoryOffset() = 0x08U;
+  Instructions = {MemoryAtomicWait32, End};
+  Output = {};
+  EXPECT_TRUE(Ser.serializeSection(createCodeSec(Instructions), Output));
+  Expected[6] = 0x01U; // OpCode Memory__atomic__wait32.
+  EXPECT_EQ(Output, Expected);
+
+  I32AtomicLoad.getMemoryAlign() = 0x02U;
+  I32AtomicLoad.getMemoryOffset() = 0x08U;
+  Instructions = {I32AtomicLoad, End};
+  Output = {};
+  EXPECT_FALSE(Ser.serializeSection(createCodeSec(Instructions), Output));
+  Output = {};
+  EXPECT_TRUE(SerThreads.serializeSection(createCodeSec(Instructions), Output));
+  Expected[6] = 0x10U; // OpCode I32__atomic__load.
+  EXPECT_EQ(Output, Expected);
+
+  I32AtomicStore.getMemoryAlign() = 0x02U;
+  I32AtomicStore.getMemoryOffset() = 0x08U;
+  Instructions = {I32AtomicStore, End};
+  Output = {};
+  EXPECT_TRUE(SerThreads.serializeSection(createCodeSec(Instructions), Output));
+  Expected[6] = 0x17U; // OpCode I32__atomic__store.
+  EXPECT_EQ(Output, Expected);
+
+  I32AtomicRmwAdd.getMemoryAlign() = 0x02U;
+  I32AtomicRmwAdd.getMemoryOffset() = 0x08U;
+  Instructions = {I32AtomicRmwAdd, End};
+  Output = {};
+  EXPECT_TRUE(SerThreads.serializeSection(createCodeSec(Instructions), Output));
+  Expected[6] = 0x1EU; // OpCode I32__atomic__rmw__add.
+  EXPECT_EQ(Output, Expected);
+}
+
+TEST(SerializeInstructionTest, SerializeMultiMemoryMemArgInstruction) {
+  std::vector<uint8_t> Expected;
+  std::vector<uint8_t> Output;
+  std::vector<WasmEdge::AST::Instruction> Instructions;
+
+  // 23. Test multi-memory memarg encoding.
+  //
+  //   1.  Serialize i32_load with a non-zero memory index (MultiMemories on).
+  //   2.  Serialize i32_store with a non-zero memory index (MultiMemories on).
+  //   3.  Serialize i32_load with memory index 0 (single-memory encoding).
+  //   4.  Serialize i32_load with a non-zero memory index but MultiMemories off
+  //       (the memory index is dropped).
+
+  WasmEdge::AST::Instruction End(WasmEdge::OpCode::End);
+
+  WasmEdge::AST::Instruction I32Load(WasmEdge::OpCode::I32__load);
+  I32Load.getMemoryAlign() = 0x02U;
+  I32Load.getTargetIndex() = 0x03U;
+  I32Load.getMemoryOffset() = 0x10U;
+  Instructions = {I32Load, End};
+  Output = {};
+  EXPECT_TRUE(Ser.serializeSection(createCodeSec(Instructions), Output));
+  Expected = {
+      0x0AU, // Code section
+      0x08U, // Content size = 8
+      0x01U, // Vector length = 1
+      0x06U, // Code segment size = 6
+      0x00U, // Local vec(0)
+      0x28U, // OpCode I32__load.
+      0x42U, // Align with multi-memory flag (0x02 + 0x40).
+      0x03U, // Memory index.
+      0x10U, // Offset.
+      0x0BU  // Expression End.
+  };
+  EXPECT_EQ(Output, Expected);
+
+  WasmEdge::AST::Instruction I32Store(WasmEdge::OpCode::I32__store);
+  I32Store.getMemoryAlign() = 0x02U;
+  I32Store.getTargetIndex() = 0x03U;
+  I32Store.getMemoryOffset() = 0x10U;
+  Instructions = {I32Store, End};
+  Output = {};
+  EXPECT_TRUE(Ser.serializeSection(createCodeSec(Instructions), Output));
+  Expected = {
+      0x0AU, // Code section
+      0x08U, // Content size = 8
+      0x01U, // Vector length = 1
+      0x06U, // Code segment size = 6
+      0x00U, // Local vec(0)
+      0x36U, // OpCode I32__store.
+      0x42U, // Align with multi-memory flag (0x02 + 0x40).
+      0x03U, // Memory index.
+      0x10U, // Offset.
+      0x0BU  // Expression End.
+  };
+  EXPECT_EQ(Output, Expected);
+
+  WasmEdge::AST::Instruction I32LoadMem0(WasmEdge::OpCode::I32__load);
+  I32LoadMem0.getMemoryAlign() = 0x02U;
+  I32LoadMem0.getTargetIndex() = 0x00U;
+  I32LoadMem0.getMemoryOffset() = 0x10U;
+  Instructions = {I32LoadMem0, End};
+  Output = {};
+  EXPECT_TRUE(Ser.serializeSection(createCodeSec(Instructions), Output));
+  Expected = {
+      0x0AU, // Code section
+      0x07U, // Content size = 7
+      0x01U, // Vector length = 1
+      0x05U, // Code segment size = 5
+      0x00U, // Local vec(0)
+      0x28U, // OpCode I32__load.
+      0x02U, // Align (no multi-memory flag, memory index 0).
+      0x10U, // Offset.
+      0x0BU  // Expression End.
+  };
+  EXPECT_EQ(Output, Expected);
+
+  WasmEdge::Configure ConfNoMM;
+  ConfNoMM.removeProposal(WasmEdge::Proposal::MultiMemories);
+  WasmEdge::Loader::Serializer SerNoMM(ConfNoMM);
+  Instructions = {I32Load, End};
+  Output = {};
+  EXPECT_TRUE(SerNoMM.serializeSection(createCodeSec(Instructions), Output));
+  Expected = {
+      0x0AU, // Code section
+      0x07U, // Content size = 7
+      0x01U, // Vector length = 1
+      0x05U, // Code segment size = 5
+      0x00U, // Local vec(0)
+      0x28U, // OpCode I32__load.
+      0x02U, // Align (multi-memory disabled, memory index dropped).
+      0x10U, // Offset.
+      0x0BU  // Expression End.
+  };
+  EXPECT_EQ(Output, Expected);
+}
 } // namespace

--- a/test/loader/serializeModuleTest.cpp
+++ b/test/loader/serializeModuleTest.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
+#include "loader/loader.h"
 #include "loader/serialize.h"
 
 #include <cstdint>
@@ -11,6 +12,48 @@ namespace {
 
 WasmEdge::Configure Conf;
 WasmEdge::Loader::Serializer Ser(Conf);
+
+WasmEdge::AST::Module createPopulatedModule() {
+  WasmEdge::AST::Module Module;
+  Module.getMagic() = {0x00U, 0x61U, 0x73U, 0x6DU};
+  Module.getVersion() = {0x01U, 0x00U, 0x00U, 0x00U};
+
+  // The serializer emits sections in ascending start-offset order (see
+  // Serializer::serializeModule, which std::sorts sections by getStartOffset()).
+  // The ascending offsets below therefore pin the section order that the
+  // Expected byte sequences assume: type, function, memory, export, code.
+
+  WasmEdge::AST::FunctionType FuncType;
+  FuncType.getReturnTypes() = {WasmEdge::TypeCode::I32};
+  Module.getTypeSection().getContent() = {FuncType};
+  Module.getTypeSection().setStartOffset(1);
+
+  Module.getFunctionSection().getContent() = {0x00U};
+  Module.getFunctionSection().setStartOffset(2);
+
+  WasmEdge::AST::MemoryType MemoryType;
+  MemoryType.getLimit().setType(WasmEdge::AST::Limit::LimitType::HasMin);
+  MemoryType.getLimit().setMin(1);
+  Module.getMemorySection().getContent() = {MemoryType};
+  Module.getMemorySection().setStartOffset(3);
+
+  WasmEdge::AST::ExportDesc ExportDesc;
+  ExportDesc.setExternalName("main");
+  ExportDesc.setExternalType(WasmEdge::ExternalType::Function);
+  ExportDesc.setExternalIndex(0x00U);
+  Module.getExportSection().getContent() = {ExportDesc};
+  Module.getExportSection().setStartOffset(4);
+
+  WasmEdge::AST::Instruction I32Const(WasmEdge::OpCode::I32__const);
+  WasmEdge::AST::Instruction End(WasmEdge::OpCode::End);
+  I32Const.setNum(static_cast<uint32_t>(42));
+  WasmEdge::AST::CodeSegment CodeSeg;
+  CodeSeg.getExpr().getInstrs() = {I32Const, End};
+  Module.getCodeSection().getContent() = {CodeSeg};
+  Module.getCodeSection().setStartOffset(5);
+
+  return Module;
+}
 
 TEST(serializeModuleTest, SerializeModule) {
   std::vector<uint8_t> Expected;
@@ -52,5 +95,57 @@ TEST(serializeModuleTest, SerializeModule) {
       0x00U, 0x02U, 0x01U, 0x33U, // Sec2
   };
   EXPECT_EQ(Output, Expected);
+}
+
+TEST(serializeModuleTest, PopulatedMultiSectionModule) {
+  std::vector<uint8_t> Expected;
+  std::vector<uint8_t> Output;
+
+  // 2. Test serialize module with multiple populated sections.
+  //
+  //   1.  Serialize module with type, function, memory, export, and code
+  //       sections all containing real content.
+
+  WasmEdge::AST::Module Module = createPopulatedModule();
+
+  auto SerRes = Ser.serializeModule(Module);
+  ASSERT_TRUE(SerRes);
+  Output = *SerRes;
+  Expected = {
+      0x00U, 0x61U, 0x73U, 0x6DU,                     // Magic
+      0x01U, 0x00U, 0x00U, 0x00U,                     // Version
+      0x01U, 0x05U, 0x01U, 0x60U, 0x00U, 0x01U, 0x7FU, // Type section
+      0x03U, 0x02U, 0x01U, 0x00U,                     // Function section
+      0x05U, 0x03U, 0x01U, 0x00U, 0x01U,              // Memory section
+      0x07U, 0x08U, 0x01U, 0x04U, 0x6DU, 0x61U, 0x69U,
+      0x6EU, 0x00U, 0x00U,                            // Export section
+      0x0AU, 0x06U, 0x01U, 0x04U, 0x00U, 0x41U, 0x2AU,
+      0x0BU,                                          // Code section
+  };
+  EXPECT_EQ(Output, Expected);
+}
+
+TEST(serializeModuleTest, ModuleRoundTrip) {
+  // 3. Test that serialize -> load -> serialize is lossless.
+  //
+  //   1.  Serialize a module to bytes, parse those bytes back via the Loader,
+  //       serialize the loaded module again, and assert both byte sequences
+  //       are bit-for-bit identical.
+
+  WasmEdge::AST::Module Module = createPopulatedModule();
+
+  auto SerRes1 = Ser.serializeModule(Module);
+  ASSERT_TRUE(SerRes1);
+  std::vector<uint8_t> Bytes1 = *SerRes1;
+
+  WasmEdge::Loader::Loader Ldr(Conf);
+  auto Res = Ldr.parseModule(Bytes1);
+  ASSERT_TRUE(Res);
+  auto &ModPtr = *Res;
+
+  auto SerRes2 = Ser.serializeModule(*ModPtr);
+  ASSERT_TRUE(SerRes2);
+  std::vector<uint8_t> Bytes2 = *SerRes2;
+  EXPECT_EQ(Bytes1, Bytes2);
 }
 } // namespace

--- a/test/loader/serializeSegmentTest.cpp
+++ b/test/loader/serializeSegmentTest.cpp
@@ -62,6 +62,143 @@ TEST(SerializeSegmentTest, SerializeGlobalSegment) {
   EXPECT_EQ(Output, Expected);
 }
 
+TEST(SerializeSegmentTest, SerializeTableSegment) {
+  // The init-expression (0x40) table form is gated on the FunctionReferences
+  // proposal. Use a serializer that explicitly enables it for the positive
+  // init-expr cases, and one under WASM 2.0 (which lacks it) for the negative
+  // case, so the gate is exercised from both sides without relying on the
+  // ambient default configuration.
+  WasmEdge::Configure ConfFuncRef;
+  ConfFuncRef.addProposal(WasmEdge::Proposal::FunctionReferences);
+  WasmEdge::Loader::Serializer SerFuncRef(ConfFuncRef);
+
+  WasmEdge::Configure ConfWASM2;
+  ConfWASM2.setWASMStandard(WasmEdge::Standard::WASM_2);
+  WasmEdge::Loader::Serializer SerWASM2(ConfWASM2);
+
+  std::vector<uint8_t> Expected;
+  std::vector<uint8_t> Output;
+
+  // Test serialize table segment.
+  //
+  //   1. Serialize plain table type (MVP form) with min-max limit.
+  //   2. Serialize plain table type (MVP form) with min-only limit and a
+  //      different reference type.
+  //   3. Serialize table segment with init expression (the 0x40 0x00 form from
+  //      the FunctionReferences proposal) using an expression of only the End
+  //      operation.
+  //   4. Serialize table segment with init expression carrying a non-empty
+  //      ref.func initializer.
+  //   5. Serialize table segment with init expression without the
+  //      FunctionReferences proposal (negative).
+
+  WasmEdge::AST::Instruction End(WasmEdge::OpCode::End);
+  WasmEdge::AST::Instruction RefFunc(WasmEdge::OpCode::Ref__func);
+
+  // 1. Plain table type, funcref, limit [0, 14]. No init expression is present,
+  //    so only the table type (reftype + limit) is emitted.
+  {
+    WasmEdge::AST::TableSection TableSec;
+    WasmEdge::AST::TableSegment TableSeg;
+    TableSeg.getTableType() =
+        WasmEdge::AST::TableType(WasmEdge::TypeCode::FuncRef, 0, 14);
+    TableSec.getContent() = {TableSeg};
+
+    Output = {};
+    EXPECT_TRUE(Ser.serializeSection(TableSec, Output));
+    Expected = {
+        0x04U,                     // Table section
+        0x05U,                     // Content size = 5
+        0x01U,                     // Vector length = 1
+        0x70U, 0x01U, 0x00U, 0x0EU // Table type: funcref + limit [0, 14]
+    };
+    EXPECT_EQ(Output, Expected);
+  }
+
+  // 2. Plain table type, externref, min-only limit [5]. Exercises the no-max
+  //    limit flag (0x00) and a non-funcref reference type.
+  {
+    WasmEdge::AST::TableSection TableSec;
+    WasmEdge::AST::TableSegment TableSeg;
+    TableSeg.getTableType() =
+        WasmEdge::AST::TableType(WasmEdge::TypeCode::ExternRef, 5);
+    TableSec.getContent() = {TableSeg};
+
+    Output = {};
+    EXPECT_TRUE(Ser.serializeSection(TableSec, Output));
+    Expected = {
+        0x04U,              // Table section
+        0x04U,              // Content size = 4
+        0x01U,              // Vector length = 1
+        0x6FU, 0x00U, 0x05U // Table type: externref + limit [5]
+    };
+    EXPECT_EQ(Output, Expected);
+  }
+
+  // 3. Table segment with init expression (FunctionReferences proposal). A
+  //    non-empty expression triggers the 0x40 0x00 prefix followed by the table
+  //    type and the expression.
+  {
+    WasmEdge::AST::TableSection TableSec;
+    WasmEdge::AST::TableSegment TableSeg;
+    TableSeg.getTableType() =
+        WasmEdge::AST::TableType(WasmEdge::TypeCode::FuncRef, 0);
+    TableSeg.getExpr().getInstrs() = {End};
+    TableSec.getContent() = {TableSeg};
+
+    Output = {};
+    EXPECT_TRUE(SerFuncRef.serializeSection(TableSec, Output));
+    Expected = {
+        0x04U,              // Table section
+        0x07U,              // Content size = 7
+        0x01U,              // Vector length = 1
+        0x40U, 0x00U,       // Init-expression form prefix
+        0x70U, 0x00U, 0x00U, // Table type: funcref + limit [0]
+        0x0BU               // Expression
+    };
+    EXPECT_EQ(Output, Expected);
+  }
+
+  // 4. Table segment with init expression carrying a ref.func initializer and a
+  //    min-max limit [1, 16].
+  {
+    WasmEdge::AST::TableSection TableSec;
+    WasmEdge::AST::TableSegment TableSeg;
+    TableSeg.getTableType() =
+        WasmEdge::AST::TableType(WasmEdge::TypeCode::FuncRef, 1, 16);
+    RefFunc.getTargetIndex() = 0x00U;
+    TableSeg.getExpr().getInstrs() = {RefFunc, End};
+    TableSec.getContent() = {TableSeg};
+
+    Output = {};
+    EXPECT_TRUE(SerFuncRef.serializeSection(TableSec, Output));
+    Expected = {
+        0x04U,                      // Table section
+        0x0AU,                      // Content size = 10
+        0x01U,                      // Vector length = 1
+        0x40U, 0x00U,               // Init-expression form prefix
+        0x70U, 0x01U, 0x01U, 0x10U, // Table type: funcref + limit [1, 16]
+        0xD2U, 0x00U,               // ref.func 0
+        0x0BU                       // End
+    };
+    EXPECT_EQ(Output, Expected);
+  }
+
+  // 5. The init-expression (0x40) form requires the FunctionReferences proposal.
+  //    Serializing it under WASM 2.0 (which lacks the proposal) must fail.
+  {
+    WasmEdge::AST::TableSection TableSec;
+    WasmEdge::AST::TableSegment TableSeg;
+    TableSeg.getTableType() =
+        WasmEdge::AST::TableType(WasmEdge::TypeCode::FuncRef, 0);
+    TableSeg.getExpr().getInstrs() = {End};
+    TableSec.getContent() = {TableSeg};
+
+    Output = {};
+    EXPECT_FALSE(SerWASM2.serializeSection(TableSec, Output));
+  }
+}
+
 TEST(SerializeSegmentTest, SerializeElementSegment) {
   WasmEdge::Configure ConfWASM1;
   ConfWASM1.setWASMStandard(WasmEdge::Standard::WASM_1);


### PR DESCRIPTION
## Description

Consolidates all serializer test coverage into a single PR as requested by @hydai.
Closes the test gaps tracked in #4992 across three serializer test files.

Supersedes #5002 and #5007.
Part of #4992.

---

### serializeInstructionTest.cpp

Added the three missing instruction categories:

- **Base SIMD (0xFD prefix):** v128.load/store, splat, lane extract/replace,
  lane arithmetic (including two-byte LEB128 opcode suffixes)
- **Atomics (0xFE prefix):** memory.atomic.notify/wait32, i32.atomic.load/store,
  i32.atomic.rmw.add with memarg; Threads-proposal gate asserted
- **Multi-memory memarg:** i32.load/store with explicit non-zero memory index,
  plus proposal-off negative case

---

### serializeSegmentTest.cpp

Added `SerializeTableSegment` — 5 cases:

| # | Scenario | Key bytes |
|---|---|---|
| 1 | MVP tabletype, funcref, min+max [0,14] | `04 05 01 70 01 00 0E` |
| 2 | MVP tabletype, externref, min-only [5] | `04 04 01 6F 00 05` |
| 3 | `0x40 0x00` init-expr form, `{End}` (never before exercised) | `04 07 01 40 00 70 00 00 0B` |
| 4 | `0x40` init-expr form, `ref.func` initializer | `04 0A 01 40 00 70 01 01 10 D2 00 0B` |
| 5 | Negative: `0x40` form rejected without FunctionReferences proposal | `EXPECT_FALSE` |

---

### serializeModuleTest.cpp

Added two new test cases:

- **PopulatedMultiSectionModule** — builds a module with real Type, Function,
  Memory, Export, and Code sections and asserts the exact encoded bytes.
  Proves section framing and ordering are correct together, not just in isolation.
- **ModuleRoundTrip** — serializes a module, loads the bytes back through the
  Loader, serializes again, and asserts both byte sequences are bit-for-bit
  identical. Proves the full pipeline is lossless.

A small `createPopulatedModule()` helper is shared by both tests.

---
## Test Evidence : 
<img width="1163" height="995" alt="image" src="https://github.com/user-attachments/assets/16266997-b58a-45e3-acaa-42a5616b7ab0" />
----
<img width="1895" height="996" alt="image" src="https://github.com/user-attachments/assets/2a668b77-1138-4b3b-bb5d-1cddd887277a" />

## Files Changed

- `test/loader/serializeInstructionTest.cpp` (+346 lines)
- `test/loader/serializeSegmentTest.cpp` (+128 lines)
- `test/loader/serializeModuleTest.cpp` (+84 lines)

No production code changes.

This contribution was developed with assistance from Perplexity AI (GPT-5.4).

## Checklist
- [x] **DCO Signed-off**: commits signed with `git commit -s`
- [x] **Commit Messages**: Conventional Commits format
- [x] **AI Disclosure**: `Assisted-by:` trailer in commit message; disclosure in this PR description
- [x] **Human-in-the-loop**: analysis and tests verified locally by contributor
