### PR TITLE
test(serializer): add multi-section module and round-trip tests

### DIFF
--- a/test/loader/serializeModuleTest.cpp
+++ b/test/loader/serializeModuleTest.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2019-2024 Second State INC
 
+#include "loader/loader.h"
 #include "loader/serialize.h"
 
 #include <cstdint>
@@ -11,6 +12,43 @@ namespace {
 
 WasmEdge::Configure Conf;
 WasmEdge::Loader::Serializer Ser(Conf);
+
+WasmEdge::AST::Module createPopulatedModule() {
+  WasmEdge::AST::Module Module;
+  Module.getMagic() = {0x00U, 0x61U, 0x73U, 0x6DU};
+  Module.getVersion() = {0x01U, 0x00U, 0x00U, 0x00U};
+
+  WasmEdge::AST::FunctionType FuncType;
+  FuncType.getReturnTypes() = {WasmEdge::TypeCode::I32};
+  Module.getTypeSection().getContent() = {FuncType};
+  Module.getTypeSection().setStartOffset(1);
+
+  Module.getFunctionSection().getContent() = {0x00U};
+  Module.getFunctionSection().setStartOffset(2);
+
+  WasmEdge::AST::MemoryType MemoryType;
+  MemoryType.getLimit().setType(WasmEdge::AST::Limit::LimitType::HasMin);
+  MemoryType.getLimit().setMin(1);
+  Module.getMemorySection().getContent() = {MemoryType};
+  Module.getMemorySection().setStartOffset(3);
+
+  WasmEdge::AST::ExportDesc ExportDesc;
+  ExportDesc.setExternalName("main");
+  ExportDesc.setExternalType(WasmEdge::ExternalType::Function);
+  ExportDesc.setExternalIndex(0x00U);
+  Module.getExportSection().getContent() = {ExportDesc};
+  Module.getExportSection().setStartOffset(4);
+
+  WasmEdge::AST::Instruction I32Const(WasmEdge::OpCode::I32__const);
+  WasmEdge::AST::Instruction End(WasmEdge::OpCode::End);
+  I32Const.setNum(static_cast<uint32_t>(42));
+  WasmEdge::AST::CodeSegment CodeSeg;
+  CodeSeg.getExpr().getInstrs() = {I32Const, End};
+  Module.getCodeSection().getContent() = {CodeSeg};
+  Module.getCodeSection().setStartOffset(5);
+
+  return Module;
+}
 
 TEST(serializeModuleTest, SerializeModule) {
   std::vector<uint8_t> Expected;
@@ -52,5 +90,51 @@ TEST(serializeModuleTest, SerializeModule) {
       0x00U, 0x02U, 0x01U, 0x33U, // Sec2
   };
   EXPECT_EQ(Output, Expected);
+}
+
+TEST(serializeModuleTest, PopulatedMultiSectionModule) {
+  std::vector<uint8_t> Expected;
+  std::vector<uint8_t> Output;
+
+  // 2. Test serialize module with multiple populated sections.
+  //
+  //   1.  Serialize module with type, function, memory, export, and code
+  //       sections all containing real content.
+
+  WasmEdge::AST::Module Module = createPopulatedModule();
+
+  Output = *Ser.serializeModule(Module);
+  Expected = {
+      0x00U, 0x61U, 0x73U, 0x6DU,                     // Magic
+      0x01U, 0x00U, 0x00U, 0x00U,                     // Version
+      0x01U, 0x05U, 0x01U, 0x60U, 0x00U, 0x01U, 0x7FU, // Type section
+      0x03U, 0x02U, 0x01U, 0x00U,                     // Function section
+      0x05U, 0x03U, 0x01U, 0x00U, 0x01U,              // Memory section
+      0x07U, 0x08U, 0x01U, 0x04U, 0x6DU, 0x61U, 0x69U,
+      0x6EU, 0x00U, 0x00U,                            // Export section
+      0x0AU, 0x06U, 0x01U, 0x04U, 0x00U, 0x41U, 0x2AU,
+      0x0BU,                                          // Code section
+  };
+  EXPECT_EQ(Output, Expected);
+}
+
+TEST(serializeModuleTest, ModuleRoundTrip) {
+  // 3. Test that serialize -> load -> serialize is lossless.
+  //
+  //   1.  Serialize a module to bytes, parse those bytes back via the Loader,
+  //       serialize the loaded module again, and assert both byte sequences
+  //       are bit-for-bit identical.
+
+  WasmEdge::AST::Module Module = createPopulatedModule();
+
+  std::vector<uint8_t> Bytes1 = *Ser.serializeModule(Module);
+
+  WasmEdge::Loader::Loader Ldr(Conf);
+  auto Res = Ldr.parseModule(Bytes1);
+  EXPECT_TRUE(Res);
+  auto &ModB = *Res;
+
+  std::vector<uint8_t> Bytes2 = *Ser.serializeModule(*ModB);
+  EXPECT_EQ(Bytes1, Bytes2);
 }
 } // namespace


### PR DESCRIPTION
## Description

`serializeModuleTest.cpp` only covered the magic+version header and custom-section ordering. Nothing tested a module whose sections actually carry content, and nothing checked that serialization is lossless — so a bug in section framing or encoding would have gone unnoticed.

This adds two tests:

- **PopulatedMultiSectionModule** — builds a module with real Type, Function, Memory, Export, and Code sections and asserts the exact encoded bytes.
- **ModuleRoundTrip** — serializes a module, loads the bytes back through the Loader, serializes again, and checks both byte sequences are identical (proving the pipeline is lossless).

A small `createPopulatedModule()` helper is shared by both tests.

Only `test/loader/serializeModuleTest.cpp` is touched — no production code.

Part of #4992.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: 
<img width="1740" height="861" alt="Screenshot From 2026-06-16 17-14-13" src="https://github.com/user-attachments/assets/0fd2f7d8-8182-4164-8712-5b38004f8b69" />
## Test Evidence
```
$ ./build/test/loader/wasmedgeLoaderSerializerTests --gtest_filter='serializeModuleTest.*'
[==========] Running 3 tests from 1 test suite.
[ RUN      ] serializeModuleTest.SerializeModule
[       OK ] serializeModuleTest.SerializeModule (0 ms)
[ RUN      ] serializeModuleTest.PopulatedMultiSectionModule
[       OK ] serializeModuleTest.PopulatedMultiSectionModule (0 ms)
[ RUN      ] serializeModuleTest.ModuleRoundTrip
[       OK ] serializeModuleTest.ModuleRoundTrip (0 ms)
[  PASSED  ] 3 tests.
```