### PR TITLE
feat(driver): add wasmedge plugins subcommand

### DIFF
--- a/include/driver/unitool.h
+++ b/include/driver/unitool.h
@@ -22,10 +22,13 @@ enum class ToolType : char {
   Tool,
   Parse,
   Validate,
-  Instantiate
+  Instantiate,
+  Plugins
 };
 
 int UniTool(int Argc, const char *Argv[], const ToolType ToolSelect) noexcept;
+
+int PluginsTool() noexcept;
 
 } // namespace Driver
 } // namespace WasmEdge

--- a/lib/driver/CMakeLists.txt
+++ b/lib/driver/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
   validateTool.cpp
   parseTool.cpp
   instantiateTool.cpp
+  pluginsTool.cpp
   toolConfig.cpp
 )
 

--- a/lib/driver/pluginsTool.cpp
+++ b/lib/driver/pluginsTool.cpp
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+#include "driver/unitool.h"
+#include "common/spdlog.h"
+#include "plugin/plugin.h"
+
+#include <cstdlib>
+#include <string_view>
+
+using namespace std::literals;
+
+namespace WasmEdge {
+namespace Driver {
+
+int PluginsTool() noexcept {
+  std::ios::sync_with_stdio(false);
+
+  Plugin::Plugin::loadFromDefaultPaths();
+  const auto &Plugins = Plugin::Plugin::plugins();
+
+  if (Plugins.empty()) {
+    fmt::print("No plugins loaded.\n"sv);
+    return EXIT_SUCCESS;
+  }
+
+  fmt::print("Loaded Plugins ({}):\n\n"sv, Plugins.size());
+  for (const auto &P : Plugins) {
+    const auto Ver = P.version();
+    fmt::print("  \"{}\" v{}.{}.{}.{}\n"sv, P.name(), Ver.Major, Ver.Minor,
+               Ver.Patch, Ver.Build);
+    fmt::print("  path: {}\n"sv, P.path().string());
+
+    const char *Desc = P.description();
+    if (Desc && Desc[0] != '\0') {
+      fmt::print("  description: {}\n"sv, Desc);
+    }
+
+    const auto Mods = P.modules();
+    if (!Mods.empty()) {
+      fmt::print("  modules ({}):\n"sv, Mods.size());
+      for (const auto &M : Mods) {
+        const char *ModDesc = M.description();
+        if (ModDesc && ModDesc[0] != '\0') {
+          fmt::print("    - \"{}\": {}\n"sv, M.name(), ModDesc);
+        } else {
+          fmt::print("    - \"{}\"\n"sv, M.name());
+        }
+      }
+    }
+
+    const auto Comps = P.components();
+    if (!Comps.empty()) {
+      fmt::print("  components ({}):\n"sv, Comps.size());
+      for (const auto &C : Comps) {
+        const char *CompDesc = C.description();
+        if (CompDesc && CompDesc[0] != '\0') {
+          fmt::print("    - \"{}\": {}\n"sv, C.name(), CompDesc);
+        } else {
+          fmt::print("    - \"{}\"\n"sv, C.name());
+        }
+      }
+    }
+
+    fmt::print("\n"sv);
+  }
+
+  return EXIT_SUCCESS;
+}
+
+} // namespace Driver
+} // namespace WasmEdge

--- a/lib/driver/uniTool.cpp
+++ b/lib/driver/uniTool.cpp
@@ -29,6 +29,8 @@ int UniTool(int Argc, const char *Argv[], const ToolType ToolSelect) noexcept {
       PO::Description("Wasmedge instantiate tool subcommand"sv));
   PO::SubCommand ValidateSubCommand(
       PO::Description("Wasmedge validate tool subcommand"sv));
+  PO::SubCommand PluginsSubCommand(
+      PO::Description("List loaded WasmEdge plugins"sv));
   struct DriverToolOptions ToolOptions;
   struct DriverCompilerOptions CompilerOptions;
   struct DriverToolOptions ParseOptions;
@@ -54,6 +56,8 @@ int UniTool(int Argc, const char *Argv[], const ToolType ToolSelect) noexcept {
     Parser.begin_subcommand(ValidateSubCommand, "validate"sv);
     ValidateOptions.addParserOptions(Parser);
     Parser.end_subcommand();
+    Parser.begin_subcommand(PluginsSubCommand, "plugins"sv);
+    Parser.end_subcommand();
   } else if (ToolSelect == ToolType::Tool) {
     ToolOptions.addOptions(Parser);
   } else if (ToolSelect == ToolType::Compiler) {
@@ -64,6 +68,8 @@ int UniTool(int Argc, const char *Argv[], const ToolType ToolSelect) noexcept {
     ValidateOptions.addParserOptions(Parser);
   } else if (ToolSelect == ToolType::Instantiate) {
     InstantiateOptions.addLinkerOptions(Parser);
+  } else if (ToolSelect == ToolType::Plugins) {
+    // No options for the plugins subcommand.
   } else {
     return EXIT_FAILURE;
   }
@@ -121,6 +127,9 @@ int UniTool(int Argc, const char *Argv[], const ToolType ToolSelect) noexcept {
   } else if (InstantiateSubCommand.is_selected() ||
              ToolSelect == ToolType::Instantiate) {
     return InstantiateTool(InstantiateOptions);
+  } else if (PluginsSubCommand.is_selected() ||
+             ToolSelect == ToolType::Plugins) {
+    return PluginsTool();
   } else {
     return Tool(ToolOptions);
   }

--- a/test/driver/driverToolTest.cpp
+++ b/test/driver/driverToolTest.cpp
@@ -1027,6 +1027,71 @@ TEST(NoSubcommand, FallbackToRun) {
             EXIT_SUCCESS);
 }
 
+// ---------------------------------------------------------------------------
+// PluginsSubcommand tests
+// ---------------------------------------------------------------------------
+
+int callPlugins(std::initializer_list<const char *> Args) {
+  std::vector<const char *> Argv = {"wasmedge"};
+  Argv.insert(Argv.end(), Args.begin(), Args.end());
+  return WasmEdge::Driver::UniTool(static_cast<int>(Argv.size()), Argv.data(),
+                                   WasmEdge::Driver::ToolType::Plugins);
+}
+
+TEST(PluginsSubcommand, Succeeds) { EXPECT_EQ(callPlugins({}), EXIT_SUCCESS); }
+
+TEST(PluginsSubcommand, RejectsUnknownFlag) {
+  EXPECT_NE(callPlugins({"--no-such-flag"}), EXIT_SUCCESS);
+}
+
+TEST(PluginsSubcommand, UniToolRouting) {
+  std::vector<const char *> Argv = {"wasmedge", "plugins"};
+  EXPECT_EQ(WasmEdge::Driver::UniTool(static_cast<int>(Argv.size()),
+                                      Argv.data(),
+                                      WasmEdge::Driver::ToolType::All),
+            EXIT_SUCCESS);
+}
+
+#if !WASMEDGE_OS_WINDOWS
+ToolResult callPluginsCaptureStdout() {
+  std::vector<const char *> Argv = {"wasmedge"};
+  int Pipe[2];
+  if (pipe(Pipe) != 0) {
+    return {-1, {}};
+  }
+  int SavedStdout = dup(STDOUT_FILENO);
+  dup2(Pipe[1], STDOUT_FILENO);
+  close(Pipe[1]);
+  int Ret = WasmEdge::Driver::UniTool(static_cast<int>(Argv.size()),
+                                      Argv.data(),
+                                      WasmEdge::Driver::ToolType::Plugins);
+  fflush(stdout);
+  dup2(SavedStdout, STDOUT_FILENO);
+  close(SavedStdout);
+  std::string Output;
+  char Buf[4096];
+  ssize_t N;
+  while ((N = read(Pipe[0], Buf, sizeof(Buf))) > 0) {
+    Output.append(Buf, static_cast<size_t>(N));
+  }
+  close(Pipe[0]);
+  return {Ret, std::move(Output)};
+}
+
+TEST(PluginsSubcommand, OutputContainsBuiltInPlugin) {
+  auto R = callPluginsCaptureStdout();
+  ASSERT_EQ(R.ExitCode, EXIT_SUCCESS);
+  // wasi_logging is always registered as a built-in plugin.
+  EXPECT_TRUE(containsAll(R.Stdout, {"wasi_logging", "wasi:logging/logging"}));
+}
+
+TEST(PluginsSubcommand, OutputContainsHeader) {
+  auto R = callPluginsCaptureStdout();
+  ASSERT_EQ(R.ExitCode, EXIT_SUCCESS);
+  EXPECT_TRUE(containsAll(R.Stdout, {"Loaded Plugins"}));
+}
+#endif
+
 } // namespace
 
 GTEST_API_ int main(int Argc, char *Argv[]) {


### PR DESCRIPTION
## Description

This PR adds a new `plugins` subcommand to WasmEdge, making it easy to view loaded plugins directly from the CLI.
Users can now inspect plugin details such as version, path, description, and available modules instead of relying on the limited output from `wasmedge --version`.

## Checklist

* [x] DCO Signed-off
* [x] Commit message follows project guidelines
* [x] Local tests passed

## Test Evidence

Added tests for command execution, routing, invalid flag handling, and built-in plugin output verification (`wasi_logging`).
All new and existing tests pass successfully.
