### PR TITLE
feat(validator): enforce component value linearity (GAP-EX-4)

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1144,6 +1144,11 @@ E(ComponentGlobalTypeMismatch, 0x02BD, "type mismatch in global type")
 E(ComponentTableLimitsMismatch, 0x02BE, "mismatch in table limits")
 // Core instance arg table element type does not match the import
 E(ComponentTableElemTypeMismatch, 0x02BF, "type mismatch in table element type")
+// Value linearity: each value must be consumed exactly once (GAP-EX-4)
+E(ComponentValueAlreadyConsumed, 0x02C0,
+  "value has already been consumed")
+E(ComponentValueNotConsumed, 0x02C1,
+  "value was not consumed before end of component")
 // @}
 
 // Instantiation phase

--- a/include/validator/component_context.h
+++ b/include/validator/component_context.h
@@ -127,7 +127,7 @@ public:
     std::vector<InstanceSlot> Instances;                 // instance
     std::vector<const AST::Component::DefType *> Types;  // type
     std::vector<const AST::Component::FuncType *> Funcs; // func (i may be null)
-    uint32_t ValueCount = 0;                             // value
+    std::vector<bool> ValueConsumed;                     // value (consumed?)
 
     // ---- Type annotations (keyed by type index) ----
     // ResourceType bodies live on Resources[i].Body (see below).
@@ -536,7 +536,34 @@ public:
     const auto &V = getCurrentContext().Funcs;
     return Idx < V.size() ? V[Idx] : nullptr;
   }
-  uint32_t addValue() noexcept { return getCurrentContext().ValueCount++; }
+  uint32_t addValue(bool Consumed = false) noexcept {
+    auto &V = getCurrentContext().ValueConsumed;
+    uint32_t Idx = static_cast<uint32_t>(V.size());
+    V.push_back(Consumed);
+    return Idx;
+  }
+
+  Expect<void> consumeValue(uint32_t Idx) noexcept {
+    auto &V = getCurrentContext().ValueConsumed;
+    if (Idx >= V.size()) {
+      return Unexpect(ErrCode::Value::InvalidIndex);
+    }
+    if (V[Idx]) {
+      return Unexpect(ErrCode::Value::ComponentValueAlreadyConsumed);
+    }
+    V[Idx] = true;
+    return {};
+  }
+
+  std::optional<uint32_t> firstUnconsumedValue() const noexcept {
+    const auto &V = getCurrentContext().ValueConsumed;
+    for (uint32_t I = 0; I < V.size(); ++I) {
+      if (!V[I]) {
+        return I;
+      }
+    }
+    return std::nullopt;
+  }
 
   // ==========================================================================
   // Validation state

--- a/lib/validator/component_context.cpp
+++ b/lib/validator/component_context.cpp
@@ -11,7 +11,7 @@ ComponentContext::Context::getSortIndexSize(Sort::SortType ST) const noexcept {
   case Sort::SortType::Func:
     return static_cast<uint32_t>(Funcs.size());
   case Sort::SortType::Value:
-    return ValueCount;
+    return static_cast<uint32_t>(ValueConsumed.size());
   case Sort::SortType::Type:
     return static_cast<uint32_t>(Types.size());
   case Sort::SortType::Component:

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -338,6 +338,17 @@ Validator::validateComponent(const AST::Component::Component &Comp) noexcept {
     };
     EXPECTED_TRY(std::visit(Func, Sec));
   }
+  // Value linearity: every value in the value index space must have been
+  // consumed exactly once before the component scope closes.
+  if (auto Idx = CompCtx.firstUnconsumedValue()) {
+    spdlog::error(ErrCode::Value::ComponentValueNotConsumed);
+    spdlog::error(
+        "    Component: value index {} was not consumed before end of component"sv,
+        *Idx);
+    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Component));
+    CompCtx.exitComponent();
+    return Unexpect(ErrCode::Value::ComponentValueNotConsumed);
+  }
   CompCtx.exitComponent();
   return {};
 }
@@ -515,10 +526,8 @@ Validator::validate(const AST::Component::StartSection &StartSec) noexcept {
   //   2. `f`'s functype param arity equals |arg*| and result arity equals
   //      `r`. Per-argument value-type subtype is checked once subtype
   //      machinery exists (Phase 3).
-  //   3. Each argument index is in bounds of the value index space.
-  //      Per-value linearity (consume-once) is the responsibility of
-  //      GAP-EX-4: the per-value `consumed` flag and the end-of-component
-  //      "all consumed" pass. They are not yet wired here.
+  //   3. Each argument index is in bounds of the value index space and
+  //      has not already been consumed (value linearity).
   //   4. The function's result types are appended to the value index space
   //      as fresh values, so later definitions can reference them.
   const auto &Start = StartSec.getContent();
@@ -563,18 +572,21 @@ Validator::validate(const AST::Component::StartSection &StartSec) noexcept {
     }
   }
 
-  // 3. Argument indices must be in value index space bounds. Per-arg
-  // consume-once tracking is deferred (GAP-EX-4).
-  const uint32_t ValueSpaceSize =
-      CompCtx.getSortIndexSize(AST::Component::Sort::SortType::Value);
+  // 3. Each argument index must be in value index space bounds and must not
+  // have been consumed already (value linearity).
   for (const uint32_t ArgIdx : Start.getArguments()) {
-    if (ArgIdx >= ValueSpaceSize) {
-      spdlog::error(ErrCode::Value::InvalidIndex);
-      spdlog::error(
-          "    Start: argument value index {} exceeds value index space size {}"sv,
-          ArgIdx, ValueSpaceSize);
+    if (auto Res = CompCtx.consumeValue(ArgIdx); !Res) {
+      spdlog::error(Res.error());
+      if (Res.error() == ErrCode::Value::InvalidIndex) {
+        spdlog::error(
+            "    Start: argument value index {} is out of value index space bounds"sv,
+            ArgIdx);
+      } else {
+        spdlog::error("    Start: value index {} has already been consumed"sv,
+                      ArgIdx);
+      }
       spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Sec_Start));
-      return Unexpect(ErrCode::Value::InvalidIndex);
+      return Unexpect(Res);
     }
   }
 
@@ -2223,9 +2235,9 @@ Expect<void> Validator::validate(const AST::Component::Export &Ex) noexcept {
   //   4. The export name is strongly-unique across exports.
   //   5. The export introduces a new index aliasing the definition in the
   //      component's own index space for its sort.
+  //   6. If the sort is `value`, the value is consumed (value linearity).
   //
-  // Not yet enforced: transitive resource-avoidance in exported types;
-  // flipping the "consumed" flag for value exports.
+  // Not yet enforced: transitive resource-avoidance in exported types.
 
   // Validate the sortidx bounds.
   const auto &Sort = Ex.getSortIndex().getSort();
@@ -2252,6 +2264,15 @@ Expect<void> Validator::validate(const AST::Component::Export &Ex) noexcept {
       spdlog::error("    Export: sort index {} out of bounds"sv, Idx);
       spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Export));
       return Unexpect(ErrCode::Value::DefTypeIndexOutOfBounds);
+    }
+    if (Sort.getSortType() == AST::Component::Sort::SortType::Value) {
+      if (auto Res = CompCtx.consumeValue(Idx); !Res) {
+        spdlog::error(Res.error());
+        spdlog::error("    Export: value index {} has already been consumed"sv,
+                      Idx);
+        spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Export));
+        return Unexpect(Res);
+      }
     }
   }
 
@@ -2310,7 +2331,11 @@ Expect<void> Validator::validate(const AST::Component::Export &Ex) noexcept {
         }
       }
     }
-    uint32_t NewIdx = CompCtx.incSortIndexSize(Sort.getSortType());
+
+    uint32_t NewIdx =
+        Sort.getSortType() == AST::Component::Sort::SortType::Value
+            ? CompCtx.addValue(/*Consumed=*/true)
+            : CompCtx.incSortIndexSize(Sort.getSortType());
     if (IsInst) {
       if (IT != nullptr) {
         populateInstanceFromType(NewIdx, *IT);
@@ -2337,7 +2362,7 @@ Validator::validate(const AST::Component::ExternDesc &Desc) noexcept {
   // matching the descriptor's sort:
   //   * core module (CoreType) → core:module
   //   * func                   → func
-  //   * value                  → value (consumed=false; not yet tracked)
+  //   * value                  → value (consumed=false)
   //   * type (eq i)            → type aliased to i (resource property
   //                              propagated when i refers to a resource)
   //   * type (sub resource)    → fresh abstract resource type

--- a/test/component/ComponentValidatorTest.cpp
+++ b/test/component/ComponentValidatorTest.cpp
@@ -2459,4 +2459,221 @@ TEST(ComponentValidatorTest,
   ASSERT_FALSE(V.validate(Comp));
 }
 
+TEST(ComponentValidatorTest, ValueNotConsumedAtEndOfComponent) {
+  // Import a value, never consume it -> reject
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+  auto &ImpSec =
+      std::get<AST::Component::ImportSection>(Comp.getSections().back());
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "val0";
+  ImpSec.getContent().back().getDesc().setValueBound(
+      ComponentValType(ComponentTypeCode::U32));
+
+  Validator::Validator V(Conf);
+  auto Res = V.validate(Comp);
+  EXPECT_FALSE(Res);
+  EXPECT_EQ(Res.error(), ErrCode::Value::ComponentValueNotConsumed);
+}
+
+TEST(ComponentValidatorTest, ValueConsumedExactlyOnceByExport) {
+  // Import a value, export it once -> accept
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+  auto &ImpSec =
+      std::get<AST::Component::ImportSection>(Comp.getSections().back());
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "val0";
+  ImpSec.getContent().back().getDesc().setValueBound(
+      ComponentValType(ComponentTypeCode::U32));
+
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ExportSection>();
+  auto &ExpSec =
+      std::get<AST::Component::ExportSection>(Comp.getSections().back());
+  ExpSec.getContent().emplace_back();
+  ExpSec.getContent().back().getName() = "exp0";
+  ExpSec.getContent().back().getSortIndex().getSort().setIsCore(false);
+  ExpSec.getContent().back().getSortIndex().getSort().setSortType(
+      AST::Component::Sort::SortType::Value);
+  ExpSec.getContent().back().getSortIndex().setIdx(0);
+
+  Validator::Validator V(Conf);
+  auto Res = V.validate(Comp);
+  EXPECT_TRUE(Res);
+}
+
+TEST(ComponentValidatorTest, ExportConsumesSameValueTwice) {
+  // Import a value, export it twice -> reject
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+  auto &ImpSec =
+      std::get<AST::Component::ImportSection>(Comp.getSections().back());
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "val0";
+  ImpSec.getContent().back().getDesc().setValueBound(
+      ComponentValType(ComponentTypeCode::U32));
+
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ExportSection>();
+  auto &ExpSec =
+      std::get<AST::Component::ExportSection>(Comp.getSections().back());
+
+  ExpSec.getContent().emplace_back();
+  ExpSec.getContent().back().getName() = "exp0";
+  ExpSec.getContent().back().getSortIndex().getSort().setIsCore(false);
+  ExpSec.getContent().back().getSortIndex().getSort().setSortType(
+      AST::Component::Sort::SortType::Value);
+  ExpSec.getContent().back().getSortIndex().setIdx(0);
+
+  ExpSec.getContent().emplace_back();
+  ExpSec.getContent().back().getName() = "exp1";
+  ExpSec.getContent().back().getSortIndex().getSort().setIsCore(false);
+  ExpSec.getContent().back().getSortIndex().getSort().setSortType(
+      AST::Component::Sort::SortType::Value);
+  ExpSec.getContent().back().getSortIndex().setIdx(0);
+
+  Validator::Validator V(Conf);
+  auto Res = V.validate(Comp);
+  EXPECT_FALSE(Res);
+  EXPECT_EQ(Res.error(), ErrCode::Value::ComponentValueAlreadyConsumed);
+}
+
+TEST(ComponentValidatorTest, ValueConsumedExactlyOnceByStart) {
+  // Import a value, call a start function with that value -> accept
+  AST::Component::Component Comp;
+
+  // 1. Define a function type (param: u32, result: none)
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+  TypeSec.getContent().emplace_back();
+  AST::Component::FuncType FT;
+  FT.setParamList({AST::Component::LabelValType(
+      "arg0"s, ComponentValType(ComponentTypeCode::U32))});
+  TypeSec.getContent().back().setFuncType(std::move(FT));
+
+  // 2. Import section: first import the value, then the function using type 0
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+  auto &ImpSec =
+      std::get<AST::Component::ImportSection>(Comp.getSections().back());
+
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "val0";
+  ImpSec.getContent().back().getDesc().setValueBound(
+      ComponentValType(ComponentTypeCode::U32));
+
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "func0";
+  ImpSec.getContent().back().getDesc().setFuncTypeIdx(0);
+
+  // 3. Start section calling func0 (funcidx 0) with val0 (valueidx 0)
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::StartSection>();
+  auto &StartSec =
+      std::get<AST::Component::StartSection>(Comp.getSections().back());
+  StartSec.getContent().getFunctionIndex() = 0;
+  StartSec.getContent().getArguments() = {0};
+  StartSec.getContent().getResult() = 0;
+
+  Validator::Validator V(Conf);
+  auto Res = V.validate(Comp);
+  EXPECT_TRUE(Res);
+}
+
+TEST(ComponentValidatorTest, StartConsumesSameValueTwice) {
+  // Import a value, call a start function with two params using same value
+  // twice
+  // -> reject
+  AST::Component::Component Comp;
+
+  // 1. Define a function type (param: u32, u32, result: none)
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+  TypeSec.getContent().emplace_back();
+  AST::Component::FuncType FT;
+  FT.setParamList({AST::Component::LabelValType(
+                       "arg0"s, ComponentValType(ComponentTypeCode::U32)),
+                   AST::Component::LabelValType(
+                       "arg1"s, ComponentValType(ComponentTypeCode::U32))});
+  TypeSec.getContent().back().setFuncType(std::move(FT));
+
+  // 2. Import section: first import the value, then the function using type 0
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+  auto &ImpSec =
+      std::get<AST::Component::ImportSection>(Comp.getSections().back());
+
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "val0";
+  ImpSec.getContent().back().getDesc().setValueBound(
+      ComponentValType(ComponentTypeCode::U32));
+
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "func0";
+  ImpSec.getContent().back().getDesc().setFuncTypeIdx(0);
+
+  // 3. Start section calling func0 (funcidx 0) with args {0, 0}
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::StartSection>();
+  auto &StartSec =
+      std::get<AST::Component::StartSection>(Comp.getSections().back());
+  StartSec.getContent().getFunctionIndex() = 0;
+  StartSec.getContent().getArguments() = {0, 0};
+  StartSec.getContent().getResult() = 0;
+
+  Validator::Validator V(Conf);
+  auto Res = V.validate(Comp);
+  EXPECT_FALSE(Res);
+  EXPECT_EQ(Res.error(), ErrCode::Value::ComponentValueAlreadyConsumed);
+}
+
+TEST(ComponentValidatorTest, StartArgumentValueIndexOutOfBounds) {
+  // Call a start function whose argument references a value index that does not
+  // exist in the (empty) value index space -> reject with InvalidIndex.
+  AST::Component::Component Comp;
+
+  // 1. Define a function type (param: u32, result: none).
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+  TypeSec.getContent().emplace_back();
+  AST::Component::FuncType FT;
+  FT.setParamList({AST::Component::LabelValType(
+      "arg0"s, ComponentValType(ComponentTypeCode::U32))});
+  TypeSec.getContent().back().setFuncType(std::move(FT));
+
+  // 2. Import only the function (no value is imported, so the value index
+  // space stays empty).
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+  auto &ImpSec =
+      std::get<AST::Component::ImportSection>(Comp.getSections().back());
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "func0";
+  ImpSec.getContent().back().getDesc().setFuncTypeIdx(0);
+
+  // 3. Start section calling func0 with value index 0, which is out of bounds.
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::StartSection>();
+  auto &StartSec =
+      std::get<AST::Component::StartSection>(Comp.getSections().back());
+  StartSec.getContent().getFunctionIndex() = 0;
+  StartSec.getContent().getArguments() = {0};
+  StartSec.getContent().getResult() = 0;
+
+  Validator::Validator V(Conf);
+  auto Res = V.validate(Comp);
+  EXPECT_FALSE(Res);
+  EXPECT_EQ(Res.error(), ErrCode::Value::InvalidIndex);
+}
+
 } // namespace


### PR DESCRIPTION
## Background

The Component Model requires values in the value index space to be consumed exactly once. WasmEdge currently tracks only the number of values and does not validate linear consumption semantics (GAP-EX-4).

## Changes

* Replace value count tracking with per-value consumption state in `ComponentContext`
* Track value consumption when values are used by:

  * `start` arguments
  * value exports
* Reject double consumption of the same value
* Reject components that finish validation with unconsumed values
* Remove existing GAP-EX-4 TODOs
* Add unit tests covering valid and invalid consumption scenarios

## Notes

* This PR only wires consumption checks for currently reachable validation paths (`start` arguments and value exports).
* Support for value consumption through component instantiation arguments can be added when the corresponding value feature path is enabled.

