### PR TITLE
fix(test/plugins): remove concrete host-function casts for devirtualization

### DIFF
--- a/test/plugins/wasi_logging/wasi_logging.cpp
+++ b/test/plugins/wasi_logging/wasi_logging.cpp
@@ -87,10 +87,8 @@ TEST(WasiLoggingTests, func_log) {
   EXPECT_NE(FuncInst2, nullptr);
   EXPECT_TRUE(FuncInst1->isHostFunction());
   EXPECT_TRUE(FuncInst2->isHostFunction());
-  auto &HostFuncInst1 = dynamic_cast<WasmEdge::Host::WASILogging::Log &>(
-      FuncInst1->getHostFunc());
-  auto &HostFuncInst2 = dynamic_cast<WasmEdge::Host::WASILogging::Log &>(
-      FuncInst2->getHostFunc());
+  auto &HostFuncInst1 = FuncInst1->getHostFunc();
+  auto &HostFuncInst2 = FuncInst2->getHostFunc();
 
   // Show All Level
   EXPECT_TRUE(HostFuncInst1.run(
@@ -205,8 +203,7 @@ TEST(WasiLoggingTests, func_log_oob) {
   auto *FuncInst = WasiLoggingMod->findFuncExports("log");
   ASSERT_NE(FuncInst, nullptr);
   ASSERT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncInst =
-      dynamic_cast<WasmEdge::Host::WASILogging::Log &>(FuncInst->getHostFunc());
+  auto &HostFuncInst = FuncInst->getHostFunc();
 
   // OOB context: CxtPtr=65535, CxtLen=100 extends 99 bytes past the page end.
   // Expected: HostFuncError (not a crash).

--- a/test/plugins/wasi_logging/wasi_logging.cpp
+++ b/test/plugins/wasi_logging/wasi_logging.cpp
@@ -83,10 +83,10 @@ TEST(WasiLoggingTests, func_log) {
   // Get the function "log".
   auto *FuncInst1 = WasiLoggingMod1->findFuncExports("log");
   auto *FuncInst2 = WasiLoggingMod2->findFuncExports("log");
-  EXPECT_NE(FuncInst1, nullptr);
-  EXPECT_NE(FuncInst2, nullptr);
-  EXPECT_TRUE(FuncInst1->isHostFunction());
-  EXPECT_TRUE(FuncInst2->isHostFunction());
+  ASSERT_NE(FuncInst1, nullptr);
+  ASSERT_NE(FuncInst2, nullptr);
+  ASSERT_TRUE(FuncInst1->isHostFunction());
+  ASSERT_TRUE(FuncInst2->isHostFunction());
   auto &HostFuncInst1 = FuncInst1->getHostFunc();
   auto &HostFuncInst2 = FuncInst2->getHostFunc();
 

--- a/test/plugins/wasm_bpf/simple_map_test.cpp
+++ b/test/plugins/wasm_bpf/simple_map_test.cpp
@@ -161,7 +161,7 @@ TEST(WasmBpfTest, SimpleMapTest) {
   auto mapFd = mapFdResult[0].get<int32_t>();
   ASSERT_GE(mapFd, 0);
 
-  // Get function `wasm_bpf_map_fd_by_name`
+  // Get function `wasm_bpf_map_operate`
   auto *mapOptFunc = module->findFuncExports("wasm_bpf_map_operate");
   ASSERT_NE(mapOptFunc, nullptr);
   ASSERT_TRUE(mapOptFunc->isHostFunction());

--- a/test/plugins/wasm_bpf/simple_map_test.cpp
+++ b/test/plugins/wasm_bpf/simple_map_test.cpp
@@ -163,8 +163,8 @@ TEST(WasmBpfTest, SimpleMapTest) {
 
   // Get function `wasm_bpf_map_fd_by_name`
   auto *mapOptFunc = module->findFuncExports("wasm_bpf_map_operate");
-  EXPECT_NE(mapOptFunc, nullptr);
-  EXPECT_TRUE(mapOptFunc->isHostFunction());
+  ASSERT_NE(mapOptFunc, nullptr);
+  ASSERT_TRUE(mapOptFunc->isHostFunction());
   auto &mapOptFuncHost = mapOptFunc->getHostFunc();
 
   // A wrapper to call wasm_bpf_map_operate

--- a/test/plugins/wasm_bpf/simple_map_test.cpp
+++ b/test/plugins/wasm_bpf/simple_map_test.cpp
@@ -113,8 +113,7 @@ TEST(WasmBpfTest, SimpleMapTest) {
   auto *loadFunc = module->findFuncExports("wasm_load_bpf_object");
   ASSERT_NE(loadFunc, nullptr);
   ASSERT_TRUE(loadFunc->isHostFunction());
-  auto &loadFuncHost =
-      dynamic_cast<WasmEdge::Host::LoadBpfObject &>(loadFunc->getHostFunc());
+  auto &loadFuncHost = loadFunc->getHostFunc();
 
   // call "wasm_load_bpf_object" to Load `bootstrap.bpf.o`, and check the
   // result
@@ -132,8 +131,7 @@ TEST(WasmBpfTest, SimpleMapTest) {
   auto *attachFunc = module->findFuncExports("wasm_attach_bpf_program");
   ASSERT_NE(attachFunc, nullptr);
   ASSERT_TRUE(attachFunc->isHostFunction());
-  auto &attachFuncHost = dynamic_cast<WasmEdge::Host::AttachBpfProgram &>(
-      attachFunc->getHostFunc());
+  auto &attachFuncHost = attachFunc->getHostFunc();
 
   // Call "wasm_attach_bpf_program" to attach, and check the result
   std::array<WasmEdge::ValVariant, 1> attachResult;
@@ -151,8 +149,7 @@ TEST(WasmBpfTest, SimpleMapTest) {
   auto *mapFdFunc = module->findFuncExports("wasm_bpf_map_fd_by_name");
   ASSERT_NE(mapFdFunc, nullptr);
   ASSERT_TRUE(mapFdFunc->isHostFunction());
-  auto &mapFdFuncHost =
-      dynamic_cast<WasmEdge::Host::BpfMapFdByName &>(mapFdFunc->getHostFunc());
+  auto &mapFdFuncHost = mapFdFunc->getHostFunc();
 
   // Call "wasm_bpf_map_fd_by_name" to get the map fd, and check the result
   std::array<WasmEdge::ValVariant, 1> mapFdResult;
@@ -168,8 +165,7 @@ TEST(WasmBpfTest, SimpleMapTest) {
   auto *mapOptFunc = module->findFuncExports("wasm_bpf_map_operate");
   EXPECT_NE(mapOptFunc, nullptr);
   EXPECT_TRUE(mapOptFunc->isHostFunction());
-  auto &mapOptFuncHost =
-      dynamic_cast<WasmEdge::Host::BpfMapOperate &>(mapOptFunc->getHostFunc());
+  auto &mapOptFuncHost = mapOptFunc->getHostFunc();
 
   // A wrapper to call wasm_bpf_map_operate
   auto callMapOperate = [&](int32_t fd, int32_t cmd, uint32_t key,
@@ -278,8 +274,7 @@ TEST(WasmBpfTest, SimpleMapTest) {
   auto *closeFunc = module->findFuncExports("wasm_close_bpf_object");
   ASSERT_NE(closeFunc, nullptr);
   ASSERT_TRUE(closeFunc->isHostFunction());
-  auto &closeFuncHost =
-      dynamic_cast<WasmEdge::Host::CloseBpfObject &>(closeFunc->getHostFunc());
+  auto &closeFuncHost = closeFunc->getHostFunc();
 
   // Call "wasm_close_bpf_object" to attach, and check the result
   std::array<WasmEdge::ValVariant, 1> closeResult;

--- a/test/plugins/wasm_bpf/simple_ringbuf_test.cpp
+++ b/test/plugins/wasm_bpf/simple_ringbuf_test.cpp
@@ -133,8 +133,7 @@ TEST(WasmBpfTest, SimpleRingbuf) {
   auto *loadFunc = module->findFuncExports("wasm_load_bpf_object");
   ASSERT_NE(loadFunc, nullptr);
   ASSERT_TRUE(loadFunc->isHostFunction());
-  auto &loadFuncHost =
-      dynamic_cast<WasmEdge::Host::LoadBpfObject &>(loadFunc->getHostFunc());
+  auto &loadFuncHost = loadFunc->getHostFunc();
 
   // call "wasm_load_bpf_object" to Load `bootstrap.bpf.o`, and check the
   // result
@@ -152,8 +151,7 @@ TEST(WasmBpfTest, SimpleRingbuf) {
   auto *attachFunc = module->findFuncExports("wasm_attach_bpf_program");
   ASSERT_NE(attachFunc, nullptr);
   ASSERT_TRUE(attachFunc->isHostFunction());
-  auto &attachFuncHost = dynamic_cast<WasmEdge::Host::AttachBpfProgram &>(
-      attachFunc->getHostFunc());
+  auto &attachFuncHost = attachFunc->getHostFunc();
 
   // Call "wasm_attach_bpf_program" to attach, and check the result
   std::array<WasmEdge::ValVariant, 1> attachResult;
@@ -171,8 +169,7 @@ TEST(WasmBpfTest, SimpleRingbuf) {
   auto *mapFdFunc = module->findFuncExports("wasm_bpf_map_fd_by_name");
   ASSERT_NE(mapFdFunc, nullptr);
   ASSERT_TRUE(mapFdFunc->isHostFunction());
-  auto &mapFdFuncHost =
-      dynamic_cast<WasmEdge::Host::BpfMapFdByName &>(mapFdFunc->getHostFunc());
+  auto &mapFdFuncHost = mapFdFunc->getHostFunc();
 
   // Call "wasm_bpf_map_fd_by_name" to get the map fd, and check the result
   std::array<WasmEdge::ValVariant, 1> mapFdResult;
@@ -205,8 +202,7 @@ TEST(WasmBpfTest, SimpleRingbuf) {
   auto *bufferPollFunc = module->findFuncExports("wasm_bpf_buffer_poll");
   ASSERT_NE(bufferPollFunc, nullptr);
   ASSERT_TRUE(bufferPollFunc->isHostFunction());
-  auto &bufferPollFuncHost = dynamic_cast<WasmEdge::Host::BpfBufferPoll &>(
-      bufferPollFunc->getHostFunc());
+  auto &bufferPollFuncHost = bufferPollFunc->getHostFunc();
 
   // Call the polling function
   std::array<WasmEdge::ValVariant, 1> pollResult;
@@ -231,8 +227,7 @@ TEST(WasmBpfTest, SimpleRingbuf) {
   auto *closeFunc = module->findFuncExports("wasm_close_bpf_object");
   ASSERT_NE(closeFunc, nullptr);
   ASSERT_TRUE(closeFunc->isHostFunction());
-  auto &closeFuncHost =
-      dynamic_cast<WasmEdge::Host::CloseBpfObject &>(closeFunc->getHostFunc());
+  auto &closeFuncHost = closeFunc->getHostFunc();
 
   // Call "wasm_close_bpf_object" to attach, and check the result
   std::array<WasmEdge::ValVariant, 1> closeResult;

--- a/test/plugins/wasm_bpf/wasm_bpf.cpp
+++ b/test/plugins/wasm_bpf/wasm_bpf.cpp
@@ -214,8 +214,7 @@ TEST(WasmBpfTest, RunBpfProgramWithPolling) {
   auto *loadFunc = module->findFuncExports("wasm_load_bpf_object");
   EXPECT_NE(loadFunc, nullptr);
   EXPECT_TRUE(loadFunc->isHostFunction());
-  auto &loadFuncHost =
-      dynamic_cast<WasmEdge::Host::LoadBpfObject &>(loadFunc->getHostFunc());
+  auto &loadFuncHost = loadFunc->getHostFunc();
 
   // call "wasm_load_bpf_object" to Load `bootstrap.bpf.o`, and check the
   // result
@@ -233,8 +232,7 @@ TEST(WasmBpfTest, RunBpfProgramWithPolling) {
   auto *attachFunc = module->findFuncExports("wasm_attach_bpf_program");
   EXPECT_NE(attachFunc, nullptr);
   EXPECT_TRUE(attachFunc->isHostFunction());
-  auto &attachFuncHost = dynamic_cast<WasmEdge::Host::AttachBpfProgram &>(
-      attachFunc->getHostFunc());
+  auto &attachFuncHost = attachFunc->getHostFunc();
 
   // Call "wasm_attach_bpf_program" to attach, and check the result
   std::array<WasmEdge::ValVariant, 1> attachResult;
@@ -267,8 +265,7 @@ TEST(WasmBpfTest, RunBpfProgramWithPolling) {
   auto *mapFdFunc = module->findFuncExports("wasm_bpf_map_fd_by_name");
   EXPECT_NE(mapFdFunc, nullptr);
   EXPECT_TRUE(mapFdFunc->isHostFunction());
-  auto &mapFdFuncHost =
-      dynamic_cast<WasmEdge::Host::BpfMapFdByName &>(mapFdFunc->getHostFunc());
+  auto &mapFdFuncHost = mapFdFunc->getHostFunc();
 
   // Call "wasm_bpf_map_fd_by_name" to get the map fd, and check the result
   std::array<WasmEdge::ValVariant, 1> mapFdResult;
@@ -301,8 +298,7 @@ TEST(WasmBpfTest, RunBpfProgramWithPolling) {
   auto *bufferPollFunc = module->findFuncExports("wasm_bpf_buffer_poll");
   EXPECT_NE(bufferPollFunc, nullptr);
   EXPECT_TRUE(bufferPollFunc->isHostFunction());
-  auto &bufferPollFuncHost = dynamic_cast<WasmEdge::Host::BpfBufferPoll &>(
-      bufferPollFunc->getHostFunc());
+  auto &bufferPollFuncHost = bufferPollFunc->getHostFunc();
 
   // Call the polling function
   std::array<WasmEdge::ValVariant, 1> pollResult;
@@ -327,8 +323,7 @@ TEST(WasmBpfTest, RunBpfProgramWithPolling) {
   auto *closeFunc = module->findFuncExports("wasm_close_bpf_object");
   EXPECT_NE(closeFunc, nullptr);
   EXPECT_TRUE(closeFunc->isHostFunction());
-  auto &closeFuncHost =
-      dynamic_cast<WasmEdge::Host::CloseBpfObject &>(closeFunc->getHostFunc());
+  auto &closeFuncHost = closeFunc->getHostFunc();
 
   // Call "wasm_close_bpf_object" to attach, and check the result
   std::array<WasmEdge::ValVariant, 1> closeResult;
@@ -407,8 +402,7 @@ TEST(WasmBpfTest, RunBpfProgramWithMapOperation) {
   auto *loadFunc = module->findFuncExports("wasm_load_bpf_object");
   EXPECT_NE(loadFunc, nullptr);
   EXPECT_TRUE(loadFunc->isHostFunction());
-  auto &loadFuncHost =
-      dynamic_cast<WasmEdge::Host::LoadBpfObject &>(loadFunc->getHostFunc());
+  auto &loadFuncHost = loadFunc->getHostFunc();
 
   // call "wasm_load_bpf_object" to Load `bootstrap.bpf.o`, and check the
   // result
@@ -426,8 +420,7 @@ TEST(WasmBpfTest, RunBpfProgramWithMapOperation) {
   auto *attachFunc = module->findFuncExports("wasm_attach_bpf_program");
   EXPECT_NE(attachFunc, nullptr);
   EXPECT_TRUE(attachFunc->isHostFunction());
-  auto &attachFuncHost = dynamic_cast<WasmEdge::Host::AttachBpfProgram &>(
-      attachFunc->getHostFunc());
+  auto &attachFuncHost = attachFunc->getHostFunc();
   std::array<size_t, 3> programNameIndexes = {1, 2, 3};
 
   // Attach the programs
@@ -449,8 +442,7 @@ TEST(WasmBpfTest, RunBpfProgramWithMapOperation) {
   auto *mapFdFunc = module->findFuncExports("wasm_bpf_map_fd_by_name");
   EXPECT_NE(mapFdFunc, nullptr);
   EXPECT_TRUE(mapFdFunc->isHostFunction());
-  auto &mapFdFuncHost =
-      dynamic_cast<WasmEdge::Host::BpfMapFdByName &>(mapFdFunc->getHostFunc());
+  auto &mapFdFuncHost = mapFdFunc->getHostFunc();
 
   // Call "wasm_bpf_map_fd_by_name" to get the map fd, and check the result
   std::array<WasmEdge::ValVariant, 1> mapFdResult;
@@ -466,8 +458,7 @@ TEST(WasmBpfTest, RunBpfProgramWithMapOperation) {
   auto *mapOptFunc = module->findFuncExports("wasm_bpf_map_operate");
   EXPECT_NE(mapOptFunc, nullptr);
   EXPECT_TRUE(mapOptFunc->isHostFunction());
-  auto &mapOptFuncHost =
-      dynamic_cast<WasmEdge::Host::BpfMapOperate &>(mapOptFunc->getHostFunc());
+  auto &mapOptFuncHost = mapOptFunc->getHostFunc();
   // A wrapper to call wasm_bpf_map_operate
   auto callMapOperate = [&](int32_t fd, int32_t cmd, uint32_t key,
                             uint32_t value, uint32_t nextKey,
@@ -562,8 +553,7 @@ TEST(WasmBpfTest, RunBpfProgramWithMapOperation) {
   auto *closeFunc = module->findFuncExports("wasm_close_bpf_object");
   EXPECT_NE(closeFunc, nullptr);
   EXPECT_TRUE(closeFunc->isHostFunction());
-  auto &closeFuncHost =
-      dynamic_cast<WasmEdge::Host::CloseBpfObject &>(closeFunc->getHostFunc());
+  auto &closeFuncHost = closeFunc->getHostFunc();
 
   // Call "wasm_close_bpf_object" to attach, and check the result
   std::array<WasmEdge::ValVariant, 1> closeResult;

--- a/test/plugins/wasm_bpf/wasm_bpf.cpp
+++ b/test/plugins/wasm_bpf/wasm_bpf.cpp
@@ -212,8 +212,8 @@ TEST(WasmBpfTest, RunBpfProgramWithPolling) {
 
   // Get function "wasm_load_bpf_object"
   auto *loadFunc = module->findFuncExports("wasm_load_bpf_object");
-  EXPECT_NE(loadFunc, nullptr);
-  EXPECT_TRUE(loadFunc->isHostFunction());
+  ASSERT_NE(loadFunc, nullptr);
+  ASSERT_TRUE(loadFunc->isHostFunction());
   auto &loadFuncHost = loadFunc->getHostFunc();
 
   // call "wasm_load_bpf_object" to Load `bootstrap.bpf.o`, and check the
@@ -230,8 +230,8 @@ TEST(WasmBpfTest, RunBpfProgramWithPolling) {
 
   // Get function `wasm_attach_bpf_program`
   auto *attachFunc = module->findFuncExports("wasm_attach_bpf_program");
-  EXPECT_NE(attachFunc, nullptr);
-  EXPECT_TRUE(attachFunc->isHostFunction());
+  ASSERT_NE(attachFunc, nullptr);
+  ASSERT_TRUE(attachFunc->isHostFunction());
   auto &attachFuncHost = attachFunc->getHostFunc();
 
   // Call "wasm_attach_bpf_program" to attach, and check the result
@@ -263,8 +263,8 @@ TEST(WasmBpfTest, RunBpfProgramWithPolling) {
 
   // Get function `wasm_bpf_map_fd_by_name`
   auto *mapFdFunc = module->findFuncExports("wasm_bpf_map_fd_by_name");
-  EXPECT_NE(mapFdFunc, nullptr);
-  EXPECT_TRUE(mapFdFunc->isHostFunction());
+  ASSERT_NE(mapFdFunc, nullptr);
+  ASSERT_TRUE(mapFdFunc->isHostFunction());
   auto &mapFdFuncHost = mapFdFunc->getHostFunc();
 
   // Call "wasm_bpf_map_fd_by_name" to get the map fd, and check the result
@@ -296,8 +296,8 @@ TEST(WasmBpfTest, RunBpfProgramWithPolling) {
 
   // Get the "wasm_bpf_buffer_poll" function
   auto *bufferPollFunc = module->findFuncExports("wasm_bpf_buffer_poll");
-  EXPECT_NE(bufferPollFunc, nullptr);
-  EXPECT_TRUE(bufferPollFunc->isHostFunction());
+  ASSERT_NE(bufferPollFunc, nullptr);
+  ASSERT_TRUE(bufferPollFunc->isHostFunction());
   auto &bufferPollFuncHost = bufferPollFunc->getHostFunc();
 
   // Call the polling function
@@ -321,8 +321,8 @@ TEST(WasmBpfTest, RunBpfProgramWithPolling) {
 
   // Get function `wasm_close_bpf_object`
   auto *closeFunc = module->findFuncExports("wasm_close_bpf_object");
-  EXPECT_NE(closeFunc, nullptr);
-  EXPECT_TRUE(closeFunc->isHostFunction());
+  ASSERT_NE(closeFunc, nullptr);
+  ASSERT_TRUE(closeFunc->isHostFunction());
   auto &closeFuncHost = closeFunc->getHostFunc();
 
   // Call "wasm_close_bpf_object" to attach, and check the result
@@ -400,8 +400,8 @@ TEST(WasmBpfTest, RunBpfProgramWithMapOperation) {
 
   // Get function "wasm_load_bpf_object"
   auto *loadFunc = module->findFuncExports("wasm_load_bpf_object");
-  EXPECT_NE(loadFunc, nullptr);
-  EXPECT_TRUE(loadFunc->isHostFunction());
+  ASSERT_NE(loadFunc, nullptr);
+  ASSERT_TRUE(loadFunc->isHostFunction());
   auto &loadFuncHost = loadFunc->getHostFunc();
 
   // call "wasm_load_bpf_object" to Load `bootstrap.bpf.o`, and check the
@@ -418,8 +418,8 @@ TEST(WasmBpfTest, RunBpfProgramWithMapOperation) {
 
   // Get function `wasm_attach_bpf_program`
   auto *attachFunc = module->findFuncExports("wasm_attach_bpf_program");
-  EXPECT_NE(attachFunc, nullptr);
-  EXPECT_TRUE(attachFunc->isHostFunction());
+  ASSERT_NE(attachFunc, nullptr);
+  ASSERT_TRUE(attachFunc->isHostFunction());
   auto &attachFuncHost = attachFunc->getHostFunc();
   std::array<size_t, 3> programNameIndexes = {1, 2, 3};
 
@@ -440,8 +440,8 @@ TEST(WasmBpfTest, RunBpfProgramWithMapOperation) {
 
   // Get function `wasm_bpf_map_fd_by_name`
   auto *mapFdFunc = module->findFuncExports("wasm_bpf_map_fd_by_name");
-  EXPECT_NE(mapFdFunc, nullptr);
-  EXPECT_TRUE(mapFdFunc->isHostFunction());
+  ASSERT_NE(mapFdFunc, nullptr);
+  ASSERT_TRUE(mapFdFunc->isHostFunction());
   auto &mapFdFuncHost = mapFdFunc->getHostFunc();
 
   // Call "wasm_bpf_map_fd_by_name" to get the map fd, and check the result
@@ -456,8 +456,8 @@ TEST(WasmBpfTest, RunBpfProgramWithMapOperation) {
 
   // Get function `wasm_bpf_map_fd_by_name`
   auto *mapOptFunc = module->findFuncExports("wasm_bpf_map_operate");
-  EXPECT_NE(mapOptFunc, nullptr);
-  EXPECT_TRUE(mapOptFunc->isHostFunction());
+  ASSERT_NE(mapOptFunc, nullptr);
+  ASSERT_TRUE(mapOptFunc->isHostFunction());
   auto &mapOptFuncHost = mapOptFunc->getHostFunc();
   // A wrapper to call wasm_bpf_map_operate
   auto callMapOperate = [&](int32_t fd, int32_t cmd, uint32_t key,
@@ -551,8 +551,8 @@ TEST(WasmBpfTest, RunBpfProgramWithMapOperation) {
 
   // Get function `wasm_close_bpf_object`
   auto *closeFunc = module->findFuncExports("wasm_close_bpf_object");
-  EXPECT_NE(closeFunc, nullptr);
-  EXPECT_TRUE(closeFunc->isHostFunction());
+  ASSERT_NE(closeFunc, nullptr);
+  ASSERT_TRUE(closeFunc->isHostFunction());
   auto &closeFuncHost = closeFunc->getHostFunc();
 
   // Call "wasm_close_bpf_object" to attach, and check the result

--- a/test/plugins/wasm_bpf/wasm_bpf.cpp
+++ b/test/plugins/wasm_bpf/wasm_bpf.cpp
@@ -454,7 +454,7 @@ TEST(WasmBpfTest, RunBpfProgramWithMapOperation) {
   auto histsFd = mapFdResult[0].get<int32_t>();
   EXPECT_GE(histsFd, 0);
 
-  // Get function `wasm_bpf_map_fd_by_name`
+  // Get function `wasm_bpf_map_operate`
   auto *mapOptFunc = module->findFuncExports("wasm_bpf_map_operate");
   ASSERT_NE(mapOptFunc, nullptr);
   ASSERT_TRUE(mapOptFunc->isHostFunction());

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avCodec.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avCodec.cpp
@@ -28,8 +28,8 @@ TEST_F(FFmpegTest, AVCodec) {
   uint32_t AVCodecId = readUInt32(MemInst, AVCodecPtr);
   auto *FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_id");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecID = FuncInst->getHostFunc();
 
@@ -43,8 +43,8 @@ TEST_F(FFmpegTest, AVCodec) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_type");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecType = FuncInst->getHostFunc();
 
@@ -59,8 +59,8 @@ TEST_F(FFmpegTest, AVCodec) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_max_lowres");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecMaxLowres = FuncInst->getHostFunc();
 
@@ -74,8 +74,8 @@ TEST_F(FFmpegTest, AVCodec) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_capabilities");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCapabilities = FuncInst->getHostFunc();
 
@@ -90,8 +90,8 @@ TEST_F(FFmpegTest, AVCodec) {
   int32_t Length = 0;
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_get_name_len");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecGetNameLen = FuncInst->getHostFunc();
 
@@ -106,8 +106,8 @@ TEST_F(FFmpegTest, AVCodec) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_get_name");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecGetName = FuncInst->getHostFunc();
 
@@ -125,8 +125,8 @@ TEST_F(FFmpegTest, AVCodec) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_get_long_name_len");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecGetLongNameLen = FuncInst->getHostFunc();
 
@@ -141,8 +141,8 @@ TEST_F(FFmpegTest, AVCodec) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_get_long_name");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecGetLongName = FuncInst->getHostFunc();
 
@@ -158,8 +158,8 @@ TEST_F(FFmpegTest, AVCodec) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_profiles");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecProfiles = FuncInst->getHostFunc();
 
@@ -173,8 +173,8 @@ TEST_F(FFmpegTest, AVCodec) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_pix_fmts_is_null");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecPixFmtIsNull = FuncInst->getHostFunc();
 
@@ -188,8 +188,8 @@ TEST_F(FFmpegTest, AVCodec) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_pix_fmts_iter");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecPixFmtIter = FuncInst->getHostFunc();
 
@@ -204,8 +204,8 @@ TEST_F(FFmpegTest, AVCodec) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_supported_framerate_is_null");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecSupportedFrameratesIsNull = FuncInst->getHostFunc();
 
@@ -219,8 +219,8 @@ TEST_F(FFmpegTest, AVCodec) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_supported_framerate_iter");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecSupportedFrameratesIter = FuncInst->getHostFunc();
 
@@ -236,8 +236,8 @@ TEST_F(FFmpegTest, AVCodec) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_supported_samplerates_is_null");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecSupportedSampleRatesIsNull = FuncInst->getHostFunc();
 
@@ -251,8 +251,8 @@ TEST_F(FFmpegTest, AVCodec) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_supported_samplerates_iter");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecSupportedSampleRatesIter = FuncInst->getHostFunc();
 
@@ -266,8 +266,8 @@ TEST_F(FFmpegTest, AVCodec) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_channel_layouts_is_null");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecChannelLayoutIsNull = FuncInst->getHostFunc();
 
@@ -281,8 +281,8 @@ TEST_F(FFmpegTest, AVCodec) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_channel_layouts_iter");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecChannelLayoutIter = FuncInst->getHostFunc();
 
@@ -296,8 +296,8 @@ TEST_F(FFmpegTest, AVCodec) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_sample_fmts_is_null");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecSampleFmtsIsNull = FuncInst->getHostFunc();
 
@@ -311,8 +311,8 @@ TEST_F(FFmpegTest, AVCodec) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_sample_fmts_iter");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecSampleFmtsIter = FuncInst->getHostFunc();
 

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avCodec.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avCodec.cpp
@@ -121,6 +121,9 @@ TEST_F(FFmpegTest, AVCodec) {
                                        AVCodecId, StringPtr, Length},
                                    Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(StringPtr),
+                               static_cast<size_t>(Length)),
+              "h264"sv);
   }
 
   FuncInst = AVCodecMod->findFuncExports(
@@ -154,6 +157,9 @@ TEST_F(FFmpegTest, AVCodec) {
                                                     Length},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(StringPtr),
+                               static_cast<size_t>(Length)),
+              "H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10"sv);
   }
 
   FuncInst =

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avCodec.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avCodec.cpp
@@ -31,9 +31,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecID =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecID &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecID = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecId"sv);
   {
@@ -48,9 +46,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecType =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecType &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecType = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecType"sv);
   {
@@ -66,9 +62,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecMaxLowres =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecMaxLowres &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecMaxLowres = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecMaxLowres"sv);
   {
@@ -83,9 +77,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCapabilities = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCapabilities &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCapabilities = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecCapabilities"sv);
   {
@@ -101,9 +93,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecGetNameLen = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecGetNameLen &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecGetNameLen = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecGetNameLen"sv);
   {
@@ -119,9 +109,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecGetName =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecGetName &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecGetName = FuncInst->getHostFunc();
 
   // Fill the Memory with 0.
   fillMemContent(MemInst, StringPtr, Length);
@@ -140,9 +128,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecGetLongNameLen = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecGetLongNameLen &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecGetLongNameLen = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecGetLongNameLen"sv);
   {
@@ -158,9 +144,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecGetLongName = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecGetLongName &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecGetLongName = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecGetLongName"sv);
   {
@@ -177,9 +161,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecProfiles =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecProfiles &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecProfiles = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecProfiles"sv);
   {
@@ -194,9 +176,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecPixFmtIsNull = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecPixFmtsIsNull &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecPixFmtIsNull = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecPixFmtsIsNull"sv);
   {
@@ -211,9 +191,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecPixFmtIter = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecPixFmtsIter &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecPixFmtIter = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecPixFmtsIter"sv);
   {
@@ -229,9 +207,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecSupportedFrameratesIsNull = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecSupportedFrameratesIsNull
-          &>(FuncInst->getHostFunc());
+  auto &HostFuncAVCodecSupportedFrameratesIsNull = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecSupportedFramratesIsNull"sv);
   {
@@ -246,9 +222,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecSupportedFrameratesIter = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecSupportedFrameratesIter
-          &>(FuncInst->getHostFunc());
+  auto &HostFuncAVCodecSupportedFrameratesIter = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecSupportedFrameratesIter"sv);
   {
@@ -265,9 +239,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecSupportedSampleRatesIsNull = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecSupportedSampleRatesIsNull
-          &>(FuncInst->getHostFunc());
+  auto &HostFuncAVCodecSupportedSampleRatesIsNull = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecSupportedSampleRatesIsNull"sv);
   {
@@ -282,9 +254,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecSupportedSampleRatesIter = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecSupportedSampleRatesIter
-          &>(FuncInst->getHostFunc());
+  auto &HostFuncAVCodecSupportedSampleRatesIter = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecSupportedSampleRatesIter"sv);
   {
@@ -299,9 +269,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecChannelLayoutIsNull = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecChannelLayoutIsNull &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecChannelLayoutIsNull = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecChannelLayoutIsNull"sv);
   {
@@ -316,9 +284,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecChannelLayoutIter = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecChannelLayoutIter &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecChannelLayoutIter = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecChannelLayoutIter"sv);
   {
@@ -333,9 +299,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecSampleFmtsIsNull = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecSampleFmtsIsNull &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecSampleFmtsIsNull = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecSampleFmtsIsNull"sv);
   {
@@ -350,9 +314,7 @@ TEST_F(FFmpegTest, AVCodec) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecSampleFmtsIter = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecSampleFmtsIter &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecSampleFmtsIter = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecSampleFmtsIter"sv);
   {

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avCodecCtx.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avCodecCtx.cpp
@@ -29,8 +29,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   auto *FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_codec_id");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxCodecID = FuncInst->getHostFunc();
 
@@ -44,8 +44,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   int32_t CodecType = 0; // MediaType Video
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_codec_type");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetCodecType = FuncInst->getHostFunc();
 
@@ -59,8 +59,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_codec_type");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxCodecType = FuncInst->getHostFunc();
 
@@ -75,8 +75,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   int32_t Den = 10;
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_time_base");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetTimebase = FuncInst->getHostFunc();
 
@@ -90,8 +90,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_time_base");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxTimeBase = FuncInst->getHostFunc();
 
@@ -111,8 +111,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   int32_t Dimension = 200;
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_width");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetWidth = FuncInst->getHostFunc();
 
@@ -126,8 +126,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_width");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxWidth = FuncInst->getHostFunc();
 
@@ -140,8 +140,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_height");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetHeight = FuncInst->getHostFunc();
 
@@ -155,8 +155,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_height");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxHeight = FuncInst->getHostFunc();
 
@@ -171,8 +171,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   Den = 20;
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_sample_aspect_ratio");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetSampleAspectRatio = FuncInst->getHostFunc();
 
@@ -186,8 +186,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_sample_aspect_ratio");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSampleAspectRatio = FuncInst->getHostFunc();
 
@@ -208,8 +208,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   uint64_t ChannelLayoutId = 1; // FRONT_LEFT;
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_channel_layout");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetChannelLayout = FuncInst->getHostFunc();
 
@@ -224,8 +224,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_channel_layout");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxChannelLayout = FuncInst->getHostFunc();
 
@@ -240,8 +240,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_pix_fmt");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetPixFormat = FuncInst->getHostFunc();
 
@@ -255,8 +255,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_pix_fmt");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxPixFormat = FuncInst->getHostFunc();
 
@@ -270,8 +270,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   uint32_t SampleFmtId = 1; // SAMPLE_FMT_U8
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_sample_format");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetSampleFormat = FuncInst->getHostFunc();
 
@@ -285,8 +285,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_sample_format");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSampleFormat = FuncInst->getHostFunc();
 
@@ -300,8 +300,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   int32_t SampleRate = 500;
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_sample_rate");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetSampleRate = FuncInst->getHostFunc();
 
@@ -315,8 +315,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_sample_rate");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSampleRate = FuncInst->getHostFunc();
 
@@ -329,8 +329,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_gop_size");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetGopSize = FuncInst->getHostFunc();
 
@@ -345,8 +345,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_max_b_frames");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetMaxBFrames = FuncInst->getHostFunc();
 
@@ -361,8 +361,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_b_quant_factor");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetBQuantFactor = FuncInst->getHostFunc();
 
@@ -377,8 +377,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_b_quant_offset");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetBQuantOffset = FuncInst->getHostFunc();
 
@@ -393,8 +393,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_i_quant_factor");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetIQuantFactor = FuncInst->getHostFunc();
 
@@ -409,8 +409,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_i_quant_offset");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetIQuantOffset = FuncInst->getHostFunc();
 
@@ -425,8 +425,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_lumi_masking");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetLumiMasking = FuncInst->getHostFunc();
 
@@ -441,8 +441,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_temporal_cplx_masking");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetTemporalCplxMasking = FuncInst->getHostFunc();
 
@@ -458,8 +458,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_spatial_cplx_masking");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetSpatialCplxMasking = FuncInst->getHostFunc();
 
@@ -475,8 +475,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_p_masking");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetPMasking = FuncInst->getHostFunc();
 
@@ -491,8 +491,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_dark_masking");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetDarkMasking = FuncInst->getHostFunc();
 
@@ -507,8 +507,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_me_cmp");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetMeCmp = FuncInst->getHostFunc();
 
@@ -523,8 +523,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_me_sub_cmp");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetMeSubCmp = FuncInst->getHostFunc();
 
@@ -539,8 +539,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_mb_cmp");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetMbCmp = FuncInst->getHostFunc();
 
@@ -555,8 +555,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_ildct_cmp");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetIldctCmp = FuncInst->getHostFunc();
 
@@ -571,8 +571,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_dia_size");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetDiaSize = FuncInst->getHostFunc();
 
@@ -587,8 +587,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_last_predictor_count");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetLastPredictorsCount = FuncInst->getHostFunc();
 
@@ -604,8 +604,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_me_pre_cmp");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetMePreCmp = FuncInst->getHostFunc();
 
@@ -620,8 +620,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_pre_dia_size");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetPreDiaSize = FuncInst->getHostFunc();
 
@@ -636,8 +636,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_me_subpel_quality");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetMeSubpelQuality = FuncInst->getHostFunc();
 
@@ -653,8 +653,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_me_range");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetMeRange = FuncInst->getHostFunc();
 
@@ -669,8 +669,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_mb_decision");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetMbDecision = FuncInst->getHostFunc();
 
@@ -685,8 +685,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_mb_lmin");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetMbLMin = FuncInst->getHostFunc();
 
@@ -701,8 +701,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_mb_lmax");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetMbLMax = FuncInst->getHostFunc();
 
@@ -717,8 +717,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_intra_dc_precision");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   int32_t IntraDcPrecision = 323;
   auto &HostFuncAVCodecCtxSetIntraDcPrecision = FuncInst->getHostFunc();
@@ -734,8 +734,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_intra_dc_precision");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxIntraDcPrecision = FuncInst->getHostFunc();
 
@@ -748,8 +748,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_qmin");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetQMin = FuncInst->getHostFunc();
 
@@ -764,8 +764,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_qmax");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetQMax = FuncInst->getHostFunc();
 
@@ -780,8 +780,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_global_quality");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetGlobalQuality = FuncInst->getHostFunc();
 
@@ -797,8 +797,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_colorspace");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetColorspace = FuncInst->getHostFunc();
 
@@ -813,8 +813,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_colorspace");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxColorspace = FuncInst->getHostFunc();
 
@@ -827,8 +827,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_color_range");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetColorRange = FuncInst->getHostFunc();
 
@@ -843,8 +843,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_color_range");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxColorRange = FuncInst->getHostFunc();
 
@@ -857,8 +857,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_frame_size");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxFrameSize = FuncInst->getHostFunc();
 
@@ -871,8 +871,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_bit_rate");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetBitRate = FuncInst->getHostFunc();
 
@@ -887,8 +887,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_bit_rate");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxBitRate = FuncInst->getHostFunc();
 
@@ -901,8 +901,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_rc_max_rate");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   int64_t RcMaxRate = 3245;
   auto &HostFuncAVCodecCtxSetRcMaxRate = FuncInst->getHostFunc();
@@ -917,8 +917,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_rc_max_rate");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxRcMaxRate = FuncInst->getHostFunc();
 
@@ -931,8 +931,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_bit_rate_tolerance");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetBitRateTolerance = FuncInst->getHostFunc();
 
@@ -948,8 +948,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_compression_level");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetCompressionLevel = FuncInst->getHostFunc();
 
@@ -965,8 +965,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_framerate");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   Num = 20;
   Den = 30;
@@ -982,8 +982,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_framerate");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxFrameRate = FuncInst->getHostFunc();
 
@@ -1002,8 +1002,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_flags");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetFlags = FuncInst->getHostFunc();
 
@@ -1018,8 +1018,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_strict_std_compliance");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetStrictStdCompliance = FuncInst->getHostFunc();
 
@@ -1034,8 +1034,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_debug");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetDebug = FuncInst->getHostFunc();
 
@@ -1050,8 +1050,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_codec");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxCodec = FuncInst->getHostFunc();
 
@@ -1066,8 +1066,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_channels");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetChannels = FuncInst->getHostFunc();
 
@@ -1082,8 +1082,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_channels");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxChannels = FuncInst->getHostFunc();
 
@@ -1096,8 +1096,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_skip_loop_filter");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetSkipLoopFilter = FuncInst->getHostFunc();
 
@@ -1112,8 +1112,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_skip_frame");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetSkipFrame = FuncInst->getHostFunc();
 
@@ -1127,8 +1127,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_skip_idct");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetSkipIdct = FuncInst->getHostFunc();
 
@@ -1142,8 +1142,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_error_concealment");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetErrorConcealment = FuncInst->getHostFunc();
 
@@ -1159,8 +1159,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_err_recognition");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetErrorRecognition = FuncInst->getHostFunc();
 
@@ -1176,8 +1176,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_delay");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxDelay = FuncInst->getHostFunc();
 
@@ -1190,8 +1190,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_skip_top");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetSkipTop = FuncInst->getHostFunc();
 
@@ -1206,8 +1206,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_skip_bottom");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetSkipBottom = FuncInst->getHostFunc();
 
@@ -1222,8 +1222,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_refs");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxRefs = FuncInst->getHostFunc();
 
@@ -1236,8 +1236,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_slice_flags");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetSliceFlags = FuncInst->getHostFunc();
 
@@ -1252,8 +1252,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_slice_count");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetSliceCount = FuncInst->getHostFunc();
 
@@ -1268,8 +1268,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_field_order");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetFieldOrder = FuncInst->getHostFunc();
 
@@ -1284,8 +1284,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_color_trc");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxColorTrc = FuncInst->getHostFunc();
 
@@ -1298,8 +1298,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_chroma_sample_location");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxChromaSampleLocation = FuncInst->getHostFunc();
 
@@ -1312,8 +1312,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_frame_number");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxFrameNumber = FuncInst->getHostFunc();
 
@@ -1326,8 +1326,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_block_align");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxBlockAlign = FuncInst->getHostFunc();
 
@@ -1340,8 +1340,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_request_sample_fmt");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetRequestSampleFmt = FuncInst->getHostFunc();
 
@@ -1355,8 +1355,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_audio_service_type");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxAudioServiceType = FuncInst->getHostFunc();
 
@@ -1369,8 +1369,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_has_b_frames");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxHasBFrames = FuncInst->getHostFunc();
 
@@ -1383,8 +1383,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_active_thread_type");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxActiveThreadType = FuncInst->getHostFunc();
 
@@ -1397,8 +1397,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_thread_type");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetThreadType = FuncInst->getHostFunc();
 
@@ -1413,8 +1413,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_set_thread_count");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxSetThreadCount = FuncInst->getHostFunc();
 
@@ -1429,8 +1429,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_thread_count");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxThreadCount = FuncInst->getHostFunc();
 
@@ -1443,8 +1443,8 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_color_primaries");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecCtxColorPrimaries = FuncInst->getHostFunc();
 

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avCodecCtx.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avCodecCtx.cpp
@@ -1293,7 +1293,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
     EXPECT_TRUE(HostFuncAVCodecCtxColorTrc.run(
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{AVCodecCtxId},
         Result));
-    ASSERT_TRUE(Result[0].get<int32_t>() > 0);
+    EXPECT_EQ(Result[0].get<int32_t>(), 2);
   }
 
   FuncInst = AVCodecMod->findFuncExports(

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avCodecCtx.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avCodecCtx.cpp
@@ -32,9 +32,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxCodecID = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxCodecID &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxCodecID = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxCodecID.run(
@@ -49,9 +47,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetCodecType = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetCodecType &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetCodecType = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSetCodecType.run(
@@ -66,9 +62,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxCodecType = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxCodecType &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxCodecType = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxCodecType.run(
@@ -84,9 +78,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetTimebase = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetTimebase &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetTimebase = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSetTimebase.run(
@@ -101,9 +93,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxTimeBase = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxTimeBase &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxTimeBase = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxTimeBase.run(
@@ -124,9 +114,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetWidth = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetWidth &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetWidth = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSetWidth.run(
@@ -141,9 +129,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxWidth =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxWidth &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxWidth = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxWidth.run(
@@ -157,9 +143,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetHeight = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetHeight &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetHeight = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSetHeight.run(
@@ -174,9 +158,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxHeight =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxHeight &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxHeight = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxHeight.run(
@@ -192,9 +174,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetSampleAspectRatio = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetSampleAspectRatio
-          &>(FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetSampleAspectRatio = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSetSampleAspectRatio.run(
@@ -209,9 +189,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSampleAspectRatio = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSampleAspectRatio &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSampleAspectRatio = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSampleAspectRatio.run(
@@ -233,9 +211,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetChannelLayout = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetChannelLayout &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetChannelLayout = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSetChannelLayout.run(
@@ -251,9 +227,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxChannelLayout = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxChannelLayout &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxChannelLayout = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxChannelLayout.run(
@@ -269,9 +243,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetPixFormat = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetPixFormat &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetPixFormat = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSetPixFormat.run(
@@ -286,9 +258,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxPixFormat = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxPixFormat &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxPixFormat = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxPixFormat.run(
@@ -303,9 +273,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetSampleFormat = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetSampleFormat &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetSampleFormat = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSetSampleFormat.run(
@@ -320,9 +288,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSampleFormat = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSampleFormat &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSampleFormat = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSampleFormat.run(
@@ -337,9 +303,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetSampleRate = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetSampleRate &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetSampleRate = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSetSampleRate.run(
@@ -354,9 +318,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSampleRate = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSampleRate &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSampleRate = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSampleRate.run(
@@ -370,9 +332,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetGopSize = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetGopSize &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetGopSize = FuncInst->getHostFunc();
 
   {
     int32_t GopSize = 20;
@@ -388,9 +348,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetMaxBFrames = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetMaxBFrames &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetMaxBFrames = FuncInst->getHostFunc();
 
   {
     int32_t MaxBFrames = 30;
@@ -406,9 +364,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetBQuantFactor = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetBQuantFactor &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetBQuantFactor = FuncInst->getHostFunc();
 
   {
     float BQuantFactor = 12.32;
@@ -424,9 +380,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetBQuantOffset = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetBQuantOffset &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetBQuantOffset = FuncInst->getHostFunc();
 
   {
     float BQuantOffset = 3.53;
@@ -442,9 +396,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetIQuantFactor = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetIQuantFactor &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetIQuantFactor = FuncInst->getHostFunc();
 
   {
     float IQuantFactor = 3.435;
@@ -460,9 +412,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetIQuantOffset = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetIQuantOffset &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetIQuantOffset = FuncInst->getHostFunc();
 
   {
     float IQuantOffset = 6.322;
@@ -478,9 +428,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetLumiMasking = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetLumiMasking &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetLumiMasking = FuncInst->getHostFunc();
 
   {
     float LumiMasking = 54.32432;
@@ -496,9 +444,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetTemporalCplxMasking = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetTemporalCplxMasking
-          &>(FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetTemporalCplxMasking = FuncInst->getHostFunc();
 
   {
     float TemporialCplxMasking = 642.32;
@@ -515,9 +461,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetSpatialCplxMasking = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetSpatialCplxMasking
-          &>(FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetSpatialCplxMasking = FuncInst->getHostFunc();
 
   {
     float SpatialCplxMasking = 324.32;
@@ -534,9 +478,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetPMasking = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetPMasking &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetPMasking = FuncInst->getHostFunc();
 
   {
     float PMasking = 65.3245;
@@ -552,9 +494,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetDarkMasking = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetDarkMasking &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetDarkMasking = FuncInst->getHostFunc();
 
   {
     float DarkMasking = 83.32;
@@ -570,9 +510,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetMeCmp = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetMeCmp &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetMeCmp = FuncInst->getHostFunc();
 
   {
     int32_t MeCmp = 532;
@@ -588,9 +526,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetMeSubCmp = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetMeSubCmp &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetMeSubCmp = FuncInst->getHostFunc();
 
   {
     int32_t MeSubCmp = 321;
@@ -606,9 +542,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetMbCmp = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetMbCmp &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetMbCmp = FuncInst->getHostFunc();
 
   {
     int32_t MbCmp = 243;
@@ -624,9 +558,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetIldctCmp = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetIldctCmp &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetIldctCmp = FuncInst->getHostFunc();
 
   {
     int32_t IldctCmp = 3;
@@ -642,9 +574,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetDiaSize = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetDiaSize &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetDiaSize = FuncInst->getHostFunc();
 
   {
     int32_t DiaSize = 9;
@@ -660,9 +590,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetLastPredictorsCount = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetLastPredictorsCount
-          &>(FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetLastPredictorsCount = FuncInst->getHostFunc();
 
   {
     int32_t LastPredictorCount = 21;
@@ -679,9 +607,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetMePreCmp = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetMePreCmp &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetMePreCmp = FuncInst->getHostFunc();
 
   {
     int32_t MePreCmp = 53;
@@ -697,9 +623,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetPreDiaSize = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetPreDiaSize &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetPreDiaSize = FuncInst->getHostFunc();
 
   {
     int32_t PreDiaSize = 74;
@@ -715,9 +639,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetMeSubpelQuality = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetMeSubpelQuality &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetMeSubpelQuality = FuncInst->getHostFunc();
 
   {
     int32_t MeSubpelQuality = 85;
@@ -734,9 +656,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetMeRange = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetMeRange &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetMeRange = FuncInst->getHostFunc();
 
   {
     int32_t SetMeRange = 31;
@@ -752,9 +672,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetMbDecision = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetMbDecision &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetMbDecision = FuncInst->getHostFunc();
 
   {
     int32_t MbDecision = 78;
@@ -770,9 +688,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetMbLMin = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetMbLMin &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetMbLMin = FuncInst->getHostFunc();
 
   {
     int32_t MbLMin = 11;
@@ -788,9 +704,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetMbLMax = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetMbLMax &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetMbLMax = FuncInst->getHostFunc();
 
   {
     int32_t MbLMax = 18;
@@ -807,9 +721,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_TRUE(FuncInst->isHostFunction());
 
   int32_t IntraDcPrecision = 323;
-  auto &HostFuncAVCodecCtxSetIntraDcPrecision = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetIntraDcPrecision &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetIntraDcPrecision = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSetIntraDcPrecision.run(
@@ -825,9 +737,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxIntraDcPrecision = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxIntraDcPrecision &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxIntraDcPrecision = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxIntraDcPrecision.run(
@@ -841,9 +751,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetQMin = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetQMin &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetQMin = FuncInst->getHostFunc();
 
   {
     int32_t QMin = 10;
@@ -859,9 +767,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetQMax = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetQMax &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetQMax = FuncInst->getHostFunc();
 
   {
     int32_t QMax = 20;
@@ -877,9 +783,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetGlobalQuality = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetGlobalQuality &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetGlobalQuality = FuncInst->getHostFunc();
 
   {
     int32_t GlobalQuality = 93;
@@ -896,9 +800,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetColorspace = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetColorspace &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetColorspace = FuncInst->getHostFunc();
 
   int32_t ColorspaceId = 1; // AVCOL_SPC_BT709
   {
@@ -914,9 +816,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxColorspace = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxColorspace &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxColorspace = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxColorspace.run(
@@ -930,9 +830,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetColorRange = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetColorRange &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetColorRange = FuncInst->getHostFunc();
 
   int32_t ColorRangeId = 1; // MPEG
   {
@@ -948,9 +846,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxColorRange = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxColorRange &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxColorRange = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxColorRange.run(
@@ -964,9 +860,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxFrameSize = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxFrameSize &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxFrameSize = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxFrameSize.run(
@@ -980,9 +874,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetBitRate = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetBitRate &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetBitRate = FuncInst->getHostFunc();
 
   int64_t BitRate = 9932;
   {
@@ -998,9 +890,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxBitRate = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxBitRate &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxBitRate = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxBitRate.run(
@@ -1015,9 +905,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_TRUE(FuncInst->isHostFunction());
 
   int64_t RcMaxRate = 3245;
-  auto &HostFuncAVCodecCtxSetRcMaxRate = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetRcMaxRate &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetRcMaxRate = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSetRcMaxRate.run(
@@ -1032,9 +920,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxRcMaxRate = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxRcMaxRate &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxRcMaxRate = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxRcMaxRate.run(
@@ -1048,9 +934,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetBitRateTolerance = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetBitRateTolerance &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetBitRateTolerance = FuncInst->getHostFunc();
 
   {
     int32_t BitRateTolerance = 9543;
@@ -1067,9 +951,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetCompressionLevel = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetCompressionLevel &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetCompressionLevel = FuncInst->getHostFunc();
 
   {
     int32_t CompressionLevel = 934;
@@ -1088,9 +970,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
 
   Num = 20;
   Den = 30;
-  auto &HostFuncAVCodecCtxSetFrameRate = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetFrameRate &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetFrameRate = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSetFrameRate.run(
@@ -1105,9 +985,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxFrameRate = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxFrameRate &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxFrameRate = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxFrameRate.run(
@@ -1127,9 +1005,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetFlags = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetFlags &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetFlags = FuncInst->getHostFunc();
 
   {
     int32_t Flags = 3;
@@ -1145,9 +1021,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetStrictStdCompliance = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetStrictStdCompliance
-          &>(FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetStrictStdCompliance = FuncInst->getHostFunc();
 
   {
     int32_t ComplianceId = 3;
@@ -1163,9 +1037,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetDebug = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetDebug &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetDebug = FuncInst->getHostFunc();
 
   {
     int32_t Debug = 50;
@@ -1181,9 +1053,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxCodec =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxCodec &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxCodec = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxCodec.run(
@@ -1199,9 +1069,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetChannels = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetChannels &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetChannels = FuncInst->getHostFunc();
 
   int32_t Channels = 10;
   {
@@ -1217,9 +1085,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxChannels = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxChannels &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxChannels = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxChannels.run(
@@ -1233,9 +1099,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetSkipLoopFilter = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetSkipLoopFilter &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetSkipLoopFilter = FuncInst->getHostFunc();
 
   int32_t DiscardId = 16; // Bidirectional
   {
@@ -1251,9 +1115,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetSkipFrame = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetSkipFrame &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetSkipFrame = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSetSkipFrame.run(
@@ -1268,9 +1130,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetSkipIdct = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetSkipIdct &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetSkipIdct = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSetSkipIdct.run(
@@ -1285,9 +1145,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetErrorConcealment = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetErrorConcealment &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetErrorConcealment = FuncInst->getHostFunc();
 
   {
     int32_t ErrorConcealment = 99;
@@ -1304,9 +1162,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetErrorRecognition = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetErrorRecognition &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetErrorRecognition = FuncInst->getHostFunc();
 
   {
     int32_t ErrorRecognition = 88;
@@ -1323,9 +1179,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxDelay =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxDelay &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxDelay = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxDelay.run(
@@ -1339,9 +1193,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetSkipTop = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetSkipTop &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetSkipTop = FuncInst->getHostFunc();
 
   {
     int32_t Value = 50;
@@ -1357,9 +1209,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetSkipBottom = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetSkipBottom &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetSkipBottom = FuncInst->getHostFunc();
 
   {
     int32_t Value = 60;
@@ -1375,9 +1225,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxRefs =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxRefs &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxRefs = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxRefs.run(
@@ -1391,9 +1239,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetSliceFlags = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetSliceFlags &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetSliceFlags = FuncInst->getHostFunc();
 
   {
     int32_t Value = 70;
@@ -1409,9 +1255,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetSliceCount = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetSliceCount &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetSliceCount = FuncInst->getHostFunc();
 
   {
     int32_t Value = 100;
@@ -1427,9 +1271,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetFieldOrder = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetFieldOrder &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetFieldOrder = FuncInst->getHostFunc();
 
   {
     int32_t Value = 200;
@@ -1445,9 +1287,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxColorTrc = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxColorTrc &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxColorTrc = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxColorTrc.run(
@@ -1461,9 +1301,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxChromaSampleLocation = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxChromaSampleLocation
-          &>(FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxChromaSampleLocation = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxChromaSampleLocation.run(
@@ -1477,9 +1315,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxFrameNumber = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxFrameNumber &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxFrameNumber = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxFrameNumber.run(
@@ -1493,9 +1329,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxBlockAlign = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxBlockAlign &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxBlockAlign = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxBlockAlign.run(
@@ -1509,9 +1343,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetRequestSampleFmt = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetRequestSampleFmt &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetRequestSampleFmt = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxSetRequestSampleFmt.run(
@@ -1526,9 +1358,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxAudioServiceType = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxAudioServiceType &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxAudioServiceType = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxAudioServiceType.run(
@@ -1542,9 +1372,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxHasBFrames = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxHasBFrames &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxHasBFrames = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxHasBFrames.run(
@@ -1558,9 +1386,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxActiveThreadType = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxActiveThreadType &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxActiveThreadType = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxActiveThreadType.run(
@@ -1574,9 +1400,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetThreadType = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetThreadType &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetThreadType = FuncInst->getHostFunc();
 
   {
     int32_t ThreadType = 1; // Frame
@@ -1592,9 +1416,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxSetThreadCount = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxSetThreadCount &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxSetThreadCount = FuncInst->getHostFunc();
 
   int32_t ThreadCount = 50;
   {
@@ -1610,9 +1432,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxThreadCount = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxThreadCount &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxThreadCount = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxThreadCount.run(
@@ -1626,9 +1446,7 @@ TEST_F(FFmpegTest, AVCodecCtx) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecCtxColorPrimaries = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxColorPrimaries &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecCtxColorPrimaries = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecCtxColorPrimaries.run(

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avCodecParameters.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avCodecParameters.cpp
@@ -27,8 +27,8 @@ TEST_F(FFmpegTest, AVCodecParameters) {
 
   auto *FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodecparam_codec_id");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecParamCodecId = FuncInst->getHostFunc();
 
@@ -41,8 +41,8 @@ TEST_F(FFmpegTest, AVCodecParameters) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodecparam_codec_type");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecParamCodecType = FuncInst->getHostFunc();
 
@@ -55,8 +55,8 @@ TEST_F(FFmpegTest, AVCodecParameters) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodecparam_set_codec_tag");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecParamSetCodecTag = FuncInst->getHostFunc();
 

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avCodecParameters.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avCodecParameters.cpp
@@ -30,9 +30,7 @@ TEST_F(FFmpegTest, AVCodecParameters) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecParamCodecId = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecParamCodecId &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecParamCodecId = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecParamCodecId.run(
@@ -46,9 +44,7 @@ TEST_F(FFmpegTest, AVCodecParameters) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecParamCodecType = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecParamCodecType &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecParamCodecType = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecParamCodecType.run(
@@ -62,9 +58,7 @@ TEST_F(FFmpegTest, AVCodecParameters) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecParamSetCodecTag = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecParamSetCodecTag &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecParamSetCodecTag = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVCodecParamSetCodecTag.run(

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avPacket.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avPacket.cpp
@@ -26,9 +26,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVPacketAlloc =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketAlloc &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVPacketAlloc = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketAlloc.run(
@@ -52,9 +50,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVNewPacket =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVNewPacket &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVNewPacket = FuncInst->getHostFunc();
 
   {
     uint32_t Size = 40;
@@ -68,9 +64,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_grow_packet");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVGrowPacket =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVGrowPacket &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVGrowPacket = FuncInst->getHostFunc();
 
   {
     uint32_t Size = 40;
@@ -84,9 +78,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_shrink_packet");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVShrinkPacket =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVShrinkPacket &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVShrinkPacket = FuncInst->getHostFunc();
 
   {
     uint32_t Size = 40;
@@ -101,9 +93,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
       "wasmedge_ffmpeg_avcodec_av_packet_set_stream_index");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVPacketSetStreamIndex = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketSetStreamIndex &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVPacketSetStreamIndex = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketSetStreamIndex.run(
@@ -117,9 +107,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
       "wasmedge_ffmpeg_avcodec_av_packet_stream_index");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVPacketStreamIndex = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketStreamIndex &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVPacketStreamIndex = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketStreamIndex.run(
@@ -133,9 +121,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_size");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVPacketSize =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketSize &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVPacketSize = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketSize.run(
@@ -151,9 +137,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
       "wasmedge_ffmpeg_avcodec_av_packet_set_flags");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVPacketSetFlags =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketSetFlags &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVPacketSetFlags = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketSetFlags.run(
@@ -166,9 +150,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_flags");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVPacketFlags =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketFlags &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVPacketFlags = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketFlags.run(
@@ -182,9 +164,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_set_pos");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVPacketSetPos =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketSetPos &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVPacketSetPos = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketSetPos.run(
@@ -197,9 +177,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_pos");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVPacketPos =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketPos &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVPacketPos = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketPos.run(
@@ -213,9 +191,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
       "wasmedge_ffmpeg_avcodec_av_packet_set_duration");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVPacketSetDuration = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketSetDuration &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVPacketSetDuration = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketSetDuration.run(
@@ -229,9 +205,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_duration");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVPacketDuration =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketDuration &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVPacketDuration = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketDuration.run(
@@ -245,9 +219,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_set_dts");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVPacketSetDts =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketSetDts &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVPacketSetDts = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketSetDts.run(
@@ -260,9 +232,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_dts");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVPacketDts =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketDts &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVPacketDts = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketDts.run(
@@ -276,9 +246,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_set_pts");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVPacketSetPts =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketSetPts &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVPacketSetPts = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketSetPts.run(
@@ -291,9 +259,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_pts");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVPacketPts =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketPts &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVPacketPts = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketPts.run(
@@ -306,9 +272,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
       "wasmedge_ffmpeg_avcodec_av_packet_is_data_null");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVPacketIsDataNull = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketIsDataNull &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVPacketIsDataNull = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketIsDataNull.run(
@@ -321,9 +285,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_data");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVPacketData =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketData &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVPacketData = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketData.run(
@@ -338,9 +300,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVPacketRef =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketRef &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVPacketRef = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketRef.run(
@@ -355,9 +315,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVPacketUnref =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketUnref &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVPacketUnref = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVPacketUnref.run(

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avPacket.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avPacket.cpp
@@ -45,6 +45,20 @@ TEST_F(FFmpegTest, AVPacketTest) {
   ASSERT_TRUE(PacketId > 0);
   ASSERT_TRUE(PacketId2 > 0);
 
+  uint32_t PacketDataSize = 0;
+  FuncInst =
+      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_size");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncAVPacketSize = FuncInst->getHostFunc();
+  auto ExpectPacketSize = [&](uint32_t ExpectedSize) {
+    EXPECT_TRUE(HostFuncAVPacketSize.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{PacketId},
+        Result));
+    PacketDataSize = static_cast<uint32_t>(Result[0].get<int32_t>());
+    EXPECT_EQ(PacketDataSize, ExpectedSize);
+  };
+
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_new_packet");
   ASSERT_NE(FuncInst, nullptr);
@@ -58,6 +72,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{PacketId, Size},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), 0);
+    ExpectPacketSize(Size);
   }
 
   FuncInst =
@@ -72,6 +87,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{PacketId, Size},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), 0);
+    ExpectPacketSize(80);
   }
 
   FuncInst =
@@ -86,6 +102,7 @@ TEST_F(FFmpegTest, AVPacketTest) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{PacketId, Size},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), 0);
+    ExpectPacketSize(Size);
   }
 
   uint32_t StreamIdx = 3;
@@ -114,21 +131,6 @@ TEST_F(FFmpegTest, AVPacketTest) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{PacketId},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), StreamIdx);
-  }
-
-  uint32_t Size = 0;
-  FuncInst =
-      AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_size");
-  ASSERT_NE(FuncInst, nullptr);
-  ASSERT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVPacketSize = FuncInst->getHostFunc();
-
-  {
-    EXPECT_TRUE(HostFuncAVPacketSize.run(
-        CallFrame, std::initializer_list<WasmEdge::ValVariant>{PacketId},
-        Result));
-    Size = Result[0].get<int32_t>();
-    EXPECT_TRUE(Size > 0);
   }
 
   uint32_t Flags = 5;
@@ -290,7 +292,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
   {
     EXPECT_TRUE(HostFuncAVPacketData.run(
         CallFrame,
-        std::initializer_list<WasmEdge::ValVariant>{PacketId, DataPtr, Size},
+        std::initializer_list<WasmEdge::ValVariant>{PacketId, DataPtr,
+                                                    PacketDataSize},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
   }

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avPacket.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avPacket.cpp
@@ -23,8 +23,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
 
   auto *FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_alloc");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVPacketAlloc = FuncInst->getHostFunc();
 
@@ -47,8 +47,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_new_packet");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVNewPacket = FuncInst->getHostFunc();
 
@@ -62,8 +62,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_grow_packet");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVGrowPacket = FuncInst->getHostFunc();
 
   {
@@ -76,8 +76,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_shrink_packet");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVShrinkPacket = FuncInst->getHostFunc();
 
   {
@@ -91,8 +91,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
   uint32_t StreamIdx = 3;
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_av_packet_set_stream_index");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPacketSetStreamIndex = FuncInst->getHostFunc();
 
   {
@@ -105,8 +105,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_av_packet_stream_index");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPacketStreamIndex = FuncInst->getHostFunc();
 
   {
@@ -119,8 +119,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
   uint32_t Size = 0;
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_size");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPacketSize = FuncInst->getHostFunc();
 
   {
@@ -135,8 +135,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_av_packet_set_flags");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPacketSetFlags = FuncInst->getHostFunc();
 
   {
@@ -148,8 +148,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_flags");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPacketFlags = FuncInst->getHostFunc();
 
   {
@@ -162,8 +162,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
   int64_t Pos = 500;
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_set_pos");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPacketSetPos = FuncInst->getHostFunc();
 
   {
@@ -175,8 +175,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_pos");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPacketPos = FuncInst->getHostFunc();
 
   {
@@ -189,8 +189,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
   int64_t Duration = 100;
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_av_packet_set_duration");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPacketSetDuration = FuncInst->getHostFunc();
 
   {
@@ -203,8 +203,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_duration");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPacketDuration = FuncInst->getHostFunc();
 
   {
@@ -217,8 +217,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
   int64_t Dts = 1000;
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_set_dts");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPacketSetDts = FuncInst->getHostFunc();
 
   {
@@ -230,8 +230,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_dts");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPacketDts = FuncInst->getHostFunc();
 
   {
@@ -244,8 +244,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
   int64_t Pts = 5000;
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_set_pts");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPacketSetPts = FuncInst->getHostFunc();
 
   {
@@ -257,8 +257,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_pts");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPacketPts = FuncInst->getHostFunc();
 
   {
@@ -270,8 +270,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_av_packet_is_data_null");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPacketIsDataNull = FuncInst->getHostFunc();
 
   {
@@ -283,8 +283,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_data");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPacketData = FuncInst->getHostFunc();
 
   {
@@ -297,8 +297,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_ref");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVPacketRef = FuncInst->getHostFunc();
 
@@ -312,8 +312,8 @@ TEST_F(FFmpegTest, AVPacketTest) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_unref");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVPacketUnref = FuncInst->getHostFunc();
 

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avcodec_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avcodec_func.cpp
@@ -36,9 +36,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecAllocContext3 = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecAllocContext3 &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecAllocContext3 = FuncInst->getHostFunc();
 
   spdlog::info("Testing AvCodecAllocContext3"sv);
   {
@@ -56,9 +54,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecParametersAlloc = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecParametersAlloc &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecParametersAlloc = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecParametersAlloc"sv);
   {
@@ -84,9 +80,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecParametersFromContext = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecParametersFromContext &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecParametersFromContext = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecParametersFromContext"sv);
   {
@@ -103,9 +97,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecGetType =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecGetType &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecGetType = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecGetType"sv);
   {
@@ -119,9 +111,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecFindDecoder = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecFindDecoder &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecFindDecoder = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecFindDecoder"sv);
   {
@@ -140,9 +130,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecFindEncoder = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecFindEncoder &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecFindEncoder = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecFindEncoder"sv);
   {
@@ -161,9 +149,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecOpen2 =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecOpen2 &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecOpen2 = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecOpen2"sv);
   // Invalid argument passed. Return -22 Error code. Means functionality
@@ -182,9 +168,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecIsEncoder =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecIsEncoder &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecIsEncoder = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecIsEncoder"sv);
   {
@@ -199,9 +183,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecIsDecoder =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecIsDecoder &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecIsDecoder = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecIsDecoder"sv);
   {
@@ -216,9 +198,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecFindDecoderByName = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecFindDecoderByName &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecFindDecoderByName = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecFindDecoderByName"sv);
   {
@@ -236,9 +216,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecFindEncoderByName = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecFindEncoderByName &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecFindEncoderByName = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecFindEncoderByName"sv);
   {
@@ -256,9 +234,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecParametersToContext = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecParametersToContext &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecParametersToContext = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecParametersToContext"sv);
   {
@@ -291,9 +267,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecVersion =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecVersion &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecVersion = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecVersion"sv);
   {
@@ -307,9 +281,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecConfigurationLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecConfigurationLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecConfigurationLength = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecConfigurationLength"sv);
   int32_t Length = 0;
@@ -325,9 +297,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecConfiguration = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecConfiguration &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecConfiguration = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecConfiguration"sv);
   {
@@ -342,9 +312,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecLicenseLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecLicenseLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecLicenseLength = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecLicenseLength"sv);
   {
@@ -360,9 +328,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecLicense =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecLicense &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecLicense = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecLicense"sv);
   {
@@ -377,9 +343,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecFreeContext = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecFreeContext &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecFreeContext = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecFreeContext"sv);
   {
@@ -394,9 +358,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecParametersFree = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecParametersFree &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecParametersFree = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecParametersFree"sv);
   {
@@ -424,9 +386,7 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecSendFrame =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecSendFrame &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecSendFrame = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecSendFrame"sv);
   // Invalid Argument Error. Should Use Encoder, I'm using decoder
@@ -446,9 +406,7 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecReceivePacket = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecReceivePacket &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecReceivePacket = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecReceivePacket"sv);
   {
@@ -464,9 +422,7 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecSendPacket = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecSendPacket &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecSendPacket = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecSendPacket"sv);
   // Send packet to Decoder.
@@ -484,9 +440,7 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
   EXPECT_TRUE(FuncInst->isHostFunction());
 
   // Decoder Receives the Packet as Frame.
-  auto &HostFuncAVCodecReceiveFrame = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecReceiveFrame &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecReceiveFrame = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecReceiveFrame"sv);
   {
@@ -502,9 +456,7 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVPacketRescaleTs = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketRescaleTs &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVPacketRescaleTs = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVPacketRescaleTs"sv);
   {
@@ -525,9 +477,7 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVPacketMakeWritable = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketMakeWritable &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVPacketMakeWritable = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVPacketMakeWritable"sv);
   {
@@ -542,9 +492,7 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecFlushBuffers = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecFlushBuffers &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecFlushBuffers = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecFlushBuffers"sv);
   {
@@ -559,9 +507,7 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVCodecClose =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecClose &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecClose = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVCodecClose"sv);
   {

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avcodec_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avcodec_func.cpp
@@ -33,8 +33,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   auto *FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_alloc_context3");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecAllocContext3 = FuncInst->getHostFunc();
 
@@ -51,8 +51,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_parameters_alloc");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecParametersAlloc = FuncInst->getHostFunc();
 
@@ -77,8 +77,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_parameters_from_context"sv);
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecParametersFromContext = FuncInst->getHostFunc();
 
@@ -94,8 +94,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_get_type");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecGetType = FuncInst->getHostFunc();
 
@@ -108,8 +108,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_find_decoder");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecFindDecoder = FuncInst->getHostFunc();
 
@@ -127,8 +127,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_find_encoder");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecFindEncoder = FuncInst->getHostFunc();
 
@@ -146,8 +146,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_open2");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecOpen2 = FuncInst->getHostFunc();
 
@@ -165,8 +165,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_av_codec_is_encoder");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecIsEncoder = FuncInst->getHostFunc();
 
@@ -180,8 +180,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_av_codec_is_decoder");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecIsDecoder = FuncInst->getHostFunc();
 
@@ -195,8 +195,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_find_decoder_by_name");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecFindDecoderByName = FuncInst->getHostFunc();
 
@@ -213,8 +213,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecFindEncoderByName = FuncInst->getHostFunc();
 
@@ -231,8 +231,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_parameters_to_context");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecParametersToContext = FuncInst->getHostFunc();
 
@@ -264,8 +264,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   //   }
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_version");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecVersion = FuncInst->getHostFunc();
 
@@ -278,8 +278,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_configuration_length");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecConfigurationLength = FuncInst->getHostFunc();
 
@@ -294,8 +294,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_configuration");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecConfiguration = FuncInst->getHostFunc();
 
@@ -309,8 +309,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_license_length");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecLicenseLength = FuncInst->getHostFunc();
 
@@ -325,8 +325,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_license");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecLicense = FuncInst->getHostFunc();
 
@@ -340,8 +340,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_free_context");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecFreeContext = FuncInst->getHostFunc();
 
@@ -355,8 +355,8 @@ TEST_F(FFmpegTest, AVCodecFunc) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_parameters_free");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecParametersFree = FuncInst->getHostFunc();
 
@@ -383,8 +383,8 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
 
   auto *FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_send_frame");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecSendFrame = FuncInst->getHostFunc();
 
@@ -403,8 +403,8 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
   // Aim is to test the functionality.
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_receive_packet");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecReceivePacket = FuncInst->getHostFunc();
 
@@ -419,8 +419,8 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_send_packet");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecSendPacket = FuncInst->getHostFunc();
 
@@ -436,8 +436,8 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_receive_frame");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   // Decoder Receives the Packet as Frame.
   auto &HostFuncAVCodecReceiveFrame = FuncInst->getHostFunc();
@@ -453,8 +453,8 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_av_packet_rescale_ts");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVPacketRescaleTs = FuncInst->getHostFunc();
 
@@ -474,8 +474,8 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_av_packet_make_writable");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVPacketMakeWritable = FuncInst->getHostFunc();
 
@@ -489,8 +489,8 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_flush_buffers");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecFlushBuffers = FuncInst->getHostFunc();
 
@@ -504,8 +504,8 @@ TEST_F(FFmpegTest, SendPacketReceiveFrame) {
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_close");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVCodecClose = FuncInst->getHostFunc();
 

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avcodec_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avcodec_func.cpp
@@ -209,6 +209,12 @@ TEST_F(FFmpegTest, AVCodecFunc) {
                                                     CodecNamePtr, Length},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+    uint32_t DecoderByNameId = readUInt32(MemInst, CodecDecoderPtr);
+    EXPECT_TRUE(HostFuncAVCodecIsDecoder.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{DecoderByNameId},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), 1);
   }
 
   FuncInst = AVCodecMod->findFuncExports(
@@ -227,6 +233,12 @@ TEST_F(FFmpegTest, AVCodecFunc) {
                                                     CodecNamePtr, Length},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+
+    uint32_t EncoderByNameId = readUInt32(MemInst, CodecEncoderPtr);
+    EXPECT_TRUE(HostFuncAVCodecIsEncoder.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{EncoderByNameId},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), 1);
   }
 
   FuncInst = AVCodecMod->findFuncExports(
@@ -273,7 +285,7 @@ TEST_F(FFmpegTest, AVCodecFunc) {
   {
     EXPECT_TRUE(HostFuncAVCodecVersion.run(
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{}, Result));
-    EXPECT_TRUE(Result[0].get<int32_t>() > 0);
+    EXPECT_TRUE((Result[0].get<int32_t>() >> 16) > 0);
   }
 
   FuncInst = AVCodecMod->findFuncExports(
@@ -305,6 +317,10 @@ TEST_F(FFmpegTest, AVCodecFunc) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{StrPtr, Length},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_NE(std::string_view(MemInst->getPointer<char *>(StrPtr),
+                               static_cast<size_t>(Length))
+                  .find("--"),
+              std::string_view::npos);
   }
 
   FuncInst = AVCodecMod->findFuncExports(
@@ -336,6 +352,10 @@ TEST_F(FFmpegTest, AVCodecFunc) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{StrPtr, Length},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(StrPtr),
+                               static_cast<size_t>(Length))
+                  .find("--"),
+              std::string_view::npos);
   }
 
   FuncInst = AVCodecMod->findFuncExports(

--- a/test/plugins/wasmedge_ffmpeg/avfilter/avfilter.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avfilter/avfilter.cpp
@@ -14,6 +14,7 @@ namespace Host {
 namespace WasmEdgeFFmpeg {
 
 TEST_F(FFmpegTest, AVFilterStructs) {
+  using namespace std::literals::string_view_literals;
   ASSERT_TRUE(AVFilterMod != nullptr);
 
   uint32_t FilterPtr = UINT32_C(8);
@@ -82,6 +83,9 @@ TEST_F(FFmpegTest, AVFilterStructs) {
         std::initializer_list<WasmEdge::ValVariant>{FilterId, StrPtr, Length},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(StrPtr),
+                               static_cast<size_t>(Length)),
+              "abuffer"sv);
   }
 
   FuncInst = AVFilterMod->findFuncExports(
@@ -114,6 +118,10 @@ TEST_F(FFmpegTest, AVFilterStructs) {
         std::initializer_list<WasmEdge::ValVariant>{FilterId, StrPtr, Length},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(StrPtr),
+                               static_cast<size_t>(Length)),
+              "Buffer audio frames, and make them accessible to the "
+              "filterchain."sv);
   }
 
   FuncInst = AVFilterMod->findFuncExports(
@@ -166,12 +174,14 @@ TEST_F(FFmpegTest, AVFilterStructs) {
   auto &HostFuncAVFilterGetInputsFilterPad = FuncInst->getHostFunc();
 
   {
+    writeUInt32(MemInst, UINT32_C(0), InputFilterPadPtr);
     EXPECT_TRUE(HostFuncAVFilterGetInputsFilterPad.run(
         CallFrame,
         std::initializer_list<WasmEdge::ValVariant>{FilterId,
                                                     InputFilterPadPtr},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(readUInt32(MemInst, InputFilterPadPtr), UINT32_C(0));
   }
 
   FuncInst = AVFilterMod->findFuncExports(
@@ -224,6 +234,9 @@ TEST_F(FFmpegTest, AVFilterStructs) {
                                                     StrPtr, Length},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(StrPtr),
+                               static_cast<size_t>(Length)),
+              "default"sv);
   }
 
   FuncInst = AVFilterMod->findFuncExports(

--- a/test/plugins/wasmedge_ffmpeg/avfilter/avfilter.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avfilter/avfilter.cpp
@@ -34,9 +34,7 @@ TEST_F(FFmpegTest, AVFilterStructs) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterGetByName = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterGetByName &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterGetByName = FuncInst->getHostFunc();
 
   {
     int32_t Length = InputName.length();
@@ -59,9 +57,7 @@ TEST_F(FFmpegTest, AVFilterStructs) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterNameLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterNameLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterNameLength = FuncInst->getHostFunc();
 
   int32_t Length = 0;
   {
@@ -77,9 +73,7 @@ TEST_F(FFmpegTest, AVFilterStructs) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterName =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterName &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFilterName = FuncInst->getHostFunc();
 
   fillMemContent(MemInst, StrPtr, Length);
   {
@@ -95,9 +89,7 @@ TEST_F(FFmpegTest, AVFilterStructs) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterDescriptionLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterDescriptionLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterDescriptionLength = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterDescriptionLength.run(
@@ -113,9 +105,7 @@ TEST_F(FFmpegTest, AVFilterStructs) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterDescription = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterDescription &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterDescription = FuncInst->getHostFunc();
 
   fillMemContent(MemInst, StrPtr, Length);
   {
@@ -131,9 +121,7 @@ TEST_F(FFmpegTest, AVFilterStructs) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterNbInputs = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterNbInputs &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterNbInputs = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterNbInputs.run(
@@ -147,9 +135,7 @@ TEST_F(FFmpegTest, AVFilterStructs) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterNbOutputs = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterNbOutputs &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterNbOutputs = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterNbOutputs.run(
@@ -163,9 +149,7 @@ TEST_F(FFmpegTest, AVFilterStructs) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterFlags =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterFlags &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFilterFlags = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterFlags.run(
@@ -179,9 +163,7 @@ TEST_F(FFmpegTest, AVFilterStructs) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterGetInputsFilterPad = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterGetInputsFilterPad &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterGetInputsFilterPad = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterGetInputsFilterPad.run(
@@ -197,9 +179,7 @@ TEST_F(FFmpegTest, AVFilterStructs) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterGetOutputsFilterPad = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterGetOutputsFilterPad &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterGetOutputsFilterPad = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterGetOutputsFilterPad.run(
@@ -218,9 +198,7 @@ TEST_F(FFmpegTest, AVFilterStructs) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterPadGetNameLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterPadGetNameLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterPadGetNameLength = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterPadGetNameLength.run(
@@ -236,9 +214,7 @@ TEST_F(FFmpegTest, AVFilterStructs) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterPadGetName = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterPadGetName &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterPadGetName = FuncInst->getHostFunc();
 
   {
     int32_t Idx = 0;
@@ -255,9 +231,7 @@ TEST_F(FFmpegTest, AVFilterStructs) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterPadGetType = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterPadGetType &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterPadGetType = FuncInst->getHostFunc();
 
   {
     int32_t Idx = 0;
@@ -273,9 +247,7 @@ TEST_F(FFmpegTest, AVFilterStructs) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterPadDrop =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterPadDrop &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFilterPadDrop = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterPadDrop.run(

--- a/test/plugins/wasmedge_ffmpeg/avfilter/avfilter.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avfilter/avfilter.cpp
@@ -31,8 +31,8 @@ TEST_F(FFmpegTest, AVFilterStructs) {
 
   auto *FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_get_by_name");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterGetByName = FuncInst->getHostFunc();
 
@@ -54,8 +54,8 @@ TEST_F(FFmpegTest, AVFilterStructs) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_name_length");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterNameLength = FuncInst->getHostFunc();
 
@@ -70,8 +70,8 @@ TEST_F(FFmpegTest, AVFilterStructs) {
 
   FuncInst =
       AVFilterMod->findFuncExports("wasmedge_ffmpeg_avfilter_avfilter_name");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterName = FuncInst->getHostFunc();
 
@@ -86,8 +86,8 @@ TEST_F(FFmpegTest, AVFilterStructs) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_description_length");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterDescriptionLength = FuncInst->getHostFunc();
 
@@ -102,8 +102,8 @@ TEST_F(FFmpegTest, AVFilterStructs) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_description");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterDescription = FuncInst->getHostFunc();
 
@@ -118,8 +118,8 @@ TEST_F(FFmpegTest, AVFilterStructs) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_nb_inputs");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterNbInputs = FuncInst->getHostFunc();
 
@@ -132,8 +132,8 @@ TEST_F(FFmpegTest, AVFilterStructs) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_nb_outputs");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterNbOutputs = FuncInst->getHostFunc();
 
@@ -146,8 +146,8 @@ TEST_F(FFmpegTest, AVFilterStructs) {
 
   FuncInst =
       AVFilterMod->findFuncExports("wasmedge_ffmpeg_avfilter_avfilter_flags");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterFlags = FuncInst->getHostFunc();
 
@@ -160,8 +160,8 @@ TEST_F(FFmpegTest, AVFilterStructs) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_get_inputs_filter_pad");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterGetInputsFilterPad = FuncInst->getHostFunc();
 
@@ -176,8 +176,8 @@ TEST_F(FFmpegTest, AVFilterStructs) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_get_outputs_filter_pad");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterGetOutputsFilterPad = FuncInst->getHostFunc();
 
@@ -195,8 +195,8 @@ TEST_F(FFmpegTest, AVFilterStructs) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_pad_get_name_length");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterPadGetNameLength = FuncInst->getHostFunc();
 
@@ -211,8 +211,8 @@ TEST_F(FFmpegTest, AVFilterStructs) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_pad_get_name");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterPadGetName = FuncInst->getHostFunc();
 
@@ -228,8 +228,8 @@ TEST_F(FFmpegTest, AVFilterStructs) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_pad_get_type");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterPadGetType = FuncInst->getHostFunc();
 
@@ -244,8 +244,8 @@ TEST_F(FFmpegTest, AVFilterStructs) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_pad_drop");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterPadDrop = FuncInst->getHostFunc();
 

--- a/test/plugins/wasmedge_ffmpeg/avfilter/avfilter_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avfilter/avfilter_func.cpp
@@ -384,7 +384,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   {
     EXPECT_TRUE(HostFuncAVFilterVersion.run(
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{}, Result));
-    ASSERT_TRUE(Result[0].get<int32_t>() > 0);
+    ASSERT_TRUE((Result[0].get<int32_t>() >> 16) > 0);
   }
 
   FuncInst = AVFilterMod->findFuncExports(
@@ -414,6 +414,10 @@ TEST_F(FFmpegTest, AVFilterFunc) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{StrPtr, Length},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_NE(std::string_view(MemInst->getPointer<char *>(StrPtr),
+                               static_cast<size_t>(Length))
+                  .find("--"),
+              std::string_view::npos);
   }
 
   FuncInst = AVFilterMod->findFuncExports(
@@ -442,6 +446,10 @@ TEST_F(FFmpegTest, AVFilterFunc) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{StrPtr, Length},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(StrPtr),
+                               static_cast<size_t>(Length))
+                  .find("--"),
+              std::string_view::npos);
   }
 
   // ==================================================================

--- a/test/plugins/wasmedge_ffmpeg/avfilter/avfilter_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avfilter/avfilter_func.cpp
@@ -63,9 +63,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterGraphAlloc = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterGraphAlloc &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterGraphAlloc = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterGraphAlloc.run(
@@ -82,9 +80,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterGetByName = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterGetByName &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterGetByName = FuncInst->getHostFunc();
 
   {
     int32_t Length = InputName.length();
@@ -114,9 +110,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterGraphCreateFilter = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterGraphCreateFilter &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterGraphCreateFilter = FuncInst->getHostFunc();
 
   {
     int32_t NameLen = InputFilterName.length();
@@ -146,9 +140,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterInOutAlloc = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterInOutAlloc &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterInOutAlloc = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterInOutAlloc.run(
@@ -173,9 +165,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterGraphGetFilter = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterGraphGetFilter &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterGraphGetFilter = FuncInst->getHostFunc();
 
   {
     int32_t Length = OutputFilterName.length();
@@ -210,9 +200,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterInOutSetName = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterInOutSetName &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterInOutSetName = FuncInst->getHostFunc();
 
   {
     int32_t Length = InputFilterName.length();
@@ -237,9 +225,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterInOutSetFilterCtx = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterInOutSetFilterCtx &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterInOutSetFilterCtx = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterInOutSetFilterCtx.run(
@@ -262,9 +248,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterInOutSetPadIdx = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterInOutSetPadIdx &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterInOutSetPadIdx = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterInOutSetPadIdx.run(
@@ -283,9 +267,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterInOutSetNext = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterInOutSetNext &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterInOutSetNext = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterInOutSetNext.run(
@@ -308,9 +290,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterGraphParsePtr = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterGraphParsePtr &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterGraphParsePtr = FuncInst->getHostFunc();
 
   {
     int32_t Length = SpecStr.length();
@@ -327,9 +307,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterGraphConfig = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterGraphConfig &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterGraphConfig = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterGraphConfig.run(
@@ -343,9 +321,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterGraphDumpLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterGraphDumpLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterGraphDumpLength = FuncInst->getHostFunc();
 
   int32_t GraphStrLen = 0;
   {
@@ -361,9 +337,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterGraphDump = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterGraphDump &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterGraphDump = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterGraphDump.run(
@@ -405,9 +379,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterVersion =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterVersion &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFilterVersion = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterVersion.run(
@@ -420,9 +392,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterConfigurationLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterConfigurationLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterConfigurationLength = FuncInst->getHostFunc();
 
   int32_t Length = 0;
   {
@@ -437,9 +407,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterConfiguration = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterConfiguration &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterConfiguration = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterConfiguration.run(
@@ -453,9 +421,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterLicenseLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterLicenseLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterLicenseLength = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterLicenseLength.run(
@@ -469,9 +435,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterLicense =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterLicense &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFilterLicense = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterLicense.run(
@@ -489,9 +453,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVBufferSrcGetNbFailedRequests = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVBufferSrcGetNbFailedRequests
-          &>(FuncInst->getHostFunc());
+  auto &HostFuncAVBufferSrcGetNbFailedRequests = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVBufferSrcGetNbFailedRequests.run(
@@ -505,9 +467,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVBufferSrcAddFrame = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVBufferSrcAddFrame &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVBufferSrcAddFrame = FuncInst->getHostFunc();
 
   // Returning Error Code -22 (Invalid Argument), Due to Passing Empty Frame.
   {
@@ -548,9 +508,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVBufferSinkGetFrame = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVBufferSinkGetFrame &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVBufferSinkGetFrame = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVBufferSinkGetFrame.run(
@@ -565,9 +523,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVBufferSinkGetSamples = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVBufferSinkGetSamples &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVBufferSinkGetSamples = FuncInst->getHostFunc();
 
   // Passing Empty frames. Return AVERROR due to no frames presen Return AVERROR
   // due to no frames present.
@@ -585,9 +541,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAvBufferSinkSetFrameSize = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AvBufferSinkSetFrameSize &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAvBufferSinkSetFrameSize = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAvBufferSinkSetFrameSize.run(
@@ -610,9 +564,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterFreeGraphStr = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterFreeGraphStr &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterFreeGraphStr = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterFreeGraphStr.run(
@@ -626,9 +578,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterDrop =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterDrop &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFilterDrop = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterDrop.run(
@@ -642,9 +592,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterContextDrop = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterContextDrop &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterContextDrop = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterContextDrop.run(
@@ -664,9 +612,7 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
 
-  auto &HostFuncAVFilterGraphFree = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFilter::AVFilterGraphFree &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFilterGraphFree = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFilterGraphFree.run(

--- a/test/plugins/wasmedge_ffmpeg/avfilter/avfilter_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avfilter/avfilter_func.cpp
@@ -60,8 +60,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   auto *FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_graph_alloc");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterGraphAlloc = FuncInst->getHostFunc();
 
@@ -77,8 +77,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_get_by_name");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterGetByName = FuncInst->getHostFunc();
 
@@ -107,8 +107,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_graph_create_filter");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterGraphCreateFilter = FuncInst->getHostFunc();
 
@@ -137,8 +137,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_inout_alloc");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterInOutAlloc = FuncInst->getHostFunc();
 
@@ -162,8 +162,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_graph_get_filter");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterGraphGetFilter = FuncInst->getHostFunc();
 
@@ -197,8 +197,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_inout_set_name");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterInOutSetName = FuncInst->getHostFunc();
 
@@ -222,8 +222,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_inout_set_filter_ctx");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterInOutSetFilterCtx = FuncInst->getHostFunc();
 
@@ -245,8 +245,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_inout_set_pad_idx");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterInOutSetPadIdx = FuncInst->getHostFunc();
 
@@ -264,8 +264,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_inout_set_next");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterInOutSetNext = FuncInst->getHostFunc();
 
@@ -287,8 +287,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_graph_parse_ptr");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterGraphParsePtr = FuncInst->getHostFunc();
 
@@ -304,8 +304,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_graph_config");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterGraphConfig = FuncInst->getHostFunc();
 
@@ -318,8 +318,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_graph_dump_length");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterGraphDumpLength = FuncInst->getHostFunc();
 
@@ -334,8 +334,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_graph_dump");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterGraphDump = FuncInst->getHostFunc();
 
@@ -376,8 +376,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst =
       AVFilterMod->findFuncExports("wasmedge_ffmpeg_avfilter_avfilter_version");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterVersion = FuncInst->getHostFunc();
 
@@ -389,8 +389,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_configuration_length");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterConfigurationLength = FuncInst->getHostFunc();
 
@@ -404,8 +404,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_configuration");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterConfiguration = FuncInst->getHostFunc();
 
@@ -418,8 +418,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_license_length");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterLicenseLength = FuncInst->getHostFunc();
 
@@ -432,8 +432,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst =
       AVFilterMod->findFuncExports("wasmedge_ffmpeg_avfilter_avfilter_license");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterLicense = FuncInst->getHostFunc();
 
@@ -450,8 +450,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_av_buffersrc_get_nb_failed_requests");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVBufferSrcGetNbFailedRequests = FuncInst->getHostFunc();
 
@@ -464,8 +464,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_av_buffersrc_add_frame");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVBufferSrcAddFrame = FuncInst->getHostFunc();
 
@@ -505,8 +505,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
   // due to no frames present.
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_av_buffersink_get_frame");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVBufferSinkGetFrame = FuncInst->getHostFunc();
 
@@ -520,8 +520,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_av_buffersink_get_samples");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVBufferSinkGetSamples = FuncInst->getHostFunc();
 
@@ -538,8 +538,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_av_buffersink_set_frame_size");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAvBufferSinkSetFrameSize = FuncInst->getHostFunc();
 
@@ -561,8 +561,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_free_graph_str");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterFreeGraphStr = FuncInst->getHostFunc();
 
@@ -575,8 +575,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst =
       AVFilterMod->findFuncExports("wasmedge_ffmpeg_avfilter_avfilter_drop");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterDrop = FuncInst->getHostFunc();
 
@@ -589,8 +589,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_context_drop");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterContextDrop = FuncInst->getHostFunc();
 
@@ -609,8 +609,8 @@ TEST_F(FFmpegTest, AVFilterFunc) {
 
   FuncInst = AVFilterMod->findFuncExports(
       "wasmedge_ffmpeg_avfilter_avfilter_graph_free");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
 
   auto &HostFuncAVFilterGraphFree = FuncInst->getHostFunc();
 

--- a/test/plugins/wasmedge_ffmpeg/avformat/avChapter.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avChapter.cpp
@@ -30,8 +30,8 @@ TEST_F(FFmpegTest, AVChapter) {
 
   auto *FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avChapter_id");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVChapterId = FuncInst->getHostFunc();
 
   {
@@ -44,8 +44,8 @@ TEST_F(FFmpegTest, AVChapter) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avChapter_timebase");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVChapterTimebase = FuncInst->getHostFunc();
 
   {
@@ -61,8 +61,8 @@ TEST_F(FFmpegTest, AVChapter) {
 
   FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avChapter_start");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVChapterStart = FuncInst->getHostFunc();
 
   {
@@ -75,8 +75,8 @@ TEST_F(FFmpegTest, AVChapter) {
 
   FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avChapter_end");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVChapterEnd = FuncInst->getHostFunc();
 
   {
@@ -89,8 +89,8 @@ TEST_F(FFmpegTest, AVChapter) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avChapter_metadata");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVChapterMetadata = FuncInst->getHostFunc();
 
   {
@@ -105,8 +105,8 @@ TEST_F(FFmpegTest, AVChapter) {
 
   FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avChapter_set_id");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVChapterSetId = FuncInst->getHostFunc();
 
   {
@@ -128,8 +128,8 @@ TEST_F(FFmpegTest, AVChapter) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avChapter_set_timebase");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVChapterSetTimebase = FuncInst->getHostFunc();
 
   {
@@ -155,8 +155,8 @@ TEST_F(FFmpegTest, AVChapter) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avChapter_set_start");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVChapterSetStart = FuncInst->getHostFunc();
 
   {
@@ -178,8 +178,8 @@ TEST_F(FFmpegTest, AVChapter) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avChapter_set_end");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVChapterSetEnd = FuncInst->getHostFunc();
 
   {

--- a/test/plugins/wasmedge_ffmpeg/avformat/avChapter.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avChapter.cpp
@@ -32,9 +32,7 @@ TEST_F(FFmpegTest, AVChapter) {
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avChapter_id");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVChapterId =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVChapterId &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVChapterId = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVChapterId.run(
@@ -48,9 +46,7 @@ TEST_F(FFmpegTest, AVChapter) {
       "wasmedge_ffmpeg_avformat_avChapter_timebase");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVChapterTimebase = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVChapterTimebase &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVChapterTimebase = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVChapterTimebase.run(
@@ -67,9 +63,7 @@ TEST_F(FFmpegTest, AVChapter) {
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avChapter_start");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVChapterStart =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVChapterStart &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVChapterStart = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVChapterStart.run(
@@ -83,9 +77,7 @@ TEST_F(FFmpegTest, AVChapter) {
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avChapter_end");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVChapterEnd =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVChapterEnd &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVChapterEnd = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVChapterEnd.run(
@@ -99,9 +91,7 @@ TEST_F(FFmpegTest, AVChapter) {
       "wasmedge_ffmpeg_avformat_avChapter_metadata");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVChapterMetadata = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVChapterMetadata &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVChapterMetadata = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVChapterMetadata.run(
@@ -117,9 +107,7 @@ TEST_F(FFmpegTest, AVChapter) {
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avChapter_set_id");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVChapterSetId =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVChapterSetId &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVChapterSetId = FuncInst->getHostFunc();
 
   {
     int64_t ChapterId = 10000;
@@ -142,9 +130,7 @@ TEST_F(FFmpegTest, AVChapter) {
       "wasmedge_ffmpeg_avformat_avChapter_set_timebase");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVChapterSetTimebase = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVChapterSetTimebase &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVChapterSetTimebase = FuncInst->getHostFunc();
 
   {
     int32_t Num = 3;
@@ -171,9 +157,7 @@ TEST_F(FFmpegTest, AVChapter) {
       "wasmedge_ffmpeg_avformat_avChapter_set_start");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVChapterSetStart = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVChapterSetStart &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVChapterSetStart = FuncInst->getHostFunc();
 
   {
     int64_t StartValue = 1000;
@@ -196,9 +180,7 @@ TEST_F(FFmpegTest, AVChapter) {
       "wasmedge_ffmpeg_avformat_avChapter_set_end");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVChapterSetEnd =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVChapterSetEnd &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVChapterSetEnd = FuncInst->getHostFunc();
 
   {
     int64_t EndValue = 99999;

--- a/test/plugins/wasmedge_ffmpeg/avformat/avInputOutputContext.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avInputOutputContext.cpp
@@ -14,6 +14,7 @@ namespace Host {
 namespace WasmEdgeFFmpeg {
 
 TEST_F(FFmpegTest, AVInputFormat) {
+  using namespace std::literals::string_view_literals;
   std::string FileName = "ffmpeg-assets/sample_video.mp4"; // 32 chars
   uint32_t FormatCtxPtr = UINT32_C(24);
   uint32_t InputFormatPtr = UINT32_C(28);
@@ -78,6 +79,9 @@ TEST_F(FFmpegTest, AVInputFormat) {
                                                     Length},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(StrBuf),
+                               static_cast<size_t>(Length)),
+              "mov,mp4,m4a,3gp,3g2,mj2"sv);
   }
 
   FuncInst = AVFormatMod->findFuncExports(
@@ -109,6 +113,9 @@ TEST_F(FFmpegTest, AVInputFormat) {
         Result));
 
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(StrBuf),
+                               static_cast<size_t>(Length)),
+              "QuickTime / MOV"sv);
   }
 
   FuncInst = AVFormatMod->findFuncExports(

--- a/test/plugins/wasmedge_ffmpeg/avformat/avInputOutputContext.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avInputOutputContext.cpp
@@ -32,9 +32,7 @@ TEST_F(FFmpegTest, AVInputFormat) {
       "wasmedge_ffmpeg_avformat_avformatContext_iformat");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatCtxIFormat = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatCtxIFormat &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatCtxIFormat = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFormatCtxIFormat.run(
@@ -55,9 +53,7 @@ TEST_F(FFmpegTest, AVInputFormat) {
       "wasmedge_ffmpeg_avformat_avIOFormat_name_length");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVIOFormatNameLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVIOFormatNameLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVIOFormatNameLength = FuncInst->getHostFunc();
 
   int32_t Length = 0;
   {
@@ -72,9 +68,7 @@ TEST_F(FFmpegTest, AVInputFormat) {
       "wasmedge_ffmpeg_avformat_avInputFormat_name");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVInputFormatName = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVInputFormatName &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVInputFormatName = FuncInst->getHostFunc();
 
   fillMemContent(MemInst, StrBuf, Length);
   {
@@ -90,9 +84,7 @@ TEST_F(FFmpegTest, AVInputFormat) {
       "wasmedge_ffmpeg_avformat_avIOFormat_long_name_length");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVIOFormatLongNameLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVIOFormatLongNameLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVIOFormatLongNameLength = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVIOFormatLongNameLength.run(
@@ -107,9 +99,7 @@ TEST_F(FFmpegTest, AVInputFormat) {
       "wasmedge_ffmpeg_avformat_avInputFormat_long_name");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVInputFormatLongName = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVInputFormatLongName &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVInputFormatLongName = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVInputFormatLongName.run(
@@ -125,9 +115,7 @@ TEST_F(FFmpegTest, AVInputFormat) {
       "wasmedge_ffmpeg_avformat_avIOFormat_extensions_length");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVIOFormatExtensionsLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVIOFormatExtensionsLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVIOFormatExtensionsLength = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVIOFormatExtensionsLength.run(
@@ -142,9 +130,7 @@ TEST_F(FFmpegTest, AVInputFormat) {
       "wasmedge_ffmpeg_avformat_avInputFormat_extensions");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVInputFormatExtensions = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVInputFormatExtensions &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVInputFormatExtensions = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVInputFormatExtensions.run(
@@ -159,9 +145,7 @@ TEST_F(FFmpegTest, AVInputFormat) {
       "wasmedge_ffmpeg_avformat_avIOFormat_mime_type_length");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVIOFormatMimeTypeLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVIOFormatMimeTypeLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVIOFormatMimeTypeLength = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVIOFormatMimeTypeLength.run(
@@ -176,9 +160,7 @@ TEST_F(FFmpegTest, AVInputFormat) {
       "wasmedge_ffmpeg_avformat_avInputFormat_mime_type");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVInputFormatMimeType = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVInputFormatMimeType &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVInputFormatMimeType = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVInputFormatMimeType.run(
@@ -193,9 +175,7 @@ TEST_F(FFmpegTest, AVInputFormat) {
       "wasmedge_ffmpeg_avformat_avInputOutputFormat_free");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVInputOutputFormatFree = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVInputOutputFormatFree &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVInputOutputFormatFree = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVInputOutputFormatFree.run(

--- a/test/plugins/wasmedge_ffmpeg/avformat/avInputOutputContext.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avInputOutputContext.cpp
@@ -30,8 +30,8 @@ TEST_F(FFmpegTest, AVInputFormat) {
 
   auto *FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformatContext_iformat");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatCtxIFormat = FuncInst->getHostFunc();
 
   {
@@ -51,8 +51,8 @@ TEST_F(FFmpegTest, AVInputFormat) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avIOFormat_name_length");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVIOFormatNameLength = FuncInst->getHostFunc();
 
   int32_t Length = 0;
@@ -66,8 +66,8 @@ TEST_F(FFmpegTest, AVInputFormat) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avInputFormat_name");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVInputFormatName = FuncInst->getHostFunc();
 
   fillMemContent(MemInst, StrBuf, Length);
@@ -82,8 +82,8 @@ TEST_F(FFmpegTest, AVInputFormat) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avIOFormat_long_name_length");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVIOFormatLongNameLength = FuncInst->getHostFunc();
 
   {
@@ -97,8 +97,8 @@ TEST_F(FFmpegTest, AVInputFormat) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avInputFormat_long_name");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVInputFormatLongName = FuncInst->getHostFunc();
 
   {
@@ -113,8 +113,8 @@ TEST_F(FFmpegTest, AVInputFormat) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avIOFormat_extensions_length");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVIOFormatExtensionsLength = FuncInst->getHostFunc();
 
   {
@@ -128,8 +128,8 @@ TEST_F(FFmpegTest, AVInputFormat) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avInputFormat_extensions");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVInputFormatExtensions = FuncInst->getHostFunc();
 
   {
@@ -143,8 +143,8 @@ TEST_F(FFmpegTest, AVInputFormat) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avIOFormat_mime_type_length");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVIOFormatMimeTypeLength = FuncInst->getHostFunc();
 
   {
@@ -158,8 +158,8 @@ TEST_F(FFmpegTest, AVInputFormat) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avInputFormat_mime_type");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVInputFormatMimeType = FuncInst->getHostFunc();
 
   {
@@ -173,8 +173,8 @@ TEST_F(FFmpegTest, AVInputFormat) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avInputOutputFormat_free");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVInputOutputFormatFree = FuncInst->getHostFunc();
 
   {

--- a/test/plugins/wasmedge_ffmpeg/avformat/avStream.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avStream.cpp
@@ -31,8 +31,8 @@ TEST_F(FFmpegTest, AVStreamStruct) {
 
   auto *FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avStream_id");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamId = FuncInst->getHostFunc();
 
   uint32_t AvFormatCtxId = readUInt32(MemInst, FormatCtxPtr);
@@ -46,8 +46,8 @@ TEST_F(FFmpegTest, AVStreamStruct) {
 
   FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avStream_index");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamIndex = FuncInst->getHostFunc();
 
   {
@@ -60,8 +60,8 @@ TEST_F(FFmpegTest, AVStreamStruct) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_codecpar");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamCodecPar = FuncInst->getHostFunc();
 
   {
@@ -76,14 +76,14 @@ TEST_F(FFmpegTest, AVStreamStruct) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_timebase");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamTimebase = FuncInst->getHostFunc();
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_set_timebase");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamSetTimebase = FuncInst->getHostFunc();
 
   {
@@ -108,8 +108,8 @@ TEST_F(FFmpegTest, AVStreamStruct) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_duration");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamDuration = FuncInst->getHostFunc();
 
   {
@@ -122,8 +122,8 @@ TEST_F(FFmpegTest, AVStreamStruct) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_start_time");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamStartTime = FuncInst->getHostFunc();
 
   {
@@ -136,8 +136,8 @@ TEST_F(FFmpegTest, AVStreamStruct) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_nb_frames");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamNbFrames = FuncInst->getHostFunc();
 
   {
@@ -150,8 +150,8 @@ TEST_F(FFmpegTest, AVStreamStruct) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_disposition");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamDisposition = FuncInst->getHostFunc();
 
   {
@@ -164,14 +164,14 @@ TEST_F(FFmpegTest, AVStreamStruct) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_set_r_frame_rate");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamSetRFrameRate = FuncInst->getHostFunc();
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_r_frame_rate");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamRFrameRate = FuncInst->getHostFunc();
 
   {
@@ -196,14 +196,14 @@ TEST_F(FFmpegTest, AVStreamStruct) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_set_avg_frame_rate");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamSetAvgFrameRate = FuncInst->getHostFunc();
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_avg_frame_rate");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamAvgFrameRate = FuncInst->getHostFunc();
 
   {
@@ -229,14 +229,14 @@ TEST_F(FFmpegTest, AVStreamStruct) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_metadata");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamMetadata = FuncInst->getHostFunc();
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_set_metadata");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamSetMetadata = FuncInst->getHostFunc();
   {
     EXPECT_TRUE(HostFuncAVStreamMetadata.run(
@@ -257,8 +257,8 @@ TEST_F(FFmpegTest, AVStreamStruct) {
 
   FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avStream_discard");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamDiscard = FuncInst->getHostFunc();
   {
     EXPECT_TRUE(HostFuncAVStreamDiscard.run(

--- a/test/plugins/wasmedge_ffmpeg/avformat/avStream.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avStream.cpp
@@ -33,9 +33,7 @@ TEST_F(FFmpegTest, AVStreamStruct) {
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avStream_id");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVStreamId =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVStreamId &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVStreamId = FuncInst->getHostFunc();
 
   uint32_t AvFormatCtxId = readUInt32(MemInst, FormatCtxPtr);
   {
@@ -50,9 +48,7 @@ TEST_F(FFmpegTest, AVStreamStruct) {
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avStream_index");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVStreamIndex =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVStreamIndex &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVStreamIndex = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVStreamIndex.run(
@@ -66,9 +62,7 @@ TEST_F(FFmpegTest, AVStreamStruct) {
       "wasmedge_ffmpeg_avformat_avStream_codecpar");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVStreamCodecPar = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVStreamCodecPar &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVStreamCodecPar = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVStreamCodecPar.run(
@@ -84,17 +78,13 @@ TEST_F(FFmpegTest, AVStreamStruct) {
       "wasmedge_ffmpeg_avformat_avStream_timebase");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVStreamTimebase = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVStreamTimebase &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVStreamTimebase = FuncInst->getHostFunc();
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_set_timebase");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVStreamSetTimebase = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVStreamSetTimebase &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVStreamSetTimebase = FuncInst->getHostFunc();
 
   {
     int32_t Num = 3;
@@ -120,9 +110,7 @@ TEST_F(FFmpegTest, AVStreamStruct) {
       "wasmedge_ffmpeg_avformat_avStream_duration");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVStreamDuration = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVStreamDuration &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVStreamDuration = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVStreamDuration.run(
@@ -136,9 +124,7 @@ TEST_F(FFmpegTest, AVStreamStruct) {
       "wasmedge_ffmpeg_avformat_avStream_start_time");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVStreamStartTime = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVStreamStartTime &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVStreamStartTime = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVStreamStartTime.run(
@@ -152,9 +138,7 @@ TEST_F(FFmpegTest, AVStreamStruct) {
       "wasmedge_ffmpeg_avformat_avStream_nb_frames");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVStreamNbFrames = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVStreamNbFrames &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVStreamNbFrames = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVStreamNbFrames.run(
@@ -168,9 +152,7 @@ TEST_F(FFmpegTest, AVStreamStruct) {
       "wasmedge_ffmpeg_avformat_avStream_disposition");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVStreamDisposition = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVStreamDisposition &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVStreamDisposition = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVStreamDisposition.run(
@@ -184,17 +166,13 @@ TEST_F(FFmpegTest, AVStreamStruct) {
       "wasmedge_ffmpeg_avformat_avStream_set_r_frame_rate");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVStreamSetRFrameRate = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVStreamSetRFrameRate &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVStreamSetRFrameRate = FuncInst->getHostFunc();
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_r_frame_rate");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVStreamRFrameRate = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVStreamRFrameRate &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVStreamRFrameRate = FuncInst->getHostFunc();
 
   {
     int32_t Num = 3;
@@ -220,17 +198,13 @@ TEST_F(FFmpegTest, AVStreamStruct) {
       "wasmedge_ffmpeg_avformat_avStream_set_avg_frame_rate");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVStreamSetAvgFrameRate = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVStreamSetAvgFrameRate &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVStreamSetAvgFrameRate = FuncInst->getHostFunc();
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_avg_frame_rate");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVStreamAvgFrameRate = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVStreamAvgFrameRate &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVStreamAvgFrameRate = FuncInst->getHostFunc();
 
   {
     int32_t Num = 3;
@@ -257,17 +231,13 @@ TEST_F(FFmpegTest, AVStreamStruct) {
       "wasmedge_ffmpeg_avformat_avStream_metadata");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVStreamMetadata = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVStreamMetadata &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVStreamMetadata = FuncInst->getHostFunc();
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_set_metadata");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVStreamSetMetadata = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVStreamSetMetadata &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVStreamSetMetadata = FuncInst->getHostFunc();
   {
     EXPECT_TRUE(HostFuncAVStreamMetadata.run(
         CallFrame,
@@ -289,9 +259,7 @@ TEST_F(FFmpegTest, AVStreamStruct) {
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avStream_discard");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVStreamDiscard =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVStreamDiscard &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVStreamDiscard = FuncInst->getHostFunc();
   {
     EXPECT_TRUE(HostFuncAVStreamDiscard.run(
         CallFrame,

--- a/test/plugins/wasmedge_ffmpeg/avformat/avStream.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avStream.cpp
@@ -117,7 +117,7 @@ TEST_F(FFmpegTest, AVStreamStruct) {
         CallFrame,
         std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, StreamIdx},
         Result));
-    EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
+    EXPECT_EQ(Result[0].get<int64_t>(), INT64_C(30720));
   }
 
   FuncInst = AVFormatMod->findFuncExports(
@@ -131,7 +131,7 @@ TEST_F(FFmpegTest, AVStreamStruct) {
         CallFrame,
         std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, StreamIdx},
         Result));
-    EXPECT_TRUE(Result[0].get<int64_t>() >= 0);
+    EXPECT_EQ(Result[0].get<int64_t>(), INT64_C(0));
   }
 
   FuncInst = AVFormatMod->findFuncExports(
@@ -145,7 +145,7 @@ TEST_F(FFmpegTest, AVStreamStruct) {
         CallFrame,
         std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, StreamIdx},
         Result));
-    EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
+    EXPECT_EQ(Result[0].get<int64_t>(), INT64_C(120));
   }
 
   FuncInst = AVFormatMod->findFuncExports(
@@ -159,7 +159,7 @@ TEST_F(FFmpegTest, AVStreamStruct) {
         CallFrame,
         std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, StreamIdx},
         Result));
-    EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
+    EXPECT_EQ(Result[0].get<int32_t>(), 1); // AV_DISPOSITION_DEFAULT
   }
 
   FuncInst = AVFormatMod->findFuncExports(

--- a/test/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
@@ -28,9 +28,7 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
       "wasmedge_ffmpeg_avformat_avformatContext_iformat");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatCtxIFormat = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatCtxIFormat &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatCtxIFormat = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFormatCtxIFormat.run(
@@ -46,9 +44,7 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
       "wasmedge_ffmpeg_avformat_avformatContext_oformat");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatCtxOFormat = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatCtxOFormat &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatCtxOFormat = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFormatCtxOFormat.run(
@@ -64,9 +60,7 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
       "wasmedge_ffmpeg_avformat_avformatContext_probescope");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatCtxProbeScore = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatCtxProbeScore &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatCtxProbeScore = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFormatCtxProbeScore.run(
@@ -79,9 +73,7 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
       "wasmedge_ffmpeg_avformat_avformatContext_nb_streams");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatCtxNbStreams = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatCtxNbStreams &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatCtxNbStreams = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFormatCtxNbStreams.run(
@@ -94,9 +86,7 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
       "wasmedge_ffmpeg_avformat_avformatContext_duration");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatCtxDuration = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatCtxDuration &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatCtxDuration = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFormatCtxDuration.run(
@@ -109,9 +99,7 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
       "wasmedge_ffmpeg_avformat_avformatContext_bit_rate");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatCtxBitRate = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatCtxBitRate &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatCtxBitRate = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFormatCtxBitRate.run(
@@ -124,17 +112,13 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
       "wasmedge_ffmpeg_avformat_avformatContext_set_nb_chapters");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatCtxSetNbChapters = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatCtxSetNbChapters &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatCtxSetNbChapters = FuncInst->getHostFunc();
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformatContext_nb_chapters");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatCtxNbChapters = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatCtxNbChapters &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatCtxNbChapters = FuncInst->getHostFunc();
   {
     uint32_t NbChapters = 200;
     EXPECT_TRUE(HostFuncAVFormatCtxSetNbChapters.run(
@@ -153,17 +137,13 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
       "wasmedge_ffmpeg_avformat_avformatContext_metadata");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatCtxMetadata = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatCtxMetadata &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatCtxMetadata = FuncInst->getHostFunc();
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformatContext_set_metadata");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatCtxSetMetadata = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatCtxSetMetadata &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatCtxSetMetadata = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncAVFormatCtxMetadata.run(

--- a/test/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
@@ -92,7 +92,7 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
     EXPECT_TRUE(HostFuncAVFormatCtxDuration.run(
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
         Result));
-    EXPECT_TRUE(Result[0].get<int64_t>() >= 0 || Result[0].get<int64_t>() < 0);
+    EXPECT_EQ(Result[0].get<int64_t>(), INT64_C(2000000));
   }
 
   FuncInst = AVFormatMod->findFuncExports(

--- a/test/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
@@ -26,8 +26,8 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
 
   auto *FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformatContext_iformat");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatCtxIFormat = FuncInst->getHostFunc();
 
   {
@@ -42,8 +42,8 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformatContext_oformat");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatCtxOFormat = FuncInst->getHostFunc();
 
   {
@@ -58,8 +58,8 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformatContext_probescope");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatCtxProbeScore = FuncInst->getHostFunc();
 
   {
@@ -71,8 +71,8 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformatContext_nb_streams");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatCtxNbStreams = FuncInst->getHostFunc();
 
   {
@@ -84,8 +84,8 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformatContext_duration");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatCtxDuration = FuncInst->getHostFunc();
 
   {
@@ -97,8 +97,8 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformatContext_bit_rate");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatCtxBitRate = FuncInst->getHostFunc();
 
   {
@@ -110,14 +110,14 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformatContext_set_nb_chapters");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatCtxSetNbChapters = FuncInst->getHostFunc();
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformatContext_nb_chapters");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatCtxNbChapters = FuncInst->getHostFunc();
   {
     uint32_t NbChapters = 200;
@@ -135,14 +135,14 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformatContext_metadata");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatCtxMetadata = FuncInst->getHostFunc();
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformatContext_set_metadata");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatCtxSetMetadata = FuncInst->getHostFunc();
 
   {

--- a/test/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
@@ -92,7 +92,7 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
     EXPECT_TRUE(HostFuncAVFormatCtxDuration.run(
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
         Result));
-    EXPECT_EQ(Result[0].get<int64_t>(), INT64_C(2000000));
+    EXPECT_EQ(Result[0].get<int64_t>(), AV_NOPTS_VALUE);
   }
 
   FuncInst = AVFormatMod->findFuncExports(

--- a/test/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
@@ -33,9 +33,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
       "wasmedge_ffmpeg_avformat_avformat_open_input");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatOpenInput = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatOpenInput &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatOpenInput = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatOpenInput"sv);
   {
@@ -64,9 +62,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
       "wasmedge_ffmpeg_avformat_avformat_find_stream_info");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatFindStreamInfo = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatFindStreamInfo &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatFindStreamInfo = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatFindStreamInfo"sv);
   {
@@ -81,9 +77,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_av_dump_format");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatAVDumpFormat =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVDumpFormat &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFormatAVDumpFormat = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVDumpFormat"sv);
   {
@@ -99,9 +93,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
       "wasmedge_ffmpeg_avformat_av_find_best_stream");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFindBestStream = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFindBestStream &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFindBestStream = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFindBestStream"sv);
   {
@@ -117,9 +109,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_av_read_frame");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVReadFrame =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVReadFrame &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVReadFrame = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVReadFrame"sv);
   {
@@ -137,9 +127,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
       "wasmedge_ffmpeg_avformat_avformat_network_init");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatNetworkInit = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatNetworkInit &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatNetworkInit = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatNetworkInit"sv);
   {
@@ -153,9 +141,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
       "wasmedge_ffmpeg_avformat_avformat_seek_file");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatSeekFile = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatSeekFile &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatSeekFile = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatSeekFile"sv);
   {
@@ -178,9 +164,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_av_read_play");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatAVReadPlay =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVReadPlay &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFormatAVReadPlay = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVReadPlay"sv);
   {
@@ -195,9 +179,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_av_read_pause");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatAVReadPause =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVReadPause &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFormatAVReadPause = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVReadPause"sv);
   {
@@ -212,9 +194,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
       "wasmedge_ffmpeg_avformat_avformat_network_deinit");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatNetworkDeInit = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatNetworkDeInit &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatNetworkDeInit = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatNetworkDeInit"sv);
   {
@@ -228,9 +208,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
       "wasmedge_ffmpeg_avformat_avformat_close_input");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatCloseInput = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatCloseInput &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatCloseInput = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatCloseInput"sv);
   {
@@ -244,9 +222,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
       "wasmedge_ffmpeg_avformat_avformat_free_context");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFreeContext = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatFreeContext &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFreeContext = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatFreeContext"sv);
   {
@@ -260,9 +236,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avformat_version");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatVersion =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatVersion &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFormatVersion = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatVersion"sv);
   {
@@ -276,9 +250,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
       "wasmedge_ffmpeg_avformat_avformat_configuration_length");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatConfigurationLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatConfigurationLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatConfigurationLength = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatConfigurationLength"sv);
   int32_t Length = 0;
@@ -293,9 +265,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
       "wasmedge_ffmpeg_avformat_avformat_configuration");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatConfiguration = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatConfiguration &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatConfiguration = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatConfiguration"sv);
   {
@@ -310,9 +280,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
       "wasmedge_ffmpeg_avformat_avformat_license_length");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatLicenseLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatLicenseLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatLicenseLength = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatLicenseLength"sv);
   {
@@ -327,9 +295,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avformat_license");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatLicense =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatLicense &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFormatLicense = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatLicense"sv);
   {
@@ -368,9 +334,7 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
       "wasmedge_ffmpeg_avformat_avformat_alloc_output_context2");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatAllocOutputContext2 = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatAllocOutputContext2 &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatAllocOutputContext2 = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatAllocOutputContext2"sv);
   {
@@ -400,9 +364,7 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
   FuncInst = AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avio_open");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVIOOpen =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVIOOpen &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVIOOpen = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVIOOpen"sv);
   {
@@ -419,9 +381,7 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avio_open2");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVIOOpen2 =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVIOOpen2 &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVIOOpen2 = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVIOOpen2"sv);
   {
@@ -457,9 +417,7 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
       "wasmedge_ffmpeg_avformat_avformat_write_header");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatWriteHeader = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatWriteHeader &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatWriteHeader = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatWriteHeader"sv);
   {
@@ -496,9 +454,7 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
       "wasmedge_ffmpeg_avformat_avchapter_mallocz");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVIOClose = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVChapterMallocz &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVIOClose = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVChapterMallocz"sv);
   {
@@ -534,9 +490,7 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avformat_avfreep");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVFormatAVFreep =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFreeP &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFormatAVFreep = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFreeP"sv);
   {
@@ -551,9 +505,7 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_av_write_frame");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVWriteFrame =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVWriteFrame &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVWriteFrame = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVWriteFrame"sv);
   // Passing Empty Frame, Hence giving Invalid Argument Error.
@@ -570,9 +522,7 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
       "wasmedge_ffmpeg_avformat_av_interleaved_write_frame");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVInterleavedWriteFrame = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVInterleavedWriteFrame &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVInterleavedWriteFrame = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVInterleavedWriteFrame"sv);
   // Passing Empty Frame, Hence giving Invalid Argument Error.

--- a/test/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
@@ -243,7 +243,7 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
     EXPECT_TRUE(HostFuncAVFormatVersion.run(
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{}, Result));
 
-    EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
+    EXPECT_TRUE((Result[0].get<int32_t>() >> 16) > 0);
   }
 
   FuncInst = AVFormatMod->findFuncExports(
@@ -274,6 +274,10 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
         Result));
 
     EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
+    EXPECT_NE(std::string_view(MemInst->getPointer<char *>(StrPtr),
+                               static_cast<size_t>(Length))
+                  .find("--"),
+              std::string_view::npos);
   }
 
   FuncInst = AVFormatMod->findFuncExports(
@@ -304,6 +308,10 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
         Result));
 
     EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(StrPtr),
+                               static_cast<size_t>(Length))
+                  .find("--"),
+              std::string_view::npos);
   }
 }
 

--- a/test/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avformat_func.cpp
@@ -31,8 +31,8 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
 
   auto *FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformat_open_input");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatOpenInput = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatOpenInput"sv);
@@ -60,8 +60,8 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformat_find_stream_info");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatFindStreamInfo = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatFindStreamInfo"sv);
@@ -75,8 +75,8 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
 
   FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_av_dump_format");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatAVDumpFormat = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVDumpFormat"sv);
@@ -91,8 +91,8 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_av_find_best_stream");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFindBestStream = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFindBestStream"sv);
@@ -107,8 +107,8 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
 
   FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_av_read_frame");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVReadFrame = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVReadFrame"sv);
@@ -125,8 +125,8 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformat_network_init");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatNetworkInit = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatNetworkInit"sv);
@@ -139,8 +139,8 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformat_seek_file");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatSeekFile = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatSeekFile"sv);
@@ -162,8 +162,8 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
 
   FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_av_read_play");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatAVReadPlay = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVReadPlay"sv);
@@ -177,8 +177,8 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
 
   FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_av_read_pause");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatAVReadPause = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVReadPause"sv);
@@ -192,8 +192,8 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformat_network_deinit");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatNetworkDeInit = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatNetworkDeInit"sv);
@@ -206,8 +206,8 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformat_close_input");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatCloseInput = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatCloseInput"sv);
@@ -220,8 +220,8 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformat_free_context");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFreeContext = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatFreeContext"sv);
@@ -234,8 +234,8 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
 
   FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avformat_version");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatVersion = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatVersion"sv);
@@ -248,8 +248,8 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformat_configuration_length");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatConfigurationLength = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatConfigurationLength"sv);
@@ -263,8 +263,8 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformat_configuration");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatConfiguration = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatConfiguration"sv);
@@ -278,8 +278,8 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformat_license_length");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatLicenseLength = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatLicenseLength"sv);
@@ -293,8 +293,8 @@ TEST_F(FFmpegTest, AVInputFormatFunc) {
 
   FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avformat_license");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatLicense = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatLicense"sv);
@@ -332,8 +332,8 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
 
   auto *FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformat_alloc_output_context2");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatAllocOutputContext2 = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatAllocOutputContext2"sv);
@@ -362,8 +362,8 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
   }
 
   FuncInst = AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avio_open");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVIOOpen = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVIOOpen"sv);
@@ -379,8 +379,8 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
 
   FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avio_open2");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVIOOpen2 = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVIOOpen2"sv);
@@ -415,8 +415,8 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformat_write_header");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatWriteHeader = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatWriteHeader"sv);
@@ -452,8 +452,8 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avchapter_mallocz");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVIOClose = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVChapterMallocz"sv);
@@ -488,8 +488,8 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
 
   FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_avformat_avfreep");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatAVFreep = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFreeP"sv);
@@ -503,8 +503,8 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
 
   FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_av_write_frame");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVWriteFrame = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVWriteFrame"sv);
@@ -520,8 +520,8 @@ TEST_F(FFmpegTest, AVOutputFormatFunc) {
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_av_interleaved_write_frame");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVInterleavedWriteFrame = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVInterleavedWriteFrame"sv);

--- a/test/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
@@ -30,9 +30,7 @@ TEST_F(FFmpegTest, AVDictionary) {
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVDictSet =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVDictSet &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVDictSet = FuncInst->getHostFunc();
 
   // Fill 0 in WasmMemory.
   fillMemContent(MemInst, KeyStart, KeyLen + ValueLen);
@@ -54,9 +52,7 @@ TEST_F(FFmpegTest, AVDictionary) {
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_copy");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVDictCopy =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVDictCopy &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVDictCopy = FuncInst->getHostFunc();
 
   {
     uint32_t DestDictPtr = UINT32_C(80);
@@ -72,9 +68,7 @@ TEST_F(FFmpegTest, AVDictionary) {
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_get");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVDictGet =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVDictGet &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVDictGet = FuncInst->getHostFunc();
 
   {
     // Store the string lengths of Key and value in the pointers below.
@@ -106,9 +100,7 @@ TEST_F(FFmpegTest, AVDictionary) {
       "wasmedge_ffmpeg_avutil_av_dict_get_key_value");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVDictGetKeyValue =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVDictGetKeyValue &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVDictGetKeyValue = FuncInst->getHostFunc();
 
   {
     // Store the strings of Key and value in the buffer pointers below.
@@ -138,9 +130,7 @@ TEST_F(FFmpegTest, AVDictionary) {
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_free");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVDictFree =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVDictFree &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVDictFree = FuncInst->getHostFunc();
 
   {
     uint32_t DictId = readUInt32(MemInst, DictPtr);

--- a/test/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
@@ -28,8 +28,8 @@ TEST_F(FFmpegTest, AVDictionary) {
 
   auto *FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVDictSet = FuncInst->getHostFunc();
 
   // Fill 0 in WasmMemory.
@@ -50,8 +50,8 @@ TEST_F(FFmpegTest, AVDictionary) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_copy");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVDictCopy = FuncInst->getHostFunc();
 
   {
@@ -66,8 +66,8 @@ TEST_F(FFmpegTest, AVDictionary) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_get");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVDictGet = FuncInst->getHostFunc();
 
   {
@@ -98,8 +98,8 @@ TEST_F(FFmpegTest, AVDictionary) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_dict_get_key_value");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVDictGetKeyValue = FuncInst->getHostFunc();
 
   {
@@ -128,8 +128,8 @@ TEST_F(FFmpegTest, AVDictionary) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_free");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVDictFree = FuncInst->getHostFunc();
 
   {

--- a/test/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avDictionary.cpp
@@ -114,7 +114,12 @@ TEST_F(FFmpegTest, AVDictionary) {
             UINT32_C(3), PrevDictEntryIdx, Flags},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), 1);
-    // Verify String. Read String from MemInst
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(KeyBufPtr),
+                               static_cast<size_t>(KeyLen)),
+              "KEY"sv);
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(ValueBufPtr),
+                               static_cast<size_t>(ValueLen)),
+              "VALUE"sv);
 
     // Pass a Null Dict and testing.
     EXPECT_TRUE(HostFuncAVDictGetKeyValue.run(

--- a/test/plugins/wasmedge_ffmpeg/avutil/avError.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avError.cpp
@@ -24,9 +24,7 @@ TEST_F(FFmpegTest, AVError) {
 
   auto *FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_strerror");
-  auto &HostFuncAVUtilAVStrError =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVUtilAVStrError &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVUtilAVStrError = FuncInst->getHostFunc();
 
   {
     HostFuncAVUtilAVStrError.run(
@@ -36,9 +34,7 @@ TEST_F(FFmpegTest, AVError) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_AVERROR");
-  auto &HostFuncAVUtilAVError =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVUtilAVError &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVUtilAVError = FuncInst->getHostFunc();
 
   {
     HostFuncAVUtilAVError.run(
@@ -49,9 +45,7 @@ TEST_F(FFmpegTest, AVError) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_AVUNERROR");
-  auto &HostFuncAVUtilAVUNError =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVUtilAVUNError &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVUtilAVUNError = FuncInst->getHostFunc();
 
   {
     HostFuncAVUtilAVUNError.run(

--- a/test/plugins/wasmedge_ffmpeg/avutil/avError.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avError.cpp
@@ -24,6 +24,8 @@ TEST_F(FFmpegTest, AVError) {
 
   auto *FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_strerror");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVUtilAVStrError = FuncInst->getHostFunc();
 
   {
@@ -34,6 +36,8 @@ TEST_F(FFmpegTest, AVError) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_AVERROR");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVUtilAVError = FuncInst->getHostFunc();
 
   {
@@ -45,6 +49,8 @@ TEST_F(FFmpegTest, AVError) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_AVUNERROR");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVUtilAVUNError = FuncInst->getHostFunc();
 
   {

--- a/test/plugins/wasmedge_ffmpeg/avutil/avError.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avError.cpp
@@ -29,10 +29,11 @@ TEST_F(FFmpegTest, AVError) {
   auto &HostFuncAVUtilAVStrError = FuncInst->getHostFunc();
 
   {
-    HostFuncAVUtilAVStrError.run(
-        CallFrame, std::initializer_list<WasmEdge::ValVariant>{}, Result);
-
-    EXPECT_EQ(Result[0].get<int32_t>(), 0);
+    EXPECT_TRUE(HostFuncAVUtilAVStrError.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{ErrNum, ErrStartPtr,
+                                                    ErrSize},
+        Result));
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_AVERROR");

--- a/test/plugins/wasmedge_ffmpeg/avutil/avFrame.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avFrame.cpp
@@ -36,12 +36,13 @@ TEST_F(FFmpegTest, AVFrame) {
   ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameAlloc = FuncInst->getHostFunc();
 
-  uint32_t EmptyFramePtr = UINT32_C(64);
+  uint32_t EmptyFramePtr = UINT32_C(88);
 
   {
-    HostFuncAVFrameAlloc.run(
+    writeUInt32(MemInst, UINT32_C(0), EmptyFramePtr);
+    EXPECT_TRUE(HostFuncAVFrameAlloc.run(
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{EmptyFramePtr},
-        Result);
+        Result));
 
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
     EXPECT_TRUE(readUInt32(MemInst, EmptyFramePtr) > 0);

--- a/test/plugins/wasmedge_ffmpeg/avutil/avFrame.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avFrame.cpp
@@ -32,6 +32,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   auto *FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_alloc");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameAlloc = FuncInst->getHostFunc();
 
   uint32_t EmptyFramePtr = UINT32_C(64);
@@ -46,6 +48,8 @@ TEST_F(FFmpegTest, AVFrame) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_free");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameFree = FuncInst->getHostFunc();
 
   {
@@ -59,6 +63,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_width");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameWidth = FuncInst->getHostFunc();
 
   {
@@ -71,6 +77,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_height");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameHeight = FuncInst->getHostFunc();
 
   {
@@ -83,6 +91,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_video_format");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameVideoFormat = FuncInst->getHostFunc();
 
   {
@@ -95,6 +105,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_isnull");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameIsNull = FuncInst->getHostFunc();
 
   {
@@ -107,6 +119,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_linesize");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameLinesize = FuncInst->getHostFunc();
 
   int32_t Stride = 0;
@@ -122,6 +136,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_get_buffer");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameGetBuffer = FuncInst->getHostFunc();
   {
     // For video, it is 32.
@@ -135,6 +151,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_best_effort_timestamp");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameBestEffortTimestamp = FuncInst->getHostFunc();
 
   {
@@ -146,6 +164,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_pict_type");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFramePictType = FuncInst->getHostFunc();
 
   {
@@ -157,6 +177,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_interlaced_frame");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameInterlacedFrame = FuncInst->getHostFunc();
 
   {
@@ -168,6 +190,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_top_field_first");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameTopFieldFirst = FuncInst->getHostFunc();
 
   {
@@ -179,6 +203,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_palette_has_changed");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFramePaletteHasChanged = FuncInst->getHostFunc();
 
   {
@@ -190,6 +216,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_colorspace");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameColorspace = FuncInst->getHostFunc();
 
   {
@@ -201,6 +229,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_color_range");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameColorRange = FuncInst->getHostFunc();
 
   {
@@ -212,6 +242,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_color_trc");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostAVFrameColorTransferCharacteristic = FuncInst->getHostFunc();
 
   {
@@ -223,6 +255,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_chroma_location");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostAVFrameChromaLocation = FuncInst->getHostFunc();
 
   {
@@ -234,6 +268,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_repeat_pict");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostAVFrameRepeatPict = FuncInst->getHostFunc();
 
   {
@@ -245,6 +281,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_flags");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostAVFrameFlags = FuncInst->getHostFunc();
 
   {
@@ -256,6 +294,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_quality");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostAVFrameQuality = FuncInst->getHostFunc();
 
   {
@@ -267,6 +307,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_metadata");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostAVFrameMetadata = FuncInst->getHostFunc();
 
   {
@@ -281,6 +323,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_metadata");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostAVFrameSetMetadata = FuncInst->getHostFunc();
 
   {
@@ -292,6 +336,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_key_frame");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostAVFrameKeyFrame = FuncInst->getHostFunc();
 
   {
@@ -302,6 +348,8 @@ TEST_F(FFmpegTest, AVFrame) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_pts");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostAVFramePts = FuncInst->getHostFunc();
 
   {
@@ -312,6 +360,8 @@ TEST_F(FFmpegTest, AVFrame) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_copy");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostAVFrameCopy = FuncInst->getHostFunc();
 
   {
@@ -324,6 +374,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_copy_props");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostAVFrameCopyProps = FuncInst->getHostFunc();
 
   {
@@ -336,6 +388,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_set_width");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameSetWidth = FuncInst->getHostFunc();
 
   {
@@ -353,6 +407,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_set_height");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameSetHeight = FuncInst->getHostFunc();
 
   int32_t Height = 100;
@@ -369,6 +425,8 @@ TEST_F(FFmpegTest, AVFrame) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_data");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameData = FuncInst->getHostFunc();
 
   {
@@ -383,6 +441,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_video_format");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameSetVideoFormat = FuncInst->getHostFunc();
 
   {
@@ -401,6 +461,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_pict_type");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameSetPictType = FuncInst->getHostFunc();
 
   {
@@ -419,6 +481,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_colorspace");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameSetColorSpace = FuncInst->getHostFunc();
 
   {
@@ -437,6 +501,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_color_range");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameSetColorRange = FuncInst->getHostFunc();
 
   {
@@ -455,6 +521,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_color_trc");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameSetColorTransferCharacteristic = FuncInst->getHostFunc();
 
   {
@@ -473,6 +541,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_set_pts");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameSetPts = FuncInst->getHostFunc();
 
   {
@@ -490,6 +560,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_sample_aspect_ratio");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameSampleAspectRatio = FuncInst->getHostFunc();
 
   {
@@ -503,6 +575,8 @@ TEST_F(FFmpegTest, AVFrame) {
   int32_t ColorPrimariesId = 1; // BT709
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_color_primaries");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameSetColorPrimaries = FuncInst->getHostFunc();
 
   {
@@ -516,6 +590,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_color_primaries");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameColorPrimaries = FuncInst->getHostFunc();
 
   {
@@ -533,6 +609,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_audio_format");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameSetAudioFormat = FuncInst->getHostFunc();
 
   uint32_t SampleFormatId = 4;
@@ -546,6 +624,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_audio_format");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameAudioFormat = FuncInst->getHostFunc();
 
   {
@@ -557,6 +637,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_nb_samples");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameSetNbSamples = FuncInst->getHostFunc();
 
   int32_t NbSamples = 32;
@@ -570,6 +652,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_nb_samples");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameNbSamples = FuncInst->getHostFunc();
 
   {
@@ -581,6 +665,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_sample_rate");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameSetSampleRate = FuncInst->getHostFunc();
 
   int32_t SampleRate = 10;
@@ -594,6 +680,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_sample_rate");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameSampleRate = FuncInst->getHostFunc();
 
   {
@@ -605,6 +693,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_channels");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameSetChannels = FuncInst->getHostFunc();
 
   int32_t Channels = 3;
@@ -618,6 +708,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_channels");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameChannels = FuncInst->getHostFunc();
 
   {
@@ -629,6 +721,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_channel_layout");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameSetChannelLayout = FuncInst->getHostFunc();
 
   uint64_t ChannelLayout = 1UL << 10;
@@ -642,6 +736,8 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_channel_layout");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameChannelLayout = FuncInst->getHostFunc();
 
   {

--- a/test/plugins/wasmedge_ffmpeg/avutil/avFrame.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avFrame.cpp
@@ -32,9 +32,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   auto *FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_alloc");
-  auto &HostFuncAVFrameAlloc =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameAlloc &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameAlloc = FuncInst->getHostFunc();
 
   uint32_t EmptyFramePtr = UINT32_C(64);
 
@@ -48,9 +46,7 @@ TEST_F(FFmpegTest, AVFrame) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_free");
-  auto &HostFuncAVFrameFree =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameFree &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameFree = FuncInst->getHostFunc();
 
   {
     uint32_t EmptyFrameId = readUInt32(MemInst, EmptyFramePtr);
@@ -63,9 +59,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_width");
-  auto &HostFuncAVFrameWidth =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameWidth &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameWidth = FuncInst->getHostFunc();
 
   {
     HostFuncAVFrameWidth.run(
@@ -77,9 +71,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_height");
-  auto &HostFuncAVFrameHeight =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameHeight &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameHeight = FuncInst->getHostFunc();
 
   {
     HostFuncAVFrameHeight.run(
@@ -91,9 +83,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_video_format");
-  auto &HostFuncAVFrameVideoFormat = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameVideoFormat &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameVideoFormat = FuncInst->getHostFunc();
 
   {
     HostFuncAVFrameVideoFormat.run(
@@ -105,9 +95,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_isnull");
-  auto &HostFuncAVFrameIsNull =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameIsNull &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameIsNull = FuncInst->getHostFunc();
 
   {
     HostFuncAVFrameIsNull.run(
@@ -119,9 +107,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_linesize");
-  auto &HostFuncAVFrameLinesize =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameLinesize &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameLinesize = FuncInst->getHostFunc();
 
   int32_t Stride = 0;
   uint32_t Idx = 0;
@@ -136,9 +122,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_get_buffer");
-  auto &HostFuncAVFrameGetBuffer =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameGetBuffer &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameGetBuffer = FuncInst->getHostFunc();
   {
     // For video, it is 32.
     int32_t Align = 32;
@@ -151,9 +135,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_best_effort_timestamp");
-  auto &HostFuncAVFrameBestEffortTimestamp = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameBestEffortTimestamp &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameBestEffortTimestamp = FuncInst->getHostFunc();
 
   {
     HostFuncAVFrameBestEffortTimestamp.run(
@@ -164,9 +146,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_pict_type");
-  auto &HostFuncAVFramePictType =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFramePictType &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFramePictType = FuncInst->getHostFunc();
 
   {
     HostFuncAVFramePictType.run(
@@ -177,9 +157,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_interlaced_frame");
-  auto &HostFuncAVFrameInterlacedFrame = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameInterlacedFrame &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameInterlacedFrame = FuncInst->getHostFunc();
 
   {
     HostFuncAVFrameInterlacedFrame.run(
@@ -190,9 +168,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_top_field_first");
-  auto &HostFuncAVFrameTopFieldFirst = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameTopFieldFirst &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameTopFieldFirst = FuncInst->getHostFunc();
 
   {
     HostFuncAVFrameTopFieldFirst.run(
@@ -203,9 +179,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_palette_has_changed");
-  auto &HostFuncAVFramePaletteHasChanged = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFramePaletteHasChanged &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFramePaletteHasChanged = FuncInst->getHostFunc();
 
   {
     HostFuncAVFramePaletteHasChanged.run(
@@ -216,9 +190,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_colorspace");
-  auto &HostFuncAVFrameColorspace =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameColorSpace &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameColorspace = FuncInst->getHostFunc();
 
   {
     HostFuncAVFrameColorspace.run(
@@ -229,9 +201,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_color_range");
-  auto &HostFuncAVFrameColorRange =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameColorRange &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameColorRange = FuncInst->getHostFunc();
 
   {
     HostFuncAVFrameColorRange.run(
@@ -242,9 +212,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_color_trc");
-  auto &HostAVFrameColorTransferCharacteristic = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameColorTransferCharacteristic
-          &>(FuncInst->getHostFunc());
+  auto &HostAVFrameColorTransferCharacteristic = FuncInst->getHostFunc();
 
   {
     HostAVFrameColorTransferCharacteristic.run(
@@ -255,9 +223,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_chroma_location");
-  auto &HostAVFrameChromaLocation = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameChromaLocation &>(
-      FuncInst->getHostFunc());
+  auto &HostAVFrameChromaLocation = FuncInst->getHostFunc();
 
   {
     HostAVFrameChromaLocation.run(
@@ -268,9 +234,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_repeat_pict");
-  auto &HostAVFrameRepeatPict =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameRepeatPict &>(
-          FuncInst->getHostFunc());
+  auto &HostAVFrameRepeatPict = FuncInst->getHostFunc();
 
   {
     HostAVFrameRepeatPict.run(
@@ -281,9 +245,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_flags");
-  auto &HostAVFrameFlags =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameFlags &>(
-          FuncInst->getHostFunc());
+  auto &HostAVFrameFlags = FuncInst->getHostFunc();
 
   {
     HostAVFrameFlags.run(CallFrame,
@@ -294,9 +256,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_quality");
-  auto &HostAVFrameQuality =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameQuality &>(
-          FuncInst->getHostFunc());
+  auto &HostAVFrameQuality = FuncInst->getHostFunc();
 
   {
     HostAVFrameQuality.run(
@@ -307,9 +267,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_metadata");
-  auto &HostAVFrameMetadata =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameMetadata &>(
-          FuncInst->getHostFunc());
+  auto &HostAVFrameMetadata = FuncInst->getHostFunc();
 
   {
     HostAVFrameMetadata.run(
@@ -323,9 +281,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_metadata");
-  auto &HostAVFrameSetMetadata = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameSetMetadata &>(
-      FuncInst->getHostFunc());
+  auto &HostAVFrameSetMetadata = FuncInst->getHostFunc();
 
   {
     HostAVFrameSetMetadata.run(
@@ -336,9 +292,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_key_frame");
-  auto &HostAVFrameKeyFrame =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameKeyFrame &>(
-          FuncInst->getHostFunc());
+  auto &HostAVFrameKeyFrame = FuncInst->getHostFunc();
 
   {
     HostAVFrameKeyFrame.run(
@@ -348,9 +302,7 @@ TEST_F(FFmpegTest, AVFrame) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_pts");
-  auto &HostAVFramePts =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFramePts &>(
-          FuncInst->getHostFunc());
+  auto &HostAVFramePts = FuncInst->getHostFunc();
 
   {
     HostAVFramePts.run(CallFrame,
@@ -360,9 +312,7 @@ TEST_F(FFmpegTest, AVFrame) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_copy");
-  auto &HostAVFrameCopy =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameCopy &>(
-          FuncInst->getHostFunc());
+  auto &HostAVFrameCopy = FuncInst->getHostFunc();
 
   {
     HostAVFrameCopy.run(
@@ -374,9 +324,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_copy_props");
-  auto &HostAVFrameCopyProps =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameCopyProps &>(
-          FuncInst->getHostFunc());
+  auto &HostAVFrameCopyProps = FuncInst->getHostFunc();
 
   {
     HostAVFrameCopyProps.run(
@@ -388,9 +336,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_set_width");
-  auto &HostFuncAVFrameSetWidth =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameSetWidth &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameSetWidth = FuncInst->getHostFunc();
 
   {
     int32_t Width = 100;
@@ -407,9 +353,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_set_height");
-  auto &HostFuncAVFrameSetHeight =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameSetHeight &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameSetHeight = FuncInst->getHostFunc();
 
   int32_t Height = 100;
   {
@@ -425,9 +369,7 @@ TEST_F(FFmpegTest, AVFrame) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_data");
-  auto &HostFuncAVFrameData =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameData &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameData = FuncInst->getHostFunc();
 
   {
     int32_t Size = 1; // Just reading One byte data for test.
@@ -441,9 +383,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_video_format");
-  auto &HostFuncAVFrameSetVideoFormat = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameSetVideoFormat &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameSetVideoFormat = FuncInst->getHostFunc();
 
   {
     uint32_t PixFormatId = 10; // GRAY8
@@ -461,9 +401,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_pict_type");
-  auto &HostFuncAVFrameSetPictType = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameSetPictType &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameSetPictType = FuncInst->getHostFunc();
 
   {
     int32_t PictureId = 4; // AV_PICTURE_TYPE_S
@@ -481,9 +419,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_colorspace");
-  auto &HostFuncAVFrameSetColorSpace = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameSetColorSpace &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameSetColorSpace = FuncInst->getHostFunc();
 
   {
     int32_t ColorSpaceId = 4; // FCC
@@ -501,9 +437,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_color_range");
-  auto &HostFuncAVFrameSetColorRange = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameSetColorRange &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameSetColorRange = FuncInst->getHostFunc();
 
   {
     int32_t ColorRangeId = 1; //  MPEG
@@ -521,10 +455,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_color_trc");
-  auto &HostFuncAVFrameSetColorTransferCharacteristic =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::
-                       AVFrameSetColorTransferCharacteristic &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameSetColorTransferCharacteristic = FuncInst->getHostFunc();
 
   {
     int32_t ColorTrcId = 5; // GAMMA28
@@ -542,9 +473,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_set_pts");
-  auto &HostFuncAVFrameSetPts =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameSetPts &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameSetPts = FuncInst->getHostFunc();
 
   {
     int64_t Pts = 10;
@@ -561,9 +490,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_sample_aspect_ratio");
-  auto &HostFuncAVFrameSampleAspectRatio = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameSampleAspectRatio &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameSampleAspectRatio = FuncInst->getHostFunc();
 
   {
     HostFuncAVFrameSampleAspectRatio.run(
@@ -576,9 +503,7 @@ TEST_F(FFmpegTest, AVFrame) {
   int32_t ColorPrimariesId = 1; // BT709
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_color_primaries");
-  auto &HostFuncAVFrameSetColorPrimaries = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameSetColorPrimaries &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameSetColorPrimaries = FuncInst->getHostFunc();
 
   {
     HostFuncAVFrameSetColorPrimaries.run(
@@ -591,9 +516,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_color_primaries");
-  auto &HostFuncAVFrameColorPrimaries = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameColorPrimaries &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameColorPrimaries = FuncInst->getHostFunc();
 
   {
     HostFuncAVFrameColorPrimaries.run(
@@ -610,9 +533,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_audio_format");
-  auto &HostFuncAVFrameSetAudioFormat = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameSetAudioFormat &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameSetAudioFormat = FuncInst->getHostFunc();
 
   uint32_t SampleFormatId = 4;
   {
@@ -625,9 +546,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_audio_format");
-  auto &HostFuncAVFrameAudioFormat = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameAudioFormat &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameAudioFormat = FuncInst->getHostFunc();
 
   {
     HostFuncAVFrameAudioFormat.run(
@@ -638,9 +557,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_nb_samples");
-  auto &HostFuncAVFrameSetNbSamples = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameSetNbSamples &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameSetNbSamples = FuncInst->getHostFunc();
 
   int32_t NbSamples = 32;
   {
@@ -653,9 +570,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_nb_samples");
-  auto &HostFuncAVFrameNbSamples =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameNbSamples &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameNbSamples = FuncInst->getHostFunc();
 
   {
     HostFuncAVFrameNbSamples.run(
@@ -666,9 +581,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_sample_rate");
-  auto &HostFuncAVFrameSetSampleRate = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameSetSampleRate &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameSetSampleRate = FuncInst->getHostFunc();
 
   int32_t SampleRate = 10;
   {
@@ -681,9 +594,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_sample_rate");
-  auto &HostFuncAVFrameSampleRate =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameSampleRate &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameSampleRate = FuncInst->getHostFunc();
 
   {
     HostFuncAVFrameSampleRate.run(
@@ -694,9 +605,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_channels");
-  auto &HostFuncAVFrameSetChannels = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameSetChannels &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameSetChannels = FuncInst->getHostFunc();
 
   int32_t Channels = 3;
   {
@@ -709,9 +618,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_channels");
-  auto &HostFuncAVFrameChannels =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameChannels &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameChannels = FuncInst->getHostFunc();
 
   {
     HostFuncAVFrameChannels.run(
@@ -722,9 +629,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_set_channel_layout");
-  auto &HostFuncAVFrameSetChannelLayout = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameSetChannelLayout &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameSetChannelLayout = FuncInst->getHostFunc();
 
   uint64_t ChannelLayout = 1UL << 10;
   {
@@ -737,9 +642,7 @@ TEST_F(FFmpegTest, AVFrame) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_frame_channel_layout");
-  auto &HostFuncAVFrameChannelLayout = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameChannelLayout &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFrameChannelLayout = FuncInst->getHostFunc();
 
   {
     HostFuncAVFrameChannelLayout.run(

--- a/test/plugins/wasmedge_ffmpeg/avutil/avPixfmt.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avPixfmt.cpp
@@ -17,9 +17,7 @@ TEST_F(FFmpegTest, AVPixFmt) {
 
   auto *FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_avpixfmtdescriptor_nb_components");
-  auto &HostFuncAVPixFmtDescriptorNbComponents = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AvPixFmtDescriptorNbComponents &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVPixFmtDescriptorNbComponents = FuncInst->getHostFunc();
 
   uint32_t PixFmtId = 3; // RGB24
 
@@ -33,9 +31,7 @@ TEST_F(FFmpegTest, AVPixFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_avpixfmtdescriptor_log2_chromaw");
-  auto &HostFuncAvPixFmtDescriptorLog2ChromaW = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AvPixFmtDescriptorLog2ChromaW &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAvPixFmtDescriptorLog2ChromaW = FuncInst->getHostFunc();
 
   {
     HostFuncAvPixFmtDescriptorLog2ChromaW.run(
@@ -46,9 +42,7 @@ TEST_F(FFmpegTest, AVPixFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_avpixfmtdescriptor_log2_chromah");
-  auto &HostFuncAvPixFmtDescriptorLog2ChromaH = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AvPixFmtDescriptorLog2ChromaH &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAvPixFmtDescriptorLog2ChromaH = FuncInst->getHostFunc();
 
   {
     HostFuncAvPixFmtDescriptorLog2ChromaH.run(
@@ -62,9 +56,7 @@ TEST_F(FFmpegTest, AVPixFmt) {
   int32_t TransferCharacteristicId = 6; // (SMPTE170M)
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_color_transfer_name_length");
-  auto &HostFuncAVColorTransferNameLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVColorTransferNameLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVColorTransferNameLength = FuncInst->getHostFunc();
 
   {
     HostFuncAVColorTransferNameLength.run(
@@ -79,9 +71,7 @@ TEST_F(FFmpegTest, AVPixFmt) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_color_transfer_name");
-  auto &HostFuncAVColorTransferName = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVColorTransferName &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVColorTransferName = FuncInst->getHostFunc();
 
   {
     HostFuncAVColorTransferName.run(
@@ -96,9 +86,7 @@ TEST_F(FFmpegTest, AVPixFmt) {
   int32_t ColorRangeId = 2; //; JPEG
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_color_range_name_length");
-  auto &HostFuncAVColorRangeNameLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVColorRangeNameLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVColorRangeNameLength = FuncInst->getHostFunc();
 
   {
     HostFuncAVColorRangeNameLength.run(
@@ -113,9 +101,7 @@ TEST_F(FFmpegTest, AVPixFmt) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_color_range_name");
-  auto &HostFuncAVColorRangeName =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVColorRangeName &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVColorRangeName = FuncInst->getHostFunc();
 
   {
     HostFuncAVColorRangeName.run(CallFrame,
@@ -129,9 +115,7 @@ TEST_F(FFmpegTest, AVPixFmt) {
   int32_t ColorSpaceId = 1; // BT709
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_color_space_name_length");
-  auto &HostFuncAVColorSpaceNameLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVColorSpaceNameLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVColorSpaceNameLength = FuncInst->getHostFunc();
 
   {
     HostFuncAVColorSpaceNameLength.run(
@@ -146,9 +130,7 @@ TEST_F(FFmpegTest, AVPixFmt) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_color_space_name");
-  auto &HostFuncAVColorSpaceName =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVColorSpaceName &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVColorSpaceName = FuncInst->getHostFunc();
 
   {
     HostFuncAVColorSpaceName.run(CallFrame,
@@ -162,9 +144,7 @@ TEST_F(FFmpegTest, AVPixFmt) {
   int32_t ColorPrimariesId = 1; // BT709
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_color_primaries_name_length");
-  auto &HostFuncAVColorPrimariesNameLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVColorPrimariesNameLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVColorPrimariesNameLength = FuncInst->getHostFunc();
 
   {
     HostFuncAVColorPrimariesNameLength.run(
@@ -179,9 +159,7 @@ TEST_F(FFmpegTest, AVPixFmt) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_color_primaries_name");
-  auto &HostFuncAVColorPrimariesName = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVColorPrimariesName &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVColorPrimariesName = FuncInst->getHostFunc();
 
   {
     HostFuncAVColorPrimariesName.run(
@@ -196,9 +174,7 @@ TEST_F(FFmpegTest, AVPixFmt) {
   PixFmtId = 1; // YUV420P
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_pix_format_name_length");
-  auto &HostFuncAVPixFormatNameLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVPixelFormatNameLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVPixFormatNameLength = FuncInst->getHostFunc();
 
   {
     HostFuncAVPixFormatNameLength.run(
@@ -213,9 +189,7 @@ TEST_F(FFmpegTest, AVPixFmt) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_pix_format_name");
-  auto &HostFuncAVPixFormatName =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVPixelFormatName &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVPixFormatName = FuncInst->getHostFunc();
 
   {
     HostFuncAVPixFormatName.run(
@@ -228,9 +202,7 @@ TEST_F(FFmpegTest, AVPixFmt) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_pix_format_mask");
-  auto &HostFuncAVPixFormatMask =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVPixelFormatMask &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVPixFormatMask = FuncInst->getHostFunc();
 
   {
     uint32_t PixId = 3; //  AV_PIX_FMT_RGB24:

--- a/test/plugins/wasmedge_ffmpeg/avutil/avPixfmt.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avPixfmt.cpp
@@ -38,11 +38,14 @@ TEST_F(FFmpegTest, AVPixFmt) {
   ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAvPixFmtDescriptorLog2ChromaW = FuncInst->getHostFunc();
 
-  {
-    HostFuncAvPixFmtDescriptorLog2ChromaW.run(
-        CallFrame, std::initializer_list<WasmEdge::ValVariant>{1}, Result);
+  uint32_t Yuv422PId = 5; // YUV422P: chroma subsampled on width only
 
-    EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
+  {
+    EXPECT_TRUE(HostFuncAvPixFmtDescriptorLog2ChromaW.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{Yuv422PId},
+        Result));
+
+    EXPECT_EQ(Result[0].get<int32_t>(), 1);
   }
 
   FuncInst = AVUtilMod->findFuncExports(
@@ -52,11 +55,11 @@ TEST_F(FFmpegTest, AVPixFmt) {
   auto &HostFuncAvPixFmtDescriptorLog2ChromaH = FuncInst->getHostFunc();
 
   {
-    HostFuncAvPixFmtDescriptorLog2ChromaH.run(
-        CallFrame, std::initializer_list<WasmEdge::ValVariant>{PixFmtId},
-        Result);
+    EXPECT_TRUE(HostFuncAvPixFmtDescriptorLog2ChromaH.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{Yuv422PId},
+        Result));
 
-    EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
+    EXPECT_EQ(Result[0].get<int32_t>(), 0);
   }
 
   int32_t Length = 0;

--- a/test/plugins/wasmedge_ffmpeg/avutil/avPixfmt.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avPixfmt.cpp
@@ -17,6 +17,8 @@ TEST_F(FFmpegTest, AVPixFmt) {
 
   auto *FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_avpixfmtdescriptor_nb_components");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPixFmtDescriptorNbComponents = FuncInst->getHostFunc();
 
   uint32_t PixFmtId = 3; // RGB24
@@ -31,6 +33,8 @@ TEST_F(FFmpegTest, AVPixFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_avpixfmtdescriptor_log2_chromaw");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAvPixFmtDescriptorLog2ChromaW = FuncInst->getHostFunc();
 
   {
@@ -42,6 +46,8 @@ TEST_F(FFmpegTest, AVPixFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_avpixfmtdescriptor_log2_chromah");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAvPixFmtDescriptorLog2ChromaH = FuncInst->getHostFunc();
 
   {
@@ -56,6 +62,8 @@ TEST_F(FFmpegTest, AVPixFmt) {
   int32_t TransferCharacteristicId = 6; // (SMPTE170M)
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_color_transfer_name_length");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVColorTransferNameLength = FuncInst->getHostFunc();
 
   {
@@ -71,6 +79,8 @@ TEST_F(FFmpegTest, AVPixFmt) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_color_transfer_name");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVColorTransferName = FuncInst->getHostFunc();
 
   {
@@ -86,6 +96,8 @@ TEST_F(FFmpegTest, AVPixFmt) {
   int32_t ColorRangeId = 2; //; JPEG
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_color_range_name_length");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVColorRangeNameLength = FuncInst->getHostFunc();
 
   {
@@ -101,6 +113,8 @@ TEST_F(FFmpegTest, AVPixFmt) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_color_range_name");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVColorRangeName = FuncInst->getHostFunc();
 
   {
@@ -115,6 +129,8 @@ TEST_F(FFmpegTest, AVPixFmt) {
   int32_t ColorSpaceId = 1; // BT709
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_color_space_name_length");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVColorSpaceNameLength = FuncInst->getHostFunc();
 
   {
@@ -130,6 +146,8 @@ TEST_F(FFmpegTest, AVPixFmt) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_color_space_name");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVColorSpaceName = FuncInst->getHostFunc();
 
   {
@@ -144,6 +162,8 @@ TEST_F(FFmpegTest, AVPixFmt) {
   int32_t ColorPrimariesId = 1; // BT709
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_color_primaries_name_length");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVColorPrimariesNameLength = FuncInst->getHostFunc();
 
   {
@@ -159,6 +179,8 @@ TEST_F(FFmpegTest, AVPixFmt) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_color_primaries_name");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVColorPrimariesName = FuncInst->getHostFunc();
 
   {
@@ -174,6 +196,8 @@ TEST_F(FFmpegTest, AVPixFmt) {
   PixFmtId = 1; // YUV420P
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_pix_format_name_length");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPixFormatNameLength = FuncInst->getHostFunc();
 
   {
@@ -189,6 +213,8 @@ TEST_F(FFmpegTest, AVPixFmt) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_pix_format_name");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPixFormatName = FuncInst->getHostFunc();
 
   {
@@ -202,6 +228,8 @@ TEST_F(FFmpegTest, AVPixFmt) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_pix_format_mask");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPixFormatMask = FuncInst->getHostFunc();
 
   {

--- a/test/plugins/wasmedge_ffmpeg/avutil/avPixfmt.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avPixfmt.cpp
@@ -13,6 +13,7 @@ namespace Host {
 namespace WasmEdgeFFmpeg {
 
 TEST_F(FFmpegTest, AVPixFmt) {
+  using namespace std::literals::string_view_literals;
   uint32_t NamePtr = UINT32_C(4);
 
   auto *FuncInst = AVUtilMod->findFuncExports(
@@ -91,6 +92,9 @@ TEST_F(FFmpegTest, AVPixFmt) {
         Result);
 
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(NamePtr),
+                               static_cast<size_t>(Length)),
+              "smpte170m"sv);
   }
 
   int32_t ColorRangeId = 2; //; JPEG
@@ -124,6 +128,9 @@ TEST_F(FFmpegTest, AVPixFmt) {
                                  Result);
 
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(NamePtr),
+                               static_cast<size_t>(Length)),
+              std::string_view("pc"sv));
   }
 
   int32_t ColorSpaceId = 1; // BT709
@@ -157,6 +164,9 @@ TEST_F(FFmpegTest, AVPixFmt) {
                                  Result);
 
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(NamePtr),
+                               static_cast<size_t>(Length)),
+              "bt709"sv);
   }
 
   int32_t ColorPrimariesId = 1; // BT709
@@ -191,6 +201,9 @@ TEST_F(FFmpegTest, AVPixFmt) {
         Result);
 
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(NamePtr),
+                               static_cast<size_t>(Length)),
+              "bt709"sv);
   }
 
   PixFmtId = 1; // YUV420P
@@ -224,6 +237,9 @@ TEST_F(FFmpegTest, AVPixFmt) {
         Result);
 
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(NamePtr),
+                               static_cast<size_t>(Length)),
+              "yuv420p"sv);
   }
 
   FuncInst =

--- a/test/plugins/wasmedge_ffmpeg/avutil/avRational.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avRational.cpp
@@ -23,9 +23,7 @@ TEST_F(FFmpegTest, AVRational) {
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_add_q");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVAddQ =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVAddQ &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVAddQ = FuncInst->getHostFunc();
 
   {
     int32_t ANum = 3;
@@ -46,9 +44,7 @@ TEST_F(FFmpegTest, AVRational) {
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_sub_q");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVSubQ =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVSubQ &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVSubQ = FuncInst->getHostFunc();
 
   {
     int32_t ANum = -843;
@@ -71,9 +67,7 @@ TEST_F(FFmpegTest, AVRational) {
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_mul_q");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVMulQ =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVMulQ &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVMulQ = FuncInst->getHostFunc();
 
   {
     int32_t ANum = -6;
@@ -96,9 +90,7 @@ TEST_F(FFmpegTest, AVRational) {
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_div_q");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVDivQ =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVDivQ &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVDivQ = FuncInst->getHostFunc();
 
   {
     int32_t ANum = -6;
@@ -123,9 +115,7 @@ TEST_F(FFmpegTest, AVRational) {
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_d2q");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVD2Q =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVD2Q &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVD2Q = FuncInst->getHostFunc();
 
   {
     double D = 5;
@@ -147,9 +137,7 @@ TEST_F(FFmpegTest, AVRational) {
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_q2d");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVQ2d =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVQ2d &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVQ2d = FuncInst->getHostFunc();
 
   {
     // Convert Rational Number to Double.
@@ -167,9 +155,7 @@ TEST_F(FFmpegTest, AVRational) {
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_inv_q");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncInvQ =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVInvQ &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncInvQ = FuncInst->getHostFunc();
 
   {
     // Inverse a Rational Number.
@@ -191,9 +177,7 @@ TEST_F(FFmpegTest, AVRational) {
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_q2intfloat");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVQ2IntFloat =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVQ2IntFloat &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVQ2IntFloat = FuncInst->getHostFunc();
 
   {
     int32_t ANum = 1;
@@ -208,9 +192,7 @@ TEST_F(FFmpegTest, AVRational) {
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_nearer_q");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVNearerQ =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVNearerQ &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVNearerQ = FuncInst->getHostFunc();
 
   {
     int32_t ANum = 1;
@@ -253,9 +235,7 @@ TEST_F(FFmpegTest, AVRational) {
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_cmp_q");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVCmpQ =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVCmpQ &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCmpQ = FuncInst->getHostFunc();
 
   {
     int32_t ANum = 1;
@@ -295,9 +275,7 @@ TEST_F(FFmpegTest, AVRational) {
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_reduce");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVReduce =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVReduce &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVReduce = FuncInst->getHostFunc();
 
   {
     int64_t ANum = 1;

--- a/test/plugins/wasmedge_ffmpeg/avutil/avRational.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avRational.cpp
@@ -21,8 +21,8 @@ TEST_F(FFmpegTest, AVRational) {
   // Addition Function
   auto *FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_add_q");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVAddQ = FuncInst->getHostFunc();
 
   {
@@ -42,8 +42,8 @@ TEST_F(FFmpegTest, AVRational) {
 
   // Subtraction Function
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_sub_q");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVSubQ = FuncInst->getHostFunc();
 
   {
@@ -65,8 +65,8 @@ TEST_F(FFmpegTest, AVRational) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_mul_q");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVMulQ = FuncInst->getHostFunc();
 
   {
@@ -88,8 +88,8 @@ TEST_F(FFmpegTest, AVRational) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_div_q");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVDivQ = FuncInst->getHostFunc();
 
   {
@@ -113,8 +113,8 @@ TEST_F(FFmpegTest, AVRational) {
   // How to Pass a Double functions.
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_d2q");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVD2Q = FuncInst->getHostFunc();
 
   {
@@ -135,8 +135,8 @@ TEST_F(FFmpegTest, AVRational) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_q2d");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVQ2d = FuncInst->getHostFunc();
 
   {
@@ -153,8 +153,8 @@ TEST_F(FFmpegTest, AVRational) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_inv_q");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncInvQ = FuncInst->getHostFunc();
 
   {
@@ -175,8 +175,8 @@ TEST_F(FFmpegTest, AVRational) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_q2intfloat");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVQ2IntFloat = FuncInst->getHostFunc();
 
   {
@@ -190,8 +190,8 @@ TEST_F(FFmpegTest, AVRational) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_nearer_q");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVNearerQ = FuncInst->getHostFunc();
 
   {
@@ -233,8 +233,8 @@ TEST_F(FFmpegTest, AVRational) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_cmp_q");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVCmpQ = FuncInst->getHostFunc();
 
   {
@@ -273,8 +273,8 @@ TEST_F(FFmpegTest, AVRational) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_reduce");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVReduce = FuncInst->getHostFunc();
 
   {

--- a/test/plugins/wasmedge_ffmpeg/avutil/avSampleFmt.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avSampleFmt.cpp
@@ -23,9 +23,7 @@ TEST_F(FFmpegTest, AVSampleFmt) {
   uint32_t SampleFmtId = 1; // AV_SAMPLE_FMT_S32
   auto *FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_get_packed_sample_fmt");
-  auto &HostFuncAVGetPackedSampleFmt = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVGetPackedSampleFmt &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVGetPackedSampleFmt = FuncInst->getHostFunc();
 
   {
     HostFuncAVGetPackedSampleFmt.run(
@@ -37,9 +35,7 @@ TEST_F(FFmpegTest, AVSampleFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_get_planar_sample_fmt");
-  auto &HostFuncAVGetPlanarSampleFmt = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVGetPlanarSampleFmt &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVGetPlanarSampleFmt = FuncInst->getHostFunc();
 
   {
     HostFuncAVGetPlanarSampleFmt.run(
@@ -51,9 +47,7 @@ TEST_F(FFmpegTest, AVSampleFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_sample_fmt_is_planar");
-  auto &HostFuncAVSampleFmtIsPlanar = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVSampleFmtIsPlanar &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVSampleFmtIsPlanar = FuncInst->getHostFunc();
 
   {
     HostFuncAVSampleFmtIsPlanar.run(
@@ -65,9 +59,7 @@ TEST_F(FFmpegTest, AVSampleFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_get_bytes_per_sample");
-  auto &HostFuncAVGetBytesPerSample = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVGetBytesPerSample &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVGetBytesPerSample = FuncInst->getHostFunc();
 
   {
     HostFuncAVGetBytesPerSample.run(
@@ -79,9 +71,7 @@ TEST_F(FFmpegTest, AVSampleFmt) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_get_sample_fmt");
-  auto &HostFuncAVGetSampleFmt =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVGetSampleFmt &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVGetSampleFmt = FuncInst->getHostFunc();
 
   uint32_t SampleFmtStart = 100;
   uint32_t SampleFmtSize = 2;
@@ -99,9 +89,7 @@ TEST_F(FFmpegTest, AVSampleFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_samples_get_buffer_size");
-  auto &HostFuncAVSamplesGetBufferSize = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVSamplesGetBufferSize &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVSamplesGetBufferSize = FuncInst->getHostFunc();
 
   int32_t NbChannels = 1;
   int32_t NbSamples = 5;
@@ -120,9 +108,7 @@ TEST_F(FFmpegTest, AVSampleFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_samples_alloc_array_and_samples");
-  auto &HostFuncAVSamplesAllocArrayAndSamples = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVSamplesAllocArrayAndSamples &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVSamplesAllocArrayAndSamples = FuncInst->getHostFunc();
 
   {
     HostFuncAVSamplesAllocArrayAndSamples.run(
@@ -140,9 +126,7 @@ TEST_F(FFmpegTest, AVSampleFmt) {
   int32_t Length = 0;
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_get_sample_fmt_name_length");
-  auto &HostFuncAVGetSampleFmtNameLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVGetSampleFmtNameLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVGetSampleFmtNameLength = FuncInst->getHostFunc();
 
   {
     HostFuncAVGetSampleFmtNameLength.run(
@@ -155,9 +139,7 @@ TEST_F(FFmpegTest, AVSampleFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_get_sample_fmt_name");
-  auto &HostFuncAVGetSampleFmtName = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVGetSampleFmtName &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVGetSampleFmtName = FuncInst->getHostFunc();
 
   // Fill Memory with 0.
   fillMemContent(MemInst, NamePtr, Length);
@@ -172,9 +154,7 @@ TEST_F(FFmpegTest, AVSampleFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_get_sample_fmt_mask");
-  auto &HostFuncAVGetSampleFmtMask = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVGetSampleFmtMask &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVGetSampleFmtMask = FuncInst->getHostFunc();
 
   {
     uint32_t SampleId = 2; // AV_SAMPLE_FMT_S16;
@@ -186,9 +166,7 @@ TEST_F(FFmpegTest, AVSampleFmt) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_freep");
-  auto &HostFuncAVFreep =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFreep &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFreep = FuncInst->getHostFunc();
 
   {
     uint32_t BufferId = readUInt32(MemInst, BufferPtr);

--- a/test/plugins/wasmedge_ffmpeg/avutil/avSampleFmt.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avSampleFmt.cpp
@@ -20,7 +20,7 @@ TEST_F(FFmpegTest, AVSampleFmt) {
   uint32_t NamePtr = UINT32_C(80);
   uint32_t LinesizePtr = UINT32_C(20);
 
-  uint32_t SampleFmtId = 1; // AV_SAMPLE_FMT_S32
+  uint32_t SampleFmtId = 1; // AV_SAMPLE_FMT_U8
   auto *FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_get_packed_sample_fmt");
   ASSERT_NE(FuncInst, nullptr);
@@ -70,11 +70,11 @@ TEST_F(FFmpegTest, AVSampleFmt) {
   auto &HostFuncAVGetBytesPerSample = FuncInst->getHostFunc();
 
   {
-    HostFuncAVGetBytesPerSample.run(
+    EXPECT_TRUE(HostFuncAVGetBytesPerSample.run(
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{SampleFmtId},
-        Result);
+        Result));
 
-    EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
+    EXPECT_EQ(Result[0].get<int32_t>(), 1);
   }
 
   FuncInst =

--- a/test/plugins/wasmedge_ffmpeg/avutil/avSampleFmt.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avSampleFmt.cpp
@@ -168,6 +168,9 @@ TEST_F(FFmpegTest, AVSampleFmt) {
                                    Result);
 
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(NamePtr),
+                               static_cast<size_t>(Length)),
+              "u8"sv);
   }
 
   FuncInst = AVUtilMod->findFuncExports(

--- a/test/plugins/wasmedge_ffmpeg/avutil/avSampleFmt.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avSampleFmt.cpp
@@ -23,6 +23,8 @@ TEST_F(FFmpegTest, AVSampleFmt) {
   uint32_t SampleFmtId = 1; // AV_SAMPLE_FMT_S32
   auto *FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_get_packed_sample_fmt");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVGetPackedSampleFmt = FuncInst->getHostFunc();
 
   {
@@ -35,6 +37,8 @@ TEST_F(FFmpegTest, AVSampleFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_get_planar_sample_fmt");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVGetPlanarSampleFmt = FuncInst->getHostFunc();
 
   {
@@ -47,6 +51,8 @@ TEST_F(FFmpegTest, AVSampleFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_sample_fmt_is_planar");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVSampleFmtIsPlanar = FuncInst->getHostFunc();
 
   {
@@ -59,6 +65,8 @@ TEST_F(FFmpegTest, AVSampleFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_get_bytes_per_sample");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVGetBytesPerSample = FuncInst->getHostFunc();
 
   {
@@ -71,6 +79,8 @@ TEST_F(FFmpegTest, AVSampleFmt) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_get_sample_fmt");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVGetSampleFmt = FuncInst->getHostFunc();
 
   uint32_t SampleFmtStart = 100;
@@ -89,6 +99,8 @@ TEST_F(FFmpegTest, AVSampleFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_samples_get_buffer_size");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVSamplesGetBufferSize = FuncInst->getHostFunc();
 
   int32_t NbChannels = 1;
@@ -108,6 +120,8 @@ TEST_F(FFmpegTest, AVSampleFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_samples_alloc_array_and_samples");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVSamplesAllocArrayAndSamples = FuncInst->getHostFunc();
 
   {
@@ -126,6 +140,8 @@ TEST_F(FFmpegTest, AVSampleFmt) {
   int32_t Length = 0;
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_get_sample_fmt_name_length");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVGetSampleFmtNameLength = FuncInst->getHostFunc();
 
   {
@@ -139,6 +155,8 @@ TEST_F(FFmpegTest, AVSampleFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_get_sample_fmt_name");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVGetSampleFmtName = FuncInst->getHostFunc();
 
   // Fill Memory with 0.
@@ -154,6 +172,8 @@ TEST_F(FFmpegTest, AVSampleFmt) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_get_sample_fmt_mask");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVGetSampleFmtMask = FuncInst->getHostFunc();
 
   {
@@ -166,6 +186,8 @@ TEST_F(FFmpegTest, AVSampleFmt) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_freep");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFreep = FuncInst->getHostFunc();
 
   {

--- a/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
@@ -49,9 +49,10 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVLogSetFlags = FuncInst->getHostFunc();
 
+  int32_t FlagId = 1;
   {
-    HostFuncAVLogSetFlags.run(
-        CallFrame, std::initializer_list<WasmEdge::ValVariant>{1}, Result);
+    EXPECT_TRUE(HostFuncAVLogSetFlags.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{FlagId}, {}));
   }
 
   FuncInst =
@@ -61,10 +62,10 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   auto &HostFuncAVLogGetFlags = FuncInst->getHostFunc();
 
   {
-    HostFuncAVLogGetFlags.run(
-        CallFrame, std::initializer_list<WasmEdge::ValVariant>{1}, Result);
+    EXPECT_TRUE(HostFuncAVLogGetFlags.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{}, Result));
 
-    EXPECT_EQ(Result[0].get<int32_t>(), 32);
+    EXPECT_EQ(Result[0].get<int32_t>(), FlagId);
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_rescale_q");
@@ -110,10 +111,10 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   auto &HostFuncAVUtilVersion = FuncInst->getHostFunc();
 
   {
-    HostFuncAVUtilVersion.run(
-        CallFrame, std::initializer_list<WasmEdge::ValVariant>{}, Result);
+    EXPECT_TRUE(HostFuncAVUtilVersion.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{}, Result));
 
-    EXPECT_TRUE(Result[0].get<uint32_t>() > 0);
+    EXPECT_TRUE((Result[0].get<uint32_t>() >> 16) > 0);
   }
 
   uint64_t ChannelId = 1; // FRONT_LEFT
@@ -171,6 +172,10 @@ TEST_F(FFmpegTest, AVUtilFunc) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{NamePtr, Length},
         Result);
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_NE(std::string_view(MemInst->getPointer<char *>(NamePtr),
+                               static_cast<size_t>(Length))
+                  .find("--"),
+              std::string_view::npos);
   }
 
   FuncInst = AVUtilMod->findFuncExports(
@@ -200,6 +205,10 @@ TEST_F(FFmpegTest, AVUtilFunc) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{NamePtr, Length},
         Result);
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(NamePtr),
+                               static_cast<size_t>(Length))
+                  .find("--"),
+              std::string_view::npos);
   }
 }
 

--- a/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
@@ -20,9 +20,7 @@ TEST_F(FFmpegTest, AVUtilFunc) {
 
   auto *FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_log_set_level");
-  auto &HostFuncAVLogSetLevel =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVLogSetLevel &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVLogSetLevel = FuncInst->getHostFunc();
 
   int32_t LogLvlId = 32;
   {
@@ -33,9 +31,7 @@ TEST_F(FFmpegTest, AVUtilFunc) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_log_get_level");
-  auto &HostFuncAVLogGetLevel =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVLogGetLevel &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVLogGetLevel = FuncInst->getHostFunc();
 
   {
     HostFuncAVLogGetLevel.run(
@@ -45,9 +41,7 @@ TEST_F(FFmpegTest, AVUtilFunc) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_log_set_flags");
-  auto &HostFuncAVLogSetFlags =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVLogSetFlags &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVLogSetFlags = FuncInst->getHostFunc();
 
   {
     HostFuncAVLogSetFlags.run(
@@ -56,9 +50,7 @@ TEST_F(FFmpegTest, AVUtilFunc) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_log_get_flags");
-  auto &HostFuncAVLogGetFlags =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVLogGetFlags &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVLogGetFlags = FuncInst->getHostFunc();
 
   {
     HostFuncAVLogGetFlags.run(
@@ -68,9 +60,7 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_rescale_q");
-  auto &HostFuncAVRescaleQ =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVRescaleQ &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVRescaleQ = FuncInst->getHostFunc();
 
   int64_t A = 20;
   int32_t BNum = 5;
@@ -89,9 +79,7 @@ TEST_F(FFmpegTest, AVUtilFunc) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_rescale_q_rnd");
-  auto &HostFuncAVRescaleQRnd =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVRescaleQRnd &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVRescaleQRnd = FuncInst->getHostFunc();
 
   {
     int32_t RoundingId = 2;
@@ -105,9 +93,7 @@ TEST_F(FFmpegTest, AVUtilFunc) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_avutil_version");
-  auto &HostFuncAVUtilVersion =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVUtilVersion &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVUtilVersion = FuncInst->getHostFunc();
 
   {
     HostFuncAVUtilVersion.run(
@@ -119,9 +105,7 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   uint64_t ChannelId = 1; // FRONT_LEFT
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_get_channel_layout_nb_channels");
-  auto &HostFuncAVGetChannelLayoutNbChannels = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVGetChannelLayoutNbChannels &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVGetChannelLayoutNbChannels = FuncInst->getHostFunc();
 
   {
     HostFuncAVGetChannelLayoutNbChannels.run(
@@ -132,9 +116,7 @@ TEST_F(FFmpegTest, AVUtilFunc) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_get_default_channel_layout");
-  auto &HostFuncAVGetDefaultChannelLayout = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVGetDefaultChannelLayout &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVGetDefaultChannelLayout = FuncInst->getHostFunc();
 
   {
     HostFuncAVGetDefaultChannelLayout.run(
@@ -146,9 +128,7 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   uint32_t Length = 0;
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_avutil_configuration_length");
-  auto &HostFuncAVUtilConfigurationLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVUtilConfigurationLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVUtilConfigurationLength = FuncInst->getHostFunc();
 
   {
     HostFuncAVUtilConfigurationLength.run(
@@ -162,9 +142,7 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_avutil_configuration");
-  auto &HostFuncAVUtilConfiguration = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVUtilConfiguration &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVUtilConfiguration = FuncInst->getHostFunc();
 
   {
     HostFuncAVUtilConfiguration.run(
@@ -175,9 +153,7 @@ TEST_F(FFmpegTest, AVUtilFunc) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_avutil_license_length");
-  auto &HostFuncAVUtilLicenseLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVUtilLicenseLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVUtilLicenseLength = FuncInst->getHostFunc();
 
   {
     HostFuncAVUtilLicenseLength.run(
@@ -191,9 +167,7 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_avutil_license");
-  auto &HostFuncAVUtilLicense =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVUtilLicense &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVUtilLicense = FuncInst->getHostFunc();
 
   {
     HostFuncAVUtilLicense.run(
@@ -209,9 +183,7 @@ TEST_F(FFmpegTest, AVTime) {
 
   auto *FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_gettime");
-  auto &HostFuncAVGetTime =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVGetTime &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVGetTime = FuncInst->getHostFunc();
 
   {
     HostFuncAVGetTime.run(
@@ -222,9 +194,7 @@ TEST_F(FFmpegTest, AVTime) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_gettime_relative");
-  auto &HostFuncAVGetTimeRelative =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVGetTimeRelative &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVGetTimeRelative = FuncInst->getHostFunc();
 
   {
     HostFuncAVGetTimeRelative.run(
@@ -235,9 +205,7 @@ TEST_F(FFmpegTest, AVTime) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_gettime_relative_is_monotonic");
-  auto &HostFuncAVGetTimeRelativeIsMonotonic = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVGetTimeRelativeIsMonotonic &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVGetTimeRelativeIsMonotonic = FuncInst->getHostFunc();
 
   {
     HostFuncAVGetTimeRelativeIsMonotonic.run(
@@ -247,9 +215,7 @@ TEST_F(FFmpegTest, AVTime) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_usleep");
-  auto &HostFuncAVUSleep =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVUSleep &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVUSleep = FuncInst->getHostFunc();
 
   {
     HostFuncAVUSleep.run(

--- a/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
@@ -20,6 +20,8 @@ TEST_F(FFmpegTest, AVUtilFunc) {
 
   auto *FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_log_set_level");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVLogSetLevel = FuncInst->getHostFunc();
 
   int32_t LogLvlId = 32;
@@ -31,6 +33,8 @@ TEST_F(FFmpegTest, AVUtilFunc) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_log_get_level");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVLogGetLevel = FuncInst->getHostFunc();
 
   {
@@ -41,6 +45,8 @@ TEST_F(FFmpegTest, AVUtilFunc) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_log_set_flags");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVLogSetFlags = FuncInst->getHostFunc();
 
   {
@@ -50,6 +56,8 @@ TEST_F(FFmpegTest, AVUtilFunc) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_log_get_flags");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVLogGetFlags = FuncInst->getHostFunc();
 
   {
@@ -60,6 +68,8 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_rescale_q");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVRescaleQ = FuncInst->getHostFunc();
 
   int64_t A = 20;
@@ -79,6 +89,8 @@ TEST_F(FFmpegTest, AVUtilFunc) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_rescale_q_rnd");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVRescaleQRnd = FuncInst->getHostFunc();
 
   {
@@ -93,6 +105,8 @@ TEST_F(FFmpegTest, AVUtilFunc) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_avutil_version");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVUtilVersion = FuncInst->getHostFunc();
 
   {
@@ -105,6 +119,8 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   uint64_t ChannelId = 1; // FRONT_LEFT
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_get_channel_layout_nb_channels");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVGetChannelLayoutNbChannels = FuncInst->getHostFunc();
 
   {
@@ -116,6 +132,8 @@ TEST_F(FFmpegTest, AVUtilFunc) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_get_default_channel_layout");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVGetDefaultChannelLayout = FuncInst->getHostFunc();
 
   {
@@ -128,6 +146,8 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   uint32_t Length = 0;
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_avutil_configuration_length");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVUtilConfigurationLength = FuncInst->getHostFunc();
 
   {
@@ -142,6 +162,8 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_avutil_configuration");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVUtilConfiguration = FuncInst->getHostFunc();
 
   {
@@ -153,6 +175,8 @@ TEST_F(FFmpegTest, AVUtilFunc) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_avutil_license_length");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVUtilLicenseLength = FuncInst->getHostFunc();
 
   {
@@ -167,6 +191,8 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_avutil_license");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVUtilLicense = FuncInst->getHostFunc();
 
   {
@@ -183,6 +209,8 @@ TEST_F(FFmpegTest, AVTime) {
 
   auto *FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_gettime");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVGetTime = FuncInst->getHostFunc();
 
   {
@@ -194,6 +222,8 @@ TEST_F(FFmpegTest, AVTime) {
 
   FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_gettime_relative");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVGetTimeRelative = FuncInst->getHostFunc();
 
   {
@@ -205,6 +235,8 @@ TEST_F(FFmpegTest, AVTime) {
 
   FuncInst = AVUtilMod->findFuncExports(
       "wasmedge_ffmpeg_avutil_av_gettime_relative_is_monotonic");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVGetTimeRelativeIsMonotonic = FuncInst->getHostFunc();
 
   {
@@ -215,6 +247,8 @@ TEST_F(FFmpegTest, AVTime) {
   }
 
   FuncInst = AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_usleep");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVUSleep = FuncInst->getHostFunc();
 
   {

--- a/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
@@ -24,11 +24,10 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVLogSetLevel = FuncInst->getHostFunc();
 
-  int32_t LogLvlId = 32;
+  int32_t LogLvlId = 16; // AV_LOG_ERROR, distinct from the default AV_LOG_INFO
   {
-    HostFuncAVLogSetLevel.run(
-        CallFrame, std::initializer_list<WasmEdge::ValVariant>{LogLvlId},
-        Result);
+    EXPECT_TRUE(HostFuncAVLogSetLevel.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{LogLvlId}, {}));
   }
 
   FuncInst =
@@ -38,8 +37,8 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   auto &HostFuncAVLogGetLevel = FuncInst->getHostFunc();
 
   {
-    HostFuncAVLogGetLevel.run(
-        CallFrame, std::initializer_list<WasmEdge::ValVariant>{}, Result);
+    EXPECT_TRUE(HostFuncAVLogGetLevel.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{}, Result));
     EXPECT_EQ(Result[0].get<int32_t>(), LogLvlId);
   }
 
@@ -125,10 +124,10 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   auto &HostFuncAVGetChannelLayoutNbChannels = FuncInst->getHostFunc();
 
   {
-    HostFuncAVGetChannelLayoutNbChannels.run(
+    EXPECT_TRUE(HostFuncAVGetChannelLayoutNbChannels.run(
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{ChannelId},
-        Result);
-    EXPECT_TRUE(Result[0].get<int32_t>() > 0);
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), 1);
   }
 
   FuncInst = AVUtilMod->findFuncExports(
@@ -138,10 +137,11 @@ TEST_F(FFmpegTest, AVUtilFunc) {
   auto &HostFuncAVGetDefaultChannelLayout = FuncInst->getHostFunc();
 
   {
-    HostFuncAVGetDefaultChannelLayout.run(
+    EXPECT_TRUE(HostFuncAVGetDefaultChannelLayout.run(
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{ChannelId},
-        Result);
-    EXPECT_TRUE(Result[0].get<uint64_t>() > 0);
+        Result));
+    EXPECT_EQ(Result[0].get<uint64_t>(),
+              UINT64_C(67108868)); // guest-encoded AV_CH_LAYOUT_MONO
   }
 
   uint32_t Length = 0;
@@ -222,11 +222,14 @@ TEST_F(FFmpegTest, AVTime) {
   ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVGetTime = FuncInst->getHostFunc();
 
+  int64_t AbsTime = 0;
   {
-    HostFuncAVGetTime.run(
-        CallFrame, std::initializer_list<WasmEdge::ValVariant>{}, Result);
+    EXPECT_TRUE(HostFuncAVGetTime.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{}, Result));
 
-    EXPECT_TRUE(Result[0].get<int64_t>() > 0);
+    AbsTime = Result[0].get<int64_t>();
+    // Wall-clock epoch microseconds: well past 2020-01-01.
+    EXPECT_GT(AbsTime, INT64_C(1577836800000000));
   }
 
   FuncInst =
@@ -236,10 +239,13 @@ TEST_F(FFmpegTest, AVTime) {
   auto &HostFuncAVGetTimeRelative = FuncInst->getHostFunc();
 
   {
-    HostFuncAVGetTimeRelative.run(
-        CallFrame, std::initializer_list<WasmEdge::ValVariant>{}, Result);
+    EXPECT_TRUE(HostFuncAVGetTimeRelative.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{}, Result));
 
-    EXPECT_TRUE(Result[0].get<int64_t>() > 0);
+    int64_t RelTime = Result[0].get<int64_t>();
+    EXPECT_GT(RelTime, 0);
+    // Relative monotonic clock is not epoch time; it stays smaller.
+    EXPECT_LT(RelTime, AbsTime);
   }
 
   FuncInst = AVUtilMod->findFuncExports(

--- a/test/plugins/wasmedge_ffmpeg/swresample/swresample_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/swresample/swresample_func.cpp
@@ -43,7 +43,7 @@ TEST_F(FFmpegTest, SWResampleFunc) {
 
   {
     EXPECT_TRUE(HostFuncSWResampleVersion.run(CallFrame, {}, Result));
-    ASSERT_TRUE(Result[0].get<int32_t>() > 0);
+    ASSERT_TRUE((Result[0].get<int32_t>() >> 16) > 0);
   }
 
   FuncInst = SWResampleMod->findFuncExports(
@@ -199,6 +199,10 @@ TEST_F(FFmpegTest, SWResampleFunc) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{StrPtr, Length},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_NE(std::string_view(MemInst->getPointer<char *>(StrPtr),
+                               static_cast<size_t>(Length))
+                  .find("--"),
+              std::string_view::npos);
   }
 
   FuncInst = SWResampleMod->findFuncExports(
@@ -228,6 +232,10 @@ TEST_F(FFmpegTest, SWResampleFunc) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{StrPtr, Length},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(StrPtr),
+                               static_cast<size_t>(Length))
+                  .find("--"),
+              std::string_view::npos);
   }
 }
 

--- a/test/plugins/wasmedge_ffmpeg/swresample/swresample_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/swresample/swresample_func.cpp
@@ -37,8 +37,8 @@ TEST_F(FFmpegTest, SWResampleFunc) {
 
   auto *FuncInst = SWResampleMod->findFuncExports(
       "wasmedge_ffmpeg_swresample_swresample_version");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSWResampleVersion = FuncInst->getHostFunc();
 
   {
@@ -48,8 +48,8 @@ TEST_F(FFmpegTest, SWResampleFunc) {
 
   FuncInst = SWResampleMod->findFuncExports(
       "wasmedge_ffmpeg_swresample_swr_alloc_set_opts");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwrAllocSetOpts = FuncInst->getHostFunc();
 
   // Testing with Null Old SwrCtx. Hence 2nd argument is 0.
@@ -96,8 +96,8 @@ TEST_F(FFmpegTest, SWResampleFunc) {
 
   FuncInst =
       SWResampleMod->findFuncExports("wasmedge_ffmpeg_swresample_swr_free");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwrFree = FuncInst->getHostFunc();
 
   {
@@ -108,8 +108,8 @@ TEST_F(FFmpegTest, SWResampleFunc) {
 
   FuncInst =
       SWResampleMod->findFuncExports("wasmedge_ffmpeg_swresample_swr_init");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwrInit = FuncInst->getHostFunc();
 
   {
@@ -121,8 +121,8 @@ TEST_F(FFmpegTest, SWResampleFunc) {
 
   FuncInst = SWResampleMod->findFuncExports(
       "wasmedge_ffmpeg_swresample_av_opt_set_dict");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVOptSetDict = FuncInst->getHostFunc();
 
   {
@@ -145,8 +145,8 @@ TEST_F(FFmpegTest, SWResampleFunc) {
 
   FuncInst = SWResampleMod->findFuncExports(
       "wasmedge_ffmpeg_swresample_swr_convert_frame");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwrConvertFrame = FuncInst->getHostFunc();
 
   {
@@ -160,8 +160,8 @@ TEST_F(FFmpegTest, SWResampleFunc) {
 
   FuncInst = SWResampleMod->findFuncExports(
       "wasmedge_ffmpeg_swresample_swr_get_delay");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwrGetDelay = FuncInst->getHostFunc();
 
   {
@@ -174,8 +174,8 @@ TEST_F(FFmpegTest, SWResampleFunc) {
 
   FuncInst = SWResampleMod->findFuncExports(
       "wasmedge_ffmpeg_swresample_swresample_configuration_length");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwrConfigLength = FuncInst->getHostFunc();
 
   int32_t Length = 0;
@@ -189,8 +189,8 @@ TEST_F(FFmpegTest, SWResampleFunc) {
 
   FuncInst = SWResampleMod->findFuncExports(
       "wasmedge_ffmpeg_swresample_swresample_configuration");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwrConfig = FuncInst->getHostFunc();
 
   {
@@ -203,8 +203,8 @@ TEST_F(FFmpegTest, SWResampleFunc) {
 
   FuncInst = SWResampleMod->findFuncExports(
       "wasmedge_ffmpeg_swresample_swresample_license_length");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwrLicenseLen = FuncInst->getHostFunc();
 
   {
@@ -218,8 +218,8 @@ TEST_F(FFmpegTest, SWResampleFunc) {
 
   FuncInst = SWResampleMod->findFuncExports(
       "wasmedge_ffmpeg_swresample_swresample_license");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwrLicense = FuncInst->getHostFunc();
 
   {

--- a/test/plugins/wasmedge_ffmpeg/swresample/swresample_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/swresample/swresample_func.cpp
@@ -39,9 +39,7 @@ TEST_F(FFmpegTest, SWResampleFunc) {
       "wasmedge_ffmpeg_swresample_swresample_version");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSWResampleVersion = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWResampleVersion &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncSWResampleVersion = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncSWResampleVersion.run(CallFrame, {}, Result));
@@ -52,9 +50,7 @@ TEST_F(FFmpegTest, SWResampleFunc) {
       "wasmedge_ffmpeg_swresample_swr_alloc_set_opts");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwrAllocSetOpts = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWRAllocSetOpts &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncSwrAllocSetOpts = FuncInst->getHostFunc();
 
   // Testing with Null Old SwrCtx. Hence 2nd argument is 0.
   {
@@ -102,9 +98,7 @@ TEST_F(FFmpegTest, SWResampleFunc) {
       SWResampleMod->findFuncExports("wasmedge_ffmpeg_swresample_swr_free");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwrFree =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWRFree &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwrFree = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncSwrFree.run(
@@ -116,9 +110,7 @@ TEST_F(FFmpegTest, SWResampleFunc) {
       SWResampleMod->findFuncExports("wasmedge_ffmpeg_swresample_swr_init");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwrInit =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWRInit &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwrInit = FuncInst->getHostFunc();
 
   {
     SwrId = readUInt32(MemInst, SWResamplePtr);
@@ -131,9 +123,7 @@ TEST_F(FFmpegTest, SWResampleFunc) {
       "wasmedge_ffmpeg_swresample_av_opt_set_dict");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncAVOptSetDict =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWResample::AVOptSetDict &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVOptSetDict = FuncInst->getHostFunc();
 
   {
     uint32_t EmptyDictId = 0;
@@ -157,9 +147,7 @@ TEST_F(FFmpegTest, SWResampleFunc) {
       "wasmedge_ffmpeg_swresample_swr_convert_frame");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwrConvertFrame = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWRConvertFrame &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncSwrConvertFrame = FuncInst->getHostFunc();
 
   {
     SwrId = readUInt32(MemInst, SWResamplePtr);
@@ -174,9 +162,7 @@ TEST_F(FFmpegTest, SWResampleFunc) {
       "wasmedge_ffmpeg_swresample_swr_get_delay");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwrGetDelay =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWRGetDelay &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwrGetDelay = FuncInst->getHostFunc();
 
   {
     SwrId = readUInt32(MemInst, SWResamplePtr);
@@ -190,9 +176,7 @@ TEST_F(FFmpegTest, SWResampleFunc) {
       "wasmedge_ffmpeg_swresample_swresample_configuration_length");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwrConfigLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWResampleConfigurationLength
-          &>(FuncInst->getHostFunc());
+  auto &HostFuncSwrConfigLength = FuncInst->getHostFunc();
 
   int32_t Length = 0;
   {
@@ -207,9 +191,7 @@ TEST_F(FFmpegTest, SWResampleFunc) {
       "wasmedge_ffmpeg_swresample_swresample_configuration");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwrConfig = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWResampleConfiguration &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncSwrConfig = FuncInst->getHostFunc();
 
   {
     SwrId = readUInt32(MemInst, SWResamplePtr);
@@ -223,9 +205,7 @@ TEST_F(FFmpegTest, SWResampleFunc) {
       "wasmedge_ffmpeg_swresample_swresample_license_length");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwrLicenseLen = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWResampleLicenseLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncSwrLicenseLen = FuncInst->getHostFunc();
 
   {
     SwrId = readUInt32(MemInst, SWResamplePtr);
@@ -240,9 +220,7 @@ TEST_F(FFmpegTest, SWResampleFunc) {
       "wasmedge_ffmpeg_swresample_swresample_license");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwrLicense = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::SWResample::SWResampleLicense &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncSwrLicense = FuncInst->getHostFunc();
 
   {
     SwrId = readUInt32(MemInst, SWResamplePtr);

--- a/test/plugins/wasmedge_ffmpeg/swscale/swscale_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/swscale/swscale_func.cpp
@@ -23,9 +23,7 @@ TEST_F(FFmpegTest, SwsContext) {
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getContext");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsGetContext =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsGetContext &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwsGetContext = FuncInst->getHostFunc();
 
   uint32_t SWScalePtr = UINT32_C(4);
   uint32_t SWCachedScalePtr = UINT32_C(8);
@@ -73,9 +71,7 @@ TEST_F(FFmpegTest, SwsContext) {
   FuncInst = SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_scale");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsScale =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsScale &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwsScale = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(
@@ -90,9 +86,7 @@ TEST_F(FFmpegTest, SwsContext) {
       "wasmedge_ffmpeg_swscale_sws_getCachedContext");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsGetCachedContext = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsGetCachedContext &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncSwsGetCachedContext = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncSwsGetCachedContext.run(
@@ -109,9 +103,7 @@ TEST_F(FFmpegTest, SwsContext) {
       "wasmedge_ffmpeg_swscale_sws_isSupportedInput");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsIsSupportedInput = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsIsSupportedInput &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncSwsIsSupportedInput = FuncInst->getHostFunc();
 
   {
     // AV_PIX_FMT_RGB24 is a supported pixel format.
@@ -131,9 +123,7 @@ TEST_F(FFmpegTest, SwsContext) {
       "wasmedge_ffmpeg_swscale_sws_isSupportedOutput");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsIsSupportedOutput = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsIsSupportedOutput &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncSwsIsSupportedOutput = FuncInst->getHostFunc();
 
   {
     // AV_PIX_FMT_RGB24 is a supported pixel format.
@@ -153,10 +143,7 @@ TEST_F(FFmpegTest, SwsContext) {
       "wasmedge_ffmpeg_swscale_sws_isSupportedEndiannessConversion");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsIsSupportedEndiannessConversion =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::
-                       SwsIsSupportedEndiannessConversion &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwsIsSupportedEndiannessConversion = FuncInst->getHostFunc();
 
   {
     // AV_PIX_FMT_XVMC is not a supported pixel format for
@@ -170,9 +157,7 @@ TEST_F(FFmpegTest, SwsContext) {
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_freeContext");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsFreeContext =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsFreeContext &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwsFreeContext = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncSwsFreeContext.run(
@@ -207,9 +192,7 @@ TEST_F(FFmpegTest, SwsFilter) {
       "wasmedge_ffmpeg_swscale_sws_getDefaultFilter");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsGetDefaultFilter = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsGetDefaultFilter &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncSwsGetDefaultFilter = FuncInst->getHostFunc();
 
   uint32_t SwsFilterPtr = UINT32_C(40);
   {
@@ -236,9 +219,7 @@ TEST_F(FFmpegTest, SwsFilter) {
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getLumaH");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsGetLumaH =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsGetLumaH &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwsGetLumaH = FuncInst->getHostFunc();
 
   uint32_t SwsVectorPtr = UINT32_C(20);
   {
@@ -254,9 +235,7 @@ TEST_F(FFmpegTest, SwsFilter) {
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getLumaV");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsGetLumaV =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsGetLumaV &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwsGetLumaV = FuncInst->getHostFunc();
 
   {
     writeUInt32(MemInst, UINT32_C(0), SwsVectorPtr);
@@ -272,9 +251,7 @@ TEST_F(FFmpegTest, SwsFilter) {
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getChromaH");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsGetChromaH =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsGetChromaH &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwsGetChromaH = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncSwsGetChromaH.run(
@@ -289,9 +266,7 @@ TEST_F(FFmpegTest, SwsFilter) {
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getChromaV");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsGetChromaV =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsGetChromaV &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwsGetChromaV = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncSwsGetChromaV.run(
@@ -306,9 +281,7 @@ TEST_F(FFmpegTest, SwsFilter) {
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_freeFilter");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsFreeFilter =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsFreeFilter &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwsFreeFilter = FuncInst->getHostFunc();
 
   {
     EXPECT_TRUE(HostFuncSwsFreeFilter.run(
@@ -331,9 +304,7 @@ TEST_F(FFmpegTest, SwsVector) {
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_allocVec");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsAllocVec =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsAllocVec &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwsAllocVec = FuncInst->getHostFunc();
 
   {
     writeUInt32(MemInst, UINT32_C(0), SwsVectorPtr);
@@ -350,9 +321,7 @@ TEST_F(FFmpegTest, SwsVector) {
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getGaussianVec");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsGetGaussianVec = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsGetGaussianVec &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncSwsGetGaussianVec = FuncInst->getHostFunc();
 
   {
     writeUInt32(MemInst, UINT32_C(0), SwsVectorPtr);
@@ -371,9 +340,7 @@ TEST_F(FFmpegTest, SwsVector) {
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_scaleVec");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsScaleVec =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsScaleVec &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwsScaleVec = FuncInst->getHostFunc();
 
   {
     uint32_t SwsVecId = readUInt32(MemInst, SwsVectorPtr);
@@ -388,9 +355,7 @@ TEST_F(FFmpegTest, SwsVector) {
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_normalizeVec");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsNormalizeVec =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsNormalizeVec &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwsNormalizeVec = FuncInst->getHostFunc();
 
   {
     uint32_t SwsVecId = readUInt32(MemInst, SwsVectorPtr);
@@ -405,9 +370,7 @@ TEST_F(FFmpegTest, SwsVector) {
       "wasmedge_ffmpeg_swscale_sws_getCoeffVecLength");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsGetCoeffVecLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsGetCoeffVecLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncSwsGetCoeffVecLength = FuncInst->getHostFunc();
 
   int Length = 0;
   {
@@ -423,9 +386,7 @@ TEST_F(FFmpegTest, SwsVector) {
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getCoeff");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsGetCoeff =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsGetCoeff &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwsGetCoeff = FuncInst->getHostFunc();
 
   fillMemContent(MemInst, CoeffPtr, Length);
   {
@@ -440,9 +401,7 @@ TEST_F(FFmpegTest, SwsVector) {
   FuncInst = SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_freeVec");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncSwsFreeVec =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwsFreeVec &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwsFreeVec = FuncInst->getHostFunc();
 
   {
     uint32_t SwsVecId = readUInt32(MemInst, SwsVectorPtr);
@@ -465,9 +424,7 @@ TEST_F(FFmpegTest, SWScaleVersion) {
 
   auto *FuncInst =
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_swscale_version");
-  auto &HostFuncSwscaleVersion =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwscaleVersion &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwscaleVersion = FuncInst->getHostFunc();
 
   {
     HostFuncSwscaleVersion.run(
@@ -478,9 +435,7 @@ TEST_F(FFmpegTest, SWScaleVersion) {
 
   FuncInst = SWScaleMod->findFuncExports(
       "wasmedge_ffmpeg_swscale_swscale_configuration_length");
-  auto &HostFuncSwscaleConfigurationLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwscaleConfigurationLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncSwscaleConfigurationLength = FuncInst->getHostFunc();
 
   {
     HostFuncSwscaleConfigurationLength.run(
@@ -495,9 +450,7 @@ TEST_F(FFmpegTest, SWScaleVersion) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst = SWScaleMod->findFuncExports(
       "wasmedge_ffmpeg_swscale_swscale_configuration");
-  auto &HostFuncSwscaleConfiguration = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwscaleConfiguration &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncSwscaleConfiguration = FuncInst->getHostFunc();
 
   {
     HostFuncSwscaleConfiguration.run(
@@ -508,9 +461,7 @@ TEST_F(FFmpegTest, SWScaleVersion) {
 
   FuncInst = SWScaleMod->findFuncExports(
       "wasmedge_ffmpeg_swscale_swscale_license_length");
-  auto &HostFuncSwscaleLicenseLength = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwscaleLicenseLength &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncSwscaleLicenseLength = FuncInst->getHostFunc();
 
   {
     HostFuncSwscaleLicenseLength.run(
@@ -524,9 +475,7 @@ TEST_F(FFmpegTest, SWScaleVersion) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst =
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_swscale_license");
-  auto &HostFuncSwscaleLicense =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::SWScale::SwscaleLicense &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncSwscaleLicense = FuncInst->getHostFunc();
 
   {
     HostFuncSwscaleLicense.run(

--- a/test/plugins/wasmedge_ffmpeg/swscale/swscale_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/swscale/swscale_func.cpp
@@ -429,10 +429,10 @@ TEST_F(FFmpegTest, SWScaleVersion) {
   auto &HostFuncSwscaleVersion = FuncInst->getHostFunc();
 
   {
-    HostFuncSwscaleVersion.run(
-        CallFrame, std::initializer_list<WasmEdge::ValVariant>{}, Result);
+    EXPECT_TRUE(HostFuncSwscaleVersion.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{}, Result));
 
-    EXPECT_TRUE(Result[0].get<uint32_t>() > 0);
+    EXPECT_TRUE((Result[0].get<uint32_t>() >> 16) > 0);
   }
 
   FuncInst = SWScaleMod->findFuncExports(
@@ -463,6 +463,10 @@ TEST_F(FFmpegTest, SWScaleVersion) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{NamePtr, Length},
         Result);
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_NE(std::string_view(MemInst->getPointer<char *>(NamePtr),
+                               static_cast<size_t>(Length))
+                  .find("--"),
+              std::string_view::npos);
   }
 
   FuncInst = SWScaleMod->findFuncExports(
@@ -492,6 +496,10 @@ TEST_F(FFmpegTest, SWScaleVersion) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{NamePtr, Length},
         Result);
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(NamePtr),
+                               static_cast<size_t>(Length))
+                  .find("--"),
+              std::string_view::npos);
   }
 }
 

--- a/test/plugins/wasmedge_ffmpeg/swscale/swscale_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/swscale/swscale_func.cpp
@@ -21,8 +21,8 @@ TEST_F(FFmpegTest, SwsContext) {
 
   auto *FuncInst =
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getContext");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsGetContext = FuncInst->getHostFunc();
 
   uint32_t SWScalePtr = UINT32_C(4);
@@ -69,8 +69,8 @@ TEST_F(FFmpegTest, SwsContext) {
 
   // Checking correctness of function. Returns Invalid Argument Error.
   FuncInst = SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_scale");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsScale = FuncInst->getHostFunc();
 
   {
@@ -84,8 +84,8 @@ TEST_F(FFmpegTest, SwsContext) {
 
   FuncInst = SWScaleMod->findFuncExports(
       "wasmedge_ffmpeg_swscale_sws_getCachedContext");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsGetCachedContext = FuncInst->getHostFunc();
 
   {
@@ -101,8 +101,8 @@ TEST_F(FFmpegTest, SwsContext) {
 
   FuncInst = SWScaleMod->findFuncExports(
       "wasmedge_ffmpeg_swscale_sws_isSupportedInput");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsIsSupportedInput = FuncInst->getHostFunc();
 
   {
@@ -121,8 +121,8 @@ TEST_F(FFmpegTest, SwsContext) {
 
   FuncInst = SWScaleMod->findFuncExports(
       "wasmedge_ffmpeg_swscale_sws_isSupportedOutput");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsIsSupportedOutput = FuncInst->getHostFunc();
 
   {
@@ -141,8 +141,8 @@ TEST_F(FFmpegTest, SwsContext) {
 
   FuncInst = SWScaleMod->findFuncExports(
       "wasmedge_ffmpeg_swscale_sws_isSupportedEndiannessConversion");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsIsSupportedEndiannessConversion = FuncInst->getHostFunc();
 
   {
@@ -155,8 +155,8 @@ TEST_F(FFmpegTest, SwsContext) {
 
   FuncInst =
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_freeContext");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsFreeContext = FuncInst->getHostFunc();
 
   {
@@ -190,8 +190,8 @@ TEST_F(FFmpegTest, SwsFilter) {
   ASSERT_TRUE(SWScaleMod != nullptr);
   auto *FuncInst = SWScaleMod->findFuncExports(
       "wasmedge_ffmpeg_swscale_sws_getDefaultFilter");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsGetDefaultFilter = FuncInst->getHostFunc();
 
   uint32_t SwsFilterPtr = UINT32_C(40);
@@ -217,8 +217,8 @@ TEST_F(FFmpegTest, SwsFilter) {
   uint32_t FilterId = readUInt32(MemInst, SwsFilterPtr);
   FuncInst =
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getLumaH");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsGetLumaH = FuncInst->getHostFunc();
 
   uint32_t SwsVectorPtr = UINT32_C(20);
@@ -233,8 +233,8 @@ TEST_F(FFmpegTest, SwsFilter) {
 
   FuncInst =
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getLumaV");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsGetLumaV = FuncInst->getHostFunc();
 
   {
@@ -249,8 +249,8 @@ TEST_F(FFmpegTest, SwsFilter) {
 
   FuncInst =
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getChromaH");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsGetChromaH = FuncInst->getHostFunc();
 
   {
@@ -264,8 +264,8 @@ TEST_F(FFmpegTest, SwsFilter) {
 
   FuncInst =
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getChromaV");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsGetChromaV = FuncInst->getHostFunc();
 
   {
@@ -279,8 +279,8 @@ TEST_F(FFmpegTest, SwsFilter) {
 
   FuncInst =
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_freeFilter");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsFreeFilter = FuncInst->getHostFunc();
 
   {
@@ -302,8 +302,8 @@ TEST_F(FFmpegTest, SwsVector) {
 
   auto *FuncInst =
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_allocVec");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsAllocVec = FuncInst->getHostFunc();
 
   {
@@ -319,8 +319,8 @@ TEST_F(FFmpegTest, SwsVector) {
 
   FuncInst =
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getGaussianVec");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsGetGaussianVec = FuncInst->getHostFunc();
 
   {
@@ -338,8 +338,8 @@ TEST_F(FFmpegTest, SwsVector) {
 
   FuncInst =
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_scaleVec");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsScaleVec = FuncInst->getHostFunc();
 
   {
@@ -353,8 +353,8 @@ TEST_F(FFmpegTest, SwsVector) {
 
   FuncInst =
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_normalizeVec");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsNormalizeVec = FuncInst->getHostFunc();
 
   {
@@ -368,8 +368,8 @@ TEST_F(FFmpegTest, SwsVector) {
 
   FuncInst = SWScaleMod->findFuncExports(
       "wasmedge_ffmpeg_swscale_sws_getCoeffVecLength");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsGetCoeffVecLength = FuncInst->getHostFunc();
 
   int Length = 0;
@@ -384,8 +384,8 @@ TEST_F(FFmpegTest, SwsVector) {
 
   FuncInst =
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_getCoeff");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsGetCoeff = FuncInst->getHostFunc();
 
   fillMemContent(MemInst, CoeffPtr, Length);
@@ -399,8 +399,8 @@ TEST_F(FFmpegTest, SwsVector) {
   }
 
   FuncInst = SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_sws_freeVec");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwsFreeVec = FuncInst->getHostFunc();
 
   {
@@ -424,6 +424,8 @@ TEST_F(FFmpegTest, SWScaleVersion) {
 
   auto *FuncInst =
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_swscale_version");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwscaleVersion = FuncInst->getHostFunc();
 
   {
@@ -435,6 +437,8 @@ TEST_F(FFmpegTest, SWScaleVersion) {
 
   FuncInst = SWScaleMod->findFuncExports(
       "wasmedge_ffmpeg_swscale_swscale_configuration_length");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwscaleConfigurationLength = FuncInst->getHostFunc();
 
   {
@@ -450,6 +454,8 @@ TEST_F(FFmpegTest, SWScaleVersion) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst = SWScaleMod->findFuncExports(
       "wasmedge_ffmpeg_swscale_swscale_configuration");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwscaleConfiguration = FuncInst->getHostFunc();
 
   {
@@ -461,6 +467,8 @@ TEST_F(FFmpegTest, SWScaleVersion) {
 
   FuncInst = SWScaleMod->findFuncExports(
       "wasmedge_ffmpeg_swscale_swscale_license_length");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwscaleLicenseLength = FuncInst->getHostFunc();
 
   {
@@ -475,6 +483,8 @@ TEST_F(FFmpegTest, SWScaleVersion) {
   fillMemContent(MemInst, NamePtr, Length);
   FuncInst =
       SWScaleMod->findFuncExports("wasmedge_ffmpeg_swscale_swscale_license");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncSwscaleLicense = FuncInst->getHostFunc();
 
   {

--- a/test/plugins/wasmedge_ffmpeg/swscale/swscale_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/swscale/swscale_func.cpp
@@ -42,6 +42,7 @@ TEST_F(FFmpegTest, SwsContext) {
   uint32_t YUV420PId = 1; // YUV420P AVPixFormatId (From Bindings.h)
   uint32_t RGB24Id = 3;   // RGB24  AVPixFormatId (From Bindings.h)
   uint32_t XVMCId = 174;  // XVMC AVPixFormatId (From Bindings.h)
+  uint32_t PAL8Id = 13;   // PAL8 AVPixFormatId (From Bindings.h)
 
   uint32_t SrcWidth = 100;
   uint32_t SrcHeight = 100;
@@ -117,6 +118,12 @@ TEST_F(FFmpegTest, SwsContext) {
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{XVMCId},
         Result));
     ASSERT_TRUE(Result[0].get<int32_t>() == 0);
+
+    // AV_PIX_FMT_PAL8 is supported as input but not as output.
+    EXPECT_TRUE(HostFuncSwsIsSupportedInput.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{PAL8Id},
+        Result));
+    ASSERT_TRUE(Result[0].get<int32_t>() > 0);
   }
 
   FuncInst = SWScaleMod->findFuncExports(
@@ -135,6 +142,12 @@ TEST_F(FFmpegTest, SwsContext) {
     // AV_PIX_FMT_XVMC is not a supported pixel format.
     EXPECT_TRUE(HostFuncSwsIsSupportedOutput.run(
         CallFrame, std::initializer_list<WasmEdge::ValVariant>{XVMCId},
+        Result));
+    ASSERT_TRUE(Result[0].get<int32_t>() == 0);
+
+    // AV_PIX_FMT_PAL8 is supported as input but not as output.
+    EXPECT_TRUE(HostFuncSwsIsSupportedOutput.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{PAL8Id},
         Result));
     ASSERT_TRUE(Result[0].get<int32_t>() == 0);
   }

--- a/test/plugins/wasmedge_ffmpeg/utils.cpp
+++ b/test/plugins/wasmedge_ffmpeg/utils.cpp
@@ -18,9 +18,7 @@ namespace WasmEdgeFFmpeg {
 void FFmpegTest::initEmptyFrame(uint32_t FramePtr) {
   auto *FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_alloc");
-  auto &HostFuncAVFrameAlloc =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVFrameAlloc &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVFrameAlloc = FuncInst->getHostFunc();
   HostFuncAVFrameAlloc.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{FramePtr}, Result);
 }
@@ -36,9 +34,7 @@ void FFmpegTest::initFFmpegStructs(uint32_t AVCodecPtr, uint32_t AVFormatCtxPtr,
 
   auto *FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_av_find_best_stream");
-  auto &HostFuncAVFindBestStream = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFindBestStream &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFindBestStream = FuncInst->getHostFunc();
   uint32_t MediaTypeId = 0; // Video
   uint32_t WantedStream = -1;
   uint32_t RelatedStream = -1;
@@ -55,9 +51,7 @@ void FFmpegTest::initFFmpegStructs(uint32_t AVCodecPtr, uint32_t AVFormatCtxPtr,
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_codecpar");
 
-  auto &HostFuncAVStreamCodecpar = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVStreamCodecPar &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVStreamCodecpar = FuncInst->getHostFunc();
 
   HostFuncAVStreamCodecpar.run(CallFrame,
                                std::initializer_list<WasmEdge::ValVariant>{
@@ -68,9 +62,7 @@ void FFmpegTest::initFFmpegStructs(uint32_t AVCodecPtr, uint32_t AVFormatCtxPtr,
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_alloc_context3");
-  auto &HostFuncAVCodecAllocContext3 = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecAllocContext3 &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecAllocContext3 = FuncInst->getHostFunc();
 
   HostFuncAVCodecAllocContext3.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{0, AVCodecCtxPtr},
@@ -80,9 +72,7 @@ void FFmpegTest::initFFmpegStructs(uint32_t AVCodecPtr, uint32_t AVFormatCtxPtr,
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_parameters_to_context");
-  auto &HostFuncAVCodecParametersToContext = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecParametersToContext &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecParametersToContext = FuncInst->getHostFunc();
 
   HostFuncAVCodecParametersToContext.run(
       CallFrame,
@@ -92,9 +82,7 @@ void FFmpegTest::initFFmpegStructs(uint32_t AVCodecPtr, uint32_t AVFormatCtxPtr,
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_codec_id");
-  auto &HostFuncAVCodecContextCodecId = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecCtxCodecID &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecContextCodecId = FuncInst->getHostFunc();
 
   HostFuncAVCodecContextCodecId.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{AVCodecCtxId},
@@ -104,9 +92,7 @@ void FFmpegTest::initFFmpegStructs(uint32_t AVCodecPtr, uint32_t AVFormatCtxPtr,
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_find_decoder");
-  auto &HostFuncAVCodecFindDecoder = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecFindDecoder &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecFindDecoder = FuncInst->getHostFunc();
 
   HostFuncAVCodecFindDecoder.run(
       CallFrame,
@@ -116,9 +102,7 @@ void FFmpegTest::initFFmpegStructs(uint32_t AVCodecPtr, uint32_t AVFormatCtxPtr,
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_open2");
-  auto &HostFuncAVCodecOpen2 =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecOpen2 &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVCodecOpen2 = FuncInst->getHostFunc();
 
   HostFuncAVCodecOpen2.run(
       CallFrame,
@@ -130,27 +114,19 @@ void FFmpegTest::initFFmpegStructs(uint32_t AVCodecPtr, uint32_t AVFormatCtxPtr,
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_receive_frame");
-  auto &HostFuncAVCodecReceiveFrame = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecReceiveFrame &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecReceiveFrame = FuncInst->getHostFunc();
 
   FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_av_read_frame");
-  auto &HostFuncAVReadFrame =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVReadFrame &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVReadFrame = FuncInst->getHostFunc();
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_send_packet");
-  auto &HostFuncAVCodecSendPacket = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecSendPacket &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVCodecSendPacket = FuncInst->getHostFunc();
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_av_packet_stream_index");
-  auto &HostFuncAVPacketStreamIndex = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketStreamIndex &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVPacketStreamIndex = FuncInst->getHostFunc();
 
   while (true) {
     HostFuncAVCodecReceiveFrame.run(
@@ -210,9 +186,7 @@ void FFmpegTest::initFormatCtx(uint32_t AVFormatCtxPtr, uint32_t FilePtr,
 
   auto *FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformat_open_input");
-  auto &HostFuncAVFormatOpenInput = dynamic_cast<
-      WasmEdge::Host::WasmEdgeFFmpeg::AVFormat::AVFormatOpenInput &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncAVFormatOpenInput = FuncInst->getHostFunc();
   HostFuncAVFormatOpenInput.run(
       CallFrame,
       std::initializer_list<WasmEdge::ValVariant>{
@@ -230,9 +204,7 @@ void FFmpegTest::initDict(uint32_t DictPtr, uint32_t KeyPtr, std::string Key,
 
   auto *FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
-  auto &HostFuncAVDictSet =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVUtil::AVDictSet &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVDictSet = FuncInst->getHostFunc();
 
   HostFuncAVDictSet.run(CallFrame,
                         std::initializer_list<WasmEdge::ValVariant>{
@@ -243,9 +215,7 @@ void FFmpegTest::initDict(uint32_t DictPtr, uint32_t KeyPtr, std::string Key,
 void FFmpegTest::allocPacket(uint32_t PacketPtr) {
   auto *FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_alloc");
-  auto &HostFuncAVPacketAlloc =
-      dynamic_cast<WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVPacketAlloc &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncAVPacketAlloc = FuncInst->getHostFunc();
 
   HostFuncAVPacketAlloc.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{PacketPtr},

--- a/test/plugins/wasmedge_ffmpeg/utils.cpp
+++ b/test/plugins/wasmedge_ffmpeg/utils.cpp
@@ -18,6 +18,8 @@ namespace WasmEdgeFFmpeg {
 void FFmpegTest::initEmptyFrame(uint32_t FramePtr) {
   auto *FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_frame_alloc");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameAlloc = FuncInst->getHostFunc();
   HostFuncAVFrameAlloc.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{FramePtr}, Result);
@@ -34,6 +36,8 @@ void FFmpegTest::initFFmpegStructs(uint32_t AVCodecPtr, uint32_t AVFormatCtxPtr,
 
   auto *FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_av_find_best_stream");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFindBestStream = FuncInst->getHostFunc();
   uint32_t MediaTypeId = 0; // Video
   uint32_t WantedStream = -1;
@@ -50,7 +54,8 @@ void FFmpegTest::initFFmpegStructs(uint32_t AVCodecPtr, uint32_t AVFormatCtxPtr,
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_codecpar");
-
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamCodecpar = FuncInst->getHostFunc();
 
   HostFuncAVStreamCodecpar.run(CallFrame,
@@ -62,6 +67,8 @@ void FFmpegTest::initFFmpegStructs(uint32_t AVCodecPtr, uint32_t AVFormatCtxPtr,
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_alloc_context3");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVCodecAllocContext3 = FuncInst->getHostFunc();
 
   HostFuncAVCodecAllocContext3.run(
@@ -72,6 +79,8 @@ void FFmpegTest::initFFmpegStructs(uint32_t AVCodecPtr, uint32_t AVFormatCtxPtr,
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_parameters_to_context");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVCodecParametersToContext = FuncInst->getHostFunc();
 
   HostFuncAVCodecParametersToContext.run(
@@ -82,6 +91,8 @@ void FFmpegTest::initFFmpegStructs(uint32_t AVCodecPtr, uint32_t AVFormatCtxPtr,
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodeccontext_codec_id");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVCodecContextCodecId = FuncInst->getHostFunc();
 
   HostFuncAVCodecContextCodecId.run(
@@ -92,6 +103,8 @@ void FFmpegTest::initFFmpegStructs(uint32_t AVCodecPtr, uint32_t AVFormatCtxPtr,
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_find_decoder");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVCodecFindDecoder = FuncInst->getHostFunc();
 
   HostFuncAVCodecFindDecoder.run(
@@ -102,6 +115,8 @@ void FFmpegTest::initFFmpegStructs(uint32_t AVCodecPtr, uint32_t AVFormatCtxPtr,
 
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_open2");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVCodecOpen2 = FuncInst->getHostFunc();
 
   HostFuncAVCodecOpen2.run(
@@ -114,18 +129,26 @@ void FFmpegTest::initFFmpegStructs(uint32_t AVCodecPtr, uint32_t AVFormatCtxPtr,
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_receive_frame");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVCodecReceiveFrame = FuncInst->getHostFunc();
 
   FuncInst =
       AVFormatMod->findFuncExports("wasmedge_ffmpeg_avformat_av_read_frame");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVReadFrame = FuncInst->getHostFunc();
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_avcodec_send_packet");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVCodecSendPacket = FuncInst->getHostFunc();
 
   FuncInst = AVCodecMod->findFuncExports(
       "wasmedge_ffmpeg_avcodec_av_packet_stream_index");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPacketStreamIndex = FuncInst->getHostFunc();
 
   while (true) {
@@ -186,6 +209,8 @@ void FFmpegTest::initFormatCtx(uint32_t AVFormatCtxPtr, uint32_t FilePtr,
 
   auto *FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avformat_open_input");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFormatOpenInput = FuncInst->getHostFunc();
   HostFuncAVFormatOpenInput.run(
       CallFrame,
@@ -204,6 +229,8 @@ void FFmpegTest::initDict(uint32_t DictPtr, uint32_t KeyPtr, std::string Key,
 
   auto *FuncInst =
       AVUtilMod->findFuncExports("wasmedge_ffmpeg_avutil_av_dict_set");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVDictSet = FuncInst->getHostFunc();
 
   HostFuncAVDictSet.run(CallFrame,
@@ -215,6 +242,8 @@ void FFmpegTest::initDict(uint32_t DictPtr, uint32_t KeyPtr, std::string Key,
 void FFmpegTest::allocPacket(uint32_t PacketPtr) {
   auto *FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_av_packet_alloc");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVPacketAlloc = FuncInst->getHostFunc();
 
   HostFuncAVPacketAlloc.run(

--- a/test/plugins/wasmedge_ffmpeg/utils.cpp
+++ b/test/plugins/wasmedge_ffmpeg/utils.cpp
@@ -21,8 +21,8 @@ void FFmpegTest::initEmptyFrame(uint32_t FramePtr) {
   ASSERT_NE(FuncInst, nullptr);
   ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVFrameAlloc = FuncInst->getHostFunc();
-  HostFuncAVFrameAlloc.run(
-      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FramePtr}, Result);
+  ASSERT_TRUE(HostFuncAVFrameAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FramePtr}, Result));
 }
 
 void FFmpegTest::initFFmpegStructs(uint32_t AVCodecPtr, uint32_t AVFormatCtxPtr,

--- a/test/plugins/wasmedge_process/wasmedge_process.cpp
+++ b/test/plugins/wasmedge_process/wasmedge_process.cpp
@@ -84,9 +84,7 @@ TEST(WasmEdgeProcessTest, SetProgName) {
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_set_prog_name");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncInst =
-      dynamic_cast<WasmEdge::Host::WasmEdgeProcessSetProgName &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Test: Run function successfully.
   EXPECT_TRUE(HostFuncInst.run(
@@ -130,8 +128,7 @@ TEST(WasmEdgeProcessTest, AddArg) {
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_add_arg");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncInst = dynamic_cast<WasmEdge::Host::WasmEdgeProcessAddArg &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Test: Run function successfully to add "arg1".
   EXPECT_TRUE(HostFuncInst.run(
@@ -194,8 +191,7 @@ TEST(WasmEdgeProcessTest, AddEnv) {
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_add_env");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncInst = dynamic_cast<WasmEdge::Host::WasmEdgeProcessAddEnv &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Test: Run function successfully to add "ENV1", "VALUE1".
   EXPECT_TRUE(
@@ -249,8 +245,7 @@ TEST(WasmEdgeProcessTest, AddStdIn) {
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_add_stdin");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncInst = dynamic_cast<WasmEdge::Host::WasmEdgeProcessAddStdIn &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Test: Run function successfully to add "\01\02\03\04".
   EXPECT_TRUE(HostFuncInst.run(
@@ -288,9 +283,7 @@ TEST(WasmEdgeProcessTest, SetTimeOut) {
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_set_timeout");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncInst =
-      dynamic_cast<WasmEdge::Host::WasmEdgeProcessSetTimeOut &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Test: Run function successfully to set timeout 100.
   EXPECT_TRUE(HostFuncInst.run(
@@ -325,8 +318,7 @@ TEST(WasmEdgeProcessTest, Run) {
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_run");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncInst = dynamic_cast<WasmEdge::Host::WasmEdgeProcessRun &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Return value.
   std::array<WasmEdge::ValVariant, 1> RetVal;
@@ -387,8 +379,7 @@ TEST(WasmEdgeProcessTest, TimeoutPrecision) {
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_run");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncRun = dynamic_cast<WasmEdge::Host::WasmEdgeProcessRun &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncRun = FuncInst->getHostFunc();
 
   // Return value.
   std::array<WasmEdge::ValVariant, 1> RetVal;
@@ -430,9 +421,7 @@ TEST(WasmEdgeProcessTest, GetExitCode) {
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_get_exit_code");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncInst =
-      dynamic_cast<WasmEdge::Host::WasmEdgeProcessGetExitCode &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Test: Run function successfully to get exit code.
   std::array<WasmEdge::ValVariant, 1> RetVal;
@@ -462,22 +451,17 @@ TEST(WasmEdgeProcessTest, GetStdOut) {
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_run");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncRun = dynamic_cast<WasmEdge::Host::WasmEdgeProcessRun &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncRun = FuncInst->getHostFunc();
   // Get the function "wasmedge_process_run".
   FuncInst = ProcMod->findFuncExports("wasmedge_process_get_stdout_len");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncGetStdOutLen =
-      dynamic_cast<WasmEdge::Host::WasmEdgeProcessGetStdOutLen &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncGetStdOutLen = FuncInst->getHostFunc();
   // Get the function "wasmedge_process_run".
   FuncInst = ProcMod->findFuncExports("wasmedge_process_get_stdout");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncGetStdOut =
-      dynamic_cast<WasmEdge::Host::WasmEdgeProcessGetStdOut &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncGetStdOut = FuncInst->getHostFunc();
 
   // Return value.
   std::array<WasmEdge::ValVariant, 1> RetVal;
@@ -529,22 +513,17 @@ TEST(WasmEdgeProcessTest, GetStdErr) {
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_run");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncRun = dynamic_cast<WasmEdge::Host::WasmEdgeProcessRun &>(
-      FuncInst->getHostFunc());
+  auto &HostFuncRun = FuncInst->getHostFunc();
   // Get the function "wasmedge_process_run".
   FuncInst = ProcMod->findFuncExports("wasmedge_process_get_stderr_len");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncGetStdErrLen =
-      dynamic_cast<WasmEdge::Host::WasmEdgeProcessGetStdErrLen &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncGetStdErrLen = FuncInst->getHostFunc();
   // Get the function "wasmedge_process_run".
   FuncInst = ProcMod->findFuncExports("wasmedge_process_get_stderr");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncGetStdErr =
-      dynamic_cast<WasmEdge::Host::WasmEdgeProcessGetStdErr &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncGetStdErr = FuncInst->getHostFunc();
 
   // Return value.
   std::array<WasmEdge::ValVariant, 1> RetVal;

--- a/test/plugins/wasmedge_process/wasmedge_process.cpp
+++ b/test/plugins/wasmedge_process/wasmedge_process.cpp
@@ -82,8 +82,8 @@ TEST(WasmEdgeProcessTest, SetProgName) {
 
   // Get the function "wasmedge_process_set_prog_name".
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_set_prog_name");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Test: Run function successfully.
@@ -126,8 +126,8 @@ TEST(WasmEdgeProcessTest, AddArg) {
 
   // Get the function "wasmedge_process_add_arg".
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_add_arg");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Test: Run function successfully to add "arg1".
@@ -189,8 +189,8 @@ TEST(WasmEdgeProcessTest, AddEnv) {
 
   // Get the function "wasmedge_process_add_env".
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_add_env");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Test: Run function successfully to add "ENV1", "VALUE1".
@@ -243,8 +243,8 @@ TEST(WasmEdgeProcessTest, AddStdIn) {
 
   // Get the function "wasmedge_process_add_stdin".
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_add_stdin");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Test: Run function successfully to add "\01\02\03\04".
@@ -281,8 +281,8 @@ TEST(WasmEdgeProcessTest, SetTimeOut) {
 
   // Get the function "wasmedge_process_set_timeout".
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_set_timeout");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Test: Run function successfully to set timeout 100.
@@ -316,8 +316,8 @@ TEST(WasmEdgeProcessTest, Run) {
 
   // Get the function "wasmedge_process_run".
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_run");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Return value.
@@ -377,8 +377,8 @@ TEST(WasmEdgeProcessTest, TimeoutPrecision) {
 
   // Get the function "wasmedge_process_run".
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_run");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncRun = FuncInst->getHostFunc();
 
   // Return value.
@@ -419,8 +419,8 @@ TEST(WasmEdgeProcessTest, GetExitCode) {
 
   // Get the function "wasmedge_process_get_exit_code".
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_get_exit_code");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Test: Run function successfully to get exit code.
@@ -449,18 +449,18 @@ TEST(WasmEdgeProcessTest, GetStdOut) {
 
   // Get the function "wasmedge_process_run".
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_run");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncRun = FuncInst->getHostFunc();
   // Get the function "wasmedge_process_run".
   FuncInst = ProcMod->findFuncExports("wasmedge_process_get_stdout_len");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncGetStdOutLen = FuncInst->getHostFunc();
   // Get the function "wasmedge_process_run".
   FuncInst = ProcMod->findFuncExports("wasmedge_process_get_stdout");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncGetStdOut = FuncInst->getHostFunc();
 
   // Return value.
@@ -511,18 +511,18 @@ TEST(WasmEdgeProcessTest, GetStdErr) {
 
   // Get the function "wasmedge_process_run".
   auto *FuncInst = ProcMod->findFuncExports("wasmedge_process_run");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncRun = FuncInst->getHostFunc();
   // Get the function "wasmedge_process_run".
   FuncInst = ProcMod->findFuncExports("wasmedge_process_get_stderr_len");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncGetStdErrLen = FuncInst->getHostFunc();
   // Get the function "wasmedge_process_run".
   FuncInst = ProcMod->findFuncExports("wasmedge_process_get_stderr");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncGetStdErr = FuncInst->getHostFunc();
 
   // Return value.

--- a/test/plugins/wasmedge_process/wasmedge_process.cpp
+++ b/test/plugins/wasmedge_process/wasmedge_process.cpp
@@ -424,9 +424,10 @@ TEST(WasmEdgeProcessTest, GetExitCode) {
   auto &HostFuncInst = FuncInst->getHostFunc();
 
   // Test: Run function successfully to get exit code.
+  ProcMod->getEnv().ExitCode = 42;
   std::array<WasmEdge::ValVariant, 1> RetVal;
   EXPECT_TRUE(HostFuncInst.run(DummyCallFrame, {}, RetVal));
-  EXPECT_EQ(RetVal[0].get<int32_t>(), 0);
+  EXPECT_EQ(RetVal[0].get<int32_t>(), 42);
 }
 
 TEST(WasmEdgeProcessTest, GetStdOut) {
@@ -547,8 +548,8 @@ TEST(WasmEdgeProcessTest, GetStdErr) {
   // Test: Run wasmedge_process_get_stdout successfully.
   EXPECT_TRUE(HostFuncGetStdErr.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0)}, {}));
-  EXPECT_TRUE(std::equal(ProcMod->getEnv().StdOut.begin(),
-                         ProcMod->getEnv().StdOut.end(),
+  EXPECT_TRUE(std::equal(ProcMod->getEnv().StdErr.begin(),
+                         ProcMod->getEnv().StdErr.end(),
                          MemInst.getPointer<uint8_t *>(0)));
 }
 

--- a/test/plugins/wasmedge_stablediffusion/wasmedge_stablediffusion.cpp
+++ b/test/plugins/wasmedge_stablediffusion/wasmedge_stablediffusion.cpp
@@ -89,30 +89,22 @@ TEST(WasmEdgeStableDiffusionTest, ModuleFunctions) {
   auto *FuncInst = SBMod->findFuncExports("convert");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncConvert =
-      dynamic_cast<WasmEdge::Host::StableDiffusion::SDConvert &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncConvert = FuncInst->getHostFunc();
   // Get the function "create_context".
   FuncInst = SBMod->findFuncExports("create_context");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncCreateContext =
-      dynamic_cast<WasmEdge::Host::StableDiffusion::SDCreateContext &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncCreateContext = FuncInst->getHostFunc();
   // Get the function "text_to_image".
   FuncInst = SBMod->findFuncExports("text_to_image");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncTextToImage =
-      dynamic_cast<WasmEdge::Host::StableDiffusion::SDTextToImage &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncTextToImage = FuncInst->getHostFunc();
   // Get the function "image_to_image".
   FuncInst = SBMod->findFuncExports("image_to_image");
   EXPECT_NE(FuncInst, nullptr);
   EXPECT_TRUE(FuncInst->isHostFunction());
-  auto &HostFuncImageToImage =
-      dynamic_cast<WasmEdge::Host::StableDiffusion::SDImageToImage &>(
-          FuncInst->getHostFunc());
+  auto &HostFuncImageToImage = FuncInst->getHostFunc();
 
   std::string Prompt = "a lovely cat";
   std::string Prompt2 = "with blue eyes";

--- a/test/plugins/wasmedge_stablediffusion/wasmedge_stablediffusion.cpp
+++ b/test/plugins/wasmedge_stablediffusion/wasmedge_stablediffusion.cpp
@@ -87,23 +87,23 @@ TEST(WasmEdgeStableDiffusionTest, ModuleFunctions) {
 
   // Get the function "convert".
   auto *FuncInst = SBMod->findFuncExports("convert");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncConvert = FuncInst->getHostFunc();
   // Get the function "create_context".
   FuncInst = SBMod->findFuncExports("create_context");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncCreateContext = FuncInst->getHostFunc();
   // Get the function "text_to_image".
   FuncInst = SBMod->findFuncExports("text_to_image");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncTextToImage = FuncInst->getHostFunc();
   // Get the function "image_to_image".
   FuncInst = SBMod->findFuncExports("image_to_image");
-  EXPECT_NE(FuncInst, nullptr);
-  EXPECT_TRUE(FuncInst->isHostFunction());
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncImageToImage = FuncInst->getHostFunc();
 
   std::string Prompt = "a lovely cat";


### PR DESCRIPTION
## Description

Remove direct casts to concrete plugin host-function types from plugin tests and call exported host functions through `getHostFunc()` instead.

This updates tests for:
- `wasmedge_ffmpeg`
- `wasm_bpf`
- `wasmedge_process`
- `wasmedge_stablediffusion`
- `wasi_logging`

This avoids test code depending on concrete host-function implementation types and keeps the plugin tests compatible with devirtualization-related changes.

This contribution was developed with assistance from Claude (Anthropic).

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.
