### PR TITLE
fix(vm):unsafeUnregisterModule silently succeeds when module is not found

### DIFF
--- a/lib/vm/vm.cpp
+++ b/lib/vm/vm.cpp
@@ -219,7 +219,8 @@ Expect<void> VM::unsafeUnregisterModule(std::string_view Name) {
     }
   }
 
-  return {};
+  spdlog::error(ErrCode::Value::WrongInstanceAddress);
+  return Unexpect(ErrCode::Value::WrongInstanceAddress);
 }
 
 VM::WasmUnitKind


### PR DESCRIPTION
## Description
### Summary


**File:** [`lib/vm/vm.cpp`](file:///c:/Users/Hp/WasmEdge/lib/vm/vm.cpp#L180-L222)

### What is wrong?

When you call `unsafeUnregisterModule("some-name")` and the module with that name does not exist in any list, the function simply returns `{}` (success) — as if it deleted something. This is misleading. The caller has no way to know the module was never found.

### Why fix this?

This breaks the **API contract**: a function named `unregister` should either confirm it removed something or tell you it could not find it. If calling code relies on the return value to decide whether to retry or log an error, it will incorrectly assume the module was removed. This kind of silent false-success is a classic source of hard-to-reproduce bugs in production.

### Flow diagram

```
unsafeUnregisterModule("foo")
        │
        ├─► search RegModInsts  ──── not found ──►┐
        ├─► search BuiltInModInsts ─ not found ──►│
        ├─► search PlugInModInsts ── not found ──►│
        │                                         ▼
        └─────────────────────────── return {}  ← BUG: should be an error
```

### Code — Before (line 221–222)

```cpp
  }

  return {};   // ← always succeeds even if nothing was removed
}
```

### Code — After 

```cpp
  }

  spdlog::error(ErrCode::Value::UnknownImport);
  return Unexpect(ErrCode::Value::UnknownImport);
  
}
```



## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
