### PR TITLE
fix(Plugins): Out-of-Bounds Memory Corruption & Crash via Double Free of Graph IDs

### DIFF
--- a/plugins/wasi_nn/wasinnenv.h
+++ b/plugins/wasi_nn/wasinnenv.h
@@ -314,13 +314,25 @@ struct WasiNNEnvironment :
   void deleteGraph(const uint32_t Id) noexcept {
     // TODO: Add the deallocation callback.
     std::unique_lock Lock(GraphMutex);
-    if (Id < NNGraph.size()) {
+    if (Id < NNGraph.size() &&
+        NNGraphRecycle.find(Id) == NNGraphRecycle.end() &&
+        !NNGraph[Id].isFinalized()) {
       auto &G = NNGraph[Id];
       G.setFinalized();
       if (G.getContextCount() == 0) {
         // All contexts are deleted. Release the graph ID.
         if (Id == NNGraph.size() - 1) {
           NNGraph.pop_back();
+          while (!NNGraph.empty() &&
+                 ((NNGraph.back().isFinalized() &&
+                   NNGraph.back().getContextCount() == 0) ||
+                  NNGraphRecycle.find(
+                      static_cast<uint32_t>(NNGraph.size() - 1)) !=
+                      NNGraphRecycle.end())) {
+            uint32_t BackId = static_cast<uint32_t>(NNGraph.size() - 1);
+            NNGraphRecycle.erase(BackId);
+            NNGraph.pop_back();
+          }
         } else {
           G.reset();
           NNGraphRecycle.insert(Id);
@@ -341,6 +353,16 @@ struct WasiNNEnvironment :
         // All contexts are deleted. Release the graph ID.
         if (GId == NNGraph.size() - 1) {
           NNGraph.pop_back();
+          while (!NNGraph.empty() &&
+                 ((NNGraph.back().isFinalized() &&
+                   NNGraph.back().getContextCount() == 0) ||
+                  NNGraphRecycle.find(
+                      static_cast<uint32_t>(NNGraph.size() - 1)) !=
+                      NNGraphRecycle.end())) {
+            uint32_t BackId = static_cast<uint32_t>(NNGraph.size() - 1);
+            NNGraphRecycle.erase(BackId);
+            NNGraph.pop_back();
+          }
         } else {
           G.reset();
           NNGraphRecycle.insert(GId);
@@ -348,6 +370,14 @@ struct WasiNNEnvironment :
       }
       if (Id == NNContext.size() - 1) {
         NNContext.pop_back();
+        while (!NNContext.empty() &&
+               NNContextRecycle.find(
+                   static_cast<uint32_t>(NNContext.size() - 1)) !=
+                   NNContextRecycle.end()) {
+          uint32_t BackId = static_cast<uint32_t>(NNContext.size() - 1);
+          NNContextRecycle.erase(BackId);
+          NNContext.pop_back();
+        }
       } else {
         NNContext[Id].reset();
         NNContextRecycle.insert(Id);

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -2814,6 +2814,14 @@ TEST(WasiNNTest, ChatTTSBackend) {
         Errno));
     EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
   }
+  // Test: unload -- double unload should fail.
+  {
+    EXPECT_TRUE(HostFuncUnload.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0)},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(),
+              static_cast<uint32_t>(ErrNo::InvalidArgument));
+  }
 }
 #endif // WASMEDGE_PLUGIN_WASI_NN_BACKEND_CHATTTS
 
@@ -3393,5 +3401,104 @@ TEST(WasiNNTest, BitNetBackend) {
     EXPECT_EQ(Errno[0].get<int32_t>(),
               static_cast<uint32_t>(ErrNo::InvalidArgument));
   }
+  // Test: unload -- double unload should fail.
+  {
+    EXPECT_TRUE(HostFuncUnload.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{GraphId},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(),
+              static_cast<uint32_t>(ErrNo::InvalidArgument));
+  }
 }
 #endif // WASMEDGE_PLUGIN_WASI_NN_BACKEND_BITNET
+
+#if defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_OPENVINO) ||                       \
+    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_TORCH) ||                          \
+    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_TFLITE) ||                         \
+    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML) ||                           \
+    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_PIPER) ||                          \
+    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_WHISPER) ||                        \
+    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_CHATTTS) ||                        \
+    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_MLX) ||                            \
+    defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_BITNET)
+
+TEST(WasiNNTest, EnvironmentDoubleFreeSafety) {
+#if defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_OPENVINO)
+  constexpr Backend TestBackend = Backend::OpenVINO;
+#elif defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_TORCH)
+  constexpr Backend TestBackend = Backend::PyTorch;
+#elif defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_TFLITE)
+  constexpr Backend TestBackend = Backend::TensorflowLite;
+#elif defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML)
+  constexpr Backend TestBackend = Backend::GGML;
+#elif defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_PIPER)
+  constexpr Backend TestBackend = Backend::Piper;
+#elif defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_WHISPER)
+  constexpr Backend TestBackend = Backend::Whisper;
+#elif defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_CHATTTS)
+  constexpr Backend TestBackend = Backend::ChatTTS;
+#elif defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_MLX)
+  constexpr Backend TestBackend = Backend::MLX;
+#elif defined(WASMEDGE_PLUGIN_WASI_NN_BACKEND_BITNET)
+  constexpr Backend TestBackend = Backend::BitNet;
+#endif
+
+  auto NNMod = createModule();
+  ASSERT_TRUE(NNMod != nullptr);
+  auto &Env = NNMod->getEnv();
+
+  // Clear existing graphs/contexts to ensure a clean state for the unit test
+  {
+    std::unique_lock Lock(Env.GraphMutex);
+    Env.NNGraph.clear();
+    Env.NNContext.clear();
+    Env.NNGraphRecycle.clear();
+    Env.NNContextRecycle.clear();
+  }
+
+  // 1. Create a graph
+  uint32_t GId0 = Env.newGraph(TestBackend);
+  Env.NNGraph[GId0].setReady();
+  EXPECT_EQ(GId0, 0U);
+
+  // 2. Initialize a context linked to that graph
+  uint32_t CtxId0 = Env.newContext(GId0, Env.NNGraph[GId0]);
+  EXPECT_EQ(CtxId0, 0U);
+  EXPECT_EQ(Env.NNGraph[GId0].getContextCount(), 1U);
+
+  // 3. deleteGraph should finalize it but not recycle it because context count is 1
+  Env.deleteGraph(GId0);
+  EXPECT_TRUE(Env.NNGraph[GId0].isFinalized());
+  EXPECT_TRUE(Env.NNGraphRecycle.empty());
+
+  // 4. Double deleteGraph on GId0 should be ignored safely
+  Env.deleteGraph(GId0);
+  EXPECT_TRUE(Env.NNGraph[GId0].isFinalized());
+
+  // 5. deleteContext should decrease context count to 0, triggering deletion and popping from vectors
+  Env.deleteContext(CtxId0);
+  EXPECT_TRUE(Env.NNGraph.empty());
+  EXPECT_TRUE(Env.NNContext.empty());
+
+  // 6. Double deleteContext should be ignored safely
+  Env.deleteContext(CtxId0);
+
+  // 7. Test multiple graphs and recursive popping of recycled graph IDs
+  uint32_t GId1 = Env.newGraph(TestBackend); // GId = 0
+  Env.NNGraph[GId1].setReady();
+  uint32_t GId2 = Env.newGraph(TestBackend); // GId = 1
+  Env.NNGraph[GId2].setReady();
+  EXPECT_EQ(GId1, 0U);
+  EXPECT_EQ(GId2, 1U);
+
+  // Finalize GId1 (index 0) - it has 0 contexts, so it gets reset and recycled
+  Env.deleteGraph(GId1);
+  EXPECT_EQ(Env.NNGraphRecycle.size(), 1U);
+  EXPECT_TRUE(Env.NNGraphRecycle.count(GId1));
+
+  // Finalize GId2 (index 1) - it has 0 contexts, so it gets popped, which recursively pops GId1
+  Env.deleteGraph(GId2);
+  EXPECT_TRUE(Env.NNGraph.empty());
+  EXPECT_TRUE(Env.NNGraphRecycle.empty());
+}
+#endif


### PR DESCRIPTION
## Description
In `wasinnenv.h`, `deleteGraph` does not verify if the Graph ID is already in `NNGraphRecycle`. If `deleteGraph(0)` is called twice (a double free of the Graph ID):
1. Graph 0 gets reset and its index `0` is added to `NNGraphRecycle`.
2. On the second call, since `Id < NNGraph.size()` is still true, `NNGraph.pop_back()` is triggered, reducing the size of the graph vector to `0`.
3. The index `0` remains in `NNGraphRecycle`.
4. When a new graph is created, `newGraph` retrieves `ID = 0` from `NNGraphRecycle` and attempts to write to `NNGraph[0]`. Since the vector is empty, this leads to an out-of-bounds memory access and a crash.


### Reproduction steps

# WasmEdge Double Free Vulnerability Simulation


## The Setup

A WebAssembly guest application loads two models.
* The host allocates two graphs: **Graph 0** and **Graph 1**.
* `NNGraph` vector has a size of **2** (indices 0 and 1).
* `NNGraphRecycle` (the recycle bin) is **empty**.

---

## Step-by-Step Simulation of the Crash

### Step 1: Guest unloads Graph 0
The guest calls `wasi_nn::unload` on Graph 0.
* **Host State Check:** `Id = 0`. Since `0 < 2` (size is 2) and `0 != 2 - 1` (not the last index), WasmEdge does not shrink the vector.
* **Recycle Bin:** Graph 0 is reset, and index `0` is added to `NNGraphRecycle`.
* **Result:** `NNGraph` size is still **2**. `NNGraphRecycle` has `{0}`.

### Step 2: Guest unloads Graph 1
The guest calls `wasi_nn::unload` on Graph 1.
* **Host State Check:** `Id = 1`. Since `1 < 2` and `1 == 2 - 1` (is the last index), WasmEdge shrinks the vector.
* **Action:** `NNGraph.pop_back()` is called.
* **Result:** `NNGraph` size is reduced to **1** (only index 0 remains). `NNGraphRecycle` still has `{0}`.

### Step 3: Guest unloads Graph 0 again (The Double Free)
Due to a bug in the guest application (e.g. double destruction), the guest calls `wasi_nn::unload` on Graph 0 a second time.
* **Host State Check:** `Id = 0`. WasmEdge does not check if `0` is already in the recycle bin.
* **Action:**
  1. `0 < 1` (size is 1) is **true**.
  2. `0 == 1 - 1` (is the last index now) is **true**.
  3. WasmEdge calls `NNGraph.pop_back()`, shrinking the vector size to **0**.
* **Result:** `NNGraph` size is now **0** (empty). `NNGraphRecycle` still has `{0}`.

### Step 4: Guest loads a new model (The Crash)
The guest calls `wasi_nn::load` to load a new model.
* **Host State Check:** The host tries to allocate a new Graph ID. It sees that `NNGraphRecycle` is not empty (contains `{0}`).
* **Action:** The host assigns `ID = 0` and attempts to initialize the graph:
  ```cpp
  NNGraph[0].init(BE);
  ```
* **Result:** Since `NNGraph` is empty (size is 0), accessing index `0` causes an **out-of-bounds memory access** and WasmEdge crashes instantly.


## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<img width="1090" height="310" alt="image" src="https://github.com/user-attachments/assets/a7603f26-aa61-4829-9f76-e4cdd1e8fa41" />

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
