### PR TITLE
docs(AI): add AI disclosure checklist and refine contributor guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,11 +9,15 @@ Before submitting this PR, please ensure the following:
 - [ ] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
 - [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.
 
+If you are using AI-assisted tools, please ensure the following:
+
+- [ ] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
+- [ ] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.
+
 ## Test Evidence
 <!-- Paste your test output screenshot or logs here -->
 
 ---
 
 > **Important:** This PR will be automatically closed if the above requirements are not met.
-
 > **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,7 @@ cmake --build build -j$(nproc)
 ## Build Artifacts
 
 After building, key paths are:
+
 - Binary: `build/tools/wasmedge/wasmedge`
 - AOT compiler: `build/tools/wasmedge/wasmedgec` when `WASMEDGE_USE_LLVM=ON`
 - WASI-NN RPC server: `build/tools/wasmedge/wasi_nn_rpcserver` when
@@ -176,6 +177,7 @@ After building, key paths are:
 - Built-in `wasi_logging`: `build/lib/plugin/wasi_logging/`
 
 To run with plugins:
+
 ```bash
 WASMEDGE_PLUGIN_PATH=build/plugins ./build/tools/wasmedge/wasmedge <wasm-file>
 ```
@@ -186,16 +188,23 @@ subdirectory; the loader recursively scans plugin directories.
 ## Testing
 
 Tests use the Google Test framework:
+
 ```bash
-cmake --build build --target test
+cmake --build build --target <test-name-regex>
 ```
 
 Run a specific test:
+
 ```bash
 cd build && ctest -R <test-name-regex>
 ```
 
 Test files are located in `test/`, with a structure mirroring `lib/`. Plugin tests live in `test/plugins/`.
+
+### Test Case Guidelines
+
+- **Avoid adding new test targets**: Do not casually register a new CMake test executable (`wasmedge_add_test` / `add_test`) for new cases. Prefer adding `TEST(...)` cases to an existing test target whose scope matches (e.g. add loader/serializer cases to `test/loader`), so the suite stays consolidated and CI does not gain extra binaries to build and run.
+- Only create a new test target when the work introduces a genuinely new component or test category with no suitable existing home; when you do, justify it and register it in the directory's `CMakeLists.txt` following the surrounding pattern.
 
 ## Plugin System
 
@@ -264,7 +273,7 @@ After adding files, verify the build works.
 
 Use the Conventional Commits format with DCO sign-off:
 
-```
+```text
 <type>: <description>
 
 Signed-off-by: Your Name <email@example.com>
@@ -273,6 +282,7 @@ Signed-off-by: Your Name <email@example.com>
 Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`
 
 Rules:
+
 - Header: 100 characters maximum
 - Each logical change gets its own commit
 - Sign-off required: `git commit -s`
@@ -284,7 +294,7 @@ Use the `Assisted-by:` trailer for the AI assistance disclosure.
 
 The `Assisted-by:` trailer should be placed before `Signed-off-by:` to indicate that AI assistance was used, with the human sign-off as the final confirmation.
 
-```
+```text
 <type>: <description>
 
 Assisted-by: <name of AI tool or service>


### PR DESCRIPTION
Add an AI Disclosure checklist item to the PR template directing contributors to use the `Assisted-by:` trailer and note AI assistance in the PR description.

Refine AGENTS.md: document test-case guidelines that discourage adding new CMake test targets, switch the test build command to a target regex, tag fenced commit-message blocks as `text`, and fix surrounding markdown spacing.

Assisted-by: Claude (Anthropic)

## Description
<!-- Describe your changes here -->

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.

> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
