### PR TITLE
feat(driver): add --summary flag to parse subcommand

### DIFF
--- a/include/driver/tool.h
+++ b/include/driver/tool.h
@@ -104,7 +104,11 @@ struct DriverToolOptions : public DriverProposalOptions {
             PO::Description(
                 "Set logging level. Valid values: off, trace, debug, info, "
                 "warning, error, fatal. Default is info."sv),
-            PO::MetaVar("LEVEL"sv), PO::DefaultValue(std::string())) {}
+            PO::MetaVar("LEVEL"sv), PO::DefaultValue(std::string())),
+        ParseSummary(PO::Description(
+            "Print a compact section-header table instead of full section "
+            "details. Shows each section's file offset, byte size, and item "
+            "count. Equivalent to wasm-objdump -h."sv)) {}
 
   PO::Option<std::string> SoName;
   PO::List<std::string> Args;
@@ -130,6 +134,7 @@ struct DriverToolOptions : public DriverProposalOptions {
   PO::List<std::string> LinkedModules;
   PO::List<std::string> ForbiddenPlugins;
   PO::Option<std::string> LogLevel;
+  PO::Option<PO::Toggle> ParseSummary;
 
 private:
   void addGlobalOptions(PO::ArgumentParser &Parser) noexcept {
@@ -145,6 +150,7 @@ public:
         .add_option("enable-exception-handling"sv,
                     PropExceptionHandlingDeprecated)
         .add_option("enable-component"sv, PropComponent)
+        .add_option("summary"sv, ParseSummary)
         .add_option(SoName);
   }
 

--- a/lib/driver/parseTool.cpp
+++ b/lib/driver/parseTool.cpp
@@ -236,9 +236,9 @@ static void PrintSummary(const AST::Module &Mod,
     printSummaryRow("Element"sv, S, E, Elems.size(), ""sv);
   }
 
-  if (Mod.getDataCountSection().getContent().has_value()) {
+  if (auto DC = Mod.getDataCountSection().getContent()) {
     bounds(Mod.getDataCountSection(), S, E);
-    printSummaryRow("DataCount"sv, S, E, 1, ""sv);
+    printSummaryRow("DataCount"sv, S, E, *DC, ""sv);
   }
 
   const auto &Codes = Mod.getCodeSection().getContent();

--- a/lib/driver/parseTool.cpp
+++ b/lib/driver/parseTool.cpp
@@ -8,6 +8,7 @@
 #include "driver/tool.h"
 #include "loader/loader.h"
 
+#include <cstdint>
 #include <cstdlib>
 #include <map>
 #include <string>
@@ -120,6 +121,145 @@ std::string getElemEntryStr(const AST::Expression &Expr) {
   }
 }
 
+// Number of bytes that the unsigned LEB128 encoding of V occupies.
+static uint32_t uleb128Width(uint64_t V) noexcept {
+  if (V == 0)
+    return 1;
+  uint32_t W = 0;
+  while (V > 0) {
+    V >>= 7;
+    ++W;
+  }
+  return W;
+}
+
+// Print one summary row. start/end are byte offsets into the file.
+static void printSummaryRow(std::string_view Name, uint64_t Start, uint64_t End,
+                            uint64_t Count, std::string_view Extra) noexcept {
+  using namespace std::literals;
+  if (Extra.empty()) {
+    fmt::print("  {:>10}   start=0x{:08x}   end=0x{:08x}   "
+               "(size=0x{:08x})   count={}\n"sv,
+               Name, Start, End, End - Start, Count);
+  } else {
+    fmt::print("  {:>10}   start=0x{:08x}   end=0x{:08x}   "
+               "(size=0x{:08x})   {}\n"sv,
+               Name, Start, End, End - Start, Extra);
+  }
+}
+
+static void PrintSummary(const AST::Module &Mod,
+                         const std::filesystem::path &InputPath) noexcept {
+  using namespace std::literals;
+
+  // Header line.
+  std::error_code EC;
+  const auto FileSize = std::filesystem::file_size(InputPath, EC);
+  if (!EC) {
+    fmt::print("{}:  file format wasm 0x1  ({} bytes)\n\n"sv,
+               InputPath.filename().string(), FileSize);
+  } else {
+    fmt::print("{}:  file format wasm 0x1\n\n"sv,
+               InputPath.filename().string());
+  }
+  fmt::print("Section Summary:\n\n"sv);
+
+  // Helper: given a Section base, compute content start and end offsets.
+  // StartOffset is the position of the LEB128-encoded content-size field;
+  // content begins immediately after that field.
+  auto bounds = [](const AST::Section &Sec,
+                   uint64_t &Start,
+                   uint64_t &End) noexcept {
+    const uint64_t SzFieldWidth = uleb128Width(Sec.getContentSize());
+    Start = Sec.getStartOffset() + SzFieldWidth;
+    End = Start + Sec.getContentSize();
+  };
+
+  uint64_t S = 0, E = 0;
+
+  const auto &Types = Mod.getTypeSection().getContent();
+  if (!Types.empty()) {
+    bounds(Mod.getTypeSection(), S, E);
+    printSummaryRow("Type"sv, S, E, Types.size(), ""sv);
+  }
+
+  const auto &Imports = Mod.getImportSection().getContent();
+  if (!Imports.empty()) {
+    bounds(Mod.getImportSection(), S, E);
+    printSummaryRow("Import"sv, S, E, Imports.size(), ""sv);
+  }
+
+  const auto &Funcs = Mod.getFunctionSection().getContent();
+  if (!Funcs.empty()) {
+    bounds(Mod.getFunctionSection(), S, E);
+    printSummaryRow("Function"sv, S, E, Funcs.size(), ""sv);
+  }
+
+  const auto &Tables = Mod.getTableSection().getContent();
+  if (!Tables.empty()) {
+    bounds(Mod.getTableSection(), S, E);
+    printSummaryRow("Table"sv, S, E, Tables.size(), ""sv);
+  }
+
+  const auto &Mems = Mod.getMemorySection().getContent();
+  if (!Mems.empty()) {
+    bounds(Mod.getMemorySection(), S, E);
+    printSummaryRow("Memory"sv, S, E, Mems.size(), ""sv);
+  }
+
+  const auto &Tags = Mod.getTagSection().getContent();
+  if (!Tags.empty()) {
+    bounds(Mod.getTagSection(), S, E);
+    printSummaryRow("Tag"sv, S, E, Tags.size(), ""sv);
+  }
+
+  const auto &Globals = Mod.getGlobalSection().getContent();
+  if (!Globals.empty()) {
+    bounds(Mod.getGlobalSection(), S, E);
+    printSummaryRow("Global"sv, S, E, Globals.size(), ""sv);
+  }
+
+  const auto &Exports = Mod.getExportSection().getContent();
+  if (!Exports.empty()) {
+    bounds(Mod.getExportSection(), S, E);
+    printSummaryRow("Export"sv, S, E, Exports.size(), ""sv);
+  }
+
+  if (Mod.getStartSection().getContent().has_value()) {
+    bounds(Mod.getStartSection(), S, E);
+    printSummaryRow("Start"sv, S, E, 1, ""sv);
+  }
+
+  const auto &Elems = Mod.getElementSection().getContent();
+  if (!Elems.empty()) {
+    bounds(Mod.getElementSection(), S, E);
+    printSummaryRow("Element"sv, S, E, Elems.size(), ""sv);
+  }
+
+  if (Mod.getDataCountSection().getContent().has_value()) {
+    bounds(Mod.getDataCountSection(), S, E);
+    printSummaryRow("DataCount"sv, S, E, 1, ""sv);
+  }
+
+  const auto &Codes = Mod.getCodeSection().getContent();
+  if (!Codes.empty()) {
+    bounds(Mod.getCodeSection(), S, E);
+    printSummaryRow("Code"sv, S, E, Codes.size(), ""sv);
+  }
+
+  const auto &Datas = Mod.getDataSection().getContent();
+  if (!Datas.empty()) {
+    bounds(Mod.getDataSection(), S, E);
+    printSummaryRow("Data"sv, S, E, Datas.size(), ""sv);
+  }
+
+  for (const auto &Custom : Mod.getCustomSections()) {
+    bounds(Custom, S, E);
+    printSummaryRow("Custom"sv, S, E, 0,
+                    fmt::format("name=\"{}\""sv, Custom.getName()));
+  }
+}
+
 } // namespace
 
 int ParseTool(struct DriverToolOptions &Opt) noexcept {
@@ -136,6 +276,11 @@ int ParseTool(struct DriverToolOptions &Opt) noexcept {
     return EXIT_FAILURE;
   }
   const auto &Mod = **Res;
+
+  if (Opt.ParseSummary.value()) {
+    PrintSummary(Mod, InputPath);
+    return EXIT_SUCCESS;
+  }
 
   const auto &Customs = Mod.getCustomSections();
   NameSection NS;

--- a/test/driver/driverToolTest.cpp
+++ b/test/driver/driverToolTest.cpp
@@ -551,6 +551,74 @@ TEST(ParseSubcommand, OutputTagSection) {
       R.Stdout, {"Table[", "Memory[", "Start:", "Element[",
                  "DataCount section", "Data["}));
 }
+
+// --summary flag: compact section-header output.
+
+TEST(ParseSubcommand, SummaryFormat) {
+  // Verify top-level structure: header line, "Section Summary:", hex offsets,
+  // and counts appear; verbose detail lines do not.
+  auto R = callParseCaptureStdout({"--summary", parseTestPath().c_str()});
+  ASSERT_EQ(R.ExitCode, EXIT_SUCCESS);
+  EXPECT_TRUE(containsAll(R.Stdout, {"file format wasm 0x1", "Section Summary:",
+                                     "start=0x", "end=0x", "(size=0x",
+                                     "count="}));
+  EXPECT_TRUE(containsNone(R.Stdout, {"Section Details:", " - type[", " - func[",
+                                      " - global[", " - memory[", " - table["}));
+}
+
+TEST(ParseSubcommand, SummaryCountsPresent) {
+  // parse_test.wasm has 4 types, 5 imports, 4 functions, 6 globals, 12 exports,
+  // 4 code entries, and a "name" custom section.
+  auto R = callParseCaptureStdout({"--summary", parseTestPath().c_str()});
+  ASSERT_EQ(R.ExitCode, EXIT_SUCCESS);
+  EXPECT_TRUE(containsAll(R.Stdout, {"Type", "count=4", "Import", "count=5",
+                                     "Function", "count=4", "Global", "count=6",
+                                     "Export", "count=12", "Code", "count=4"}));
+  EXPECT_TRUE(containsAll(R.Stdout, {"Custom", "name=\"name\""}));
+}
+
+TEST(ParseSubcommand, SummarySkipsEmptySections) {
+  // MinimalWasm is just magic+version with no sections; summary should show
+  // only the file header and a blank section table.
+  std::string Path =
+      writeWasmToFile(MinimalWasm.data(), MinimalWasm.size(), "minimal_sum.wasm");
+  auto R = callParseCaptureStdout({"--summary", Path.c_str()});
+  std::filesystem::remove(Path.c_str());
+  ASSERT_EQ(R.ExitCode, EXIT_SUCCESS);
+  EXPECT_TRUE(containsAll(R.Stdout, {"file format wasm 0x1", "Section Summary:"}));
+  EXPECT_TRUE(containsNone(R.Stdout, {"Type", "Import", "Function", "Global",
+                                      "Export", "Code", "Custom", "count="}));
+}
+
+TEST(ParseSubcommand, SummaryOffsetsIncreasing) {
+  // Extract all "start=0x..." values and verify they are strictly increasing,
+  // confirming sections appear in file order.
+  auto R = callParseCaptureStdout({"--summary", parseTestPath().c_str()});
+  ASSERT_EQ(R.ExitCode, EXIT_SUCCESS);
+  std::vector<uint64_t> Starts;
+  const std::string &Out = R.Stdout;
+  size_t Pos = 0;
+  while ((Pos = Out.find("start=0x", Pos)) != std::string::npos) {
+    Pos += 8; // skip "start=0x"
+    uint64_t V = std::stoull(Out.substr(Pos, 8), nullptr, 16);
+    Starts.push_back(V);
+  }
+  ASSERT_GT(Starts.size(), 1u);
+  for (size_t I = 1; I < Starts.size(); ++I) {
+    EXPECT_GT(Starts[I], Starts[I - 1])
+        << "section[" << I << "] start not greater than section[" << I - 1
+        << "] start";
+  }
+}
+
+TEST(ParseSubcommand, SummaryFileSize) {
+  // The header line should mention the file's byte count when available.
+  auto R = callParseCaptureStdout({"--summary", parseTestPath().c_str()});
+  ASSERT_EQ(R.ExitCode, EXIT_SUCCESS);
+  // ParseTestWasm is 502 bytes; check that a numeric byte count appears in the
+  // first line of the summary header.
+  EXPECT_TRUE(containsAll(R.Stdout, {"502 bytes"}));
+}
 #endif
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

This PR adds a `--summary` flag to `wasmedge parse` for a quick overview of a WebAssembly module.
The summary output shows section offsets, sizes, and counts, making it easier to inspect large binaries without scrolling through the full section dump.

## Checklist

* [x] DCO Signed-off
* [x] Commit message follows project guidelines
* [x] Local tests passed

## Test Evidence

Added tests for summary output, section counts, empty modules, custom sections, and section ordering. All new and existing tests pass successfully.
