### PR TITLE
test(common): add unit tests for byteswap and Statistics

### DIFF
--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -5,6 +5,8 @@ wasmedge_add_executable(wasmedgeCommonTests
   int128Test.cpp
   hashTest.cpp
   spdlogTest.cpp
+  byteswapTest.cpp
+  statisticsTest.cpp
 )
 
 add_test(wasmedgeCommonTests wasmedgeCommonTests)

--- a/test/common/byteswapTest.cpp
+++ b/test/common/byteswapTest.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+#include "common/endian.h"
+
+#include <cstdint>
+#include <gtest/gtest.h>
+
+namespace {
+
+// WasmEdge::byteswap<T> backs EndianValue::switchEndian in common/types.h,
+// which performs the byte-order conversion for Wasm value loads/stores on
+// big-endian targets (e.g. s390x). A wrong swap silently corrupts data, so
+// these cases pin the result for each integer width the runtime actually uses.
+//
+// The 128-bit overload is intentionally not exercised here: std::is_integral_v
+// for __int128 is toolchain-dependent under strict -std=c++17, so a 128-bit
+// instantiation would not compile portably across all CI compilers.
+
+TEST(ByteswapTest, KnownValues) {
+  EXPECT_EQ(WasmEdge::byteswap<uint16_t>(0x0102),
+            static_cast<uint16_t>(0x0201));
+  EXPECT_EQ(WasmEdge::byteswap<uint32_t>(0x01020304U), 0x04030201U);
+  EXPECT_EQ(WasmEdge::byteswap<uint64_t>(0x0102030405060708ULL),
+            0x0807060504030201ULL);
+}
+
+TEST(ByteswapTest, IsInvolution) {
+  for (uint16_t V :
+       {static_cast<uint16_t>(0x0000), static_cast<uint16_t>(0x0001),
+        static_cast<uint16_t>(0xabcd), static_cast<uint16_t>(0xffff)}) {
+    EXPECT_EQ(WasmEdge::byteswap(WasmEdge::byteswap(V)), V);
+  }
+  for (uint32_t V : {0x00000000U, 0x00000001U, 0xdeadbeefU, 0x12345678U}) {
+    EXPECT_EQ(WasmEdge::byteswap(WasmEdge::byteswap(V)), V);
+  }
+  for (uint64_t V : {0x0000000000000000ULL, 0x0000000000000001ULL,
+                     0x0123456789abcdefULL, 0xfedcba9876543210ULL}) {
+    EXPECT_EQ(WasmEdge::byteswap(WasmEdge::byteswap(V)), V);
+  }
+}
+
+TEST(ByteswapTest, SignedIntegers) {
+  EXPECT_EQ(WasmEdge::byteswap<int32_t>(0x01020304), 0x04030201);
+  // All-ones swaps to all-ones; round-trip preserves the value.
+  EXPECT_EQ(WasmEdge::byteswap<int64_t>(-1), static_cast<int64_t>(-1));
+  EXPECT_EQ(WasmEdge::byteswap(WasmEdge::byteswap<int32_t>(-12345)),
+            static_cast<int32_t>(-12345));
+}
+
+} // namespace

--- a/test/common/statisticsTest.cpp
+++ b/test/common/statisticsTest.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2019-2024 Second State INC
+
+#include "common/statistics.h"
+#include "common/enum_ast.hpp"
+
+#include <cstdint>
+#include <gtest/gtest.h>
+
+namespace {
+using WasmEdge::OpCode;
+using WasmEdge::Statistics::Statistics;
+
+// Statistics is the gas/cost-metering and instruction-counting helper used by
+// the executor, VM, and C API. The cost-limit and counter logic is pure and
+// deterministic, so it can be exercised directly without a running VM.
+
+TEST(StatisticsTest, AddCostRespectsLimit) {
+  Statistics S(100);
+  EXPECT_EQ(S.getCostLimit(), UINT64_C(100));
+  EXPECT_TRUE(S.addCost(10));
+  EXPECT_EQ(S.getTotalCost(), UINT64_C(10));
+  EXPECT_TRUE(S.addCost(90)); // reaches exactly the limit
+  EXPECT_EQ(S.getTotalCost(), UINT64_C(100));
+  EXPECT_FALSE(S.addCost(1)); // would exceed; rejected and sum unchanged
+  EXPECT_EQ(S.getTotalCost(), UINT64_C(100));
+}
+
+TEST(StatisticsTest, SubCostGuardsUnderflow) {
+  Statistics S;
+  EXPECT_TRUE(S.addCost(10));
+  EXPECT_TRUE(S.subCost(5));
+  EXPECT_EQ(S.getTotalCost(), UINT64_C(5));
+  // subCost rejects when the remaining sum is less than or equal to the cost,
+  // so it can never drive the total to or below zero.
+  EXPECT_FALSE(S.subCost(5));
+  EXPECT_EQ(S.getTotalCost(), UINT64_C(5));
+  EXPECT_FALSE(S.subCost(10));
+  EXPECT_EQ(S.getTotalCost(), UINT64_C(5));
+}
+
+TEST(StatisticsTest, SetCostLimit) {
+  Statistics S;
+  S.setCostLimit(5);
+  EXPECT_EQ(S.getCostLimit(), UINT64_C(5));
+  EXPECT_TRUE(S.addCost(5));
+  EXPECT_FALSE(S.addCost(1));
+}
+
+TEST(StatisticsTest, InstructionCounter) {
+  Statistics S;
+  EXPECT_EQ(S.getInstrCount(), UINT64_C(0));
+  S.incInstrCount();
+  S.incInstrCount();
+  S.incInstrCount();
+  EXPECT_EQ(S.getInstrCount(), UINT64_C(3));
+}
+
+TEST(StatisticsTest, DefaultCostTableChargesOnePerInstr) {
+  Statistics S;
+  EXPECT_TRUE(S.addInstrCost(OpCode::Block));
+  EXPECT_TRUE(S.addInstrCost(OpCode::Br));
+  EXPECT_EQ(S.getTotalCost(), UINT64_C(2)); // default table entry is 1
+  // addInstrCost charges gas only; it does not bump the instruction counter.
+  EXPECT_EQ(S.getInstrCount(), UINT64_C(0));
+}
+
+TEST(StatisticsTest, CustomCostTableAndSubInstrCost) {
+  Statistics S;
+  S.getCostTable()[static_cast<uint16_t>(OpCode::Block)] = 7;
+  EXPECT_TRUE(S.addInstrCost(OpCode::Block));
+  EXPECT_TRUE(S.addInstrCost(OpCode::Block));
+  EXPECT_EQ(S.getTotalCost(), UINT64_C(14));
+  EXPECT_TRUE(S.subInstrCost(OpCode::Block)); // 14 > 7
+  EXPECT_EQ(S.getTotalCost(), UINT64_C(7));
+  EXPECT_FALSE(S.subInstrCost(OpCode::Block)); // 7 <= 7 -> rejected
+  EXPECT_EQ(S.getTotalCost(), UINT64_C(7));
+}
+
+TEST(StatisticsTest, ClearResetsCountersNotLimit) {
+  Statistics S(1000);
+  S.incInstrCount();
+  EXPECT_TRUE(S.addCost(50));
+  S.clear();
+  EXPECT_EQ(S.getInstrCount(), UINT64_C(0));
+  EXPECT_EQ(S.getTotalCost(), UINT64_C(0));
+  EXPECT_EQ(S.getCostLimit(), UINT64_C(1000)); // clear does not reset the limit
+}
+
+} // namespace


### PR DESCRIPTION
FIXES #5033

## Description

Two header-only utilities in `include/common/` are used in production but had no direct unit tests. This PR adds focused, deterministic coverage for both.

**What is now tested**

- `byteswap<T>` (`include/common/endian.h`) — byte-order swapping used by `EndianValue::switchEndian` for Wasm value loads/stores on big-endian targets (e.g. s390x). Tests cover known swaps for u16/u32/u64, the `byteswap(byteswap(x)) == x` involution, and signed integers.

- `Statistics` (`include/common/statistics.h`) — gas/cost metering and instruction counting used by the executor, VM, and C API. Tests cover the cost-limit boundary (`addCost` up to and over the limit, sum unchanged on rejection), `subCost` underflow guard, the default and custom cost tables via `addInstrCost`/`subInstrCost`, the instruction counter, and `clear()` (resets counters but preserves the limit).

**Files changed**

- `test/common/byteswapTest.cpp` (new)
- `test/common/statisticsTest.cpp` (new)
- `test/common/CMakeLists.txt` (register both into `wasmedgeCommonTests`)

No production code is changed.

## Checklist

- [x] **DCO Signed-off**: commit is signed off (`git commit -s`)
- [x] **Commit Messages**: `commitlint` passes — 0 problems, 0 warnings (screenshot below)
- [x] **Local Tests Passed**: 10/10 new tests pass; 53/53 full suite passes (screenshots below)

## Test Evidence

**New suites — `[ PASSED ] 10 tests`**

<img width="1293" height="933" alt="Screenshot From 2026-06-18 20-25-34" src="https://github.com/user-attachments/assets/b20971a1-7988-425c-ac4c-6955f1a9e4a7" />


**Full common suite — `[ PASSED ] 53 tests`**

<img width="1293" height="933" alt="Screenshot From 2026-06-18 20-25-53" src="https://github.com/user-attachments/assets/0b6c020c-72e0-4f24-8eb1-bcac7e0cb960" />

**commitlint — 0 problems, 0 warnings**

<img width="1030" height="307" alt="Screenshot From 2026-06-18 20-27-43" src="https://github.com/user-attachments/assets/dec8d579-594c-493d-98e5-ad2a809742e8" />
---
