### PR TITLE
feat(validator): validate canonical options on component lift/lower

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1153,13 +1153,21 @@ E(ComponentValueAlreadyConsumed, 0x02C0,
 E(ComponentValueNotConsumed, 0x02C1,
   "value was not consumed before end of component")
 // More than one string-encoding canonical option was specified
-E(ComponentCanonEncodingConflict, 0x02C2, "canonical encoding option conflicts")
+E(ComponentCanonEncodingConflict, 0x02C4, "canonical encoding option conflicts")
 // Canonical option `memory` references a core memory index out of bounds
-E(ComponentCanonMemoryOutOfBounds, 0x02C3, "memory index out of bounds")
+E(ComponentCanonMemoryOutOfBounds, 0x02C5, "memory index out of bounds")
 // Canon lift/lower target type index does not reference a component func type
-E(ComponentCanonNotFuncType, 0x02C4, "not a function type")
-// A canonical option (memory / realloc / post-return) was specified twice
-E(ComponentCanonDuplicateOption, 0x02C5, "canonical option")
+E(ComponentCanonNotFuncType, 0x02C6, "not a function type")
+// A canonical option is invalid: specified twice, missing when required by the
+// flat ABI (memory / realloc), or names a core func with the wrong signature
+// (realloc). The registered string "canonical option" is a prefix of the
+// spec's expected texts for these cases.
+E(ComponentCanonInvalidOption, 0x02C7, "canonical option")
+// Lifted/lowered core function parameter types do not match the flattened
+// component func type parameter types. Verbatim string so result-type
+// mismatches (which expect "lowered result types ...") are NOT matched here.
+E(ComponentCanonLoweredTypeMismatch, 0x02C8,
+  "lowered parameter types do not match parameter types")
 // @}
 
 // Instantiation phase

--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1152,6 +1152,14 @@ E(ComponentValueAlreadyConsumed, 0x02C0,
   "value has already been consumed")
 E(ComponentValueNotConsumed, 0x02C1,
   "value was not consumed before end of component")
+// More than one string-encoding canonical option was specified
+E(ComponentCanonEncodingConflict, 0x02C2, "canonical encoding option conflicts")
+// Canonical option `memory` references a core memory index out of bounds
+E(ComponentCanonMemoryOutOfBounds, 0x02C3, "memory index out of bounds")
+// Canon lift/lower target type index does not reference a component func type
+E(ComponentCanonNotFuncType, 0x02C4, "not a function type")
+// A canonical option (memory / realloc / post-return) was specified twice
+E(ComponentCanonDuplicateOption, 0x02C5, "canonical option")
 // @}
 
 // Instantiation phase

--- a/include/validator/component_context.h
+++ b/include/validator/component_context.h
@@ -88,13 +88,18 @@ public:
       std::optional<AST::MemoryType> Mem;
       std::optional<AST::TableType> Tab;
       std::optional<AST::GlobalType> Glob;
+      // For function exports: the address-stable core SubType of the exported
+      // func, when resolvable from a concrete core module. Used so a
+      // `(core func $i "foo")` alias can thread foo's real signature into the
+      // core:func space for canon signature checks. nullptr when unknown.
+      const AST::SubType *Func = nullptr;
 
       CoreInstanceExport() noexcept = default;
       // Copies whichever core extern type is provided (the others stay empty).
       CoreInstanceExport(ExternalType K, const AST::MemoryType *M,
-                         const AST::TableType *T,
-                         const AST::GlobalType *G) noexcept
-          : Kind(K) {
+                         const AST::TableType *T, const AST::GlobalType *G,
+                         const AST::SubType *F = nullptr) noexcept
+          : Kind(K), Func(F) {
         if (M != nullptr) {
           Mem = *M;
         }
@@ -287,9 +292,10 @@ public:
                              ExternalType ET,
                              const AST::MemoryType *Mem = nullptr,
                              const AST::TableType *Tab = nullptr,
-                             const AST::GlobalType *Glob = nullptr) {
+                             const AST::GlobalType *Glob = nullptr,
+                             const AST::SubType *Func = nullptr) {
     getCurrentContext().CoreInstances.at(InstIdx)[std::string(Name)] =
-        Context::CoreInstanceExport{ET, Mem, Tab, Glob};
+        Context::CoreInstanceExport{ET, Mem, Tab, Glob, Func};
   }
 
   // ==========================================================================

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -1536,13 +1536,21 @@ Expect<void> Validator::validateCanonOptions(
     case OptCode::Encode_UTF16:
     case OptCode::Encode_Latin1:
       if (HasEncoding) {
-        return RejectDup("string-encoding");
+        spdlog::error(ErrCode::Value::ComponentCanonEncodingConflict);
+        spdlog::error(
+            "    canonical encoding option conflicts with a previous one"sv);
+        spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+        return Unexpect(ErrCode::Value::ComponentCanonEncodingConflict);
       }
       HasEncoding = true;
       break;
     case OptCode::Memory:
       if (HasMemory) {
-        return RejectDup("memory");
+        spdlog::error(ErrCode::Value::ComponentCanonDuplicateOption);
+        spdlog::error(
+            "    canonical option `memory` is specified more than once"sv);
+        spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+        return Unexpect(ErrCode::Value::ComponentCanonDuplicateOption);
       }
       HasMemory = true;
       MemoryIdx = Opt.getIndex();
@@ -1632,12 +1640,12 @@ Expect<void> Validator::validateCanonOptions(
   if (HasMemory &&
       MemoryIdx >= CompCtx.getCoreSortIndexSize(
                        AST::Component::Sort::CoreSortType::Memory)) {
-    spdlog::error(ErrCode::Value::InvalidIndex);
+    spdlog::error(ErrCode::Value::ComponentCanonMemoryOutOfBounds);
     spdlog::error(
         "    canonical option 'memory': core memory index {} out of bounds"sv,
         MemoryIdx);
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
-    return Unexpect(ErrCode::Value::InvalidIndex);
+    return Unexpect(ErrCode::Value::ComponentCanonMemoryOutOfBounds);
   }
   // The canonical ABI requires a 32-bit linear memory (GAP-CI-1).
   if (HasMemory) {
@@ -1915,12 +1923,12 @@ Validator::validateCanonLift(const AST::Component::Canonical &Canon) noexcept {
     return Unexpect(ErrCode::Value::InvalidTypeReference);
   }
   if (!DT->isFuncType()) {
-    spdlog::error(ErrCode::Value::InvalidTypeReference);
+    spdlog::error(ErrCode::Value::ComponentCanonNotFuncType);
     spdlog::error(
-        "    canon lift: target type index {} does not reference a component func type"sv,
+        "    canon lift: target type index {} is not a function type"sv,
         TypeIdx);
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
-    return Unexpect(ErrCode::Value::InvalidTypeReference);
+    return Unexpect(ErrCode::Value::ComponentCanonNotFuncType);
   }
   // 4. Validate canonical options (Lift site allows all).
   EXPECTED_TRY(validateCanonOptions(Canon.getOpCode(), Canon.getOptions()));

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -1712,7 +1712,8 @@ Expect<void> Validator::validateCanonOptions(
     return Unexpect(ErrCode::Value::InvalidIndex);
   }
   // The `realloc` target must be (func (param i32 i32 i32 i32) (result i32)).
-  // Only checked when the core func's SubType is known; else defer to instantiate.
+  // Only checked when the core func's SubType is known; else defer to
+  // instantiate.
   if (HasRealloc) {
     if (const auto *RT = CompCtx.getCoreFunc(ReallocIdx);
         RT != nullptr && RT->getCompositeType().isFunc()) {
@@ -1731,8 +1732,9 @@ Expect<void> Validator::validateCanonOptions(
       }
       if (!SigOk) {
         spdlog::error(ErrCode::Value::ComponentCanonInvalidOption);
-        spdlog::error("    canonical option `realloc` uses a core function with "
-                      "an incorrect signature"sv);
+        spdlog::error(
+            "    canonical option `realloc` uses a core function with "
+            "an incorrect signature"sv);
         spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
         return Unexpect(ErrCode::Value::ComponentCanonInvalidOption);
       }
@@ -1885,18 +1887,20 @@ Expect<void> checkCanonFlatRules(const ComponentContext &CompCtx,
     PreFlatResults += Sub.size();
   }
 
-  const bool ParamsSpill = PreFlatParams > Executor::CanonicalABI::MaxFlatParams;
+  const bool ParamsSpill =
+      PreFlatParams > Executor::CanonicalABI::MaxFlatParams;
   const bool ResultsSpill =
       PreFlatResults > Executor::CanonicalABI::MaxFlatResults;
 
   // Spec L3290-3296 (lift) / L3519-3524 (lower). `memory` is required if either
   // side has a list/string or spills; `realloc` for the allocating direction
   // (params on lift, results on lower).
-  const bool MemoryRequired = ParamsHaveListOrString || ResultsHaveListOrString ||
-                              ParamsSpill || ResultsSpill;
-  const bool ReallocRequired =
-      IsLift ? (ParamsHaveListOrString || ParamsSpill)
-             : (ResultsHaveListOrString || ResultsSpill);
+  const bool MemoryRequired = ParamsHaveListOrString ||
+                              ResultsHaveListOrString || ParamsSpill ||
+                              ResultsSpill;
+  const bool ReallocRequired = IsLift
+                                   ? (ParamsHaveListOrString || ParamsSpill)
+                                   : (ResultsHaveListOrString || ResultsSpill);
 
   // Check memory before realloc so the reported option matches the spec order.
   if (MemoryRequired && !O.HasMemory) {
@@ -2020,7 +2024,8 @@ Validator::validateCanonLift(const AST::Component::Canonical &Canon) noexcept {
     if (!sameFlatSignature(CalleeSub->getCompositeType().getFuncType(),
                            FlatSig)) {
       spdlog::error(ErrCode::Value::ComponentCanonLoweredTypeMismatch);
-      spdlog::error("    lowered parameter types do not match parameter types"sv);
+      spdlog::error(
+          "    lowered parameter types do not match parameter types"sv);
       spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
       return Unexpect(ErrCode::Value::ComponentCanonLoweredTypeMismatch);
     }

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -437,6 +437,23 @@ Validator::validate(const AST::Component::AliasSection &AliasSec) noexcept {
           }
         }
         NewCoreIdx = CompCtx.addCoreMemory(std::move(SrcMem));
+      } else if (Alias.getTargetType() ==
+                     AST::Component::Alias::TargetType::CoreExport &&
+                 Sort.getCoreSortType() ==
+                     AST::Component::Sort::CoreSortType::Func) {
+        // Carry the source func's SubType into the core:func space so canon
+        // signature checks can run. nullptr if not resolvable.
+        const AST::SubType *SrcFunc = nullptr;
+        const auto SrcIdx = Alias.getExport().first;
+        if (SrcIdx < CompCtx.getCoreSortIndexSize(
+                         AST::Component::Sort::CoreSortType::Instance)) {
+          const auto &Exports = CompCtx.getCoreInstance(SrcIdx);
+          const auto It = Exports.find(std::string(Alias.getExport().second));
+          if (It != Exports.end()) {
+            SrcFunc = It->second.Func;
+          }
+        }
+        NewCoreIdx = CompCtx.addCoreFunc(SrcFunc);
       } else {
         NewCoreIdx = CompCtx.incCoreSortIndexSize(Sort.getCoreSortType());
       }
@@ -844,8 +861,32 @@ Validator::validate(const AST::Component::CoreInstance &Inst) noexcept {
             }
           }
         }
+        // Resolve the exported func's SubType so an alias can thread its
+        // signature into the core:func space for canon signature checks.
+        const AST::SubType *FuncTy = nullptr;
+        if (ExportDesc.getExternalType() == ExternalType::Function) {
+          const uint32_t Target = ExportDesc.getExternalIndex();
+          uint32_t FuncImpCount = 0;
+          for (const auto &Imp : Mod->getImportSection().getContent()) {
+            if (Imp.getExternalType() == ExternalType::Function) {
+              ++FuncImpCount;
+            }
+          }
+          if (Target >= FuncImpCount) {
+            const auto Funcs = Mod->getFunctionSection().getContent();
+            const uint32_t Local = Target - FuncImpCount;
+            if (Local < Funcs.size()) {
+              const uint32_t TypeIdx = Funcs[Local];
+              const auto Types = Mod->getTypeSection().getContent();
+              if (TypeIdx < Types.size()) {
+                FuncTy = &Types[TypeIdx];
+              }
+            }
+          }
+        }
         CompCtx.addCoreInstanceExport(InstanceIdx, ExportDesc.getExternalName(),
-                                      ExportDesc.getExternalType(), MemTy);
+                                      ExportDesc.getExternalType(), MemTy,
+                                      nullptr, nullptr, FuncTy);
       }
     } else if (ModTy != nullptr && ModTy->isModuleType()) {
       for (const auto &Decl : ModTy->getModuleType()) {
@@ -1546,11 +1587,11 @@ Expect<void> Validator::validateCanonOptions(
       break;
     case OptCode::Memory:
       if (HasMemory) {
-        spdlog::error(ErrCode::Value::ComponentCanonDuplicateOption);
+        spdlog::error(ErrCode::Value::ComponentCanonInvalidOption);
         spdlog::error(
             "    canonical option `memory` is specified more than once"sv);
         spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
-        return Unexpect(ErrCode::Value::ComponentCanonDuplicateOption);
+        return Unexpect(ErrCode::Value::ComponentCanonInvalidOption);
       }
       HasMemory = true;
       MemoryIdx = Opt.getIndex();
@@ -1670,6 +1711,33 @@ Expect<void> Validator::validateCanonOptions(
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
     return Unexpect(ErrCode::Value::InvalidIndex);
   }
+  // The `realloc` target must be (func (param i32 i32 i32 i32) (result i32)).
+  // Only checked when the core func's SubType is known; else defer to instantiate.
+  if (HasRealloc) {
+    if (const auto *RT = CompCtx.getCoreFunc(ReallocIdx);
+        RT != nullptr && RT->getCompositeType().isFunc()) {
+      const auto &RFunc = RT->getCompositeType().getFuncType();
+      const auto &RParams = RFunc.getParamTypes();
+      const auto &RResults = RFunc.getReturnTypes();
+      bool SigOk = RParams.size() == 4 && RResults.size() == 1 &&
+                   RResults[0].getCode() == TypeCode::I32;
+      if (SigOk) {
+        for (const auto &P : RParams) {
+          if (P.getCode() != TypeCode::I32) {
+            SigOk = false;
+            break;
+          }
+        }
+      }
+      if (!SigOk) {
+        spdlog::error(ErrCode::Value::ComponentCanonInvalidOption);
+        spdlog::error("    canonical option `realloc` uses a core function with "
+                      "an incorrect signature"sv);
+        spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+        return Unexpect(ErrCode::Value::ComponentCanonInvalidOption);
+      }
+    }
+  }
   if (HasCallback && CallbackIdx >= CoreFuncSpaceSize) {
     spdlog::error(ErrCode::Value::InvalidIndex);
     spdlog::error(
@@ -1784,37 +1852,19 @@ Expect<void> checkCanonFlatRules(const ComponentContext &CompCtx,
                                  const ParsedCanonOpts &O) noexcept {
   Executor::CanonicalABI::CanonCtx Cx = makeValidatorCanonCtx(CompCtx);
 
-  const char *Site = IsLift ? "canon lift" : "canon lower";
-  const bool RequireReallocForList = [&]() {
-    // lift(T) requires realloc if T contains list/string (params);
-    // lower(T) requires realloc if T contains list/string (result).
-    if (IsLift) {
-      for (const auto &P : FT.getParamList()) {
-        if (Executor::CanonicalABI::containsListOrString(Cx, P.getValType())) {
-          return true;
-        }
-      }
-    } else {
-      for (const auto &R : FT.getResultList()) {
-        if (Executor::CanonicalABI::containsListOrString(Cx, R.getValType())) {
-          return true;
-        }
+  // Whether params / results contain any list or string.
+  const bool ParamsHaveListOrString = [&]() {
+    for (const auto &P : FT.getParamList()) {
+      if (Executor::CanonicalABI::containsListOrString(Cx, P.getValType())) {
+        return true;
       }
     }
     return false;
   }();
-  const bool RequireMemoryForList = [&]() {
-    if (IsLift) {
-      for (const auto &R : FT.getResultList()) {
-        if (Executor::CanonicalABI::containsListOrString(Cx, R.getValType())) {
-          return true;
-        }
-      }
-    } else {
-      for (const auto &P : FT.getParamList()) {
-        if (Executor::CanonicalABI::containsListOrString(Cx, P.getValType())) {
-          return true;
-        }
+  const bool ResultsHaveListOrString = [&]() {
+    for (const auto &R : FT.getResultList()) {
+      if (Executor::CanonicalABI::containsListOrString(Cx, R.getValType())) {
+        return true;
       }
     }
     return false;
@@ -1835,49 +1885,31 @@ Expect<void> checkCanonFlatRules(const ComponentContext &CompCtx,
     PreFlatResults += Sub.size();
   }
 
-  // Spec L3293-3294 (lift) / L3520-3521 (lower).
-  if (RequireReallocForList && !O.HasRealloc) {
-    spdlog::error(ErrCode::Value::InvalidCanonOption);
-    spdlog::error(
-        "    {}: 'realloc' is required because {} contains a list / string"sv,
-        Site, IsLift ? "param" : "result");
-    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
-    return Unexpect(ErrCode::Value::InvalidCanonOption);
-  }
-  if (RequireMemoryForList && !O.HasMemory) {
-    spdlog::error(ErrCode::Value::InvalidCanonOption);
-    spdlog::error(
-        "    {}: 'memory' is required because {} contains a list / string"sv,
-        Site, IsLift ? "result" : "param");
-    spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
-    return Unexpect(ErrCode::Value::InvalidCanonOption);
-  }
+  const bool ParamsSpill = PreFlatParams > Executor::CanonicalABI::MaxFlatParams;
+  const bool ResultsSpill =
+      PreFlatResults > Executor::CanonicalABI::MaxFlatResults;
 
-  // Threshold rules (L3295-3296 for lift, L3522-3523 for lower). Sync only —
-  // async would set different caps but is already rejected by flattenFuncType.
-  // For lift: params need realloc to spill, results need memory. For lower
-  // the two swap.
-  const char *ParamsSpillOpt = IsLift ? "realloc" : "memory";
-  const bool ParamsSpillOptPresent = IsLift ? O.HasRealloc : O.HasMemory;
-  const char *ResultsSpillOpt = IsLift ? "memory" : "realloc";
-  const bool ResultsSpillOptPresent = IsLift ? O.HasMemory : O.HasRealloc;
-  if (PreFlatParams > Executor::CanonicalABI::MaxFlatParams &&
-      !ParamsSpillOptPresent) {
-    spdlog::error(ErrCode::Value::InvalidCanonOption);
-    spdlog::error("    {}: param flat count {} exceeds MAX_FLAT_PARAMS, "
-                  "'{}' is required"sv,
-                  Site, PreFlatParams, ParamsSpillOpt);
+  // Spec L3290-3296 (lift) / L3519-3524 (lower). `memory` is required if either
+  // side has a list/string or spills; `realloc` for the allocating direction
+  // (params on lift, results on lower).
+  const bool MemoryRequired = ParamsHaveListOrString || ResultsHaveListOrString ||
+                              ParamsSpill || ResultsSpill;
+  const bool ReallocRequired =
+      IsLift ? (ParamsHaveListOrString || ParamsSpill)
+             : (ResultsHaveListOrString || ResultsSpill);
+
+  // Check memory before realloc so the reported option matches the spec order.
+  if (MemoryRequired && !O.HasMemory) {
+    spdlog::error(ErrCode::Value::ComponentCanonInvalidOption);
+    spdlog::error("    canonical option `memory` is required"sv);
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
-    return Unexpect(ErrCode::Value::InvalidCanonOption);
+    return Unexpect(ErrCode::Value::ComponentCanonInvalidOption);
   }
-  if (PreFlatResults > Executor::CanonicalABI::MaxFlatResults &&
-      !ResultsSpillOptPresent) {
-    spdlog::error(ErrCode::Value::InvalidCanonOption);
-    spdlog::error("    {}: result flat count {} exceeds MAX_FLAT_RESULTS, "
-                  "'{}' is required"sv,
-                  Site, PreFlatResults, ResultsSpillOpt);
+  if (ReallocRequired && !O.HasRealloc) {
+    spdlog::error(ErrCode::Value::ComponentCanonInvalidOption);
+    spdlog::error("    canonical option `realloc` is required"sv);
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
-    return Unexpect(ErrCode::Value::InvalidCanonOption);
+    return Unexpect(ErrCode::Value::ComponentCanonInvalidOption);
   }
   return {};
 }
@@ -1987,11 +2019,10 @@ Validator::validateCanonLift(const AST::Component::Canonical &Canon) noexcept {
       CalleeSub != nullptr && CalleeSub->getCompositeType().isFunc()) {
     if (!sameFlatSignature(CalleeSub->getCompositeType().getFuncType(),
                            FlatSig)) {
-      spdlog::error(ErrCode::Value::InvalidCanonOption);
-      spdlog::error("    canon lift: $callee signature does not match "
-                    "flatten_functype($opts, $ft, 'lift')"sv);
+      spdlog::error(ErrCode::Value::ComponentCanonLoweredTypeMismatch);
+      spdlog::error("    lowered parameter types do not match parameter types"sv);
       spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
-      return Unexpect(ErrCode::Value::InvalidCanonOption);
+      return Unexpect(ErrCode::Value::ComponentCanonLoweredTypeMismatch);
     }
   }
 

--- a/test/component/ComponentValidatorTest.cpp
+++ b/test/component/ComponentValidatorTest.cpp
@@ -1728,6 +1728,209 @@ TEST(ComponentValidatorTest, CanonLift_Valid_Passes) {
   ASSERT_TRUE(V.validate(Comp));
 }
 
+// Append a FuncType with a `string` result (and no params) at the next type
+// index of an existing TypeSection-bearing fixture. Returns the new type index.
+// Lift-flattening such a type requires `memory` (string result must be written
+// out through linear memory).
+inline uint32_t appendStringResultFuncType(AST::Component::Component &Comp) {
+  auto &TypeSec = std::get<AST::Component::TypeSection>(Comp.getSections()[0]);
+  AST::Component::FuncType FT;
+  FT.setResultList(ComponentValType(ComponentTypeCode::String));
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setFuncType(std::move(FT));
+  return static_cast<uint32_t>(TypeSec.getContent().size() - 1);
+}
+
+// Build a component that:
+//   (core module $M (func ...sig...) (export "f" (func 0)))
+//   (core instance $i (instantiate $M))
+//   (alias core export $i "f" (core func))   ;; core func 0
+//   (type ...FuncType at type 0...)
+// so a subsequent `canon lift (core func 0) (type 0)` runs with the aliased
+// core func's real SubType threaded through (exercises the plumbing for
+// adapt.9 / adapt.14-style signature checks). `ParamTys` / `ResultTys` set the
+// exported core func's signature.
+inline AST::Component::Component
+makeCompWithAliasedCoreFunc(const std::vector<TypeCode> &ParamTys,
+                            const std::vector<TypeCode> &ResultTys,
+                            AST::Component::FuncType TargetFT,
+                            bool WithMemory = false) {
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CoreModuleSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CoreInstanceSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::AliasSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CanonSection>();
+
+  // type 0: the component FuncType the lift targets.
+  auto &TypeSec = std::get<AST::Component::TypeSection>(Comp.getSections()[0]);
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setFuncType(std::move(TargetFT));
+
+  // Core module $M: one local func of the given signature, exported as "f",
+  // and (optionally) a memory exported as "m".
+  auto &ModSec =
+      std::get<AST::Component::CoreModuleSection>(Comp.getSections()[1]);
+  auto &Mod = ModSec.getContent();
+  AST::FunctionType CoreFT;
+  for (auto C : ParamTys) {
+    CoreFT.getParamTypes().emplace_back(C);
+  }
+  for (auto C : ResultTys) {
+    CoreFT.getReturnTypes().emplace_back(C);
+  }
+  AST::SubType ST;
+  ST.getCompositeType().setFunctionType(std::move(CoreFT));
+  Mod.getTypeSection().getContent().push_back(std::move(ST));
+  Mod.getFunctionSection().getContent().push_back(0U); // local func 0 : type 0
+  {
+    AST::ExportDesc ED;
+    ED.setExternalName("f");
+    ED.setExternalType(ExternalType::Function);
+    ED.setExternalIndex(0); // func 0
+    Mod.getExportSection().getContent().push_back(std::move(ED));
+  }
+  if (WithMemory) {
+    AST::MemoryType MT;
+    Mod.getMemorySection().getContent().push_back(MT);
+    AST::ExportDesc ED;
+    ED.setExternalName("m");
+    ED.setExternalType(ExternalType::Memory);
+    ED.setExternalIndex(0); // memory 0
+    Mod.getExportSection().getContent().push_back(std::move(ED));
+  }
+
+  // Core instance: instantiate module 0.
+  auto &CoreInstSec =
+      std::get<AST::Component::CoreInstanceSection>(Comp.getSections()[2]);
+  CoreInstSec.getContent().emplace_back();
+  CoreInstSec.getContent().back().setInstantiateArgs(
+      0U, AST::Component::CoreInstance::InstantiateArgs{});
+
+  // Alias core:export 0 "f" -> core func 0, then (optionally) "m" -> core
+  // memory 0. Both precede the canon section so they are in scope for it.
+  auto &AliasSec =
+      std::get<AST::Component::AliasSection>(Comp.getSections()[3]);
+  {
+    AliasSec.getContent().emplace_back();
+    auto &A = AliasSec.getContent().back();
+    A.setTargetType(AST::Component::Alias::TargetType::CoreExport);
+    A.getSort().setIsCore(true);
+    A.getSort().setCoreSortType(AST::Component::Sort::CoreSortType::Func);
+    A.setExport(0U, "f");
+  }
+  if (WithMemory) {
+    AliasSec.getContent().emplace_back();
+    auto &A = AliasSec.getContent().back();
+    A.setTargetType(AST::Component::Alias::TargetType::CoreExport);
+    A.getSort().setIsCore(true);
+    A.getSort().setCoreSortType(AST::Component::Sort::CoreSortType::Memory);
+    A.setExport(0U, "m");
+  }
+
+  return Comp;
+}
+
+TEST(ComponentValidatorTest, CanonLift_MemoryRequiredForStringResult_Fails) {
+  // (canon lift (core func 0) (type 2)) where type 2 has a `string` result and
+  // no `memory` option -> reject with ComponentCanonInvalidOption (0x2c5).
+  auto Comp = makeCompWithCoreFuncAndFuncType();
+  const uint32_t StrTy = appendStringResultFuncType(Comp);
+  auto &CanonSec =
+      std::get<AST::Component::CanonSection>(Comp.getSections().back());
+  AST::Component::Canonical Lift;
+  Lift.setOpCode(ComponentCanonOpCode::Lift);
+  Lift.setIndex(0); // core func 0
+  Lift.setTargetIndex(StrTy);
+  CanonSec.getContent().emplace_back(std::move(Lift));
+  Validator::Validator V(Conf);
+  auto Res = V.validate(Comp);
+  ASSERT_FALSE(Res);
+  EXPECT_EQ(Res.error(), ErrCode::Value::ComponentCanonInvalidOption);
+}
+
+TEST(ComponentValidatorTest, CanonLift_ReallocRequiredForStringParam_Fails) {
+  // canon lift of a func type with a `string` param, with `memory` present but
+  // `realloc` missing -> reject with ComponentCanonInvalidOption (0x2c5). The
+  // aliased core memory makes `(memory 0)` in-bounds so the realloc-required
+  // rule is what fires.
+  AST::Component::FuncType TargetFT;
+  std::vector<AST::Component::LabelValType> Params;
+  Params.emplace_back("p", ComponentValType(ComponentTypeCode::String));
+  TargetFT.setParamList(std::move(Params));
+  // Core func signature is irrelevant to the realloc-required check (it runs
+  // before the callee-signature check); give it [i32] -> [i32].
+  auto Comp = makeCompWithAliasedCoreFunc(
+      /*ParamTys=*/{TypeCode::I32}, /*ResultTys=*/{TypeCode::I32},
+      std::move(TargetFT), /*WithMemory=*/true);
+  auto &CanonSec =
+      std::get<AST::Component::CanonSection>(Comp.getSections().back());
+  AST::Component::Canonical Lift;
+  Lift.setOpCode(ComponentCanonOpCode::Lift);
+  Lift.setIndex(0);       // core func 0 = aliased func
+  Lift.setTargetIndex(0); // type 0 = (param string)
+  Lift.setOptions({mkOpt(ComponentCanonOptCode::Memory, 0)});
+  CanonSec.getContent().emplace_back(std::move(Lift));
+  Validator::Validator V(Conf);
+  auto Res = V.validate(Comp);
+  ASSERT_FALSE(Res);
+  EXPECT_EQ(Res.error(), ErrCode::Value::ComponentCanonInvalidOption);
+}
+
+TEST(ComponentValidatorTest, CanonOptions_ReallocWrongSignature_Fails) {
+  // realloc must be (func (param i32 i32 i32 i32) (result i32)). The aliased
+  // core func has the wrong signature ([i32] -> [i32]); pointing `realloc` at
+  // it (core func 0) -> reject with ComponentCanonInvalidOption (0x2c5). The
+  // target func type carries a `string` param so `memory`/`realloc` are
+  // legitimately requested.
+  AST::Component::FuncType TargetFT;
+  std::vector<AST::Component::LabelValType> Params;
+  Params.emplace_back("p", ComponentValType(ComponentTypeCode::String));
+  TargetFT.setParamList(std::move(Params));
+  auto Comp = makeCompWithAliasedCoreFunc(
+      /*ParamTys=*/{TypeCode::I32}, /*ResultTys=*/{TypeCode::I32},
+      std::move(TargetFT), /*WithMemory=*/true);
+  auto &CanonSec =
+      std::get<AST::Component::CanonSection>(Comp.getSections().back());
+  AST::Component::Canonical Lift;
+  Lift.setOpCode(ComponentCanonOpCode::Lift);
+  Lift.setIndex(0);       // core func 0 = aliased wrong-sig func
+  Lift.setTargetIndex(0); // type 0 = (param string)
+  Lift.setOptions({mkOpt(ComponentCanonOptCode::Memory, 0),
+                   mkOpt(ComponentCanonOptCode::Realloc, 0)});
+  CanonSec.getContent().emplace_back(std::move(Lift));
+  Validator::Validator V(Conf);
+  auto Res = V.validate(Comp);
+  ASSERT_FALSE(Res);
+  EXPECT_EQ(Res.error(), ErrCode::Value::ComponentCanonInvalidOption);
+}
+
+TEST(ComponentValidatorTest, CanonLift_CalleeSignatureMismatch_Fails) {
+  // The aliased core func has signature [i32] -> [], but the target FuncType
+  // (no params, no results) lift-flattens to [] -> []. The callee signature
+  // therefore does not match flatten_functype($opts, $ft, 'lift') -> reject
+  // with ComponentCanonLoweredTypeMismatch (0x2c6).
+  AST::Component::FuncType TargetFT; // empty: [] -> []
+  auto Comp = makeCompWithAliasedCoreFunc(
+      /*ParamTys=*/{TypeCode::I32}, /*ResultTys=*/{}, std::move(TargetFT));
+  auto &CanonSec =
+      std::get<AST::Component::CanonSection>(Comp.getSections().back());
+  AST::Component::Canonical Lift;
+  Lift.setOpCode(ComponentCanonOpCode::Lift);
+  Lift.setIndex(0);       // core func 0 = aliased [i32] -> [] func
+  Lift.setTargetIndex(0); // type 0 = empty func type
+  CanonSec.getContent().emplace_back(std::move(Lift));
+  Validator::Validator V(Conf);
+  auto Res = V.validate(Comp);
+  ASSERT_FALSE(Res);
+  EXPECT_EQ(Res.error(), ErrCode::Value::ComponentCanonLoweredTypeMismatch);
+}
+
 TEST(ComponentValidatorTest, CanonLift_WithPostReturn_Passes) {
   // post-return is a Lift-only option; exercise the happy path. Target type 1
   // lift-flattens to [i32] -> [i32], so spec L3564 requires post-return to have

--- a/test/component/ComponentValidatorTest.cpp
+++ b/test/component/ComponentValidatorTest.cpp
@@ -1498,6 +1498,69 @@ TEST(ComponentValidatorTest, CanonResourceDrop_TypeIndexOutOfBounds_Fails) {
   ASSERT_FALSE(V.validate(Comp));
 }
 
+// Canonical option validation (string-encoding / memory / lift target).
+
+TEST(ComponentValidatorTest, CanonOptionsStringEncodingConflictRejected) {
+  // (canon lower (func 0) string-encoding=utf8 string-encoding=utf16) -> reject
+  auto Comp = makeCompWithImportedFunc();
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(ComponentCanonOpCode::Lower);
+  C.setIndex(0);
+  C.setOptions({mkOpt(ComponentCanonOptCode::Encode_UTF8),
+                mkOpt(ComponentCanonOptCode::Encode_UTF16)});
+  CanonSec.getContent().emplace_back(std::move(C));
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonOptionsDuplicateMemoryRejected) {
+  // (canon lower (func 0) (memory 0) (memory 0)) -> reject (option specified
+  // more than once)
+  auto Comp = makeCompWithImportedFunc();
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(ComponentCanonOpCode::Lower);
+  C.setIndex(0);
+  C.setOptions({mkOpt(ComponentCanonOptCode::Memory, 0),
+                mkOpt(ComponentCanonOptCode::Memory, 0)});
+  CanonSec.getContent().emplace_back(std::move(C));
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonOptionsMemoryIndexOutOfBoundsRejected) {
+  // (canon lower (func 0) (memory 0)) with no core memory in scope -> reject
+  auto Comp = makeCompWithImportedFunc();
+  auto &CanonSec = appendCanonSection(Comp);
+  AST::Component::Canonical C;
+  C.setOpCode(ComponentCanonOpCode::Lower);
+  C.setIndex(0);
+  C.setOptions({mkOpt(ComponentCanonOptCode::Memory, 0)});
+  CanonSec.getContent().emplace_back(std::move(C));
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CanonLiftTargetNotFuncTypeRejected) {
+  // (canon lift (core func 0) (type 0)) where type 0 is a resource, not a
+  // function type -> reject.
+  auto Comp = makeCompWithCoreFuncAndFuncType();
+  auto &CanonSec =
+      std::get<AST::Component::CanonSection>(Comp.getSections().back());
+  AST::Component::Canonical C;
+  C.setOpCode(ComponentCanonOpCode::Lift);
+  C.setIndex(0);       // core func 0 (allocated by resource.new)
+  C.setTargetIndex(0); // type 0 = resource, not a function type
+  CanonSec.getContent().emplace_back(std::move(C));
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
 TEST(ComponentValidatorTest, CanonResourceDropAsync_OnLocalResource_Passes) {
   auto Comp = makeCompWithLocalResource();
   auto &CanonSec = appendCanonSection(Comp);


### PR DESCRIPTION
Adds validation for the canonical options on component canon lift / canon lower, replacing the generic errors produced before with proper validation-phase ones:

a second string-encoding option is rejected as a conflict
a memory option whose index is past the core memory space is rejected as out-of-bounds
a duplicate memory option is rejected
a canon lift whose target type isn't a function type is reported as such
Each check has a unit test in ComponentValidatorTest.cpp.

These are the option-level checks for the component-model adapt spec folder. I've left the folder disabled on purpose: the rest of adapt depends on canonical-ABI signature validation realloc/post-return signatures and lowered-result matching, the flat_lifted / flatten_functype work currently marked deferred in the code. That's a larger, self-contained piece, so it's coming as a follow-up PR (phase 2), which is where the adapt folder gets enabled and exercises all of this end-to-end.

No change for valid components; all existing tests pass.