### PR TITLE
fix(OSS-Fuzz): add the missing PropComponent in the driver fuzzer

### DIFF
--- a/lib/driver/fuzzPO.cpp
+++ b/lib/driver/fuzzPO.cpp
@@ -178,6 +178,8 @@ int FuzzPO(const uint8_t *Data, size_t Size) noexcept {
   //     PO::Description("Disable Memory64 proposal"sv));
   PO::Option<PO::Toggle> PropThreads(
       PO::Description("Enable Threads proposal"sv));
+  PO::Option<PO::Toggle> PropComponent(PO::Description(
+      "Enable Component Model proposal, this is experimental"sv));
   PO::Option<PO::Toggle> PropAll(PO::Description("Enable all features"sv));
 
   PO::Option<PO::Toggle> ConfEnableInstructionCounting(PO::Description(


### PR DESCRIPTION
This PR adds the missing PropComponent that cause OSS-Fuzz fuzzing build failing.