### PR TITLE
ci: add fuzzer build to Ubuntu CI matrix

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -87,7 +87,7 @@ filter.
 
 | Workflow | What it does | If it fails |
 | -------- | ------------ | ----------- |
-| **Core** (`build.yml`) | The main build: clang-format gate, then build and unit tests across macOS, manylinux, Ubuntu (gcc/clang x Debug/Release), Windows (+MSVC), Android, Fedora, Debian, and Alpine (static). Its Ubuntu coverage job also produces the **CodeCov** report. | Fix the build or unit-test failure on the reported platform. |
+| **Core** (`build.yml`) | The main build: clang-format gate, then build and unit tests across macOS, manylinux, Ubuntu (gcc/clang x Debug/Release), Windows (+MSVC), Android, Fedora, Debian, and Alpine (static). Its Ubuntu matrix also includes single-environment coverage and fuzzer-build checks; coverage uploads the **CodeCov** report. | Fix the build or unit-test failure on the reported platform. |
 | **Extensions** (`build-extensions.yml`) | Also triggered by shared build paths such as `thirdparty/`, `tools/`, `cmake/`, and `CMakeLists.txt`; plugin matrix scope still follows the Extensions path filter. | Investigate like any triggered check; for failures clearly unrelated to your shared change, follow [Interpreting failures](#interpreting-failures). |
 | **CodeQL** (`codeql-analysis.yml`) | Security analysis of C/C++ sources (excludes `docs/`, `.github/`, `utils/`); also runs weekly. | Address the flagged security finding. |
 | **IWYU checker** (`IWYU_scan.yml`) | Include-what-you-use scan on Fedora and macOS; reports header suggestions as logs/artifacts. | Review the log and tidy includes where applicable. |
@@ -159,7 +159,7 @@ workflows are called by the entries below and are not listed here; see
 
 | Name | File | Triggers (events, branches, paths) | Notes |
 | ---- | ---- | ---------------------------------- | ----- |
-| Core | `build.yml` | `push` (`master`, `X.Y.x`), `pull_request` (`master`, `proposal/**`, `X.Y.x`); paths: core build workflows, `include/`, `lib/`, `test/` (not `test/plugins/`), `utils/docker/*static*`, `thirdparty/`, `tools/`, `cmake/`, `CMakeLists.txt` | clang-format gate, then cross-platform build/test; coverage job uploads CodeCov |
+| Core | `build.yml` | `push` (`master`, `X.Y.x`), `pull_request` (`master`, `proposal/**`, `X.Y.x`); paths: core build workflows, `include/`, `lib/`, `test/` (not `test/plugins/`), `utils/docker/*static*`, `thirdparty/`, `tools/`, `cmake/`, `CMakeLists.txt` | clang-format gate, then cross-platform build/test; Ubuntu matrix includes coverage upload and fuzzer build |
 | Extensions | `build-extensions.yml` | same events/branches as Core; paths: extension build workflows + config, `plugins/`, `test/plugins/`, `thirdparty/`, `tools/`, `cmake/`, `CMakeLists.txt` | clang-format gate; always runs WASI-NN GGML RPC + Windows WASI-NN jobs; path-filters the plugin build matrix |
 | Commit Lint | `commitlint.yml` | `pull_request` (opened/synchronize/reopened/edited); no path filter | validates commit messages + PR title |
 | Misc linters | `misc-linters.yml` | `push`, `pull_request`; no path filter | codespell + lineguard |
@@ -225,7 +225,8 @@ Some required checks are not `.yml` workflows in this directory:
 | manylinux_2_28 | aarch64 | gcc | `manylinux_2_28_aarch64` | o | o |
 | Ubuntu 24.04 | x86_64 | clang | `ubuntu-24.04-build-clang` | o ||
 | Ubuntu 24.04 | x86_64 | gcc | `ubuntu-24.04-build-gcc` | o ||
-| Ubuntu 22.04 | x86_64 | gcc | `ubuntu-22.04-build-gcc` | coverage ||
+| Ubuntu 24.04 | x86_64 | clang | `ubuntu-24.04-build-clang` | fuzzer build ||
+| Ubuntu 24.04 | x86_64 | gcc | `ubuntu-24.04-build-gcc` | coverage ||
 | Ubuntu 20.04 | x86_64 | clang | `ubuntu-20.04-build-clang` | o | o |
 | Ubuntu 20.04 | aarch64 | clang | `ubuntu-20.04-build-clang-aarch64` | o | o |
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,8 @@ jobs:
                 {'name':'ubuntu-20.04','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-20.04-build-clang','tests':true},
                 {'name':'ubuntu-20.04','arch':'aarch64','runner':'ubuntu-24.04-arm','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-20.04-build-clang-aarch64','tests':true},
                 {'name':'linux-static','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Release','docker_tag':'ubuntu-24.04-build-clang','options':'-DWASMEDGE_BUILD_SHARED_LIB=Off -DWASMEDGE_BUILD_STATIC_LIB=On -DWASMEDGE_LINK_TOOLS_STATIC=On -DWASMEDGE_BUILD_PLUGINS=Off'},
-                {'name':'ubuntu-22.04-coverage','arch':'x86_64','runner':'ubuntu-latest','compiler':'g++','build_type':'Debug','docker_tag':'ubuntu-22.04-build-gcc','coverage':true,'tests':true}]"
+                {'name':'ubuntu-24.04-fuzzer','arch':'x86_64','runner':'ubuntu-latest','compiler':'clang++','build_type':'Debug','docker_tag':'ubuntu-24.04-build-clang','fuzzing':true},
+                {'name':'ubuntu-24.04-coverage','arch':'x86_64','runner':'ubuntu-latest','compiler':'g++','build_type':'Debug','docker_tag':'ubuntu-24.04-build-gcc','coverage':true,'tests':true}]"
 
   build_on_windows:
     permissions:

--- a/.github/workflows/reusable-build-on-ubuntu.yml
+++ b/.github/workflows/reusable-build-on-ubuntu.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           git config --global --add safe.directory $(pwd)
       - name: Build (${{ matrix.compiler }}, ${{ matrix.build_type }})
-        if: ${{ !matrix.coverage }}
+        if: ${{ !matrix.coverage && !matrix.fuzzing }}
         shell: bash
         env:
           CMAKE_BUILD_TYPE: ${{ matrix.build_type }}
@@ -68,8 +68,17 @@ jobs:
           fi
           cmake --build build
           cmake --build build --target package
+      - name: Build fuzzer (${{ matrix.compiler }}, ${{ matrix.build_type }})
+        if: ${{ matrix.fuzzing }}
+        shell: bash
+        env:
+          CMAKE_BUILD_TYPE: ${{ matrix.build_type }}
+        run: |
+          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" -DWASMEDGE_LINK_LLVM_STATIC=ON -DWASMEDGE_BUILD_FUZZING=ON -DWASMEDGE_BUILD_TOOLS=OFF .
+          cmake --build build --target wasmedge-fuzzpo
+          cmake --build build --target wasmedge-fuzztool
       - name: Test
-        if: ${{ !matrix.coverage && matrix.tests }}
+        if: ${{ !matrix.coverage && !matrix.fuzzing && matrix.tests }}
         run: |
           export LD_LIBRARY_PATH="$(pwd)/build/lib/api:$LD_LIBRARY_PATH"
           cd build
@@ -77,13 +86,13 @@ jobs:
           ctest
           cd -
       - name: Install wasm-tools
-        if: ${{ !matrix.coverage && matrix.tests }}
+        if: ${{ !matrix.coverage && !matrix.fuzzing && matrix.tests }}
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           source "$HOME/.cargo/env"
           cargo install wasm-tools@1.245.1
       - name: Component Fuzz Test
-        if: ${{ !matrix.coverage && matrix.tests }}
+        if: ${{ !matrix.coverage && !matrix.fuzzing && matrix.tests }}
         env:
           FUZZ_ITERATION_COUNT: 100
         run: |
@@ -91,7 +100,7 @@ jobs:
           export LD_LIBRARY_PATH="$(pwd)/build/lib/api:$LD_LIBRARY_PATH"
           bash test/component/fuzzing/run_fuzz.sh ./build/test/component/fuzzing/wasmedgeComponentFuzzTest
       - name: Check symbol exposure
-        if: ${{ !matrix.coverage }}
+        if: ${{ !matrix.coverage && !matrix.fuzzing }}
         run: |
           bash .github/scripts/check_symbols.sh
       - name: Build (${{ matrix.compiler }}, Coverage)
@@ -103,7 +112,7 @@ jobs:
           cmake --build build
           LD_LIBRARY_PATH=$(pwd)/build/lib/api cmake --build build --target codecov
       - name: Upload artifact
-        if: ${{ !inputs.release && !matrix.coverage }}
+        if: ${{ !inputs.release && !matrix.coverage && !matrix.fuzzing }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: WasmEdge-${{ inputs.version }}-${{ matrix.name }}-${{ matrix.compiler }}-${{ matrix.build_type }}-${{ matrix.arch }}.tar.gz


### PR DESCRIPTION
## Description

Follow-up to #5035. Add a dedicated Ubuntu CI matrix entry that configures WASMEDGE_BUILD_FUZZING=ON and builds the fuzzer targets.

Also move the coverage job to the Ubuntu 24.04 GCC image and update the workflow README to document the new Ubuntu matrix entries.

Assisted-by: OpenAI Codex

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

Local fuzzer build passed on macOS arm64 with Homebrew clang/LLVM 22.1.7.

```console
$ cmake -S . -B /private/tmp/wasmedge-fuzzer-build-homebrew-clang -GNinja \
  -DCMAKE_BUILD_TYPE=Debug \
  -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang \
  -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
  -DLLVM_DIR=/opt/homebrew/opt/llvm/lib/cmake/llvm \
  -DLLD_DIR=/opt/homebrew/opt/lld/lib/cmake/lld \
  -DWASMEDGE_LINK_LLVM_STATIC=OFF \
  -DWASMEDGE_BUILD_FUZZING=ON \
  -DWASMEDGE_BUILD_TOOLS=OFF

-- The CXX compiler identification is Clang 22.1.7
-- The C compiler identification is Clang 22.1.7
-- Configuring done
-- Generating done
-- Build files have been written to: /private/tmp/wasmedge-fuzzer-build-homebrew-clang

$ cmake --build /private/tmp/wasmedge-fuzzer-build-homebrew-clang \
  --target wasmedge-fuzzpo wasmedge-fuzztool --parallel 8

[129/134] Linking CXX shared library lib/api/libwasmedge.0.1.1.dylib
[130/134] Creating library symlink lib/api/libwasmedge.0.dylib lib/api/libwasmedge.dylib
[131/134] Creating text-based stubs lib/api/libwasmedge.0.1.1.tbd
[132/134] Creating import library symlink lib/api/libwasmedge.0.tbd lib/api/libwasmedge.tbd
[133/134] Linking CXX executable tools/fuzz/wasmedge-fuzzpo
[134/134] Linking CXX executable tools/fuzz/wasmedge-fuzztool

$ ls -lh /private/tmp/wasmedge-fuzzer-build-homebrew-clang/tools/fuzz/wasmedge-fuzzpo \
  /private/tmp/wasmedge-fuzzer-build-homebrew-clang/tools/fuzz/wasmedge-fuzztool

-rwxr-xr-x  1 hydai  wheel   413K Jun 19 05:00 /private/tmp/wasmedge-fuzzer-build-homebrew-clang/tools/fuzz/wasmedge-fuzzpo
-rwxr-xr-x  1 hydai  wheel   413K Jun 19 05:00 /private/tmp/wasmedge-fuzzer-build-homebrew-clang/tools/fuzz/wasmedge-fuzztool
```

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
