### PR TITLE
feat(validator): enable nested-modules tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ on:
     branches:
       - master
       - "proposal/**"
+      - "dev/component"
     paths:
       - ".github/workflows/build.yml"
       - ".github/workflows/reusable-build-on-**"

--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1132,6 +1132,12 @@ E(ComponentImportNameConflict, 0x02B8,
 E(ComponentUnknownExport, 0x02B9, "unknown export")
 // Core type index referenced in a component core:moduledecl is out of bounds
 E(CoreTypeIndexOutOfBounds, 0x02BA, "type index out of bounds")
+// Core instance arg memory index type does not match the import (i32 vs i64)
+E(ComponentMemoryIndexTypeMismatch, 0x02BB,
+  "mismatch in index type used for memories")
+// Canonical option `memory` must reference a 32-bit linear memory
+E(ComponentCanonMemoryNot32Bit, 0x02BC,
+  "canonical ABI memory is not a 32-bit linear memory")
 // @}
 
 // Instantiation phase

--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1130,6 +1130,8 @@ E(ComponentImportNameConflict, 0x02B8,
   "import name conflicts with previous name")
 // Component alias references an export the instance does not provide
 E(ComponentUnknownExport, 0x02B9, "unknown export")
+// Core type index referenced in a component core:moduledecl is out of bounds
+E(CoreTypeIndexOutOfBounds, 0x02BA, "type index out of bounds")
 // @}
 
 // Instantiation phase

--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1120,6 +1120,16 @@ E(InvalidExportName, 0x02B3, "not a valid export name")
 E(InvalidExternName, 0x02B4, "not a valid extern name")
 // Core tag referenced by a core-export alias or inline-export does not exist
 E(UnknownCoreTag, 0x02B5, "unknown tag")
+// Component name label is not in kebab case
+E(ComponentNameNotKebab, 0x02B6, "not in kebab case")
+// Component package name/namespace is not lowercase
+E(ComponentPackageNameNotLowercase, 0x02B7,
+  "not lowercase in package name/namespace")
+// Component import name conflicts with a previous import name
+E(ComponentImportNameConflict, 0x02B8,
+  "import name conflicts with previous name")
+// Component alias references an export the instance does not provide
+E(ComponentUnknownExport, 0x02B9, "unknown export")
 // @}
 
 // Instantiation phase

--- a/include/validator/component_context.h
+++ b/include/validator/component_context.h
@@ -57,6 +57,8 @@ public:
       const AST::Component::InstanceType *IT;
       std::optional<uint32_t> NestedInstIdx;
       std::optional<uint64_t> ResourceId;
+      // Set when this export is a `(core module)`; ST is unused then.
+      bool IsCoreModule = false;
     };
     // Instance slot. Type is set only when bound via
     // validate(ExternDesc::InstanceType) (GAP-I-5b follow-up otherwise).
@@ -417,6 +419,14 @@ public:
       std::optional<uint64_t> ResourceId = std::nullopt) noexcept {
     getCurrentContext().Instances.at(InstIdx).Exports[std::string(Name)] = {
         ST, IT, NestedInstIdx, ResourceId};
+  }
+
+  // Record a `(core module)` export so a later `alias export` can resolve it.
+  void addCoreModuleInstanceExport(uint32_t InstIdx,
+                                   std::string_view Name) noexcept {
+    getCurrentContext().Instances.at(InstIdx).Exports[std::string(Name)] =
+        InstanceExport{AST::Component::Sort::SortType::Max, nullptr,
+                       std::nullopt, std::nullopt, /*IsCoreModule=*/true};
   }
 
   // ==========================================================================

--- a/include/validator/component_context.h
+++ b/include/validator/component_context.h
@@ -74,6 +74,13 @@ public:
       // True for validate(DefType) in this scope. Gates resource.new/.rep.
       bool LocallyDefined = false;
     };
+    // Export of a core:instance. Kind is always set; Mem is populated for
+    // memory exports so instantiation can subtype-check the index type
+    // (GAP-CI-1).
+    struct CoreInstanceExport {
+      ExternalType Kind;
+      const AST::MemoryType *Mem = nullptr;
+    };
 
     // ---- Scope identity ----
     const AST::Component::Component *Component;
@@ -81,7 +88,7 @@ public:
 
     // ---- Core sort index spaces ----
     std::vector<CoreModuleSlot> CoreModules; // core:module
-    std::vector<std::unordered_map<std::string, ExternalType>>
+    std::vector<std::unordered_map<std::string, CoreInstanceExport>>
         CoreInstances;                                 // core:instance
     std::vector<const AST::SubType *> CoreTypes;       // core:type
     std::vector<const AST::SubType *> CoreFuncs;       // core:func
@@ -243,14 +250,16 @@ public:
     return Idx;
   }
 
-  const std::unordered_map<std::string, ExternalType> &
+  const std::unordered_map<std::string, Context::CoreInstanceExport> &
   getCoreInstance(uint32_t Idx) const noexcept {
     return getCurrentContext().CoreInstances.at(Idx);
   }
 
   void addCoreInstanceExport(uint32_t InstIdx, std::string_view Name,
-                             ExternalType ET) {
-    getCurrentContext().CoreInstances.at(InstIdx)[std::string(Name)] = ET;
+                             ExternalType ET,
+                             const AST::MemoryType *Mem = nullptr) {
+    getCurrentContext().CoreInstances.at(InstIdx)[std::string(Name)] =
+        Context::CoreInstanceExport{ET, Mem};
   }
 
   // ==========================================================================
@@ -285,6 +294,10 @@ public:
     uint32_t Idx = static_cast<uint32_t>(V.size());
     V.push_back(MT);
     return Idx;
+  }
+  const AST::MemoryType *getCoreMemory(uint32_t Idx) const noexcept {
+    const auto &V = getCurrentContext().CoreMemories;
+    return Idx < V.size() ? V[Idx] : nullptr;
   }
   uint32_t addCoreGlobal(const AST::GlobalType *GT = nullptr) noexcept {
     auto &V = getCurrentContext().CoreGlobals;

--- a/lib/validator/component_name.cpp
+++ b/lib/validator/component_name.cpp
@@ -316,16 +316,24 @@ Expect<PkgPath> parsePkgPath(std::string_view &Next,
   std::string_view Namespace;
   if (!readUntil(Next, ':', Namespace))
     return reportError("expected ':' in namespace"sv);
-  if (!isLowercaseKebabString(Namespace))
-    return reportError("invalid namespace"sv);
+  if (!isLowercaseKebabString(Namespace)) {
+    spdlog::error(ErrCode::Value::ComponentPackageNameNotLowercase);
+    spdlog::error("    Component name: namespace '{}' is not lowercase"sv,
+                  Namespace);
+    return Unexpect(ErrCode::Value::ComponentPackageNameNotLowercase);
+  }
 
   size_t PkgEnd = Next.find_first_of(StopChars);
   if (PkgEnd == Next.npos)
     return reportError("unterminated package name"sv);
   std::string_view Package = Next.substr(0, PkgEnd);
   Next.remove_prefix(PkgEnd);
-  if (!isLowercaseKebabString(Package))
-    return reportError("invalid package name"sv);
+  if (!isLowercaseKebabString(Package)) {
+    spdlog::error(ErrCode::Value::ComponentPackageNameNotLowercase);
+    spdlog::error("    Component name: package '{}' is not lowercase"sv,
+                  Package);
+    return Unexpect(ErrCode::Value::ComponentPackageNameNotLowercase);
+  }
 
   return PkgPath{Namespace, Package};
 }
@@ -570,7 +578,10 @@ Expect<ComponentName> ComponentName::parse(std::string_view Name) {
     while (readUntil(Next, ':', Namespace)) {
       Counter++;
       if (!isLowercaseKebabString(Namespace)) {
-        return reportError("invalid namespace in interface name"sv);
+        spdlog::error(ErrCode::Value::ComponentPackageNameNotLowercase);
+        spdlog::error("    Component name: namespace '{}' is not lowercase"sv,
+                      Namespace);
+        return Unexpect(ErrCode::Value::ComponentPackageNameNotLowercase);
       }
     }
     if (Counter == 0) {
@@ -583,7 +594,10 @@ Expect<ComponentName> ComponentName::parse(std::string_view Name) {
 
     // interfacename ::= <namespace> <words> <projection> ...
     if (!tryReadKebab(Next, Package) || !isLowercaseKebabString(Package)) {
-      return reportError("invalid package in interface name"sv);
+      spdlog::error(ErrCode::Value::ComponentPackageNameNotLowercase);
+      spdlog::error("    Component name: package '{}' is not lowercase"sv,
+                    Package);
+      return Unexpect(ErrCode::Value::ComponentPackageNameNotLowercase);
     }
 
     Counter = 0;
@@ -618,7 +632,10 @@ Expect<ComponentName> ComponentName::parse(std::string_view Name) {
 
 ParseLabel:
   if (!isKebabString(Next)) {
-    return reportError("invalid label"sv);
+    spdlog::error(ErrCode::Value::ComponentNameNotKebab);
+    spdlog::error("    Component name: label '{}' is not in kebab case"sv,
+                  Next);
+    return Unexpect(ErrCode::Value::ComponentNameNotKebab);
   }
   Result.Detail.emplace<LabelDetail>();
   Result.Kind = ComponentNameKind::Label;

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -405,8 +405,28 @@ Validator::validate(const AST::Component::AliasSection &AliasSec) noexcept {
     const bool IsOuter =
         Alias.getTargetType() == AST::Component::Alias::TargetType::Outer;
     if (Sort.isCore()) {
-      uint32_t NewCoreIdx =
-          CompCtx.incCoreSortIndexSize(Sort.getCoreSortType());
+      uint32_t NewCoreIdx;
+      // For an `alias core export` of a memory, carry the source memory's type
+      // into the core-memory sort space so canonical options can subtype-check
+      // its index type later (GAP-CI-1).
+      if (Alias.getTargetType() ==
+              AST::Component::Alias::TargetType::CoreExport &&
+          Sort.getCoreSortType() ==
+              AST::Component::Sort::CoreSortType::Memory) {
+        const AST::MemoryType *SrcMem = nullptr;
+        const auto SrcIdx = Alias.getExport().first;
+        if (SrcIdx < CompCtx.getCoreSortIndexSize(
+                         AST::Component::Sort::CoreSortType::Instance)) {
+          const auto &Exports = CompCtx.getCoreInstance(SrcIdx);
+          const auto It = Exports.find(std::string(Alias.getExport().second));
+          if (It != Exports.end()) {
+            SrcMem = It->second.Mem;
+          }
+        }
+        NewCoreIdx = CompCtx.addCoreMemory(SrcMem);
+      } else {
+        NewCoreIdx = CompCtx.incCoreSortIndexSize(Sort.getCoreSortType());
+      }
       // Carry the outer-aliased module's slot so the alias stays enumerable
       // when instantiated.
       if (IsOuter && Sort.getCoreSortType() ==
@@ -654,12 +674,73 @@ Validator::validate(const AST::Component::CoreInstance &Inst) noexcept {
       }
     }
 
+    // GAP-CI-1: the index type (i32/i64) of each provided memory must match
+    // the corresponding memory import of the instantiated module.
+    if (Mod != nullptr) {
+      const uint32_t InstCount = CompCtx.getCoreSortIndexSize(
+          AST::Component::Sort::CoreSortType::Instance);
+      for (const auto &Import : Mod->getImportSection().getContent()) {
+        if (Import.getExternalType() != ExternalType::Memory) {
+          continue;
+        }
+        const auto ArgIt =
+            std::find_if(Args.begin(), Args.end(), [&](const auto &Arg) {
+              return Arg.getName() == Import.getModuleName();
+            });
+        if (ArgIt == Args.end() || ArgIt->getIndex() >= InstCount) {
+          continue;
+        }
+        const auto &ProvExports = CompCtx.getCoreInstance(ArgIt->getIndex());
+        const auto ExpIt =
+            ProvExports.find(std::string(Import.getExternalName()));
+        if (ExpIt == ProvExports.end() ||
+            ExpIt->second.Kind != ExternalType::Memory ||
+            ExpIt->second.Mem == nullptr) {
+          continue;
+        }
+        if (Import.getExternalMemoryType().getLimit().is64() !=
+            ExpIt->second.Mem->getLimit().is64()) {
+          spdlog::error(ErrCode::Value::ComponentMemoryIndexTypeMismatch);
+          spdlog::error(
+              "    CoreInstance: memory import '{}'.'{}' index type does not "
+              "match the provided memory"sv,
+              Import.getModuleName(), Import.getExternalName());
+          spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_CoreInstance));
+          return Unexpect(ErrCode::Value::ComponentMemoryIndexTypeMismatch);
+        }
+      }
+    }
+
     // Allocate the core:instance and bind exports to it.
     uint32_t InstanceIdx = CompCtx.addCoreInstance();
     if (Mod != nullptr) {
       for (const auto &ExportDesc : Mod->getExportSection().getContent()) {
+        // Resolve the memory type so re-exports carry their index type for
+        // later instantiation subtype checks (GAP-CI-1).
+        const AST::MemoryType *MemTy = nullptr;
+        if (ExportDesc.getExternalType() == ExternalType::Memory) {
+          const uint32_t Target = ExportDesc.getExternalIndex();
+          uint32_t MemImpCount = 0;
+          for (const auto &Imp : Mod->getImportSection().getContent()) {
+            if (Imp.getExternalType() != ExternalType::Memory) {
+              continue;
+            }
+            if (MemImpCount == Target) {
+              MemTy = &Imp.getExternalMemoryType();
+              break;
+            }
+            ++MemImpCount;
+          }
+          if (MemTy == nullptr) {
+            const auto Mems = Mod->getMemorySection().getContent();
+            const uint32_t Local = Target - MemImpCount;
+            if (Local < Mems.size()) {
+              MemTy = &Mems[Local];
+            }
+          }
+        }
         CompCtx.addCoreInstanceExport(InstanceIdx, ExportDesc.getExternalName(),
-                                      ExportDesc.getExternalType());
+                                      ExportDesc.getExternalType(), MemTy);
       }
     } else if (ModTy != nullptr && ModTy->isModuleType()) {
       for (const auto &Decl : ModTy->getModuleType()) {
@@ -1108,7 +1189,7 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
       return Unexpect(ErrCode::Value::ExportNotFound);
     }
 
-    const auto ExternTy = It->second;
+    const auto ExternTy = It->second.Kind;
     AST::Component::Sort::CoreSortType ST;
     switch (ExternTy) {
     case ExternalType::Function:
@@ -1442,6 +1523,19 @@ Expect<void> Validator::validateCanonOptions(
         MemoryIdx);
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
     return Unexpect(ErrCode::Value::InvalidIndex);
+  }
+  // The canonical ABI requires a 32-bit linear memory (GAP-CI-1).
+  if (HasMemory) {
+    const auto *Mem = CompCtx.getCoreMemory(MemoryIdx);
+    if (Mem != nullptr && Mem->getLimit().is64()) {
+      spdlog::error(ErrCode::Value::ComponentCanonMemoryNot32Bit);
+      spdlog::error(
+          "    canonical option 'memory': core memory {} is not a 32-bit "
+          "linear memory"sv,
+          MemoryIdx);
+      spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Canonical));
+      return Unexpect(ErrCode::Value::ComponentCanonMemoryNot32Bit);
+    }
   }
   const uint32_t CoreFuncSpaceSize =
       CompCtx.getCoreSortIndexSize(AST::Component::Sort::CoreSortType::Func);

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -937,6 +937,11 @@ Validator::validate(const AST::Component::Instance &Inst) noexcept {
     // Inline-export names on a component instance must be strongly-unique.
     std::unordered_set<std::string_view> SeenExports;
     for (const auto &Export : Inst.getInlineExports()) {
+      // Inline-export names must be valid component export names.
+      if (auto Res = validateExportName(Export.getName()); !Res) {
+        spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Instance));
+        return Unexpect(Res.error());
+      }
       if (!SeenExports.insert(Export.getName()).second) {
         spdlog::error(ErrCode::Value::ComponentDuplicateName);
         spdlog::error("    Instance: Duplicate inline-export name '{}'"sv,
@@ -1055,11 +1060,11 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
     const auto &InstExports = CompCtx.getInstance(Idx).Exports;
     auto It = InstExports.find(std::string(Name));
     if (It == InstExports.cend()) {
-      spdlog::error(ErrCode::Value::ExportNotFound);
+      spdlog::error(ErrCode::Value::ComponentUnknownExport);
       spdlog::error(
           "    Alias export: No matching export '{}' found in component instance index {}"sv,
           Name, Idx);
-      return Unexpect(ErrCode::Value::ExportNotFound);
+      return Unexpect(ErrCode::Value::ComponentUnknownExport);
     }
 
     if (It->second.ST != Sort.getSortType()) {
@@ -1735,10 +1740,10 @@ Expect<void> Validator::validate(const AST::Component::Import &Im) noexcept {
   }
 
   if (!CompCtx.addImportedName(CName)) {
-    spdlog::error(ErrCode::Value::ComponentDuplicateName);
+    spdlog::error(ErrCode::Value::ComponentImportNameConflict);
     spdlog::error("    Import: Duplicate import name"sv);
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Import));
-    return Unexpect(ErrCode::Value::ComponentDuplicateName);
+    return Unexpect(ErrCode::Value::ComponentImportNameConflict);
   }
 
   // If this import introduced a TypeBound resource with a label name,
@@ -2077,10 +2082,10 @@ Validator::validate(const AST::Component::ImportDecl &Decl) noexcept {
 
   // Check import name uniqueness.
   if (!CompCtx.addImportedName(CName)) {
-    spdlog::error(ErrCode::Value::ComponentDuplicateName);
+    spdlog::error(ErrCode::Value::ComponentImportNameConflict);
     spdlog::error("    ImportDecl: Duplicate import name"sv);
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Decl_Import));
-    return Unexpect(ErrCode::Value::ComponentDuplicateName);
+    return Unexpect(ErrCode::Value::ComponentImportNameConflict);
   }
 
   return {};
@@ -2267,11 +2272,11 @@ Validator::validate(const AST::Component::DefValType &DVT) noexcept {
         return Unexpect(ErrCode::Value::NameCannotBeEmpty);
       }
       if (!isKebabString(LT.getLabel())) {
-        spdlog::error(ErrCode::Value::ComponentInvalidName);
+        spdlog::error(ErrCode::Value::ComponentNameNotKebab);
         spdlog::error(
             "    DefValType: record field '{}' is not valid kebab-case"sv,
             LT.getLabel());
-        return Unexpect(ErrCode::Value::ComponentInvalidName);
+        return Unexpect(ErrCode::Value::ComponentNameNotKebab);
       }
       if (!Seen.insert(toLowerStr(LT.getLabel())).second) {
         spdlog::error(ErrCode::Value::RecordFieldNameConflicts);
@@ -2294,11 +2299,11 @@ Validator::validate(const AST::Component::DefValType &DVT) noexcept {
         return Unexpect(ErrCode::Value::NameCannotBeEmpty);
       }
       if (!isKebabString(C.first)) {
-        spdlog::error(ErrCode::Value::ComponentInvalidName);
+        spdlog::error(ErrCode::Value::ComponentNameNotKebab);
         spdlog::error(
             "    DefValType: variant case '{}' is not valid kebab-case"sv,
             C.first);
-        return Unexpect(ErrCode::Value::ComponentInvalidName);
+        return Unexpect(ErrCode::Value::ComponentNameNotKebab);
       }
       if (!Seen.insert(toLowerStr(C.first)).second) {
         spdlog::error(ErrCode::Value::VariantCaseNameConflicts);
@@ -2348,10 +2353,10 @@ Validator::validate(const AST::Component::DefValType &DVT) noexcept {
         return Unexpect(ErrCode::Value::NameCannotBeEmpty);
       }
       if (!isKebabString(L)) {
-        spdlog::error(ErrCode::Value::ComponentInvalidName);
+        spdlog::error(ErrCode::Value::ComponentNameNotKebab);
         spdlog::error(
             "    DefValType: flags label '{}' is not valid kebab-case"sv, L);
-        return Unexpect(ErrCode::Value::ComponentInvalidName);
+        return Unexpect(ErrCode::Value::ComponentNameNotKebab);
       }
       if (!Seen.insert(toLowerStr(L)).second) {
         spdlog::error(ErrCode::Value::FlagNameConflicts);
@@ -2373,10 +2378,10 @@ Validator::validate(const AST::Component::DefValType &DVT) noexcept {
         return Unexpect(ErrCode::Value::NameCannotBeEmpty);
       }
       if (!isKebabString(L)) {
-        spdlog::error(ErrCode::Value::ComponentInvalidName);
+        spdlog::error(ErrCode::Value::ComponentNameNotKebab);
         spdlog::error(
             "    DefValType: enum label '{}' is not valid kebab-case"sv, L);
-        return Unexpect(ErrCode::Value::ComponentInvalidName);
+        return Unexpect(ErrCode::Value::ComponentNameNotKebab);
       }
       if (!Seen.insert(toLowerStr(L)).second) {
         spdlog::error(ErrCode::Value::EnumTagNameConflicts);
@@ -2402,11 +2407,11 @@ Expect<void> Validator::validate(const AST::Component::FuncType &FT) noexcept {
   for (const auto &P : FT.getParamList()) {
     if (!P.getLabel().empty()) {
       if (!isKebabString(P.getLabel())) {
-        spdlog::error(ErrCode::Value::ComponentInvalidName);
+        spdlog::error(ErrCode::Value::ComponentNameNotKebab);
         spdlog::error(
             "    FuncType: parameter name '{}' is not valid kebab-case"sv,
             P.getLabel());
-        return Unexpect(ErrCode::Value::ComponentInvalidName);
+        return Unexpect(ErrCode::Value::ComponentNameNotKebab);
       }
       if (!ParamNames.insert(P.getLabel()).second) {
         spdlog::error(ErrCode::Value::ComponentDuplicateName);

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -172,12 +172,9 @@ void Validator::populateInstanceFromType(
     const auto &ED = Exp.getExternDesc();
     auto ST = descTypeToSortType(ED.getDescType());
     if (!ST.has_value()) {
-      // InstanceExport::ST has no `(core module)` variant — skip rather
-      // than crash. TODO: extend InstanceExport with a core-sort alternative.
-      spdlog::debug(
-          "    populateInstanceFromType: skipping `(core module)` export "
-          "'{}'"sv,
-          Exp.getName());
+      // A `(core module)` export has no component sort; record it so an
+      // alias export can still resolve it (GAP-ED-2).
+      CompCtx.addCoreModuleInstanceExport(InstIdx, Exp.getName());
       continue;
     }
     const AST::Component::InstanceType *NestedIT = nullptr;
@@ -1121,13 +1118,6 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
     const auto Idx = Alias.getExport().first;
     const auto &Name = Alias.getExport().second;
 
-    if (Sort.isCore()) {
-      spdlog::error(ErrCode::Value::InvalidTypeReference);
-      spdlog::error("    Alias export: Mapping an export '{}' to core:sort"sv,
-                    Name);
-      return Unexpect(ErrCode::Value::InvalidTypeReference);
-    }
-
     if (Idx >=
         CompCtx.getSortIndexSize(AST::Component::Sort::SortType::Instance)) {
       spdlog::error(ErrCode::Value::InvalidIndex);
@@ -1148,7 +1138,13 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
       return Unexpect(ErrCode::Value::ComponentUnknownExport);
     }
 
-    if (It->second.ST != Sort.getSortType()) {
+    // A component instance can only export a core module as a core sort.
+    const bool Matches = Sort.isCore()
+                             ? (It->second.IsCoreModule &&
+                                Sort.getCoreSortType() ==
+                                    AST::Component::Sort::CoreSortType::Module)
+                             : (It->second.ST == Sort.getSortType());
+    if (!Matches) {
       spdlog::error(ErrCode::Value::InvalidTypeReference);
       spdlog::error("    Alias export: Type mapping mismatch for export '{}'"sv,
                     Name);

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -1998,10 +1998,10 @@ Validator::validate(const AST::Component::CoreImportDesc &Desc) noexcept {
     uint32_t TypeIdx = Desc.getTypeIndex();
     if (TypeIdx >= CompCtx.getCoreSortIndexSize(
                        AST::Component::Sort::CoreSortType::Type)) {
-      spdlog::error(ErrCode::Value::InvalidIndex);
+      spdlog::error(ErrCode::Value::CoreTypeIndexOutOfBounds);
       spdlog::error("    CoreImportDesc: func type index {} out of bounds"sv,
                     TypeIdx);
-      return Unexpect(ErrCode::Value::InvalidIndex);
+      return Unexpect(ErrCode::Value::CoreTypeIndexOutOfBounds);
     }
     CompCtx.addCoreFunc();
   } else if (Desc.isTable()) {

--- a/test/component/ComponentValidatorTest.cpp
+++ b/test/component/ComponentValidatorTest.cpp
@@ -2031,4 +2031,76 @@ TEST(ComponentValidatorTest, InstantiateImportedComponentMissingArgRejected) {
   ASSERT_FALSE(V.validate(Comp));
 }
 
+// =============================================================================
+// Core instance memory index-type checking on instantiation (GAP-CI-1)
+// =============================================================================
+
+namespace {
+// Builds:
+//   (core module $A (import "" "" (memory 1)))   ;; imports a 32-bit memory
+//   (core module $B (memory (export "") <mem>))  ;; exports `Mem`
+//   (core instance $b (instantiate $B))
+//   (core instance $a (instantiate $A (with "" (instance $b))))
+// so the provided memory's index type is checked against $A's import.
+AST::Component::Component buildMemoryLinkComponent(const AST::MemoryType &Mem) {
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CoreModuleSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CoreModuleSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CoreInstanceSection>();
+
+  // Module 0 ($A): import a 32-bit memory.
+  auto &ModA =
+      std::get<AST::Component::CoreModuleSection>(Comp.getSections()[0])
+          .getContent();
+  AST::ImportDesc ImpA;
+  ImpA.setModuleName("");
+  ImpA.setExternalName("");
+  ImpA.setExternalType(ExternalType::Memory);
+  ImpA.getExternalMemoryType() = AST::MemoryType(AST::Limit(1));
+  ModA.getImportSection().getContent().push_back(std::move(ImpA));
+
+  // Module 1 ($B): define and export `Mem`.
+  auto &ModB =
+      std::get<AST::Component::CoreModuleSection>(Comp.getSections()[1])
+          .getContent();
+  ModB.getMemorySection().getContent().push_back(Mem);
+  AST::ExportDesc EDB;
+  EDB.setExternalName("");
+  EDB.setExternalType(ExternalType::Memory);
+  EDB.setExternalIndex(0);
+  ModB.getExportSection().getContent().push_back(std::move(EDB));
+
+  // Core instance 0: instantiate module 1 ($B).
+  auto &CoreInstSec =
+      std::get<AST::Component::CoreInstanceSection>(Comp.getSections()[2]);
+  CoreInstSec.getContent().emplace_back();
+  CoreInstSec.getContent().back().setInstantiateArgs(
+      1U, AST::Component::CoreInstance::InstantiateArgs{});
+  // Core instance 1: instantiate module 0 ($A) with instance 0 as arg "".
+  AST::Component::InstantiateArg<uint32_t> Arg;
+  Arg.getName() = "";
+  Arg.getIndex() = 0U;
+  CoreInstSec.getContent().emplace_back();
+  CoreInstSec.getContent().back().setInstantiateArgs(0U, {Arg});
+  return Comp;
+}
+} // namespace
+
+TEST(ComponentValidatorTest, CoreInstanceMemoryIndexTypeMismatchRejected) {
+  // Provide a 64-bit memory where a 32-bit memory is imported -> reject.
+  auto Comp = buildMemoryLinkComponent(AST::MemoryType(AST::Limit(1, true)));
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CoreInstanceMemoryIndexTypeMatchAccepted) {
+  // Provide a 32-bit memory matching the 32-bit import -> accept.
+  auto Comp = buildMemoryLinkComponent(AST::MemoryType(AST::Limit(1)));
+  Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
 } // namespace

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -339,7 +339,7 @@ std::map<std::string, ComponentModelSupport> ComponentModelFolders = {
     {"module-link",             {true, true,  false, false}},
     {"more-flags",              {true, true,  true,  false}},
     {"naming",                  {true, true,  false, false}},
-    {"nested-modules",          {true, false, false, false}},
+    {"nested-modules",          {true, true,  false, false}},
     {"resources",               {true, false, false, false}},
     {"tags",                    {true, true,  false, false}},
     {"type-export-restrictions",{true, false, false, false}},

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -335,7 +335,7 @@ std::map<std::string, ComponentModelSupport> ComponentModelFolders = {
     {"link",                    {true, true,  true,  false}},
     {"lots-of-aliases",         {true, true,  true,  false}},
     {"lower",                   {true, false, false, false}},
-    {"memory64",                {true, false, false, false}},
+    {"memory64",                {true, true,  false, false}},
     {"module-link",             {true, true,  false, false}},
     {"more-flags",              {true, true,  true,  false}},
     {"naming",                  {true, true,  false, false}},

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -331,7 +331,7 @@ std::map<std::string, ComponentModelSupport> ComponentModelFolders = {
     {"inline-exports",          {true, true,  true,  false}},
     {"instance-types",          {true, true,  true,  false}},
     {"instantiate",             {true, false, false, false}},
-    {"invalid",                 {true, false, false, false}},
+    {"invalid",                 {true, true,  false, false}},
     {"link",                    {true, true,  true,  false}},
     {"lots-of-aliases",         {true, true,  true,  false}},
     {"lower",                   {true, false, false, false}},

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -338,7 +338,7 @@ std::map<std::string, ComponentModelSupport> ComponentModelFolders = {
     {"memory64",                {true, false, false, false}},
     {"module-link",             {true, true,  false, false}},
     {"more-flags",              {true, true,  true,  false}},
-    {"naming",                  {true, false, false, false}},
+    {"naming",                  {true, true,  false, false}},
     {"nested-modules",          {true, false, false, false}},
     {"resources",               {true, false, false, false}},
     {"tags",                    {true, true,  false, false}},


### PR DESCRIPTION
## Summary

Enable the `nested-modules` component-model validation spec tests.

A component instance can export a `(core module)`, but the validator previously did not record that export in the instance export table. As a result, a later `alias export ... (core module)` could not resolve the exported core module during validation.

This change:

* Records `(core module)` exports in component instance export tables.
* Extends alias-export validation to recognize and resolve core-module exports.

With these changes, the `nested-modules` validation spec tests pass successfully.

Refs #4441, #4236.

## Checklist

Before submitting this PR, please ensure the following:

* [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`).

If you are using AI-assisted tools, please ensure the following:

* [x] **AI Disclosure**: Ai was used in the pr for checking code quality written by me, websearch and short comments for maintainer to understand the changed code.
* [x] **Human-in-the-loop**: I reviewed, tested, and verified the changes before submission.

## Test Evidence

<img width="946" height="375" alt="Screenshot 2026-06-22 at 4 34 35 PM" src="https://github.com/user-attachments/assets/3cf98995-c139-4d34-a497-a312e7d84571" />

