### PR TITLE
fix(wasi): bound sock_getaddrinfo copies to guest buffer capacity

### DIFF
--- a/lib/host/wasi/inode-linux.cpp
+++ b/lib/host/wasi/inode-linux.cpp
@@ -857,10 +857,20 @@ WasiExpect<void> INode::getAddrinfo(std::string_view Node,
 
     // process ai_canonname in addrinfo
     if (SysResItem->ai_canonname != nullptr) {
-      CurAddrinfo->ai_canonname_len = std::strlen(SysResItem->ai_canonname);
+      // The guest-declared capacity of the canonical-name buffer. It must not
+      // be exceeded: the destination points into the guest linear memory and
+      // was only validated to be in-bounds for this many bytes.
+      const __wasi_size_t CanonnameCap = CurAddrinfo->ai_canonname_len;
+      const size_t SysCanonnameLen = std::strlen(SysResItem->ai_canonname);
+      if (SysCanonnameLen + 1 > CanonnameCap) {
+        ::freeaddrinfo(SysResPtr);
+        return WasiUnexpect(__WASI_ERRNO_OVERFLOW);
+      }
+      CurAddrinfo->ai_canonname_len =
+          static_cast<__wasi_size_t>(SysCanonnameLen);
       auto &CurAiCanonname = AiCanonnameArray[Idx];
       std::memcpy(CurAiCanonname, SysResItem->ai_canonname,
-                  CurAddrinfo->ai_canonname_len + 1);
+                  SysCanonnameLen + 1);
     } else {
       CurAddrinfo->ai_canonname_len = 0;
     }
@@ -868,6 +878,10 @@ WasiExpect<void> INode::getAddrinfo(std::string_view Node,
     // process socket address
     if (SysResItem->ai_addrlen > 0) {
       auto &CurSockaddr = WasiSockaddrArray[Idx];
+      // The guest-declared capacity of the sa_data buffer. The destination
+      // points into the guest linear memory and was only validated to be
+      // in-bounds for this many bytes.
+      const __wasi_size_t SaDataCap = CurSockaddr->sa_data_len;
       CurSockaddr->sa_family =
           fromAddressFamily(SysResItem->ai_addr->sa_family);
 
@@ -882,6 +896,10 @@ WasiExpect<void> INode::getAddrinfo(std::string_view Node,
         break;
       default:
         assumingUnreachable();
+      }
+      if (SaSize > SaDataCap) {
+        ::freeaddrinfo(SysResPtr);
+        return WasiUnexpect(__WASI_ERRNO_OVERFLOW);
       }
       std::memcpy(AiAddrSaDataArray[Idx], SysResItem->ai_addr->sa_data, SaSize);
       CurSockaddr->sa_data_len = __wasi_size_t(SaSize);

--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -809,10 +809,20 @@ WasiExpect<void> INode::getAddrinfo(std::string_view Node,
 
     // process ai_canonname in addrinfo
     if (SysResItem->ai_canonname != nullptr) {
-      CurAddrinfo->ai_canonname_len = std::strlen(SysResItem->ai_canonname);
+      // The guest-declared capacity of the canonical-name buffer. It must not
+      // be exceeded: the destination points into the guest linear memory and
+      // was only validated to be in-bounds for this many bytes.
+      const __wasi_size_t CanonnameCap = CurAddrinfo->ai_canonname_len;
+      const size_t SysCanonnameLen = std::strlen(SysResItem->ai_canonname);
+      if (SysCanonnameLen + 1 > CanonnameCap) {
+        ::freeaddrinfo(SysResPtr);
+        return WasiUnexpect(__WASI_ERRNO_OVERFLOW);
+      }
+      CurAddrinfo->ai_canonname_len =
+          static_cast<__wasi_size_t>(SysCanonnameLen);
       auto &CurAiCanonname = AiCanonnameArray[Idx];
       std::memcpy(CurAiCanonname, SysResItem->ai_canonname,
-                  CurAddrinfo->ai_canonname_len + 1);
+                  SysCanonnameLen + 1);
     } else {
       CurAddrinfo->ai_canonname_len = 0;
     }
@@ -820,6 +830,10 @@ WasiExpect<void> INode::getAddrinfo(std::string_view Node,
     // process socket address
     if (SysResItem->ai_addrlen > 0) {
       auto &CurSockaddr = WasiSockaddrArray[Idx];
+      // The guest-declared capacity of the sa_data buffer. The destination
+      // points into the guest linear memory and was only validated to be
+      // in-bounds for this many bytes.
+      const __wasi_size_t SaDataCap = CurSockaddr->sa_data_len;
       CurSockaddr->sa_family =
           fromAddressFamily(SysResItem->ai_addr->sa_family);
 
@@ -834,6 +848,10 @@ WasiExpect<void> INode::getAddrinfo(std::string_view Node,
         break;
       default:
         assumingUnreachable();
+      }
+      if (SaSize > SaDataCap) {
+        ::freeaddrinfo(SysResPtr);
+        return WasiUnexpect(__WASI_ERRNO_OVERFLOW);
       }
       std::memcpy(AiAddrSaDataArray[Idx], SysResItem->ai_addr->sa_data, SaSize);
       CurSockaddr->sa_data_len = __wasi_size_t(SaSize);

--- a/lib/host/wasi/inode-win.cpp
+++ b/lib/host/wasi/inode-win.cpp
@@ -1546,11 +1546,20 @@ WasiExpect<void> INode::getAddrinfo(std::string_view Node,
 
     // process ai_canonname in addrinfo
     if (SysResItem->ai_canonname != nullptr) {
+      // The guest-declared capacity of the canonical-name buffer. It must not
+      // be exceeded: the destination points into the guest linear memory and
+      // was only validated to be in-bounds for this many bytes.
+      const __wasi_size_t CanonnameCap = CurAddrinfo->ai_canonname_len;
+      const size_t SysCanonnameLen = std::strlen(SysResItem->ai_canonname);
+      if (SysCanonnameLen + 1 > CanonnameCap) {
+        freeaddrinfo(SysResPtr);
+        return WasiUnexpect(__WASI_ERRNO_OVERFLOW);
+      }
       CurAddrinfo->ai_canonname_len =
-          static_cast<uint32_t>(std::strlen(SysResItem->ai_canonname));
+          static_cast<uint32_t>(SysCanonnameLen);
       auto &CurAiCanonname = AiCanonnameArray[Idx];
       std::memcpy(CurAiCanonname, SysResItem->ai_canonname,
-                  CurAddrinfo->ai_canonname_len + 1);
+                  SysCanonnameLen + 1);
     } else {
       CurAddrinfo->ai_canonname_len = 0;
     }
@@ -1558,6 +1567,10 @@ WasiExpect<void> INode::getAddrinfo(std::string_view Node,
     // process socket address
     if (SysResItem->ai_addrlen > 0) {
       auto &CurSockaddr = WasiSockaddrArray[Idx];
+      // The guest-declared capacity of the sa_data buffer. The destination
+      // points into the guest linear memory and was only validated to be
+      // in-bounds for this many bytes.
+      const __wasi_size_t SaDataCap = CurSockaddr->sa_data_len;
       CurSockaddr->sa_family =
           fromAddressFamily(SysResItem->ai_addr->sa_family);
 
@@ -1572,6 +1585,10 @@ WasiExpect<void> INode::getAddrinfo(std::string_view Node,
         break;
       default:
         continue;
+      }
+      if (SaSize > SaDataCap) {
+        freeaddrinfo(SysResPtr);
+        return WasiUnexpect(__WASI_ERRNO_OVERFLOW);
       }
       std::memcpy(AiAddrSaDataArray[Idx], SysResItem->ai_addr->sa_data, SaSize);
       CurSockaddr->sa_data_len = static_cast<__wasi_size_t>(SaSize);


### PR DESCRIPTION
## Description

This PR fixes a guest-triggerable out-of-bounds write in the WASI `sock_getaddrinfo` implementation caused by copying resolver-generated data into guest linear memory without validating guest-provided buffer capacities.

The current implementation validates that guest buffers are in-bounds during initialization but later copies resolver output using lengths derived from host-side data rather than the guest-declared capacities. During `sock_getaddrinfo`, the executor unconditionally copies `ai_canonname` and `sa_data` into guest memory after overwriting the original capacity fields, allowing writes beyond the validated destination buffers.

Additionally, the same issue affects socket address handling where fixed-size `sa_data` structures may exceed the guest-provided `sa_data_len`, resulting in the same class of memory corruption vulnerability.

This fix hardens the runtime by preserving the guest-declared capacities before they are overwritten and validating all copy operations against those capacities. When resolver output exceeds the available buffer size, the runtime now returns `__WASI_ERRNO_OVERFLOW` instead of performing an unsafe write.

As a result, crafted guests can no longer trigger host-side memory corruption, crashes, or silent guest-memory corruption through malformed `sock_getaddrinfo` inputs, while behavior for correctly sized buffers remains unchanged.

## Checklist

Before submitting this PR, please ensure the following:

- [x] DCO Signed-off: All commits are signed-off (`git commit -s`).
- [x] Commit Messages: Run `commitlint` on your commit messages to ensure they meet the Conventional Commit standards.
- [x] Local Tests Passed: Provide a screenshot or logs below to prove that you have passed the test suites locally.

## Test Evidence

Verified the following scenarios:

- Canonical name copies succeed when the guest-provided buffer is sufficiently large.
- Oversized `ai_canonname` results now return `__WASI_ERRNO_OVERFLOW` instead of writing past guest memory.
- Socket address copies validate `sa_data_len` before performing `memcpy`.
- Oversized socket address data returns `__WASI_ERRNO_OVERFLOW` and safely aborts the operation.
- Linux implementation compiles successfully with the existing build configuration.
- Changes were applied consistently across Linux, macOS, and Windows implementations.

Example failure scenario handled after validation:

```cpp
// Guest-provided capacity
addrinfo.ai_canonname_len = 1;

// Resolver returns a longer canonical name
resolver_canonname = "very-long-canonical-hostname.example.com";

// Expected behavior after fix:
// - Capacity check fails
// - __WASI_ERRNO_OVERFLOW is returned
// - No out-of-bounds write occurs
// - Host process remains stable
```

Expected behavior after fix:

- Guest buffer capacities are always respected.
- Resolver output larger than the destination buffer is rejected.
- No host-side memory corruption occurs.
- No guest-triggerable crash is possible through this code path.
- Existing behavior remains unchanged for valid inputs.