### PR TITLE
fix(issue_template): correct typo in bug_report.yml field id

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,7 @@ body:
     validations:
       required: false
   - type: textarea
-    id: reproducuction_steps
+    id: reproduction_steps
     attributes:
       label: "Reproduction steps"
       description: Please provide as much information as necessary to reproduce the bug.


### PR DESCRIPTION
## Description
Fixes a double-'c' typo in `.github/ISSUE_TEMPLATE/bug_report.yml` line 31.
fix #5046
The internal field `id` was misspelled as `reproducuction_steps` instead of
`reproduction_steps`. The displayed label text was already correct, but the
wrong field ID could break scripts or integrations that reference form fields
by their ID.

**Change:** `id: reproducuction_steps` → `id: reproduction_steps`
