### PR TITLE
feat(runtime): finalize module instances to drop getter locks on the hot path

### DIFF
--- a/include/api/wasmedge/wasmedge_instance.h
+++ b/include/api/wasmedge/wasmedge_instance.h
@@ -35,6 +35,12 @@ extern "C" {
 /// The caller owns the object and should call `WasmEdge_ModuleInstanceDelete`
 /// to destroy it.
 ///
+/// The created module instance is mutable: host instances can be added through
+/// the `WasmEdge_ModuleInstanceAdd*` APIs until it is first used during
+/// execution (e.g. one of its host functions is invoked). After that it becomes
+/// finalized (immutable), and subsequent `WasmEdge_ModuleInstanceAdd*` calls
+/// fail with `WrongVMWorkflow`.
+///
 /// \param ModuleName the module name WasmEdge_String of this host module to
 /// import.
 ///
@@ -51,6 +57,12 @@ WasmEdge_ModuleInstanceCreate(const WasmEdge_String ModuleName)
 /// tags, and globals. When this module instance is destroyed, the host data
 /// finalizer will be invoked. The caller owns the object and should call
 /// `WasmEdge_ModuleInstanceDelete` to destroy it.
+///
+/// The created module instance is mutable: host instances can be added through
+/// the `WasmEdge_ModuleInstanceAdd*` APIs until it is first used during
+/// execution (e.g. one of its host functions is invoked). After that it becomes
+/// finalized (immutable), and subsequent `WasmEdge_ModuleInstanceAdd*` calls
+/// fail with `WrongVMWorkflow`.
 ///
 /// \param ModuleName the module name WasmEdge_String of this host module to
 /// import.
@@ -441,61 +453,93 @@ WasmEdge_ModuleInstanceListGlobal(const WasmEdge_ModuleInstanceContext *Cxt,
 
 /// Add a function instance context to a WasmEdge_ModuleInstanceContext.
 ///
-/// Export and move the ownership of the function instance into the module
-/// instance. The caller should __NOT__ access or destroy the function instance
-/// context after calling this function.
+/// On success, export and move the ownership of the function instance into the
+/// module instance; the caller should __NOT__ access or destroy the function
+/// instance context afterwards. On failure, the ownership is __NOT__ taken: the
+/// caller still owns the function instance context and is responsible for
+/// destroying it.
+///
+/// This function will fail with `WrongVMWorkflow` if the module instance has
+/// already been finalized, i.e. it has been used during execution and become
+/// immutable.
 ///
 /// This function is thread-safe.
 ///
 /// \param Cxt the WasmEdge_ModuleInstanceContext to add the function instance.
 /// \param Name the export function name WasmEdge_String.
 /// \param FuncCxt the WasmEdge_FunctionInstanceContext to add.
-WASMEDGE_CAPI_EXPORT extern void WasmEdge_ModuleInstanceAddFunction(
+///
+/// \returns WasmEdge_Result. Call `WasmEdge_ResultOK` to check the value.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_Result WasmEdge_ModuleInstanceAddFunction(
     WasmEdge_ModuleInstanceContext *Cxt, const WasmEdge_String Name,
     WasmEdge_FunctionInstanceContext *FuncCxt) WASMEDGE_CAPI_NOEXCEPT;
 
 /// Add a table instance context to a WasmEdge_ModuleInstanceContext.
 ///
-/// Export and move the ownership of the table instance into the module
-/// instance. The caller should __NOT__ access or destroy the table instance
-/// context after calling this function.
+/// On success, export and move the ownership of the table instance into the
+/// module instance; the caller should __NOT__ access or destroy the table
+/// instance context afterwards. On failure, the ownership is __NOT__ taken: the
+/// caller still owns the table instance context and is responsible for
+/// destroying it.
+///
+/// This function will fail with `WrongVMWorkflow` if the module instance has
+/// already been finalized, i.e. it has been used during execution and become
+/// immutable.
 ///
 /// This function is thread-safe.
 ///
 /// \param Cxt the WasmEdge_ModuleInstanceContext to add the table instance.
 /// \param Name the export table name WasmEdge_String.
 /// \param TableCxt the WasmEdge_TableInstanceContext to add.
-WASMEDGE_CAPI_EXPORT extern void WasmEdge_ModuleInstanceAddTable(
+///
+/// \returns WasmEdge_Result. Call `WasmEdge_ResultOK` to check the value.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_Result WasmEdge_ModuleInstanceAddTable(
     WasmEdge_ModuleInstanceContext *Cxt, const WasmEdge_String Name,
     WasmEdge_TableInstanceContext *TableCxt) WASMEDGE_CAPI_NOEXCEPT;
 
 /// Add a memory instance context to a WasmEdge_ModuleInstanceContext.
 ///
-/// Export and move the ownership of the memory instance into the module
-/// instance. The caller should __NOT__ access or destroy the memory instance
-/// context after calling this function.
+/// On success, export and move the ownership of the memory instance into the
+/// module instance; the caller should __NOT__ access or destroy the memory
+/// instance context afterwards. On failure, the ownership is __NOT__ taken: the
+/// caller still owns the memory instance context and is responsible for
+/// destroying it.
+///
+/// This function will fail with `WrongVMWorkflow` if the module instance has
+/// already been finalized, i.e. it has been used during execution and become
+/// immutable.
 ///
 /// This function is thread-safe.
 ///
 /// \param Cxt the WasmEdge_ModuleInstanceContext to add the memory instance.
 /// \param Name the export memory name WasmEdge_String.
 /// \param MemoryCxt the WasmEdge_MemoryInstanceContext to add.
-WASMEDGE_CAPI_EXPORT extern void WasmEdge_ModuleInstanceAddMemory(
+///
+/// \returns WasmEdge_Result. Call `WasmEdge_ResultOK` to check the value.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_Result WasmEdge_ModuleInstanceAddMemory(
     WasmEdge_ModuleInstanceContext *Cxt, const WasmEdge_String Name,
     WasmEdge_MemoryInstanceContext *MemoryCxt) WASMEDGE_CAPI_NOEXCEPT;
 
 /// Add a global instance context to a WasmEdge_ModuleInstanceContext.
 ///
-/// Export and move the ownership of the global instance into the module
-/// instance. The caller should __NOT__ access or destroy the global instance
-/// context after calling this function.
+/// On success, export and move the ownership of the global instance into the
+/// module instance; the caller should __NOT__ access or destroy the global
+/// instance context afterwards. On failure, the ownership is __NOT__ taken: the
+/// caller still owns the global instance context and is responsible for
+/// destroying it.
+///
+/// This function will fail with `WrongVMWorkflow` if the module instance has
+/// already been finalized, i.e. it has been used during execution and become
+/// immutable.
 ///
 /// This function is thread-safe.
 ///
 /// \param Cxt the WasmEdge_ModuleInstanceContext to add the global instance.
 /// \param Name the export global name WasmEdge_String.
 /// \param GlobalCxt the WasmEdge_GlobalInstanceContext to add.
-WASMEDGE_CAPI_EXPORT extern void WasmEdge_ModuleInstanceAddGlobal(
+///
+/// \returns WasmEdge_Result. Call `WasmEdge_ResultOK` to check the value.
+WASMEDGE_CAPI_EXPORT extern WasmEdge_Result WasmEdge_ModuleInstanceAddGlobal(
     WasmEdge_ModuleInstanceContext *Cxt, const WasmEdge_String Name,
     WasmEdge_GlobalInstanceContext *GlobalCxt) WASMEDGE_CAPI_NOEXCEPT;
 

--- a/include/runtime/instance/module.h
+++ b/include/runtime/instance/module.h
@@ -105,6 +105,20 @@ public:
     }
   }
 
+  /// Mark this module instance finalized (immutable). Idempotent, thread-safe.
+  void finalizeInstantiation() const noexcept {
+    if (InstantiateFinalized.load(std::memory_order_acquire)) {
+      return;
+    }
+    std::unique_lock Lock(Mutex);
+    InstantiateFinalized.store(true, std::memory_order_release);
+  }
+
+  /// Return true if this module instance has been finalized (immutable).
+  bool isInstantiateFinalized() const noexcept {
+    return InstantiateFinalized.load(std::memory_order_acquire);
+  }
+
   std::string_view getModuleName() const noexcept {
     std::shared_lock Lock(Mutex);
     return ModName;
@@ -137,42 +151,67 @@ public:
   }
 
   /// Add existing instances and move ownership with the export name.
-  void addHostFunc(std::string_view Name,
-                   std::unique_ptr<HostFunctionBase> &&Func) {
+  ///
+  /// These functions fail with `ErrCode::Value::WrongVMWorkflow` if the module
+  /// instance has already been finalized, i.e. it has been used during
+  /// execution and become immutable. On failure the passed-in `unique_ptr` is
+  /// not moved from, so the caller retains ownership of the instance.
+  Expect<void> addHostFunc(std::string_view Name,
+                           std::unique_ptr<HostFunctionBase> &&Func) {
     std::unique_lock Lock(Mutex);
+    if (unlikely(InstantiateFinalized.load(std::memory_order_acquire))) {
+      return Unexpect(ErrCode::Value::WrongVMWorkflow);
+    }
     unsafeImportDefinedType(Func->getDefinedType());
     unsafeAddHostInstance(
         Name, OwnedFuncInsts, FuncInsts, ExpFuncs,
         std::make_unique<FunctionInstance>(
             this, static_cast<uint32_t>(Types.size()) - 1, std::move(Func)));
+    return {};
   }
-  void addHostFunc(std::string_view Name,
-                   std::unique_ptr<FunctionInstance> &&Func) {
+  Expect<void> addHostFunc(std::string_view Name,
+                           std::unique_ptr<FunctionInstance> &&Func) {
     std::unique_lock Lock(Mutex);
+    if (unlikely(InstantiateFinalized.load(std::memory_order_acquire))) {
+      return Unexpect(ErrCode::Value::WrongVMWorkflow);
+    }
     assuming(Func->isHostFunction());
     unsafeImportDefinedType(Func->getHostFunc().getDefinedType());
     Func->linkDefinedType(this, static_cast<uint32_t>(Types.size()) - 1);
     unsafeAddHostInstance(Name, OwnedFuncInsts, FuncInsts, ExpFuncs,
                           std::move(Func));
+    return {};
   }
 
-  void addHostTable(std::string_view Name,
-                    std::unique_ptr<TableInstance> &&Tab) {
+  Expect<void> addHostTable(std::string_view Name,
+                            std::unique_ptr<TableInstance> &&Tab) {
     std::unique_lock Lock(Mutex);
+    if (unlikely(InstantiateFinalized.load(std::memory_order_acquire))) {
+      return Unexpect(ErrCode::Value::WrongVMWorkflow);
+    }
     unsafeAddHostInstance(Name, OwnedTabInsts, TabInsts, ExpTables,
                           std::move(Tab));
+    return {};
   }
-  void addHostMemory(std::string_view Name,
-                     std::unique_ptr<MemoryInstance> &&Mem) {
+  Expect<void> addHostMemory(std::string_view Name,
+                             std::unique_ptr<MemoryInstance> &&Mem) {
     std::unique_lock Lock(Mutex);
+    if (unlikely(InstantiateFinalized.load(std::memory_order_acquire))) {
+      return Unexpect(ErrCode::Value::WrongVMWorkflow);
+    }
     unsafeAddHostInstance(Name, OwnedMemInsts, MemInsts, ExpMems,
                           std::move(Mem));
+    return {};
   }
-  void addHostGlobal(std::string_view Name,
-                     std::unique_ptr<GlobalInstance> &&Glob) {
+  Expect<void> addHostGlobal(std::string_view Name,
+                             std::unique_ptr<GlobalInstance> &&Glob) {
     std::unique_lock Lock(Mutex);
+    if (unlikely(InstantiateFinalized.load(std::memory_order_acquire))) {
+      return Unexpect(ErrCode::Value::WrongVMWorkflow);
+    }
     unsafeAddHostInstance(Name, OwnedGlobInsts, GlobInsts, ExpGlobals,
                           std::move(Glob));
+    return {};
   }
 
   /// Find and get the exported instance by name.
@@ -663,6 +702,10 @@ protected:
   /// External data and its finalizer function pointer.
   void *HostData;
   std::function<void(void *)> HostDataFinalizer;
+
+  /// Whether this module instance has been finalized (immutable). Once set,
+  /// the indexed instances will not be mutated anymore.
+  mutable std::atomic<bool> InstantiateFinalized{false};
 
   /// Intrusive lifetime: owner flag plus importer count, packed into one
   /// atomic.

--- a/lib/api/libwasmedge.lds
+++ b/lib/api/libwasmedge.lds
@@ -6,9 +6,9 @@ WASMEDGE_0.16 {
     };
 
   local:
-    # Internal names of the 0.16 backward-compat shims (see
+    # Internal names of the backward-compat shims (see
     # lib/api/wasmedge_compat.cpp).
-    # They need default visibility so `.symver` can export their `@WASMEDGE_0.16`
+    # They need default visibility so `.symver` can export their versioned
     # aliases, but their own names match the `WasmEdge*` pattern above; listing
     # them here (an exact match outranks the wildcard) keeps them unexported.
     WasmEdge_LimitIsEqual_Compat_016;
@@ -16,6 +16,10 @@ WASMEDGE_0.16 {
     WasmEdge_MemoryTypeGetLimit_Compat_016;
     WasmEdge_TableTypeCreate_Compat_016;
     WasmEdge_TableTypeGetLimit_Compat_016;
+    WasmEdge_ModuleInstanceAddFunction_Compat_017;
+    WasmEdge_ModuleInstanceAddTable_Compat_017;
+    WasmEdge_ModuleInstanceAddMemory_Compat_017;
+    WasmEdge_ModuleInstanceAddGlobal_Compat_017;
     *;
 };
 
@@ -27,3 +31,11 @@ WASMEDGE_0.17 {
     WasmEdge_TableTypeCreate;
     WasmEdge_TableTypeGetLimit;
 } WASMEDGE_0.16;
+
+WASMEDGE_0.18 {
+  global:
+    WasmEdge_ModuleInstanceAddFunction;
+    WasmEdge_ModuleInstanceAddTable;
+    WasmEdge_ModuleInstanceAddMemory;
+    WasmEdge_ModuleInstanceAddGlobal;
+} WASMEDGE_0.17;

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -2619,48 +2619,72 @@ WASMEDGE_CAPI_EXPORT uint32_t WasmEdge_ModuleInstanceListGlobal(
   return 0;
 }
 
-WASMEDGE_CAPI_EXPORT void WasmEdge_ModuleInstanceAddFunction(
+WASMEDGE_CAPI_EXPORT WasmEdge_Result WasmEdge_ModuleInstanceAddFunction(
     WasmEdge_ModuleInstanceContext *Cxt, const WasmEdge_String Name,
     WasmEdge_FunctionInstanceContext *FuncCxt) noexcept {
-  if (Cxt && FuncCxt) {
-    fromModCxt(Cxt)->addHostFunc(
-        genStrView(Name),
-        std::unique_ptr<WasmEdge::Runtime::Instance::FunctionInstance>(
-            fromFuncCxt(FuncCxt)));
-  }
+  return wrap(
+      [&]() -> WasmEdge::Expect<void> {
+        std::unique_ptr<WasmEdge::Runtime::Instance::FunctionInstance> Inst(
+            fromFuncCxt(FuncCxt));
+        auto Res =
+            fromModCxt(Cxt)->addHostFunc(genStrView(Name), std::move(Inst));
+        if (!Res) {
+          static_cast<void>(Inst.release());
+        }
+        return Res;
+      },
+      EmptyThen, Cxt, FuncCxt);
 }
 
-WASMEDGE_CAPI_EXPORT void WasmEdge_ModuleInstanceAddTable(
+WASMEDGE_CAPI_EXPORT WasmEdge_Result WasmEdge_ModuleInstanceAddTable(
     WasmEdge_ModuleInstanceContext *Cxt, const WasmEdge_String Name,
     WasmEdge_TableInstanceContext *TableCxt) noexcept {
-  if (Cxt && TableCxt) {
-    fromModCxt(Cxt)->addHostTable(
-        genStrView(Name),
-        std::unique_ptr<WasmEdge::Runtime::Instance::TableInstance>(
-            fromTabCxt(TableCxt)));
-  }
+  return wrap(
+      [&]() -> WasmEdge::Expect<void> {
+        std::unique_ptr<WasmEdge::Runtime::Instance::TableInstance> Inst(
+            fromTabCxt(TableCxt));
+        auto Res =
+            fromModCxt(Cxt)->addHostTable(genStrView(Name), std::move(Inst));
+        if (!Res) {
+          static_cast<void>(Inst.release());
+        }
+        return Res;
+      },
+      EmptyThen, Cxt, TableCxt);
 }
 
-WASMEDGE_CAPI_EXPORT void WasmEdge_ModuleInstanceAddMemory(
+WASMEDGE_CAPI_EXPORT WasmEdge_Result WasmEdge_ModuleInstanceAddMemory(
     WasmEdge_ModuleInstanceContext *Cxt, const WasmEdge_String Name,
     WasmEdge_MemoryInstanceContext *MemoryCxt) noexcept {
-  if (Cxt && MemoryCxt) {
-    fromModCxt(Cxt)->addHostMemory(
-        genStrView(Name),
-        std::unique_ptr<WasmEdge::Runtime::Instance::MemoryInstance>(
-            fromMemCxt(MemoryCxt)));
-  }
+  return wrap(
+      [&]() -> WasmEdge::Expect<void> {
+        std::unique_ptr<WasmEdge::Runtime::Instance::MemoryInstance> Inst(
+            fromMemCxt(MemoryCxt));
+        auto Res =
+            fromModCxt(Cxt)->addHostMemory(genStrView(Name), std::move(Inst));
+        if (!Res) {
+          static_cast<void>(Inst.release());
+        }
+        return Res;
+      },
+      EmptyThen, Cxt, MemoryCxt);
 }
 
-WASMEDGE_CAPI_EXPORT void WasmEdge_ModuleInstanceAddGlobal(
+WASMEDGE_CAPI_EXPORT WasmEdge_Result WasmEdge_ModuleInstanceAddGlobal(
     WasmEdge_ModuleInstanceContext *Cxt, const WasmEdge_String Name,
     WasmEdge_GlobalInstanceContext *GlobalCxt) noexcept {
-  if (Cxt && GlobalCxt) {
-    fromModCxt(Cxt)->addHostGlobal(
-        genStrView(Name),
-        std::unique_ptr<WasmEdge::Runtime::Instance::GlobalInstance>(
-            fromGlobCxt(GlobalCxt)));
-  }
+  return wrap(
+      [&]() -> WasmEdge::Expect<void> {
+        std::unique_ptr<WasmEdge::Runtime::Instance::GlobalInstance> Inst(
+            fromGlobCxt(GlobalCxt));
+        auto Res =
+            fromModCxt(Cxt)->addHostGlobal(genStrView(Name), std::move(Inst));
+        if (!Res) {
+          static_cast<void>(Inst.release());
+        }
+        return Res;
+      },
+      EmptyThen, Cxt, GlobalCxt);
 }
 
 WASMEDGE_CAPI_EXPORT void

--- a/lib/api/wasmedge_compat.cpp
+++ b/lib/api/wasmedge_compat.cpp
@@ -1,13 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
-// >>>>>>>> WasmEdge 0.16 compat ABI shims >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+// >>>>>>>> WasmEdge compat ABI shims >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 //
-// The 0.16 -> 0.17 transition changed five C API functions from the by-value
-// `WasmEdge_Limit` struct to the opaque `WasmEdge_LimitContext` handle. These
-// shims provide the old `@WASMEDGE_0.16` symbols (bound with `.symver`) while
-// `wasmedge.cpp` keeps the default `@@WASMEDGE_0.17` ones; they are a frozen
-// copy of the 0.16.4-rc.1 implementations so the old ABI stays pinned.
+// Several C API functions changed their signatures across releases. Each such
+// change pins the previous ABI under its historical version node (bound with
+// `.symver`) while `wasmedge.cpp` keeps the new default version, so binaries
+// built against the old library keep resolving the old symbol.
+//
+//   - 0.16 -> 0.17: five functions changed from the by-value `WasmEdge_Limit`
+//     struct to the opaque `WasmEdge_LimitContext` handle. Old ABI pinned at
+//     `@WASMEDGE_0.16`, new default `@@WASMEDGE_0.17`.
+//   - 0.17 -> 0.18: the four `WasmEdge_ModuleInstanceAdd{Function,Table,Memory,
+//     Global}` functions changed their return type from `void` to
+//     `WasmEdge_Result`. Old ABI pinned at `@WASMEDGE_0.17`, new default
+//     `@@WASMEDGE_0.18`.
+//
+// The shims are frozen copies of the previous-release implementations so the
+// old ABIs stay pinned bit-for-bit.
 //
 // Compiled only into the shared library on Linux/Android (see CMakeLists.txt).
 // Kept in a separate TU because under ThinLTO the module-level `.symver` asm
@@ -16,10 +26,13 @@
 #include "wasmedge/wasmedge.h"
 
 #include "ast/type.h"
+#include "runtime/instance/module.h"
 
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <memory>
+#include <string_view>
 
 #if defined(__ELF__) && (defined(__linux__) || defined(__ANDROID__))
 
@@ -45,6 +58,24 @@ inline auto *toMemTypeCxt(AST::MemoryType *Cxt) noexcept {
 inline const auto *
 fromMemTypeCxt(const WasmEdge_MemoryTypeContext *Cxt) noexcept {
   return reinterpret_cast<const AST::MemoryType *>(Cxt);
+}
+inline std::string_view genStrView(const WasmEdge_String S) noexcept {
+  return std::string_view(S.Buf, S.Length);
+}
+inline auto *fromModCxt(WasmEdge_ModuleInstanceContext *Cxt) noexcept {
+  return reinterpret_cast<Runtime::Instance::ModuleInstance *>(Cxt);
+}
+inline auto *fromFuncCxt(WasmEdge_FunctionInstanceContext *Cxt) noexcept {
+  return reinterpret_cast<Runtime::Instance::FunctionInstance *>(Cxt);
+}
+inline auto *fromTabCxt(WasmEdge_TableInstanceContext *Cxt) noexcept {
+  return reinterpret_cast<Runtime::Instance::TableInstance *>(Cxt);
+}
+inline auto *fromMemCxt(WasmEdge_MemoryInstanceContext *Cxt) noexcept {
+  return reinterpret_cast<Runtime::Instance::MemoryInstance *>(Cxt);
+}
+inline auto *fromGlobCxt(WasmEdge_GlobalInstanceContext *Cxt) noexcept {
+  return reinterpret_cast<Runtime::Instance::GlobalInstance *>(Cxt);
 }
 } // namespace
 
@@ -119,6 +150,54 @@ WasmEdge_MemoryTypeGetLimit_Compat_016(const WasmEdge_MemoryTypeContext *Cxt) {
                              /* Min */ 0, /* Max */ 0};
 }
 
+// The 0.17 -> 0.18 transition changed these four functions from returning
+// `void` to returning `WasmEdge_Result`. These shims pin the old `void` ABI:
+// they perform the same best-effort add and discard the result, matching the
+// 0.17 behavior.
+__attribute__((used, visibility("default"))) void
+WasmEdge_ModuleInstanceAddFunction_Compat_017(
+    WasmEdge_ModuleInstanceContext *Cxt, const WasmEdge_String Name,
+    WasmEdge_FunctionInstanceContext *FuncCxt) {
+  if (Cxt && FuncCxt) {
+    static_cast<void>(fromModCxt(Cxt)->addHostFunc(
+        genStrView(Name), std::unique_ptr<Runtime::Instance::FunctionInstance>(
+                              fromFuncCxt(FuncCxt))));
+  }
+}
+
+__attribute__((used, visibility("default"))) void
+WasmEdge_ModuleInstanceAddTable_Compat_017(
+    WasmEdge_ModuleInstanceContext *Cxt, const WasmEdge_String Name,
+    WasmEdge_TableInstanceContext *TableCxt) {
+  if (Cxt && TableCxt) {
+    static_cast<void>(fromModCxt(Cxt)->addHostTable(
+        genStrView(Name), std::unique_ptr<Runtime::Instance::TableInstance>(
+                              fromTabCxt(TableCxt))));
+  }
+}
+
+__attribute__((used, visibility("default"))) void
+WasmEdge_ModuleInstanceAddMemory_Compat_017(
+    WasmEdge_ModuleInstanceContext *Cxt, const WasmEdge_String Name,
+    WasmEdge_MemoryInstanceContext *MemoryCxt) {
+  if (Cxt && MemoryCxt) {
+    static_cast<void>(fromModCxt(Cxt)->addHostMemory(
+        genStrView(Name), std::unique_ptr<Runtime::Instance::MemoryInstance>(
+                              fromMemCxt(MemoryCxt))));
+  }
+}
+
+__attribute__((used, visibility("default"))) void
+WasmEdge_ModuleInstanceAddGlobal_Compat_017(
+    WasmEdge_ModuleInstanceContext *Cxt, const WasmEdge_String Name,
+    WasmEdge_GlobalInstanceContext *GlobalCxt) {
+  if (Cxt && GlobalCxt) {
+    static_cast<void>(fromModCxt(Cxt)->addHostGlobal(
+        genStrView(Name), std::unique_ptr<Runtime::Instance::GlobalInstance>(
+                              fromGlobCxt(GlobalCxt))));
+  }
+}
+
 } // extern "C"
 
 // Bind each shim to its historical `@WASMEDGE_0.16` symbol name. The shims need
@@ -135,7 +214,15 @@ __asm__(".symver WasmEdge_MemoryTypeCreate_Compat_016, "
         "WasmEdge_MemoryTypeCreate@WASMEDGE_0.16");
 __asm__(".symver WasmEdge_MemoryTypeGetLimit_Compat_016, "
         "WasmEdge_MemoryTypeGetLimit@WASMEDGE_0.16");
+__asm__(".symver WasmEdge_ModuleInstanceAddFunction_Compat_017, "
+        "WasmEdge_ModuleInstanceAddFunction@WASMEDGE_0.17");
+__asm__(".symver WasmEdge_ModuleInstanceAddTable_Compat_017, "
+        "WasmEdge_ModuleInstanceAddTable@WASMEDGE_0.17");
+__asm__(".symver WasmEdge_ModuleInstanceAddMemory_Compat_017, "
+        "WasmEdge_ModuleInstanceAddMemory@WASMEDGE_0.17");
+__asm__(".symver WasmEdge_ModuleInstanceAddGlobal_Compat_017, "
+        "WasmEdge_ModuleInstanceAddGlobal@WASMEDGE_0.17");
 
 #endif // __ELF__ && (__linux__ || __ANDROID__)
 
-// <<<<<<<< WasmEdge 0.16 compat ABI shims <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+// <<<<<<<< WasmEdge compat ABI shims <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

--- a/lib/executor/engine/controlInstr.cpp
+++ b/lib/executor/engine/controlInstr.cpp
@@ -196,7 +196,7 @@ Expect<void> Executor::runCallIndirectOp(Runtime::StackManager &StackMgr,
 
   // Get function type at index x.
   const auto *ModInst = StackMgr.getModule();
-  const auto &ExpDefType = **ModInst->getType(Instr.getTargetIndex());
+  const auto &ExpDefType = *ModInst->unsafeGetType(Instr.getTargetIndex());
 
   // Pop the value of index from the Stack.
   const auto AddrType = TabInst->getTableType().getLimit().getAddrType();

--- a/lib/executor/engine/proxy.cpp
+++ b/lib/executor/engine/proxy.cpp
@@ -168,7 +168,7 @@ Expect<void> Executor::proxyCallIndirect(Runtime::StackManager &StackMgr,
 
   const auto *ModInst = StackMgr.getModule();
   assuming(ModInst);
-  const auto &ExpDefType = **ModInst->getType(FuncTypeIdx);
+  const auto &ExpDefType = *ModInst->unsafeGetType(FuncTypeIdx);
   const auto *FuncInst = retrieveFuncRef(*Ref);
   assuming(FuncInst);
 
@@ -644,7 +644,7 @@ Expect<void *> Executor::proxyTableGetFuncSymbol(
 
   const auto *ModInst = StackMgr.getModule();
   assuming(ModInst);
-  const auto &ExpDefType = **ModInst->getType(FuncTypeIdx);
+  const auto &ExpDefType = *ModInst->unsafeGetType(FuncTypeIdx);
   const auto *FuncInst = retrieveFuncRef(*Ref);
   assuming(FuncInst);
   bool IsMatch = false;

--- a/lib/executor/executor.cpp
+++ b/lib/executor/executor.cpp
@@ -182,7 +182,7 @@ Executor::invoke(const Runtime::Instance::FunctionInstance *FuncInst,
         // because the independent host function instance cannot be imported and
         // be referred by instructions.
         const auto *ModInst = Inst->getModule();
-        auto *DefType = *ModInst->getType(RefType.getTypeIndex());
+        const auto *DefType = *ModInst->getType(RefType.getTypeIndex());
         RefType =
             ValType(RefType.getCode(), DefType->getCompositeType().expand());
       }

--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -73,6 +73,12 @@ Executor::enterFunction(Runtime::StackManager &StackMgr,
     // Host function case: Push args and call function.
     auto &HostFunc = Func.getHostFunc();
 
+    // Finalize the host module on its first host-function invocation, after
+    // which adding host instances to it is rejected.
+    if (const auto *HostModInst = Func.getModule()) {
+      HostModInst->finalizeInstantiation();
+    }
+
     // Generate CallingFrame from current frame.
     // The module instance will be nullptr if current frame is a dummy frame.
     // For this case, use the module instance of this host function.
@@ -215,9 +221,9 @@ Executor::enterFunction(Runtime::StackManager &StackMgr,
         // For non-abstract heap types (concrete type indices), convert the
         // null ref to the abstract heap type so that ref.cast/ref.test won't
         // dereference a null pointer when checking the type.
-        const auto &CompType =
-            (*Func.getModule()->getType(Def.second.getTypeIndex()))
-                ->getCompositeType();
+        const auto &CompType = Func.getModule()
+                                   ->unsafeGetType(Def.second.getTypeIndex())
+                                   ->getCompositeType();
         auto BotTypeCode =
             CompType.isFunc() ? TypeCode::NullFuncRef : TypeCode::NullRef;
         RefVariant InitVal(ValType(TypeCode::RefNull, BotTypeCode));
@@ -469,9 +475,9 @@ TypeCode Executor::toBottomType(Runtime::StackManager &StackMgr,
         assumingUnreachable();
       }
     } else {
-      const auto &CompType =
-          (*StackMgr.getModule()->getType(Type.getTypeIndex()))
-              ->getCompositeType();
+      const auto &CompType = StackMgr.getModule()
+                                 ->unsafeGetType(Type.getTypeIndex())
+                                 ->getCompositeType();
       if (CompType.isFunc()) {
         return TypeCode::NullFuncRef;
       } else {

--- a/lib/executor/instantiate/module.cpp
+++ b/lib/executor/instantiate/module.cpp
@@ -154,6 +154,9 @@ Executor::instantiate(Runtime::StoreManager &StoreMgr, const AST::Module &Mod,
   // Pop Frame.
   StackMgr.popFrame();
 
+  // Instantiation done; finalize so the executor reads instances lock-free.
+  ModInst->finalizeInstantiation();
+
   // For a named module, register it in the store.
   if (Name.has_value()) {
     StoreMgr.registerModule(ModInst.get());

--- a/test/api/APIUnitTest.cpp
+++ b/test/api/APIUnitTest.cpp
@@ -1919,6 +1919,27 @@ TEST(APICoreTest, ExecutorWithStatistics) {
       WasmEdge_ResultOK(WasmEdge_ExecutorInvoke(ExecCxt, FuncCxt, P, 1, R, 1)));
   EXPECT_EQ(1000, WasmEdge_ValueGetI32(R[0]));
   EXPECT_TRUE(WasmEdge_ValTypeIsI32(R[0].Type));
+
+  // The "extern" host module is now finalized (a host function was invoked), so
+  // adding to it fails with WrongVMWorkflow and the caller keeps ownership.
+  {
+    WasmEdge_String FinName = WasmEdge_StringCreateByCString("func-finalized");
+    WasmEdge_ValType FinParam[2] = {WasmEdge_ValTypeGenExternRef(),
+                                    WasmEdge_ValTypeGenI32()},
+                     FinResult[1] = {WasmEdge_ValTypeGenI32()};
+    WasmEdge_FunctionTypeContext *FinFType =
+        WasmEdge_FunctionTypeCreate(FinParam, 2, FinResult, 1);
+    WasmEdge_FunctionInstanceContext *FinFunc =
+        WasmEdge_FunctionInstanceCreate(FinFType, externAdd, nullptr, 0);
+    EXPECT_TRUE(isErrMatch(
+        WasmEdge_ErrCode_WrongVMWorkflow,
+        WasmEdge_ModuleInstanceAddFunction(HostMod, FinName, FinFunc)));
+    // Add failed: the caller still owns FinFunc and must destroy it.
+    WasmEdge_FunctionInstanceDelete(FinFunc);
+    WasmEdge_FunctionTypeDelete(FinFType);
+    WasmEdge_StringDelete(FinName);
+  }
+
   // Call sub: (123) - (456)
   FuncName = WasmEdge_StringCreateByCString("func-host-sub");
   FuncCxt = WasmEdge_ModuleInstanceFindFunction(ModCxt, FuncName);
@@ -2662,12 +2683,14 @@ TEST(APICoreTest, ModuleInstance) {
   HostFunc = WasmEdge_FunctionInstanceCreate(HostFType, externAdd, nullptr, 0);
   EXPECT_NE(HostFunc, nullptr);
   HostName = WasmEdge_StringCreateByCString("func-add");
-  WasmEdge_ModuleInstanceAddFunction(nullptr, HostName, HostFunc);
-  EXPECT_TRUE(true);
-  WasmEdge_ModuleInstanceAddFunction(HostMod, HostName, nullptr);
-  EXPECT_TRUE(true);
-  WasmEdge_ModuleInstanceAddFunction(HostMod, HostName, HostFunc);
-  EXPECT_TRUE(true);
+  EXPECT_TRUE(isErrMatch(
+      WasmEdge_ErrCode_WrongVMWorkflow,
+      WasmEdge_ModuleInstanceAddFunction(nullptr, HostName, HostFunc)));
+  EXPECT_TRUE(isErrMatch(
+      WasmEdge_ErrCode_WrongVMWorkflow,
+      WasmEdge_ModuleInstanceAddFunction(HostMod, HostName, nullptr)));
+  EXPECT_TRUE(WasmEdge_ResultOK(
+      WasmEdge_ModuleInstanceAddFunction(HostMod, HostName, HostFunc)));
   WasmEdge_FunctionTypeDelete(HostFType);
   WasmEdge_StringDelete(HostName);
 
@@ -2679,12 +2702,14 @@ TEST(APICoreTest, ModuleInstance) {
   HostTable = WasmEdge_TableInstanceCreate(HostTType);
   EXPECT_NE(HostTable, nullptr);
   HostName = WasmEdge_StringCreateByCString("table");
-  WasmEdge_ModuleInstanceAddTable(nullptr, HostName, HostTable);
-  EXPECT_TRUE(true);
-  WasmEdge_ModuleInstanceAddTable(HostMod, HostName, nullptr);
-  EXPECT_TRUE(true);
-  WasmEdge_ModuleInstanceAddTable(HostMod, HostName, HostTable);
-  EXPECT_TRUE(true);
+  EXPECT_TRUE(isErrMatch(
+      WasmEdge_ErrCode_WrongVMWorkflow,
+      WasmEdge_ModuleInstanceAddTable(nullptr, HostName, HostTable)));
+  EXPECT_TRUE(
+      isErrMatch(WasmEdge_ErrCode_WrongVMWorkflow,
+                 WasmEdge_ModuleInstanceAddTable(HostMod, HostName, nullptr)));
+  EXPECT_TRUE(WasmEdge_ResultOK(
+      WasmEdge_ModuleInstanceAddTable(HostMod, HostName, HostTable)));
   WasmEdge_TableTypeDelete(HostTType);
   WasmEdge_StringDelete(HostName);
 
@@ -2696,12 +2721,14 @@ TEST(APICoreTest, ModuleInstance) {
   HostMemory = WasmEdge_MemoryInstanceCreate(HostMType);
   EXPECT_NE(HostMemory, nullptr);
   HostName = WasmEdge_StringCreateByCString("memory");
-  WasmEdge_ModuleInstanceAddMemory(nullptr, HostName, HostMemory);
-  EXPECT_TRUE(true);
-  WasmEdge_ModuleInstanceAddMemory(HostMod, HostName, nullptr);
-  EXPECT_TRUE(true);
-  WasmEdge_ModuleInstanceAddMemory(HostMod, HostName, HostMemory);
-  EXPECT_TRUE(true);
+  EXPECT_TRUE(isErrMatch(
+      WasmEdge_ErrCode_WrongVMWorkflow,
+      WasmEdge_ModuleInstanceAddMemory(nullptr, HostName, HostMemory)));
+  EXPECT_TRUE(
+      isErrMatch(WasmEdge_ErrCode_WrongVMWorkflow,
+                 WasmEdge_ModuleInstanceAddMemory(HostMod, HostName, nullptr)));
+  EXPECT_TRUE(WasmEdge_ResultOK(
+      WasmEdge_ModuleInstanceAddMemory(HostMod, HostName, HostMemory)));
   WasmEdge_MemoryTypeDelete(HostMType);
   WasmEdge_StringDelete(HostName);
 
@@ -2712,12 +2739,14 @@ TEST(APICoreTest, ModuleInstance) {
       WasmEdge_GlobalInstanceCreate(HostGType, WasmEdge_ValueGenI32(666));
   EXPECT_NE(HostGlobal, nullptr);
   HostName = WasmEdge_StringCreateByCString("global_i32");
-  WasmEdge_ModuleInstanceAddGlobal(nullptr, HostName, HostGlobal);
-  EXPECT_TRUE(true);
-  WasmEdge_ModuleInstanceAddGlobal(HostMod, HostName, nullptr);
-  EXPECT_TRUE(true);
-  WasmEdge_ModuleInstanceAddGlobal(HostMod, HostName, HostGlobal);
-  EXPECT_TRUE(true);
+  EXPECT_TRUE(isErrMatch(
+      WasmEdge_ErrCode_WrongVMWorkflow,
+      WasmEdge_ModuleInstanceAddGlobal(nullptr, HostName, HostGlobal)));
+  EXPECT_TRUE(
+      isErrMatch(WasmEdge_ErrCode_WrongVMWorkflow,
+                 WasmEdge_ModuleInstanceAddGlobal(HostMod, HostName, nullptr)));
+  EXPECT_TRUE(WasmEdge_ResultOK(
+      WasmEdge_ModuleInstanceAddGlobal(HostMod, HostName, HostGlobal)));
   WasmEdge_GlobalTypeDelete(HostGType);
   WasmEdge_StringDelete(HostName);
 


### PR DESCRIPTION
## Description

Module instances are immutable after their construction phase, yet every indexed getter took a shared_lock to guard against concurrent host-instance additions. In call_indirect-heavy workloads this lock/unlock pair on getType dominated the runtime (issue #4369).

Introduce an InstantiateFinalized flag on ModuleInstance:

- WASM module instances are finalized at the end of Executor::instantiate.
- Host module instances are finalized lazily on their first host-function invocation, after which they are immutable.

The executor now reads instance types through the unsafe (lock-free) getter on the finalized module, removing the shared_lock from the call_indirect path. Measured on a call_indirect-bound loop: ~3x faster JIT and ~1.2x faster interpreter, from eliminating the ~11-12ns per-call lock.

The host-instance APIs are adjusted accordingly:

- ModuleInstance::addHost{Func,Table,Memory,Global} and the C API WasmEdge_ModuleInstanceAdd* now return a result and reject additions to a finalized module with WrongVMWorkflow.
- On failure the module does not take ownership of the passed-in instance; the caller retains it.

The C ABI return-type change (void -> WasmEdge_Result) is symbol-versioned: the old void behavior is pinned at @WASMEDGE_0.17 via frozen compat shims, and the new functions become the @@WASMEDGE_0.18 defaults (Linux/Android only).

Close #4633
Related to #4369 (partition resolve)
Replace #4621

Assisted-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
