### PR TITLE
ci(lint): bump clang-format from 20 to 22

### DIFF
--- a/.github/workflows/reusable-call-linter.yml
+++ b/.github/workflows/reusable-call-linter.yml
@@ -23,8 +23,10 @@ jobs:
           git config --global --add safe.directory $(pwd)
       - name: Install clang-format
         run: |
+          curl -sSfL https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
+          sudo add-apt-repository -y "deb http://apt.llvm.org/$(lsb_release -sc)/ llvm-toolchain-$(lsb_release -sc)-22 main"
           sudo apt update
-          sudo apt install -y clang-format-20
+          sudo apt install -y clang-format-22
       - name: Run clang-format
         run: |
-          bash ./.github/scripts/clang-format.sh `which clang-format-20`
+          bash ./.github/scripts/clang-format.sh `which clang-format-22`

--- a/include/common/int128.h
+++ b/include/common/int128.h
@@ -128,14 +128,12 @@ public:
   constexpr uint128(unsigned long V) noexcept : Low(V), High(0) {}
   constexpr uint128(unsigned long long V) noexcept : Low(V), High(0) {}
   constexpr uint128(int128 V) noexcept;
-  constexpr uint128(uint64_t H, uint64_t L) noexcept
-      : Low(L), High(H){}
+  constexpr uint128(uint64_t H, uint64_t L) noexcept : Low(L), High(H) {}
 
 #if defined(__x86_64__) || defined(__aarch64__) ||                             \
     (defined(__riscv) && __riscv_xlen == 64) || defined(__s390x__)
-        constexpr uint128(unsigned __int128 V) noexcept
-      : Low(static_cast<uint64_t>(V)), High(static_cast<uint64_t>(V >> 64)) {
-  }
+  constexpr uint128(unsigned __int128 V) noexcept
+      : Low(static_cast<uint64_t>(V)), High(static_cast<uint64_t>(V >> 64)) {}
 #endif
 
   constexpr operator bool() const noexcept {
@@ -395,13 +393,11 @@ public:
   constexpr int128(unsigned long V) noexcept : Low(V), High(INT64_C(0)) {}
   constexpr int128(unsigned long long V) noexcept : Low(V), High(INT64_C(0)) {}
   constexpr int128(uint128 V) noexcept;
-  constexpr int128(int64_t H, uint64_t L) noexcept
-      : Low(L), High(H){}
+  constexpr int128(int64_t H, uint64_t L) noexcept : Low(L), High(H) {}
 #if defined(__x86_64__) || defined(__aarch64__) ||                             \
     (defined(__riscv) && __riscv_xlen == 64) || defined(__s390x__)
-        constexpr int128(__int128 V) noexcept
-      : Low(static_cast<uint64_t>(V)), High(V >> 64) {
-  }
+  constexpr int128(__int128 V) noexcept
+      : Low(static_cast<uint64_t>(V)), High(V >> 64) {}
 #endif
 
   constexpr int128 &operator=(int V) noexcept { return *this = int128(V); }

--- a/include/system/winapi.h
+++ b/include/system/winapi.h
@@ -851,8 +851,7 @@ WriteFile(WasmEdge::winapi::HANDLE_ hFile, WasmEdge::winapi::LPCVOID_ lpBuffer,
 
 #if WINAPI_PARTITION_DESKTOP
 WASMEDGE_WINAPI_SYMBOL_IMPORT WasmEdge::winapi::HANDLE_
-    WASMEDGE_WINAPI_WINAPI_CC
-    CreateFileMappingW(
+    WASMEDGE_WINAPI_WINAPI_CC CreateFileMappingW(
         WasmEdge::winapi::HANDLE_ hFile,
         WasmEdge::winapi::LPSECURITY_ATTRIBUTES_ lpFileMappingAttributes,
         WasmEdge::winapi::DWORD_ flProtect,
@@ -976,12 +975,12 @@ MoveFileTransactedW(WasmEdge::winapi::LPCWSTR_ lpExistingFileName,
 #endif
 
 #if !WINAPI_PARTITION_DESKTOP || NTDDI_VERSION >= NTDDI_VISTA
-WASMEDGE_WINAPI_SYMBOL_IMPORT WasmEdge::winapi::BOOL_ WASMEDGE_WINAPI_WINAPI_CC
-GetFileInformationByHandleEx(
-    WasmEdge::winapi::HANDLE_ hFile,
-    WasmEdge::winapi::FILE_INFO_BY_HANDLE_CLASS_ FileInformationClass,
-    WasmEdge::winapi::LPVOID_ lpFileInformation,
-    WasmEdge::winapi::DWORD_ dwBufferSize);
+WASMEDGE_WINAPI_SYMBOL_IMPORT WasmEdge::winapi::BOOL_
+    WASMEDGE_WINAPI_WINAPI_CC GetFileInformationByHandleEx(
+        WasmEdge::winapi::HANDLE_ hFile,
+        WasmEdge::winapi::FILE_INFO_BY_HANDLE_CLASS_ FileInformationClass,
+        WasmEdge::winapi::LPVOID_ lpFileInformation,
+        WasmEdge::winapi::DWORD_ dwBufferSize);
 
 WASMEDGE_WINAPI_SYMBOL_IMPORT WasmEdge::winapi::DWORD_ WASMEDGE_WINAPI_WINAPI_CC
 GetFinalPathNameByHandleW(WasmEdge::winapi::HANDLE_ hFile,
@@ -999,8 +998,7 @@ SetFileInformationByHandle(
 
 #if !WINAPI_PARTITION_DESKTOP || NTDDI_VERSION >= NTDDI_WIN8
 WASMEDGE_WINAPI_SYMBOL_IMPORT WasmEdge::winapi::HANDLE_
-    WASMEDGE_WINAPI_WINAPI_CC
-    CreateFile2(
+    WASMEDGE_WINAPI_WINAPI_CC CreateFile2(
         WasmEdge::winapi::LPCWSTR_ lpFileName,
         WasmEdge::winapi::DWORD_ dwDesiredAccess,
         WasmEdge::winapi::DWORD_ dwShareMode,
@@ -1296,11 +1294,10 @@ WASMEDGE_WINAPI_SYMBOL_IMPORT WasmEdge::winapi::HRESULT_
 
 #if NTDDI_VERSION >= NTDDI_VISTA
 WASMEDGE_WINAPI_SYMBOL_IMPORT WasmEdge::winapi::HRESULT_
-    WASMEDGE_WINAPI_WINAPI_CC
-    SHGetKnownFolderPath(WasmEdge::winapi::REFKNOWNFOLDERID_ rfid,
-                         WasmEdge::winapi::DWORD_ dwFlags,
-                         WasmEdge::winapi::HANDLE_ hToken,
-                         WasmEdge::winapi::PWSTR_ *ppszPath);
+    WASMEDGE_WINAPI_WINAPI_CC SHGetKnownFolderPath(
+        WasmEdge::winapi::REFKNOWNFOLDERID_ rfid,
+        WasmEdge::winapi::DWORD_ dwFlags, WasmEdge::winapi::HANDLE_ hToken,
+        WasmEdge::winapi::PWSTR_ *ppszPath);
 #endif
 
 } // extern "C"


### PR DESCRIPTION
## Description

Bump clang-format from 20 to 22 and reformat all files with the clang-format-22

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

We need to verify the behavior on CI for the bumped workflow.

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
