### PR TITLE
fix(runtime): add END sentinel to WasmFunction instructions

### DIFF
--- a/include/runtime/instance/function.h
+++ b/include/runtime/instance/function.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "ast/instruction.h"
+#include "common/enum_ast.hpp"
 #include "common/symbol.h"
 #include "runtime/hostfunc.h"
 #include "runtime/instance/composite.h"
@@ -141,9 +142,9 @@ private:
                               [](uint32_t N, const auto &Pair) -> uint32_t {
                                 return N + Pair.first;
                               })) {
-      // FIXME: Modify the capacity to prevent connecting 2 vectors.
       Instrs.reserve(Expr.size() + 1);
       Instrs.assign(Expr.begin(), Expr.end());
+      Instrs.emplace_back(OpCode::End);
     }
   };
 


### PR DESCRIPTION
## Description

This PR fixes a FIXME comment in the `FunctionInstance::WasmFunction` constructor regarding vector capacity reservation.

### Problem
- The constructor reserved `Expr.size() + 1` capacity but only copied `Expr.size()` instructions
- The extra `+1` had no clear purpose, causing potential issues when connecting two instruction vectors
- The `OpCode::END` sentinel was not explicitly added as the last instruction

### Solution
- Append `OpCode::END` as a sentinel after copying instructions
- The `+1` capacity now serves a clear purpose: to hold the END opcode
- Add missing include for `common/enum_ast.hpp` to resolve `OpCode` definition

### Changes
- `include/runtime/instance/function.h`: Add END sentinel and missing include
## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence


