### PR TITLE
ci: remove unused packages in fedora rawhide

### DIFF
--- a/.github/workflows/reusable-build-on-fedora.yml
+++ b/.github/workflows/reusable-build-on-fedora.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           dnf update -y
           dnf install -y cmake ninja-build llvm llvm-devel lld-devel clang git file rpm-build dpkg-dev spdlog-devel \
-            pkgconf-pkg-config protobuf-c-compiler grpc-cpp grpc-plugins grpc-devel
+            pkgconf-pkg-config
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Description
The current Fedora Rawhide CI failed due to broken gRPC-related packages. However, these gRPC-related dependencies are unused in this CI job. Removing them will help make Fedora Rawhide CI great again.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [ ] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [ ] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

CI will tell us.

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
