### PR TITLE
fix(runtime): change FailedMod to vector of unique_ptr

### DIFF
--- a/include/runtime/storemgr.h
+++ b/include/runtime/storemgr.h
@@ -89,6 +89,7 @@ public:
     }
     NamedMod.clear();
     NamedComp.clear();
+    FailedMod.clear();
   }
 
   /// Register a named module in this store.
@@ -150,13 +151,7 @@ private:
 
   /// Collect the instantiation failed module.
   void recycleModule(std::unique_ptr<Instance::ModuleInstance> &&Mod) {
-    if (FailedMod) {
-      auto *OldMod = FailedMod.release();
-      if (OldMod) {
-        OldMod->terminate();
-      }
-    }
-    FailedMod = std::move(Mod);
+    FailedMod.emplace_back(std::move(Mod));
   }
 
   /// \name Module name mapping.
@@ -165,12 +160,13 @@ private:
   std::map<std::string, const Instance::ComponentInstance *, std::less<>>
       NamedComp;
 
-  /// \name Last instantiation failed module.
+  /// \name Failed instantiation modules.
   /// According to the current spec, instances should remain referenceable even
-  /// if instantiation failed. Therefore, store the failed module instance here
+  /// if instantiation failed. Therefore, store the failed module instances here
   /// to keep the instances alive.
-  /// FIXME: Is this necessary to be a vector?
-  std::unique_ptr<Instance::ModuleInstance> FailedMod;
+  /// Using a vector of unique_ptr allows storing multiple failed modules
+  /// without copying the non-copyable ModuleInstance objects.
+  std::vector<std::unique_ptr<Instance::ModuleInstance>> FailedMod;
 };
 
 } // namespace Runtime


### PR DESCRIPTION
## Description

Changed `FailedMod` from `std::unique_ptr<ModuleInstance>` to `std::vector<std::unique_ptr<ModuleInstance>>` to support multiple failed module instances as required by the WebAssembly specification.

### Changes:
1. Changed type of `FailedMod` to `vector<unique_ptr<ModuleInstance>>`.
2. Updated `recycleModule()` to move the `unique_ptr` directly.
3. Updated `reset()` to clear the vector.
4. **Updated the comment** to reflect the new design and removed the `FIXME.`
 
## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

<img width="1061" height="525" alt="Screenshot from 2026-06-27 16-54-06" src="https://github.com/user-attachments/assets/7438834d-dc90-4021-ab62-816b07147d4b" />

