### PR TITLE
fix(executor): use matching address types for memory.copy and table.copy operands

### DIFF
--- a/lib/executor/engine/memoryInstr.cpp
+++ b/lib/executor/engine/memoryInstr.cpp
@@ -70,8 +70,8 @@ Executor::runMemoryCopyOp(Runtime::StackManager &StackMgr,
   const auto AddrType1 = MemInstSrc.getMemoryType().getLimit().getAddrType();
   const auto AddrType2 = MemInstDst.getMemoryType().getLimit().getAddrType();
   uint64_t Len = extractAddr(StackMgr.pop(), std::min(AddrType1, AddrType2));
-  uint64_t Src = extractAddr(StackMgr.pop(), AddrType2);
-  uint64_t Dst = extractAddr(StackMgr.pop(), AddrType1);
+  uint64_t Src = extractAddr(StackMgr.pop(), AddrType1);
+  uint64_t Dst = extractAddr(StackMgr.pop(), AddrType2);
 
   // Replace mem[Dst : Dst + Len] with mem[Src : Src + Len].
   // When source and destination are the same memory instance, overlapping

--- a/lib/executor/engine/tableInstr.cpp
+++ b/lib/executor/engine/tableInstr.cpp
@@ -84,8 +84,8 @@ Executor::runTableCopyOp(Runtime::StackManager &StackMgr,
   const auto AddrType1 = TabInstSrc.getTableType().getLimit().getAddrType();
   const auto AddrType2 = TabInstDst.getTableType().getLimit().getAddrType();
   uint64_t Len = extractAddr(StackMgr.pop(), std::min(AddrType1, AddrType2));
-  uint64_t Src = extractAddr(StackMgr.pop(), AddrType2);
-  uint64_t Dst = extractAddr(StackMgr.pop(), AddrType1);
+  uint64_t Src = extractAddr(StackMgr.pop(), AddrType1);
+  uint64_t Dst = extractAddr(StackMgr.pop(), AddrType2);
 
   // Replace tab_dst[Dst : Dst + Len] with tab_src[Src : Src + Len].
   return TabInstSrc.getRefs(0, Src + Len)


### PR DESCRIPTION
Fixes #5074.

### What

`memory.copy` and `table.copy` extract the source and destination offsets using
each other's address type. `Src` is read with the destination's type and `Dst`
with the source's. This is a no-op when both memories/tables share an index type,
but with the memory64 and multiple-memories proposals the two can differ (one
i32, one i64), and the offsets are then read with the wrong width — truncated or
wrongly extended.

### Why

The validator and the executor disagreed on which operand carries which type.

The validator (`lib/validator/formchecker.cpp`, `Memory__copy` / `Table__copy`)
pushes the operands as `dst : ATDst`, `src : ATSrc`, `len : min(ATDst, ATSrc)`:

```cpp
return StackTrans({ValType(ATDst), ValType(ATSrc), ValType(ATMin)}, {});
```

The executor (`runMemoryCopyOp` / `runTableCopyOp`) popped them back with `Src`
and `Dst` swapped:

```cpp
const auto AddrType1 = MemInstSrc...getAddrType(); // source
const auto AddrType2 = MemInstDst...getAddrType(); // destination
uint64_t Len = extractAddr(StackMgr.pop(), std::min(AddrType1, AddrType2));
uint64_t Src = extractAddr(StackMgr.pop(), AddrType2); // used dst's type
uint64_t Dst = extractAddr(StackMgr.pop(), AddrType1); // used src's type
```

`extractAddr` reads the value as `uint32_t` or `uint64_t` based on the address
type, so once the two types differ the offsets are misread. `len` was already
correct because it uses the symmetric `min` of both.

### Fix

Extract `Src` with the source's type and `Dst` with the destination's, in both
`runMemoryCopyOp` and `runTableCopyOp`.

### Notes

- The bundled spec testsuite only covers same-index-type copies, which is why
  this wasn't caught.
- Built locally (`wasmedgeExecutor`) to confirm it compiles.

---

This contribution was developed with assistance from Claude (Anthropic); the
analysis and change were reviewed before submitting.
