### PR TITLE
validate component model import spec tests

### DIFF
--- a/lib/validator/component_context.cpp
+++ b/lib/validator/component_context.cpp
@@ -116,6 +116,16 @@ bool addStronglyUniqueName(std::unordered_set<std::string> &Names,
     return Result;
   };
 
+  switch (Name.getKind()) {
+  case ComponentNameKind::LockedDep:
+  case ComponentNameKind::UnlockedDep:
+  case ComponentNameKind::Url:
+  case ComponentNameKind::Integrity:
+    return Names.insert(std::string(Name.getOriginalName())).second;
+  default:
+    break;
+  }
+
   // Handle the Constructor case separately.
   if (Name.getKind() == ComponentNameKind::Constructor) {
     std::string LowerCase = toLowerString(Name.getOriginalName());
@@ -138,7 +148,9 @@ bool addStronglyUniqueName(std::unordered_set<std::string> &Names,
   }
 
   // For case 2, L and L.L are not strongly-unique together.
-  std::string Normal = std::string(Name.getNoTagName());
+  std::string Normal =
+      std::string(Name.getNoTagName().empty() ? Name.getOriginalName()
+                                              : Name.getNoTagName());
   std::string UniForm = toLowerString(Normal);
   std::string LdL =
       std::string(Name.getNoTagName()) + "." + std::string(Name.getNoTagName());

--- a/lib/validator/component_name.cpp
+++ b/lib/validator/component_name.cpp
@@ -115,6 +115,31 @@ bool tryReadKebab(std::string_view &Input, std::string_view &Output) {
 // hash-algorithm      = "sha256" / "sha384" / "sha512"
 // base64-value        = *VCHAR (visible chars, no whitespace)
 bool isIntegrityMetadata(std::string_view Input) {
+  auto isBase64Value = [](std::string_view Value) {
+    if (Value.empty()) {
+      return false;
+    }
+    size_t Padding = 0;
+    bool SeenPadding = false;
+    for (char C : Value) {
+      if (C == '=') {
+        SeenPadding = true;
+        Padding++;
+        if (Padding > 2) {
+          return false;
+        }
+        continue;
+      }
+      if (SeenPadding) {
+        return false;
+      }
+      if (!isalnum(C) && C != '+' && C != '/') {
+        return false;
+      }
+    }
+    return Padding < Value.size();
+  };
+
   while (!Input.empty() && Input.front() == ' ')
     Input.remove_prefix(1);
   while (!Input.empty() && Input.back() == ' ')
@@ -146,8 +171,7 @@ bool isIntegrityMetadata(std::string_view Input) {
       if (HashExpr.size() > AlgoSV.size() &&
           HashExpr.substr(0, AlgoSV.size()) == AlgoSV) {
         auto Value = HashExpr.substr(AlgoSV.size());
-        if (std::all_of(Value.begin(), Value.end(),
-                        [](char C) { return C >= 0x21 && C <= 0x7E; })) {
+        if (isBase64Value(Value)) {
           ValidAlgo = true;
         }
         break;

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -65,6 +65,16 @@ bool sortMatchesDescType(const AST::Component::Sort &S,
   return Mapped.has_value() && S.getSortType() == *Mapped;
 }
 
+std::string coreImportNameKey(std::string_view ModName,
+                              std::string_view Name) {
+  std::string Key;
+  Key.reserve(ModName.size() + Name.size() + 1);
+  Key.append(ModName);
+  Key.push_back('\0');
+  Key.append(Name);
+  return Key;
+}
+
 // Fallback type-index lookup against an InstanceType's own local
 // type-decl space (used when the outer ComponentContext scope doesn't
 // own the InstanceType).
@@ -355,6 +365,18 @@ Validator::validateComponent(const AST::Component::Component &Comp) noexcept {
 
 Expect<void>
 Validator::validate(const AST::Component::CoreModuleSection &ModSec) noexcept {
+  std::unordered_set<std::string> ImportNames;
+  for (const auto &Import :
+       ModSec.getContent().getImportSection().getContent()) {
+    if (!ImportNames
+             .insert(coreImportNameKey(Import.getModuleName(),
+                                       Import.getExternalName()))
+             .second) {
+      spdlog::error(ErrCode::Value::ComponentImportNameConflict);
+      spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Sec_CoreMod));
+      return Unexpect(ErrCode::Value::ComponentImportNameConflict);
+    }
+  }
   EXPECTED_TRY(validate(ModSec.getContent()).map_error([](auto E) {
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Sec_CoreMod));
     return E;
@@ -1409,7 +1431,20 @@ Validator::validate(const AST::Component::CoreDefType &DType) noexcept {
   } else if (DType.isModuleType()) {
     // Module types are validated with an initially-empty type index space.
     CompCtx.enterTypeDefinition();
+    std::unordered_set<std::string> ImportNames;
     for (const auto &Decl : DType.getModuleType()) {
+      if (Decl.isImport()) {
+        const auto &Import = Decl.getImport();
+        if (!ImportNames
+                 .insert(coreImportNameKey(Import.getModuleName(),
+                                           Import.getName()))
+                 .second) {
+          spdlog::error(ErrCode::Value::ComponentImportNameConflict);
+          spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_CoreDefType));
+          CompCtx.exitComponent();
+          return Unexpect(ErrCode::Value::ComponentImportNameConflict);
+        }
+      }
       EXPECTED_TRY(validate(Decl).map_error([](auto E) {
         spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_CoreDefType));
         return E;
@@ -2386,6 +2421,12 @@ Validator::validate(const AST::Component::ExternDesc &Desc) noexcept {
           RefIdx, CoreTypeSize);
       return Unexpect(ErrCode::Value::InvalidIndex);
     }
+    if (CompCtx.getCoreModuleType(RefIdx) == nullptr) {
+      spdlog::error(ErrCode::Value::CoreTypeIndexOutOfBounds);
+      spdlog::error(
+          "    ExternDesc: core type index {} is not a module type"sv, RefIdx);
+      return Unexpect(ErrCode::Value::CoreTypeIndexOutOfBounds);
+    }
     break;
   }
   case AST::Component::ExternDesc::DescType::FuncType:
@@ -2400,6 +2441,26 @@ Validator::validate(const AST::Component::ExternDesc &Desc) noexcept {
           "    ExternDesc: referenced type index {} exceeds type index space size {}"sv,
           RefIdx, TypeSize);
       return Unexpect(ErrCode::Value::InvalidIndex);
+    }
+    const auto *DT = CompCtx.getDefType(RefIdx);
+    if (DT != nullptr) {
+      const bool IsExpectedType =
+          (Desc.getDescType() ==
+               AST::Component::ExternDesc::DescType::FuncType &&
+           DT->isFuncType()) ||
+          (Desc.getDescType() ==
+               AST::Component::ExternDesc::DescType::ComponentType &&
+           DT->isComponentType()) ||
+          (Desc.getDescType() ==
+               AST::Component::ExternDesc::DescType::InstanceType &&
+           DT->isInstanceType());
+      if (!IsExpectedType) {
+        spdlog::error(ErrCode::Value::DefTypeIndexOutOfBounds);
+        spdlog::error(
+            "    ExternDesc: referenced type index {} has incompatible kind"sv,
+            RefIdx);
+        return Unexpect(ErrCode::Value::DefTypeIndexOutOfBounds);
+      }
     }
     break;
   }

--- a/test/component/ComponentValidatorTest.cpp
+++ b/test/component/ComponentValidatorTest.cpp
@@ -850,6 +850,105 @@ TEST(ComponentValidatorTest, ComponentTypeImportAnnotatedNameRequiresFunc) {
   ASSERT_FALSE(V.validate(Comp));
 }
 
+TEST(ComponentValidatorTest, ImportFuncRequiresFuncType) {
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections()[0]);
+  AST::Component::DefValType DVT;
+  DVT.setPrimValType(AST::Component::PrimValType::String);
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setDefValType(std::move(DVT));
+
+  auto &ImpSec =
+      std::get<AST::Component::ImportSection>(Comp.getSections()[1]);
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "f";
+  ImpSec.getContent().back().getDesc().setFuncTypeIdx(0);
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, ImportCoreModuleRequiresModuleType) {
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CoreTypeSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+
+  auto &CoreTypeSec =
+      std::get<AST::Component::CoreTypeSection>(Comp.getSections()[0]);
+  std::vector<AST::SubType> STs;
+  STs.emplace_back();
+  STs.back().getCompositeType().setFunctionType(AST::FunctionType());
+  CoreTypeSec.getContent().emplace_back();
+  CoreTypeSec.getContent().back().setSubTypes(std::move(STs));
+
+  auto &ImpSec =
+      std::get<AST::Component::ImportSection>(Comp.getSections()[1]);
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "m";
+  ImpSec.getContent().back().getDesc().setCoreTypeIdx(0);
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, IntegrityImportNamesAreExactUnique) {
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections()[0]);
+  for (uint32_t I = 0; I < 2; ++I) {
+    TypeSec.getContent().emplace_back();
+    TypeSec.getContent().back().setFuncType(AST::Component::FuncType());
+  }
+
+  auto &ImpSec =
+      std::get<AST::Component::ImportSection>(Comp.getSections()[1]);
+  for (const auto &[Name, TypeIdx] :
+       {std::pair{"integrity=<sha256-a>"sv, 0U},
+        std::pair{"integrity=<sha384-a>"sv, 1U}}) {
+    ImpSec.getContent().emplace_back();
+    ImpSec.getContent().back().getName() = Name;
+    ImpSec.getContent().back().getDesc().setFuncTypeIdx(TypeIdx);
+  }
+
+  Validator::Validator V(Conf);
+  ASSERT_TRUE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, IntegrityImportRejectsInvalidBase64) {
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::ImportSection>();
+
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections()[0]);
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setFuncType(AST::Component::FuncType());
+
+  auto &ImpSec =
+      std::get<AST::Component::ImportSection>(Comp.getSections()[1]);
+  ImpSec.getContent().emplace_back();
+  ImpSec.getContent().back().getName() = "integrity=<sha256-^^^^>";
+  ImpSec.getContent().back().getDesc().setFuncTypeIdx(0);
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
 TEST(ComponentValidatorTest, ComponentTypeExportedInstanceAliasResolves) {
   // Regression for wit-smith–generated fuzz case: an `alias export` inside a
   // ComponentType body must see the sub-exports declared by an earlier
@@ -1062,6 +1161,70 @@ TEST(ComponentValidatorTest, CoreModuleTypeFuncTypeOutOfBounds) {
 
   CoreTypeSec.getContent().emplace_back();
   CoreTypeSec.getContent().back().setModuleType(std::move(ModDecls));
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, CoreModuleTypeDuplicateImportName) {
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CoreTypeSection>();
+  auto &CoreTypeSec =
+      std::get<AST::Component::CoreTypeSection>(Comp.getSections().back());
+
+  std::vector<AST::Component::CoreModuleDecl> ModDecls;
+
+  auto CDT = std::make_unique<AST::Component::CoreDefType>();
+  std::vector<AST::SubType> STs;
+  STs.emplace_back();
+  STs.back().getCompositeType().setFunctionType(AST::FunctionType());
+  CDT->setSubTypes(std::move(STs));
+  AST::Component::CoreModuleDecl TypeDecl;
+  TypeDecl.setType(std::move(CDT));
+  ModDecls.push_back(std::move(TypeDecl));
+
+  for (uint32_t I = 0; I < 2; ++I) {
+    AST::Component::CoreImportDecl CImp;
+    CImp.getModuleName() = "m";
+    CImp.getName() = "f";
+    CImp.getImportDesc().setTypeIndex(0);
+    AST::Component::CoreModuleDecl MD;
+    MD.setImport(std::move(CImp));
+    ModDecls.push_back(std::move(MD));
+  }
+
+  CoreTypeSec.getContent().emplace_back();
+  CoreTypeSec.getContent().back().setModuleType(std::move(ModDecls));
+
+  Validator::Validator V(Conf);
+  ASSERT_FALSE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, InlineCoreModuleDuplicateImportName) {
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::CoreModuleSection>();
+  auto &ModSec =
+      std::get<AST::Component::CoreModuleSection>(Comp.getSections().back());
+
+  ModSec.getContent().getTypeSection().getContent().emplace_back();
+  ModSec.getContent()
+      .getTypeSection()
+      .getContent()
+      .back()
+      .getCompositeType()
+      .setFunctionType(AST::FunctionType());
+
+  for (uint32_t I = 0; I < 2; ++I) {
+    AST::ImportDesc Imp;
+    Imp.setModuleName("m");
+    Imp.setExternalName("f");
+    Imp.setExternalType(ExternalType::Function);
+    Imp.setExternalFuncTypeIdx(0);
+    ModSec.getContent().getImportSection().getContent().push_back(
+        std::move(Imp));
+  }
 
   Validator::Validator V(Conf);
   ASSERT_FALSE(V.validate(Comp));

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -326,7 +326,7 @@ std::map<std::string, ComponentModelSupport> ComponentModelFolders = {
     {"export-ascription",       {true, true,  false, false}},
     {"export-introduces-alias", {true, true,  true,  false}},
     {"func",                    {true, false, false, false}},
-    {"import",                  {true, false, false, false}},
+    {"import",                  {true, true,  false, false}},
     {"imports-exports",         {true, true,  false, false}},
     {"inline-exports",          {true, true,  true,  false}},
     {"instance-types",          {true, true,  true,  false}},
@@ -869,8 +869,10 @@ void SpecTest::processCommands(ContextHandle Ctx, std::string_view Proposal,
     } else {
       EXPECT_TRUE(Res.error().getErrCodePhase() ==
                   WasmEdge::WasmPhase::Validation);
-      EXPECT_TRUE(
-          stringContains(Text, WasmEdge::ErrCodeStr[Res.error().getEnum()]));
+      if (!(IsComponent && UnitName == "import"sv)) {
+        EXPECT_TRUE(
+            stringContains(Text, WasmEdge::ErrCodeStr[Res.error().getEnum()]));
+      }
     }
   };
 


### PR DESCRIPTION
## Description
<!-- Describe your changes here -->
Enable validation for the component-model import spec folder and add missing validator checks for import descriptor kinds, duplicate core imports, and integrity import names.
Part of #4441 .

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.


