### PR TITLE
test(component): add regression tests for ResourceType validation in type scopes

### DIFF
--- a/test/component/ComponentValidatorTest.cpp
+++ b/test/component/ComponentValidatorTest.cpp
@@ -2031,4 +2031,57 @@ TEST(ComponentValidatorTest, InstantiateImportedComponentMissingArgRejected) {
   ASSERT_FALSE(V.validate(Comp));
 }
 
+TEST(ComponentValidatorTest, ResourceTypeInTypeScopeRejected) {
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+
+  std::vector<AST::Component::ComponentDecl> Decls;
+  AST::Component::ComponentDecl CD;
+  AST::Component::InstanceDecl Inst;
+  auto DT = std::make_unique<AST::Component::DefType>();
+  DT->setResourceType(AST::Component::ResourceType{});
+  Inst.setType(std::move(DT));
+  CD.setInstance(std::move(Inst));
+  Decls.push_back(std::move(CD));
+
+  AST::Component::ComponentType CT;
+  CT.setDecl(std::move(Decls));
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setComponentType(std::move(CT));
+
+  Validator::Validator V(Conf);
+  auto Result = V.validate(Comp);
+  EXPECT_FALSE(Result);
+  EXPECT_EQ(Result.error(), ErrCode::Value::InvalidTypeReference);
+}
+
+TEST(ComponentValidatorTest, ResourceTypeInInstanceTypeScopeRejected) {
+  AST::Component::Component Comp;
+  Comp.getSections().emplace_back();
+  Comp.getSections().back().emplace<AST::Component::TypeSection>();
+  auto &TypeSec =
+      std::get<AST::Component::TypeSection>(Comp.getSections().back());
+
+  std::vector<AST::Component::InstanceDecl> Decls;
+  AST::Component::InstanceDecl Inst;
+  auto DT = std::make_unique<AST::Component::DefType>();
+  DT->setResourceType(AST::Component::ResourceType{});
+  Inst.setType(std::move(DT));
+  Decls.push_back(std::move(Inst));
+
+  AST::Component::InstanceType IT;
+  IT.setDecl(std::move(Decls));
+  TypeSec.getContent().emplace_back();
+  TypeSec.getContent().back().setInstanceType(std::move(IT));
+
+  Validator::Validator V(Conf);
+  auto Result = V.validate(Comp);
+  EXPECT_FALSE(Result);
+  EXPECT_EQ(Result.error(), ErrCode::Value::InvalidTypeReference);
+}
+
 } // namespace
+


### PR DESCRIPTION
Fixes #5095

Description

This PR adds regression tests for the existing validation that rejects `ResourceType` definitions inside type definition scopes.

The following scenarios are now covered:

- `ResourceType` nested inside a `componenttype`
- `ResourceType` nested inside an `instancetype`

Both tests verify that validation fails with `ErrCode::Value::InvalidTypeReference`, matching the current validator behavior.

No production code is changed in this PR; it only adds regression test coverage.

Checklist

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`).
- [x] **Commit Messages**: Commit follows the Conventional Commits format.
- [x] **Local Tests Passed**

- [x] **Human-in-the-loop**: The implementation and testing were manually reviewed and verified.

Test Evidence

Built and ran the component regression tests locally:

```bash
make wasmedgeComponentRegressionTests -j4

./test/component/wasmedgeComponentRegressionTests \
  --gtest_filter=ComponentValidatorTest.ResourceTypeInTypeScopeRejected

./test/component/wasmedgeComponentRegressionTests \
  --gtest_filter=ComponentValidatorTest.ResourceTypeInInstanceTypeScopeRejected
```

Both new tests pass successfully, and the full component regression test suite also passes locally.