### PR TITLE
fix: add missing sv suffix to spdlog and fmt format strings across the codebase

### DIFF
--- a/include/host/mock/log.h
+++ b/include/host/mock/log.h
@@ -11,8 +11,9 @@ namespace WasmEdge {
 namespace Host {
 
 inline void printPluginMock(std::string_view PluginName) {
+  using namespace std::literals;
   spdlog::error("{} plugin not installed. Please install the plugin and "
-                "restart WasmEdge.",
+                "restart WasmEdge."sv,
                 PluginName);
 }
 

--- a/include/po/parser.h
+++ b/include/po/parser.h
@@ -37,7 +37,7 @@ stringToInteger(ConvResultT (&Conv)(const char *, char **, int),
   if (Value.empty() || *EndPtr != '\0') {
     return cxx20::unexpected<Error>(
         std::in_place, ErrCode::InvalidArgument,
-        fmt::format("invalid integer value: {}", Value));
+        fmt::format("invalid integer value: {}"sv, Value));
   }
   auto InsideRange = [](auto WiderResult) constexpr noexcept {
     using WiderResultT = decltype(WiderResult);
@@ -53,7 +53,7 @@ stringToInteger(ConvResultT (&Conv)(const char *, char **, int),
   if (SavedErrNo == ERANGE || !InsideRange(Result)) {
     return cxx20::unexpected<Error>(
         std::in_place, ErrCode::OutOfRange,
-        fmt::format("integer value out of range: {}", Value));
+        fmt::format("integer value out of range: {}"sv, Value));
   }
   return static_cast<ResultT>(Result);
 }
@@ -71,12 +71,12 @@ stringToFloating(ConvResultT (&Conv)(const char *, char **),
   if (Value.empty() || *EndPtr != '\0') {
     return cxx20::unexpected<Error>(
         std::in_place, ErrCode::InvalidArgument,
-        fmt::format("invalid floating-point value: {}", Value));
+        fmt::format("invalid floating-point value: {}"sv, Value));
   }
   if (SavedErrNo == ERANGE) {
     return cxx20::unexpected<Error>(
         std::in_place, ErrCode::OutOfRange,
-        fmt::format("floating-point value out of range: {}", Value));
+        fmt::format("floating-point value out of range: {}"sv, Value));
   }
   return Result;
 }

--- a/include/runtime/instance/memory.h
+++ b/include/runtime/instance/memory.h
@@ -110,6 +110,7 @@ public:
 
   /// Grow page
   bool growPage(const uint64_t Count) noexcept {
+    using namespace std::literals;
     if (Count == 0) {
       return true;
     }
@@ -127,7 +128,7 @@ public:
     assuming(PageLimit >= Min);
     if (Count > PageLimit - Min) {
       spdlog::error("Memory Instance: Memory grow page failed, exceeded "
-                    "limited {} page size in configuration.",
+                    "limited {} page size in configuration."sv,
                     PageLimit);
       return false;
     }

--- a/lib/common/hexstr.cpp
+++ b/lib/common/hexstr.cpp
@@ -6,6 +6,8 @@
 #include <algorithm>
 #include <spdlog/fmt/fmt.h>
 
+using namespace std::literals;
+
 namespace WasmEdge {
 
 uint8_t convertCharToHex(const char C) {
@@ -27,11 +29,11 @@ void convertBytesToHexStr(Span<const uint8_t> Src, std::string &Dst,
   Dst.reserve(Src.size() * 2);
   if (IsLittleEndian) {
     for (auto It = Src.rbegin(); It != Src.rend(); It++) {
-      Dst += fmt::format("{:02x}", *It);
+      Dst += fmt::format("{:02x}"sv, *It);
     }
   } else {
     for (auto It = Src.begin(); It != Src.end(); It++) {
-      Dst += fmt::format("{:02x}", *It);
+      Dst += fmt::format("{:02x}"sv, *It);
     }
   }
   if (Dst.length() < Padding) {
@@ -82,7 +84,7 @@ void convertHexStrToValVec(std::string_view Src, std::vector<uint8_t> &Dst,
 }
 
 std::string convertUIntToHexStr(const uint64_t Num, uint32_t MinLen) {
-  return fmt::format("0x{:0{}x}", Num, std::min(MinLen, UINT32_C(16)));
+  return fmt::format("0x{:0{}x}"sv, Num, std::min(MinLen, UINT32_C(16)));
 }
 
 } // namespace WasmEdge

--- a/lib/driver/parseTool.cpp
+++ b/lib/driver/parseTool.cpp
@@ -85,19 +85,19 @@ std::string getInitExprStr(const AST::Expression &Expr) {
   const auto &Instr = Instrs[0];
   switch (Instr.getOpCode()) {
   case OpCode::I32__const:
-    return fmt::format("i32={}", Instr.getNum().get<int32_t>());
+    return fmt::format("i32={}"sv, Instr.getNum().get<int32_t>());
   case OpCode::I64__const:
-    return fmt::format("i64={}", Instr.getNum().get<int64_t>());
+    return fmt::format("i64={}"sv, Instr.getNum().get<int64_t>());
   case OpCode::F32__const:
-    return fmt::format("f32={}", Instr.getNum().get<float>());
+    return fmt::format("f32={}"sv, Instr.getNum().get<float>());
   case OpCode::F64__const:
-    return fmt::format("f64={}", Instr.getNum().get<double>());
+    return fmt::format("f64={}"sv, Instr.getNum().get<double>());
   case OpCode::Global__get:
-    return fmt::format("global.get {}", Instr.getTargetIndex());
+    return fmt::format("global.get {}"sv, Instr.getTargetIndex());
   case OpCode::Ref__func:
-    return fmt::format("ref.func {}", Instr.getTargetIndex());
+    return fmt::format("ref.func {}"sv, Instr.getTargetIndex());
   case OpCode::Ref__null:
-    return fmt::format("ref.null {}", Instr.getValType());
+    return fmt::format("ref.null {}"sv, Instr.getValType());
   default:
     return {};
   }
@@ -112,7 +112,7 @@ std::string getElemEntryStr(const AST::Expression &Expr) {
   const auto &Instr = Instrs[0];
   switch (Instr.getOpCode()) {
   case OpCode::Ref__func:
-    return fmt::format("func[{}]", Instr.getTargetIndex());
+    return fmt::format("func[{}]"sv, Instr.getTargetIndex());
   case OpCode::Ref__null:
     return "ref.null";
   default:
@@ -168,14 +168,14 @@ int ParseTool(struct DriverToolOptions &Opt) noexcept {
   auto FuncName = [&](uint32_t Idx) -> std::string {
     auto It = NS.FuncNames.find(Idx);
     if (It != NS.FuncNames.end())
-      return fmt::format(" <{}>", It->second);
+      return fmt::format(" <{}>"sv, It->second);
     return {};
   };
 
   auto GlobalName = [&](uint32_t Idx) -> std::string {
     auto It = NS.GlobalNames.find(Idx);
     if (It != NS.GlobalNames.end())
-      return fmt::format(" <{}>", It->second);
+      return fmt::format(" <{}>"sv, It->second);
     return {};
   };
 

--- a/lib/executor/instantiate/import.cpp
+++ b/lib/executor/instantiate/import.cpp
@@ -138,7 +138,7 @@ Expect<void> Executor::instantiate(
                  ModName == "wasi_crypto_symmetric"sv) {
         spdlog::error("    This is a WASI-Crypto related import. Please ensure "
                       "that you've turned on the WASI-Crypto configuration and "
-                      "installed the WASI-Crypto plug-in.");
+                      "installed the WASI-Crypto plug-in."sv);
       } else if (ModName == "env"sv) {
         spdlog::error(
             "    This may be the import of host environment like JavaScript or "

--- a/lib/host/wasi/vfs_io.cpp
+++ b/lib/host/wasi/vfs_io.cpp
@@ -341,7 +341,7 @@ OFStream::OFStream(const std::string_view FileName,
       }
     } else {
       HasError = true;
-      spdlog::error("Failed to open file for writing: {}",
+      spdlog::error("Failed to open file for writing: {}"sv,
                     std::string(FileName));
     }
   } else {

--- a/lib/llvm/compiler.cpp
+++ b/lib/llvm/compiler.cpp
@@ -6024,12 +6024,12 @@ Expect<void> Compiler::checkConfigure() noexcept {
   if (Conf.hasProposal(Proposal::ExceptionHandling)) {
     spdlog::warn("Proposal Exception Handling is not yet supported in WasmEdge "
                  "AOT/JIT. The compilation will be trapped when related data "
-                 "structure or instructions found in WASM.");
+                 "structure or instructions found in WASM."sv);
   }
   if (Conf.hasProposal(Proposal::Annotations)) {
     spdlog::error(ErrCode::Value::InvalidAOTConfigure);
     spdlog::error("    Proposal Custom Annotation Syntax is not yet supported "
-                  "in WasmEdge AOT/JIT.");
+                  "in WasmEdge AOT/JIT."sv);
     return Unexpect(ErrCode::Value::InvalidAOTConfigure);
   }
   return {};

--- a/lib/loader/ast/module.cpp
+++ b/lib/loader/ast/module.cpp
@@ -166,19 +166,19 @@ Expect<void> Loader::loadExecutable(AST::Module &Mod,
   auto IntrinsicsSymbol = Exec->getIntrinsics();
   if (unlikely(FuncTypeSymbols.size() != SubTypes.size())) {
     spdlog::error("    AOT section -- number of types not matching:{} {}, "
-                  "use interpreter mode instead.",
+                  "use interpreter mode instead."sv,
                   FuncTypeSymbols.size(), SubTypes.size());
     return Unexpect(ErrCode::Value::IllegalGrammar);
   }
   if (unlikely(CodeSymbols.size() != CodeSegs.size())) {
     spdlog::error("    AOT section -- number of codes not matching:{} {}, "
-                  "use interpreter mode instead.",
+                  "use interpreter mode instead."sv,
                   CodeSymbols.size(), CodeSegs.size());
     return Unexpect(ErrCode::Value::IllegalGrammar);
   }
   if (unlikely(!IntrinsicsSymbol)) {
     spdlog::error("    AOT section -- intrinsics table symbol not found, use "
-                  "interpreter mode instead.");
+                  "interpreter mode instead."sv);
     return Unexpect(ErrCode::Value::IllegalGrammar);
   }
 
@@ -298,10 +298,10 @@ Expect<void> Loader::loadModuleAOT(AST::AOTSection &AOTSection) {
           // interpreter mode.
           if (WASMType == InputType::UniversalWASM) {
             spdlog::info(
-                "    Load AOT section failed. Use the previous succeeded one.");
+                "    Load AOT section failed. Use the previous succeeded one."sv);
           } else {
             spdlog::info(
-                "    Load AOT section failed. Use interpreter mode instead.");
+                "    Load AOT section failed. Use interpreter mode instead."sv);
           }
         }
       } else {

--- a/lib/po/argument_parser.cpp
+++ b/lib/po/argument_parser.cpp
@@ -279,7 +279,7 @@ ArgumentParser::SubCommandDescriptor::consume_long_option_with_argument(
     } else if (ArgumentDescriptor *CurrentDesc = *Res; !CurrentDesc) {
       return cxx20::unexpected<Error>(
           std::in_place, ErrCode::InvalidArgument,
-          fmt::format("option {} doesn't need arguments.", Option));
+          fmt::format("option {} doesn't need arguments."sv, Option));
     } else {
       if (auto ConsumeRes = consume_argument(*CurrentDesc, Argument);
           !ConsumeRes) {

--- a/plugins/wasi_nn/GGML/metadata/metadata_parser.cpp
+++ b/plugins/wasi_nn/GGML/metadata/metadata_parser.cpp
@@ -57,7 +57,7 @@ ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
     parseJsonWithProcessorAuto<int64_t>(
         Doc, "n-cpu-moe", [&GraphRef](const int64_t &NCpuMoe) -> bool {
           if (NCpuMoe < 0) {
-            spdlog::error("[WASI-NN] GGML backend: Invalid n-cpu-moe value.");
+            spdlog::error("[WASI-NN] GGML backend: Invalid n-cpu-moe value."sv);
             return false;
           }
           for (int I = 0; I < NCpuMoe; I++) {
@@ -85,7 +85,7 @@ ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
           if (TensorSplitSize > NDevices) {
             spdlog::error(
                 "[WASI-NN] GGML backend: Number of Tensor-Split is larger than "
-                "MaxDevices, please reduce the size of tensor-split.");
+                "MaxDevices, please reduce the size of tensor-split."sv);
             return false;
           }
           for (size_t Idx = TensorSplitSize; Idx < NDevices; Idx++) {
@@ -105,7 +105,7 @@ ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
             GraphRef.Params.split_mode = LLAMA_SPLIT_MODE_ROW;
           } else {
             spdlog::error("[WASI-NN] GGML backend: Unknown split-mode: "
-                          "{}. Valid: none, layer, row.",
+                          "{}. Valid: none, layer, row."sv,
                           SplitMode);
             return false;
           }
@@ -385,7 +385,7 @@ ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
           } else {
             spdlog::error(
                 "[WASI-NN] GGML backend: The flash-attn option must be "
-                "one of: on, off, auto.");
+                "one of: on, off, auto."sv);
             return false;
           }
           return true;

--- a/plugins/wasi_nn/GGML/metadata/metadata_parser.h
+++ b/plugins/wasi_nn/GGML/metadata/metadata_parser.h
@@ -18,8 +18,8 @@ T getJsonValue(const simdjson::dom::element &Doc, std::string_view Key) {
     T Value{};
     auto Err = Doc[Key].get<T>().get(Value);
     if (Err) {
-      std::string Msg = fmt::format("Unable to retrieve the {} option.", Key);
-      spdlog::error("[WASI-NN] GGML backend: {}", Msg);
+      std::string Msg = fmt::format("Unable to retrieve the {} option."sv, Key);
+      spdlog::error("[WASI-NN] GGML backend: {}"sv, Msg);
       throw ErrNo(ErrNo::InvalidArgument);
     }
     return Value;

--- a/plugins/wasi_nn/MLX/mlx/pooling.cpp
+++ b/plugins/wasi_nn/MLX/mlx/pooling.cpp
@@ -81,7 +81,7 @@ mx::array slidingWindows(const mx::array &X,
 
     spdlog::error(
         "The window shapes and strides must have the same number of spatial "
-        "dimensions as the signal.");
+        "dimensions as the signal."sv);
     assumingUnreachable();
   }
   bool UseNonOverlap = true;

--- a/plugins/wasi_nn/MLX/model/gemma3/gemma3.cpp
+++ b/plugins/wasi_nn/MLX/model/gemma3/gemma3.cpp
@@ -183,7 +183,7 @@ std::shared_ptr<Model> Model::fromPretrained(const std::string &ModelPath) {
   simdjson::dom::element Doc;
   auto Error = Parser.load((Path / "config.json").string()).get(Doc);
   if (Error) {
-    spdlog::error("Could not open config.json");
+    spdlog::error("Could not open config.json"sv);
     assumingUnreachable();
   }
   auto Obj = Doc.get_object();

--- a/plugins/wasi_nn/MLX/model/llm/transformer.h
+++ b/plugins/wasi_nn/MLX/model/llm/transformer.h
@@ -150,7 +150,7 @@ public:
       : Dim(Dim), HiddenDim(HiddenDim), Gemma(Gemma),
         EmbedAsHead(EmbedAsHeadPar) {
     if (VocabSize <= 0) {
-      spdlog::error("VocabSize must be greater than 0.");
+      spdlog::error("VocabSize must be greater than 0."sv);
       assumingUnreachable();
     }
     EmbedAsHead = Gemma ? true : EmbedAsHead;

--- a/plugins/wasi_nn/MLX/model/vlm_base.cpp
+++ b/plugins/wasi_nn/MLX/model/vlm_base.cpp
@@ -381,7 +381,7 @@ std::vector<int> Module::generate(
   //   assumingUnreachable();
   // }
   if (Kwargs.count("pixel_values") == 0) {
-    spdlog::error("Not implemented");
+    spdlog::error("Not implemented"sv);
     assumingUnreachable();
   } else {
     InputIds = *std::get_if<mx::array>(&Kwargs.find("input_ids")->second);
@@ -424,7 +424,7 @@ std::vector<int> Module::generate(
   };
 
   if (RepetitionPenalty.has_value() && RepetitionPenalty < 0) {
-    spdlog::error("Repetition penalty must be greater than 0");
+    spdlog::error("Repetition penalty must be greater than 0"sv);
     assumingUnreachable();
   }
 

--- a/plugins/wasi_nn/MLX/model/whisper/whisper.cpp
+++ b/plugins/wasi_nn/MLX/model/whisper/whisper.cpp
@@ -432,7 +432,7 @@ std::shared_ptr<Whisper> Whisper::fromPretrained(const std::string &ModelPath) {
   simdjson::dom::element Doc;
   auto Error = Parser.load((Path / "config.json").string()).get(Doc);
   if (Error) {
-    spdlog::error("Could not open config.json at {}", Path.string());
+    spdlog::error("Could not open config.json at {}"sv, Path.string());
     assumingUnreachable();
   }
   auto Obj = Doc.get_object();
@@ -444,7 +444,7 @@ std::shared_ptr<Whisper> Whisper::fromPretrained(const std::string &ModelPath) {
       WeightFiles.push_back(P.path());
   }
   if (WeightFiles.empty()) {
-    spdlog::error("No safetensors found in {}.", Path.string());
+    spdlog::error("No safetensors found in {}."sv, Path.string());
     assumingUnreachable();
   }
   std::unordered_map<std::string, mx::array> Weights;

--- a/plugins/wasi_nn/wasinn_mlx.cpp
+++ b/plugins/wasi_nn/wasinn_mlx.cpp
@@ -78,7 +78,7 @@ mx::array fromBytes(const Span<uint8_t> &Bytes) {
     return mx::array(static_cast<const int64_t *>(DataPtr), Shape, mx::int64);
   }
   default:
-    spdlog::error("[WASI-NN] MLX backend: Unsupported rtype: {}", RtypeValue);
+    spdlog::error("[WASI-NN] MLX backend: Unsupported rtype: {}"sv, RtypeValue);
     return mx::array({0.0f});
   }
 }
@@ -663,7 +663,7 @@ Expect<WASINN::ErrNo> compute(WasiNNEnvironment &Env,
   const std::chrono::duration<double> ElapsedSeconds{End - Start};
   if (GraphRef.EnableDebugLog) {
     spdlog::info("[WASI-NN] MLX backend: Generate {} tokens."sv, TokenListSize);
-    spdlog::info("Elapsed time: {} s. TPS: {}.", ElapsedSeconds.count(),
+    spdlog::info("Elapsed time: {} s. TPS: {}."sv, ElapsedSeconds.count(),
                  TokenListSize / ElapsedSeconds.count());
   }
   return WASINN::ErrNo::Success;

--- a/plugins/wasmedge_ocr/ocr_env.h
+++ b/plugins/wasmedge_ocr/ocr_env.h
@@ -29,7 +29,7 @@ public:
     // without specifying the tessdata path.
     if (TesseractApi->Init(NULL, "eng")) {
       spdlog::error(
-          "[WasmEdge-OCR] Error occurred when initializing tesseract.");
+          "[WasmEdge-OCR] Error occurred when initializing tesseract."sv);
     }
   }
   ~OCREnv() noexcept {

--- a/plugins/wasmedge_ocr/ocr_func.cpp
+++ b/plugins/wasmedge_ocr/ocr_func.cpp
@@ -50,7 +50,7 @@ Expect<uint32_t> GetOutput::body(const Runtime::CallingFrame &Frame,
   auto Buf = MemInst->getSpan<char>(OutBufferPtr, OutBufferMaxSize);
   if (unlikely(Buf.empty())) {
     spdlog::error(
-        "[WasmEdge-OCR] Failed when accessing the return OutBufferPtr memory.");
+        "[WasmEdge-OCR] Failed when accessing the return OutBufferPtr memory."sv);
     return static_cast<uint32_t>(ErrNo::InvalidArgument);
   }
 

--- a/test/api/APIAOTNestedVMTest.cpp
+++ b/test/api/APIAOTNestedVMTest.cpp
@@ -15,13 +15,15 @@
 #include <gtest/gtest.h>
 #include <stack>
 
+using namespace std::literals;
+
 namespace {
 /// C++ overloaded error checking functions
 /// `try` is keyword, `_try` is reserved in msvc
 void _Try(const char *Name, const WasmEdge_Result &R) {
   if (not WasmEdge_ResultOK(R)) {
     throw std::runtime_error{
-        fmt::format("{}: {}", Name, WasmEdge_ResultGetMessage(R))};
+        fmt::format("{}: {}"sv, Name, WasmEdge_ResultGetMessage(R))};
   }
 }
 template <typename T> T *_Try(const char *Name, T *R) {

--- a/test/common/spdlogTest.cpp
+++ b/test/common/spdlogTest.cpp
@@ -181,7 +181,7 @@ TEST(SpdlogTest, SetLoggingCallback_CallbackIsInvoked) {
   WasmEdge::Log::setErrorLoggingLevel();
 
   // Emit a log message at a level that will be delivered.
-  spdlog::error("spdlogTest callback probe");
+  spdlog::error("spdlogTest callback probe"sv);
 
   EXPECT_GT(CallCount.load(), 0);
 
@@ -198,7 +198,7 @@ TEST(SpdlogTest, SetLoggingCallback_CallbackReceivesCorrectLevel) {
       });
   WasmEdge::Log::setWarnLoggingLevel();
 
-  spdlog::warn("level probe");
+  spdlog::warn("level probe"sv);
 
   EXPECT_EQ(Captured, spdlog::level::warn);
 
@@ -223,12 +223,12 @@ TEST(SpdlogTest, SetLoggingCallback_ReplaceCallback) {
   WasmEdge::Log::setLoggingCallback(
       [&FirstCount](const spdlog::details::log_msg &) { ++FirstCount; });
   WasmEdge::Log::setErrorLoggingLevel();
-  spdlog::error("first callback");
+  spdlog::error("first callback"sv);
 
   // Replace with a second callback.
   WasmEdge::Log::setLoggingCallback(
       [&SecondCount](const spdlog::details::log_msg &) { ++SecondCount; });
-  spdlog::error("second callback");
+  spdlog::error("second callback"sv);
 
   EXPECT_GT(FirstCount.load(), 0);
   EXPECT_GT(SecondCount.load(), 0);
@@ -261,7 +261,7 @@ TEST(SpdlogTest, EdgeCase_CallbackSetResetSet) {
   WasmEdge::Log::setLoggingCallback(Cb);
 
   WasmEdge::Log::setErrorLoggingLevel();
-  spdlog::error("edge case probe");
+  spdlog::error("edge case probe"sv);
 
   EXPECT_GT(Count.load(), 0);
 


### PR DESCRIPTION
## Description

Following up on #5055.
Scanning the entire repository to apply the `sv` suffix to all remaining spdlog and fmt logging calls whose string literal format strings are missing the required `sv` suffix.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
