### PR TITLE
refactor(wasi_nn): redesign graph/context lifetime around shared-ownership handles

### DIFF
--- a/plugins/wasi_nn/DESIGN.md
+++ b/plugins/wasi_nn/DESIGN.md
@@ -1,0 +1,131 @@
+# WASI-NN Plugin: Ownership and Lifetime Design
+
+This note describes how the WASI-NN plugin manages graph and execution-context
+lifetimes, what the concurrency rules are, and what a backend author must (and
+must not) do. It reflects the shared-ownership redesign of the core.
+
+## Ownership model
+
+```text
+ResourceTable<Graph>   NNGraph   --shared_ptr-->  Graph   (variant payload,
+ResourceTable<Context> NNContext --shared_ptr-->  Context  status, op mutex)
+                                                     |
+                                                     +-- shared_ptr<Graph>
+```
+
+- Guest-visible handles are opaque `uint32_t` keys into two `ResourceTable`s
+  (`resource_table.h`). Handles are allocated monotonically and **never
+  reused**: a stale handle stops resolving instead of aliasing a resource
+  created later.
+- Every host operation resolves its handle to a `shared_ptr` and holds it for
+  the whole call. An in-flight operation therefore structurally cannot lose
+  its graph or context to a concurrent `unload`/`finalize_execution_context`.
+- A `Context` owns a `shared_ptr` to its parent `Graph`, so a live context
+  keeps the model alive to drain after the guest unloads the graph.
+- Backend resources are released by the payload destructors (RAII) at the last
+  `shared_ptr` release — never under a lock, and on whichever thread drops the
+  final reference. There are no per-backend `unload`/`finalizeExecCtx`
+  functions.
+
+## Publish discipline
+
+`load` and `init_execution_context` fully construct the wrapper and its
+backend payload **before** inserting it into a table. A table entry is always
+a complete, usable resource; a failed load simply never publishes and the
+discarded wrapper cleans itself up through the payload destructors. There is
+no observable "uninitialized" state and no rollback bookkeeping.
+
+## Status model
+
+`GraphStatus` (atomic, on the wrapper): `Ready`, `Invalid` (a set_input
+metadata reload failed; reloadable), `Detached` (unloaded; drain-only).
+Contexts need no status: they are only visible fully built.
+
+Each host op declares the graph status it requires in `hostOpPolicy()`
+(`wasinnenv.h`) via `GraphReq`:
+
+| Op | Tier | Meaning |
+|---|---|---|
+| init_execution_context | Ready | needs a usable model |
+| compute / compute_single | Ready | needs a usable model |
+| set_input | NotDetached | admits Invalid for metadata reload |
+| get_output | Any | drains a live context regardless of its graph |
+| get_output_single | Drainable | reads the model, so Ready or Detached |
+| fini_single | Any | resets context-owned streaming state |
+
+The table is the single place the drain-after-unload contract lives; a new op
+must add itself there.
+
+## Concurrency rules
+
+- The table mutexes only guard the id maps (nanosecond critical sections).
+- Each `Graph` carries one `std::mutex` (`opMutex()`); `withGraphOp` /
+  `withContextOp` take it around every backend dispatch, so all operations on
+  one graph — including operations on different contexts of that graph — are
+  serialized. This is required because several backends keep mutable inference
+  state on the graph payload (e.g. the GGML `llama_context`).
+- Status is re-checked after acquiring the op mutex, closing the race with a
+  concurrent unload or a failed set_input reload.
+- `unload` / `finalize_execution_context` do **not** take the op mutex: they
+  detach the handle immediately and let the last release run the destructor.
+  An unload during a long compute returns at once; memory is reclaimed when
+  the compute finishes.
+- Lock order: `MdMutex` before a table mutex (only in `mdGet`). The op mutex
+  is never held while acquiring either. `RawMdMap` (preloaded model bytes) is
+  immutable after construction and read without locks; `MdMutex` guards only
+  the name→handle map and is never held across a model load.
+- Global third-party log callbacks (llama.cpp, mtmd, whisper.cpp) are bound
+  once with **no user pointer** and gated by ref-counted atomic counters
+  (`wasinn_log_gate.h`): each graph that wants logs holds a RAII `LogToken`.
+
+## Writing a backend
+
+Backend entry points receive resolved wrapper references and must not touch
+the tables (they cannot — no table API is exposed to them):
+
+```cpp
+Expect<WASINN::ErrNo> load(WasiNNEnvironment &Env, WASINN::Graph &G,
+                           Span<const Span<uint8_t>> Builders,
+                           WASINN::Device Device) noexcept;
+Expect<WASINN::ErrNo> initExecCtx(WasiNNEnvironment &Env, WASINN::Graph &G,
+                                  WASINN::Context &C) noexcept;
+Expect<WASINN::ErrNo> setInput(WasiNNEnvironment &Env, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
+                               const TensorData &Tensor) noexcept;
+Expect<WASINN::ErrNo> getOutput(WasiNNEnvironment &Env, WASINN::Graph &G,
+                                WASINN::Context &C, uint32_t Index,
+                                Span<uint8_t> OutBuffer,
+                                uint32_t &BytesWritten) noexcept;
+Expect<WASINN::ErrNo> compute(WasiNNEnvironment &Env, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept;
+```
+
+Rules of thumb:
+
+- Resolve payloads once at the top: `auto &GraphRef = G.get<Graph>();`,
+  `auto &CxtRef = C.get<Context>();`.
+- `load` populates `GraphRef` and returns; the core publishes on success. Do
+  not allocate ids, set ready flags, or clean up on failure.
+- Own every resource in the payload structs via smart pointers or explicit
+  destructors. Value-initialize raw members so destroying a partially built
+  payload frees nothing invalid. If you add a destructor, delete the copy
+  operations (and re-default the default constructor for `Graph` payloads —
+  the core default-constructs them).
+- A failed set_input metadata reload marks the graph with `G.setInvalid()`;
+  a successful one restores it with `G.setReady()`.
+- Never register a global callback with a pointer to your payload; use a
+  ref-counted gate like the llama/whisper log gates.
+- Your ops run under the graph's op mutex: you may assume no other op touches
+  the same graph concurrently, and you must not block on other graphs.
+
+## Known limitations / future work
+
+- Per-graph serialization costs backends with genuinely independent
+  per-context state (e.g. OpenVINO `InferRequest`) their intra-graph
+  parallelism. A per-backend concurrency trait could relax the dispatch to a
+  per-context mutex for those backends.
+- `mdBuild` runs concurrent same-name loads independently; the last one wins
+  the name cache and the loser stays reachable only through its returned
+  handle. Per-name build deduplication would remove the redundant load.
+- Handles exhaust after 2^32 loads per table; `insert` then fails and the
+  host call reports `RuntimeError`.

--- a/plugins/wasi_nn/DESIGN.md
+++ b/plugins/wasi_nn/DESIGN.md
@@ -73,10 +73,14 @@ must add itself there.
   detach the handle immediately and let the last release run the destructor.
   An unload during a long compute returns at once; memory is reclaimed when
   the compute finishes.
-- Lock order: `MdMutex` before a table mutex (only in `mdGet`). The op mutex
-  is never held while acquiring either. `RawMdMap` (preloaded model bytes) is
-  immutable after construction and read without locks; `MdMutex` guards only
-  the name→handle map and is never held across a model load.
+- Lock order: `MdMutex` before a table mutex (only in `mdGet` and the
+  `mdBuild` cache re-check). The op mutex is never held while acquiring
+  either. `RawMdMap` (preloaded model bytes) is immutable after construction
+  and read without locks; `MdMutex` guards only the name→handle map and is
+  never held across a model load. Because builds run outside the lock,
+  concurrent `load_by_name` calls for one name may both build; `mdBuild`
+  re-checks the cache before publishing and folds later finishers onto the
+  first cached graph, dropping their duplicate builds.
 - Global third-party log callbacks (llama.cpp, mtmd, whisper.cpp) are bound
   once with **no user pointer** and gated by ref-counted atomic counters
   (`wasinn_log_gate.h`): each graph that wants logs holds a RAII `LogToken`.

--- a/plugins/wasi_nn/DESIGN.md
+++ b/plugins/wasi_nn/DESIGN.md
@@ -39,7 +39,10 @@ no observable "uninitialized" state and no rollback bookkeeping.
 
 `GraphStatus` (atomic, on the wrapper): `Ready`, `Invalid` (a set_input
 metadata reload failed; reloadable), `Detached` (unloaded; drain-only).
-Contexts need no status: they are only visible fully built.
+`Detached` is terminal: `setReady`/`setInvalid` CAS and give up once they
+observe it, so a reload that was in flight when the guest unloaded cannot
+resurrect the graph. Contexts need no status: they are only visible fully
+built.
 
 Each host op declares the graph status it requires in `hostOpPolicy()`
 (`wasinnenv.h`) via `GraphReq`:
@@ -112,7 +115,8 @@ Rules of thumb:
   operations (and re-default the default constructor for `Graph` payloads —
   the core default-constructs them).
 - A failed set_input metadata reload marks the graph with `G.setInvalid()`;
-  a successful one restores it with `G.setReady()`.
+  a successful one restores it with `G.setReady()`. Both are no-ops on a
+  `Detached` graph, so a reload finishing after an unload cannot undo it.
 - Never register a global callback with a pointer to your payload; use a
   ref-counted gate like the llama/whisper log gates.
 - Your ops run under the graph's op mutex: you may assume no other op touches

--- a/plugins/wasi_nn/GGML/compute/compute_engine.cpp
+++ b/plugins/wasi_nn/GGML/compute/compute_engine.cpp
@@ -13,9 +13,10 @@
 namespace WasmEdge::Host::WASINN::GGML {
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
 
-Expect<ErrNo> compute(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+Expect<ErrNo> compute(WasiNNEnvironment &Env, WASINN::Graph &G,
+                      WASINN::Context &C) noexcept {
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   LOG_DEBUG(GraphRef.EnableDebugLog, "compute")
 
   // Clear the context and reset the sampler.
@@ -88,10 +89,10 @@ Expect<ErrNo> compute(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
   return ReturnCode;
 }
 
-Expect<ErrNo> computeSingle(WasiNNEnvironment &Env,
-                            uint32_t ContextId) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+Expect<ErrNo> computeSingle(WasiNNEnvironment &, WASINN::Graph &G,
+                            WASINN::Context &C) noexcept {
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   LOG_DEBUG(GraphRef.EnableDebugLog, "computeSingle"sv)
 
   // New compute single token context.

--- a/plugins/wasi_nn/GGML/core/ggml_core.cpp
+++ b/plugins/wasi_nn/GGML/core/ggml_core.cpp
@@ -55,11 +55,9 @@ void llamaLogCallback(ggml_log_level LogLevel, const char *LogText,
 }
 } // namespace
 
-Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
-                   [[maybe_unused]] Device Device, uint32_t &GraphId) noexcept {
-  // Add a new graph.
-  EndianValue<uint32_t> GId = Env.newGraph(Backend::GGML);
-  auto &GraphRef = Env.NNGraph[GId.raw()].get<Graph>();
+Expect<ErrNo> load(WasiNNEnvironment &Env, WASINN::Graph &G,
+                   Span<const Span<uint8_t>> Builders, Device) noexcept {
+  auto &GraphRef = G.get<Graph>();
 
   // Initialize the plugin parameters.
   GraphRef.EnableLog = false;
@@ -103,7 +101,6 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
     // Ignore context or model updates when initializing the graph.
     auto Res = parseMetadata(GraphRef, GraphRef.Conf, Metadata);
     if (Res != ErrNo::Success) {
-      Env.deleteGraph(GId.raw());
       RET_ERROR(Res, "load: Failed to parse metadata."sv)
     }
   }
@@ -131,7 +128,6 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
         GraphRef.Params.model.path, std::ios_base::out | std::ios_base::binary,
         Env.getEnv());
     if (!TempFile) {
-      Env.deleteGraph(GId.raw());
       RET_ERROR(ErrNo::InvalidArgument,
                 "load: Failed to create the temporary file. Currently, our "sv
                 "workaround involves creating a temporary model file named "sv
@@ -148,7 +144,6 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
   // Check if the model exists.
   if (!std::filesystem::exists(
           std::filesystem::u8path(GraphRef.Params.model.path))) {
-    Env.deleteGraph(GId.raw());
     RET_ERROR(ErrNo::ModelNotFound, "load: model file not found."sv)
   }
   GraphRef.Params.model = GraphRef.Params.model;
@@ -170,13 +165,11 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
   GraphRef.LlamaModel = llama_model_ptr(
       llama_model_load_from_file(Params.model.path.c_str(), ModelParams));
   if (GraphRef.LlamaModel == nullptr) {
-    Env.deleteGraph(GId.raw());
     RET_ERROR(ErrNo::InvalidArgument, "load: unable to init model."sv)
   }
   GraphRef.LlamaContext = llama_context_ptr(llama_init_from_model(
       GraphRef.LlamaModel.get(), common_context_params_to_llama(Params)));
   if (GraphRef.LlamaContext == nullptr) {
-    Env.deleteGraph(GId.raw());
     RET_ERROR(ErrNo::InvalidArgument, "load: unable to init context."sv)
   }
   LOG_DEBUG(GraphRef.EnableDebugLog,
@@ -191,35 +184,28 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
     GraphRef.TTSModel = llama_model_ptr(
         llama_model_load_from_file(Params.model.path.c_str(), TTSModelParams));
     if (GraphRef.TTSModel == nullptr) {
-      Env.deleteGraph(GId.raw());
       RET_ERROR(ErrNo::InvalidArgument, "load: unable to init TTS model."sv)
     }
     GraphRef.TTSContext = llama_context_ptr(llama_init_from_model(
         GraphRef.TTSModel.get(), common_context_params_to_llama(Params)));
     if (GraphRef.TTSContext == nullptr) {
-      Env.deleteGraph(GId.raw());
       RET_ERROR(ErrNo::InvalidArgument, "load: unable to init TTS context."sv)
     }
     LOG_DEBUG(GraphRef.EnableDebugLog, "load: initialize TTS model...Done"sv)
   }
 
-  // Store the loaded graph.
-  GraphId = GId.le();
-  Env.NNGraph[GId.raw()].setReady();
-
   LOG_DEBUG(GraphRef.EnableDebugLog, "load...Done"sv)
   return ErrNo::Success;
 }
 
-Expect<ErrNo> initExecCtx(WasiNNEnvironment &Env, uint32_t GraphId,
-                          uint32_t &ContextId) noexcept {
-  auto &GraphRef = Env.NNGraph[GraphId].get<Graph>();
+Expect<ErrNo> initExecCtx(WasiNNEnvironment &, WASINN::Graph &G,
+                          WASINN::Context &C) noexcept {
+  auto &GraphRef = G.get<Graph>();
   LOG_DEBUG(GraphRef.EnableDebugLog, "initExecCtx"sv)
-  ContextId = Env.newContext(GraphId, Env.NNGraph[GraphId]);
   LOG_INFO(GraphRef.EnableLog, "llama_system_info: {}"sv,
            llama_print_system_info())
 
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
+  auto &CxtRef = C.get<Context>();
   // Allocate the batch for input string prompt tokens.
   CxtRef.LlamaBatch = allocBatch(GraphRef.Params.n_batch);
   CxtRef.CurrentBatchSize = GraphRef.Params.n_batch;
@@ -231,15 +217,14 @@ Expect<ErrNo> initExecCtx(WasiNNEnvironment &Env, uint32_t GraphId,
   CxtRef.LlamaSampler =
       common_sampler_init(GraphRef.LlamaModel.get(), GraphRef.Params.sampling);
 
-  Env.NNContext[ContextId].setReady();
-  ContextId = EndianValue(ContextId).le();
   LOG_DEBUG(GraphRef.EnableDebugLog, "initExecCtx...Done"sv)
   return ErrNo::Success;
 }
 
-Expect<ErrNo> finiSingle(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+Expect<ErrNo> finiSingle(WasiNNEnvironment &, WASINN::Graph &G,
+                         WASINN::Context &C) noexcept {
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   LOG_DEBUG(GraphRef.EnableDebugLog, "finiSingle"sv)
 
   // Logging for the llama timings.
@@ -264,77 +249,6 @@ Expect<ErrNo> finiSingle(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
   return ErrNo::Success;
 }
 
-Expect<ErrNo> unload(WasiNNEnvironment &Env, uint32_t GraphId) noexcept {
-  auto &GraphRef = Env.NNGraph[GraphId].get<Graph>();
-  const bool IsDebugLog = GraphRef.EnableDebugLog;
-  LOG_DEBUG(IsDebugLog, "unload"sv)
-
-  // TODO: Move the resource deallocation into the destructor.
-  if (GraphRef.LlamaModel != nullptr) {
-    LOG_DEBUG(IsDebugLog, "unload: free llama model"sv)
-    GraphRef.LlamaModel.reset();
-    LOG_DEBUG(IsDebugLog, "unload: free llama model...Done"sv)
-  }
-  if (GraphRef.LlamaContext != nullptr) {
-    LOG_DEBUG(IsDebugLog, "unload: free llama context"sv)
-    GraphRef.LlamaContext.reset();
-    LOG_DEBUG(IsDebugLog, "unload: free llama context...Done"sv)
-  }
-  if (GraphRef.VisionContext != nullptr) {
-    LOG_DEBUG(IsDebugLog, "unload: free mtmd context"sv)
-    GraphRef.VisionContext.reset();
-    LOG_DEBUG(IsDebugLog, "unload: free mtmd context...Done"sv)
-  }
-  if (GraphRef.VisionInputChunks != nullptr) {
-    LOG_DEBUG(IsDebugLog, "unload: free mtmd chunks"sv)
-    GraphRef.VisionInputChunks.reset();
-    LOG_DEBUG(IsDebugLog, "unload: free mtmd chunks...Done"sv)
-  }
-  if (GraphRef.TTSModel != nullptr) {
-    LOG_DEBUG(IsDebugLog, "unload: free TTS model"sv)
-    GraphRef.TTSModel.reset();
-    LOG_DEBUG(IsDebugLog, "unload: free TTS model...Done"sv)
-  }
-  if (GraphRef.TTSContext != nullptr) {
-    LOG_DEBUG(IsDebugLog, "unload: free TTS context"sv)
-    GraphRef.TTSContext.reset();
-    LOG_DEBUG(IsDebugLog, "unload: free TTS context...Done"sv)
-  }
-  if (!GraphRef.TensorBuftOverrides.empty()) {
-    LOG_DEBUG(IsDebugLog, "unload: free tensor buffer overrides"sv)
-    GraphRef.TensorBuftOverrides.clear();
-    LOG_DEBUG(IsDebugLog, "unload: free tensor buffer overrides...Done"sv)
-  }
-  Env.deleteGraph(GraphId);
-  Env.mdRemoveById(GraphId);
-
-  LOG_DEBUG(IsDebugLog, "unload...Done"sv)
-  return ErrNo::Success;
-}
-
-Expect<ErrNo> finalizeExecCtx(WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
-  LOG_DEBUG(GraphRef.EnableDebugLog, "finalize_execution_context"sv)
-
-  if (CxtRef.LlamaSampler != nullptr) {
-    LOG_DEBUG(GraphRef.EnableDebugLog,
-              "finalize_execution_context: free compute_single sampler"sv)
-    common_sampler_free(CxtRef.LlamaSampler);
-    CxtRef.LlamaSampler = nullptr;
-    LOG_DEBUG(
-        GraphRef.EnableDebugLog,
-        "finalize_execution_context: free compute_single sampler...Done"sv)
-  }
-  llama_batch_free(CxtRef.LlamaBatch);
-  llama_batch_free(CxtRef.OutputBatch);
-  Env.deleteContext(ContextId);
-
-  LOG_DEBUG(GraphRef.EnableDebugLog, "finalize_execution_context...Done"sv)
-  return ErrNo::Success;
-}
-
 #else
 namespace {
 Expect<ErrNo> reportBackendNotSupported() noexcept {
@@ -344,38 +258,37 @@ Expect<ErrNo> reportBackendNotSupported() noexcept {
 }
 } // namespace
 
-Expect<ErrNo> load(WasiNNEnvironment &, Span<const Span<uint8_t>>, Device,
-                   uint32_t &) noexcept {
+Expect<ErrNo> load(WasiNNEnvironment &, WASINN::Graph &,
+                   Span<const Span<uint8_t>>, Device) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> initExecCtx(WasiNNEnvironment &, uint32_t, uint32_t &) noexcept {
+Expect<ErrNo> initExecCtx(WasiNNEnvironment &, WASINN::Graph &,
+                          WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> setInput(WasiNNEnvironment &, uint32_t, uint32_t,
-                       const TensorData &) noexcept {
+Expect<ErrNo> setInput(WasiNNEnvironment &, WASINN::Graph &, WASINN::Context &,
+                       uint32_t, const TensorData &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> getOutput(WasiNNEnvironment &, uint32_t, uint32_t, Span<uint8_t>,
-                        uint32_t &) noexcept {
+Expect<ErrNo> getOutput(WasiNNEnvironment &, WASINN::Graph &, WASINN::Context &,
+                        uint32_t, Span<uint8_t>, uint32_t &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> compute(WasiNNEnvironment &, uint32_t) noexcept {
+Expect<ErrNo> compute(WasiNNEnvironment &, WASINN::Graph &,
+                      WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> getOutputSingle(WasiNNEnvironment &, uint32_t, uint32_t,
-                              Span<uint8_t>, uint32_t &) noexcept {
+Expect<ErrNo> getOutputSingle(WasiNNEnvironment &, WASINN::Graph &,
+                              WASINN::Context &, uint32_t, Span<uint8_t>,
+                              uint32_t &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> computeSingle(WasiNNEnvironment &, uint32_t) noexcept {
+Expect<ErrNo> computeSingle(WasiNNEnvironment &, WASINN::Graph &,
+                            WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> finiSingle(WasiNNEnvironment &, uint32_t) noexcept {
-  return reportBackendNotSupported();
-}
-Expect<ErrNo> unload(WasiNNEnvironment &, uint32_t) noexcept {
-  return reportBackendNotSupported();
-}
-Expect<ErrNo> finalizeExecCtx(WasiNNEnvironment &, uint32_t) noexcept {
+Expect<ErrNo> finiSingle(WasiNNEnvironment &, WASINN::Graph &,
+                         WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
 #endif

--- a/plugins/wasi_nn/GGML/core/ggml_core.cpp
+++ b/plugins/wasi_nn/GGML/core/ggml_core.cpp
@@ -227,8 +227,10 @@ Expect<ErrNo> finiSingle(WasiNNEnvironment &, WASINN::Graph &G,
   auto &GraphRef = G.get<Graph>();
   LOG_DEBUG(GraphRef.EnableDebugLog, "finiSingle"sv)
 
-  // Logging for the llama timings.
-  if (GraphRef.EnableLog) {
+  // A failed set_input reload can leave a null llama context or sampler and
+  // fini_single still admits the graph, so guard both.
+  if (GraphRef.EnableLog && GraphRef.LlamaContext != nullptr &&
+      CxtRef.LlamaSampler != nullptr) {
     common_perf_print(GraphRef.LlamaContext.get(), CxtRef.LlamaSampler);
   }
 
@@ -241,7 +243,9 @@ Expect<ErrNo> finiSingle(WasiNNEnvironment &, WASINN::Graph &G,
             "finiSingle: clear the previous output and tokens...Done"sv)
 
   // Reset the llama sampler.
-  common_sampler_reset(CxtRef.LlamaSampler);
+  if (CxtRef.LlamaSampler != nullptr) {
+    common_sampler_reset(CxtRef.LlamaSampler);
+  }
   CxtRef.ComputeSingleStarted = false;
   CxtRef.NPos = 0;
 

--- a/plugins/wasi_nn/GGML/core/ggml_core.cpp
+++ b/plugins/wasi_nn/GGML/core/ggml_core.cpp
@@ -10,6 +10,7 @@
 
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
 #include "GGML/metadata/metadata_parser.h"
+#include "wasinn_ggml_log.h"
 #include <base64.hpp>
 #include <common.h>
 #include <cstdlib>
@@ -23,37 +24,30 @@
 
 #include <filesystem>
 #include <math.h>
+#include <mutex>
 #endif
 
 namespace WasmEdge::Host::WASINN::GGML {
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
 namespace {
 
-// Llama logging callback.
-void llamaLogCallback(ggml_log_level LogLevel, const char *LogText,
-                      void *UserData) {
-  Graph &GraphRef = *reinterpret_cast<Graph *>(UserData);
-  if (!GraphRef.EnableLog) {
+// No per-graph user pointer (would dangle); gated on the shared llama gate.
+void llamaLogCallback(ggml_log_level LogLevel, const char *LogText, void *) {
+  if (!llamaLogEnabled()) {
     return;
   }
-  std::string Text(LogText);
-  // Remove the trailing newlines.
-  Text = Text.erase(Text.find_last_not_of("\n") + 1);
-  // Skip for "."
-  if (Text == ".") {
-    return;
-  }
-  if (LogLevel == GGML_LOG_LEVEL_ERROR) {
-    spdlog::error("[WASI-NN] llama.cpp: {}"sv, Text);
-  } else if (LogLevel == GGML_LOG_LEVEL_WARN) {
-    spdlog::warn("[WASI-NN] llama.cpp: {}"sv, Text);
-  } else if (LogLevel == GGML_LOG_LEVEL_INFO) {
-    spdlog::info("[WASI-NN] llama.cpp: {}"sv, Text);
-  } else if (LogLevel == GGML_LOG_LEVEL_DEBUG) {
-    spdlog::debug("[WASI-NN] llama.cpp: {}"sv, Text);
-  }
+  logGgmlMessage(LogLevel, LogText, "llama.cpp"sv);
 }
 } // namespace
+
+void installLlamaLog(Graph &GraphRef) noexcept {
+  static std::once_flag LogOnce;
+  std::call_once(LogOnce, []() noexcept {
+    llama_log_set(llamaLogCallback, nullptr);
+    mtmd_helper_log_set(llamaLogCallback, nullptr);
+  });
+  GraphRef.LlamaLog.set(GraphRef.EnableLog);
+}
 
 Expect<ErrNo> load(WasiNNEnvironment &Env, WASINN::Graph &G,
                    Span<const Span<uint8_t>> Builders, Device) noexcept {
@@ -89,10 +83,6 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, WASINN::Graph &G,
   GraphRef.Conf.ReversePrompt = ""sv;
   GraphRef.Conf.ImagePath = ""sv;
 
-  // Set llama log callback.
-  llama_log_set(llamaLogCallback, &GraphRef);
-  mtmd_helper_log_set(llamaLogCallback, &GraphRef);
-
   // If the graph builder length is greater than 1, builder[1] contains the
   // metadata.
   if (Builders.size() > 1) {
@@ -104,6 +94,9 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, WASINN::Graph &G,
       RET_ERROR(Res, "load: Failed to parse metadata."sv)
     }
   }
+
+  // EnableLog is only known after metadata parsing; sync the log gate now.
+  installLlamaLog(GraphRef);
 
   // Logging.
   LOG_DEBUG(GraphRef.EnableDebugLog, "load"sv)

--- a/plugins/wasi_nn/GGML/core/ggml_core.h
+++ b/plugins/wasi_nn/GGML/core/ggml_core.h
@@ -13,35 +13,34 @@
 
 namespace WasmEdge::Host::WASINN {
 struct WasiNNEnvironment;
+class Graph;
+class Context;
 } // namespace WasmEdge::Host::WASINN
 namespace WasmEdge::Host::WASINN::GGML {
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
                            Span<const Span<uint8_t>> Builders,
-                           WASINN::Device Device, uint32_t &GraphId) noexcept;
+                           WASINN::Device Device) noexcept;
 Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
-                                  uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept;
+                                  WASINN::Graph &G,
+                                  WASINN::Context &C) noexcept;
 Expect<WASINN::ErrNo> finiSingle(WASINN::WasiNNEnvironment &Env,
-                                 uint32_t ContextId) noexcept;
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
-                               uint32_t ContextId, uint32_t Index,
+                                 WASINN::Graph &G, WASINN::Context &C) noexcept;
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept;
 Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
-                                uint32_t ContextId, uint32_t Index,
-                                Span<uint8_t> OutBuffer,
+                                WASINN::Graph &G, WASINN::Context &C,
+                                uint32_t Index, Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept;
 Expect<WASINN::ErrNo> getOutputSingle(WASINN::WasiNNEnvironment &Env,
-                                      uint32_t ContextId, uint32_t Index,
-                                      Span<uint8_t> OutBuffer,
+                                      WASINN::Graph &G, WASINN::Context &C,
+                                      uint32_t Index, Span<uint8_t> OutBuffer,
                                       uint32_t &BytesWritten) noexcept;
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept;
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept;
 Expect<WASINN::ErrNo> computeSingle(WASINN::WasiNNEnvironment &Env,
-                                    uint32_t ContextId) noexcept;
-Expect<WASINN::ErrNo> unload(WASINN::WasiNNEnvironment &Env,
-                             uint32_t GraphId) noexcept;
-Expect<WASINN::ErrNo> finalizeExecCtx(WASINN::WasiNNEnvironment &Env,
-                                      uint32_t ContextId) noexcept;
+                                    WASINN::Graph &G,
+                                    WASINN::Context &C) noexcept;
 
 } // namespace WasmEdge::Host::WASINN::GGML

--- a/plugins/wasi_nn/GGML/core/ggml_core.h
+++ b/plugins/wasi_nn/GGML/core/ggml_core.h
@@ -18,6 +18,11 @@ class Context;
 } // namespace WasmEdge::Host::WASINN
 namespace WasmEdge::Host::WASINN::GGML {
 
+#ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
+// Bind the llama/mtmd log callback once and sync the graph's log gate.
+void installLlamaLog(Graph &GraphRef) noexcept;
+#endif
+
 Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
                            Span<const Span<uint8_t>> Builders,
                            WASINN::Device Device) noexcept;

--- a/plugins/wasi_nn/GGML/core/ggml_type.h
+++ b/plugins/wasi_nn/GGML/core/ggml_type.h
@@ -7,6 +7,7 @@
 #include "wasinntypes.h"
 
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
+#include "wasinn_llama_log.h"
 #include "wasinntypes.h"
 #include <ggml.h>
 #include <list>
@@ -47,6 +48,8 @@ struct Graph {
   // Plugin parameters:
   bool EnableLog = false;
   bool EnableDebugLog = false;
+  // This graph's unit in the shared llama log gate.
+  LlamaLogToken LlamaLog;
   common_params Params;
   std::list<std::string> TensorBuftOverrides;
   // Model context:

--- a/plugins/wasi_nn/GGML/core/ggml_type.h
+++ b/plugins/wasi_nn/GGML/core/ggml_type.h
@@ -68,6 +68,16 @@ struct Graph {
 struct Context {
 public:
   Context(uint32_t GId, Graph &G) noexcept : GraphId(GId), Conf(G.Conf) {}
+  Context(const Context &) = delete;
+  Context &operator=(const Context &) = delete;
+  ~Context() noexcept {
+    if (LlamaSampler != nullptr) {
+      common_sampler_free(LlamaSampler);
+      LlamaSampler = nullptr;
+    }
+    llama_batch_free(LlamaBatch);
+    llama_batch_free(OutputBatch);
+  }
   uint32_t GraphId;
   // Llama inputs:
   std::vector<llama_token> LlamaInputs;
@@ -79,9 +89,10 @@ public:
   bool ComputeSingleStarted = false;
   struct common_sampler *LlamaSampler = nullptr;
   // Handle the batch in the context to prevent reallocation during every
-  // computation.
-  struct llama_batch LlamaBatch;
-  struct llama_batch OutputBatch;
+  // computation. Value-initialized so destroying a context whose batches were
+  // never allocated frees nothing.
+  struct llama_batch LlamaBatch{};
+  struct llama_batch OutputBatch{};
   int64_t CurrentBatchSize = 0;
   size_t ImagePosition = 0;
   int32_t NPos = 0;

--- a/plugins/wasi_nn/GGML/core/input_processor.cpp
+++ b/plugins/wasi_nn/GGML/core/input_processor.cpp
@@ -35,6 +35,8 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, WASINN::Graph &G,
     if (Res != ErrNo::Success) {
       RET_ERROR(Res, "setInput: failed to parse metadata."sv)
     }
+    // Reconcile this graph's llama log gate with the reparsed EnableLog.
+    installLlamaLog(GraphRef);
 
 #ifndef __APPLE__
     // XXX: Because of the limitation in the WASI-NN proposal, this is a

--- a/plugins/wasi_nn/GGML/core/input_processor.cpp
+++ b/plugins/wasi_nn/GGML/core/input_processor.cpp
@@ -14,10 +14,11 @@
 namespace WasmEdge::Host::WASINN::GGML {
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
 
-Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
-                       uint32_t Index, const TensorData &Tensor) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+Expect<ErrNo> setInput(WasiNNEnvironment &Env, WASINN::Graph &G,
+                       WASINN::Context &C, uint32_t Index,
+                       const TensorData &Tensor) noexcept {
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   LOG_DEBUG(GraphRef.EnableDebugLog, "setInput"sv)
 
   // Use index 1 for metadata.
@@ -63,7 +64,7 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
         GraphRef.LlamaModel = llama_model_ptr(llama_model_load_from_file(
             GraphRef.Params.model.path.c_str(), ModelParams));
         if (GraphRef.LlamaModel == nullptr) {
-          Env.NNGraph[CxtRef.GraphId].setInvalid();
+          G.setInvalid();
           RET_ERROR(ErrNo::InvalidArgument, "setInput: unable to init model."sv)
         }
       }
@@ -80,7 +81,7 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
           GraphRef.LlamaModel.get(),
           common_context_params_to_llama(GraphRef.Params)));
       if (GraphRef.LlamaContext == nullptr) {
-        Env.NNGraph[CxtRef.GraphId].setInvalid();
+        G.setInvalid();
         RET_ERROR(ErrNo::InvalidArgument, "setInput: unable to init context."sv)
       }
     }
@@ -96,7 +97,7 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
       CxtRef.LlamaSampler = common_sampler_init(GraphRef.LlamaModel.get(),
                                                 GraphRef.Params.sampling);
       if (GraphRef.LlamaContext == nullptr) {
-        Env.NNGraph[CxtRef.GraphId].setInvalid();
+        G.setInvalid();
         RET_ERROR(ErrNo::InvalidArgument, "setInput: unable to init sampler."sv)
       }
     }
@@ -108,7 +109,7 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
       CxtRef.CurrentBatchSize = GraphRef.Params.n_batch;
     }
 
-    Env.NNGraph[CxtRef.GraphId].setReady();
+    G.setReady();
     LOG_DEBUG(GraphRef.EnableDebugLog,
               "setInput: found Metadata, processing...Done"sv)
     return ErrNo::Success;
@@ -116,7 +117,7 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
 
   // Check that the graph is valid after reloading during the previous
   // set_input.
-  if (!Env.NNGraph[CxtRef.GraphId].isReady()) {
+  if (!G.isReady()) {
     RET_ERROR(
         ErrNo::InvalidArgument,
         "setInput: Graph is invalid. Please reload again by passing metadata "sv

--- a/plugins/wasi_nn/GGML/core/output_generator.cpp
+++ b/plugins/wasi_nn/GGML/core/output_generator.cpp
@@ -46,6 +46,14 @@ Expect<ErrNo> getOutputSingle(WasiNNEnvironment &, WASINN::Graph &G,
     return ErrNo::Success;
   }
 
+  // A failed set_input reload can null the llama context; unload then makes
+  // the Invalid graph Drainable, so this op can be admitted without one.
+  if (GraphRef.LlamaContext == nullptr) {
+    RET_ERROR(ErrNo::InvalidArgument,
+              "getOutputSingle: the llama context is gone. The last reload "sv
+              "failed and the graph was unloaded."sv)
+  }
+
   std::string LastToken = common_token_to_piece(
       GraphRef.LlamaContext.get(), CxtRef.LlamaOutputTokens.back());
   BytesWritten = EndianValue(static_cast<uint32_t>(LastToken.length())).le();

--- a/plugins/wasi_nn/GGML/core/output_generator.cpp
+++ b/plugins/wasi_nn/GGML/core/output_generator.cpp
@@ -17,11 +17,12 @@ std::string buildOutputMetadata(Context &CxtRef) noexcept {
 }
 } // namespace
 
-Expect<ErrNo> getOutputSingle(WasiNNEnvironment &Env, uint32_t ContextId,
-                              uint32_t Index, Span<uint8_t> OutBuffer,
+Expect<ErrNo> getOutputSingle(WasiNNEnvironment &, WASINN::Graph &G,
+                              WASINN::Context &C, uint32_t Index,
+                              Span<uint8_t> OutBuffer,
                               uint32_t &BytesWritten) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   LOG_DEBUG(GraphRef.EnableDebugLog, "getOutputSingle: with Index {}"sv, Index)
 
   // Use index 1 for output metadata.
@@ -60,11 +61,12 @@ Expect<ErrNo> getOutputSingle(WasiNNEnvironment &Env, uint32_t ContextId,
   return ErrNo::Success;
 }
 
-Expect<ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
-                        uint32_t Index, Span<uint8_t> OutBuffer,
+Expect<ErrNo> getOutput(WasiNNEnvironment &, WASINN::Graph &G,
+                        WASINN::Context &C, uint32_t Index,
+                        Span<uint8_t> OutBuffer,
                         uint32_t &BytesWritten) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   LOG_DEBUG(GraphRef.EnableDebugLog, "getOutput: with Index {}"sv, Index)
 
   // Use index 1 for output metadata.

--- a/plugins/wasi_nn/resource_table.h
+++ b/plugins/wasi_nn/resource_table.h
@@ -70,6 +70,16 @@ public:
     return static_cast<uint32_t>(Map.size());
   }
 
+  // Swap contents including the id counter; lets tests stage a scratch table.
+  void swap(ResourceTable &Other) noexcept {
+    if (this == &Other) {
+      return;
+    }
+    std::scoped_lock Lock(Mutex, Other.Mutex);
+    Map.swap(Other.Map);
+    std::swap(NextId, Other.NextId);
+  }
+
 private:
   mutable std::mutex Mutex;
   uint32_t NextId = 0;

--- a/plugins/wasi_nn/resource_table.h
+++ b/plugins/wasi_nn/resource_table.h
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The WasmEdge Authors
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+
+namespace WasmEdge {
+namespace Host {
+namespace WASINN {
+
+// A thread-safe table of shared-ownership resources addressed by opaque
+// uint32_t handles, backing the WASI-NN graph and execution-context pools.
+//
+// Contract:
+// - Handles are never reused: a stale handle stops resolving instead of
+//   aliasing a later resource. insert() fails once the id space is exhausted.
+// - get() pins the resource for the caller; the payload address stays stable
+//   for the resource's whole lifetime.
+// - remove() returns the table's reference, so destruction runs at the final
+//   release and never under the table mutex.
+// - The mutex only guards the id map; user code never runs under it.
+template <typename T> class ResourceTable {
+public:
+  ResourceTable() noexcept = default;
+  explicit ResourceTable(uint32_t FirstId) noexcept : NextId(FirstId) {}
+  ResourceTable(const ResourceTable &) = delete;
+  ResourceTable &operator=(const ResourceTable &) = delete;
+
+  // Publish a fully-built resource; std::nullopt once the id space is gone.
+  std::optional<uint32_t> insert(std::shared_ptr<T> Value) noexcept {
+    std::lock_guard<std::mutex> Lock(Mutex);
+    if (NextId == std::numeric_limits<uint32_t>::max()) {
+      return std::nullopt;
+    }
+    const uint32_t Id = NextId++;
+    Map.emplace(Id, std::move(Value));
+    return Id;
+  }
+
+  // Pin a handle's resource; nullptr if it never existed or was removed.
+  std::shared_ptr<T> get(uint32_t Id) const noexcept {
+    std::lock_guard<std::mutex> Lock(Mutex);
+    if (auto It = Map.find(Id); It != Map.end()) {
+      return It->second;
+    }
+    return nullptr;
+  }
+
+  // Detach a handle and return the table's reference; nullptr if the handle
+  // does not resolve, so a double remove is a no-op.
+  std::shared_ptr<T> remove(uint32_t Id) noexcept {
+    std::lock_guard<std::mutex> Lock(Mutex);
+    if (auto It = Map.find(Id); It != Map.end()) {
+      auto Value = std::move(It->second);
+      Map.erase(It);
+      return Value;
+    }
+    return nullptr;
+  }
+
+  uint32_t size() const noexcept {
+    std::lock_guard<std::mutex> Lock(Mutex);
+    return static_cast<uint32_t>(Map.size());
+  }
+
+private:
+  mutable std::mutex Mutex;
+  uint32_t NextId = 0;
+  std::unordered_map<uint32_t, std::shared_ptr<T>> Map;
+};
+
+} // namespace WASINN
+} // namespace Host
+} // namespace WasmEdge

--- a/plugins/wasi_nn/wasinn_bitnet.cpp
+++ b/plugins/wasi_nn/wasinn_bitnet.cpp
@@ -2343,12 +2343,17 @@ Expect<ErrNo> finiSingle(WasiNNEnvironment &, WASINN::Graph &G,
   auto &GraphRef = G.get<Graph>();
   LOG_DEBUG(GraphRef.EnableDebugLog, "finiSingle");
 
-  if (GraphRef.EnableLog) {
+  // A failed set_input reload can leave a null llama context or sampler and
+  // fini_single still admits the graph, so guard both.
+  if (GraphRef.EnableLog && GraphRef.LlamaContext != nullptr &&
+      CxtRef.LlamaSampler != nullptr) {
     common_perf_print(GraphRef.LlamaContext.get(), CxtRef.LlamaSampler.get());
   }
 
   // Reset the llama sampler.
-  common_sampler_reset(CxtRef.LlamaSampler.get());
+  if (CxtRef.LlamaSampler != nullptr) {
+    common_sampler_reset(CxtRef.LlamaSampler.get());
+  }
 
   // Clear the outputs.
   LOG_DEBUG(GraphRef.EnableDebugLog,

--- a/plugins/wasi_nn/wasinn_bitnet.cpp
+++ b/plugins/wasi_nn/wasinn_bitnet.cpp
@@ -1857,16 +1857,14 @@ Expect<ErrNo> getEmbedding(Graph &GraphRef, Context &CxtRef) noexcept {
 
 } // namespace
 
-Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
-                   [[maybe_unused]] Device Device, uint32_t &GraphId) noexcept {
+Expect<ErrNo> load(WasiNNEnvironment &, WASINN::Graph &G,
+                   Span<const Span<uint8_t>> Builders, Device) noexcept {
   if (Builders.empty()) {
     RET_ERROR(ErrNo::InvalidArgument,
               "Invalid builders size, builders size must be > 0.");
   }
 
-  // Add a graph
-  const uint32_t GId = Env.newGraph(Backend::BitNet);
-  auto &GraphRef = Env.NNGraph[GId].get<Graph>();
+  auto &GraphRef = G.get<Graph>();
 
   // Initialize the plugin parameters.
   GraphRef.EnableLog = false;
@@ -1934,7 +1932,6 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
     // Ignore context or model updates when initializing the graph.
     auto Res = parseMetadata(GraphRef, GraphRef.Conf, Metadata);
     if (Res != ErrNo::Success) {
-      Env.deleteGraph(GId);
       RET_ERROR(Res, "load: Failed to parse metadata."sv);
     }
   }
@@ -1957,7 +1954,6 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
     std::ofstream TempFile(GraphRef.Params.model,
                            std::ios::out | std::ios::binary | std::ios::trunc);
     if (!TempFile) {
-      Env.deleteGraph(GId);
       RET_ERROR(ErrNo::InvalidArgument, "Failed to create temp model file."sv)
     }
     TempFile.write(BinModel.data(), BinModel.size());
@@ -1970,7 +1966,6 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
   // Check if the model exists.
   if (!std::filesystem::exists(
           std::filesystem::u8path(GraphRef.Params.model))) {
-    Env.deleteGraph(GId);
     RET_ERROR(ErrNo::ModelNotFound,
               "load: Model file not found at path: '{}'."sv,
               GraphRef.Params.model)
@@ -1992,31 +1987,24 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
   GraphRef.LlamaContext.reset(LlamaInit.context);
 
   if (GraphRef.LlamaModel == nullptr) {
-    Env.deleteGraph(GId);
     RET_ERROR(ErrNo::InvalidArgument, "load: Unable to init model."sv)
   }
   if (GraphRef.LlamaContext == nullptr) {
-    Env.deleteGraph(GId);
     RET_ERROR(ErrNo::InvalidArgument, "load: Unable to init context."sv)
   }
 
   LOG_DEBUG(GraphRef.EnableDebugLog,
             "load: initialize model with given parameters...Done"sv)
 
-  // Store the loaded graph.
-  GraphId = GId;
-  Env.NNGraph[GId].setReady();
-
   LOG_DEBUG(GraphRef.EnableDebugLog, "load...Done"sv)
   return ErrNo::Success;
 }
 
-Expect<ErrNo> initExecCtx(WasiNNEnvironment &Env, uint32_t GraphId,
-                          uint32_t &ContextId) noexcept {
-  auto &GraphRef = Env.NNGraph[GraphId].get<Graph>();
+Expect<ErrNo> initExecCtx(WasiNNEnvironment &, WASINN::Graph &G,
+                          WASINN::Context &C) noexcept {
+  auto &GraphRef = G.get<Graph>();
+  auto &CxtRef = C.get<Context>();
   LOG_DEBUG(GraphRef.EnableDebugLog, "initExecCtx"sv)
-  ContextId = Env.newContext(GraphId, Env.NNGraph[GraphId]);
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
 
   LOG_INFO(GraphRef.EnableLog, "llama_system_info: {}"sv,
            llama_print_system_info())
@@ -2032,15 +2020,15 @@ Expect<ErrNo> initExecCtx(WasiNNEnvironment &Env, uint32_t GraphId,
   CxtRef.LlamaSampler.reset(
       common_sampler_init(GraphRef.LlamaModel.get(), GraphRef.Params.sparams));
 
-  Env.NNContext[ContextId].setReady();
   LOG_DEBUG(GraphRef.EnableDebugLog, "initExecCtx...Done"sv)
   return ErrNo::Success;
 }
 
-Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
-                       uint32_t Index, const TensorData &Tensor) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+Expect<ErrNo> setInput(WasiNNEnvironment &, WASINN::Graph &G,
+                       WASINN::Context &C, uint32_t Index,
+                       const TensorData &Tensor) noexcept {
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   LOG_DEBUG(GraphRef.EnableDebugLog, "setInput"sv)
 
   // Handle Metadata at Index 1
@@ -2088,7 +2076,7 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
       GraphRef.LlamaModel.reset(llama_load_model_from_file(
           GraphRef.Params.model.c_str(), ModelParams));
       if (GraphRef.LlamaModel == nullptr) {
-        Env.NNGraph[CxtRef.GraphId].setInvalid();
+        G.setInvalid();
         RET_ERROR(ErrNo::InvalidArgument, "setInput: unable to init model."sv)
       }
     }
@@ -2104,7 +2092,7 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
       GraphRef.LlamaContext.reset(
           llama_new_context_with_model(GraphRef.LlamaModel.get(), CtxParams));
       if (GraphRef.LlamaContext == nullptr) {
-        Env.NNGraph[CxtRef.GraphId].setInvalid();
+        G.setInvalid();
         RET_ERROR(ErrNo::InvalidArgument, "setInput: unable to init context."sv)
       }
     }
@@ -2116,7 +2104,7 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
       CxtRef.LlamaSampler.reset(common_sampler_init(GraphRef.LlamaModel.get(),
                                                     GraphRef.Params.sparams));
       if (CxtRef.LlamaSampler == nullptr) {
-        Env.NNGraph[CxtRef.GraphId].setInvalid();
+        G.setInvalid();
         RET_ERROR(ErrNo::InvalidArgument, "setInput: unable to init sampler."sv)
       }
     }
@@ -2133,7 +2121,7 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
       CxtRef.CurrentBatchSize = GraphRef.Params.n_batch;
     }
 
-    Env.NNGraph[CxtRef.GraphId].setReady();
+    G.setReady();
     LOG_DEBUG(GraphRef.EnableDebugLog, "setInput: metadata processing...Done");
     return ErrNo::Success;
   }
@@ -2145,7 +2133,7 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
 
   // Check that the graph is valid after reloading during the previous
   // set_input.
-  if (!Env.NNGraph[CxtRef.GraphId].isReady()) {
+  if (!G.isReady()) {
     RET_ERROR(
         ErrNo::InvalidArgument,
         "setInput: Graph is invalid. Please reload again by passing metadata "sv
@@ -2181,11 +2169,12 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
   return ErrNo::Success;
 }
 
-Expect<ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
-                        uint32_t Index, Span<uint8_t> OutBuffer,
+Expect<ErrNo> getOutput(WasiNNEnvironment &, WASINN::Graph &G,
+                        WASINN::Context &C, uint32_t Index,
+                        Span<uint8_t> OutBuffer,
                         uint32_t &BytesWritten) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   LOG_DEBUG(GraphRef.EnableDebugLog, "getOutput: with Index {}"sv, Index)
 
   // Handle Metadata Output at Index 1
@@ -2218,9 +2207,10 @@ Expect<ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
   return ErrNo::Success;
 }
 
-Expect<ErrNo> compute(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+Expect<ErrNo> compute(WasiNNEnvironment &, WASINN::Graph &G,
+                      WASINN::Context &C) noexcept {
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   LOG_DEBUG(GraphRef.EnableDebugLog, "compute");
 
   // Clear the context and reset the sampler.
@@ -2268,11 +2258,12 @@ Expect<ErrNo> compute(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
   return ReturnCode;
 }
 
-Expect<ErrNo> getOutputSingle(WasiNNEnvironment &Env, uint32_t ContextId,
-                              uint32_t Index, Span<uint8_t> OutBuffer,
+Expect<ErrNo> getOutputSingle(WasiNNEnvironment &, WASINN::Graph &G,
+                              WASINN::Context &C, uint32_t Index,
+                              Span<uint8_t> OutBuffer,
                               uint32_t &BytesWritten) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   LOG_DEBUG(GraphRef.EnableDebugLog, "getOutputSingle: with Index {}"sv, Index)
 
   // Metadata Output at Index 1
@@ -2313,10 +2304,10 @@ Expect<ErrNo> getOutputSingle(WasiNNEnvironment &Env, uint32_t ContextId,
   return ErrNo::Success;
 }
 
-Expect<ErrNo> computeSingle(WasiNNEnvironment &Env,
-                            uint32_t ContextId) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+Expect<ErrNo> computeSingle(WasiNNEnvironment &, WASINN::Graph &G,
+                            WASINN::Context &C) noexcept {
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   LOG_DEBUG(GraphRef.EnableDebugLog, "computeSingle"sv)
 
   auto ReturnCode = ErrNo::Success;
@@ -2346,9 +2337,10 @@ Expect<ErrNo> computeSingle(WasiNNEnvironment &Env,
   return ReturnCode;
 }
 
-Expect<ErrNo> finiSingle(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+Expect<ErrNo> finiSingle(WasiNNEnvironment &, WASINN::Graph &G,
+                         WASINN::Context &C) noexcept {
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   LOG_DEBUG(GraphRef.EnableDebugLog, "finiSingle");
 
   if (GraphRef.EnableLog) {
@@ -2373,40 +2365,6 @@ Expect<ErrNo> finiSingle(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
   return ErrNo::Success;
 }
 
-Expect<ErrNo> unload(WasiNNEnvironment &Env, uint32_t GraphId) noexcept {
-
-  if (GraphId >= Env.NNGraph.size()) {
-    return ErrNo::Success;
-  }
-  auto &GraphRef = Env.NNGraph[GraphId].get<Graph>();
-  if (GraphRef.LlamaModel == nullptr) {
-    return ErrNo::Success;
-  }
-
-  LOG_DEBUG(GraphRef.EnableDebugLog, "unload"sv)
-
-  Env.deleteGraph(GraphId);
-
-  LOG_DEBUG(GraphRef.EnableDebugLog, "unload...Done"sv)
-  return ErrNo::Success;
-}
-
-Expect<ErrNo> finalizeExecCtx(WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept {
-
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
-  LOG_DEBUG(GraphRef.EnableDebugLog, "finalizeExecCtx"sv)
-
-  CxtRef.LlamaSampler.reset();
-  llama_batch_free(CxtRef.LlamaBatch);
-  llama_batch_free(CxtRef.OutputBatch);
-  Env.deleteContext(ContextId);
-
-  LOG_DEBUG(GraphRef.EnableDebugLog, "finalizeExecCtx...Done"sv)
-  return ErrNo::Success;
-}
-
 #else
 namespace {
 Expect<ErrNo> reportBackendNotSupported() noexcept {
@@ -2416,38 +2374,37 @@ Expect<ErrNo> reportBackendNotSupported() noexcept {
 }
 } // namespace
 
-Expect<ErrNo> load(WasiNNEnvironment &, Span<const Span<uint8_t>>, Device,
-                   uint32_t &) noexcept {
+Expect<ErrNo> load(WasiNNEnvironment &, WASINN::Graph &,
+                   Span<const Span<uint8_t>>, Device) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> initExecCtx(WasiNNEnvironment &, uint32_t, uint32_t &) noexcept {
+Expect<ErrNo> initExecCtx(WasiNNEnvironment &, WASINN::Graph &,
+                          WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> setInput(WasiNNEnvironment &, uint32_t, uint32_t,
-                       const TensorData &) noexcept {
+Expect<ErrNo> setInput(WasiNNEnvironment &, WASINN::Graph &, WASINN::Context &,
+                       uint32_t, const TensorData &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> getOutput(WasiNNEnvironment &, uint32_t, uint32_t, Span<uint8_t>,
-                        uint32_t &) noexcept {
+Expect<ErrNo> getOutput(WasiNNEnvironment &, WASINN::Graph &, WASINN::Context &,
+                        uint32_t, Span<uint8_t>, uint32_t &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> compute(WasiNNEnvironment &, uint32_t) noexcept {
+Expect<ErrNo> compute(WasiNNEnvironment &, WASINN::Graph &,
+                      WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> getOutputSingle(WasiNNEnvironment &, uint32_t, uint32_t,
-                              Span<uint8_t>, uint32_t &) noexcept {
+Expect<ErrNo> getOutputSingle(WasiNNEnvironment &, WASINN::Graph &,
+                              WASINN::Context &, uint32_t, Span<uint8_t>,
+                              uint32_t &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> computeSingle(WasiNNEnvironment &, uint32_t) noexcept {
+Expect<ErrNo> computeSingle(WasiNNEnvironment &, WASINN::Graph &,
+                            WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> finiSingle(WasiNNEnvironment &, uint32_t) noexcept {
-  return reportBackendNotSupported();
-}
-Expect<ErrNo> unload(WasiNNEnvironment &, uint32_t) noexcept {
-  return reportBackendNotSupported();
-}
-Expect<ErrNo> finalizeExecCtx(WasiNNEnvironment &, uint32_t) noexcept {
+Expect<ErrNo> finiSingle(WasiNNEnvironment &, WASINN::Graph &,
+                         WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
 

--- a/plugins/wasi_nn/wasinn_bitnet.cpp
+++ b/plugins/wasi_nn/wasinn_bitnet.cpp
@@ -2284,6 +2284,14 @@ Expect<ErrNo> getOutputSingle(WasiNNEnvironment &, WASINN::Graph &G,
     return ErrNo::Success;
   }
 
+  // A failed set_input reload can null the llama context; unload then makes
+  // the Invalid graph Drainable, so this op can be admitted without one.
+  if (GraphRef.LlamaContext == nullptr) {
+    RET_ERROR(ErrNo::InvalidArgument,
+              "getOutputSingle: the llama context is gone. The last reload "sv
+              "failed and the graph was unloaded."sv)
+  }
+
   const std::string LastTokenStr = common_token_to_piece(
       GraphRef.LlamaContext.get(), CxtRef.LlamaOutputTokens.back());
 

--- a/plugins/wasi_nn/wasinn_bitnet.cpp
+++ b/plugins/wasi_nn/wasinn_bitnet.cpp
@@ -4,12 +4,14 @@
 
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_BITNET
 #include "simdjson.h"
+#include "wasinn_ggml_log.h"
 #include <algorithm>
 #include <common.h>
 #include <filesystem>
 #include <fmt/ranges.h>
 #include <fstream>
 #include <llama.h>
+#include <mutex>
 #include <sampling.h>
 #include <sstream>
 #endif
@@ -43,29 +45,20 @@ namespace {
   spdlog::error("[WASI-NN] BitNet backend: "sv __VA_ARGS__);                   \
   return Error;
 
-// Llama logging callback.
-void llamaLogCallback(ggml_log_level LogLevel, const char *LogText,
-                      void *UserData) {
-  Graph &GraphRef = *reinterpret_cast<Graph *>(UserData);
-  if (!GraphRef.EnableLog) {
+// No per-graph user pointer (would dangle); gated on the shared llama gate.
+void llamaLogCallback(ggml_log_level LogLevel, const char *LogText, void *) {
+  if (!llamaLogEnabled()) {
     return;
   }
-  std::string Text(LogText);
-  // Remove the trailing newlines.
-  Text = Text.erase(Text.find_last_not_of("\n") + 1);
-  // Skip for "."
-  if (Text == ".") {
-    return;
-  }
-  if (LogLevel == GGML_LOG_LEVEL_ERROR) {
-    spdlog::error("[WASI-NN] BitNet.cpp: {}"sv, Text);
-  } else if (LogLevel == GGML_LOG_LEVEL_WARN) {
-    spdlog::warn("[WASI-NN] BitNet.cpp: {}"sv, Text);
-  } else if (LogLevel == GGML_LOG_LEVEL_INFO) {
-    spdlog::info("[WASI-NN] BitNet.cpp: {}"sv, Text);
-  } else if (LogLevel == GGML_LOG_LEVEL_DEBUG) {
-    spdlog::debug("[WASI-NN] BitNet.cpp: {}"sv, Text);
-  }
+  logGgmlMessage(LogLevel, LogText, "BitNet.cpp"sv);
+}
+
+// Bind the llama log callback once and sync the graph's log gate.
+void installLlamaLog(Graph &GraphRef) noexcept {
+  static std::once_flag LogOnce;
+  std::call_once(LogOnce,
+                 []() noexcept { llama_log_set(llamaLogCallback, nullptr); });
+  GraphRef.LlamaLog.set(GraphRef.EnableLog);
 }
 
 // >>>>>>>> Metadata related functions >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
@@ -1920,8 +1913,6 @@ Expect<ErrNo> load(WasiNNEnvironment &, WASINN::Graph &G,
   GraphRef.Conf.NPredict = ContextParamsDefault.n_ctx;
   GraphRef.Conf.ReversePrompt = ""sv;
 
-  // Set llama log callback.
-  llama_log_set(llamaLogCallback, &GraphRef);
   LOG_DEBUG(GraphRef.EnableDebugLog, "load start."sv)
 
   // If the graph builder length is greater than 1, builder[1] contains the
@@ -1935,6 +1926,9 @@ Expect<ErrNo> load(WasiNNEnvironment &, WASINN::Graph &G,
       RET_ERROR(Res, "load: Failed to parse metadata."sv);
     }
   }
+
+  // EnableLog is only known after metadata parsing; sync the log gate now.
+  installLlamaLog(GraphRef);
 
   LOG_INFO(GraphRef.EnableLog, "LLAMA_COMMIT {}"sv, LLAMA_COMMIT)
   LOG_INFO(GraphRef.EnableLog, "LLAMA_BUILD_NUMBER {}"sv, LLAMA_BUILD_NUMBER)
@@ -2046,6 +2040,8 @@ Expect<ErrNo> setInput(WasiNNEnvironment &, WASINN::Graph &G,
     if (Res != ErrNo::Success) {
       RET_ERROR(Res, "setInput: failed to parse metadata."sv)
     }
+    // Reconcile this graph's llama log gate with the reparsed EnableLog.
+    installLlamaLog(GraphRef);
 
     if (IsModelUpdated || GraphRef.LlamaModel == nullptr) {
       // The llama model may be nullptr if set_input updated the model params

--- a/plugins/wasi_nn/wasinn_bitnet.h
+++ b/plugins/wasi_nn/wasinn_bitnet.h
@@ -13,7 +13,9 @@
 
 namespace WasmEdge::Host::WASINN {
 struct WasiNNEnvironment;
-}
+class Graph;
+class Context;
+} // namespace WasmEdge::Host::WASINN
 
 namespace WasmEdge::Host::WASINN::BitNet {
 
@@ -73,6 +75,12 @@ struct Graph {
 struct Context {
 public:
   Context(uint32_t GId, Graph &G) noexcept : GraphId(GId), Conf(G.Conf) {}
+  Context(const Context &) = delete;
+  Context &operator=(const Context &) = delete;
+  ~Context() noexcept {
+    llama_batch_free(LlamaBatch);
+    llama_batch_free(OutputBatch);
+  }
 
   uint32_t GraphId;
   bool ComputeSingleStarted = false;
@@ -84,8 +92,8 @@ public:
   std::vector<uint8_t> LlamaOutputs;
   CommonSamplerPtr LlamaSampler = nullptr;
   int64_t CurrentBatchSize = 0;
-  struct llama_batch LlamaBatch;
-  struct llama_batch OutputBatch;
+  struct llama_batch LlamaBatch{};
+  struct llama_batch OutputBatch{};
 
   LocalConfig Conf;
 };
@@ -100,41 +108,36 @@ struct Context {
 
 struct Environ {};
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
                            Span<const Span<uint8_t>> Builders,
-                           WASINN::Device Device, uint32_t &GraphId) noexcept;
+                           WASINN::Device Device) noexcept;
 
 Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
-                                  uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept;
+                                  WASINN::Graph &G,
+                                  WASINN::Context &C) noexcept;
 
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
-                               uint32_t ContextId, uint32_t Index,
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept;
 
 Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
-                                uint32_t ContextId, uint32_t Index,
-                                Span<uint8_t> OutBuffer,
+                                WASINN::Graph &G, WASINN::Context &C,
+                                uint32_t Index, Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept;
 
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept;
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept;
 
 Expect<WASINN::ErrNo> getOutputSingle(WASINN::WasiNNEnvironment &Env,
-                                      uint32_t ContextId, uint32_t Index,
-                                      Span<uint8_t> OutBuffer,
+                                      WASINN::Graph &G, WASINN::Context &C,
+                                      uint32_t Index, Span<uint8_t> OutBuffer,
                                       uint32_t &BytesWritten) noexcept;
 
 Expect<WASINN::ErrNo> computeSingle(WASINN::WasiNNEnvironment &Env,
-                                    uint32_t ContextId) noexcept;
+                                    WASINN::Graph &G,
+                                    WASINN::Context &C) noexcept;
 
 Expect<WASINN::ErrNo> finiSingle(WASINN::WasiNNEnvironment &Env,
-                                 uint32_t ContextId) noexcept;
-
-Expect<WASINN::ErrNo> finalizeExecCtx(WASINN::WasiNNEnvironment &Env,
-                                      uint32_t ContextId) noexcept;
-
-Expect<WASINN::ErrNo> unload(WASINN::WasiNNEnvironment &Env,
-                             uint32_t GraphId) noexcept;
+                                 WASINN::Graph &G, WASINN::Context &C) noexcept;
 
 } // namespace WasmEdge::Host::WASINN::BitNet

--- a/plugins/wasi_nn/wasinn_bitnet.h
+++ b/plugins/wasi_nn/wasinn_bitnet.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_BITNET
+#include "wasinn_llama_log.h"
 #include <common.h>
 #include <llama.h>
 #include <memory>
@@ -66,6 +67,8 @@ struct LocalConfig {
 struct Graph {
   bool EnableLog = false;
   bool EnableDebugLog = false;
+  // This graph's unit in the shared llama log gate.
+  LlamaLogToken LlamaLog;
   common_params Params;
   LlamaModelPtr LlamaModel = nullptr;
   LlamaContextPtr LlamaContext = nullptr;

--- a/plugins/wasi_nn/wasinn_chattts.cpp
+++ b/plugins/wasi_nn/wasinn_chattts.cpp
@@ -23,12 +23,9 @@ HINSTANCE SharedLib = LoadLibrary(PYTHON_LIB_PATH);
 #else
 void *SharedLib = dlopen(PYTHON_LIB_PATH, RTLD_GLOBAL | RTLD_NOW);
 #endif
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
-                           Span<const Span<uint8_t>>, WASINN::Device,
-                           uint32_t &GraphId) noexcept {
-  // Add a new graph.
-  uint32_t GId = Env.newGraph(Backend::ChatTTS);
-  auto &GraphRef = Env.NNGraph[GId].get<Graph>();
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &, WASINN::Graph &G,
+                           Span<const Span<uint8_t>>, WASINN::Device) noexcept {
+  auto &GraphRef = G.get<Graph>();
   // Initialize the plugin parameters.
   if (GraphRef.EnableDebugLog) {
     spdlog::info("[WASI-NN] ChatTTS backend: Load."sv);
@@ -47,7 +44,6 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
     if (GraphRef.ChatTTSModule == nullptr) {
       spdlog::error(
           "[WASI-NN] ChatTTS backend: Can not find ChatTTS library."sv);
-      Env.deleteGraph(GId);
       return WASINN::ErrNo::RuntimeError;
     }
   }
@@ -57,50 +53,42 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
     if (ChatFunction == nullptr || !PyCallable_Check(ChatFunction)) {
       spdlog::error(
           "[WASI-NN] ChatTTS backend: Can not find Chat class in ChatTTS."sv);
-      Env.deleteGraph(GId);
       return WASINN::ErrNo::RuntimeError;
     }
     GraphRef.Chat = PyObject_CallObject(ChatFunction, nullptr);
     Py_XDECREF(ChatFunction);
     if (GraphRef.Chat == nullptr) {
       spdlog::error("[WASI-NN] ChatTTS backend: Can not create chat."sv);
-      Env.deleteGraph(GId);
       return WASINN::ErrNo::RuntimeError;
     }
     PyObject *LoadMethod = PyObject_GetAttrString(GraphRef.Chat, "load");
     if (LoadMethod == nullptr || !PyCallable_Check(LoadMethod)) {
       spdlog::error("[WASI-NN] ChatTTS backend: Can not load chat."sv);
-      Env.deleteGraph(GId);
       return WASINN::ErrNo::RuntimeError;
     }
     PyObject *Value = PyObject_CallObject(LoadMethod, nullptr);
     Py_XDECREF(Value);
     Py_XDECREF(LoadMethod);
   }
-  // Store the loaded graph.
-  GraphId = GId;
-  Env.NNGraph[GId].setReady();
 
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> initExecCtx(WasiNNEnvironment &Env, uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept {
+Expect<WASINN::ErrNo> initExecCtx(WasiNNEnvironment &, WASINN::Graph &,
+                                  WASINN::Context &) noexcept {
   if (!Py_IsInitialized()) {
     spdlog::error(
         "[WASI-NN] ChatTTS backend: Model has been released, please reload it."sv);
     return WASINN::ErrNo::RuntimeError;
   }
-  ContextId = Env.newContext(GraphId, Env.NNGraph[GraphId]);
-  Env.NNContext[ContextId].setReady();
   return ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
-                               uint32_t Index,
+Expect<WASINN::ErrNo> setInput(WasiNNEnvironment &, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   if (!Py_IsInitialized()) {
     spdlog::error(
         "[WASI-NN] ChatTTS backend: Model has been released, please reload it."sv);
@@ -227,11 +215,12 @@ Expect<WASINN::ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
   return WASINN::ErrNo::InvalidArgument;
 }
 
-Expect<WASINN::ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
-                                uint32_t Index, Span<uint8_t> OutBuffer,
+Expect<WASINN::ErrNo> getOutput(WasiNNEnvironment &, WASINN::Graph &G,
+                                WASINN::Context &C, uint32_t Index,
+                                Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   if (GraphRef.EnableDebugLog) {
     spdlog::info("[WASI-NN] ChatTTS backend: getOutput"sv);
   }
@@ -249,15 +238,15 @@ Expect<WASINN::ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
   return WASINN::ErrNo::InvalidArgument;
 }
 
-Expect<WASINN::ErrNo> compute(WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept {
+Expect<WASINN::ErrNo> compute(WasiNNEnvironment &, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept {
   if (!Py_IsInitialized()) {
     spdlog::error(
         "[WASI-NN] ChatTTS backend: Model has been released, please reload it."sv);
     return WASINN::ErrNo::RuntimeError;
   }
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   if (GraphRef.EnableDebugLog) {
     spdlog::info("[WASI-NN] ChatTTS backend: compute"sv);
   }
@@ -320,27 +309,6 @@ Expect<WASINN::ErrNo> compute(WasiNNEnvironment &Env,
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> unload(WASINN::WasiNNEnvironment &Env,
-                             uint32_t GraphId) noexcept {
-  auto &GraphRef = Env.NNGraph[GraphId].get<Graph>();
-  if (GraphRef.EnableDebugLog) {
-    spdlog::info("[WASI-NN] ChatTTS backend: start unload."sv);
-  }
-  if (Py_IsInitialized()) {
-    GIL Lock;
-    Py_XDECREF(GraphRef.ParamsRefineText);
-    Py_XDECREF(GraphRef.ParamsInferCode);
-    Py_XDECREF(GraphRef.Chat);
-    Py_XDECREF(GraphRef.ChatTTSModule);
-    GraphRef.ParamsRefineText = nullptr;
-    GraphRef.ParamsInferCode = nullptr;
-    GraphRef.Chat = nullptr;
-    GraphRef.ChatTTSModule = nullptr;
-  }
-  Env.deleteGraph(GraphId);
-  return WASINN::ErrNo::Success;
-}
-
 #else
 namespace {
 Expect<WASINN::ErrNo> reportBackendNotSupported() noexcept {
@@ -350,27 +318,26 @@ Expect<WASINN::ErrNo> reportBackendNotSupported() noexcept {
 }
 } // namespace
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &,
-                           Span<const Span<uint8_t>>, WASINN::Device,
-                           uint32_t &) noexcept {
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                           Span<const Span<uint8_t>>, WASINN::Device) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, uint32_t,
-                                  uint32_t &) noexcept {
+Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                  WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                               WASINN::Context &, uint32_t,
                                const TensorData &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
-                                Span<uint8_t>, uint32_t &) noexcept {
+Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                WASINN::Context &, uint32_t, Span<uint8_t>,
+                                uint32_t &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, uint32_t) noexcept {
-  return reportBackendNotSupported();
-}
-Expect<WASINN::ErrNo> unload(WASINN::WasiNNEnvironment &, uint32_t) noexcept {
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                              WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
 #endif

--- a/plugins/wasi_nn/wasinn_chattts.h
+++ b/plugins/wasi_nn/wasinn_chattts.h
@@ -13,7 +13,9 @@
 
 namespace WasmEdge::Host::WASINN {
 struct WasiNNEnvironment;
-}
+class Graph;
+class Context;
+} // namespace WasmEdge::Host::WASINN
 
 namespace WasmEdge::Host::WASINN::ChatTTS {
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_CHATTTS
@@ -37,9 +39,13 @@ struct Graph {
       }
     }
   }
+  Graph(const Graph &) = delete;
+  Graph &operator=(const Graph &) = delete;
   ~Graph() noexcept {
     if (Py_IsInitialized()) {
       GIL Lock;
+      Py_XDECREF(ParamsRefineText);
+      Py_XDECREF(ParamsInferCode);
       Py_XDECREF(Chat);
       Py_XDECREF(ChatTTSModule);
     }
@@ -64,21 +70,19 @@ struct Context {
 
 struct Environ {};
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
                            Span<const Span<uint8_t>> Builders,
-                           WASINN::Device Device, uint32_t &GraphId) noexcept;
+                           WASINN::Device Device) noexcept;
 Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
-                                  uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept;
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
-                               uint32_t ContextId, uint32_t Index,
+                                  WASINN::Graph &G,
+                                  WASINN::Context &C) noexcept;
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept;
 Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
-                                uint32_t ContextId, uint32_t Index,
-                                Span<uint8_t> OutBuffer,
+                                WASINN::Graph &G, WASINN::Context &C,
+                                uint32_t Index, Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept;
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept;
-Expect<WASINN::ErrNo> unload(WASINN::WasiNNEnvironment &Env,
-                             uint32_t GraphId) noexcept;
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept;
 } // namespace WasmEdge::Host::WASINN::ChatTTS

--- a/plugins/wasi_nn/wasinn_ggml_log.h
+++ b/plugins/wasi_nn/wasinn_ggml_log.h
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The WasmEdge Authors
+
+#pragma once
+
+#include "common/spdlog.h"
+
+#include <ggml.h>
+#include <string>
+#include <string_view>
+
+namespace WasmEdge {
+namespace Host {
+namespace WASINN {
+
+// Shared body of the GGML, BitNet, and whisper log callbacks; callers check
+// their enable gate first. Kept in a .cpp-only header because it needs
+// <ggml.h>, which the broadly included type headers must stay free of.
+inline void logGgmlMessage(ggml_log_level LogLevel, const char *LogText,
+                           std::string_view Prefix) noexcept {
+  using namespace std::literals;
+  std::string Text(LogText);
+  // Remove the trailing newlines.
+  Text = Text.erase(Text.find_last_not_of("\n") + 1);
+  // Skip for "."
+  if (Text == ".") {
+    return;
+  }
+  if (LogLevel == GGML_LOG_LEVEL_ERROR) {
+    spdlog::error("[WASI-NN] {}: {}"sv, Prefix, Text);
+  } else if (LogLevel == GGML_LOG_LEVEL_WARN) {
+    spdlog::warn("[WASI-NN] {}: {}"sv, Prefix, Text);
+  } else if (LogLevel == GGML_LOG_LEVEL_INFO) {
+    spdlog::info("[WASI-NN] {}: {}"sv, Prefix, Text);
+  } else if (LogLevel == GGML_LOG_LEVEL_DEBUG) {
+    spdlog::debug("[WASI-NN] {}: {}"sv, Prefix, Text);
+  }
+}
+
+} // namespace WASINN
+} // namespace Host
+} // namespace WasmEdge

--- a/plugins/wasi_nn/wasinn_llama_log.h
+++ b/plugins/wasi_nn/wasinn_llama_log.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The WasmEdge Authors
+
+#pragma once
+
+#include "wasinn_log_gate.h"
+
+#include <atomic>
+#include <cstdint>
+
+namespace WasmEdge {
+namespace Host {
+namespace WASINN {
+
+// Gate for llama.cpp's process-global log callback (llama_log_set), shared by
+// every llama-based backend (GGML, BitNet).
+inline std::atomic<uint32_t> LlamaLogEnabledCount{0};
+
+using LlamaLogToken = LogToken<LlamaLogEnabledCount>;
+
+inline bool llamaLogEnabled() noexcept {
+  return logGateEnabled<LlamaLogEnabledCount>();
+}
+
+} // namespace WASINN
+} // namespace Host
+} // namespace WasmEdge

--- a/plugins/wasi_nn/wasinn_log_gate.h
+++ b/plugins/wasi_nn/wasinn_log_gate.h
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The WasmEdge Authors
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+namespace WasmEdge {
+namespace Host {
+namespace WASINN {
+
+// llama.cpp and whisper.cpp expose only process-global log callbacks, so
+// logging cannot be gated per graph at the callback. Instead it stays enabled
+// while at least one loaded graph wants logs: each such graph holds a LogToken
+// owning one unit of the subsystem's Counter.
+template <std::atomic<uint32_t> &Counter> class LogToken {
+public:
+  LogToken() noexcept = default;
+  LogToken(const LogToken &) = delete;
+  LogToken &operator=(const LogToken &) = delete;
+  ~LogToken() noexcept { set(false); }
+
+  // Idempotent: repeated calls keep this graph's contribution at one unit.
+  void set(bool Enable) noexcept {
+    if (Enable == Counted) {
+      return;
+    }
+    if (Enable) {
+      Counter.fetch_add(1, std::memory_order_relaxed);
+    } else {
+      Counter.fetch_sub(1, std::memory_order_relaxed);
+    }
+    Counted = Enable;
+  }
+
+private:
+  bool Counted = false;
+};
+
+template <std::atomic<uint32_t> &Counter>
+inline bool logGateEnabled() noexcept {
+  return Counter.load(std::memory_order_relaxed) != 0;
+}
+
+} // namespace WASINN
+} // namespace Host
+} // namespace WasmEdge

--- a/plugins/wasi_nn/wasinn_mlx.cpp
+++ b/plugins/wasi_nn/wasinn_mlx.cpp
@@ -328,7 +328,7 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
       }
       // Write model to file.
       // TODO: handle different model format.
-      ModelFilePath = "MLX" + std::to_string(Idx) + ".safetensors";
+      ModelFilePath = uniqueModelFileName(Idx);
       WasmEdge::FStream::OFStream TempFile(
           ModelFilePath, std::ios_base::out | std::ios_base::binary,
           Env.getEnv());

--- a/plugins/wasi_nn/wasinn_mlx.cpp
+++ b/plugins/wasi_nn/wasinn_mlx.cpp
@@ -204,12 +204,10 @@ AnswerSataus answerSataus(std::string Text, std::string End) {
   return GO;
 }
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
-                           Span<const Span<uint8_t>> Builders, WASINN::Device,
-                           uint32_t &GraphId) noexcept {
-  // Add a new graph.
-  uint32_t GId = Env.newGraph(Backend::MLX);
-  auto &GraphRef = Env.NNGraph[GId].get<Graph>();
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                           Span<const Span<uint8_t>> Builders,
+                           WASINN::Device) noexcept {
+  auto &GraphRef = G.get<Graph>();
   if (GraphRef.EnableDebugLog) {
     spdlog::info("[WASI-NN] MLX backend: Load."sv);
   }
@@ -218,7 +216,6 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
   if (Builders.size() <= 1) {
     spdlog::error(
         "[WASI-NN] MLX backend: Lack model weight or required metadata (model_type)."sv);
-    Env.deleteGraph(GId);
     return ErrNo::InvalidArgument;
   }
   const std::string Metadata = std::string(
@@ -228,7 +225,6 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
   auto ParseError = Parser.parse(Metadata).get(Doc);
   if (ParseError) {
     spdlog::error("[WASI-NN] MLX backend: Parse metadata error"sv);
-    Env.deleteGraph(GId);
     return ErrNo::InvalidEncoding;
   }
   if (Doc.at_key("model_type").error() == simdjson::SUCCESS) {
@@ -237,14 +233,12 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
     if (Err) {
       spdlog::error(
           "[WASI-NN] MLX backend: Unable to retrieve the model_type option."sv);
-      Env.deleteGraph(GId);
       return ErrNo::InvalidArgument;
     }
     GraphRef.ModelType = ModelType;
   } else {
     spdlog::error(
         "[WASI-NN] MLX backend: Unable to retrieve the model_type option."sv);
-    Env.deleteGraph(GId);
     return ErrNo::InvalidArgument;
   }
   if (Doc.at_key("enable_debug_log").error() == simdjson::SUCCESS) {
@@ -253,7 +247,6 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
     if (Err) {
       spdlog::error(
           "[WASI-NN] MLX backend: Unable to retrieve the enable_debug_log option."sv);
-      Env.deleteGraph(GId);
       return ErrNo::InvalidArgument;
     }
     GraphRef.EnableDebugLog = EnableDebugLog;
@@ -264,7 +257,6 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
     if (Err) {
       spdlog::error(
           "[WASI-NN] MLX backend: Unable to retrieve the tokenizer option."sv);
-      Env.deleteGraph(GId);
       return ErrNo::InvalidArgument;
     }
     TokenizerPath = TokenizerPathView;
@@ -275,7 +267,6 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
     if (Err) {
       spdlog::error(
           "[WASI-NN] MLX backend: Unable to retrieve the max_token option."sv);
-      Env.deleteGraph(GId);
       return ErrNo::InvalidArgument;
     }
     GraphRef.MaxToken = MaxToken;
@@ -292,7 +283,6 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
     if (ErrQBits || ErrGroupSize || ErrIsQuantized) {
       spdlog::error(
           "[WASI-NN] MLX backend: Unable to retrieve the q_bits or group_size option."sv);
-      Env.deleteGraph(GId);
       return ErrNo::InvalidArgument;
     }
     GraphRef.IsQuantized = IsQuantized;
@@ -306,14 +296,12 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
     if (Err) {
       spdlog::error(
           "[WASI-NN] MLX backend: Unable to retrieve the group size from quantization option."sv);
-      Env.deleteGraph(GId);
       return ErrNo::InvalidArgument;
     }
     Err = QuantResult.value()["bits"].get<uint64_t>().get(GraphRef.QBits);
     if (Err) {
       spdlog::error(
           "[WASI-NN] MLX backend: Unable to retrieve the group size from quantization option."sv);
-      Env.deleteGraph(GId);
       return ErrNo::InvalidArgument;
     }
     GraphRef.IsQuantized = true;
@@ -327,7 +315,6 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
                                WeightData.size());
     spdlog::info("[WASI-NN] MLX BinModel: {}"sv, BinModel.size());
     if (BinModel.size() == 0) {
-      Env.deleteGraph(GId);
       return ErrNo::InvalidArgument;
     }
     std::string ModelFilePath;
@@ -348,7 +335,6 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
       if (!TempFile) {
         spdlog::error(
             "[WASI-NN] MLX backend: Failed to create the temporary file. "sv);
-        Env.deleteGraph(GId);
         return ErrNo::InvalidArgument;
       }
       TempFile.write(BinModel.data(), BinModel.size());
@@ -377,7 +363,6 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
     } else {
       spdlog::error("[WASI-NN] MLX backend: Model type {} not supported."sv,
                     GraphRef.ModelType);
-      Env.deleteGraph(GId);
       return ErrNo::InvalidArgument;
     }
   }
@@ -425,7 +410,6 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
   } else {
     spdlog::error("[WASI-NN] MLX backend: Model type {} not supported."sv,
                   GraphRef.ModelType);
-    Env.deleteGraph(GId);
     return ErrNo::InvalidArgument;
   }
 
@@ -434,13 +418,11 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
     auto Bytes = loadBytesFromFile(TokenizerPath, Env.getEnv());
     if (Bytes.empty()) {
       spdlog::error("[WASI-NN] MLX backend: Load tokenizer failed."sv);
-      Env.deleteGraph(GId);
       return ErrNo::InvalidArgument;
     }
     GraphRef.Tok = tokenizers::Tokenizer::FromBlobJSON(Bytes);
   } else if (GraphRef.ModelArch == "llm") {
     spdlog::error("[WASI-NN] MLX backend: Tokenizer path not found."sv);
-    Env.deleteGraph(GId);
     return ErrNo::InvalidArgument;
   }
 
@@ -466,7 +448,6 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
   } else {
     spdlog::error("[WASI-NN] MLX backend: Model type {} not supported."sv,
                   GraphRef.ModelType);
-    Env.deleteGraph(GId);
     return ErrNo::InvalidArgument;
   }
 
@@ -477,17 +458,13 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
     GraphRef.Model->toQuantized(GraphRef.GroupSize, GraphRef.QBits);
   }
 
-  GraphId = GId;
-  Env.NNGraph[GId].setReady();
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> initExecCtx(WasiNNEnvironment &Env, uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept {
-  ContextId = Env.newContext(GraphId, Env.NNGraph[GraphId]);
-  Env.NNContext[ContextId].setReady();
-  auto &GraphRef = Env.NNGraph[GraphId].get<Graph>();
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
+Expect<WASINN::ErrNo> initExecCtx(WasiNNEnvironment &, WASINN::Graph &G,
+                                  WASINN::Context &C) noexcept {
+  auto &GraphRef = G.get<Graph>();
+  auto &CxtRef = C.get<Context>();
   if (GraphRef.ModelArch == "llm") {
     CxtRef.Inputs = LLMInput();
   } else if (GraphRef.ModelArch == "vlm") {
@@ -498,17 +475,16 @@ Expect<WASINN::ErrNo> initExecCtx(WasiNNEnvironment &Env, uint32_t GraphId,
     spdlog::error(
         "[WASI-NN] MLX backend: Model architecture {} not supported."sv,
         GraphRef.ModelArch);
-    Env.deleteContext(ContextId);
     return ErrNo::InvalidArgument;
   }
   return ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
-                               uint32_t Index,
+Expect<WASINN::ErrNo> setInput(WasiNNEnvironment &, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   if (GraphRef.EnableDebugLog) {
     spdlog::info("[WASI-NN] MLX backend: setInput"sv);
   }
@@ -548,11 +524,12 @@ Expect<WASINN::ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
-                                uint32_t, Span<uint8_t> OutBuffer,
+Expect<WASINN::ErrNo> getOutput(WasiNNEnvironment &, WASINN::Graph &G,
+                                WASINN::Context &C, uint32_t,
+                                Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   if (GraphRef.EnableDebugLog) {
     spdlog::info("[WASI-NN] MLX backend: getOutput"sv);
   }
@@ -614,10 +591,10 @@ Expect<WASINN::ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> compute(WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+Expect<WASINN::ErrNo> compute(WasiNNEnvironment &, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept {
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
 
   const auto Start{std::chrono::steady_clock::now()};
   size_t TokenListSize = 0;
@@ -677,24 +654,26 @@ Expect<WASINN::ErrNo> reportBackendNotSupported() noexcept {
 }
 } // namespace
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &,
-                           Span<const Span<uint8_t>>, WASINN::Device,
-                           uint32_t &) noexcept {
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                           Span<const Span<uint8_t>>, WASINN::Device) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, uint32_t,
-                                  uint32_t &) noexcept {
+Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                  WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                               WASINN::Context &, uint32_t,
                                const TensorData &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
-                                Span<uint8_t>, uint32_t &) noexcept {
+Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                WASINN::Context &, uint32_t, Span<uint8_t>,
+                                uint32_t &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, uint32_t) noexcept {
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                              WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
 #endif

--- a/plugins/wasi_nn/wasinn_mlx.h
+++ b/plugins/wasi_nn/wasinn_mlx.h
@@ -22,7 +22,9 @@
 
 namespace WasmEdge::Host::WASINN {
 struct WasiNNEnvironment;
-}
+class Graph;
+class Context;
+} // namespace WasmEdge::Host::WASINN
 
 namespace WasmEdge::Host::WASINN::MLX {
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_MLX
@@ -71,21 +73,19 @@ struct Context {
 
 struct Environ {};
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
                            Span<const Span<uint8_t>> Builders,
-                           WASINN::Device Device, uint32_t &GraphId) noexcept;
+                           WASINN::Device Device) noexcept;
 Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
-                                  uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept;
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
-                               uint32_t ContextId, uint32_t Index,
+                                  WASINN::Graph &G,
+                                  WASINN::Context &C) noexcept;
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept;
 Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
-                                uint32_t ContextId, uint32_t Index,
-                                Span<uint8_t> OutBuffer,
+                                WASINN::Graph &G, WASINN::Context &C,
+                                uint32_t Index, Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept;
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept;
-Expect<WASINN::ErrNo> unload(WASINN::WasiNNEnvironment &Env,
-                             uint32_t GraphId) noexcept;
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept;
 } // namespace WasmEdge::Host::WASINN::MLX

--- a/plugins/wasi_nn/wasinn_mlx.h
+++ b/plugins/wasi_nn/wasinn_mlx.h
@@ -7,7 +7,11 @@
 
 #include "plugin/plugin.h"
 
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
+#include <string>
 
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_MLX
 #include "MLX/mlx/base.h"
@@ -27,6 +31,18 @@ class Context;
 } // namespace WasmEdge::Host::WASINN
 
 namespace WasmEdge::Host::WASINN::MLX {
+
+// A raw-bytes load materializes each model builder as a temporary safetensors
+// file before conversion. The path stays relative so it resolves under the
+// same WASI preopen the writer and the reader share, and a process-wide serial
+// keeps concurrent builds from colliding on one file.
+inline std::string uniqueModelFileName(std::size_t Idx) noexcept {
+  static std::atomic<std::uint64_t> Serial{0};
+  const std::uint64_t Ticket = Serial.fetch_add(1, std::memory_order_relaxed);
+  return "MLX" + std::to_string(Ticket) + "-" + std::to_string(Idx) +
+         ".safetensors";
+}
+
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_MLX
 struct LLMInput {
   std::string Prompt = {};

--- a/plugins/wasi_nn/wasinn_neuralspeed.cpp
+++ b/plugins/wasi_nn/wasinn_neuralspeed.cpp
@@ -14,24 +14,26 @@ Expect<WASINN::ErrNo> reportBackendNotSupported() noexcept {
 }
 } // namespace
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &,
-                           Span<const Span<uint8_t>>, WASINN::Device,
-                           uint32_t &) noexcept {
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                           Span<const Span<uint8_t>>, WASINN::Device) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, uint32_t,
-                                  uint32_t &) noexcept {
+Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                  WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                               WASINN::Context &, uint32_t,
                                const TensorData &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
-                                Span<uint8_t>, uint32_t &) noexcept {
+Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                WASINN::Context &, uint32_t, Span<uint8_t>,
+                                uint32_t &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, uint32_t) noexcept {
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                              WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
 } // namespace WasmEdge::Host::WASINN::NeuralSpeed

--- a/plugins/wasi_nn/wasinn_neuralspeed.h
+++ b/plugins/wasi_nn/wasinn_neuralspeed.h
@@ -9,7 +9,9 @@
 
 namespace WasmEdge::Host::WASINN {
 struct WasiNNEnvironment;
-}
+class Graph;
+class Context;
+} // namespace WasmEdge::Host::WASINN
 
 namespace WasmEdge::Host::WASINN::NeuralSpeed {
 struct Graph {};
@@ -19,19 +21,19 @@ struct Context {
 
 struct Environ {};
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
                            Span<const Span<uint8_t>> Builders,
-                           WASINN::Device Device, uint32_t &GraphId) noexcept;
+                           WASINN::Device Device) noexcept;
 Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
-                                  uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept;
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
-                               uint32_t ContextId, uint32_t Index,
+                                  WASINN::Graph &G,
+                                  WASINN::Context &C) noexcept;
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept;
 Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
-                                uint32_t ContextId, uint32_t Index,
-                                Span<uint8_t> OutBuffer,
+                                WASINN::Graph &G, WASINN::Context &C,
+                                uint32_t Index, Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept;
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept;
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept;
 } // namespace WasmEdge::Host::WASINN::NeuralSpeed

--- a/plugins/wasi_nn/wasinn_onnx.cpp
+++ b/plugins/wasi_nn/wasinn_onnx.cpp
@@ -14,24 +14,26 @@ Expect<WASINN::ErrNo> reportBackendNotSupported() noexcept {
 }
 } // namespace
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &,
-                           Span<const Span<uint8_t>>, WASINN::Device,
-                           uint32_t &) noexcept {
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                           Span<const Span<uint8_t>>, WASINN::Device) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, uint32_t,
-                                  uint32_t &) noexcept {
+Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                  WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                               WASINN::Context &, uint32_t,
                                const TensorData &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
-                                Span<uint8_t>, uint32_t &) noexcept {
+Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                WASINN::Context &, uint32_t, Span<uint8_t>,
+                                uint32_t &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, uint32_t) noexcept {
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                              WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
 } // namespace WasmEdge::Host::WASINN::ONNX

--- a/plugins/wasi_nn/wasinn_onnx.h
+++ b/plugins/wasi_nn/wasinn_onnx.h
@@ -9,7 +9,9 @@
 
 namespace WasmEdge::Host::WASINN {
 struct WasiNNEnvironment;
-}
+class Graph;
+class Context;
+} // namespace WasmEdge::Host::WASINN
 
 namespace WasmEdge::Host::WASINN::ONNX {
 struct Graph {};
@@ -19,19 +21,19 @@ struct Context {
 
 struct Environ {};
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
                            Span<const Span<uint8_t>> Builders,
-                           WASINN::Device Device, uint32_t &GraphId) noexcept;
+                           WASINN::Device Device) noexcept;
 Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
-                                  uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept;
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
-                               uint32_t ContextId, uint32_t Index,
+                                  WASINN::Graph &G,
+                                  WASINN::Context &C) noexcept;
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept;
 Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
-                                uint32_t ContextId, uint32_t Index,
-                                Span<uint8_t> OutBuffer,
+                                WASINN::Graph &G, WASINN::Context &C,
+                                uint32_t Index, Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept;
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept;
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept;
 } // namespace WasmEdge::Host::WASINN::ONNX

--- a/plugins/wasi_nn/wasinn_openvino.cpp
+++ b/plugins/wasi_nn/wasinn_openvino.cpp
@@ -29,9 +29,11 @@ GetDeviceString(WASINN::Device TargetDevice,
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
                            Span<const Span<uint8_t>> Builders,
-                           WASINN::Device Device, uint32_t &GraphId) noexcept {
+                           WASINN::Device Device) noexcept {
+  auto &GraphRef = G.get<Graph>();
+
   // The graph builder length must be 2.
   if (Builders.size() != 2) {
     spdlog::error("[WASI-NN] Wrong GraphBuilder Length {:d}, expect 2"sv,
@@ -44,10 +46,6 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
   //   Builder-1: the Weight binary
   auto XML = Builders[0];
   auto Weight = Builders[1];
-
-  // Add a new graph.
-  uint32_t GId = Env.newGraph(Backend::OpenVINO);
-  auto &GraphRef = Env.NNGraph[GId].get<Graph>();
 
   // Store device information
   GraphRef.TargetDevice = Device;
@@ -63,35 +61,27 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
         ModelString, GraphRef.OpenVINOIWeightTensor);
   } catch (const std::exception &EX) {
     spdlog::error("[WASI-NN] Model Load Exception: {}"sv, EX.what());
-    Env.deleteGraph(GId);
     return WASINN::ErrNo::RuntimeError;
   }
-  // Store the loaded graph.
-  GraphId = GId;
-  Env.NNGraph[GId].setReady();
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
-                                  uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept {
-  // Check the network and the execution network with the graph ID.
-  auto &GraphRef = Env.NNGraph[GraphId].get<Graph>();
+Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, WASINN::Graph &G,
+                                  WASINN::Context &) noexcept {
+  // Check the network and the execution network with the graph.
+  auto &GraphRef = G.get<Graph>();
   if (GraphRef.OpenVINOModel == nullptr) {
-    spdlog::error("[WASI-NN] Model for Graph:{} is empty!"sv, GraphId);
+    spdlog::error("[WASI-NN] Model for the graph is empty!"sv);
     return WASINN::ErrNo::MissingMemory;
   }
-  // Create context.
-  ContextId = Env.newContext(GraphId, Env.NNGraph[GraphId]);
-  Env.NNContext[ContextId].setReady();
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
-                               uint32_t ContextId, uint32_t Index,
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+  auto &GraphRef = G.get<Graph>();
+  auto &CxtRef = C.get<Context>();
 
   if (GraphRef.OpenVINOModel == nullptr) {
     spdlog::error("[WASI-NN] The founded openvino session is empty"sv);
@@ -141,12 +131,12 @@ Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
-                                uint32_t ContextId, uint32_t Index,
+Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, WASINN::Graph &G,
+                                WASINN::Context &C, uint32_t Index,
                                 Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+  auto &GraphRef = G.get<Graph>();
+  auto &CxtRef = C.get<Context>();
 
   // Check the output index.
   if (GraphRef.OpenVINOModel->outputs().size() <= Index) {
@@ -175,9 +165,9 @@ Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                              WASINN::Context &C) noexcept {
+  auto &CxtRef = C.get<Context>();
   try {
     CxtRef.OpenVINOInferRequest.infer();
   } catch (const std::exception &EX) {
@@ -195,24 +185,26 @@ Expect<WASINN::ErrNo> reportBackendNotSupported() noexcept {
 }
 } // namespace
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &,
-                           Span<const Span<uint8_t>>, WASINN::Device,
-                           uint32_t &) noexcept {
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                           Span<const Span<uint8_t>>, WASINN::Device) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, uint32_t,
-                                  uint32_t &) noexcept {
+Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                  WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                               WASINN::Context &, uint32_t,
                                const TensorData &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
-                                Span<uint8_t>, uint32_t &) noexcept {
+Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                WASINN::Context &, uint32_t, Span<uint8_t>,
+                                uint32_t &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, uint32_t) noexcept {
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                              WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
 #endif

--- a/plugins/wasi_nn/wasinn_openvino.h
+++ b/plugins/wasi_nn/wasinn_openvino.h
@@ -13,7 +13,9 @@
 
 namespace WasmEdge::Host::WASINN {
 struct WasiNNEnvironment;
-}
+class Graph;
+class Context;
+} // namespace WasmEdge::Host::WASINN
 
 namespace WasmEdge::Host::WASINN::OpenVINO {
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_OPENVINO
@@ -44,19 +46,19 @@ struct Context {
 struct Environ {};
 #endif
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
                            Span<const Span<uint8_t>> Builders,
-                           WASINN::Device Device, uint32_t &GraphId) noexcept;
+                           WASINN::Device Device) noexcept;
 Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
-                                  uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept;
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
-                               uint32_t ContextId, uint32_t Index,
+                                  WASINN::Graph &G,
+                                  WASINN::Context &C) noexcept;
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept;
 Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
-                                uint32_t ContextId, uint32_t Index,
-                                Span<uint8_t> OutBuffer,
+                                WASINN::Graph &G, WASINN::Context &C,
+                                uint32_t Index, Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept;
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept;
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept;
 } // namespace WasmEdge::Host::WASINN::OpenVINO

--- a/plugins/wasi_nn/wasinn_openvino_genai.cpp
+++ b/plugins/wasi_nn/wasinn_openvino_genai.cpp
@@ -109,9 +109,9 @@ LLMPipelineBackend::GetContextOutput(Context &CxtRef, uint32_t Index,
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &, WASINN::Graph &G,
                            Span<const Span<uint8_t>> Builders,
-                           WASINN::Device Device, uint32_t &GraphId) noexcept {
+                           WASINN::Device Device) noexcept {
   // The graph builder length must be 3.
   if (Builders.size() != 3) {
     spdlog::error("[WASI-NN] Wrong GraphBuilder Length {:d}, expect 3"sv,
@@ -134,9 +134,7 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
   [[maybe_unused]] auto ModelExtra = std::string(
       reinterpret_cast<const char *>(Builders[2].data()), Builders[2].size());
 
-  // Add a new graph.
-  uint32_t GId = Env.newGraph(Backend::OpenVINOGenAI);
-  auto &GraphRef = Env.NNGraph[GId].get<Graph>();
+  auto &GraphRef = G.get<Graph>();
 
   // Store device information
   GraphRef.TargetDevice = Device;
@@ -159,35 +157,26 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
 
   } catch (const std::exception &EX) {
     spdlog::error("[WASI-NN] Model Load Exception: {}"sv, EX.what());
-    Env.deleteGraph(GId);
     return WASINN::ErrNo::RuntimeError;
   }
-  // Store the loaded graph.
-  GraphId = GId;
-  Env.NNGraph[GId].setReady();
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
-                                  uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept {
-  // Check the network and the execution network with the graph ID.
-  auto &GraphRef = Env.NNGraph[GraphId].get<Graph>();
+Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, WASINN::Graph &G,
+                                  WASINN::Context &) noexcept {
+  auto &GraphRef = G.get<Graph>();
   if (GraphRef.OpenVINOGenAI == nullptr) {
-    spdlog::error("[WASI-NN] Model for Graph:{} is empty!"sv, GraphId);
+    spdlog::error("[WASI-NN] Model for Graph is empty!"sv);
     return WASINN::ErrNo::MissingMemory;
   }
-  // Create context.
-  ContextId = Env.newContext(GraphId, Env.NNGraph[GraphId]);
-  Env.NNContext[ContextId].setReady();
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
-                               uint32_t ContextId, uint32_t Index,
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+  auto &GraphRef = G.get<Graph>();
+  auto &CxtRef = C.get<Context>();
 
   if (GraphRef.OpenVINOGenAI == nullptr) {
     spdlog::error("[WASI-NN] The founded openvino genei session is empty"sv);
@@ -197,12 +186,12 @@ Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
   return GraphRef.OpenVINOGenAI->SetContextInput(CxtRef, Index, Tensor);
 }
 
-Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
-                                uint32_t ContextId, uint32_t Index,
+Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, WASINN::Graph &G,
+                                WASINN::Context &C, uint32_t Index,
                                 Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+  auto &GraphRef = G.get<Graph>();
+  auto &CxtRef = C.get<Context>();
 
   if (GraphRef.OpenVINOGenAI == nullptr) {
     spdlog::error("[WASI-NN] The founded openvino genei session is empty"sv);
@@ -213,10 +202,10 @@ Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
                                                   BytesWritten);
 }
 
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept {
+  auto &GraphRef = G.get<Graph>();
+  auto &CxtRef = C.get<Context>();
   try {
     GraphRef.OpenVINOGenAI->Generate(CxtRef);
   } catch (const std::exception &EX) {
@@ -235,24 +224,26 @@ Expect<WASINN::ErrNo> reportBackendNotSupported() noexcept {
 }
 } // namespace
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &,
-                           Span<const Span<uint8_t>>, WASINN::Device,
-                           uint32_t &) noexcept {
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                           Span<const Span<uint8_t>>, WASINN::Device) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, uint32_t,
-                                  uint32_t &) noexcept {
+Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                  WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                               WASINN::Context &, uint32_t,
                                const TensorData &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
-                                Span<uint8_t>, uint32_t &) noexcept {
+Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                WASINN::Context &, uint32_t, Span<uint8_t>,
+                                uint32_t &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, uint32_t) noexcept {
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                              WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
 #endif

--- a/plugins/wasi_nn/wasinn_openvino_genai.h
+++ b/plugins/wasi_nn/wasinn_openvino_genai.h
@@ -15,7 +15,9 @@
 
 namespace WasmEdge::Host::WASINN {
 struct WasiNNEnvironment;
-}
+class Graph;
+class Context;
+} // namespace WasmEdge::Host::WASINN
 
 namespace WasmEdge::Host::WASINN::OpenVINOGenAI {
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_OPENVINOGENAI
@@ -82,19 +84,19 @@ struct Context {
 struct Environ {};
 #endif
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
                            Span<const Span<uint8_t>> Builders,
-                           WASINN::Device Device, uint32_t &GraphId) noexcept;
+                           WASINN::Device Device) noexcept;
 Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
-                                  uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept;
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
-                               uint32_t ContextId, uint32_t Index,
+                                  WASINN::Graph &G,
+                                  WASINN::Context &C) noexcept;
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept;
 Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
-                                uint32_t ContextId, uint32_t Index,
-                                Span<uint8_t> OutBuffer,
+                                WASINN::Graph &G, WASINN::Context &C,
+                                uint32_t Index, Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept;
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept;
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept;
 } // namespace WasmEdge::Host::WASINN::OpenVINOGenAI

--- a/plugins/wasi_nn/wasinn_piper.cpp
+++ b/plugins/wasi_nn/wasinn_piper.cpp
@@ -233,9 +233,9 @@ void updatePiperOptions(const SynthesisConfig &SynthesisConfig,
   }
 }
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
-                           Span<const Span<uint8_t>> Builders, WASINN::Device,
-                           uint32_t &GraphId) noexcept {
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &, WASINN::Graph &G,
+                           Span<const Span<uint8_t>> Builders,
+                           WASINN::Device) noexcept {
   // The graph builder length must be 1.
   if (Builders.size() != 1) {
     spdlog::error(
@@ -244,14 +244,11 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
     return WASINN::ErrNo::InvalidArgument;
   }
 
-  // Add a new graph.
-  uint32_t const GId = Env.newGraph(Backend::Piper);
-  auto &GraphRef = Env.NNGraph[GId].get<Graph>();
+  auto &GraphRef = G.get<Graph>();
   GraphRef.Config = std::make_unique<RunConfig>();
   auto String = std::string{Builders[0].begin(), Builders[0].end()};
   if (auto Res = parseRunConfig(*GraphRef.Config, String);
       Res != WASINN::ErrNo::Success) {
-    Env.deleteGraph(GId);
     spdlog::error("[WASI-NN] Piper backend: Failed to parse run config."sv);
     return Res;
   }
@@ -269,27 +266,20 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
   if (!Synth) {
     spdlog::error(
         "[WASI-NN] Piper backend: Failed to create piper synthesizer."sv);
-    Env.deleteGraph(GId);
     return WASINN::ErrNo::InvalidArgument;
   }
 
   GraphRef.Synth = std::unique_ptr<piper_synthesizer, PiperDeleter>(Synth);
-  GraphId = GId;
-  Env.NNGraph[GId].setReady();
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
-                                  uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept {
-  // Create context.
-  ContextId = Env.newContext(GraphId, Env.NNGraph[GraphId]);
-  Env.NNContext[ContextId].setReady();
+Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                  WASINN::Context &) noexcept {
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
-                               uint32_t ContextId, uint32_t Index,
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept {
   if (Index != 0) {
     spdlog::error("[WASI-NN] Piper backend: Input index must be 0."sv);
@@ -301,8 +291,8 @@ Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
     return WASINN::ErrNo::InvalidArgument;
   }
 
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
 
   CxtRef.Line =
       std::string(reinterpret_cast<const char *>(Tensor.Tensor.data()),
@@ -335,8 +325,8 @@ Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
-                                uint32_t ContextId, uint32_t Index,
+Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                WASINN::Context &C, uint32_t Index,
                                 Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept {
   if (Index != 0) {
@@ -344,7 +334,7 @@ Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
     return WASINN::ErrNo::InvalidArgument;
   }
 
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
+  auto &CxtRef = C.get<Context>();
 
   if (!CxtRef.Output) {
     spdlog::error("[WASI-NN] Piper backend: No output available."sv);
@@ -370,10 +360,10 @@ Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept {
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
 
   if (!CxtRef.Line) {
     spdlog::error("[WASI-NN] Piper backend: Input is not set."sv);
@@ -493,24 +483,26 @@ Expect<WASINN::ErrNo> reportBackendNotSupported() noexcept {
 }
 } // namespace
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &,
-                           Span<const Span<uint8_t>>, WASINN::Device,
-                           uint32_t &) noexcept {
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                           Span<const Span<uint8_t>>, WASINN::Device) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, uint32_t,
-                                  uint32_t &) noexcept {
+Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                  WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                               WASINN::Context &, uint32_t,
                                const TensorData &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
-                                Span<uint8_t>, uint32_t &) noexcept {
+Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                WASINN::Context &, uint32_t, Span<uint8_t>,
+                                uint32_t &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, uint32_t) noexcept {
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                              WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
 #endif

--- a/plugins/wasi_nn/wasinn_piper.h
+++ b/plugins/wasi_nn/wasinn_piper.h
@@ -19,6 +19,8 @@
 
 namespace WasmEdge::Host::WASINN {
 struct WasiNNEnvironment;
+class Graph;
+class Context;
 } // namespace WasmEdge::Host::WASINN
 
 namespace WasmEdge::Host::WASINN::Piper {
@@ -95,19 +97,19 @@ struct Context {
 
 struct Environ {};
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
                            Span<const Span<uint8_t>> Builders,
-                           WASINN::Device Device, uint32_t &GraphId) noexcept;
+                           WASINN::Device Device) noexcept;
 Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
-                                  uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept;
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
-                               uint32_t ContextId, uint32_t Index,
+                                  WASINN::Graph &G,
+                                  WASINN::Context &C) noexcept;
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept;
 Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
-                                uint32_t ContextId, uint32_t Index,
-                                Span<uint8_t> OutBuffer,
+                                WASINN::Graph &G, WASINN::Context &C,
+                                uint32_t Index, Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept;
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept;
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept;
 } // namespace WasmEdge::Host::WASINN::Piper

--- a/plugins/wasi_nn/wasinn_tf.cpp
+++ b/plugins/wasi_nn/wasinn_tf.cpp
@@ -14,24 +14,26 @@ Expect<WASINN::ErrNo> reportBackendNotSupported() noexcept {
 }
 } // namespace
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &,
-                           Span<const Span<uint8_t>>, WASINN::Device,
-                           uint32_t &) noexcept {
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                           Span<const Span<uint8_t>>, WASINN::Device) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, uint32_t,
-                                  uint32_t &) noexcept {
+Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                  WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                               WASINN::Context &, uint32_t,
                                const TensorData &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
-                                Span<uint8_t>, uint32_t &) noexcept {
+Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                WASINN::Context &, uint32_t, Span<uint8_t>,
+                                uint32_t &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, uint32_t) noexcept {
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                              WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
 } // namespace WasmEdge::Host::WASINN::Tensorflow

--- a/plugins/wasi_nn/wasinn_tf.h
+++ b/plugins/wasi_nn/wasinn_tf.h
@@ -9,7 +9,9 @@
 
 namespace WasmEdge::Host::WASINN {
 struct WasiNNEnvironment;
-}
+class Graph;
+class Context;
+} // namespace WasmEdge::Host::WASINN
 
 namespace WasmEdge::Host::WASINN::Tensorflow {
 struct Graph {};
@@ -19,19 +21,19 @@ struct Context {
 
 struct Environ {};
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
                            Span<const Span<uint8_t>> Builders,
-                           WASINN::Device Device, uint32_t &GraphId) noexcept;
+                           WASINN::Device Device) noexcept;
 Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
-                                  uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept;
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
-                               uint32_t ContextId, uint32_t Index,
+                                  WASINN::Graph &G,
+                                  WASINN::Context &C) noexcept;
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept;
 Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
-                                uint32_t ContextId, uint32_t Index,
-                                Span<uint8_t> OutBuffer,
+                                WASINN::Graph &G, WASINN::Context &C,
+                                uint32_t Index, Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept;
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept;
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept;
 } // namespace WasmEdge::Host::WASINN::Tensorflow

--- a/plugins/wasi_nn/wasinn_tfl.cpp
+++ b/plugins/wasi_nn/wasinn_tfl.cpp
@@ -12,9 +12,9 @@ using namespace std::literals;
 
 namespace WasmEdge::Host::WASINN::TensorflowLite {
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_TFLITE
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &, WASINN::Graph &G,
                            Span<const Span<uint8_t>> Builders,
-                           WASINN::Device Device, uint32_t &GraphId) noexcept {
+                           WASINN::Device Device) noexcept {
   if ((Device != WASINN::Device::CPU)) {
     spdlog::error("[WASI-NN] TensorflowLite Only support CPU target."sv);
     return WASINN::ErrNo::InvalidArgument;
@@ -25,9 +25,7 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
                   Builders.size());
     return WASINN::ErrNo::InvalidArgument;
   }
-  // Add a new graph.
-  uint32_t GId = Env.newGraph(Backend::TensorflowLite);
-  auto &GraphRef = Env.NNGraph[GId].get<Graph>();
+  auto &GraphRef = G.get<Graph>();
 
   // Copy graph builder data to TfLiteModData and create a new TfLiteModel.
   GraphRef.TfLiteModData.assign(Builders[0].begin(), Builders[0].end());
@@ -35,49 +33,39 @@ Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
                                          GraphRef.TfLiteModData.size());
   if (unlikely(GraphRef.TFLiteMod == nullptr)) {
     spdlog::error("[WASI-NN] Cannot import TFLite model"sv);
-    Env.deleteGraph(GId);
     return WASINN::ErrNo::InvalidArgument;
   }
 
-  // Store the loaded graph.
-  GraphId = GId;
-  Env.NNGraph[GId].setReady();
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
-                                  uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept {
+Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, WASINN::Graph &G,
+                                  WASINN::Context &C) noexcept {
+  auto &GraphRef = G.get<Graph>();
+  auto &CxtRef = C.get<Context>();
   // Check the network and the execution network with the graph ID.
-  if (Env.NNGraph[GraphId].get<Graph>().TFLiteMod == nullptr) {
-    spdlog::error("[WASI-NN] Model for Graph:{} is missing!"sv, GraphId);
+  if (GraphRef.TFLiteMod == nullptr) {
+    spdlog::error("[WASI-NN] Model for Graph is missing!"sv);
     return WASINN::ErrNo::MissingMemory;
   }
 
-  // Create context.
-  uint32_t CId = Env.newContext(GraphId, Env.NNGraph[GraphId]);
-  auto &CxtRef = Env.NNContext[CId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
   auto *TFLiteOps = TfLiteInterpreterOptionsCreate();
   TfLiteInterpreterOptionsSetNumThreads(TFLiteOps, 2);
   CxtRef.TFLiteInterp = TfLiteInterpreterCreate(GraphRef.TFLiteMod, TFLiteOps);
   TfLiteInterpreterOptionsDelete(TFLiteOps);
   if (unlikely(CxtRef.TFLiteInterp == nullptr)) {
     spdlog::error("[WASI-NN] Cannot create TFLite interpreter."sv);
-    Env.deleteContext(CId);
     return WASINN::ErrNo::Busy;
   }
   TfLiteInterpreterAllocateTensors(CxtRef.TFLiteInterp);
 
-  ContextId = CId;
-  Env.NNContext[ContextId].setReady();
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
-                               uint32_t ContextId, uint32_t Index,
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                               WASINN::Context &C, uint32_t Index,
                                const WASINN::TensorData &Tensor) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
+  auto &CxtRef = C.get<Context>();
   uint32_t InCnt = TfLiteInterpreterGetInputTensorCount(CxtRef.TFLiteInterp);
   if (Index >= InCnt) {
     spdlog::error("[WASI-NN] Invalid index id {} for the input, only {} "
@@ -147,11 +135,11 @@ Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
-                                uint32_t ContextId, uint32_t Index,
+Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                WASINN::Context &C, uint32_t Index,
                                 Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
+  auto &CxtRef = C.get<Context>();
   uint32_t OutCnt = TfLiteInterpreterGetOutputTensorCount(CxtRef.TFLiteInterp);
   if (Index >= OutCnt) {
     spdlog::error("[WASI-NN] Invalid index id {} for the input, only {} "
@@ -173,9 +161,9 @@ Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
   return WASINN::ErrNo::Success;
 }
 
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                              WASINN::Context &C) noexcept {
+  auto &CxtRef = C.get<Context>();
   // Run session
   if (unlikely(CxtRef.TFLiteInterp == nullptr)) {
     spdlog::error("[WASI-NN] Tensorflow Lite context empty"sv);
@@ -198,24 +186,26 @@ Expect<WASINN::ErrNo> reportBackendNotSupported() noexcept {
 }
 } // namespace
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &,
-                           Span<const Span<uint8_t>>, WASINN::Device,
-                           uint32_t &) noexcept {
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                           Span<const Span<uint8_t>>, WASINN::Device) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, uint32_t,
-                                  uint32_t &) noexcept {
+Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                  WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                               WASINN::Context &, uint32_t,
                                const TensorData &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, uint32_t, uint32_t,
-                                Span<uint8_t>, uint32_t &) noexcept {
+Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                                WASINN::Context &, uint32_t, Span<uint8_t>,
+                                uint32_t &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, uint32_t) noexcept {
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &, WASINN::Graph &,
+                              WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
 

--- a/plugins/wasi_nn/wasinn_tfl.h
+++ b/plugins/wasi_nn/wasinn_tfl.h
@@ -14,12 +14,17 @@
 
 namespace WasmEdge::Host::WASINN {
 struct WasiNNEnvironment;
-}
+class Graph;
+class Context;
+} // namespace WasmEdge::Host::WASINN
 
 namespace WasmEdge::Host::WASINN::TensorflowLite {
 
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_TFLITE
 struct Graph {
+  Graph() noexcept = default;
+  Graph(const Graph &) = delete;
+  Graph &operator=(const Graph &) = delete;
   ~Graph() noexcept {
     if (TFLiteMod) {
       TfLiteModelDelete(TFLiteMod);
@@ -32,6 +37,8 @@ struct Graph {
 struct Context {
 public:
   Context(uint32_t GId, Graph &) noexcept : GraphId(GId) {}
+  Context(const Context &) = delete;
+  Context &operator=(const Context &) = delete;
   ~Context() noexcept {
     if (TFLiteInterp) {
       TfLiteInterpreterDelete(TFLiteInterp);
@@ -49,19 +56,19 @@ struct Context {
 
 struct Environ {};
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
                            Span<const Span<uint8_t>> Builders,
-                           WASINN::Device Device, uint32_t &GraphId) noexcept;
+                           WASINN::Device Device) noexcept;
 Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
-                                  uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept;
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
-                               uint32_t ContextId, uint32_t Index,
+                                  WASINN::Graph &G,
+                                  WASINN::Context &C) noexcept;
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept;
 Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
-                                uint32_t ContextId, uint32_t Index,
-                                Span<uint8_t> OutBuffer,
+                                WASINN::Graph &G, WASINN::Context &C,
+                                uint32_t Index, Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept;
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept;
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept;
 } // namespace WasmEdge::Host::WASINN::TensorflowLite

--- a/plugins/wasi_nn/wasinn_torch.cpp
+++ b/plugins/wasi_nn/wasinn_torch.cpp
@@ -166,8 +166,9 @@ PyModelBackend guessPyModelBackendType(const std::string_view &Model) {
   return PyModelBackend::TorchScript;
 }
 
-Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
-                   Device Device, uint32_t &GraphId) noexcept {
+Expect<ErrNo> load(WasiNNEnvironment &, WASINN::Graph &G,
+                   Span<const Span<uint8_t>> Builders, Device Device) noexcept {
+  auto &GraphRef = G.get<Graph>();
   // The graph builder length must be 1.
   if (Builders.size() != 1) {
     spdlog::error("[WASI-NN] Torch: Wrong GraphBuilder Length {:d}, expect 1"sv,
@@ -176,9 +177,6 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
   }
 
   auto Weight = Builders[0];
-  // Add a new graph.
-  uint32_t GId = Env.newGraph(Backend::PyTorch);
-  auto &GraphRef = Env.NNGraph[GId].get<Graph>();
 
   // Load the model from the binary data.
   // Note: Pytorch use try catch to handle the error.
@@ -206,25 +204,22 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
     }
   } catch (const c10::Error &e) {
     spdlog::error("[WASI-NN] Torch: Failed when load the TorchScript model."sv);
-    Env.NNGraph.pop_back();
     return ErrNo::InvalidArgument;
   }
 
-  GraphId = GId;
-  Env.NNGraph[GId].setReady();
   return ErrNo::Success;
 }
 
-Expect<ErrNo> initExecCtx(WasiNNEnvironment &Env, uint32_t GraphId,
-                          uint32_t &ContextId) noexcept {
-  ContextId = Env.newContext(GraphId, Env.NNGraph[GraphId]);
-  Env.NNContext[ContextId].setReady();
+Expect<ErrNo> initExecCtx(WasiNNEnvironment &, WASINN::Graph &,
+                          WASINN::Context &) noexcept {
   return ErrNo::Success;
 }
 
-Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
-                       uint32_t Index, const TensorData &Tensor) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
+Expect<ErrNo> setInput(WasiNNEnvironment &, WASINN::Graph &G,
+                       WASINN::Context &C, uint32_t Index,
+                       const TensorData &Tensor) noexcept {
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   if (Index >= CxtRef.TorchInputs.size()) {
     CxtRef.TorchInputs.resize(Index + 1);
   }
@@ -239,7 +234,6 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
   for (size_t I = 0; I < Tensor.Dimension.size(); I++) {
     Dims.push_back(static_cast<int64_t>(Tensor.Dimension[I]));
   }
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
   torch::Tensor InTensor =
       torch::from_blob(reinterpret_cast<float *>(Tensor.Tensor.data()), Dims,
                        Options)
@@ -249,10 +243,11 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
   return ErrNo::Success;
 }
 
-Expect<ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
-                        uint32_t Index, Span<uint8_t> OutBuffer,
+Expect<ErrNo> getOutput(WasiNNEnvironment &, WASINN::Graph &,
+                        WASINN::Context &C, uint32_t Index,
+                        Span<uint8_t> OutBuffer,
                         uint32_t &BytesWritten) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
+  auto &CxtRef = C.get<Context>();
   if (CxtRef.TorchOutputs.size() <= Index) {
     spdlog::error(
         "[WASI-NN] Torch: The output index {} exceeds the outputs number {}."sv,
@@ -280,8 +275,10 @@ Expect<ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
   return ErrNo::Success;
 }
 
-Expect<ErrNo> compute(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
+Expect<ErrNo> compute(WasiNNEnvironment &, WASINN::Graph &G,
+                      WASINN::Context &C) noexcept {
+  auto &CxtRef = C.get<Context>();
+  auto &GraphRef = G.get<Graph>();
   if (CxtRef.TorchInputs.size() == 0) {
     spdlog::error("[WASI-NN] Torch: Input is not set!"sv);
     return ErrNo::InvalidArgument;
@@ -293,16 +290,7 @@ Expect<ErrNo> compute(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
       return ErrNo::InvalidArgument;
     }
   }
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
   return GraphRef.Model->run(CxtRef.TorchInputs, CxtRef.TorchOutputs);
-}
-
-Expect<ErrNo> unload(WasiNNEnvironment &Env, uint32_t GraphId) noexcept {
-  auto &GraphRef = Env.NNGraph[GraphId].get<Graph>();
-  if (GraphRef.Model) {
-    delete GraphRef.Model;
-  }
-  return ErrNo::Success;
 }
 
 #else
@@ -314,25 +302,24 @@ Expect<ErrNo> reportBackendNotSupported() noexcept {
 }
 } // namespace
 
-Expect<ErrNo> load(WasiNNEnvironment &, Span<const Span<uint8_t>>, Device,
-                   uint32_t &) noexcept {
+Expect<ErrNo> load(WasiNNEnvironment &, WASINN::Graph &,
+                   Span<const Span<uint8_t>>, Device) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> initExecCtx(WasiNNEnvironment &, uint32_t, uint32_t &) noexcept {
+Expect<ErrNo> initExecCtx(WasiNNEnvironment &, WASINN::Graph &,
+                          WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> setInput(WasiNNEnvironment &, uint32_t, uint32_t,
-                       const TensorData &) noexcept {
+Expect<ErrNo> setInput(WasiNNEnvironment &, WASINN::Graph &, WASINN::Context &,
+                       uint32_t, const TensorData &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> getOutput(WasiNNEnvironment &, uint32_t, uint32_t, Span<uint8_t>,
-                        uint32_t &) noexcept {
+Expect<ErrNo> getOutput(WasiNNEnvironment &, WASINN::Graph &, WASINN::Context &,
+                        uint32_t, Span<uint8_t>, uint32_t &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> compute(WasiNNEnvironment &, uint32_t) noexcept {
-  return reportBackendNotSupported();
-}
-Expect<ErrNo> unload(WasiNNEnvironment &, uint32_t) noexcept {
+Expect<ErrNo> compute(WasiNNEnvironment &, WASINN::Graph &,
+                      WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
 

--- a/plugins/wasi_nn/wasinn_torch.cpp
+++ b/plugins/wasi_nn/wasinn_torch.cpp
@@ -186,21 +186,25 @@ Expect<ErrNo> load(WasiNNEnvironment &, WASINN::Graph &G,
     PyModelBackend ModelType = guessPyModelBackendType(BinModel);
 
     if (ModelType == PyModelBackend::TorchScript) {
-      GraphRef.Model = new TorchScript();
+      GraphRef.Model = std::make_unique<TorchScript>();
     } else if (ModelType == PyModelBackend::AOTInductor) {
-      GraphRef.Model = new AOTInductor();
+      GraphRef.Model = std::make_unique<AOTInductor>();
     } else {
       spdlog::error("[WASI-NN] Torch: Unknown model type."sv);
       return ErrNo::InvalidArgument;
     }
 
+    Expect<ErrNo> LoadRes = ErrNo::Success;
     if (BinModel.substr(0, 8) == "preload:"sv) {
       const std::string ModelFilePath(BinModel.substr(8));
-      GraphRef.Model->loadFromPath(ModelFilePath, Device);
+      LoadRes = GraphRef.Model->loadFromPath(ModelFilePath, Device);
     } else {
       std::istringstream BinRead{std::string(BinModel)};
       // std::istringstream BinRead(BinModel); // Need C++26...
-      GraphRef.Model->loadFromBinary(BinRead, Device);
+      LoadRes = GraphRef.Model->loadFromBinary(BinRead, Device);
+    }
+    if (!LoadRes.has_value() || *LoadRes != ErrNo::Success) {
+      return LoadRes;
     }
   } catch (const c10::Error &e) {
     spdlog::error("[WASI-NN] Torch: Failed when load the TorchScript model."sv);

--- a/plugins/wasi_nn/wasinn_torch.h
+++ b/plugins/wasi_nn/wasinn_torch.h
@@ -77,15 +77,7 @@ public:
 enum class PyModelBackend { TorchScript, AOTInductor, UNKNOWN };
 
 struct Graph {
-  Graph() noexcept = default;
-  Graph(const Graph &) = delete;
-  Graph &operator=(const Graph &) = delete;
-  ~Graph() noexcept {
-    if (Model != nullptr) {
-      delete Model;
-    }
-  }
-  PyBaseModule *Model = nullptr;
+  std::unique_ptr<PyBaseModule> Model;
 };
 
 struct Context {

--- a/plugins/wasi_nn/wasinn_torch.h
+++ b/plugins/wasi_nn/wasinn_torch.h
@@ -19,7 +19,9 @@
 
 namespace WasmEdge::Host::WASINN {
 struct WasiNNEnvironment;
-}
+class Graph;
+class Context;
+} // namespace WasmEdge::Host::WASINN
 
 namespace WasmEdge::Host::WASINN::PyTorch {
 
@@ -75,6 +77,14 @@ public:
 enum class PyModelBackend { TorchScript, AOTInductor, UNKNOWN };
 
 struct Graph {
+  Graph() noexcept = default;
+  Graph(const Graph &) = delete;
+  Graph &operator=(const Graph &) = delete;
+  ~Graph() noexcept {
+    if (Model != nullptr) {
+      delete Model;
+    }
+  }
   PyBaseModule *Model = nullptr;
 };
 
@@ -94,21 +104,19 @@ struct Context {
 
 struct Environ {};
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
                            Span<const Span<uint8_t>> Builders,
-                           WASINN::Device Device, uint32_t &GraphId) noexcept;
+                           WASINN::Device Device) noexcept;
 Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
-                                  uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept;
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
-                               uint32_t ContextId, uint32_t Index,
+                                  WASINN::Graph &G,
+                                  WASINN::Context &C) noexcept;
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept;
 Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
-                                uint32_t ContextId, uint32_t Index,
-                                Span<uint8_t> OutBuffer,
+                                WASINN::Graph &G, WASINN::Context &C,
+                                uint32_t Index, Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept;
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept;
-Expect<WASINN::ErrNo> unload(WASINN::WasiNNEnvironment &Env,
-                             uint32_t GraphId) noexcept;
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept;
 } // namespace WasmEdge::Host::WASINN::PyTorch

--- a/plugins/wasi_nn/wasinn_whisper.cpp
+++ b/plugins/wasi_nn/wasinn_whisper.cpp
@@ -10,9 +10,11 @@
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_WHISPER
 #define DR_WAV_IMPLEMENTATION
 #include "simdjson.h"
+#include "wasinn_ggml_log.h"
 #include <examples/dr_wav.h>
 
 #include <algorithm>
+#include <mutex>
 #endif
 
 using namespace std::literals;
@@ -398,28 +400,20 @@ bool loadWAV(Span<const uint8_t> Buf, std::vector<float> &PCMF32,
   return true;
 }
 
-void WhisperLogCallback(ggml_log_level LogLevel, const char *LogText,
-                        void *UserData) {
-  const Graph &GraphRef = *reinterpret_cast<Graph *>(UserData);
-  if (!GraphRef.WhisperConfig.EnableLog) {
+// No per-graph user pointer (would dangle); gated on the shared whisper gate.
+void WhisperLogCallback(ggml_log_level LogLevel, const char *LogText, void *) {
+  if (!whisperLogEnabled()) {
     return;
   }
-  std::string Text(LogText);
-  // Remove the trailing newlines.
-  Text = Text.erase(Text.find_last_not_of("\n") + 1);
-  // Skip for "."
-  if (Text == ".") {
-    return;
-  }
-  if (LogLevel == GGML_LOG_LEVEL_ERROR) {
-    spdlog::error("[WASI-NN] whisper.cpp: {}"sv, Text);
-  } else if (LogLevel == GGML_LOG_LEVEL_WARN) {
-    spdlog::warn("[WASI-NN] whisper.cpp: {}"sv, Text);
-  } else if (LogLevel == GGML_LOG_LEVEL_INFO) {
-    spdlog::info("[WASI-NN] whisper.cpp: {}"sv, Text);
-  } else if (LogLevel == GGML_LOG_LEVEL_DEBUG) {
-    spdlog::debug("[WASI-NN] whisper.cpp: {}"sv, Text);
-  }
+  logGgmlMessage(LogLevel, LogText, "whisper.cpp"sv);
+}
+
+// Bind the whisper log callback once and sync the graph's log gate.
+void installWhisperLog(Graph &GraphRef, bool EnableLog) noexcept {
+  static std::once_flag LogOnce;
+  std::call_once(
+      LogOnce, []() noexcept { whisper_log_set(WhisperLogCallback, nullptr); });
+  GraphRef.WhisperLog.set(EnableLog);
 }
 
 void WhisperOutputSegmentCallback(struct whisper_context *WhisperCtx,
@@ -850,9 +844,6 @@ Expect<ErrNo> load(WasiNNEnvironment &, WASINN::Graph &G,
   GraphRef.UseGPU = CParam.use_gpu;
   GraphRef.MainGPU = CParam.gpu_device;
 
-  // Set whisper log callback.
-  whisper_log_set(WhisperLogCallback, &GraphRef);
-
   // If the graph builder length is greater than 1, builder[1] contains the
   // metadata.
   if (Builders.size() > 1) {
@@ -865,6 +856,9 @@ Expect<ErrNo> load(WasiNNEnvironment &, WASINN::Graph &G,
       return Res;
     }
   }
+
+  // EnableLog is only known after metadata parsing; sync the log gate now.
+  installWhisperLog(GraphRef, GraphRef.WhisperConfig.EnableLog);
 
   // Handle the model path.
   if (GraphRef.WhisperConfig.EnableDebugLog) {
@@ -956,6 +950,8 @@ Expect<ErrNo> setInput(WasiNNEnvironment &, WASINN::Graph &G,
       spdlog::error("[WASI-NN] Whisper backend: Failed to parse metadata."sv);
       return Res;
     }
+    // Reconcile this graph's whisper log gate with the reparsed EnableLog.
+    installWhisperLog(GraphRef, CxtRef.WhisperConfig.EnableLog);
     Res = handleTranslationConfig(GraphRef.WhisperCtx, CxtRef.WhisperConfig);
     if (Res != ErrNo::Success) {
       return Res;

--- a/plugins/wasi_nn/wasinn_whisper.cpp
+++ b/plugins/wasi_nn/wasinn_whisper.cpp
@@ -839,11 +839,9 @@ Expect<ErrNo> handleTranslationConfig(whisper_context *WhisperCtx,
 
 } // Namespace
 
-Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
-                   [[maybe_unused]] Device Device, uint32_t &GraphId) noexcept {
-  // Add a new graph.
-  uint32_t GId = Env.newGraph(Backend::Whisper);
-  auto &GraphRef = Env.NNGraph[GId].get<Graph>();
+Expect<ErrNo> load(WasiNNEnvironment &, WASINN::Graph &G,
+                   Span<const Span<uint8_t>> Builders, Device) noexcept {
+  auto &GraphRef = G.get<Graph>();
 
   // Initialize the parameters.
   auto CParam = whisper_context_default_params();
@@ -864,7 +862,6 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
     auto Res = parseMetadata(GraphRef.WhisperConfig, Metadata);
     if (Res != ErrNo::Success) {
       spdlog::error("[WASI-NN] Whisper backend: Failed to parse metadata."sv);
-      Env.deleteGraph(GId);
       return Res;
     }
   }
@@ -897,7 +894,6 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
     spdlog::error(
         "[WASI-NN] Whisper backend: Error: unable to init whisper context from "
         "model."sv);
-    Env.deleteGraph(GId);
     return ErrNo::InvalidArgument;
   }
   if (GraphRef.WhisperConfig.EnableDebugLog) {
@@ -909,25 +905,19 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, Span<const Span<uint8_t>> Builders,
   auto ResTranslateConfig =
       handleTranslationConfig(GraphRef.WhisperCtx, GraphRef.WhisperConfig);
   if (ResTranslateConfig != ErrNo::Success) {
-    Env.deleteGraph(GId);
     return ResTranslateConfig;
   }
-
-  // Store the loaded graph.
-  GraphId = GId;
-  Env.NNGraph[GId].setReady();
 
   return ErrNo::Success;
 }
 
-Expect<ErrNo> initExecCtx(WasiNNEnvironment &Env, uint32_t GraphId,
-                          uint32_t &ContextId) noexcept {
-  auto &GraphRef = Env.NNGraph[GraphId].get<Graph>();
+Expect<ErrNo> initExecCtx(WasiNNEnvironment &, WASINN::Graph &G,
+                          WASINN::Context &C) noexcept {
+  auto &GraphRef = G.get<Graph>();
+  auto &CxtRef = C.get<Context>();
   if (GraphRef.WhisperConfig.EnableDebugLog) {
     spdlog::info("[WASI-NN][Debug] Whisper backend: initExecCtx"sv);
   }
-  ContextId = Env.newContext(GraphId, Env.NNGraph[GraphId]);
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
   CxtRef.WhisperParams = whisper_full_default_params(
       whisper_sampling_strategy::WHISPER_SAMPLING_BEAM_SEARCH);
   setWhisperParams(CxtRef);
@@ -935,17 +925,17 @@ Expect<ErrNo> initExecCtx(WasiNNEnvironment &Env, uint32_t GraphId,
     spdlog::info("[WASI-NN] Whisper backend: whisper_system_info: {}"sv,
                  whisper_print_system_info());
   }
-  Env.NNContext[ContextId].setReady();
   if (GraphRef.WhisperConfig.EnableDebugLog) {
     spdlog::info("[WASI-NN][Debug] Whisper backend: initExecCtx...Done"sv);
   }
   return ErrNo::Success;
 }
 
-Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
-                       uint32_t Index [[maybe_unused]],
+Expect<ErrNo> setInput(WasiNNEnvironment &, WASINN::Graph &G,
+                       WASINN::Context &C, uint32_t Index [[maybe_unused]],
                        const TensorData &Tensor) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
+  auto &GraphRef = G.get<Graph>();
+  auto &CxtRef = C.get<Context>();
   if (CxtRef.WhisperConfig.EnableDebugLog) {
     spdlog::info("[WASI-NN][Debug] Whisper backend: setInput"sv);
   }
@@ -958,7 +948,6 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
     }
     // Set the whisper config of this context as the graph default first.
     // This will reset the config and inherit settings from the graph metadata.
-    auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
     CxtRef.WhisperConfig = GraphRef.WhisperConfig;
     const std::string Metadata(reinterpret_cast<char *>(Tensor.Tensor.data()),
                                Tensor.Tensor.size());
@@ -1011,11 +1000,12 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, uint32_t ContextId,
   return ErrNo::Success;
 }
 
-Expect<ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
-                        uint32_t Index, Span<uint8_t> OutBuffer,
+Expect<ErrNo> getOutput(WasiNNEnvironment &Env, WASINN::Graph &G,
+                        WASINN::Context &C, uint32_t Index,
+                        Span<uint8_t> OutBuffer,
                         uint32_t &BytesWritten) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+  auto &GraphRef = G.get<Graph>();
+  auto &CxtRef = C.get<Context>();
   if (CxtRef.WhisperConfig.EnableDebugLog) {
     spdlog::info("[WASI-NN][Debug] Whisper backend: getOutput with Index {}"sv,
                  Index);
@@ -1057,9 +1047,10 @@ Expect<ErrNo> getOutput(WasiNNEnvironment &Env, uint32_t ContextId,
   return ErrNo::Success;
 }
 
-Expect<ErrNo> compute(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  auto &GraphRef = Env.NNGraph[CxtRef.GraphId].get<Graph>();
+Expect<ErrNo> compute(WasiNNEnvironment &, WASINN::Graph &G,
+                      WASINN::Context &C) noexcept {
+  auto &GraphRef = G.get<Graph>();
+  auto &CxtRef = C.get<Context>();
   if (CxtRef.WhisperConfig.EnableDebugLog) {
     spdlog::info("[WASI-NN][Debug] Whisper backend: compute"sv);
   }
@@ -1079,48 +1070,6 @@ Expect<ErrNo> compute(WasiNNEnvironment &Env, uint32_t ContextId) noexcept {
   return ErrNo::Success;
 }
 
-Expect<ErrNo> unload(WasiNNEnvironment &Env, uint32_t GraphId) noexcept {
-  auto &GraphRef = Env.NNGraph[GraphId].get<Graph>();
-  const bool IsDebugLog = GraphRef.WhisperConfig.EnableDebugLog;
-  if (IsDebugLog) {
-    spdlog::info("[WASI-NN][Debug] Whisper backend: unload"sv);
-  }
-  if (GraphRef.WhisperCtx != nullptr) {
-    if (IsDebugLog) {
-      spdlog::info(
-          "[WASI-NN][Debug] Whisper backend: unload: free whisper context"sv);
-    }
-    whisper_free(GraphRef.WhisperCtx);
-    GraphRef.WhisperCtx = nullptr;
-    if (IsDebugLog) {
-      spdlog::info(
-          "[WASI-NN][Debug] Whisper backend: unload: free whisper context...Done"sv);
-    }
-  }
-  Env.deleteGraph(GraphId);
-  Env.mdRemoveById(GraphId);
-  if (IsDebugLog) {
-    spdlog::info("[WASI-NN][Debug] Whisper backend: unload...Done"sv);
-  }
-  return ErrNo::Success;
-}
-
-Expect<ErrNo> finalizeExecCtx(WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept {
-  auto &CxtRef = Env.NNContext[ContextId].get<Context>();
-  const bool IsDebugLog = CxtRef.WhisperConfig.EnableDebugLog;
-  if (IsDebugLog) {
-    spdlog::info(
-        "[WASI-NN][Debug] Whisper backend: finalize_execution_context"sv);
-  }
-  // TODO: Free resources
-  Env.deleteContext(ContextId);
-  if (IsDebugLog) {
-    spdlog::info(
-        "[WASI-NN][Debug] Whisper backend: finalize_execution_context...Done"sv);
-  }
-  return ErrNo::Success;
-}
 #else
 
 namespace {
@@ -1131,28 +1080,24 @@ Expect<ErrNo> reportBackendNotSupported() noexcept {
 }
 } // Namespace
 
-Expect<ErrNo> load(WasiNNEnvironment &, Span<const Span<uint8_t>>, Device,
-                   uint32_t &) noexcept {
+Expect<ErrNo> load(WasiNNEnvironment &, WASINN::Graph &,
+                   Span<const Span<uint8_t>>, Device) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> initExecCtx(WasiNNEnvironment &, uint32_t, uint32_t &) noexcept {
+Expect<ErrNo> initExecCtx(WasiNNEnvironment &, WASINN::Graph &,
+                          WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> setInput(WasiNNEnvironment &, uint32_t, uint32_t,
-                       const TensorData &) noexcept {
+Expect<ErrNo> setInput(WasiNNEnvironment &, WASINN::Graph &, WASINN::Context &,
+                       uint32_t, const TensorData &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> getOutput(WasiNNEnvironment &, uint32_t, uint32_t, Span<uint8_t>,
-                        uint32_t &) noexcept {
+Expect<ErrNo> getOutput(WasiNNEnvironment &, WASINN::Graph &, WASINN::Context &,
+                        uint32_t, Span<uint8_t>, uint32_t &) noexcept {
   return reportBackendNotSupported();
 }
-Expect<ErrNo> compute(WasiNNEnvironment &, uint32_t) noexcept {
-  return reportBackendNotSupported();
-}
-Expect<ErrNo> unload(WasiNNEnvironment &, uint32_t) noexcept {
-  return reportBackendNotSupported();
-}
-Expect<ErrNo> finalizeExecCtx(WasiNNEnvironment &, uint32_t) noexcept {
+Expect<ErrNo> compute(WasiNNEnvironment &, WASINN::Graph &,
+                      WASINN::Context &) noexcept {
   return reportBackendNotSupported();
 }
 

--- a/plugins/wasi_nn/wasinn_whisper.h
+++ b/plugins/wasi_nn/wasinn_whisper.h
@@ -19,7 +19,9 @@
 
 namespace WasmEdge::Host::WASINN {
 struct WasiNNEnvironment;
-}
+class Graph;
+class Context;
+} // namespace WasmEdge::Host::WASINN
 
 namespace WasmEdge::Host::WASINN::Whisper {
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_WHISPER
@@ -63,6 +65,14 @@ struct Config {
 };
 
 struct Graph {
+  Graph() = default;
+  Graph(const Graph &) = delete;
+  Graph &operator=(const Graph &) = delete;
+  ~Graph() noexcept {
+    if (WhisperCtx != nullptr) {
+      whisper_free(WhisperCtx);
+    }
+  }
   whisper_context *WhisperCtx = nullptr;
   std::string ModelFilePath;
   // Whisper config:
@@ -96,23 +106,19 @@ struct Context {
 
 struct Environ {};
 
-Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
+Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
                            Span<const Span<uint8_t>> Builders,
-                           WASINN::Device Device, uint32_t &GraphId) noexcept;
+                           WASINN::Device Device) noexcept;
 Expect<WASINN::ErrNo> initExecCtx(WASINN::WasiNNEnvironment &Env,
-                                  uint32_t GraphId,
-                                  uint32_t &ContextId) noexcept;
-Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env,
-                               uint32_t ContextId, uint32_t Index,
+                                  WASINN::Graph &G,
+                                  WASINN::Context &C) noexcept;
+Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                               WASINN::Context &C, uint32_t Index,
                                const TensorData &Tensor) noexcept;
 Expect<WASINN::ErrNo> getOutput(WASINN::WasiNNEnvironment &Env,
-                                uint32_t ContextId, uint32_t Index,
-                                Span<uint8_t> OutBuffer,
+                                WASINN::Graph &G, WASINN::Context &C,
+                                uint32_t Index, Span<uint8_t> OutBuffer,
                                 uint32_t &BytesWritten) noexcept;
-Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env,
-                              uint32_t ContextId) noexcept;
-Expect<WASINN::ErrNo> unload(WASINN::WasiNNEnvironment &Env,
-                             uint32_t GraphId) noexcept;
-Expect<WASINN::ErrNo> finalizeExecCtx(WASINN::WasiNNEnvironment &Env,
-                                      uint32_t ContextId) noexcept;
+Expect<WASINN::ErrNo> compute(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
+                              WASINN::Context &C) noexcept;
 } // namespace WasmEdge::Host::WASINN::Whisper

--- a/plugins/wasi_nn/wasinn_whisper.h
+++ b/plugins/wasi_nn/wasinn_whisper.h
@@ -9,6 +9,7 @@
 #include <cstdint>
 
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_WHISPER
+#include "wasinn_whisper_log.h"
 #include <whisper.h>
 
 #include <algorithm>
@@ -75,6 +76,8 @@ struct Graph {
   }
   whisper_context *WhisperCtx = nullptr;
   std::string ModelFilePath;
+  // This graph's unit in the shared whisper log gate.
+  WhisperLogToken WhisperLog;
   // Whisper config:
   Config WhisperConfig;
   // Context parameters:

--- a/plugins/wasi_nn/wasinn_whisper_log.h
+++ b/plugins/wasi_nn/wasinn_whisper_log.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The WasmEdge Authors
+
+#pragma once
+
+#include "wasinn_log_gate.h"
+
+#include <atomic>
+#include <cstdint>
+
+namespace WasmEdge {
+namespace Host {
+namespace WASINN {
+
+// Gate for whisper.cpp's process-global log callback (whisper_log_set), on a
+// separate counter so whisper and llama logging toggle independently.
+inline std::atomic<uint32_t> WhisperLogEnabledCount{0};
+
+using WhisperLogToken = LogToken<WhisperLogEnabledCount>;
+
+inline bool whisperLogEnabled() noexcept {
+  return logGateEnabled<WhisperLogEnabledCount>();
+}
+
+} // namespace WASINN
+} // namespace Host
+} // namespace WasmEdge

--- a/plugins/wasi_nn/wasinnenv.cpp
+++ b/plugins/wasi_nn/wasinnenv.cpp
@@ -144,8 +144,6 @@ WasiNNEnvironment::WasiNNEnvironment() noexcept {
           "[WASI-NN] Preload Model's Backend or Device is Not Support."sv);
     }
   }
-  NNGraph.reserve(16U);
-  NNContext.reserve(16U);
 }
 
 PO::List<std::string> WasiNNEnvironment::NNModels(

--- a/plugins/wasi_nn/wasinnenv.h
+++ b/plugins/wasi_nn/wasinnenv.h
@@ -301,12 +301,14 @@ struct WasiNNEnvironment :
 
   WasiNNEnvironment() noexcept;
 
-  // Resolve a preloaded model name to a live graph handle. Handles are never
-  // reused, so a cache entry whose graph was unloaded simply stops resolving.
+  // Resolve a preloaded model name to a live graph handle. A cache entry
+  // whose graph was unloaded (or is mid-unload, already Detached) simply
+  // stops resolving.
   bool mdGet(std::string_view Name, uint32_t &GraphId) noexcept {
     std::shared_lock Lock(MdMutex);
     if (auto It = MdMap.find(std::string(Name)); It != MdMap.end()) {
-      if (NNGraph.get(It->second) != nullptr) {
+      if (auto G = NNGraph.get(It->second);
+          G != nullptr && G->status() != GraphStatus::Detached) {
         GraphId = It->second;
         return true;
       }
@@ -337,18 +339,22 @@ struct WasiNNEnvironment :
     auto Result = Load(*this, Builders, std::get<1>(It->second),
                        std::get<2>(It->second), Name, GraphId);
     if (Result.has_value() && *Result == WASINN::ErrNo::Success) {
-      // Concurrent builds for the same name race here: each ran outside the
-      // lock and published its own graph. Keep the first cached live graph
-      // and fold later finishers onto it, dropping their duplicate builds,
-      // so one name never retains two copies of a model.
+      // Concurrent builds for the same name each published a graph: keep the
+      // first cached live one and fold later finishers onto it, so one name
+      // never retains two model copies. A Detached cached graph is mid-unload
+      // and gets replaced instead. A dropped build flips its status first.
       std::unique_lock Lock(MdMutex);
-      if (auto Cached = MdMap.find(Name);
-          Cached != MdMap.end() && NNGraph.get(Cached->second) != nullptr) {
+      auto Cached = MdMap.find(Name);
+      const std::shared_ptr<Graph> CachedGraph =
+          Cached != MdMap.end() ? NNGraph.get(Cached->second) : nullptr;
+      if (CachedGraph != nullptr &&
+          CachedGraph->status() != GraphStatus::Detached) {
         const uint32_t LoserId = GraphId;
         GraphId = Cached->second;
         Lock.unlock();
-        if (auto Loser = NNGraph.remove(LoserId); Loser != nullptr) {
+        if (auto Loser = NNGraph.get(LoserId); Loser != nullptr) {
           Loser->setDetached();
+          NNGraph.remove(LoserId);
         }
         return Result;
       }
@@ -357,13 +363,13 @@ struct WasiNNEnvironment :
     return Result;
   }
 
-  // Uniform graph unload: detach the handle now and let the backend payload
-  // destructor run at the last release - immediately if nothing pins the
-  // graph, or after the last draining context / in-flight op otherwise. The
-  // host call never blocks behind a running compute.
+  // Detach the handle now; the payload destructor runs at the last release,
+  // so unload never blocks behind a running compute. The status must flip
+  // before the table entry goes: context-keyed admission consults only the
+  // status, so a compute could otherwise be admitted after unload committed.
   Expect<WASINN::ErrNo> unloadGraph(uint32_t GraphId) noexcept {
     using namespace std::literals;
-    auto G = NNGraph.remove(GraphId);
+    auto G = NNGraph.get(GraphId);
     if (G == nullptr) {
       spdlog::error(
           "[WASI-NN] unload: Graph ID {} does not exist or is unloaded."sv,
@@ -371,6 +377,7 @@ struct WasiNNEnvironment :
       return WASINN::ErrNo::InvalidArgument;
     }
     G->setDetached();
+    NNGraph.remove(GraphId);
     // Evict the name cache so a later load_by_name reloads instead of
     // resolving to the dead handle; matching the cached id is exact.
     if (const auto &Name = G->getModelName(); !Name.empty()) {

--- a/plugins/wasi_nn/wasinnenv.h
+++ b/plugins/wasi_nn/wasinnenv.h
@@ -442,12 +442,17 @@ struct WasiNNEnvironment :
   std::shared_ptr<grpc::Channel> NNRPCChannel;
 #endif
 
-  const Host::WASI::Environ *getEnv() const noexcept { return Environ; }
+  const Host::WASI::Environ *getEnv() const noexcept {
+    return Environ.load(std::memory_order_acquire);
+  }
+  // Concurrent host calls re-derive the same environ; the atomic store makes
+  // that race benign instead of undefined behavior.
   void setEnviron(const Runtime::CallingFrame *CurrentFrame) noexcept {
     auto *WasiModule = CurrentFrame->getWASIModule();
     if (WasiModule != nullptr) {
-      Environ = dynamic_cast<const WasmEdge::Host::WasiModule *>(WasiModule)
-                    ->getEnv();
+      Environ.store(dynamic_cast<const WasmEdge::Host::WasiModule *>(WasiModule)
+                        ->getEnv(),
+                    std::memory_order_release);
     }
   }
 
@@ -473,7 +478,7 @@ private:
                   Op, C.getGraphId(), ContextId);
   }
 
-  const Host::WASI::Environ *Environ = nullptr;
+  std::atomic<const Host::WASI::Environ *> Environ{nullptr};
 };
 
 } // namespace WASINN

--- a/plugins/wasi_nn/wasinnenv.h
+++ b/plugins/wasi_nn/wasinnenv.h
@@ -75,14 +75,13 @@ template <Backend B> using BackendGraphT = typename BackendTrait<B>::Graph;
 template <Backend B> using BackendContextT = typename BackendTrait<B>::Context;
 } // namespace detail
 
-// Graph lifecycle status. A Graph is only published to the handle table once
-// its model is fully loaded, so a half-built graph is never observable and
-// needs no state here.
-//   Ready:    The graph can create contexts and run inference.
-//   Invalid:  A set_input metadata reload failed; the model may be gone. It
-//             can be reloaded with new metadata in set_input.
-//   Detached: The guest unloaded the graph. The handle is dead, but contexts
-//             created earlier keep the object alive to drain.
+// Graph lifecycle status. A Graph is published to the handle table only fully
+// loaded, so a half-built graph is never observable.
+//   Ready:    Can create contexts and run inference.
+//   Invalid:  A set_input metadata reload failed; reloadable in set_input.
+//   Detached: Unloaded by the guest. The handle is dead; earlier contexts
+//             keep the object alive to drain. Terminal, so a reload racing
+//             the unload cannot resurrect the graph.
 enum class GraphStatus : uint8_t { Ready, Invalid, Detached };
 
 // How strict a host op's owning-graph status check is: Any (just resolve the
@@ -153,12 +152,11 @@ public:
     return Stat.load(std::memory_order_acquire);
   }
   bool isReady() const noexcept { return status() == GraphStatus::Ready; }
-  void setReady() noexcept {
-    Stat.store(GraphStatus::Ready, std::memory_order_release);
-  }
-  void setInvalid() noexcept {
-    Stat.store(GraphStatus::Invalid, std::memory_order_release);
-  }
+  // unload writes Detached without the op mutex, so it never blocks behind a
+  // running op; a (re)load finishing later must not resurrect the graph, so
+  // these transitions CAS and give up once they observe Detached.
+  void setReady() noexcept { transitionUnlessDetached(GraphStatus::Ready); }
+  void setInvalid() noexcept { transitionUnlessDetached(GraphStatus::Invalid); }
   void setDetached() noexcept {
     Stat.store(GraphStatus::Detached, std::memory_order_release);
   }
@@ -169,6 +167,14 @@ public:
   std::mutex &opMutex() noexcept { return OpMutex; }
 
 private:
+  void transitionUnlessDetached(GraphStatus Next) noexcept {
+    auto Cur = Stat.load(std::memory_order_acquire);
+    while (Cur != GraphStatus::Detached &&
+           !Stat.compare_exchange_weak(Cur, Next, std::memory_order_acq_rel,
+                                       std::memory_order_acquire)) {
+    }
+  }
+
   std::variant<
 #define EACH(B) B::Graph,
       FOR_EACH_BACKEND(EACH)

--- a/plugins/wasi_nn/wasinnenv.h
+++ b/plugins/wasi_nn/wasinnenv.h
@@ -337,7 +337,21 @@ struct WasiNNEnvironment :
     auto Result = Load(*this, Builders, std::get<1>(It->second),
                        std::get<2>(It->second), Name, GraphId);
     if (Result.has_value() && *Result == WASINN::ErrNo::Success) {
+      // Concurrent builds for the same name race here: each ran outside the
+      // lock and published its own graph. Keep the first cached live graph
+      // and fold later finishers onto it, dropping their duplicate builds,
+      // so one name never retains two copies of a model.
       std::unique_lock Lock(MdMutex);
+      if (auto Cached = MdMap.find(Name);
+          Cached != MdMap.end() && NNGraph.get(Cached->second) != nullptr) {
+        const uint32_t LoserId = GraphId;
+        GraphId = Cached->second;
+        Lock.unlock();
+        if (auto Loser = NNGraph.remove(LoserId); Loser != nullptr) {
+          Loser->setDetached();
+        }
+        return Result;
+      }
       MdMap[Name] = GraphId;
     }
     return Result;

--- a/plugins/wasi_nn/wasinnenv.h
+++ b/plugins/wasi_nn/wasinnenv.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "GGML/core/ggml_core.h"
+#include "resource_table.h"
 #include "wasinn_bitnet.h"
 #include "wasinn_chattts.h"
 #include "wasinn_mlx.h"
@@ -25,10 +26,16 @@
 #include "plugin/plugin.h"
 #include "runtime/callingframe.h"
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <string_view>
 #include <unordered_map>
-#include <unordered_set>
+#include <utility>
 #include <vector>
 
 #ifdef WASMEDGE_BUILD_WASI_NN_RPC
@@ -68,11 +75,54 @@ template <Backend B> using BackendGraphT = typename BackendTrait<B>::Graph;
 template <Backend B> using BackendContextT = typename BackendTrait<B>::Context;
 } // namespace detail
 
+// Graph lifecycle status. A Graph is only published to the handle table once
+// its model is fully loaded, so a half-built graph is never observable and
+// needs no state here.
+//   Ready:    The graph can create contexts and run inference.
+//   Invalid:  A set_input metadata reload failed; the model may be gone. It
+//             can be reloaded with new metadata in set_input.
+//   Detached: The guest unloaded the graph. The handle is dead, but contexts
+//             created earlier keep the object alive to drain.
+enum class GraphStatus : uint8_t { Ready, Invalid, Detached };
+
+// How strict a host op's owning-graph status check is: Any (just resolve the
+// handle), NotDetached (Invalid admitted for reload), Ready (fully usable),
+// or Drainable (Ready or Detached: may read the model after unload, while a
+// model-less Invalid graph is rejected).
+enum class GraphReq : uint8_t { Any, NotDetached, Ready, Drainable };
+
+constexpr bool graphAdmits(GraphReq Req, GraphStatus Stat) noexcept {
+  switch (Req) {
+  case GraphReq::Any:
+    return true;
+  case GraphReq::NotDetached:
+    return Stat != GraphStatus::Detached;
+  case GraphReq::Ready:
+    return Stat == GraphStatus::Ready;
+  case GraphReq::Drainable:
+    return Stat == GraphStatus::Ready || Stat == GraphStatus::Detached;
+  }
+  return false;
+}
+
+// Wrapper owning one backend graph, shared_ptr-managed through the handle
+// table: host ops and child contexts pin it; the payload (and model) dies at
+// the last release. The payload variant is emplaced once and never reset, so
+// the typed accessors cannot observe a mismatched alternative.
 class Graph {
 public:
   Graph() = delete;
   Graph(Backend BE) noexcept : Impl(std::in_place_type_t<std::monostate>()) {
-    init(BE);
+    switch (BE) {
+#define EACH(B)                                                                \
+  case Backend::B:                                                             \
+    Impl.emplace<B::Graph>();                                                  \
+    break;
+      FOR_EACH_BACKEND(EACH)
+#undef EACH
+    default:
+      __builtin_unreachable();
+    }
   }
 
   Backend getBackend() const noexcept {
@@ -99,38 +149,24 @@ public:
     return *std::get_if<T>(&Impl);
   }
 
-  void init(Backend BE) noexcept {
-    switch (BE) {
-#define EACH(B)                                                                \
-  case Backend::B:                                                             \
-    Impl.emplace<B::Graph>();                                                  \
-    break;
-      FOR_EACH_BACKEND(EACH)
-#undef EACH
-    default:
-      __builtin_unreachable();
-    }
-    Stat = Status::Uninitialized;
-    CtxCnt = 0;
+  GraphStatus status() const noexcept {
+    return Stat.load(std::memory_order_acquire);
   }
-  void reset() noexcept {
-    Impl = std::monostate{};
-    Stat = Status::Uninitialized;
-    CtxCnt = 0;
+  bool isReady() const noexcept { return status() == GraphStatus::Ready; }
+  void setReady() noexcept {
+    Stat.store(GraphStatus::Ready, std::memory_order_release);
   }
-  void increaseContext() noexcept { CtxCnt++; }
-  void decreaseContext() noexcept {
-    assuming(CtxCnt > 0);
-    CtxCnt--;
+  void setInvalid() noexcept {
+    Stat.store(GraphStatus::Invalid, std::memory_order_release);
   }
-  uint32_t getContextCount() const noexcept { return CtxCnt; }
-  bool isFinalized() const noexcept {
-    return Stat == Status::Uninitialized || Stat == Status::Finalized;
+  void setDetached() noexcept {
+    Stat.store(GraphStatus::Detached, std::memory_order_release);
   }
-  bool isReady() const noexcept { return Stat == Status::Ready; }
-  void setInvalid() noexcept { Stat = Status::Invalid; }
-  void setFinalized() noexcept { Stat = Status::Finalized; }
-  void setReady() noexcept { Stat = Status::Ready; }
+
+  void setModelName(std::string Name) noexcept { ModelName = std::move(Name); }
+  const std::string &getModelName() const noexcept { return ModelName; }
+
+  std::mutex &opMutex() noexcept { return OpMutex; }
 
 private:
   std::variant<
@@ -139,25 +175,33 @@ private:
 #undef EACH
           std::monostate>
       Impl;
-  // Graph status.
-  //   Uninitialized: A new graph in monostate.
-  //   Invalid: The graph failed to load in set_input with metadata. It can be
-  //            reloaded with new metadata in set_input.
-  //   Finalized: The graph is being deleted, but there are linked contexts.
-  //              This graph ID will be released once the contexts are
-  //              deleted.
-  //   Ready: This graph can be used to create a context.
-  enum class Status : uint8_t { Uninitialized, Invalid, Finalized, Ready };
-  Status Stat;
-  uint32_t CtxCnt;
+  std::atomic<GraphStatus> Stat{GraphStatus::Ready};
+  // The nn-preload name; read on unload to evict the name cache entry.
+  std::string ModelName;
+  // Serializes backend ops on this graph; shared by its contexts because
+  // backends keep mutable inference state on the graph payload.
+  std::mutex OpMutex;
 };
 
+// Wrapper owning one backend execution context plus a pin on its parent
+// graph, so a context cannot outlive its graph: that is what lets a live
+// context drain after the guest unloads the graph.
 class Context {
 public:
   Context() = delete;
-  Context(uint32_t GId, Graph &G) noexcept
-      : Impl(std::in_place_type_t<std::monostate>()) {
-    init(GId, G);
+  Context(uint32_t GId, std::shared_ptr<Graph> G) noexcept
+      : Parent(std::move(G)), Impl(std::in_place_type_t<std::monostate>()),
+        GraphId(GId) {
+    switch (Parent->getBackend()) {
+#define EACH(B)                                                                \
+  case Backend::B:                                                             \
+    Impl.emplace<B::Context>(GId, Parent->get<Backend::B>());                  \
+    break;
+      FOR_EACH_BACKEND(EACH)
+#undef EACH
+    default:
+      __builtin_unreachable();
+    }
   }
 
   Backend getBackend() const noexcept {
@@ -184,45 +228,60 @@ public:
     return *std::get_if<T>(&Impl);
   }
 
-  void init(uint32_t GId, Graph &G) noexcept {
-    switch (G.getBackend()) {
-#define EACH(B)                                                                \
-  case Backend::B:                                                             \
-    Impl.emplace<B::Context>(GId, G.get<Backend::B>());                        \
-    break;
-      FOR_EACH_BACKEND(EACH)
-#undef EACH
-    default:
-      __builtin_unreachable();
-    }
-    Stat = Status::Uninitialized;
-    GraphId = GId;
-  }
-  void reset() noexcept {
-    Impl = std::monostate{};
-    Stat = Status::Uninitialized;
-    GraphId = 0;
-  }
-  uint32_t getGraphId() const noexcept {
-    return static_cast<uint32_t>(GraphId);
-  }
-  bool isReady() const noexcept { return Stat == Status::Ready; }
-  void setReady() noexcept { Stat = Status::Ready; }
+  Graph &parent() noexcept { return *Parent; }
+  const Graph &parent() const noexcept { return *Parent; }
+  uint32_t getGraphId() const noexcept { return GraphId; }
 
 private:
+  std::shared_ptr<Graph> Parent;
   std::variant<
 #define EACH(B) B::Context,
       FOR_EACH_BACKEND(EACH)
 #undef EACH
           std::monostate>
       Impl;
-  // Context status.
-  //   Uninitialized: A new context in monostate.
-  //   Ready: This context can be used to infer.
-  enum class Status : uint8_t { Uninitialized, Ready };
-  Status Stat;
   uint32_t GraphId;
 };
+
+// Every graph/context-resolving host op declares its GraphReq tier and
+// error-log label in hostOpPolicy(). One table keeps the whole liveness
+// contract in view, so a wrong tier stands out against its siblings and a
+// new op must make a deliberate choice.
+enum class HostOp : uint8_t {
+  InitExecCtx,
+  SetInput,
+  Compute,
+  ComputeSingle,
+  GetOutput,
+  GetOutputSingle,
+  FiniSingle,
+};
+
+struct HostOpPolicy {
+  GraphReq Req;
+  std::string_view Name;
+};
+
+constexpr HostOpPolicy hostOpPolicy(HostOp Op) noexcept {
+  using namespace std::literals;
+  switch (Op) {
+  case HostOp::InitExecCtx:
+    return {GraphReq::Ready, "init_execution_context"sv};
+  case HostOp::SetInput:
+    return {GraphReq::NotDetached, "set_input"sv};
+  case HostOp::Compute:
+    return {GraphReq::Ready, "compute"sv};
+  case HostOp::ComputeSingle:
+    return {GraphReq::Ready, "compute_single"sv};
+  case HostOp::GetOutput:
+    return {GraphReq::Any, "get_output"sv};
+  case HostOp::GetOutputSingle:
+    return {GraphReq::Drainable, "get_output_single"sv};
+  case HostOp::FiniSingle:
+    return {GraphReq::Any, "fini_single"sv};
+  }
+  return {GraphReq::Ready, ""sv};
+}
 
 struct WasiNNEnvironment :
 #define EACH(B) B::Environ,
@@ -232,142 +291,149 @@ struct WasiNNEnvironment :
 
   using Callback = std::function<Expect<WASINN::ErrNo>(
       WASINN::WasiNNEnvironment &, Span<const Span<uint8_t>>, WASINN::Backend,
-      WASINN::Device, uint32_t &)>;
+      WASINN::Device, std::string_view, uint32_t &)>;
 
   WasiNNEnvironment() noexcept;
 
-  bool mdGet(std::string Name, uint32_t &GraphId) noexcept {
+  // Resolve a preloaded model name to a live graph handle. Handles are never
+  // reused, so a cache entry whose graph was unloaded simply stops resolving.
+  bool mdGet(std::string_view Name, uint32_t &GraphId) noexcept {
     std::shared_lock Lock(MdMutex);
-    if (auto It = MdMap.find(Name); It != MdMap.end()) {
-      GraphId = EndianValue(static_cast<uint32_t>(It->second)).le();
-      return true;
+    if (auto It = MdMap.find(std::string(Name)); It != MdMap.end()) {
+      if (NNGraph.get(It->second) != nullptr) {
+        GraphId = It->second;
+        return true;
+      }
     }
     return false;
   }
 
-  void mdRemoveById(uint32_t GraphId) noexcept {
-    std::unique_lock Lock(MdMutex);
-    for (auto It = MdMap.begin(); It != MdMap.end();) {
-      if (It->second == static_cast<uint32_t>(GraphId)) {
-        It = MdMap.erase(It);
-      } else {
-        ++It;
-      }
-    }
-  }
-
+  // Build a graph from the preloaded model bytes registered under Name.
+  // MdMutex guards only the name -> handle map and is never held across the
+  // (possibly minutes-long) model load; RawMdMap is constructor-immutable.
   Expect<WASINN::ErrNo>
-  mdBuild(std::string Name, uint32_t &GraphId, Callback Load,
+  mdBuild(const std::string &Name, uint32_t &GraphId, Callback Load,
           std::vector<uint8_t> Config = std::vector<uint8_t>()) noexcept {
-    std::unique_lock Lock(MdMutex);
     auto It = RawMdMap.find(Name);
-    if (It != RawMdMap.end()) {
-      auto RawMd = std::get<0>(It->second);
-      std::vector<Span<uint8_t>> Builders;
-      Builders.reserve(RawMd.size());
-      for (auto &Builder : RawMd) {
-        Builders.emplace_back(Builder);
-      }
-      // Add config to the end of Builders if exists.
-      if (Config.size() > 0) {
-        Builders.emplace_back(Config);
-      }
-      auto Result = Load(*this, Builders, std::get<1>(It->second),
-                         std::get<2>(It->second), GraphId);
-      if (Result.has_value()) {
-        MdMap[Name] = GraphId;
-      }
-      return Result;
+    if (It == RawMdMap.end()) {
+      return WASINN::ErrNo::NotFound;
     }
-    return WASINN::ErrNo::NotFound;
+    auto &RawMd = std::get<0>(It->second);
+    std::vector<Span<uint8_t>> Builders;
+    Builders.reserve(RawMd.size() + 1);
+    for (auto &Builder : RawMd) {
+      Builders.emplace_back(Builder);
+    }
+    // Add config to the end of Builders if exists.
+    if (Config.size() > 0) {
+      Builders.emplace_back(Config);
+    }
+    auto Result = Load(*this, Builders, std::get<1>(It->second),
+                       std::get<2>(It->second), Name, GraphId);
+    if (Result.has_value() && *Result == WASINN::ErrNo::Success) {
+      std::unique_lock Lock(MdMutex);
+      MdMap[Name] = GraphId;
+    }
+    return Result;
   }
 
-  uint32_t newGraph(Backend BE) noexcept {
-    std::unique_lock Lock(GraphMutex);
-    uint32_t ID = static_cast<uint32_t>(NNGraph.size());
-    if (NNGraphRecycle.empty()) {
-      NNGraph.emplace_back(BE);
-    } else {
-      ID = *NNGraphRecycle.begin();
-      NNGraph[ID].init(BE);
-      NNGraphRecycle.erase(ID);
+  // Uniform graph unload: detach the handle now and let the backend payload
+  // destructor run at the last release - immediately if nothing pins the
+  // graph, or after the last draining context / in-flight op otherwise. The
+  // host call never blocks behind a running compute.
+  Expect<WASINN::ErrNo> unloadGraph(uint32_t GraphId) noexcept {
+    using namespace std::literals;
+    auto G = NNGraph.remove(GraphId);
+    if (G == nullptr) {
+      spdlog::error(
+          "[WASI-NN] unload: Graph ID {} does not exist or is unloaded."sv,
+          GraphId);
+      return WASINN::ErrNo::InvalidArgument;
     }
-    return ID;
-  }
-
-  uint32_t newContext(uint32_t GId, Graph &G) noexcept {
-    std::unique_lock Lock(GraphMutex);
-    assuming(NNGraph.size() > GId);
-    // TODO: Merge GId into graph class.
-    uint32_t ID = static_cast<uint32_t>(NNContext.size());
-    if (NNContextRecycle.empty()) {
-      NNContext.emplace_back(GId, G);
-    } else {
-      ID = *NNContextRecycle.begin();
-      NNContext[ID].init(GId, G);
-      NNContextRecycle.erase(ID);
-    }
-    G.increaseContext();
-    return ID;
-  }
-
-  void deleteGraph(const uint32_t Id) noexcept {
-    // TODO: Add the deallocation callback.
-    std::unique_lock Lock(GraphMutex);
-    if (Id < NNGraph.size()) {
-      auto &G = NNGraph[Id];
-      G.setFinalized();
-      if (G.getContextCount() == 0) {
-        // All contexts are deleted. Release the graph ID.
-        if (Id == NNGraph.size() - 1) {
-          NNGraph.pop_back();
-        } else {
-          G.reset();
-          NNGraphRecycle.insert(Id);
-        }
+    G->setDetached();
+    // Evict the name cache so a later load_by_name reloads instead of
+    // resolving to the dead handle; matching the cached id is exact.
+    if (const auto &Name = G->getModelName(); !Name.empty()) {
+      std::unique_lock Lock(MdMutex);
+      if (auto It = MdMap.find(Name);
+          It != MdMap.end() && It->second == GraphId) {
+        MdMap.erase(It);
       }
     }
+    return WASINN::ErrNo::Success;
   }
 
-  void deleteContext(const uint32_t Id) noexcept {
-    // TODO: Add the deallocation callback.
-    std::unique_lock Lock(GraphMutex);
-    if (Id < NNContext.size() &&
-        NNContextRecycle.find(Id) == NNContextRecycle.end()) {
-      auto GId = NNContext[Id].getGraphId();
-      auto &G = NNGraph[GId];
-      G.decreaseContext();
-      if (G.getContextCount() == 0 && G.isFinalized()) {
-        // All contexts are deleted. Release the graph ID.
-        if (GId == NNGraph.size() - 1) {
-          NNGraph.pop_back();
-        } else {
-          G.reset();
-          NNGraphRecycle.insert(GId);
-        }
-      }
-      if (Id == NNContext.size() - 1) {
-        NNContext.pop_back();
-      } else {
-        NNContext[Id].reset();
-        NNContextRecycle.insert(Id);
-      }
+  // Detach the handle; the destructor drops backend state and the graph pin.
+  Expect<WASINN::ErrNo> finalizeContext(uint32_t ContextId) noexcept {
+    using namespace std::literals;
+    if (NNContext.remove(ContextId) == nullptr) {
+      spdlog::error("[WASI-NN] finalize_execution_context: Context ID {} "
+                    "does not exist."sv,
+                    ContextId);
+      return WASINN::ErrNo::InvalidArgument;
     }
+    return WASINN::ErrNo::Success;
   }
 
-  // Md storage
+  // Resolve and pin the graph, serialize on its op mutex, then re-check the
+  // status (an unload or a failed reload may have won the race) before
+  // running Dispatch. The pin keeps the graph alive for the whole op.
+  template <typename Fn>
+  Expect<WASINN::ErrNo> withGraphOp(uint32_t GraphId, HostOp Op,
+                                    Fn &&Dispatch) noexcept {
+    const auto Policy = hostOpPolicy(Op);
+    auto G = NNGraph.get(GraphId);
+    if (G == nullptr || !graphAdmits(Policy.Req, G->status())) {
+      logGraphReject(Policy.Name, GraphId, G.get());
+      return WASINN::ErrNo::InvalidArgument;
+    }
+    std::lock_guard<std::mutex> OpLock(G->opMutex());
+    if (!graphAdmits(Policy.Req, G->status())) {
+      logGraphReject(Policy.Name, GraphId, G.get());
+      return WASINN::ErrNo::InvalidArgument;
+    }
+    return Dispatch(G);
+  }
+
+  // Context-keyed twin of withGraphOp: the context pin keeps the context and
+  // parent graph alive; the parent's op mutex serializes against every other
+  // op on the same graph.
+  template <typename Fn>
+  Expect<WASINN::ErrNo> withContextOp(uint32_t ContextId, HostOp Op,
+                                      Fn &&Dispatch) noexcept {
+    using namespace std::literals;
+    const auto Policy = hostOpPolicy(Op);
+    auto C = NNContext.get(ContextId);
+    if (C == nullptr) {
+      spdlog::error("[WASI-NN] {}: Context ID {} does not exist."sv,
+                    Policy.Name, ContextId);
+      return WASINN::ErrNo::InvalidArgument;
+    }
+    Graph &G = C->parent();
+    if (!graphAdmits(Policy.Req, G.status())) {
+      logContextGraphReject(Policy.Name, ContextId, *C);
+      return WASINN::ErrNo::InvalidArgument;
+    }
+    std::lock_guard<std::mutex> OpLock(G.opMutex());
+    if (!graphAdmits(Policy.Req, G.status())) {
+      logContextGraphReject(Policy.Name, ContextId, *C);
+      return WASINN::ErrNo::InvalidArgument;
+    }
+    return Dispatch(G, *C);
+  }
+
+  // Md storage. RawMdMap is immutable after the constructor; MdMutex guards
+  // MdMap only. Lock order: MdMutex before the handle-table mutex (mdGet).
   mutable std::shared_mutex MdMutex;
   std::unordered_map<std::string, std::tuple<std::vector<std::vector<uint8_t>>,
                                              Backend, Device>>
       RawMdMap;
   std::unordered_map<std::string, uint32_t> MdMap;
 
-  // Graph and context
-  mutable std::shared_mutex GraphMutex;
-  std::unordered_set<uint32_t> NNGraphRecycle;
-  std::vector<Graph> NNGraph;
-  std::unordered_set<uint32_t> NNContextRecycle;
-  std::vector<Context> NNContext;
+  // Graph and context handle tables. Declared in this order so contexts are
+  // destroyed before graphs on environment teardown.
+  ResourceTable<Graph> NNGraph;
+  ResourceTable<Context> NNContext;
 
   // Preload model list
   static PO::List<std::string> NNModels;
@@ -386,6 +452,27 @@ struct WasiNNEnvironment :
   }
 
 private:
+  void logGraphReject(std::string_view Op, uint32_t GraphId,
+                      const Graph *G) const noexcept {
+    using namespace std::literals;
+    if (G != nullptr && G->status() == GraphStatus::Invalid) {
+      spdlog::error("[WASI-NN] {}: Graph ID {} is invalid. Please reload or "
+                    "unload this graph."sv,
+                    Op, GraphId);
+    } else {
+      spdlog::error(
+          "[WASI-NN] {}: Graph ID {} does not exist or is unloaded."sv, Op,
+          GraphId);
+    }
+  }
+  void logContextGraphReject(std::string_view Op, uint32_t ContextId,
+                             const Context &C) const noexcept {
+    using namespace std::literals;
+    spdlog::error("[WASI-NN] {}: Graph ID {} for context ID {} does not "
+                  "exist or has released."sv,
+                  Op, C.getGraphId(), ContextId);
+  }
+
   const Host::WASI::Environ *Environ = nullptr;
 };
 

--- a/plugins/wasi_nn/wasinnfunc.cpp
+++ b/plugins/wasi_nn/wasinnfunc.cpp
@@ -26,11 +26,30 @@ inline void reportUnknownBackend(WASINN::Backend B) noexcept {
 Expect<WASINN::ErrNo> load(WASINN::WasiNNEnvironment &Env,
                            Span<const Span<uint8_t>> Builders,
                            WASINN::Backend Backend, WASINN::Device Device,
-                           uint32_t &GraphId) {
+                           std::string_view Name, uint32_t &GraphId) {
+  // Build the graph fully before publishing: a table entry is always a
+  // usable resource and a failed load leaves no trace.
+  auto LoadInto = [&](WASINN::Backend BE,
+                      auto BackendLoad) -> Expect<WASINN::ErrNo> {
+    auto G = std::make_shared<WASINN::Graph>(BE);
+    G->setModelName(std::string(Name));
+    auto Res = BackendLoad(Env, *G, Builders, Device);
+    if (!Res.has_value() || *Res != WASINN::ErrNo::Success) {
+      return Res;
+    }
+    const auto Id = Env.NNGraph.insert(std::move(G));
+    if (!Id.has_value()) {
+      spdlog::error("[WASI-NN] load: graph handle space is exhausted."sv);
+      return WASINN::ErrNo::RuntimeError;
+    }
+    GraphId = *Id;
+    return WASINN::ErrNo::Success;
+  };
   switch (Backend) {
 #define EACH(B)                                                                \
   case WASINN::Backend::B:                                                     \
-    return WASINN::B::load(Env, Builders, Device, GraphId);
+    return LoadInto(WASINN::Backend::B,                                        \
+                    [](auto &...Args) { return WASINN::B::load(Args...); });
     FOR_EACH_BACKEND(EACH)
 #undef EACH
   default:
@@ -122,7 +141,12 @@ WasiNNLoad::bodyImpl(const Runtime::CallingFrame &Frame, uint32_t BuilderPtr,
     Builders.emplace_back(Builder);
   }
   auto Backend = static_cast<WASINN::Backend>(RawEncoding);
-  return load(Env, Builders, Backend, Device, *GraphId);
+  uint32_t NewGraphId = 0;
+  auto Res = load(Env, Builders, Backend, Device, ""sv, NewGraphId);
+  if (Res.has_value() && *Res == WASINN::ErrNo::Success) {
+    *GraphId = EndianValue(NewGraphId).le();
+  }
+  return Res;
 }
 
 Expect<WASINN::ErrNo>
@@ -167,11 +191,16 @@ WasiNNLoadByName::bodyImpl(const Runtime::CallingFrame &Frame, uint32_t NamePtr,
 
   // Get the model.
   std::string ModelName(NameStrView);
-  if (Env.mdGet(ModelName, *GraphId)) {
+  uint32_t FoundGraphId = 0;
+  if (Env.mdGet(ModelName, FoundGraphId)) {
+    *GraphId = EndianValue(FoundGraphId).le();
     return WASINN::ErrNo::Success;
-  } else {
-    return Env.mdBuild(ModelName, *GraphId, load);
   }
+  auto Res = Env.mdBuild(ModelName, FoundGraphId, load);
+  if (Res.has_value() && *Res == WASINN::ErrNo::Success) {
+    *GraphId = EndianValue(FoundGraphId).le();
+  }
+  return Res;
 }
 
 Expect<WASINN::ErrNo> WasiNNLoadByNameWithConfig::bodyImpl(
@@ -226,11 +255,16 @@ Expect<WASINN::ErrNo> WasiNNLoadByNameWithConfig::bodyImpl(
   // Get the model.
   std::string ModelName(NameStrView);
   std::vector<uint8_t> ModelConfig(ConfigSpan.begin(), ConfigSpan.end());
-  if (Env.mdGet(ModelName, *GraphId)) {
+  uint32_t FoundGraphId = 0;
+  if (Env.mdGet(ModelName, FoundGraphId)) {
+    *GraphId = EndianValue(FoundGraphId).le();
     return WASINN::ErrNo::Success;
-  } else {
-    return Env.mdBuild(ModelName, *GraphId, load, ModelConfig);
   }
+  auto Res = Env.mdBuild(ModelName, FoundGraphId, load, ModelConfig);
+  if (Res.has_value() && *Res == WASINN::ErrNo::Success) {
+    *GraphId = EndianValue(FoundGraphId).le();
+  }
+  return Res;
 }
 
 Expect<WASINN::ErrNo>
@@ -266,29 +300,34 @@ WasiNNInitExecCtx::bodyImpl(const Runtime::CallingFrame &Frame,
   }
 #endif // ifdef WASMEDGE_BUILD_WASI_NN_RPC
 
-  if (Env.NNGraph.size() <= GraphId || Env.NNGraph[GraphId].isFinalized()) {
-    spdlog::error("[WASI-NN] init_execution_context: Graph ID {} does not "
-                  "exist or is unloaded."sv,
-                  GraphId);
-    return WASINN::ErrNo::InvalidArgument;
-  }
-  if (!Env.NNGraph[GraphId].isReady()) {
-    spdlog::error("[WASI-NN] init_execution_context: Graph ID {} is invalid. "
-                  "Please reload or unload this graph."sv,
-                  GraphId);
-    return WASINN::ErrNo::InvalidArgument;
-  }
-
-  switch (const auto Backend = Env.NNGraph[GraphId].getBackend()) {
+  return Env.withGraphOp(
+      GraphId, WASINN::HostOp::InitExecCtx,
+      [&](const std::shared_ptr<WASINN::Graph> &G) -> Expect<WASINN::ErrNo> {
+        auto NewContext = std::make_shared<WASINN::Context>(GraphId, G);
+        Expect<WASINN::ErrNo> Res = WASINN::ErrNo::Success;
+        switch (const auto Backend = G->getBackend()) {
 #define EACH(B)                                                                \
   case WASINN::Backend::B:                                                     \
-    return WASINN::B::initExecCtx(Env, GraphId, *Context);
-    FOR_EACH_BACKEND(EACH)
+    Res = WASINN::B::initExecCtx(Env, *G, *NewContext);                        \
+    break;
+          FOR_EACH_BACKEND(EACH)
 #undef EACH
-  default:
-    reportUnknownBackend(Backend);
-    return WASINN::ErrNo::InvalidEncoding;
-  }
+        default:
+          reportUnknownBackend(Backend);
+          return WASINN::ErrNo::InvalidEncoding;
+        }
+        if (!Res.has_value() || *Res != WASINN::ErrNo::Success) {
+          return Res;
+        }
+        const auto Id = Env.NNContext.insert(std::move(NewContext));
+        if (!Id.has_value()) {
+          spdlog::error("[WASI-NN] init_execution_context: context handle "
+                        "space is exhausted."sv);
+          return WASINN::ErrNo::RuntimeError;
+        }
+        *Context = EndianValue(*Id).le();
+        return WASINN::ErrNo::Success;
+      });
 }
 
 Expect<WASINN::ErrNo>
@@ -372,23 +411,20 @@ WasiNNSetInput::bodyImpl(const Runtime::CallingFrame &Frame, uint32_t ContextId,
   }
 #endif // ifdef WASMEDGE_BUILD_WASI_NN_RPC
 
-  if (Env.NNContext.size() <= ContextId ||
-      !Env.NNContext[ContextId].isReady()) {
-    spdlog::error("[WASI-NN] set_input: Context ID {} does not exist."sv,
-                  ContextId);
-    return WASINN::ErrNo::InvalidArgument;
-  }
-
-  switch (const auto Backend = Env.NNContext[ContextId].getBackend()) {
+  return Env.withContextOp(
+      ContextId, WASINN::HostOp::SetInput,
+      [&](WASINN::Graph &G, WASINN::Context &C) -> Expect<WASINN::ErrNo> {
+        switch (const auto Backend = C.getBackend()) {
 #define EACH(B)                                                                \
   case WASINN::Backend::B:                                                     \
-    return WASINN::B::setInput(Env, ContextId, Index, Tensor);
-    FOR_EACH_BACKEND(EACH)
+    return WASINN::B::setInput(Env, G, C, Index, Tensor);
+          FOR_EACH_BACKEND(EACH)
 #undef EACH
-  default:
-    reportUnknownBackend(Backend);
-    return WASINN::ErrNo::InvalidEncoding;
-  }
+        default:
+          reportUnknownBackend(Backend);
+          return WASINN::ErrNo::InvalidEncoding;
+        }
+      });
 }
 
 Expect<WASINN::ErrNo>
@@ -442,24 +478,20 @@ WasiNNGetOutput::bodyImpl(const Runtime::CallingFrame &Frame,
   }
 #endif // ifdef WASMEDGE_BUILD_WASI_NN_RPC
 
-  if (Env.NNContext.size() <= ContextId ||
-      !Env.NNContext[ContextId].isReady()) {
-    spdlog::error("[WASI-NN] get_output: Context ID {} does not exist."sv,
-                  ContextId);
-    return WASINN::ErrNo::InvalidArgument;
-  }
-
-  switch (const auto Backend = Env.NNContext[ContextId].getBackend()) {
+  return Env.withContextOp(
+      ContextId, WASINN::HostOp::GetOutput,
+      [&](WASINN::Graph &G, WASINN::Context &C) -> Expect<WASINN::ErrNo> {
+        switch (const auto Backend = C.getBackend()) {
 #define EACH(B)                                                                \
   case WASINN::Backend::B:                                                     \
-    return WASINN::B::getOutput(Env, ContextId, Index, OutBuffer,              \
-                                *BytesWritten);
-    FOR_EACH_BACKEND(EACH)
+    return WASINN::B::getOutput(Env, G, C, Index, OutBuffer, *BytesWritten);
+          FOR_EACH_BACKEND(EACH)
 #undef EACH
-  default:
-    reportUnknownBackend(Backend);
-    return WASINN::ErrNo::InvalidEncoding;
-  }
+        default:
+          reportUnknownBackend(Backend);
+          return WASINN::ErrNo::InvalidEncoding;
+        }
+      });
 }
 
 Expect<WASINN::ErrNo> WasiNNGetOutputSingle::bodyImpl(
@@ -512,27 +544,22 @@ Expect<WASINN::ErrNo> WasiNNGetOutputSingle::bodyImpl(
   }
 #endif // ifdef WASMEDGE_BUILD_WASI_NN_RPC
 
-  if (Env.NNContext.size() <= ContextId ||
-      !Env.NNContext[ContextId].isReady()) {
-    spdlog::error(
-        "[WASI-NN] get_output_single: Context ID {} does not exist."sv,
-        ContextId);
-    return WASINN::ErrNo::InvalidArgument;
-  }
-
-  switch (Env.NNContext[ContextId].getBackend()) {
-  case WASINN::Backend::GGML:
-    return WASINN::GGML::getOutputSingle(Env, ContextId, Index, OutBuffer,
-                                         *BytesWritten);
-  case WASINN::Backend::BitNet:
-    return WASINN::BitNet::getOutputSingle(Env, ContextId, Index, OutBuffer,
-                                           *BytesWritten);
-  default:
-    spdlog::error(
-        "[WASI-NN] get_output_single: Only GGML and BitNet backend supports "sv
-        "get_output_single."sv);
-    return WASINN::ErrNo::InvalidArgument;
-  }
+  return Env.withContextOp(
+      ContextId, WASINN::HostOp::GetOutputSingle,
+      [&](WASINN::Graph &G, WASINN::Context &C) -> Expect<WASINN::ErrNo> {
+        switch (C.getBackend()) {
+        case WASINN::Backend::GGML:
+          return WASINN::GGML::getOutputSingle(Env, G, C, Index, OutBuffer,
+                                               *BytesWritten);
+        case WASINN::Backend::BitNet:
+          return WASINN::BitNet::getOutputSingle(Env, G, C, Index, OutBuffer,
+                                                 *BytesWritten);
+        default:
+          spdlog::error("[WASI-NN] get_output_single: Only GGML and BitNet "
+                        "backend supports get_output_single."sv);
+          return WASINN::ErrNo::InvalidArgument;
+        }
+      });
 }
 
 Expect<WASINN::ErrNo>
@@ -560,32 +587,20 @@ WasiNNCompute::bodyImpl(const Runtime::CallingFrame &Frame,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  if (Env.NNContext.size() <= ContextId ||
-      !Env.NNContext[ContextId].isReady()) {
-    spdlog::error("[WASI-NN] compute: Context ID {} does not exist."sv,
-                  ContextId);
-    return WASINN::ErrNo::InvalidArgument;
-  }
-
-  auto GraphId = Env.NNContext[ContextId].getGraphId();
-  assuming(Env.NNGraph.size() > GraphId);
-  if (!Env.NNGraph[GraphId].isReady()) {
-    spdlog::error("[WASI-NN] compute: Graph ID {} for context ID {} does not "sv
-                  "exist or has released."sv,
-                  GraphId, ContextId);
-    return WASINN::ErrNo::InvalidArgument;
-  }
-
-  switch (const auto Backend = Env.NNContext[ContextId].getBackend()) {
+  return Env.withContextOp(
+      ContextId, WASINN::HostOp::Compute,
+      [&](WASINN::Graph &G, WASINN::Context &C) -> Expect<WASINN::ErrNo> {
+        switch (const auto Backend = C.getBackend()) {
 #define EACH(B)                                                                \
   case WASINN::Backend::B:                                                     \
-    return WASINN::B::compute(Env, ContextId);
-    FOR_EACH_BACKEND(EACH)
+    return WASINN::B::compute(Env, G, C);
+          FOR_EACH_BACKEND(EACH)
 #undef EACH
-  default:
-    reportUnknownBackend(Backend);
-    return WASINN::ErrNo::InvalidEncoding;
-  }
+        default:
+          reportUnknownBackend(Backend);
+          return WASINN::ErrNo::InvalidEncoding;
+        }
+      });
 }
 
 Expect<WASINN::ErrNo>
@@ -613,33 +628,20 @@ WasiNNComputeSingle::bodyImpl(const Runtime::CallingFrame &Frame,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  if (Env.NNContext.size() <= ContextId ||
-      !Env.NNContext[ContextId].isReady()) {
-    spdlog::error("[WASI-NN] compute_single: Context ID {} does not exist."sv,
-                  ContextId);
-    return WASINN::ErrNo::InvalidArgument;
-  }
-
-  auto GraphId = Env.NNContext[ContextId].getGraphId();
-  assuming(Env.NNGraph.size() > GraphId);
-  if (!Env.NNGraph[GraphId].isReady()) {
-    spdlog::error("[WASI-NN] compute_single: Graph ID {} for context ID {} "sv
-                  "does not exist or has released."sv,
-                  GraphId, ContextId);
-    return WASINN::ErrNo::InvalidArgument;
-  }
-
-  switch (Env.NNContext[ContextId].getBackend()) {
-  case WASINN::Backend::GGML:
-    return WASINN::GGML::computeSingle(Env, ContextId);
-  case WASINN::Backend::BitNet:
-    return WASINN::BitNet::computeSingle(Env, ContextId);
-  default:
-    spdlog::error(
-        "[WASI-NN] compute_single: Only GGML and BitNet backend supports "sv
-        "compute_single."sv);
-    return WASINN::ErrNo::InvalidArgument;
-  }
+  return Env.withContextOp(
+      ContextId, WASINN::HostOp::ComputeSingle,
+      [&](WASINN::Graph &G, WASINN::Context &C) -> Expect<WASINN::ErrNo> {
+        switch (C.getBackend()) {
+        case WASINN::Backend::GGML:
+          return WASINN::GGML::computeSingle(Env, G, C);
+        case WASINN::Backend::BitNet:
+          return WASINN::BitNet::computeSingle(Env, G, C);
+        default:
+          spdlog::error("[WASI-NN] compute_single: Only GGML and BitNet "
+                        "backend supports compute_single."sv);
+          return WASINN::ErrNo::InvalidArgument;
+        }
+      });
 }
 
 Expect<WASINN::ErrNo>
@@ -667,23 +669,20 @@ WasiNNFiniSingle::bodyImpl(const Runtime::CallingFrame &Frame,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  if (Env.NNContext.size() <= ContextId ||
-      !Env.NNContext[ContextId].isReady()) {
-    spdlog::error("[WASI-NN] fini_single: Context ID {} does not exist."sv,
-                  ContextId);
-    return WASINN::ErrNo::InvalidArgument;
-  }
-
-  switch (Env.NNContext[ContextId].getBackend()) {
-  case WASINN::Backend::GGML:
-    return WASINN::GGML::finiSingle(Env, ContextId);
-  case WASINN::Backend::BitNet:
-    return WASINN::BitNet::finiSingle(Env, ContextId);
-  default:
-    spdlog::error(
-        "[WASI-NN] fini_single: Only GGML and BitNet backend supports fini_single."sv);
-    return WASINN::ErrNo::InvalidArgument;
-  }
+  return Env.withContextOp(
+      ContextId, WASINN::HostOp::FiniSingle,
+      [&](WASINN::Graph &G, WASINN::Context &C) -> Expect<WASINN::ErrNo> {
+        switch (C.getBackend()) {
+        case WASINN::Backend::GGML:
+          return WASINN::GGML::finiSingle(Env, G, C);
+        case WASINN::Backend::BitNet:
+          return WASINN::BitNet::finiSingle(Env, G, C);
+        default:
+          spdlog::error("[WASI-NN] fini_single: Only GGML and BitNet backend "
+                        "supports fini_single."sv);
+          return WASINN::ErrNo::InvalidArgument;
+        }
+      });
 }
 
 Expect<WASINN::ErrNo> WasiNNUnload::bodyImpl(const Runtime::CallingFrame &Frame,
@@ -701,25 +700,7 @@ Expect<WASINN::ErrNo> WasiNNUnload::bodyImpl(const Runtime::CallingFrame &Frame,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  if (Env.NNGraph.size() <= GraphId) {
-    spdlog::error("[WASI-NN] unload: GraphId {} does not exist."sv, GraphId);
-    return WASINN::ErrNo::InvalidArgument;
-  }
-
-  switch (Env.NNGraph[GraphId].getBackend()) {
-  case WASINN::Backend::GGML:
-    return WASINN::GGML::unload(Env, GraphId);
-  case WASINN::Backend::Whisper:
-    return WASINN::Whisper::unload(Env, GraphId);
-  case WASINN::Backend::ChatTTS:
-    return WASINN::ChatTTS::unload(Env, GraphId);
-  case WASINN::Backend::BitNet:
-    return WASINN::BitNet::unload(Env, GraphId);
-  default:
-    spdlog::error("[WASI-NN] unload: Only GGML, Whisper, ChatTTS and BitNet "sv
-                  "backends support unload."sv);
-    return WASINN::ErrNo::InvalidArgument;
-  }
+  return Env.unloadGraph(GraphId);
 }
 
 Expect<WASINN::ErrNo>
@@ -739,26 +720,7 @@ WasiNNFinalizeExecCtx::bodyImpl(const Runtime::CallingFrame &Frame,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  if (Env.NNContext.size() <= ContextId) {
-    spdlog::error(
-        "[WASI-NN] finalize_execution_context: Context ID {} does not exist."sv,
-        ContextId);
-    return WASINN::ErrNo::InvalidArgument;
-  }
-
-  switch (Env.NNContext[ContextId].getBackend()) {
-  case WASINN::Backend::GGML:
-    return WASINN::GGML::finalizeExecCtx(Env, ContextId);
-  case WASINN::Backend::Whisper:
-    return WASINN::Whisper::finalizeExecCtx(Env, ContextId);
-  case WASINN::Backend::BitNet:
-    return WASINN::BitNet::finalizeExecCtx(Env, ContextId);
-  default:
-    spdlog::error(
-        "[WASI-NN] finalize_execution_context: Only GGML, BitNet and "sv
-        "Whisper backends support finalize_execution_context."sv);
-    return WASINN::ErrNo::InvalidArgument;
-  }
+  return Env.finalizeContext(ContextId);
 }
 
 } // namespace Host

--- a/test/plugins/wasi_nn/CMakeLists.txt
+++ b/test/plugins/wasi_nn/CMakeLists.txt
@@ -97,7 +97,7 @@ foreach(BACKEND ${WASMEDGE_PLUGIN_WASI_NN_BACKEND})
     # the WASI-NN RPC URI would silently fail to apply.
     if(UNIX AND NOT APPLE)
       target_link_options(wasiNNTests PRIVATE
-        "LINKER:--exclude-libs,libllama.a:libggml.a:libggml-base.a:libggml-cpu.a:libggml-blas.a:libmtmd.a:libcommon.a"
+        "LINKER:--exclude-libs,libllama.a:libggml.a:libggml-base.a:libggml-cpu.a:libggml-blas.a:libggml-cuda.a:libmtmd.a:libcommon.a"
       )
     endif()
   elseif(BACKEND STREQUAL "piper")

--- a/test/plugins/wasi_nn/CMakeLists.txt
+++ b/test/plugins/wasi_nn/CMakeLists.txt
@@ -84,6 +84,13 @@ foreach(BACKEND ${WASMEDGE_PLUGIN_WASI_NN_BACKEND})
       PRIVATE
       mtmd
     )
+    # This second llama/ggml copy must stay out of the dynamic symbol table:
+    # wasmedge_setup_target enables ENABLE_EXPORTS, and on ELF the exported
+    # copy would interpose the dlopened plugin's global llama/ggml references
+    # while its hidden internals keep using its own copy. The two half-mixed
+    # copies then tear down the same state twice at exit (glibc: double free
+    # or corruption).
+    set_target_properties(wasiNNTests PROPERTIES ENABLE_EXPORTS OFF)
   elseif(BACKEND STREQUAL "piper")
     message(STATUS "Download ML artifacts to ${CMAKE_CURRENT_BINARY_DIR}/wasinn_piper_fixtures")
     wasmedge_download(

--- a/test/plugins/wasi_nn/CMakeLists.txt
+++ b/test/plugins/wasi_nn/CMakeLists.txt
@@ -77,6 +77,13 @@ foreach(BACKEND ${WASMEDGE_PLUGIN_WASI_NN_BACKEND})
         -Wno-unused-function
       )
     endif()
+    # The lifetime tests construct WASINN::Graph values inside the test
+    # binary, so the GGML payload's mtmd member deleters must resolve at link
+    # time here, not only in the plugin library.
+    target_link_libraries(wasiNNTests
+      PRIVATE
+      mtmd
+    )
   elseif(BACKEND STREQUAL "piper")
     message(STATUS "Download ML artifacts to ${CMAKE_CURRENT_BINARY_DIR}/wasinn_piper_fixtures")
     wasmedge_download(
@@ -145,6 +152,20 @@ foreach(BACKEND ${WASMEDGE_PLUGIN_WASI_NN_BACKEND})
       ${CMAKE_CURRENT_BINARY_DIR}/wasinn_whisper_fixtures/test.wav
       MD5=6cf3f7af1ebbd6b29c373e526b548dba
     )
+    # The lifetime tests construct WASINN::Graph values inside the test
+    # binary, so whisper_free in the Whisper payload's destructor must
+    # resolve at link time here, not only in the plugin library.
+    target_link_libraries(wasiNNTests
+      PRIVATE
+      whisper
+    )
+    # Keep this second whisper/ggml copy out of the dynamic symbol table for
+    # the same reason as the ggml archives above.
+    if(UNIX AND NOT APPLE)
+      target_link_options(wasiNNTests PRIVATE
+        "LINKER:--exclude-libs,libwhisper.a:libggml.a:libggml-base.a:libggml-cpu.a:libggml-blas.a:libggml-cuda.a"
+      )
+    endif()
   elseif(BACKEND STREQUAL "mlx")
     message( STATUS "Download ML artifacts to ${CMAKE_CURRENT_BINARY_DIR}/wasinn_mlx_fixtures")
     wasmedge_download(

--- a/test/plugins/wasi_nn/CMakeLists.txt
+++ b/test/plugins/wasi_nn/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 wasmedge_add_executable(wasiNNTests
   wasi_nn.cpp
+  resource_table_test.cpp
 )
 
 # Prepare the testing data for each backends.

--- a/test/plugins/wasi_nn/CMakeLists.txt
+++ b/test/plugins/wasi_nn/CMakeLists.txt
@@ -85,12 +85,21 @@ foreach(BACKEND ${WASMEDGE_PLUGIN_WASI_NN_BACKEND})
       mtmd
     )
     # This second llama/ggml copy must stay out of the dynamic symbol table:
-    # wasmedge_setup_target enables ENABLE_EXPORTS, and on ELF the exported
-    # copy would interpose the dlopened plugin's global llama/ggml references
-    # while its hidden internals keep using its own copy. The two half-mixed
-    # copies then tear down the same state twice at exit (glibc: double free
-    # or corruption).
-    set_target_properties(wasiNNTests PROPERTIES ENABLE_EXPORTS OFF)
+    # on ELF the exported copy would interpose the dlopened plugin's global
+    # llama/ggml references while its hidden internals keep using its own
+    # copy, and the two half-mixed copies then tear down the same state twice
+    # at exit (glibc: double free or corruption). Hide only these archives
+    # rather than turning off ENABLE_EXPORTS: the test binary must keep
+    # exporting its WasmEdge internals (Hash::rapidHash in particular) so the
+    # dlopened plugin resolves them to the executable's copy. Each rapidHash
+    # copy seeds itself randomly, so if the plugin hashed PO option maps with
+    # a different copy than the test binary, option lookups would miss and
+    # the WASI-NN RPC URI would silently fail to apply.
+    if(UNIX AND NOT APPLE)
+      target_link_options(wasiNNTests PRIVATE
+        "LINKER:--exclude-libs,libllama.a:libggml.a:libggml-base.a:libggml-cpu.a:libggml-blas.a:libmtmd.a:libcommon.a"
+      )
+    endif()
   elseif(BACKEND STREQUAL "piper")
     message(STATUS "Download ML artifacts to ${CMAKE_CURRENT_BINARY_DIR}/wasinn_piper_fixtures")
     wasmedge_download(

--- a/test/plugins/wasi_nn/resource_table_test.cpp
+++ b/test/plugins/wasi_nn/resource_table_test.cpp
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The WasmEdge Authors
+
+#include "resource_table.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <set>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using WasmEdge::Host::WASINN::ResourceTable;
+
+// Payload that counts its destructions, so the tests can pin exactly where the
+// final release happens relative to table operations.
+struct Tracked {
+  explicit Tracked(std::atomic<uint32_t> &Counter) noexcept
+      : Destroyed(Counter) {}
+  ~Tracked() noexcept { Destroyed.fetch_add(1, std::memory_order_relaxed); }
+  std::atomic<uint32_t> &Destroyed;
+};
+
+TEST(WasiNNResourceTableTest, InsertAllocatesSequentialIds) {
+  ResourceTable<int> Table;
+  for (uint32_t Expected = 0; Expected < 8; ++Expected) {
+    const auto Id = Table.insert(std::make_shared<int>(0));
+    ASSERT_TRUE(Id.has_value());
+    EXPECT_EQ(*Id, Expected);
+  }
+  EXPECT_EQ(Table.size(), 8U);
+}
+
+TEST(WasiNNResourceTableTest, GetResolvesLiveHandleAndRejectsUnknown) {
+  ResourceTable<int> Table;
+  const auto Id = Table.insert(std::make_shared<int>(42));
+  ASSERT_TRUE(Id.has_value());
+  const auto Value = Table.get(*Id);
+  ASSERT_NE(Value, nullptr);
+  EXPECT_EQ(*Value, 42);
+  EXPECT_EQ(Table.get(*Id + 1), nullptr);
+  EXPECT_EQ(Table.get(std::numeric_limits<uint32_t>::max()), nullptr);
+}
+
+TEST(WasiNNResourceTableTest, RemoveDetachesHandleAndReturnsOwnership) {
+  std::atomic<uint32_t> Destroyed{0};
+  ResourceTable<Tracked> Table;
+  const auto Id = Table.insert(std::make_shared<Tracked>(Destroyed));
+  ASSERT_TRUE(Id.has_value());
+
+  auto Detached = Table.remove(*Id);
+  ASSERT_NE(Detached, nullptr);
+  EXPECT_EQ(Table.get(*Id), nullptr);
+  EXPECT_EQ(Table.size(), 0U);
+  EXPECT_EQ(Destroyed.load(), 0U);
+
+  Detached.reset();
+  EXPECT_EQ(Destroyed.load(), 1U);
+}
+
+TEST(WasiNNResourceTableTest, DoubleRemoveIsRejected) {
+  ResourceTable<int> Table;
+  const auto Id = Table.insert(std::make_shared<int>(0));
+  ASSERT_TRUE(Id.has_value());
+  EXPECT_NE(Table.remove(*Id), nullptr);
+  EXPECT_EQ(Table.remove(*Id), nullptr);
+}
+
+TEST(WasiNNResourceTableTest, IdsAreNeverReused) {
+  ResourceTable<int> Table;
+  const auto First = Table.insert(std::make_shared<int>(1));
+  ASSERT_TRUE(First.has_value());
+  ASSERT_NE(Table.remove(*First), nullptr);
+
+  const auto Second = Table.insert(std::make_shared<int>(2));
+  ASSERT_TRUE(Second.has_value());
+  EXPECT_NE(*Second, *First);
+
+  // The stale handle keeps missing instead of aliasing the new resource.
+  EXPECT_EQ(Table.get(*First), nullptr);
+  const auto Fresh = Table.get(*Second);
+  ASSERT_NE(Fresh, nullptr);
+  EXPECT_EQ(*Fresh, 2);
+}
+
+TEST(WasiNNResourceTableTest, PinnedResourceSurvivesRemoval) {
+  std::atomic<uint32_t> Destroyed{0};
+  ResourceTable<Tracked> Table;
+  const auto Id = Table.insert(std::make_shared<Tracked>(Destroyed));
+  ASSERT_TRUE(Id.has_value());
+
+  // An in-flight operation holds its pin across a concurrent unload.
+  auto Pin = Table.get(*Id);
+  ASSERT_NE(Pin, nullptr);
+  Table.remove(*Id).reset();
+  EXPECT_EQ(Destroyed.load(), 0U);
+
+  // The final release runs the destructor, wherever it happens.
+  Pin.reset();
+  EXPECT_EQ(Destroyed.load(), 1U);
+}
+
+// The table mutex is never held while a payload destructor runs, so a
+// destructor may call back into the same (non-recursive) table mutex.
+struct Reentrant {
+  explicit Reentrant(ResourceTable<Reentrant> &Owner) noexcept : Owner(Owner) {}
+  ~Reentrant() noexcept { ObservedSize = Owner.size(); }
+  ResourceTable<Reentrant> &Owner;
+  static uint32_t ObservedSize;
+};
+uint32_t Reentrant::ObservedSize = std::numeric_limits<uint32_t>::max();
+
+TEST(WasiNNResourceTableTest, DestructorMayReenterTable) {
+  ResourceTable<Reentrant> Table;
+  const auto Id = Table.insert(std::make_shared<Reentrant>(Table));
+  ASSERT_TRUE(Id.has_value());
+  Table.remove(*Id).reset();
+  EXPECT_EQ(Reentrant::ObservedSize, 0U);
+}
+
+TEST(WasiNNResourceTableTest, InsertFailsOnIdExhaustion) {
+  ResourceTable<int> Table(std::numeric_limits<uint32_t>::max() - 1);
+  const auto Last = Table.insert(std::make_shared<int>(0));
+  ASSERT_TRUE(Last.has_value());
+  EXPECT_EQ(*Last, std::numeric_limits<uint32_t>::max() - 1);
+  EXPECT_EQ(Table.insert(std::make_shared<int>(0)), std::nullopt);
+  // The failed insert did not disturb the surviving entry.
+  EXPECT_EQ(Table.size(), 1U);
+  EXPECT_NE(Table.get(*Last), nullptr);
+}
+
+// Concurrency stress: producers publish, workers pin-and-use, removers
+// detach. Under TSan this checks unique ids, exactly-once destruction, and
+// pins surviving concurrent removal.
+TEST(WasiNNResourceTableTest, ConcurrentChurnKeepsOwnershipExact) {
+  constexpr uint32_t Producers = 4;
+  constexpr uint32_t PerProducer = 256;
+  constexpr uint32_t Empty = std::numeric_limits<uint32_t>::max();
+  std::atomic<uint32_t> Destroyed{0};
+  ResourceTable<Tracked> Table;
+
+  // Each producer owns a disjoint slice; a slot flips from Empty to its id
+  // with release ordering, so readers only ever act on fully published ids.
+  struct Slot {
+    std::atomic<uint32_t> Id{Empty};
+  };
+  std::vector<Slot> Published(Producers * PerProducer);
+  std::atomic<bool> Done{false};
+
+  std::vector<std::thread> Threads;
+  for (uint32_t P = 0; P < Producers; ++P) {
+    Threads.emplace_back([&Table, &Destroyed, &Published, P] {
+      for (uint32_t I = 0; I < PerProducer; ++I) {
+        const auto Id = Table.insert(std::make_shared<Tracked>(Destroyed));
+        ASSERT_TRUE(Id.has_value());
+        Published[P * PerProducer + I].Id.store(*Id, std::memory_order_release);
+      }
+    });
+  }
+  // Removers race the producers over every published slot.
+  for (uint32_t R = 0; R < 2; ++R) {
+    Threads.emplace_back([&Table, &Published, &Done] {
+      while (!Done.load(std::memory_order_acquire)) {
+        for (auto &Slot : Published) {
+          const uint32_t Id = Slot.Id.load(std::memory_order_acquire);
+          if (Id != Empty) {
+            Table.remove(Id);
+          }
+        }
+      }
+    });
+  }
+  // Readers pin whatever they can catch; the pin must stay usable even when a
+  // remover detaches the entry mid-use.
+  for (uint32_t W = 0; W < 2; ++W) {
+    Threads.emplace_back([&Table, &Published, &Destroyed, &Done] {
+      while (!Done.load(std::memory_order_acquire)) {
+        for (auto &Slot : Published) {
+          const uint32_t Id = Slot.Id.load(std::memory_order_acquire);
+          if (Id == Empty) {
+            continue;
+          }
+          if (auto Pin = Table.get(Id)) {
+            // Touch the payload through the pin: alive even if removed now.
+            EXPECT_EQ(&Pin->Destroyed, &Destroyed);
+          }
+        }
+      }
+    });
+  }
+
+  for (uint32_t P = 0; P < Producers; ++P) {
+    Threads[P].join();
+  }
+  Done.store(true, std::memory_order_release);
+  for (uint32_t I = Producers; I < Threads.size(); ++I) {
+    Threads[I].join();
+  }
+
+  // Drain anything the removers did not catch, then check exact ownership.
+  std::set<uint32_t> Unique;
+  for (auto &Slot : Published) {
+    const uint32_t Id = Slot.Id.load(std::memory_order_acquire);
+    ASSERT_NE(Id, Empty);
+    Unique.insert(Id);
+    Table.remove(Id);
+  }
+  EXPECT_EQ(Table.size(), 0U);
+  EXPECT_EQ(Destroyed.load(), Producers * PerProducer);
+  EXPECT_EQ(Unique.size(), Published.size());
+}
+
+} // namespace

--- a/test/plugins/wasi_nn/resource_table_test.cpp
+++ b/test/plugins/wasi_nn/resource_table_test.cpp
@@ -124,6 +124,22 @@ TEST(WasiNNResourceTableTest, DestructorMayReenterTable) {
   EXPECT_EQ(Reentrant::ObservedSize, 0U);
 }
 
+TEST(WasiNNResourceTableTest, SwapExchangesContentsAndIdCounter) {
+  ResourceTable<int> A;
+  ResourceTable<int> B;
+  const auto IdA = A.insert(std::make_shared<int>(1));
+  ASSERT_TRUE(IdA.has_value());
+  A.swap(B);
+  EXPECT_EQ(A.size(), 0U);
+  EXPECT_EQ(B.size(), 1U);
+  const auto Moved = B.get(*IdA);
+  ASSERT_NE(Moved, nullptr);
+  EXPECT_EQ(*Moved, 1);
+  // The id counter moves with the contents: A restarts, B continues.
+  EXPECT_EQ(A.insert(std::make_shared<int>(2)), std::optional<uint32_t>{0U});
+  EXPECT_EQ(B.insert(std::make_shared<int>(3)), std::optional<uint32_t>{1U});
+}
+
 TEST(WasiNNResourceTableTest, InsertFailsOnIdExhaustion) {
   ResourceTable<int> Table(std::numeric_limits<uint32_t>::max() - 1);
   const auto Last = Table.insert(std::make_shared<int>(0));

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -1988,6 +1988,77 @@ TEST(WasiNNTest, LoadByNameConcurrentBuildsShareOneGraph) {
   EXPECT_EQ(CachedId, WinnerId);
 }
 
+TEST(WasiNNTest, LoadByNameSkipsDetachedGraphStillInTable) {
+  // unload publishes Detached before dropping the table entry, so a racing
+  // load_by_name can observe a Detached yet still-tabled graph. The name
+  // cache must treat it as unloaded - neither resolving it nor folding a
+  // build onto it - or the guest would get an already-rejected handle.
+  auto NNMod = createModule();
+  if (!NNMod) {
+    GTEST_SKIP() << "wasi_nn plugin not found";
+  }
+  auto &Env = NNMod->getEnv();
+  const std::string Name = "detached-window";
+  Env.RawMdMap.emplace(
+      Name, std::make_tuple(std::vector<std::vector<uint8_t>>{{0x00}},
+                            Backend::GGML, Device::CPU));
+  auto StubLoad = [](WasmEdge::Host::WASINN::WasiNNEnvironment &E,
+                     WasmEdge::Span<const WasmEdge::Span<uint8_t>>, Backend BE,
+                     Device, std::string_view MdName,
+                     uint32_t &GraphIdOut) -> WasmEdge::Expect<ErrNo> {
+    auto G = std::make_shared<WasmEdge::Host::WASINN::Graph>(BE);
+    G->setModelName(std::string(MdName));
+    auto Id = E.NNGraph.insert(std::move(G));
+    EXPECT_TRUE(Id.has_value());
+    GraphIdOut = *Id;
+    return ErrNo::Success;
+  };
+
+  uint32_t BuiltId = UINT32_C(0xFFFFFFFF);
+  auto Res = Env.mdBuild(Name, BuiltId, StubLoad);
+  ASSERT_TRUE(Res.has_value());
+  EXPECT_EQ(*Res, ErrNo::Success);
+  uint32_t ResolvedId = UINT32_C(0xFFFFFFFF);
+  EXPECT_TRUE(Env.mdGet(Name, ResolvedId));
+  EXPECT_EQ(ResolvedId, BuiltId);
+
+  // Enter the mid-unload window: Detached is visible while the table entry
+  // and the cache entry still exist.
+  auto G = Env.NNGraph.get(BuiltId);
+  ASSERT_NE(G, nullptr);
+  G->setDetached();
+  EXPECT_NE(Env.NNGraph.get(BuiltId), nullptr);
+  EXPECT_FALSE(Env.mdGet(Name, ResolvedId));
+
+  // A Ready-tier graph-keyed op rejects the half-detached graph even though
+  // its handle still resolves.
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1)));
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  auto *FuncInst = NNMod->findFuncExports("init_execution_context"sv);
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  std::array<WasmEdge::ValVariant, 1> Errno = {UINT32_C(0)};
+  EXPECT_TRUE(FuncInst->getHostFunc().run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{BuiltId, UINT32_C(0)},
+      Errno));
+  EXPECT_EQ(Errno[0].get<int32_t>(),
+            static_cast<uint32_t>(ErrNo::InvalidArgument));
+
+  // A build finishing inside the window publishes its own graph instead of
+  // folding onto the dying one.
+  uint32_t RebuiltId = UINT32_C(0xFFFFFFFF);
+  Res = Env.mdBuild(Name, RebuiltId, StubLoad);
+  ASSERT_TRUE(Res.has_value());
+  EXPECT_EQ(*Res, ErrNo::Success);
+  EXPECT_NE(RebuiltId, BuiltId);
+  EXPECT_TRUE(Env.mdGet(Name, ResolvedId));
+  EXPECT_EQ(ResolvedId, RebuiltId);
+}
+
 TEST(WasiNNTest, GGMLBackendDrainAfterInvalidReloadUnload) {
   // A failed metadata reload leaves the graph Invalid with a null llama
   // context; unload then makes it Detached, which Drainable admits, so the

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <numeric>
 #include <string>
+#include <thread>
 #include <vector>
 
 using namespace std::literals;
@@ -1614,6 +1615,302 @@ TEST(WasiNNTest, GGMLBackend) {
     EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
     EXPECT_EQ(*MemInst.getPointer<uint32_t *>(BuilderPtr), Needed);
   }
+
+  // Get the unload, finalize_execution_context, get_output_single, and
+  // fini_single host functions for the lifetime tests below.
+  FuncInst = NNMod->findFuncExports("unload");
+  EXPECT_NE(FuncInst, nullptr);
+  EXPECT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncUnload = FuncInst->getHostFunc();
+  FuncInst = NNMod->findFuncExports("finalize_execution_context");
+  EXPECT_NE(FuncInst, nullptr);
+  EXPECT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncFinalize = FuncInst->getHostFunc();
+  FuncInst = NNMod->findFuncExports("get_output_single");
+  EXPECT_NE(FuncInst, nullptr);
+  EXPECT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncGetOutputSingleDrain = FuncInst->getHostFunc();
+  FuncInst = NNMod->findFuncExports("fini_single");
+  EXPECT_NE(FuncInst, nullptr);
+  EXPECT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncFiniSingle = FuncInst->getHostFunc();
+
+  // Test: init_execution_context -- create a second, token-less context so
+  // the graph stays pinned by two contexts across the unload below.
+  uint32_t NoTokenCtx = UINT32_C(0);
+  {
+    EXPECT_TRUE(HostFuncInit.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0), BuilderPtr},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+    NoTokenCtx = *MemInst.getPointer<uint32_t *>(BuilderPtr);
+    EXPECT_EQ(NoTokenCtx, UINT32_C(1));
+  }
+
+  // Test: unload -- unload while both contexts are alive: returns
+  // immediately and the live contexts keep the model alive to drain.
+  {
+    EXPECT_TRUE(HostFuncUnload.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0)},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+  }
+
+  // Test: unload -- a second unload of the same handle is rejected; the
+  // handle died with the first call.
+  {
+    EXPECT_TRUE(HostFuncUnload.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0)},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(),
+              static_cast<uint32_t>(ErrNo::InvalidArgument));
+  }
+
+  // Test: init_execution_context -- the unloaded graph cannot create new
+  // contexts.
+  {
+    EXPECT_TRUE(HostFuncInit.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0), BuilderPtr},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(),
+              static_cast<uint32_t>(ErrNo::InvalidArgument));
+  }
+
+  // Test: get_output -- drain the still-alive context after unload. The
+  // context pins the graph, so the buffered output stays readable.
+  {
+    EXPECT_TRUE(HostFuncGetOutput.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            UINT32_C(0), UINT32_C(0), StorePtr, 65532, BuilderPtr},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+    auto BytesWritten = *MemInst.getPointer<uint32_t *>(BuilderPtr);
+    EXPECT_GE(BytesWritten, 50);
+  }
+
+  // Test: get_output_single -- drain via the model after unload. Unlike
+  // get_output's buffered copy, this detokenizes through the graph-owned
+  // llama context, so it only works if the model survived the unload.
+  {
+    EXPECT_TRUE(HostFuncGetOutputSingleDrain.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            UINT32_C(0), UINT32_C(0), StorePtr, UINT32_C(65532), BuilderPtr},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+  }
+
+  // Test: fini_single -- reset the still-alive context's streaming state
+  // after unload.
+  {
+    EXPECT_TRUE(HostFuncFiniSingle.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0)},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+  }
+
+  // Test: finalize_execution_context -- finalize both contexts. The second
+  // release drops the last pin and destroys the backend payload.
+  {
+    EXPECT_TRUE(HostFuncFinalize.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0)},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+    EXPECT_TRUE(HostFuncFinalize.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{NoTokenCtx},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+  }
+
+  // Test: finalize_execution_context -- a finalized handle stays dead.
+  {
+    EXPECT_TRUE(HostFuncFinalize.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0)},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(),
+              static_cast<uint32_t>(ErrNo::InvalidArgument));
+  }
+
+  // Test: load -- reloading yields a fresh handle: id 0 is never reused, so
+  // stale handles keep failing instead of aliasing the new graph.
+  uint32_t FreshGraphId = UINT32_C(0);
+  {
+    *MemInst.getPointer<uint32_t *>(BuilderPtr) = UINT32_C(0xFFFFFFFF);
+    EXPECT_TRUE(HostFuncLoad.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            LoadEntryPtr, UINT32_C(1), static_cast<uint32_t>(Backend::GGML),
+            static_cast<uint32_t>(Device::CPU), BuilderPtr},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+    FreshGraphId = *MemInst.getPointer<uint32_t *>(BuilderPtr);
+    EXPECT_EQ(FreshGraphId, UINT32_C(1));
+  }
+
+  // Test: concurrent host ops -- one thread hammers dead and unknown handles
+  // while another runs real inference on the fresh graph. The dead handles
+  // must keep failing cleanly and the live path must stay unaffected.
+  {
+    uint32_t FreshCtx = UINT32_C(0);
+    EXPECT_TRUE(HostFuncInit.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{FreshGraphId, BuilderPtr},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+    FreshCtx = *MemInst.getPointer<uint32_t *>(BuilderPtr);
+    EXPECT_EQ(FreshCtx, UINT32_C(2));
+
+    // Re-marshal the input tensor: the earlier get_output tests overwrote the
+    // prompt bytes at StorePtr with model output and guard bytes.
+    BuilderPtr = SetInputEntryPtr;
+    writeFatPointer(MemInst, StorePtr, static_cast<uint32_t>(TensorDim.size()),
+                    BuilderPtr);
+    writeUInt32(MemInst, UINT32_C(1), BuilderPtr);
+    writeFatPointer(MemInst,
+                    StorePtr + static_cast<uint32_t>(TensorDim.size()) * 4,
+                    static_cast<uint32_t>(TensorData.size()), BuilderPtr);
+    writeBinaries<uint32_t>(MemInst, TensorDim, StorePtr);
+    writeBinaries<uint8_t>(MemInst, TensorData,
+                           StorePtr +
+                               static_cast<uint32_t>(TensorDim.size()) * 4);
+    EXPECT_TRUE(
+        HostFuncSetInput.run(CallFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 FreshCtx, UINT32_C(0), SetInputEntryPtr},
+                             Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+
+    std::thread StaleThread([&]() {
+      WasmEdge::Runtime::Instance::ModuleInstance StaleMod("");
+      StaleMod.addHostMemory(
+          "memory",
+          std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+              WasmEdge::AST::MemoryType(1)));
+      WasmEdge::Runtime::CallingFrame StaleFrame(nullptr, &StaleMod);
+      std::array<WasmEdge::ValVariant, 1> StaleErrno = {UINT32_C(0)};
+      // A bounded number of rounds keeps the rejection logging finite while
+      // still overlapping the live computes on the main thread.
+      for (int Round = 0; Round < 100; ++Round) {
+        // The unloaded graph handle.
+        EXPECT_TRUE(
+            HostFuncInit.run(StaleFrame,
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(0), UINT32_C(0)},
+                             StaleErrno));
+        EXPECT_EQ(StaleErrno[0].get<int32_t>(),
+                  static_cast<uint32_t>(ErrNo::InvalidArgument));
+        // The finalized context handle.
+        EXPECT_TRUE(HostFuncCompute.run(
+            StaleFrame,
+            std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0)},
+            StaleErrno));
+        EXPECT_EQ(StaleErrno[0].get<int32_t>(),
+                  static_cast<uint32_t>(ErrNo::InvalidArgument));
+        // A never-allocated handle.
+        EXPECT_TRUE(HostFuncUnload.run(
+            StaleFrame,
+            std::initializer_list<WasmEdge::ValVariant>{UINT32_C(9999)},
+            StaleErrno));
+        EXPECT_EQ(StaleErrno[0].get<int32_t>(),
+                  static_cast<uint32_t>(ErrNo::InvalidArgument));
+      }
+    });
+    // Compute until finish or context full, as the earlier compute test does.
+    EXPECT_TRUE(HostFuncCompute.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{FreshCtx},
+        Errno));
+    EXPECT_TRUE(
+        Errno[0].get<int32_t>() == static_cast<uint32_t>(ErrNo::Success) ||
+        Errno[0].get<int32_t>() == static_cast<uint32_t>(ErrNo::ContextFull));
+    EXPECT_TRUE(HostFuncGetOutput.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            FreshCtx, UINT32_C(0), StorePtr, 65532, BuilderPtr},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+    StaleThread.join();
+
+    // Unload the fresh graph, drain the context once more, then finalize it.
+    EXPECT_TRUE(HostFuncUnload.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{FreshGraphId},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+    EXPECT_TRUE(HostFuncGetOutput.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            FreshCtx, UINT32_C(0), StorePtr, 65532, BuilderPtr},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+    EXPECT_TRUE(HostFuncFinalize.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{FreshCtx},
+        Errno));
+    EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+  }
+}
+
+TEST(WasiNNTest, DrainAfterUnloadHostOpTiers) {
+  // Pin each op's hostOpPolicy tier so a later edit cannot move set_input
+  // (NotDetached) or compute/init (Ready) onto a drain tier and let them
+  // reconfigure or re-run an unloaded graph.
+  using WasmEdge::Host::WASINN::GraphReq;
+  using WasmEdge::Host::WASINN::HostOp;
+  using WasmEdge::Host::WASINN::hostOpPolicy;
+  // Reconfigure- and compute-class ops require a live graph.
+  EXPECT_EQ(hostOpPolicy(HostOp::SetInput).Req, GraphReq::NotDetached);
+  EXPECT_EQ(hostOpPolicy(HostOp::InitExecCtx).Req, GraphReq::Ready);
+  EXPECT_EQ(hostOpPolicy(HostOp::Compute).Req, GraphReq::Ready);
+  EXPECT_EQ(hostOpPolicy(HostOp::ComputeSingle).Req, GraphReq::Ready);
+  // Drain-class ops keep working after unload while a context finishes.
+  EXPECT_EQ(hostOpPolicy(HostOp::GetOutput).Req, GraphReq::Any);
+  EXPECT_EQ(hostOpPolicy(HostOp::GetOutputSingle).Req, GraphReq::Drainable);
+  EXPECT_EQ(hostOpPolicy(HostOp::FiniSingle).Req, GraphReq::Any);
+}
+
+namespace {
+// Table bookkeeping is covered backend-free in resource_table_test.cpp; these
+// check the host-function wiring: guards reject an id that is not a live
+// graph/context before dispatching to any backend, so no model is needed.
+void expectRejectsUnknownId(std::string_view FuncName) {
+  auto NNMod = createModule();
+  if (!NNMod) {
+    GTEST_SKIP() << "wasi_nn plugin not found";
+  }
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1)));
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+
+  auto *FuncInst = NNMod->findFuncExports(FuncName);
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  auto &HostFunc = FuncInst->getHostFunc();
+  std::array<WasmEdge::ValVariant, 1> Errno = {UINT32_C(0)};
+
+  // The module is fresh, so no id exists; 9999 is plainly unknown.
+  const uint32_t UnknownId = 9999;
+  EXPECT_TRUE(HostFunc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{UnknownId},
+      Errno));
+  EXPECT_EQ(Errno[0].get<int32_t>(),
+            static_cast<uint32_t>(ErrNo::InvalidArgument));
+}
+} // namespace
+
+TEST(WasiNNTest, UnloadRejectsInvalidGraphId) {
+  expectRejectsUnknownId("unload"sv);
+}
+
+TEST(WasiNNTest, FinalizeRejectsInvalidContextId) {
+  expectRejectsUnknownId("finalize_execution_context"sv);
+}
+
+TEST(WasiNNTest, ComputeRejectsInvalidContextId) {
+  expectRejectsUnknownId("compute"sv);
 }
 
 namespace {

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -2007,7 +2007,7 @@ TEST(WasiNNTest, GGMLBackendDrainAfterInvalidReloadUnload) {
   std::string Prompt = "Once upon a time, ";
   std::vector<uint8_t> TensorData(Prompt.begin(), Prompt.end());
   std::string Model = WasmEdge::Endian::native == WasmEdge::Endian::little
-                          ? "./wasinn_ggml_fixtures/orca_mini.gguf"
+                          ? "./wasinn_ggml_fixtures/stories260K.gguf"
                           : "./wasinn_ggml_fixtures/granite-3.gguf";
   std::vector<uint8_t> WeightRead = readEntireFile(Model);
   ASSERT_FALSE(WeightRead.empty());

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -174,8 +174,11 @@ TEST(WasiNNTest, OpenVINOBackend) {
   std::array<WasmEdge::ValVariant, 1> Errno = {UINT32_C(0)};
 
   // Temp. values.
-  std::vector<WasmEdge::Host::WASINN::Graph> NNGraphTmp;
-  std::vector<WasmEdge::Host::WASINN::Context> NNContextTmp;
+  WasmEdge::Host::WASINN::ResourceTable<WasmEdge::Host::WASINN::Graph>
+      NNGraphTmp;
+  WasmEdge::Host::WASINN::ResourceTable<WasmEdge::Host::WASINN::Context>
+      NNContextTmp;
+  std::shared_ptr<WasmEdge::Host::WASINN::Graph> TmpGraph;
 
   // Get the function "load".
   auto *FuncInst = NNMod->findFuncExports("load");
@@ -344,8 +347,8 @@ TEST(WasiNNTest, OpenVINOBackend) {
   }
 
   // Swap to the tmp. env.
-  NNGraphTmp.emplace_back(Backend::OpenVINO);
-  NNGraphTmp.back().setReady();
+  TmpGraph = std::make_shared<WasmEdge::Host::WASINN::Graph>(Backend::OpenVINO);
+  NNGraphTmp.insert(TmpGraph);
   NNGraphTmp.swap(NNMod->getEnv().NNGraph);
   NNContextTmp.swap(NNMod->getEnv().NNContext);
   // Test: init_execution_context -- graph id exceeds.
@@ -395,8 +398,8 @@ TEST(WasiNNTest, OpenVINOBackend) {
   writeBinaries<uint8_t>(MemInst, TensorData, StorePtr + TensorDim.size() * 4);
 
   // Swap to the tmp. env.
-  NNContextTmp.emplace_back(0, NNGraphTmp[0]);
-  NNContextTmp.back().setReady();
+  NNContextTmp.insert(
+      std::make_shared<WasmEdge::Host::WASINN::Context>(0, TmpGraph));
   NNGraphTmp.swap(NNMod->getEnv().NNGraph);
   NNContextTmp.swap(NNMod->getEnv().NNContext);
   // Test: set_input -- context id exceeds.
@@ -592,8 +595,11 @@ TEST(WasiNNTest, PyTorchBackend) {
   std::array<WasmEdge::ValVariant, 1> Errno = {UINT32_C(0)};
 
   // Temp. values.
-  std::vector<WasmEdge::Host::WASINN::Graph> NNGraphTmp;
-  std::vector<WasmEdge::Host::WASINN::Context> NNContextTmp;
+  WasmEdge::Host::WASINN::ResourceTable<WasmEdge::Host::WASINN::Graph>
+      NNGraphTmp;
+  WasmEdge::Host::WASINN::ResourceTable<WasmEdge::Host::WASINN::Context>
+      NNContextTmp;
+  std::shared_ptr<WasmEdge::Host::WASINN::Graph> TmpGraph;
 
   // Get the function "load".
   auto *FuncInst = NNMod->findFuncExports("load");
@@ -739,8 +745,8 @@ TEST(WasiNNTest, PyTorchBackend) {
   }
 
   // Swap to the tmp. env.
-  NNGraphTmp.emplace_back(Backend::PyTorch);
-  NNGraphTmp.back().setReady();
+  TmpGraph = std::make_shared<WasmEdge::Host::WASINN::Graph>(Backend::PyTorch);
+  NNGraphTmp.insert(TmpGraph);
   // Test: init_execution_context -- graph id exceeds.
   // TODO: add a non-null test for PyTorch.
   //   NNGraphTmp.swap(NNMod->getEnv().NNGraph);
@@ -801,8 +807,8 @@ TEST(WasiNNTest, PyTorchBackend) {
               static_cast<uint32_t>(ErrNo::InvalidArgument));
   }
 
-  NNContextTmp.emplace_back(0, NNGraphTmp[0]);
-  NNContextTmp.back().setReady();
+  NNContextTmp.insert(
+      std::make_shared<WasmEdge::Host::WASINN::Context>(0, TmpGraph));
 
   // Test: set_input -- tensor type not FP32.
   BuilderPtr = SetInputEntryPtr;
@@ -962,8 +968,11 @@ TEST(WasiNNTest, TFLiteBackend) {
   std::array<WasmEdge::ValVariant, 1> Errno = {UINT32_C(0)};
 
   // Temp. values.
-  std::vector<WasmEdge::Host::WASINN::Graph> NNGraphTmp;
-  std::vector<WasmEdge::Host::WASINN::Context> NNContextTmp;
+  WasmEdge::Host::WASINN::ResourceTable<WasmEdge::Host::WASINN::Graph>
+      NNGraphTmp;
+  WasmEdge::Host::WASINN::ResourceTable<WasmEdge::Host::WASINN::Context>
+      NNContextTmp;
+  std::shared_ptr<WasmEdge::Host::WASINN::Graph> TmpGraph;
 
   // Get the function "load".
   auto *FuncInst = NNMod->findFuncExports("load");
@@ -1118,8 +1127,9 @@ TEST(WasiNNTest, TFLiteBackend) {
 
   // Swap to the tmp. env.
   // Test: init_execution_context -- graph id exceeds.
-  NNGraphTmp.emplace_back(Backend::TensorflowLite);
-  NNGraphTmp.back().setReady();
+  TmpGraph =
+      std::make_shared<WasmEdge::Host::WASINN::Graph>(Backend::TensorflowLite);
+  NNGraphTmp.insert(TmpGraph);
   NNGraphTmp.swap(NNMod->getEnv().NNGraph);
   NNContextTmp.swap(NNMod->getEnv().NNContext);
   {
@@ -1178,8 +1188,8 @@ TEST(WasiNNTest, TFLiteBackend) {
               static_cast<uint32_t>(ErrNo::InvalidArgument));
   }
 
-  NNContextTmp.emplace_back(0, NNGraphTmp[0]);
-  NNContextTmp.back().setReady();
+  NNContextTmp.insert(
+      std::make_shared<WasmEdge::Host::WASINN::Context>(0, TmpGraph));
 
   // Test: set_input -- set input successfully.
   BuilderPtr = SetInputEntryPtr;

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -1988,6 +1988,156 @@ TEST(WasiNNTest, LoadByNameConcurrentBuildsShareOneGraph) {
   EXPECT_EQ(CachedId, WinnerId);
 }
 
+TEST(WasiNNTest, GGMLBackendDrainAfterInvalidReloadUnload) {
+  // A failed metadata reload leaves the graph Invalid with a null llama
+  // context; unload then makes it Detached, which Drainable admits, so the
+  // backend drain must reject the null context instead of dereferencing it.
+  auto NNMod = createModule();
+  ASSERT_TRUE(NNMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(60000)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_TRUE(MemInstPtr != nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+
+  std::string Prompt = "Once upon a time, ";
+  std::vector<uint8_t> TensorData(Prompt.begin(), Prompt.end());
+  std::string Model = WasmEdge::Endian::native == WasmEdge::Endian::little
+                          ? "./wasinn_ggml_fixtures/orca_mini.gguf"
+                          : "./wasinn_ggml_fixtures/granite-3.gguf";
+  std::vector<uint8_t> WeightRead = readEntireFile(Model);
+  ASSERT_FALSE(WeightRead.empty());
+
+  std::vector<uint32_t> TensorDim{1};
+  uint32_t BuilderPtr = UINT32_C(0);
+  const uint32_t LoadEntryPtr = UINT32_C(0);
+  const uint32_t SetInputEntryPtr = UINT32_C(16);
+  const uint32_t BytesWrittenPtr = UINT32_C(40);
+  uint32_t StorePtr = UINT32_C(65536);
+  std::array<WasmEdge::ValVariant, 1> Errno = {UINT32_C(0)};
+
+  auto GetHostFunc =
+      [&](std::string_view FuncName) -> WasmEdge::Runtime::HostFunctionBase & {
+    auto *FuncInst = NNMod->findFuncExports(FuncName);
+    EXPECT_NE(FuncInst, nullptr);
+    EXPECT_TRUE(FuncInst->isHostFunction());
+    return FuncInst->getHostFunc();
+  };
+  auto &HostFuncLoad = GetHostFunc("load"sv);
+  auto &HostFuncInit = GetHostFunc("init_execution_context"sv);
+  auto &HostFuncSetInput = GetHostFunc("set_input"sv);
+  auto &HostFuncComputeSingle = GetHostFunc("compute_single"sv);
+  auto &HostFuncGetOutputSingle = GetHostFunc("get_output_single"sv);
+  auto &HostFuncFiniSingle = GetHostFunc("fini_single"sv);
+  auto &HostFuncUnload = GetHostFunc("unload"sv);
+  auto &HostFuncFinalize = GetHostFunc("finalize_execution_context"sv);
+
+  // Load the model and stream one token so the context buffers output.
+  BuilderPtr = LoadEntryPtr;
+  writeFatPointer(MemInst, StorePtr, static_cast<uint32_t>(WeightRead.size()),
+                  BuilderPtr);
+  writeBinaries<uint8_t>(MemInst, WeightRead, StorePtr);
+  StorePtr += static_cast<uint32_t>(WeightRead.size());
+  EXPECT_TRUE(HostFuncLoad.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          LoadEntryPtr, UINT32_C(1), static_cast<uint32_t>(Backend::GGML),
+          static_cast<uint32_t>(Device::CPU), BuilderPtr},
+      Errno));
+  EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+  const uint32_t GraphId = *MemInst.getPointer<uint32_t *>(BuilderPtr);
+  BuilderPtr += 4;
+  EXPECT_TRUE(HostFuncInit.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{GraphId, BuilderPtr}, Errno));
+  EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+  const uint32_t CtxId = *MemInst.getPointer<uint32_t *>(BuilderPtr);
+
+  BuilderPtr = SetInputEntryPtr;
+  writeFatPointer(MemInst, StorePtr, static_cast<uint32_t>(TensorDim.size()),
+                  BuilderPtr);
+  writeUInt32(MemInst, UINT32_C(1), BuilderPtr);
+  writeFatPointer(MemInst,
+                  StorePtr + static_cast<uint32_t>(TensorDim.size()) * 4,
+                  static_cast<uint32_t>(TensorData.size()), BuilderPtr);
+  writeBinaries<uint32_t>(MemInst, TensorDim, StorePtr);
+  writeBinaries<uint8_t>(MemInst, TensorData,
+                         StorePtr +
+                             static_cast<uint32_t>(TensorDim.size()) * 4);
+  EXPECT_TRUE(HostFuncSetInput.run(CallFrame,
+                                   std::initializer_list<WasmEdge::ValVariant>{
+                                       CtxId, UINT32_C(0), SetInputEntryPtr},
+                                   Errno));
+  EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+  EXPECT_TRUE(HostFuncComputeSingle.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CtxId}, Errno));
+  EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+  EXPECT_TRUE(HostFuncGetOutputSingle.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CtxId, UINT32_C(0), StorePtr, UINT32_C(65532), BytesWrittenPtr},
+      Errno));
+  EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+
+  // A context-parameter reload that must fail: llama rejects a context whose
+  // batch and ubatch sizes are both zero, so set_input leaves the graph
+  // Invalid and the llama context null.
+  const std::string BadMetadata =
+      "{\"embedding\": true, \"batch-size\": 0, \"ubatch-size\": 0}";
+  std::vector<uint8_t> BadMetadataData(BadMetadata.begin(), BadMetadata.end());
+  BuilderPtr = SetInputEntryPtr;
+  writeFatPointer(MemInst, StorePtr, static_cast<uint32_t>(TensorDim.size()),
+                  BuilderPtr);
+  writeUInt32(MemInst, UINT32_C(1), BuilderPtr);
+  writeFatPointer(MemInst,
+                  StorePtr + static_cast<uint32_t>(TensorDim.size()) * 4,
+                  static_cast<uint32_t>(BadMetadataData.size()), BuilderPtr);
+  writeBinaries<uint32_t>(MemInst, TensorDim, StorePtr);
+  writeBinaries<uint8_t>(MemInst, BadMetadataData,
+                         StorePtr +
+                             static_cast<uint32_t>(TensorDim.size()) * 4);
+  EXPECT_TRUE(HostFuncSetInput.run(CallFrame,
+                                   std::initializer_list<WasmEdge::ValVariant>{
+                                       CtxId, UINT32_C(1), SetInputEntryPtr},
+                                   Errno));
+  EXPECT_EQ(Errno[0].get<int32_t>(),
+            static_cast<uint32_t>(ErrNo::InvalidArgument));
+
+  // Invalid is rejected by the Drainable tier before the unload.
+  EXPECT_TRUE(HostFuncGetOutputSingle.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CtxId, UINT32_C(0), StorePtr, UINT32_C(65532), BytesWrittenPtr},
+      Errno));
+  EXPECT_EQ(Errno[0].get<int32_t>(),
+            static_cast<uint32_t>(ErrNo::InvalidArgument));
+
+  // unload admits the drain tier again; the null context must be rejected by
+  // the backend instead of crashing the drain.
+  EXPECT_TRUE(HostFuncUnload.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{GraphId}, Errno));
+  EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+  EXPECT_TRUE(HostFuncGetOutputSingle.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CtxId, UINT32_C(0), StorePtr, UINT32_C(65532), BytesWrittenPtr},
+      Errno));
+  EXPECT_EQ(Errno[0].get<int32_t>(),
+            static_cast<uint32_t>(ErrNo::InvalidArgument));
+
+  // The context still resets and finalizes cleanly without a llama context.
+  EXPECT_TRUE(HostFuncFiniSingle.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CtxId}, Errno));
+  EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+  EXPECT_TRUE(HostFuncFinalize.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CtxId}, Errno));
+  EXPECT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+}
+
 namespace {
 // Table bookkeeping is covered backend-free in resource_table_test.cpp; these
 // check the host-function wiring: guards reject an id that is not a live

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -1869,6 +1869,35 @@ TEST(WasiNNTest, DrainAfterUnloadHostOpTiers) {
   EXPECT_EQ(hostOpPolicy(HostOp::FiniSingle).Req, GraphReq::Any);
 }
 
+TEST(WasiNNTest, GraphStatusDetachedIsTerminal) {
+  // unload marks a graph Detached without the op mutex, so an in-flight
+  // set_input reload can finish afterwards; its trailing setReady/setInvalid
+  // must not overwrite Detached or a surviving context would regain compute
+  // rights on an unloaded graph.
+  using WasmEdge::Host::WASINN::Graph;
+  using WasmEdge::Host::WASINN::GraphStatus;
+
+  Graph Reloaded(Backend::GGML);
+  EXPECT_EQ(Reloaded.status(), GraphStatus::Ready);
+  Reloaded.setDetached();
+  Reloaded.setReady();
+  EXPECT_EQ(Reloaded.status(), GraphStatus::Detached);
+
+  Graph FailedReload(Backend::GGML);
+  FailedReload.setDetached();
+  FailedReload.setInvalid();
+  EXPECT_EQ(FailedReload.status(), GraphStatus::Detached);
+
+  // Outside Detached, the Ready <-> Invalid reload transitions stay allowed.
+  Graph Live(Backend::GGML);
+  Live.setInvalid();
+  EXPECT_EQ(Live.status(), GraphStatus::Invalid);
+  Live.setReady();
+  EXPECT_EQ(Live.status(), GraphStatus::Ready);
+  Live.setDetached();
+  EXPECT_EQ(Live.status(), GraphStatus::Detached);
+}
+
 namespace {
 // Table bookkeeping is covered backend-free in resource_table_test.cpp; these
 // check the host-function wiring: guards reject an id that is not a live

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
+#include "wasinn_mlx.h"
 #include "wasinnfunc.h"
 #include "wasinnmodule.h"
 
@@ -17,10 +18,12 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <fstream>
 #include <memory>
 #include <numeric>
+#include <set>
 #include <string>
 #include <thread>
 #include <vector>
@@ -3623,6 +3626,27 @@ TEST(WasiNNTest, ChatTTSBackend) {
   }
 }
 #endif // WASMEDGE_PLUGIN_WASI_NN_BACKEND_CHATTTS
+
+// A raw-bytes MLX load writes the model to a temporary safetensors file before
+// conversion. Concurrent loads must not share that path, or one build can
+// truncate the file another build is still reading. uniqueModelFileName is
+// backend-agnostic string logic, so this guard runs in every build.
+TEST(WasiNNTest, MLXTempPathIsUniquePerBuild) {
+  constexpr std::size_t Count = 64;
+  std::vector<std::string> Paths(Count);
+  std::vector<std::thread> Workers;
+  Workers.reserve(Count);
+  for (std::size_t I = 0; I < Count; ++I) {
+    Workers.emplace_back([&Paths, I]() {
+      Paths[I] = WasmEdge::Host::WASINN::MLX::uniqueModelFileName(0);
+    });
+  }
+  for (auto &Worker : Workers) {
+    Worker.join();
+  }
+  const std::set<std::string> Distinct(Paths.begin(), Paths.end());
+  EXPECT_EQ(Distinct.size(), Count);
+}
 
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_MLX
 TEST(WasiNNTest, MLXBackend) {

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -15,6 +15,8 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <fstream>
 #include <memory>
@@ -1896,6 +1898,94 @@ TEST(WasiNNTest, GraphStatusDetachedIsTerminal) {
   EXPECT_EQ(Live.status(), GraphStatus::Ready);
   Live.setDetached();
   EXPECT_EQ(Live.status(), GraphStatus::Detached);
+}
+
+TEST(WasiNNTest, LoadByNameConcurrentBuildsShareOneGraph) {
+  // Two load_by_name calls for one name can miss the cache and build
+  // concurrently (MdMutex is not held across a load); the second finisher
+  // must adopt the first one's cached graph instead of keeping a duplicate.
+  auto NNMod = createModule();
+  if (!NNMod) {
+    GTEST_SKIP() << "wasi_nn plugin not found";
+  }
+  auto &Env = NNMod->getEnv();
+  const std::string Name = "concurrent-build";
+  Env.RawMdMap.emplace(
+      Name, std::make_tuple(std::vector<std::vector<uint8_t>>{{0x00}},
+                            Backend::GGML, Device::CPU));
+
+  const auto Deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(30);
+  auto SpinUntil = [&Deadline](auto Cond) {
+    while (!Cond()) {
+      if (std::chrono::steady_clock::now() > Deadline) {
+        return false;
+      }
+      std::this_thread::yield();
+    }
+    return true;
+  };
+
+  // A stand-in for a slow backend load: park each caller until released by
+  // entry order, then publish an empty graph wrapper like the real loader.
+  std::atomic<uint32_t> Entered{0};
+  std::atomic<uint32_t> ReleaseUpTo{0};
+  std::array<uint32_t, 2> PublishedIds = {0, 0};
+  auto SlowLoad = [&](WasmEdge::Host::WASINN::WasiNNEnvironment &E,
+                      WasmEdge::Span<const WasmEdge::Span<uint8_t>>, Backend BE,
+                      Device, std::string_view MdName,
+                      uint32_t &GraphIdOut) -> WasmEdge::Expect<ErrNo> {
+    const uint32_t Order = Entered.fetch_add(1) + 1;
+    while (ReleaseUpTo.load() < Order) {
+      std::this_thread::yield();
+    }
+    auto G = std::make_shared<WasmEdge::Host::WASINN::Graph>(BE);
+    G->setModelName(std::string(MdName));
+    auto Id = E.NNGraph.insert(std::move(G));
+    EXPECT_TRUE(Id.has_value());
+    GraphIdOut = *Id;
+    PublishedIds[Order - 1] = *Id;
+    return ErrNo::Success;
+  };
+
+  uint32_t FirstId = UINT32_C(0xFFFFFFFF);
+  uint32_t SecondId = UINT32_C(0xFFFFFFFF);
+  std::atomic<uint32_t> DoneCount{0};
+  std::thread First([&]() {
+    auto Res = Env.mdBuild(Name, FirstId, SlowLoad);
+    EXPECT_TRUE(Res.has_value());
+    DoneCount.fetch_add(1);
+  });
+  std::thread Second([&]() {
+    auto Res = Env.mdBuild(Name, SecondId, SlowLoad);
+    EXPECT_TRUE(Res.has_value());
+    DoneCount.fetch_add(1);
+  });
+
+  // Both callers sit inside their builds before either caches: this is the
+  // race window between a shared cache miss and the first cache write.
+  EXPECT_TRUE(SpinUntil([&]() { return Entered.load() == 2; }));
+  // The first entrant finishes its whole build and caches its graph.
+  ReleaseUpTo.store(1);
+  EXPECT_TRUE(SpinUntil([&]() { return DoneCount.load() == 1; }));
+  // The second entrant finishes and must fold onto the cached winner.
+  ReleaseUpTo.store(2);
+  First.join();
+  Second.join();
+
+  // Exactly one graph survives for the name: both callers hold the winner's
+  // id, the loser's build was dropped, and the cache resolves to the winner.
+  EXPECT_EQ(FirstId, SecondId);
+  const uint32_t WinnerId = FirstId;
+  EXPECT_NE(Env.NNGraph.get(WinnerId), nullptr);
+  EXPECT_EQ(Env.NNGraph.size(), 1U);
+  const uint32_t LoserId =
+      PublishedIds[0] == WinnerId ? PublishedIds[1] : PublishedIds[0];
+  EXPECT_NE(LoserId, WinnerId);
+  EXPECT_EQ(Env.NNGraph.get(LoserId), nullptr);
+  uint32_t CachedId = UINT32_C(0xFFFFFFFF);
+  EXPECT_TRUE(Env.mdGet(Name, CachedId));
+  EXPECT_EQ(CachedId, WinnerId);
 }
 
 namespace {


### PR DESCRIPTION
## Description

Due to the historical issues, the whole WASI-NN related graph/execution-context design
has several issues, and we can see there are several issues and PRs try to solve it partially.
However, it's not a good way if we only keep patch them without a totally redesign to
enhance the architecture.

This PR redesigns the WASI-NN graph/execution-context core to eliminate a family of
memory-safety and lifetime defects by construction, instead of guarding against them
case by case.

### Problems in the current design

- `NNGraph`/`NNContext` are `std::vector`s of values: any `emplace_back` growth moves
  every element, dangling raw pointers held elsewhere (e.g. the process-global
  `llama_log_set(..., &GraphRef)` / `whisper_log_set(..., &GraphRef)` user pointers).
  `TensorflowLite::Graph`/`Context` even have destructor + raw pointer with implicit
  copy, so a reallocation frees the `TfLiteModel` out from under the surviving copy.
- The mutex guards only allocation/deletion; every host function and backend indexes
  the tables unlocked, so a concurrent `load`/`unload` invalidates memory an in-flight
  `compute` is using.
- Freed handles are recycled with no generation, so a stale guest handle silently
  aliases a newer graph/context (ABA).
- Teardown is hand-written per backend and wired for only 4 of 13 backends: for
  OpenVINO, PyTorch, TFLite, MLX, Piper, OpenVINO-GenAI, `unload`/
  `finalize_execution_context` return an error and the resources leak until process
  exit. GGML's own `unload` carries `// TODO: Move the resource deallocation into the
  destructor.`
- `mdBuild` caches the name→handle mapping even when the backend load fails, copies
  the preloaded model bytes on every build, and holds `MdMutex` across the entire
  (possibly minutes-long) model load.

### The redesign

- **Shared-ownership handle tables**: a new `ResourceTable<T>` maps monotonically
  allocated, never-reused `uint32_t` handles to `shared_ptr`-owned wrappers. A host op
  resolves its handle to a `shared_ptr` and holds it for the whole call, so a
  concurrent unload can never free memory an in-flight op is using. Stale handles
  stop resolving instead of aliasing newer resources.
- **Contexts own a `shared_ptr` to their parent graph**, so a live context keeps the
  model alive to drain (`get_output`, `get_output_single`, `fini_single`) after the
  guest unloads the graph.
- **Build-then-publish**: `load`/`init_execution_context` fully construct the backend
  payload before inserting it into a table; a failed load never publishes and leaves
  no trace. The observable half-initialized states and per-backend rollback
  bookkeeping are gone.
- **Uniform, non-blocking teardown for every backend**: `unload` and
  `finalize_execution_context` detach the handle immediately; backend resources are
  released by payload destructors (RAII) at the last reference, off every lock. The
  per-backend `unload`/`finalizeExecCtx` functions and the teardown backend list are
  deleted.
- **One policy table** (`hostOpPolicy`) declares the graph-status tier each host op
  requires (Ready / NotDetached / Any / Drainable), keeping the drain-after-unload
  contract in a single place. Backend ops serialize on a per-graph op mutex with a
  status re-check after acquisition.
- **Ref-counted log gates**: llama/mtmd/whisper global log callbacks are bound once
  with no user pointer and gated by atomic counters; each graph holds a RAII
  `LogToken`, so one graph's logging choice never toggles another's and nothing
  dangles.
- Backend entry points now receive resolved `WASINN::Graph &`/`WASINN::Context &`
  references and have no access to the handle tables, making the unsafe re-resolution
  pattern unrepresentable.

Also fixed along the way: PyTorch model owned via `unique_ptr` with load errors
propagated (previously swallowed, publishing a model-less graph), ChatTTS destructor
now frees all four Python handles (two previously leaked), GGML/BitNet `fini_single`
null-guards for the state a failed `set_input` reload leaves behind, and the cached
WASI environ pointer made atomic.

`plugins/wasi_nn/DESIGN.md` documents the ownership model, lock hierarchy, and the
backend-author contract.

### Deliberate behavior changes

1. Handles are never reused (previously freed ids were recycled).
2. `unload`/`finalize_execution_context` succeed uniformly on all backends
   (previously an error on ~8 backends, whose resources could never be freed).
3. `unload` during an in-flight `compute` returns immediately and defers destruction
   to the last user (previously a data race).

All three are invisible to spec-conforming guests (handles are opaque); each is
pinned by a test.

### Notes for reviewers

- The GGML backend and the shared core are fully exercised locally (see evidence).
  The other backends' implementations compile only in their SDK-equipped CI builds;
  their migration follows the same mechanical pattern as GGML.
- Net production-core size shrinks; the additions are predominantly tests and docs.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

This contribution was developed with assistance from Claude (Anthropic); every commit
carries an `Assisted-by: Claude (Anthropic)` trailer and was reviewed and verified by
a human before submission.

## Test Evidence

**Unit + behavioral suite** (GGML backend, macOS arm64, Metal), including the new
drain-after-unload, handle non-reuse, and concurrent stale-handle tests:

```console
$ ctest --test-dir build -R wasiNN --output-on-failure
1/1 Test #16: wasiNNTests ......................   Passed   11.74 sec
100% tests passed, 0 tests failed out of 1
```

**Full test suite** — identical pass set as the pre-change baseline on this
configuration (the single failure is `wasmedgeDriverToolTests/CompileSubcommand.*`,
which requires `WASMEDGE_USE_LLVM=ON` and fails identically on pristine master with
this build configuration):

```console
$ ctest --test-dir build -j8
96% tests passed, 1 tests failed out of 27
```

**ThreadSanitizer** — full wasiNNTests under `-fsanitize=thread` (CPU inference),
covering the handle-table churn stress and a thread hammering dead/unknown handles
against live llama.cpp inference:

```console
$ TSAN_OPTIONS="halt_on_error=0" ctest --test-dir build-tsan -R wasiNN
1/1 Test #16: wasiNNTests ......................   Passed  196.98 sec
100% tests passed, 0 tests failed out of 1
$ grep -c "WARNING: ThreadSanitizer" tsan-run.log
0
```

**End-to-end integration** — prebuilt example apps from
[WasmEdge-WASINN-examples](https://github.com/second-state/WasmEdge-WASINN-examples)
run against the rebuilt CLI + plugin with `orca_mini_v3_7b.Q2_K.gguf`:

| Example | Paths exercised | Result |
|---|---|---|
| `wasmedge-ggml/llama` | load / init / set_input / compute / get_output loop | output identical to a plugin built from pristine master (A/B compared) |
| `wasmedge-ggml/llama-stream` | compute_single / get_output_single / fini_single | fluent streamed generation |
| `wasmedge-ggml/basic` | template-less prompt flow | sane completion |
| `wasmedge-ggml/embedding` | embedding config + dual-index get_output | correct 4096-dim embedding JSON |
| `wasmedge-ggml/test/model-not-found` | load-failure semantics | guest receives exactly `ModelNotFound`, exits cleanly |
| `wasmedge-mlx/llama` | MLX backend: safetensors load + in-backend 4-bit quantization + full inference flow | fluent 100-token generation from TinyLlama-1.1B-Chat, clean exit |
| `wasmedge-ggml/whisper` | Whisper backend: model-bytes load + audio transcription | exact transcription "This is a test record for whisper.cpp", clean exit |
| `tflite-birds_v1-image` | TensorFlowLite backend: model-bytes load + image classification | canonical top-5 result (`Aix galericulata` 198), clean exit |

All four macOS-supported backends (GGML, MLX, Whisper, TensorFlowLite) are
therefore verified at runtime.
The wasiNNTests suite passes under both builds.

## Apendix

PRs and Issues that are included inside this PR:

Fixes #5023
Fixes #3912
Replaces #5005
Replaces #5024
Replaces #5028
Replaces #5057
