### PR TITLE
fix(plugin/zlib): harden host functions against OOB and use-after-free from guest input

### DIFF
--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -1188,6 +1188,21 @@ public:
     return Node->getNativeHandler();
   }
 
+  /// Test whether a file descriptor still holds the given rights.
+  ///
+  /// Exposes the same capability check WASI applies to fd operations so a host
+  /// bridge that lifts I/O out of WASI mediation (the zlib plugin duplicates
+  /// the native descriptor for zlib) can refuse a descriptor whose rights were
+  /// narrowed via fd_fdstat_set_rights. Returns false when the fd is unknown or
+  /// lacks any requested right.
+  bool canFd(__wasi_fd_t Fd, __wasi_rights_t Rights) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return false;
+    }
+    return Node->can(Rights);
+  }
+
   static std::string randomFilename() noexcept {
     using namespace std::literals;
     static constexpr const auto Charset =

--- a/include/host/wasi/environ.h
+++ b/include/host/wasi/environ.h
@@ -1188,6 +1188,15 @@ public:
     return Node->getNativeHandler();
   }
 
+  /// Test whether a file descriptor has the requested rights.
+  bool canFd(__wasi_fd_t Fd, __wasi_rights_t Rights) const noexcept {
+    auto Node = getNodeOrNull(Fd);
+    if (unlikely(!Node)) {
+      return false;
+    }
+    return Node->can(Rights);
+  }
+
   static std::string randomFilename() noexcept {
     using namespace std::literals;
     static constexpr const auto Charset =

--- a/plugins/wasmedge_zlib/zlibenv.h
+++ b/plugins/wasmedge_zlib/zlibenv.h
@@ -7,7 +7,9 @@
 
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 #include <zlib.h>
 
@@ -86,6 +88,12 @@ public:
        deflateSetHeader (zlib reads them) */
     bool IsInflate;
     std::unique_ptr<gz_header> HostGZHeader;
+    /* host-owned snapshots of the deflateSetHeader fields; zlib emits name and
+       comment incrementally across deflate() calls, so the buffers must stay
+       stable rather than be re-read from guest memory each call */
+    std::vector<Bytef> Extra;
+    std::string Name;
+    std::string Comment;
   };
 
   WasmEdgeZlibEnvironment() = default;
@@ -99,7 +107,7 @@ public:
 
   std::unordered_map<uint32_t, std::unique_ptr<z_stream>> ZStreamMap;
   std::unordered_map<uint32_t, gzFile> GZFileMap;
-  std::unordered_map<uint32_t, GZStore> GZHeaderMap;
+  std::unordered_map<uint32_t, std::shared_ptr<GZStore>> GZHeaderMap;
   uint32_t NextGZFile = sizeof(gzFile);
 };
 

--- a/plugins/wasmedge_zlib/zlibenv.h
+++ b/plugins/wasmedge_zlib/zlibenv.h
@@ -80,16 +80,27 @@ namespace Host {
 
 class WasmEdgeZlibEnvironment {
 public:
-  using GZFile = std::remove_pointer_t<gzFile>;
-
   struct GZStore {
     uint32_t WasmGZHeaderOffset;
+    /* true for inflateGetHeader (zlib writes the header buffers), false for
+       deflateSetHeader (zlib reads them) */
+    bool IsInflate;
     std::unique_ptr<gz_header> HostGZHeader;
   };
 
+  WasmEdgeZlibEnvironment() = default;
+  WasmEdgeZlibEnvironment(const WasmEdgeZlibEnvironment &) = delete;
+  WasmEdgeZlibEnvironment &operator=(const WasmEdgeZlibEnvironment &) = delete;
+  ~WasmEdgeZlibEnvironment() {
+    for (const auto &[Handle, File] : GZFileMap) {
+      gzclose(File);
+    }
+  }
+
   std::unordered_map<uint32_t, std::unique_ptr<z_stream>> ZStreamMap;
-  std::map<uint32_t, std::unique_ptr<GZFile>, std::greater<uint32_t>> GZFileMap;
+  std::unordered_map<uint32_t, gzFile> GZFileMap;
   std::unordered_map<uint32_t, GZStore> GZHeaderMap;
+  uint32_t NextGZFile = sizeof(gzFile);
 };
 
 } // namespace Host

--- a/plugins/wasmedge_zlib/zlibenv.h
+++ b/plugins/wasmedge_zlib/zlibenv.h
@@ -156,17 +156,38 @@ public:
     std::string Comment;
   };
 
+  /* A gz handle keeps the WASI rights probed when its descriptor was bridged:
+     zlib operates on a duplicated native descriptor outside WASI's checks, so
+     seek/tell-shaped calls must be refused up here when the fd's rights were
+     narrowed via fd_fdstat_set_rights. Handles opened without WASI mediation
+     carry full rights. */
+  struct GZFileEntry {
+    gzFile GZ;
+    bool CanSeek;
+    bool CanTell;
+    bool RestoredAppendOffset;
+    /* true when the gz mode opened the stream for reading: only read handles
+       ever lseek the descriptor, so only they need FD_SEEK. Stays false on the
+       non-WASI fallbacks, whose CanSeek == true makes it irrelevant */
+    bool OpenedForRead = false;
+    /* guest WASI fd this handle owns, or -1: gzdopen's contract transfers the
+       guest's descriptor to the gzFile, so the gzclose that frees the handle
+       must also release the fd or a guest following the zlib documentation
+       leaks one fd table entry per open/close cycle */
+    int64_t OwnedWasiFd = -1;
+  };
+
   WasmEdgeZlibEnvironment() = default;
   WasmEdgeZlibEnvironment(const WasmEdgeZlibEnvironment &) = delete;
   WasmEdgeZlibEnvironment &operator=(const WasmEdgeZlibEnvironment &) = delete;
   ~WasmEdgeZlibEnvironment() {
-    for (const auto &[Handle, File] : GZFileMap) {
-      gzclose(File);
+    for (const auto &[Handle, Entry] : GZFileMap) {
+      gzclose(Entry.GZ);
     }
   }
 
   std::unordered_map<uint32_t, ZStreamEntry> ZStreamMap;
-  std::unordered_map<uint32_t, gzFile> GZFileMap;
+  std::unordered_map<uint32_t, GZFileEntry> GZFileMap;
   std::unordered_map<uint32_t, std::shared_ptr<GZStore>> GZHeaderMap;
   uint32_t NextGZFile = sizeof(gzFile);
 };

--- a/plugins/wasmedge_zlib/zlibenv.h
+++ b/plugins/wasmedge_zlib/zlibenv.h
@@ -80,6 +80,66 @@ static_assert(sizeof(WasmGZHeader) == 52, "WasmGZHeader should be 52 bytes");
 namespace WasmEdge {
 namespace Host {
 
+enum class ZStreamKind { Deflate, Inflate, InflateBack };
+
+// RAII owner for a zlib stream: ends it exactly once, so dropping the map entry
+// (on an explicit *End, or at environment teardown) never leaks zlib's internal
+// state. The z_stream keeps a stable address because std::unordered_map never
+// relocates its nodes, so zlib's internal state->strm back-pointer stays valid.
+struct ZStreamEntry {
+  z_stream Z{};
+  ZStreamKind Kind;
+  /* wrap facts fixed by windowBits at init/reset2 time: whether the stream
+     carries a gzip wrapper (deflate windowBits 24..31; inflate 24..31 gzip or
+     40..47 auto-detect) and whether the stream is raw (negative windowBits).
+     inflateGetHeader accepts only gzip-capable inflate streams, and the
+     *SetDictionary state rejects depend on the wrapper, all decided before
+     zlib reads any caller memory. */
+  bool GzipWrap = false;
+  bool RawInflate = false;
+  bool RawDeflate = false;
+  /* true while zlib may be in DICT mode: entered only by an inflate() that
+     returned Z_NEED_DICT and left only inside a later inflate() call, so a
+     stale value can only over-validate, never pass unchecked guest memory. */
+  bool MayNeedDict = false;
+  /* true once a zlib-wrapped (wrap == 1) deflate stream has advanced past
+     INIT_STATE, which is exactly when deflateSetDictionary starts refusing a
+     preset dictionary. deflate() leaves INIT_STATE precisely when it first
+     returns Z_OK/Z_STREAM_END (an earlier avail_out == 0 call returns
+     Z_BUF_ERROR before writing the header), so this is set only on that success
+     and cleared on reset -- it can only over-reject an already-started stream,
+     never accept a mismatched buffer. Unused for raw deflate, whose reject
+     depends on live lookahead instead. */
+  bool DeflateStarted = false;
+  explicit ZStreamEntry(ZStreamKind K) noexcept : Kind(K) {
+    Z.zalloc = Z_NULL;
+    Z.zfree = Z_NULL;
+    Z.opaque = Z_NULL; // ignore opaque since zalloc and zfree are ignored
+  }
+  ZStreamEntry(const ZStreamEntry &) = delete;
+  ZStreamEntry &operator=(const ZStreamEntry &) = delete;
+  ~ZStreamEntry() {
+    // deflate/inflateEnd null out state on success, so a stream the guest
+    // already ended (or one whose init failed) is a no-op here -- never a
+    // double free. A copy that failed and left state aliasing another stream is
+    // detached (state = Z_NULL) by the caller before this runs.
+    if (Z.state == Z_NULL) {
+      return;
+    }
+    switch (Kind) {
+    case ZStreamKind::Deflate:
+      deflateEnd(&Z);
+      break;
+    case ZStreamKind::Inflate:
+      inflateEnd(&Z);
+      break;
+    case ZStreamKind::InflateBack:
+      inflateBackEnd(&Z);
+      break;
+    }
+  }
+};
+
 class WasmEdgeZlibEnvironment {
 public:
   struct GZStore {
@@ -105,7 +165,7 @@ public:
     }
   }
 
-  std::unordered_map<uint32_t, std::unique_ptr<z_stream>> ZStreamMap;
+  std::unordered_map<uint32_t, ZStreamEntry> ZStreamMap;
   std::unordered_map<uint32_t, gzFile> GZFileMap;
   std::unordered_map<uint32_t, std::shared_ptr<GZStore>> GZHeaderMap;
   uint32_t NextGZFile = sizeof(gzFile);

--- a/plugins/wasmedge_zlib/zlibenv.h
+++ b/plugins/wasmedge_zlib/zlibenv.h
@@ -82,47 +82,22 @@ namespace Host {
 
 enum class ZStreamKind { Deflate, Inflate, InflateBack };
 
-// RAII owner for a zlib stream: ends it exactly once, so dropping the map entry
-// (on an explicit *End, or at environment teardown) never leaks zlib's internal
-// state. The z_stream keeps a stable address because std::unordered_map never
-// relocates its nodes, so zlib's internal state->strm back-pointer stays valid.
 struct ZStreamEntry {
   z_stream Z{};
   ZStreamKind Kind;
-  /* wrap facts fixed by windowBits at init/reset2 time: whether the stream
-     carries a gzip wrapper (deflate windowBits 24..31; inflate 24..31 gzip or
-     40..47 auto-detect) and whether the stream is raw (negative windowBits).
-     inflateGetHeader accepts only gzip-capable inflate streams, and the
-     *SetDictionary state rejects depend on the wrapper, all decided before
-     zlib reads any caller memory. */
   bool GzipWrap = false;
   bool RawInflate = false;
   bool RawDeflate = false;
-  /* true while zlib may be in DICT mode: entered only by an inflate() that
-     returned Z_NEED_DICT and left only inside a later inflate() call, so a
-     stale value can only over-validate, never pass unchecked guest memory. */
   bool MayNeedDict = false;
-  /* true once a zlib-wrapped (wrap == 1) deflate stream has advanced past
-     INIT_STATE, which is exactly when deflateSetDictionary starts refusing a
-     preset dictionary. deflate() leaves INIT_STATE precisely when it first
-     returns Z_OK/Z_STREAM_END (an earlier avail_out == 0 call returns
-     Z_BUF_ERROR before writing the header), so this is set only on that success
-     and cleared on reset -- it can only over-reject an already-started stream,
-     never accept a mismatched buffer. Unused for raw deflate, whose reject
-     depends on live lookahead instead. */
   bool DeflateStarted = false;
   explicit ZStreamEntry(ZStreamKind K) noexcept : Kind(K) {
     Z.zalloc = Z_NULL;
     Z.zfree = Z_NULL;
-    Z.opaque = Z_NULL; // ignore opaque since zalloc and zfree are ignored
+    Z.opaque = Z_NULL;
   }
   ZStreamEntry(const ZStreamEntry &) = delete;
   ZStreamEntry &operator=(const ZStreamEntry &) = delete;
   ~ZStreamEntry() {
-    // deflate/inflateEnd null out state on success, so a stream the guest
-    // already ended (or one whose init failed) is a no-op here -- never a
-    // double free. A copy that failed and left state aliasing another stream is
-    // detached (state = Z_NULL) by the caller before this runs.
     if (Z.state == Z_NULL) {
       return;
     }
@@ -144,29 +119,33 @@ class WasmEdgeZlibEnvironment {
 public:
   struct GZStore {
     uint32_t WasmGZHeaderOffset;
-    /* true for inflateGetHeader (zlib writes the header buffers), false for
-       deflateSetHeader (zlib reads them) */
     bool IsInflate;
     std::unique_ptr<gz_header> HostGZHeader;
-    /* host-owned snapshots of the deflateSetHeader fields; zlib emits name and
-       comment incrementally across deflate() calls, so the buffers must stay
-       stable rather than be re-read from guest memory each call */
     std::vector<Bytef> Extra;
     std::string Name;
     std::string Comment;
+  };
+
+  struct GZFileEntry {
+    gzFile GZ;
+    bool CanSeek;
+    bool CanTell;
+    bool RestoredAppendOffset;
+    bool OpenedForRead = false;
+    int64_t OwnedWasiFd = -1;
   };
 
   WasmEdgeZlibEnvironment() = default;
   WasmEdgeZlibEnvironment(const WasmEdgeZlibEnvironment &) = delete;
   WasmEdgeZlibEnvironment &operator=(const WasmEdgeZlibEnvironment &) = delete;
   ~WasmEdgeZlibEnvironment() {
-    for (const auto &[Handle, File] : GZFileMap) {
-      gzclose(File);
+    for (const auto &[Handle, Entry] : GZFileMap) {
+      gzclose(Entry.GZ);
     }
   }
 
   std::unordered_map<uint32_t, ZStreamEntry> ZStreamMap;
-  std::unordered_map<uint32_t, gzFile> GZFileMap;
+  std::unordered_map<uint32_t, GZFileEntry> GZFileMap;
   std::unordered_map<uint32_t, std::shared_ptr<GZStore>> GZHeaderMap;
   uint32_t NextGZFile = sizeof(gzFile);
 };

--- a/plugins/wasmedge_zlib/zlibfunc.cpp
+++ b/plugins/wasmedge_zlib/zlibfunc.cpp
@@ -15,12 +15,53 @@ namespace Host {
     return Unexpect(ErrCode::Value::HostFuncError);                            \
   }
 
+// Bind `Var` to a guest buffer of `Len` bytes at `Offset`, validating that the
+// whole range is in bounds (zlib may touch all of it). getPointer only checks a
+// single element, so getSpan is required here. A zero-length buffer is
+// accepted.
+#define BUFFER_CHECK(Var, MemInstPtr, Offset, Len, FuncName)                   \
+  const auto Var##Span = (MemInstPtr)->getSpan<uint8_t>((Offset), (Len));      \
+  if (unlikely((Len) != 0 && Var##Span.data() == nullptr)) {                   \
+    spdlog::error("[WasmEdge-Zlib] [" FuncName                                 \
+                  "] Out-of-bounds buffer access."sv);                         \
+    return Unexpect(ErrCode::Value::HostFuncError);                            \
+  }                                                                            \
+  auto *Var = Var##Span.data();
+
+// Bind `Var` to a single `Type` object at `Offset`, rejecting an out-of-bounds
+// offset (getPointer returns nullptr rather than trapping).
+#define PTR_CHECK(Var, MemInstPtr, Offset, Type, FuncName)                     \
+  auto *Var = (MemInstPtr)->getPointer<Type *>((Offset));                      \
+  if (unlikely(Var == nullptr)) {                                              \
+    spdlog::error("[WasmEdge-Zlib] [" FuncName                                 \
+                  "] Out-of-bounds pointer access."sv);                        \
+    return Unexpect(ErrCode::Value::HostFuncError);                            \
+  }
+
 constexpr bool CheckSize(int32_t StreamSize) {
 
   return (StreamSize == static_cast<int32_t>(sizeof(WasmZStream)));
 }
 
-static constexpr uint32_t WasmGZFileStart = sizeof(gzFile);
+// Return an in-bounds, NUL-terminated C string starting at `Offset`, or nullptr
+// when the offset is out of bounds or no terminator exists before the end of
+// linear memory (which would make zlib's strlen/strcpy read out of bounds).
+static inline const char *
+getInBoundsCString(const Runtime::Instance::MemoryInstance &MemInst,
+                   uint32_t Offset) noexcept {
+  const uint64_t MemSize = MemInst.getSize();
+  if (unlikely(Offset >= MemSize)) {
+    return nullptr;
+  }
+  const auto *Str = MemInst.getPointer<const char *>(Offset);
+  if (unlikely(Str == nullptr)) {
+    return nullptr;
+  }
+  if (unlikely(std::memchr(Str, '\0', MemSize - Offset) == nullptr)) {
+    return nullptr;
+  }
+  return Str;
+}
 
 template <typename T>
 auto SyncRun(const std::string_view &Msg, WasmEdgeZlibEnvironment &Env,
@@ -29,6 +70,12 @@ auto SyncRun(const std::string_view &Msg, WasmEdgeZlibEnvironment &Env,
 
   MEMINST_CHECK(MemInst, Frame, 0)
   WasmZStream *ModuleZStream = MemInst->getPointer<WasmZStream *>(ZStreamPtr);
+  if (unlikely(ModuleZStream == nullptr)) {
+    spdlog::error("[WasmEdge-Zlib] [{}-SyncRun] "sv
+                  "Out-of-bounds ZStreamPtr received."sv,
+                  Msg);
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
 
   const auto HostZStreamIt = Env.ZStreamMap.find(ZStreamPtr);
   if (HostZStreamIt == Env.ZStreamMap.end()) {
@@ -40,13 +87,28 @@ auto SyncRun(const std::string_view &Msg, WasmEdgeZlibEnvironment &Env,
   auto HostZStream = HostZStreamIt->second.get();
   const auto GZHeaderStoreIt = Env.GZHeaderMap.find(ZStreamPtr);
 
-  HostZStream->next_in =
-      MemInst->getPointer<unsigned char *>(ModuleZStream->NextIn);
+  const auto InSpan = MemInst->getSpan<unsigned char>(ModuleZStream->NextIn,
+                                                      ModuleZStream->AvailIn);
+  if (unlikely(ModuleZStream->AvailIn != 0 && InSpan.data() == nullptr)) {
+    spdlog::error("[WasmEdge-Zlib] [{}-SyncRun] "sv
+                  "Out-of-bounds input buffer."sv,
+                  Msg);
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
+  const auto OutSpan = MemInst->getSpan<unsigned char>(ModuleZStream->NextOut,
+                                                       ModuleZStream->AvailOut);
+  if (unlikely(ModuleZStream->AvailOut != 0 && OutSpan.data() == nullptr)) {
+    spdlog::error("[WasmEdge-Zlib] [{}-SyncRun] "sv
+                  "Out-of-bounds output buffer."sv,
+                  Msg);
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
+
+  HostZStream->next_in = InSpan.data();
   HostZStream->avail_in = ModuleZStream->AvailIn;
   HostZStream->total_in = ModuleZStream->TotalIn;
 
-  HostZStream->next_out =
-      MemInst->getPointer<unsigned char *>(ModuleZStream->NextOut);
+  HostZStream->next_out = OutSpan.data();
   HostZStream->avail_out = ModuleZStream->AvailOut;
   HostZStream->total_out = ModuleZStream->TotalOut;
 
@@ -70,24 +132,69 @@ auto SyncRun(const std::string_view &Msg, WasmEdgeZlibEnvironment &Env,
 
     auto *ModuleGZHeader = MemInst->getPointer<WasmGZHeader *>(
         GZHeaderStoreIt->second.WasmGZHeaderOffset);
+    if (unlikely(ModuleGZHeader == nullptr)) {
+      spdlog::error("[WasmEdge-Zlib] [{}-SyncRun] "sv
+                    "Out-of-bounds gzip header."sv,
+                    Msg);
+      return Unexpect(ErrCode::Value::HostFuncError);
+    }
     auto *HostGZHeader = GZHeaderStoreIt->second.HostGZHeader.get();
+    const bool IsInflate = GZHeaderStoreIt->second.IsInflate;
 
     HostGZHeader->text = ModuleGZHeader->Text;
     HostGZHeader->time = ModuleGZHeader->Time;
     HostGZHeader->xflags = ModuleGZHeader->XFlags;
     HostGZHeader->os = ModuleGZHeader->OS;
 
-    HostGZHeader->extra =
-        MemInst->getPointer<unsigned char *>(ModuleGZHeader->Extra);
+    // inflateGetHeader writes into the buffers (bounded by *_max); the strings
+    // are read back as-is. deflateSetHeader reads the buffers: extra spans
+    // extra_len bytes and name/comment are zlib-scanned C strings.
+    const uint32_t ExtraCap =
+        IsInflate ? ModuleGZHeader->ExtraMax : ModuleGZHeader->ExtraLen;
+    const auto ExtraSpan =
+        MemInst->getSpan<unsigned char>(ModuleGZHeader->Extra, ExtraCap);
+    if (unlikely(ExtraCap != 0 && ExtraSpan.data() == nullptr)) {
+      spdlog::error("[WasmEdge-Zlib] [{}-SyncRun] "sv
+                    "Out-of-bounds gzip header extra field."sv,
+                    Msg);
+      return Unexpect(ErrCode::Value::HostFuncError);
+    }
+    HostGZHeader->extra = ExtraSpan.data();
     HostGZHeader->extra_len = ModuleGZHeader->ExtraLen;
     HostGZHeader->extra_max = ModuleGZHeader->ExtraMax;
 
-    HostGZHeader->name =
-        MemInst->getPointer<unsigned char *>(ModuleGZHeader->Name);
-    HostGZHeader->name_max = ModuleGZHeader->NameMax;
+    const auto BindHeaderString = [&](uint32_t FieldOffset, uint32_t MaxLen,
+                                      Bytef *&HostField) -> bool {
+      if (IsInflate) {
+        const auto FieldSpan =
+            MemInst->getSpan<unsigned char>(FieldOffset, MaxLen);
+        if (unlikely(MaxLen != 0 && FieldSpan.data() == nullptr)) {
+          return false;
+        }
+        HostField = FieldSpan.data();
+      } else if (FieldOffset != 0) {
+        const auto *FieldStr = getInBoundsCString(*MemInst, FieldOffset);
+        if (unlikely(FieldStr == nullptr)) {
+          return false;
+        }
+        HostField = reinterpret_cast<Bytef *>(const_cast<char *>(FieldStr));
+      } else {
+        HostField = nullptr;
+      }
+      return true;
+    };
 
-    HostGZHeader->comment =
-        MemInst->getPointer<unsigned char *>(ModuleGZHeader->Comment);
+    if (unlikely(
+            !BindHeaderString(ModuleGZHeader->Name, ModuleGZHeader->NameMax,
+                              HostGZHeader->name) ||
+            !BindHeaderString(ModuleGZHeader->Comment, ModuleGZHeader->CommMax,
+                              HostGZHeader->comment))) {
+      spdlog::error("[WasmEdge-Zlib] [{}-SyncRun] "sv
+                    "Out-of-bounds gzip header name/comment field."sv,
+                    Msg);
+      return Unexpect(ErrCode::Value::HostFuncError);
+    }
+    HostGZHeader->name_max = ModuleGZHeader->NameMax;
     HostGZHeader->comm_max = ModuleGZHeader->CommMax;
 
     HostGZHeader->hcrc = ModuleGZHeader->HCRC;
@@ -155,15 +262,14 @@ WasmEdgeZlibDeflateInit::body(const Runtime::CallingFrame &Frame,
   NewZStream->opaque =
       Z_NULL; // ignore opaque since zmalloc and zfree was ignored
 
-  auto It =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)))
-          .second;
+  const auto [It, Inserted] =
+      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
 
   const auto ZRes = SyncRun(
       "WasmEdgeZlibDeflateInit", Env, ZStreamPtr, Frame,
       [&](z_stream *HostZStream) { return deflateInit(HostZStream, Level); });
 
-  if (ZRes != Z_OK)
+  if (ZRes != Z_OK && Inserted)
     Env.ZStreamMap.erase(It);
 
   return ZRes;
@@ -200,15 +306,14 @@ WasmEdgeZlibInflateInit::body(const Runtime::CallingFrame &Frame,
   NewZStream->opaque =
       Z_NULL; // ignore opaque since zmalloc and zfree was ignored
 
-  auto It =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)))
-          .second;
+  const auto [It, Inserted] =
+      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
 
   const auto ZRes =
       SyncRun("WasmEdgeZlibInflateInit", Env, ZStreamPtr, Frame,
               [&](z_stream *HostZStream) { return inflateInit(HostZStream); });
 
-  if (ZRes != Z_OK)
+  if (ZRes != Z_OK && Inserted)
     Env.ZStreamMap.erase(It);
 
   return ZRes;
@@ -244,9 +349,8 @@ Expect<int32_t> WasmEdgeZlibDeflateInit2::body(
   NewZStream->opaque =
       Z_NULL; // ignore opaque since zmalloc and zfree was ignored
 
-  auto It =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)))
-          .second;
+  const auto [It, Inserted] =
+      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
 
   const auto ZRes =
       SyncRun("WasmEdgeZlibDeflateInit2", Env, ZStreamPtr, Frame,
@@ -255,7 +359,7 @@ Expect<int32_t> WasmEdgeZlibDeflateInit2::body(
                                     MemLevel, Strategy);
               });
 
-  if (ZRes != Z_OK)
+  if (ZRes != Z_OK && Inserted)
     Env.ZStreamMap.erase(It);
 
   return ZRes;
@@ -267,11 +371,22 @@ Expect<int32_t> WasmEdgeZlibDeflateSetDictionary::body(
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  const auto *Dictionary = MemInst->getPointer<const Bytef *>(DictionaryPtr);
+  BUFFER_CHECK(Dictionary, MemInst, DictionaryPtr, DictLength,
+               "WasmEdgeZlibDeflateSetDictionary")
+
+  // deflateSetDictionary never reads a zero-length dictionary yet still
+  // rejects Z_NULL, so preserve that contract exactly: a guest null maps to
+  // Z_NULL while any other offset stays non-null, including one past the end
+  // of memory whose zero-length span carries no pointer.
+  static constexpr Bytef EmptyDictionary = 0;
+  const Bytef *DictionaryArg = Dictionary;
+  if (DictLength == 0) {
+    DictionaryArg = DictionaryPtr == 0 ? Z_NULL : &EmptyDictionary;
+  }
 
   return SyncRun("WasmEdgeZlibDeflateSetDictionary", Env, ZStreamPtr, Frame,
                  [&](z_stream *HostZStream) {
-                   return deflateSetDictionary(HostZStream, Dictionary,
+                   return deflateSetDictionary(HostZStream, DictionaryArg,
                                                DictLength);
                  });
 }
@@ -282,8 +397,22 @@ Expect<int32_t> WasmEdgeZlibDeflateGetDictionary::body(
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Dictionary = MemInst->getPointer<Bytef *>(DictionaryPtr);
-  auto *DictLength = MemInst->getPointer<uint32_t *>(DictLengthPtr);
+  const auto ZStreamIt = Env.ZStreamMap.find(ZStreamPtr);
+  if (unlikely(ZStreamIt == Env.ZStreamMap.end())) {
+    spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibDeflateGetDictionary] "sv
+                  "Invalid ZStreamPtr received."sv);
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
+
+  // zlib writes up to the internal window (~32 KiB) with no caller-supplied
+  // cap, so query the exact length first and validate the destination for it.
+  uInt NeededLen = 0;
+  deflateGetDictionary(ZStreamIt->second.get(), Z_NULL, &NeededLen);
+
+  BUFFER_CHECK(Dictionary, MemInst, DictionaryPtr, NeededLen,
+               "WasmEdgeZlibDeflateGetDictionary")
+  PTR_CHECK(DictLength, MemInst, DictLengthPtr, uint32_t,
+            "WasmEdgeZlibDeflateGetDictionary")
 
   return SyncRun("WasmEdgeZlibDeflateGetDictionary", Env, ZStreamPtr, Frame,
                  [&](z_stream *HostZStream) {
@@ -307,25 +436,27 @@ WasmEdgeZlibDeflateCopy::body(const Runtime::CallingFrame &Frame,
                   "Invalid SourcePtr received."sv);
     return Unexpect(ErrCode::Value::HostFuncError);
   }
+  auto *SourceZStream = SourceZStreamIt->second.get();
 
   auto NewZStream = std::make_unique<z_stream>();
 
-  auto It =
-      Env.ZStreamMap.emplace(std::make_pair(DestPtr, std::move(NewZStream)))
-          .second;
+  const auto [It, Inserted] =
+      Env.ZStreamMap.emplace(std::make_pair(DestPtr, std::move(NewZStream)));
 
   const auto Res = SyncRun("WasmEdgeZlibDeflateCopy", Env, DestPtr, Frame,
                            [&](z_stream *) { return 0; });
-  if (!Res.has_value())
+  if (!Res.has_value()) {
+    if (Inserted)
+      Env.ZStreamMap.erase(It);
     return Res;
+  }
 
-  const auto ZRes =
-      SyncRun("WasmEdgeZlibDeflateCopy", Env, DestPtr, Frame,
-              [&](z_stream *DestZStream) {
-                return deflateCopy(DestZStream, SourceZStreamIt->second.get());
-              });
+  const auto ZRes = SyncRun("WasmEdgeZlibDeflateCopy", Env, DestPtr, Frame,
+                            [&](z_stream *DestZStream) {
+                              return deflateCopy(DestZStream, SourceZStream);
+                            });
 
-  if (ZRes != Z_OK)
+  if (ZRes != Z_OK && Inserted)
     Env.ZStreamMap.erase(It);
 
   return ZRes;
@@ -406,13 +537,12 @@ WasmEdgeZlibDeflateSetHeader::body(const Runtime::CallingFrame &Frame,
   auto HostGZHeader = std::make_unique<gz_header>();
   auto HostGZHeaderPtr = HostGZHeader.get();
 
-  auto It = Env.GZHeaderMap
-                .emplace(std::pair<uint32_t, WasmEdgeZlibEnvironment::GZStore>{
-                    ZStreamPtr,
-                    WasmEdgeZlibEnvironment::GZStore{
-                        .WasmGZHeaderOffset = HeadPtr,
-                        .HostGZHeader = std::move(HostGZHeader)}})
-                .second;
+  const auto [It, Inserted] = Env.GZHeaderMap.emplace(
+      std::pair<uint32_t, WasmEdgeZlibEnvironment::GZStore>{
+          ZStreamPtr, WasmEdgeZlibEnvironment::GZStore{
+                          .WasmGZHeaderOffset = HeadPtr,
+                          .IsInflate = false,
+                          .HostGZHeader = std::move(HostGZHeader)}});
 
   const auto ZRes =
       SyncRun("WasmEdgeZlibDeflateSetHeader", Env, ZStreamPtr, Frame,
@@ -420,7 +550,7 @@ WasmEdgeZlibDeflateSetHeader::body(const Runtime::CallingFrame &Frame,
                 return deflateSetHeader(HostZStream, HostGZHeaderPtr);
               });
 
-  if (ZRes != Z_OK)
+  if (ZRes != Z_OK && Inserted)
     Env.GZHeaderMap.erase(It);
 
   return ZRes;
@@ -435,16 +565,15 @@ WasmEdgeZlibInflateInit2::body(const Runtime::CallingFrame &Frame,
   NewZStream->opaque =
       Z_NULL; // ignore opaque since zmalloc and zfree was ignored
 
-  auto It =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)))
-          .second;
+  const auto [It, Inserted] =
+      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
 
   const auto ZRes = SyncRun("WasmEdgeZlibInflateInit2", Env, ZStreamPtr, Frame,
                             [&](z_stream *HostZStream) {
                               return inflateInit2(HostZStream, WindowBits);
                             });
 
-  if (ZRes != Z_OK)
+  if (ZRes != Z_OK && Inserted)
     Env.ZStreamMap.erase(It);
 
   return ZRes;
@@ -456,7 +585,8 @@ Expect<int32_t> WasmEdgeZlibInflateSetDictionary::body(
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Dictionary = MemInst->getPointer<Bytef *>(DictionaryPtr);
+  BUFFER_CHECK(Dictionary, MemInst, DictionaryPtr, DictLength,
+               "WasmEdgeZlibInflateSetDictionary")
 
   return SyncRun("WasmEdgeZlibInflateSetDictionary", Env, ZStreamPtr, Frame,
                  [&](z_stream *HostZStream) {
@@ -471,8 +601,22 @@ Expect<int32_t> WasmEdgeZlibInflateGetDictionary::body(
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Dictionary = MemInst->getPointer<Bytef *>(DictionaryPtr);
-  auto *DictLength = MemInst->getPointer<uint32_t *>(DictLengthPtr);
+  const auto ZStreamIt = Env.ZStreamMap.find(ZStreamPtr);
+  if (unlikely(ZStreamIt == Env.ZStreamMap.end())) {
+    spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibInflateGetDictionary] "sv
+                  "Invalid ZStreamPtr received."sv);
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
+
+  // zlib writes up to the internal window (~32 KiB) with no caller-supplied
+  // cap, so query the exact length first and validate the destination for it.
+  uInt NeededLen = 0;
+  inflateGetDictionary(ZStreamIt->second.get(), Z_NULL, &NeededLen);
+
+  BUFFER_CHECK(Dictionary, MemInst, DictionaryPtr, NeededLen,
+               "WasmEdgeZlibInflateGetDictionary")
+  PTR_CHECK(DictLength, MemInst, DictLengthPtr, uint32_t,
+            "WasmEdgeZlibInflateGetDictionary")
 
   return SyncRun("WasmEdgeZlibInflateGetDictionary", Env, ZStreamPtr, Frame,
                  [&](z_stream *HostZStream) {
@@ -499,25 +643,27 @@ WasmEdgeZlibInflateCopy::body(const Runtime::CallingFrame &Frame,
                   "Invalid SourcePtr received."sv);
     return Unexpect(ErrCode::Value::HostFuncError);
   }
+  auto *SourceZStream = SourceZStreamIt->second.get();
 
   auto NewZStream = std::make_unique<z_stream>();
 
-  auto It =
-      Env.ZStreamMap.emplace(std::make_pair(DestPtr, std::move(NewZStream)))
-          .second;
+  const auto [It, Inserted] =
+      Env.ZStreamMap.emplace(std::make_pair(DestPtr, std::move(NewZStream)));
 
   const auto Res = SyncRun("WasmEdgeZlibInflateCopy", Env, DestPtr, Frame,
                            [&](z_stream *) { return 0; });
-  if (!Res.has_value())
+  if (!Res.has_value()) {
+    if (Inserted)
+      Env.ZStreamMap.erase(It);
     return Res;
+  }
 
-  const auto ZRes =
-      SyncRun("WasmEdgeZlibInflateCopy", Env, DestPtr, Frame,
-              [&](z_stream *DestZStream) {
-                return inflateCopy(DestZStream, SourceZStreamIt->second.get());
-              });
+  const auto ZRes = SyncRun("WasmEdgeZlibInflateCopy", Env, DestPtr, Frame,
+                            [&](z_stream *DestZStream) {
+                              return inflateCopy(DestZStream, SourceZStream);
+                            });
 
-  if (ZRes != Z_OK)
+  if (ZRes != Z_OK && Inserted)
     Env.ZStreamMap.erase(It);
 
   return ZRes;
@@ -569,13 +715,12 @@ WasmEdgeZlibInflateGetHeader::body(const Runtime::CallingFrame &Frame,
   auto HostGZHeader = std::make_unique<gz_header>();
   auto HostGZHeaderPtr = HostGZHeader.get();
 
-  auto It = Env.GZHeaderMap
-                .emplace(std::pair<uint32_t, WasmEdgeZlibEnvironment::GZStore>{
-                    ZStreamPtr,
-                    WasmEdgeZlibEnvironment::GZStore{
-                        .WasmGZHeaderOffset = HeadPtr,
-                        .HostGZHeader = std::move(HostGZHeader)}})
-                .second;
+  const auto [It, Inserted] = Env.GZHeaderMap.emplace(
+      std::pair<uint32_t, WasmEdgeZlibEnvironment::GZStore>{
+          ZStreamPtr, WasmEdgeZlibEnvironment::GZStore{
+                          .WasmGZHeaderOffset = HeadPtr,
+                          .IsInflate = true,
+                          .HostGZHeader = std::move(HostGZHeader)}});
 
   const auto ZRes =
       SyncRun("WasmEdgeZlibInflateGetHeader", Env, ZStreamPtr, Frame,
@@ -583,7 +728,7 @@ WasmEdgeZlibInflateGetHeader::body(const Runtime::CallingFrame &Frame,
                 return inflateGetHeader(HostZStream, HostGZHeaderPtr);
               });
 
-  if (ZRes != Z_OK)
+  if (ZRes != Z_OK && Inserted)
     Env.GZHeaderMap.erase(It);
 
   return ZRes;
@@ -601,11 +746,22 @@ WasmEdgeZlibInflateBackInit::body(const Runtime::CallingFrame &Frame,
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Window = MemInst->getPointer<unsigned char *>(WindowPtr);
+  uint8_t *Window = nullptr;
+  if (WindowBits >= 8 && WindowBits <= 15) {
+    const auto WindowSpan =
+        MemInst->getSpan<uint8_t>(WindowPtr, UINT64_C(1) << WindowBits);
+    if (unlikely(WindowSpan.data() == nullptr)) {
+      spdlog::error("[WasmEdge-Zlib] [InflateBackInit] "sv
+                    "Out-of-bounds window buffer."sv);
+      return Unexpect(ErrCode::Value::HostFuncError);
+    }
+    Window = WindowSpan.data();
+  } else {
+    Window = MemInst->getPointer<unsigned char *>(WindowPtr);
+  }
 
-  auto It =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)))
-          .second;
+  const auto [It, Inserted] =
+      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
 
   const auto ZRes =
       SyncRun("WasmEdgeZlibInflateBackInit", Env, ZStreamPtr, Frame,
@@ -613,7 +769,7 @@ WasmEdgeZlibInflateBackInit::body(const Runtime::CallingFrame &Frame,
                 return inflateBackInit(HostZStream, WindowBits, Window);
               });
 
-  if (ZRes != Z_OK)
+  if (ZRes != Z_OK && Inserted)
     Env.ZStreamMap.erase(It);
 
   return ZRes;
@@ -637,6 +793,22 @@ WasmEdgeZlibZlibCompilerFlags::body(const Runtime::CallingFrame &) {
   return zlibCompileFlags();
 }
 
+// compress/compress2 reject a null destination (Z_STREAM_ERROR) yet answer a
+// non-null one that merely lacks capacity with Z_BUF_ERROR, all without
+// writing a byte, so mirror deflateSetDictionary's contract: a guest null
+// maps to Z_NULL while any other offset stays non-null, including one whose
+// zero-length span carries no pointer. uncompress/uncompress2 need no such
+// care -- at zero capacity they swap in an internal probe buffer and never
+// look at the caller's pointer.
+static Bytef ZeroCapacityDest;
+static inline Bytef *resolveDestArg(uint8_t *Dest, uint32_t DestPtr,
+                                    uint32_t DstCap) noexcept {
+  if (DstCap != 0) {
+    return Dest;
+  }
+  return DestPtr == 0 ? Z_NULL : &ZeroCapacityDest;
+}
+
 Expect<int32_t> WasmEdgeZlibCompress::body(const Runtime::CallingFrame &Frame,
                                            uint32_t DestPtr,
                                            uint32_t DestLenPtr,
@@ -644,14 +816,15 @@ Expect<int32_t> WasmEdgeZlibCompress::body(const Runtime::CallingFrame &Frame,
                                            uint32_t SourceLen) {
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Dest = MemInst->getPointer<Bytef *>(DestPtr);
-  auto *DestLen = MemInst->getPointer<uint32_t *>(DestLenPtr);
-  auto *Source = MemInst->getPointer<Bytef *>(SourcePtr);
+  PTR_CHECK(DestLen, MemInst, DestLenPtr, uint32_t, "WasmEdgeZlibCompress")
+  const uint32_t DstCap = *DestLen;
+  BUFFER_CHECK(Dest, MemInst, DestPtr, DstCap, "WasmEdgeZlibCompress")
+  BUFFER_CHECK(Source, MemInst, SourcePtr, SourceLen, "WasmEdgeZlibCompress")
 
-  unsigned long HostDestLen;
-  HostDestLen = *DestLen;
-  const auto ZRes = compress(Dest, &HostDestLen, Source, SourceLen);
-  *DestLen = HostDestLen;
+  unsigned long HostDestLen = DstCap;
+  const auto ZRes = compress(resolveDestArg(Dest, DestPtr, DstCap),
+                             &HostDestLen, Source, SourceLen);
+  *DestLen = static_cast<uint32_t>(HostDestLen);
 
   return ZRes;
 }
@@ -663,14 +836,23 @@ Expect<int32_t> WasmEdgeZlibCompress2::body(const Runtime::CallingFrame &Frame,
                                             uint32_t SourceLen, int32_t Level) {
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Dest = MemInst->getPointer<Bytef *>(DestPtr);
-  auto *DestLen = MemInst->getPointer<uint32_t *>(DestLenPtr);
-  auto *Source = MemInst->getPointer<Bytef *>(SourcePtr);
+  PTR_CHECK(DestLen, MemInst, DestLenPtr, uint32_t, "WasmEdgeZlibCompress2")
+  // An out-of-range level fails compress2's deflateInit before any source
+  // byte is read or dest byte written -- though only after *destLen has been
+  // zeroed -- so answer the same way instead of validating spans the
+  // rejected call would never touch.
+  if (Level != Z_DEFAULT_COMPRESSION && (Level < 0 || Level > 9)) {
+    *DestLen = 0;
+    return Z_STREAM_ERROR;
+  }
+  const uint32_t DstCap = *DestLen;
+  BUFFER_CHECK(Dest, MemInst, DestPtr, DstCap, "WasmEdgeZlibCompress2")
+  BUFFER_CHECK(Source, MemInst, SourcePtr, SourceLen, "WasmEdgeZlibCompress2")
 
-  unsigned long HostDestLen;
-  HostDestLen = *DestLen;
-  const auto ZRes = compress2(Dest, &HostDestLen, Source, SourceLen, Level);
-  *DestLen = HostDestLen;
+  unsigned long HostDestLen = DstCap;
+  const auto ZRes = compress2(resolveDestArg(Dest, DestPtr, DstCap),
+                              &HostDestLen, Source, SourceLen, Level);
+  *DestLen = static_cast<uint32_t>(HostDestLen);
 
   return ZRes;
 }
@@ -687,14 +869,14 @@ Expect<int32_t> WasmEdgeZlibUncompress::body(const Runtime::CallingFrame &Frame,
                                              uint32_t SourceLen) {
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Dest = MemInst->getPointer<Bytef *>(DestPtr);
-  auto *DestLen = MemInst->getPointer<uint32_t *>(DestLenPtr);
-  auto *Source = MemInst->getPointer<Bytef *>(SourcePtr);
+  PTR_CHECK(DestLen, MemInst, DestLenPtr, uint32_t, "WasmEdgeZlibUncompress")
+  const uint32_t DstCap = *DestLen;
+  BUFFER_CHECK(Dest, MemInst, DestPtr, DstCap, "WasmEdgeZlibUncompress")
+  BUFFER_CHECK(Source, MemInst, SourcePtr, SourceLen, "WasmEdgeZlibUncompress")
 
-  unsigned long HostDestLen;
-  HostDestLen = *DestLen;
+  unsigned long HostDestLen = DstCap;
   const auto ZRes = uncompress(Dest, &HostDestLen, Source, SourceLen);
-  *DestLen = HostDestLen;
+  *DestLen = static_cast<uint32_t>(HostDestLen);
 
   return ZRes;
 }
@@ -705,17 +887,21 @@ WasmEdgeZlibUncompress2::body(const Runtime::CallingFrame &Frame,
                               uint32_t SourcePtr, uint32_t SourceLenPtr) {
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Dest = MemInst->getPointer<Bytef *>(DestPtr);
-  auto *DestLen = MemInst->getPointer<uint32_t *>(DestLenPtr);
-  auto *Source = MemInst->getPointer<Bytef *>(SourcePtr);
-  auto *SourceLen = MemInst->getPointer<uint32_t *>(SourceLenPtr);
+  PTR_CHECK(DestLen, MemInst, DestLenPtr, uint32_t, "WasmEdgeZlibUncompress2")
+  PTR_CHECK(SourceLen, MemInst, SourceLenPtr, uint32_t,
+            "WasmEdgeZlibUncompress2")
+  const uint32_t DstCap = *DestLen;
+  const uint32_t SrcLen = *SourceLen;
+  BUFFER_CHECK(Dest, MemInst, DestPtr, DstCap, "WasmEdgeZlibUncompress2")
+  BUFFER_CHECK(Source, MemInst, SourcePtr, SrcLen, "WasmEdgeZlibUncompress2")
 
-  unsigned long HostDestLen, HostSourceLen;
-  HostDestLen = *DestLen;
-  HostSourceLen = *SourceLen;
+  unsigned long HostDestLen = DstCap, HostSourceLen = SrcLen;
   const auto ZRes = uncompress2(Dest, &HostDestLen, Source, &HostSourceLen);
-  *DestLen = HostDestLen;
-  *SourceLen = HostSourceLen;
+  // Write the source length before the destination length so an aliased guest
+  // (DestLenPtr == SourceLenPtr) is left with the produced length, matching
+  // native uncompress2, which writes *destLen last into the shared slot.
+  *SourceLen = static_cast<uint32_t>(HostSourceLen);
+  *DestLen = static_cast<uint32_t>(HostDestLen);
 
   return ZRes;
 }
@@ -724,17 +910,24 @@ Expect<uint32_t> WasmEdgeZlibGZOpen::body(const Runtime::CallingFrame &Frame,
                                           uint32_t PathPtr, uint32_t ModePtr) {
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Path = MemInst->getPointer<const char *>(PathPtr);
-  auto *Mode = MemInst->getPointer<const char *>(ModePtr);
+  const auto *Path = getInBoundsCString(*MemInst, PathPtr);
+  const auto *Mode = getInBoundsCString(*MemInst, ModePtr);
+  if (unlikely(Path == nullptr || Mode == nullptr)) {
+    spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibGZOpen] "sv
+                  "Out-of-bounds path or mode string."sv);
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
 
   auto ZRes = gzopen(Path, Mode);
+  if (unlikely(ZRes == nullptr)) {
+    // A null gzFile is zlib's ordinary open failure (e.g. a missing file);
+    // surface it to the guest as a null handle instead of trapping. No live
+    // handle is ever 0 because NextGZFile starts at sizeof(gzFile).
+    return UINT32_C(0);
+  }
 
-  const auto NewWasmGZFile = WasmGZFileStart + Env.GZFileMap.size();
-  auto El =
-      std::pair<uint32_t, std::unique_ptr<WasmEdgeZlibEnvironment::GZFile>>(
-          NewWasmGZFile, ZRes);
-
-  Env.GZFileMap.emplace(std::move(El));
+  const uint32_t NewWasmGZFile = Env.NextGZFile++;
+  Env.GZFileMap.emplace(NewWasmGZFile, ZRes);
 
   return NewWasmGZFile;
 }
@@ -743,16 +936,22 @@ Expect<uint32_t> WasmEdgeZlibGZDOpen::body(const Runtime::CallingFrame &Frame,
                                            int32_t FD, uint32_t ModePtr) {
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Mode = MemInst->getPointer<const char *>(ModePtr);
+  const auto *Mode = getInBoundsCString(*MemInst, ModePtr);
+  if (unlikely(Mode == nullptr)) {
+    spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibGZDOpen] "sv
+                  "Out-of-bounds mode string."sv);
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
 
   auto ZRes = gzdopen(FD, Mode);
+  if (unlikely(ZRes == nullptr)) {
+    // Match gzopen: a null gzFile is an ordinary failure handed back to the
+    // guest as a null handle, not a host trap.
+    return UINT32_C(0);
+  }
 
-  const auto NewWasmGZFile = WasmGZFileStart + Env.GZFileMap.size();
-  auto El =
-      std::pair<uint32_t, std::unique_ptr<WasmEdgeZlibEnvironment::GZFile>>(
-          NewWasmGZFile, ZRes);
-
-  Env.GZFileMap.emplace(std::move(El));
+  const uint32_t NewWasmGZFile = Env.NextGZFile++;
+  Env.GZFileMap.emplace(NewWasmGZFile, ZRes);
 
   return NewWasmGZFile;
 }
@@ -766,7 +965,7 @@ Expect<int32_t> WasmEdgeZlibGZBuffer::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzbuffer(GZFileIt->second.get(), Size);
+  return gzbuffer(GZFileIt->second, Size);
 }
 
 Expect<int32_t> WasmEdgeZlibGZSetParams::body(const Runtime::CallingFrame &,
@@ -779,7 +978,7 @@ Expect<int32_t> WasmEdgeZlibGZSetParams::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzsetparams(GZFileIt->second.get(), Level, Strategy);
+  return gzsetparams(GZFileIt->second, Level, Strategy);
 }
 
 Expect<int32_t> WasmEdgeZlibGZRead::body(const Runtime::CallingFrame &Frame,
@@ -794,9 +993,9 @@ Expect<int32_t> WasmEdgeZlibGZRead::body(const Runtime::CallingFrame &Frame,
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Buf = MemInst->getPointer<unsigned char *>(BufPtr);
+  BUFFER_CHECK(Buf, MemInst, BufPtr, Len, "WasmEdgeZlibGZRead")
 
-  return gzread(GZFileIt->second.get(), Buf, Len);
+  return gzread(GZFileIt->second, Buf, Len);
 }
 
 Expect<int32_t> WasmEdgeZlibGZFread::body(const Runtime::CallingFrame &Frame,
@@ -811,9 +1010,10 @@ Expect<int32_t> WasmEdgeZlibGZFread::body(const Runtime::CallingFrame &Frame,
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Buf = MemInst->getPointer<unsigned char *>(BufPtr);
+  const uint64_t Bytes = static_cast<uint64_t>(Size) * NItems;
+  BUFFER_CHECK(Buf, MemInst, BufPtr, Bytes, "WasmEdgeZlibGZFread")
 
-  return gzfread(Buf, Size, NItems, GZFileIt->second.get());
+  return gzfread(Buf, Size, NItems, GZFileIt->second);
 }
 
 Expect<int32_t> WasmEdgeZlibGZWrite::body(const Runtime::CallingFrame &Frame,
@@ -828,9 +1028,9 @@ Expect<int32_t> WasmEdgeZlibGZWrite::body(const Runtime::CallingFrame &Frame,
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Buf = MemInst->getPointer<unsigned char *>(BufPtr);
+  BUFFER_CHECK(Buf, MemInst, BufPtr, Len, "WasmEdgeZlibGZWrite")
 
-  return gzwrite(GZFileIt->second.get(), Buf, Len);
+  return gzwrite(GZFileIt->second, Buf, Len);
 }
 
 Expect<int32_t> WasmEdgeZlibGZFwrite::body(const Runtime::CallingFrame &Frame,
@@ -845,9 +1045,10 @@ Expect<int32_t> WasmEdgeZlibGZFwrite::body(const Runtime::CallingFrame &Frame,
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Buf = MemInst->getPointer<unsigned char *>(BufPtr);
+  const uint64_t Bytes = static_cast<uint64_t>(Size) * NItems;
+  BUFFER_CHECK(Buf, MemInst, BufPtr, Bytes, "WasmEdgeZlibGZFwrite")
 
-  return gzfwrite(Buf, Size, NItems, GZFileIt->second.get());
+  return gzfwrite(Buf, Size, NItems, GZFileIt->second);
 }
 
 Expect<int32_t> WasmEdgeZlibGZPuts::body(const Runtime::CallingFrame &Frame,
@@ -861,9 +1062,14 @@ Expect<int32_t> WasmEdgeZlibGZPuts::body(const Runtime::CallingFrame &Frame,
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *String = MemInst->getPointer<const char *>(StringPtr);
+  const auto *String = getInBoundsCString(*MemInst, StringPtr);
+  if (unlikely(String == nullptr)) {
+    spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibGZPuts] "sv
+                  "Out-of-bounds string."sv);
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
 
-  return gzputs(GZFileIt->second.get(), String);
+  return gzputs(GZFileIt->second, String);
 }
 
 Expect<int32_t> WasmEdgeZlibGZPutc::body(const Runtime::CallingFrame &,
@@ -875,7 +1081,7 @@ Expect<int32_t> WasmEdgeZlibGZPutc::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzputc(GZFileIt->second.get(), C);
+  return gzputc(GZFileIt->second, C);
 }
 
 Expect<int32_t> WasmEdgeZlibGZGetc::body(const Runtime::CallingFrame &,
@@ -887,7 +1093,7 @@ Expect<int32_t> WasmEdgeZlibGZGetc::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzgetc(GZFileIt->second.get());
+  return gzgetc(GZFileIt->second);
 }
 
 Expect<int32_t> WasmEdgeZlibGZUngetc::body(const Runtime::CallingFrame &,
@@ -899,7 +1105,7 @@ Expect<int32_t> WasmEdgeZlibGZUngetc::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzungetc(C, GZFileIt->second.get());
+  return gzungetc(C, GZFileIt->second);
 }
 
 Expect<int32_t> WasmEdgeZlibGZFlush::body(const Runtime::CallingFrame &,
@@ -911,7 +1117,7 @@ Expect<int32_t> WasmEdgeZlibGZFlush::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzflush(GZFileIt->second.get(), Flush);
+  return gzflush(GZFileIt->second, Flush);
 }
 
 Expect<int32_t> WasmEdgeZlibGZSeek::body(const Runtime::CallingFrame &,
@@ -924,7 +1130,7 @@ Expect<int32_t> WasmEdgeZlibGZSeek::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzseek(GZFileIt->second.get(), Offset, Whence);
+  return gzseek(GZFileIt->second, Offset, Whence);
 }
 
 Expect<int32_t> WasmEdgeZlibGZRewind::body(const Runtime::CallingFrame &,
@@ -936,7 +1142,7 @@ Expect<int32_t> WasmEdgeZlibGZRewind::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzrewind(GZFileIt->second.get());
+  return gzrewind(GZFileIt->second);
 }
 
 Expect<int32_t> WasmEdgeZlibGZTell::body(const Runtime::CallingFrame &,
@@ -948,7 +1154,7 @@ Expect<int32_t> WasmEdgeZlibGZTell::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gztell(GZFileIt->second.get());
+  return gztell(GZFileIt->second);
 }
 
 Expect<int32_t> WasmEdgeZlibGZOffset::body(const Runtime::CallingFrame &,
@@ -960,7 +1166,7 @@ Expect<int32_t> WasmEdgeZlibGZOffset::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzoffset(GZFileIt->second.get());
+  return gzoffset(GZFileIt->second);
 }
 
 Expect<int32_t> WasmEdgeZlibGZEof::body(const Runtime::CallingFrame &,
@@ -972,7 +1178,7 @@ Expect<int32_t> WasmEdgeZlibGZEof::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzeof(GZFileIt->second.get());
+  return gzeof(GZFileIt->second);
 }
 
 Expect<int32_t> WasmEdgeZlibGZDirect::body(const Runtime::CallingFrame &,
@@ -984,7 +1190,7 @@ Expect<int32_t> WasmEdgeZlibGZDirect::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzdirect(GZFileIt->second.get());
+  return gzdirect(GZFileIt->second);
 }
 
 Expect<int32_t> WasmEdgeZlibGZClose::body(const Runtime::CallingFrame &,
@@ -996,7 +1202,7 @@ Expect<int32_t> WasmEdgeZlibGZClose::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  const auto ZRes = gzclose(GZFileIt->second.get());
+  const auto ZRes = gzclose(GZFileIt->second);
 
   Env.GZFileMap.erase(GZFileIt);
 
@@ -1012,7 +1218,7 @@ Expect<int32_t> WasmEdgeZlibGZClose_r::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  const auto ZRes = gzclose_r(GZFileIt->second.get());
+  const auto ZRes = gzclose_r(GZFileIt->second);
 
   Env.GZFileMap.erase(GZFileIt);
 
@@ -1028,7 +1234,7 @@ Expect<int32_t> WasmEdgeZlibGZClose_w::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  const auto ZRes = gzclose_w(GZFileIt->second.get());
+  const auto ZRes = gzclose_w(GZFileIt->second);
 
   Env.GZFileMap.erase(GZFileIt);
 
@@ -1044,9 +1250,25 @@ Expect<void> WasmEdgeZlibGZClearerr::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  gzclearerr(GZFileIt->second.get());
+  gzclearerr(GZFileIt->second);
 
   return Expect<void>{};
+}
+
+// adler32/crc32 read Z_NULL as a request for the checksum's initial value and
+// any non-null zero-length buffer as "leave the running value unchanged",
+// mirroring deflateSetDictionary's contract above. getSpan yields a null
+// pointer for an out-of-bounds zero-length slice (which would reset the
+// caller's checksum) and a non-null pointer for guest offset 0 -- the guest's
+// Z_NULL -- (which would suppress the reset it asked for). Map a guest null to
+// Z_NULL and every other zero-length request to a non-null empty buffer.
+static inline const Bytef *
+normalizeChecksumBuf(const Bytef *Buf, uint32_t BufPtr, uint32_t Len) noexcept {
+  if (Len != 0) {
+    return Buf;
+  }
+  static constexpr Bytef EmptyBuffer = 0;
+  return BufPtr == 0 ? Z_NULL : &EmptyBuffer;
 }
 
 Expect<int32_t> WasmEdgeZlibAdler32::body(const Runtime::CallingFrame &Frame,
@@ -1054,9 +1276,9 @@ Expect<int32_t> WasmEdgeZlibAdler32::body(const Runtime::CallingFrame &Frame,
                                           uint32_t Len) {
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Buf = MemInst->getPointer<Bytef *>(BufPtr);
+  BUFFER_CHECK(Buf, MemInst, BufPtr, Len, "WasmEdgeZlibAdler32")
 
-  return adler32(Adler, Buf, Len);
+  return adler32(Adler, normalizeChecksumBuf(Buf, BufPtr, Len), Len);
 }
 
 Expect<int32_t> WasmEdgeZlibAdler32_z::body(const Runtime::CallingFrame &Frame,
@@ -1064,9 +1286,9 @@ Expect<int32_t> WasmEdgeZlibAdler32_z::body(const Runtime::CallingFrame &Frame,
                                             uint32_t Len) {
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Buf = MemInst->getPointer<Bytef *>(BufPtr);
+  BUFFER_CHECK(Buf, MemInst, BufPtr, Len, "WasmEdgeZlibAdler32_z")
 
-  return adler32_z(Adler, Buf, Len);
+  return adler32_z(Adler, normalizeChecksumBuf(Buf, BufPtr, Len), Len);
 }
 
 Expect<int32_t> WasmEdgeZlibAdler32Combine::body(const Runtime::CallingFrame &,
@@ -1081,9 +1303,9 @@ Expect<int32_t> WasmEdgeZlibCRC32::body(const Runtime::CallingFrame &Frame,
                                         uint32_t Len) {
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Buf = MemInst->getPointer<Bytef *>(BufPtr);
+  BUFFER_CHECK(Buf, MemInst, BufPtr, Len, "WasmEdgeZlibCRC32")
 
-  return crc32(CRC, Buf, Len);
+  return crc32(CRC, normalizeChecksumBuf(Buf, BufPtr, Len), Len);
 }
 
 Expect<int32_t> WasmEdgeZlibCRC32_z::body(const Runtime::CallingFrame &Frame,
@@ -1091,9 +1313,9 @@ Expect<int32_t> WasmEdgeZlibCRC32_z::body(const Runtime::CallingFrame &Frame,
                                           uint32_t Len) {
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Buf = MemInst->getPointer<Bytef *>(BufPtr);
+  BUFFER_CHECK(Buf, MemInst, BufPtr, Len, "WasmEdgeZlibCRC32_z")
 
-  return crc32_z(CRC, Buf, Len);
+  return crc32_z(CRC, normalizeChecksumBuf(Buf, BufPtr, Len), Len);
 }
 
 Expect<int32_t> WasmEdgeZlibCRC32Combine::body(const Runtime::CallingFrame &,
@@ -1120,9 +1342,8 @@ WasmEdgeZlibDeflateInit_::body(const Runtime::CallingFrame &Frame,
   // Ignore opaque because zmalloc and zfree are ignored.
   NewZStream->opaque = Z_NULL;
 
-  auto It =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)))
-          .second;
+  const auto [It, Inserted] =
+      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
 
   const auto ZRes =
       SyncRun("WasmEdgeZlibDeflateInit_", Env, ZStreamPtr, Frame,
@@ -1131,7 +1352,7 @@ WasmEdgeZlibDeflateInit_::body(const Runtime::CallingFrame &Frame,
                                     sizeof(z_stream));
               });
 
-  if (ZRes != Z_OK)
+  if (ZRes != Z_OK && Inserted)
     Env.ZStreamMap.erase(It);
 
   return ZRes;
@@ -1155,9 +1376,8 @@ WasmEdgeZlibInflateInit_::body(const Runtime::CallingFrame &Frame,
   // Ignore opaque because zmalloc and zfree are ignored.
   NewZStream->opaque = Z_NULL;
 
-  auto It =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)))
-          .second;
+  const auto [It, Inserted] =
+      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
 
   const auto ZRes = SyncRun("WasmEdgeZlibInflateInit_", Env, ZStreamPtr, Frame,
                             [&](z_stream *HostZStream) {
@@ -1165,7 +1385,7 @@ WasmEdgeZlibInflateInit_::body(const Runtime::CallingFrame &Frame,
                                                   sizeof(z_stream));
                             });
 
-  if (ZRes != Z_OK)
+  if (ZRes != Z_OK && Inserted)
     Env.ZStreamMap.erase(It);
 
   return ZRes;
@@ -1187,9 +1407,8 @@ Expect<int32_t> WasmEdgeZlibDeflateInit2_::body(
   NewZStream->opaque =
       Z_NULL; // ignore opaque since zmalloc and zfree was ignored
 
-  auto It =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)))
-          .second;
+  const auto [It, Inserted] =
+      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
 
   const auto ZRes = SyncRun(
       "WasmEdgeZlibDeflateInit2_", Env, ZStreamPtr, Frame,
@@ -1198,7 +1417,7 @@ Expect<int32_t> WasmEdgeZlibDeflateInit2_::body(
                              Strategy, WasmZlibVersion, sizeof(z_stream));
       });
 
-  if (ZRes != Z_OK)
+  if (ZRes != Z_OK && Inserted)
     Env.ZStreamMap.erase(It);
 
   return ZRes;
@@ -1220,9 +1439,8 @@ WasmEdgeZlibInflateInit2_::body(const Runtime::CallingFrame &Frame,
   NewZStream->opaque =
       Z_NULL; // ignore opaque since zmalloc and zfree was ignored
 
-  auto It =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)))
-          .second;
+  const auto [It, Inserted] =
+      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
 
   const auto ZRes =
       SyncRun("WasmEdgeZlibInflateInit2_", Env, ZStreamPtr, Frame,
@@ -1231,7 +1449,7 @@ WasmEdgeZlibInflateInit2_::body(const Runtime::CallingFrame &Frame,
                                      sizeof(z_stream));
               });
 
-  if (ZRes != Z_OK)
+  if (ZRes != Z_OK && Inserted)
     Env.ZStreamMap.erase(It);
 
   return ZRes;
@@ -1246,16 +1464,27 @@ Expect<int32_t> WasmEdgeZlibInflateBackInit_::body(
   MEMINST_CHECK(MemInst, Frame, 0)
 
   const auto *WasmZlibVersion = MemInst->getPointer<const char *>(VersionPtr);
-  auto *Window = MemInst->getPointer<unsigned char *>(WindowPtr);
+  uint8_t *Window = nullptr;
+  if (WindowBits >= 8 && WindowBits <= 15) {
+    const auto WindowSpan =
+        MemInst->getSpan<uint8_t>(WindowPtr, UINT64_C(1) << WindowBits);
+    if (unlikely(WindowSpan.data() == nullptr)) {
+      spdlog::error("[WasmEdge-Zlib] [InflateBackInit] "sv
+                    "Out-of-bounds window buffer."sv);
+      return Unexpect(ErrCode::Value::HostFuncError);
+    }
+    Window = WindowSpan.data();
+  } else {
+    Window = MemInst->getPointer<unsigned char *>(WindowPtr);
+  }
   auto NewZStream = std::make_unique<z_stream>();
   NewZStream->zalloc = Z_NULL;
   NewZStream->zfree = Z_NULL;
   NewZStream->opaque =
       Z_NULL; // ignore opaque since zmalloc and zfree was ignored
 
-  auto It =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)))
-          .second;
+  const auto [It, Inserted] =
+      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
 
   const auto ZRes =
       SyncRun("WasmEdgeZlibInflateBackInit_", Env, ZStreamPtr, Frame,
@@ -1264,7 +1493,7 @@ Expect<int32_t> WasmEdgeZlibInflateBackInit_::body(
                                         WasmZlibVersion, sizeof(z_stream));
               });
 
-  if (ZRes != Z_OK)
+  if (ZRes != Z_OK && Inserted)
     Env.ZStreamMap.erase(It);
 
   return ZRes;
@@ -1279,7 +1508,7 @@ Expect<int32_t> WasmEdgeZlibGZGetc_::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzgetc_(GZFileIt->second.get());
+  return gzgetc_(GZFileIt->second);
 }
 
 Expect<int32_t>

--- a/plugins/wasmedge_zlib/zlibfunc.cpp
+++ b/plugins/wasmedge_zlib/zlibfunc.cpp
@@ -3,9 +3,16 @@
 
 #include "zlibfunc.h"
 
+#include "host/wasi/wasimodule.h"
+
 #include <cstring>
 #include <optional>
 #include <string_view>
+
+#if !defined(_WIN32)
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 
 namespace WasmEdge {
 namespace Host {
@@ -57,26 +64,6 @@ constexpr uint64_t MaxGZHeaderStringLen = UINT64_C(1) << 20;
 // scan well above any real ZLIB_VERSION instead of letting a guest pointer
 // into a large non-NUL region drive an unbounded memchr over linear memory.
 constexpr uint64_t MaxZlibVersionLen = 63;
-
-// Return an in-bounds, NUL-terminated C string starting at `Offset`, or nullptr
-// when the offset is out of bounds or no terminator exists before the end of
-// linear memory (which would make zlib's strlen/strcpy read out of bounds).
-static inline const char *
-getInBoundsCString(const Runtime::Instance::MemoryInstance &MemInst,
-                   uint32_t Offset) noexcept {
-  const uint64_t MemSize = MemInst.getSize();
-  if (unlikely(Offset >= MemSize)) {
-    return nullptr;
-  }
-  const auto *Str = MemInst.getPointer<const char *>(Offset);
-  if (unlikely(Str == nullptr)) {
-    return nullptr;
-  }
-  if (unlikely(std::memchr(Str, '\0', MemSize - Offset) == nullptr)) {
-    return nullptr;
-  }
-  return Str;
-}
 
 static inline std::optional<std::string_view>
 getBoundedInBoundsCString(const Runtime::Instance::MemoryInstance &MemInst,
@@ -1458,54 +1445,417 @@ WasmEdgeZlibUncompress2::body(const Runtime::CallingFrame &Frame,
   return ZRes;
 }
 
+// Return the WASI environment backing this instance, or nullptr when the
+// embedder did not configure WASI. FStream and the wasi_nn plugins take the
+// same const_cast to reach WASI's mutable fd table from a host function's const
+// view of the environment.
+static WASI::Environ *
+getWasiEnviron(const Runtime::CallingFrame &Frame) noexcept {
+  const auto *WasiMod = Frame.getWASIModule();
+  if (WasiMod == nullptr) {
+    return nullptr;
+  }
+  const auto *Typed = dynamic_cast<const WasiModule *>(WasiMod);
+  if (Typed == nullptr) {
+    return nullptr;
+  }
+  return const_cast<WASI::Environ *>(Typed->getEnv());
+}
+
+// Release the guest WASI fd a gz handle owns (see GZFileEntry::OwnedWasiFd)
+// once zlib has freed the handle. A close that fails because the guest already
+// released the fd itself is ignored: that guest hits the same double close
+// natively.
+static void releaseOwnedWasiFd(const Runtime::CallingFrame &Frame,
+                               int64_t OwnedWasiFd) noexcept {
+  if (OwnedWasiFd < 0) {
+    return;
+  }
+  if (auto *WasiEnv = getWasiEnviron(Frame); WasiEnv != nullptr) {
+    WasiEnv->fdClose(static_cast<__wasi_fd_t>(OwnedWasiFd));
+  }
+}
+
+// Duplicate a WASI-owned host descriptor so zlib owns an independent one
+// (gzclose closes it) without disturbing WASI's own descriptor. Returns -1 on
+// failure.
+#if defined(_WIN32)
+// Bridging a WASI descriptor to a zlib gzFile on Windows needs the underlying
+// HANDLE duplicated (getNativeHandler yields a HANDLE, not a CRT fd). Until the
+// winapi wrapper exposes DuplicateHandle, report open failure here rather than
+// pull in <windows.h> or risk a double close; the guest sees a null handle.
+// TODO: Bridge the HANDLE to a CRT fd (DuplicateHandle + _open_osfhandle) once
+// the winapi wrapper exposes it, and add Windows CI coverage for this plugin so
+// the bridge is exercised.
+static int dupNativeHandle(uint64_t) noexcept { return -1; }
+static void closeNativeFd(int) noexcept {}
+static int64_t tellNativeFd(int) noexcept { return -1; }
+static void seekNativeFd(int, int64_t) noexcept {}
+#else
+static int dupNativeHandle(uint64_t Native) noexcept {
+  // F_DUPFD_CLOEXEC rather than a bare dup(): WASI opens every descriptor with
+  // O_CLOEXEC, so zlib's duplicate must keep close-on-exec too. A bare dup()
+  // clears it, leaking the sandboxed fd across an execve while the gz handle is
+  // live, and gzdopen cannot reapply zlib's "e" mode to an already-open fd.
+  return ::fcntl(static_cast<int>(Native), F_DUPFD_CLOEXEC, 0);
+}
+static void closeNativeFd(int Fd) noexcept { ::close(Fd); }
+static int64_t tellNativeFd(int Fd) noexcept {
+  return static_cast<int64_t>(::lseek(Fd, 0, SEEK_CUR));
+}
+static void seekNativeFd(int Fd, int64_t Offset) noexcept {
+  ::lseek(Fd, static_cast<off_t>(Offset), SEEK_SET);
+}
+#endif
+
+// The subset of zlib's gz_open mode parse that decides how the file is
+// opened: the last of r/w/a wins, 'x' requests an exclusive create, 'N'
+// (zlib >= 1.3.2) requests a nonblocking open, and the last of 'T'/'G'
+// (the latter zlib >= 1.3.2) picks between a transparent and a forced-gzip
+// stream. Any '+', a mode with no direction at all, a transparent read, or
+// a forced-gzip write or append is rejected -- gz_open refuses those before
+// opening the file. Earlier zlib ignores 'G' and 'N' outright, so refusing
+// here is the fail-closed reading that keeps a refused mode free of pathOpen
+// side effects on every zlib. Every other character only affects stream
+// semantics, not the open itself.
+enum class GZOpenDir { None, Read, Write, Append };
+enum class GZOpenDirect { Auto, Transparent, ForceGzip };
+
+struct GZOpenMode {
+  GZOpenDir Dir = GZOpenDir::None;
+  bool Exclusive = false;
+  bool NonBlock = false;
+  GZOpenDirect Direct = GZOpenDirect::Auto;
+};
+
+static std::optional<GZOpenMode>
+parseGZOpenMode(std::string_view Mode) noexcept {
+  GZOpenMode Parsed;
+  for (const char C : Mode) {
+    switch (C) {
+    case 'r':
+      Parsed.Dir = GZOpenDir::Read;
+      break;
+    case 'w':
+      Parsed.Dir = GZOpenDir::Write;
+      break;
+    case 'a':
+      Parsed.Dir = GZOpenDir::Append;
+      break;
+    case 'x':
+      Parsed.Exclusive = true;
+      break;
+    case 'N':
+      Parsed.NonBlock = true;
+      break;
+    case 'T':
+      Parsed.Direct = GZOpenDirect::Transparent;
+      break;
+    case 'G':
+      Parsed.Direct = GZOpenDirect::ForceGzip;
+      break;
+    case '+':
+      return std::nullopt;
+    default:
+      break;
+    }
+  }
+  if (Parsed.Dir == GZOpenDir::None) {
+    return std::nullopt;
+  }
+  if (Parsed.Dir == GZOpenDir::Read &&
+      Parsed.Direct == GZOpenDirect::Transparent) {
+    return std::nullopt;
+  }
+  if (Parsed.Dir != GZOpenDir::Read &&
+      Parsed.Direct == GZOpenDirect::ForceGzip) {
+    return std::nullopt;
+  }
+  return Parsed;
+}
+
+// Resolve a WASI fd to its host descriptor (capability-checked by the WASI fd
+// table), duplicate it, and hand the duplicate to zlib. When OwnWasiFd is set
+// the WASI fd was opened for this call and is released here; otherwise it
+// belongs to the guest and is left intact here -- the gzdopen caller records
+// it on the handle so the gzclose that frees the handle releases it. A failure
+// returns a null-handle entry.
+static WasmEdgeZlibEnvironment::GZFileEntry
+wasiFdToGZ(WASI::Environ &WasiEnv, __wasi_fd_t WasiFd, const char *Mode,
+           bool OwnWasiFd) noexcept {
+  // Enforce the WASI rights that mediate this fd before handing zlib a raw
+  // duplicate it operates on outside WASI's checks. Only the access direction
+  // is required up front: FD_SEEK/FD_TELL stay optional so an unseekable
+  // stream (a pipe or stdout) still opens, and are recorded on the handle for
+  // the gz calls that would lseek the duplicate. Append mode is the one
+  // exception -- gz_open itself lseeks the descriptor to EOF at open time --
+  // so it requires FD_SEEK unless the fd is already append-only, where writes
+  // land at EOF regardless and the open-time reposition is undone below.
+  const auto Parsed = parseGZOpenMode(Mode);
+  if (!Parsed) {
+    spdlog::error("[WasmEdge-Zlib] [wasiFdToGZ] "sv
+                  "Unsupported gz mode \"{}\"."sv,
+                  Mode);
+    if (OwnWasiFd) {
+      WasiEnv.fdClose(WasiFd);
+    }
+    return {};
+  }
+  const __wasi_rights_t RequiredRights = Parsed->Dir == GZOpenDir::Read
+                                             ? __WASI_RIGHTS_FD_READ
+                                             : __WASI_RIGHTS_FD_WRITE;
+  if (!WasiEnv.canFd(WasiFd, RequiredRights)) {
+    spdlog::error("[WasmEdge-Zlib] [wasiFdToGZ] "sv
+                  "WASI fd lacks the rights required by mode \"{}\"."sv,
+                  Mode);
+    if (OwnWasiFd) {
+      WasiEnv.fdClose(WasiFd);
+    }
+    return {};
+  }
+  const bool CanSeek = WasiEnv.canFd(WasiFd, __WASI_RIGHTS_FD_SEEK);
+  const bool CanTell = WasiEnv.canFd(WasiFd, __WASI_RIGHTS_FD_TELL);
+  if (Parsed->Dir == GZOpenDir::Append && !CanSeek) {
+    __wasi_fdstat_t FdStat;
+    const bool AppendOnly = WasiEnv.fdFdstatGet(WasiFd, FdStat).has_value() &&
+                            (FdStat.fs_flags & __WASI_FDFLAGS_APPEND) != 0;
+    if (!AppendOnly) {
+      spdlog::error("[WasmEdge-Zlib] [wasiFdToGZ] "sv
+                    "Append mode needs FD_SEEK on a non-append-only fd."sv);
+      if (OwnWasiFd) {
+        WasiEnv.fdClose(WasiFd);
+      }
+      return {};
+    }
+  }
+  auto HandleRes = WasiEnv.getNativeHandler(WasiFd);
+  if (!HandleRes) {
+    if (OwnWasiFd) {
+      WasiEnv.fdClose(WasiFd);
+    }
+    return {};
+  }
+  const int DupFd = dupNativeHandle(*HandleRes);
+  if (OwnWasiFd) {
+    WasiEnv.fdClose(WasiFd);
+  }
+  if (DupFd < 0) {
+    // On Windows this is the expected fail-closed path (dupNativeHandle cannot
+    // bridge the HANDLE to a CRT fd yet; see its TODO); elsewhere it means the
+    // host ran out of descriptors. Either way the guest sees a null handle.
+    spdlog::error("[WasmEdge-Zlib] [wasiFdToGZ] "sv
+                  "Failed to duplicate the host descriptor for zlib."sv);
+    return {};
+  }
+  // gz_open lseeks an append-mode descriptor to EOF at open time, and the
+  // duplicate shares the guest fd's file offset. When the fd was admitted
+  // through the append-only exception (no FD_SEEK), that reposition would
+  // still be observable through the fd's remaining FD_TELL/FD_READ rights, so
+  // put the shared offset back; the append flag keeps writes landing at EOF
+  // regardless of the offset.
+  const bool RestoreOffset =
+      !OwnWasiFd && Parsed->Dir == GZOpenDir::Append && !CanSeek;
+  const int64_t SavedOffset = RestoreOffset ? tellNativeFd(DupFd) : -1;
+  gzFile GZ = gzdopen(DupFd, Mode);
+  bool RestoredAppendOffset = false;
+  if (RestoreOffset && SavedOffset >= 0) {
+    seekNativeFd(DupFd, SavedOffset);
+    RestoredAppendOffset = true;
+  }
+  if (GZ == nullptr) {
+    // gzdopen does not close the descriptor on failure.
+    closeNativeFd(DupFd);
+    return {};
+  }
+  return {GZ, CanSeek, CanTell, RestoredAppendOffset,
+          Parsed->Dir == GZOpenDir::Read};
+}
+
+// Open a guest path through the WASI capability layer (relative to preopen fd
+// 3, the default working directory) so the guest can only reach files WASI
+// granted, then bridge the host descriptor to zlib. Guest paths are
+// normalized the way wasi-libc's open() starts its preopen match: leading '/'
+// and './' runs are stripped (the libc default cwd is '/'), so an absolute
+// spelling reaches the same sandbox entry as its relative one. With several
+// preopens only fd 3 is consulted -- a documented envelope until a full
+// preopen-table match exists. The mode is parsed the way zlib's own gz_open
+// does, and before pathOpen runs: gzopen must fail without touching the file
+// on a mode zlib rejects (such as "w+"), and an exclusive "wx" create must
+// refuse to clobber an existing sandbox file rather than truncate it. zlib's
+// own gz_open re-parses the same string afterwards and stays the final
+// authority on the stream semantics.
+static WasmEdgeZlibEnvironment::GZFileEntry
+wasiGZOpen(WASI::Environ &WasiEnv, const char *Path,
+           const char *Mode) noexcept {
+  const auto Parsed = parseGZOpenMode(Mode);
+  if (!Parsed) {
+    return {};
+  }
+#if defined(_WIN32)
+  // dupNativeHandle cannot bridge a WASI handle to a CRT descriptor yet, so
+  // this open always fails; fail before pathOpen can create or truncate the
+  // file as a side effect. This is an expected Windows limitation (see the
+  // dupNativeHandle TODO), surfaced to the guest as a null handle.
+  static_cast<void>(WasiEnv);
+  static_cast<void>(Path);
+  spdlog::error("[WasmEdge-Zlib] [wasiGZOpen] "sv
+                "WASI-mediated gzopen is not supported on Windows yet; "sv
+                "returning a null handle for mode \"{}\"."sv,
+                Mode);
+  return {};
+#else
+  auto OpenFlags = static_cast<__wasi_oflags_t>(0);
+  auto FdFlags = static_cast<__wasi_fdflags_t>(0);
+  __wasi_rights_t Rights = static_cast<__wasi_rights_t>(0);
+  switch (Parsed->Dir) {
+  case GZOpenDir::Read:
+    Rights = __WASI_RIGHTS_FD_READ;
+    break;
+  case GZOpenDir::Write:
+    OpenFlags = __WASI_OFLAGS_CREAT | __WASI_OFLAGS_TRUNC;
+    Rights = __WASI_RIGHTS_FD_WRITE;
+    break;
+  case GZOpenDir::Append:
+    OpenFlags = __WASI_OFLAGS_CREAT;
+    FdFlags = __WASI_FDFLAGS_APPEND;
+    Rights = __WASI_RIGHTS_FD_WRITE;
+    break;
+  case GZOpenDir::None:
+    return {};
+  }
+  // zlib >= 1.3.2 puts 'N' into the open(2) flags themselves; a FIFO open
+  // blocks (or fails with ENXIO on the write side) before gzdopen could apply
+  // the flag to the descriptor, so the request must ride pathOpen.
+  if (Parsed->NonBlock) {
+    FdFlags = static_cast<__wasi_fdflags_t>(FdFlags | __WASI_FDFLAGS_NONBLOCK);
+  }
+  // FD_SEEK/FD_TELL are optional for streaming use: wasiFdToGZ records them on
+  // the handle and the gz calls that would reposition the descriptor enforce
+  // them. Request them only when the preopen can inherit them (FD_SEEK implies
+  // FD_TELL, matching the fd table's own rights check); requiring them outright
+  // would make pathOpen reject a plain streaming gzopen on a directory narrowed
+  // to its direction rights.
+  __wasi_rights_t OptionalRights =
+      __WASI_RIGHTS_FD_SEEK | __WASI_RIGHTS_FD_TELL;
+  __wasi_fdstat_t DirStat;
+  if (WasiEnv.fdFdstatGet(3, DirStat).has_value()) {
+    __wasi_rights_t Inheriting = DirStat.fs_rights_inheriting;
+    if ((Inheriting & __WASI_RIGHTS_FD_SEEK) != 0) {
+      Inheriting |= __WASI_RIGHTS_FD_TELL;
+    }
+    OptionalRights &= Inheriting;
+  }
+  Rights |= OptionalRights;
+  // Native gzopen follows a final symlink the way wasi-libc's open() does
+  // (LOOKUP_SYMLINK_FOLLOW by default), and resolvePath re-walks the target
+  // with the same preopen-escape checks a guest path_open gets, so follow
+  // here too. The exception is an exclusive create: native O_EXCL refuses an
+  // existing symlink -- dangling included -- rather than following it, and
+  // gzopen applies O_EXCL only when creating (write or append); an exclusive
+  // read mode such as "rx" opens plainly.
+  auto LookupFlags = __WASI_LOOKUPFLAGS_SYMLINK_FOLLOW;
+  if (Parsed->Exclusive && Parsed->Dir != GZOpenDir::Read) {
+    OpenFlags |= __WASI_OFLAGS_EXCL;
+    LookupFlags = static_cast<__wasi_lookupflags_t>(0);
+  }
+  // resolvePath refuses an absolute path outright, so strip the leading '/'
+  // and './' runs the way wasi-libc does before it matches a preopen; the
+  // remainder still walks resolvePath's escape checks, so a ".." can not
+  // climb past the preopen root.
+  while (Path[0] == '/' || (Path[0] == '.' && Path[1] == '/') ||
+         (Path[0] == '.' && Path[1] == '\0')) {
+    Path += (Path[0] == '.' && Path[1] == '/') ? 2 : 1;
+  }
+  auto FdRes = WasiEnv.pathOpen(3, Path, LookupFlags, OpenFlags, Rights, Rights,
+                                FdFlags);
+  if (!FdRes) {
+    return {};
+  }
+  return wasiFdToGZ(WasiEnv, *FdRes, Mode, /*OwnWasiFd=*/true);
+#endif
+}
+
+// gzopen snapshots the path and mode into host memory below; bound the scans so
+// a guest cannot place the terminator at the far end of a multi-GB linear
+// memory and force a matching host allocation. Real paths stay under PATH_MAX
+// and zlib modes are only a few characters.
+constexpr uint64_t MaxGZOpenPathLen = 4096;
+constexpr uint64_t MaxGZOpenModeLen = 63;
+
 Expect<uint32_t> WasmEdgeZlibGZOpen::body(const Runtime::CallingFrame &Frame,
                                           uint32_t PathPtr, uint32_t ModePtr) {
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  const auto *Path = getInBoundsCString(*MemInst, PathPtr);
-  const auto *Mode = getInBoundsCString(*MemInst, ModePtr);
-  if (unlikely(Path == nullptr || Mode == nullptr)) {
-    spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibGZOpen] "sv
-                  "Out-of-bounds path or mode string."sv);
-    return Unexpect(ErrCode::Value::HostFuncError);
+  // gz_open answers a null path with a null handle before it parses the mode
+  // or touches the filesystem, and wasm address 0 is the guest's NULL, not
+  // the start of a path string.
+  if (PathPtr == 0) {
+    return UINT32_C(0);
   }
 
-  auto ZRes = gzopen(Path, Mode);
-  if (unlikely(ZRes == nullptr)) {
-    // A null gzFile is zlib's ordinary open failure (e.g. a missing file);
-    // surface it to the guest as a null handle instead of trapping. No live
-    // handle is ever 0 because NextGZFile starts at sizeof(gzFile).
+  const auto PathStr =
+      getBoundedInBoundsCString(*MemInst, PathPtr, MaxGZOpenPathLen);
+  const auto ModeStr =
+      getBoundedInBoundsCString(*MemInst, ModePtr, MaxGZOpenModeLen);
+  if (unlikely(!PathStr || !ModeStr)) {
+    spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibGZOpen] "sv
+                  "Out-of-bounds or oversized path or mode string."sv);
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
+  // Copy the guest path and mode into host memory before parsing or opening:
+  // the mode is checked for rights and then re-parsed by zlib's gz_open, and
+  // with shared linear memory another thread could rewrite the bytes in
+  // between (e.g. "r" -> "w") to open with rights that were never granted.
+  // Build the copies from the validated length so no fresh scan reaches past
+  // the range checked above.
+  const std::string Path(PathStr->data(), PathStr->size());
+  const std::string Mode(ModeStr->data(), ModeStr->size());
+
+  // Resolve the path through WASI's preopen capability layer when a WASI module
+  // is configured. Distinguish the two ways getWasiEnviron declines: with no
+  // WASI module at all there is no sandbox to honor, so fall back to a direct
+  // host open (matching the FStream convention) with a full-capability handle;
+  // but a WASI module that is present yet unrecognized (not Host::WasiModule --
+  // a custom or stub wasi_snapshot_preview1) means the guest expects a sandbox
+  // whose capabilities we cannot read, so fail closed rather than open a raw
+  // host path outside it.
+  WasmEdgeZlibEnvironment::GZFileEntry Entry{};
+  if (Frame.getWASIModule() == nullptr) {
+    Entry = {gzopen(Path.c_str(), Mode.c_str()), /*CanSeek=*/true,
+             /*CanTell=*/true, /*RestoredAppendOffset=*/false};
+  } else if (auto *WasiEnv = getWasiEnviron(Frame); WasiEnv != nullptr) {
+    Entry = wasiGZOpen(*WasiEnv, Path.c_str(), Mode.c_str());
+  } else {
+    spdlog::error(
+        "[WasmEdge-Zlib] [WasmEdgeZlibGZOpen] "sv
+        "A WASI module is configured but is not one this plugin can "sv
+        "read capabilities from; refusing to open outside the "sv
+        "capability layer."sv);
+    return UINT32_C(0);
+  }
+  if (unlikely(Entry.GZ == nullptr)) {
+    // A null gzFile is zlib's ordinary open failure (e.g. a missing file or a
+    // path outside the sandbox); surface it to the guest as a null handle
+    // instead of trapping. No live handle is ever 0 because NextGZFile starts
+    // at sizeof(gzFile).
     return UINT32_C(0);
   }
 
   const uint32_t NewWasmGZFile = Env.NextGZFile++;
-  Env.GZFileMap.emplace(NewWasmGZFile, ZRes);
+  Env.GZFileMap.emplace(NewWasmGZFile, Entry);
 
   return NewWasmGZFile;
 }
 
-Expect<uint32_t> WasmEdgeZlibGZDOpen::body(const Runtime::CallingFrame &Frame,
-                                           int32_t FD, uint32_t ModePtr) {
-  MEMINST_CHECK(MemInst, Frame, 0)
-
-  const auto *Mode = getInBoundsCString(*MemInst, ModePtr);
-  if (unlikely(Mode == nullptr)) {
-    spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibGZDOpen] "sv
-                  "Out-of-bounds mode string."sv);
-    return Unexpect(ErrCode::Value::HostFuncError);
-  }
-
-  auto ZRes = gzdopen(FD, Mode);
-  if (unlikely(ZRes == nullptr)) {
-    // Match gzopen: a null gzFile is an ordinary failure handed back to the
-    // guest as a null handle, not a host trap.
-    return UINT32_C(0);
-  }
-
-  const uint32_t NewWasmGZFile = Env.NextGZFile++;
-  Env.GZFileMap.emplace(NewWasmGZFile, ZRes);
-
-  return NewWasmGZFile;
+Expect<uint32_t> WasmEdgeZlibGZDOpen::body(const Runtime::CallingFrame &,
+                                           int32_t, uint32_t) {
+  // TODO(zlib): gzdopen is disabled pending an fd-lifecycle rework: bridging
+  // transfers fd ownership to the gzFile, and that owned WASI fd cannot yet be
+  // released safely at environment teardown without an explicit gzclose.
+  // Refuse with a null handle -- zlib's ordinary gzdopen failure -- without
+  // touching the descriptor, so the guest keeps its fd. Re-enable by restoring
+  // the bridge here (see the wasiFdToGZ path used by gzopen).
+  return UINT32_C(0);
 }
 
 Expect<int32_t> WasmEdgeZlibGZBuffer::body(const Runtime::CallingFrame &,
@@ -1517,12 +1867,18 @@ Expect<int32_t> WasmEdgeZlibGZBuffer::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  // Clamp a guest-declared buffer size to a sane maximum: gzbuffer makes zlib
-  // allocate three times this size on the first I/O, so an unclamped multi-GB
-  // request would exhaust host memory (and zlib rejects sizes >= 2^31
-  // outright).
+  // zlib refuses a size >= 2^31 (it must be able to double it) before
+  // recording anything, so keep that -1 answer instead of clamping the
+  // request into an accepted one; answering here also keeps the behavior
+  // uniform when the host links zlib-ng, which would silently clamp and
+  // accept. Below that, clamp a guest-declared size to a sane maximum:
+  // gzbuffer makes zlib allocate three times this size on the first I/O, so
+  // an unclamped request just under 2 GiB would exhaust host memory.
+  if (Size >= UINT32_C(0x80000000)) {
+    return INT32_C(-1);
+  }
   constexpr uint32_t MaxGZBufferSize = UINT32_C(64) * 1024 * 1024;
-  return gzbuffer(GZFileIt->second,
+  return gzbuffer(GZFileIt->second.GZ,
                   Size > MaxGZBufferSize ? MaxGZBufferSize : Size);
 }
 
@@ -1536,7 +1892,7 @@ Expect<int32_t> WasmEdgeZlibGZSetParams::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzsetparams(GZFileIt->second, Level, Strategy);
+  return gzsetparams(GZFileIt->second.GZ, Level, Strategy);
 }
 
 Expect<int32_t> WasmEdgeZlibGZRead::body(const Runtime::CallingFrame &Frame,
@@ -1551,9 +1907,17 @@ Expect<int32_t> WasmEdgeZlibGZRead::body(const Runtime::CallingFrame &Frame,
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
+  // gzread refuses a length that does not fit in a signed int -- it returns -1
+  // and sets Z_STREAM_ERROR without touching the buffer -- so let zlib answer
+  // instead of trapping on a range that could never be read anyway (0x7fffffff
+  // is INT_MAX).
+  if (Len > UINT32_C(0x7fffffff)) {
+    return gzread(GZFileIt->second.GZ, nullptr, Len);
+  }
+
   BUFFER_CHECK(Buf, MemInst, BufPtr, Len, "WasmEdgeZlibGZRead")
 
-  return gzread(GZFileIt->second, Buf, Len);
+  return gzread(GZFileIt->second.GZ, Buf, Len);
 }
 
 Expect<int32_t> WasmEdgeZlibGZFread::body(const Runtime::CallingFrame &Frame,
@@ -1569,9 +1933,20 @@ Expect<int32_t> WasmEdgeZlibGZFread::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0)
 
   const uint64_t Bytes = static_cast<uint64_t>(Size) * NItems;
+  // A wasm32 guest's z_size_t is 32-bit, so a size*nitems product that does
+  // not fit maps to zlib's documented overflow: nothing is read, zero comes
+  // back, and gz_error records a sticky Z_STREAM_ERROR that blocks further
+  // I/O until gzclearerr. Reproduce that exact path on the host stream -- its
+  // 64-bit gzfread would otherwise attempt the multi-GB read -- with a
+  // product that also overflows the host z_size_t: the buffer is never
+  // touched, and a wrong-mode or already-errored handle still answers first,
+  // as it would natively.
+  if (Bytes > UINT32_MAX) {
+    return gzfread(nullptr, static_cast<z_size_t>(-1), 2, GZFileIt->second.GZ);
+  }
   BUFFER_CHECK(Buf, MemInst, BufPtr, Bytes, "WasmEdgeZlibGZFread")
 
-  return gzfread(Buf, Size, NItems, GZFileIt->second);
+  return gzfread(Buf, Size, NItems, GZFileIt->second.GZ);
 }
 
 Expect<int32_t> WasmEdgeZlibGZWrite::body(const Runtime::CallingFrame &Frame,
@@ -1586,9 +1961,17 @@ Expect<int32_t> WasmEdgeZlibGZWrite::body(const Runtime::CallingFrame &Frame,
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
+  // gzwrite refuses a length that does not fit in a signed int -- it returns
+  // 0 and sets Z_DATA_ERROR without touching the buffer -- so as with gzread
+  // let zlib answer instead of trapping on a range that could never be
+  // written anyway (0x7fffffff is INT_MAX).
+  if (Len > UINT32_C(0x7fffffff)) {
+    return gzwrite(GZFileIt->second.GZ, nullptr, Len);
+  }
+
   BUFFER_CHECK(Buf, MemInst, BufPtr, Len, "WasmEdgeZlibGZWrite")
 
-  return gzwrite(GZFileIt->second, Buf, Len);
+  return gzwrite(GZFileIt->second.GZ, Buf, Len);
 }
 
 Expect<int32_t> WasmEdgeZlibGZFwrite::body(const Runtime::CallingFrame &Frame,
@@ -1604,9 +1987,16 @@ Expect<int32_t> WasmEdgeZlibGZFwrite::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0)
 
   const uint64_t Bytes = static_cast<uint64_t>(Size) * NItems;
+  // As with gzfread, a wasm32 size*nitems overflow is zlib's documented
+  // zero-return with a sticky Z_STREAM_ERROR; reproduce it on the host stream
+  // with a product that also overflows the host z_size_t, which never touches
+  // the buffer.
+  if (Bytes > UINT32_MAX) {
+    return gzfwrite(nullptr, static_cast<z_size_t>(-1), 2, GZFileIt->second.GZ);
+  }
   BUFFER_CHECK(Buf, MemInst, BufPtr, Bytes, "WasmEdgeZlibGZFwrite")
 
-  return gzfwrite(Buf, Size, NItems, GZFileIt->second);
+  return gzfwrite(Buf, Size, NItems, GZFileIt->second.GZ);
 }
 
 Expect<int32_t> WasmEdgeZlibGZPuts::body(const Runtime::CallingFrame &Frame,
@@ -1620,14 +2010,29 @@ Expect<int32_t> WasmEdgeZlibGZPuts::body(const Runtime::CallingFrame &Frame,
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  const auto *String = getInBoundsCString(*MemInst, StringPtr);
-  if (unlikely(String == nullptr)) {
+  const auto String =
+      getBoundedInBoundsCString(*MemInst, StringPtr, UINT64_MAX);
+  if (unlikely(!String)) {
     spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibGZPuts] "sv
                   "Out-of-bounds string."sv);
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzputs(GZFileIt->second, String);
+  // Write the validated bytes directly rather than copying them into a host
+  // string: gzputs would re-scan guest memory with strlen (a TOCTOU under
+  // shared memory), and snapshotting a guest-chosen length could force a
+  // multi-GB host allocation. gzwrite takes the measured length, so zlib never
+  // rescans and nothing is materialized. gzputs refuses a non-writing or
+  // errored handle before accepting even a zero-length string, so the empty
+  // case asks the real gzputs with a host-owned empty string, and a short
+  // write reports -1 (not the byte count) exactly as gzputs does.
+  if (String->empty()) {
+    return gzputs(GZFileIt->second.GZ, "");
+  }
+  const int Written = gzwrite(GZFileIt->second.GZ, String->data(),
+                              static_cast<unsigned>(String->size()));
+  return Written > 0 && static_cast<size_t>(Written) == String->size() ? Written
+                                                                       : -1;
 }
 
 Expect<int32_t> WasmEdgeZlibGZPutc::body(const Runtime::CallingFrame &,
@@ -1639,7 +2044,7 @@ Expect<int32_t> WasmEdgeZlibGZPutc::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzputc(GZFileIt->second, C);
+  return gzputc(GZFileIt->second.GZ, C);
 }
 
 Expect<int32_t> WasmEdgeZlibGZGetc::body(const Runtime::CallingFrame &,
@@ -1651,7 +2056,7 @@ Expect<int32_t> WasmEdgeZlibGZGetc::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzgetc(GZFileIt->second);
+  return gzgetc(GZFileIt->second.GZ);
 }
 
 Expect<int32_t> WasmEdgeZlibGZUngetc::body(const Runtime::CallingFrame &,
@@ -1663,7 +2068,7 @@ Expect<int32_t> WasmEdgeZlibGZUngetc::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzungetc(C, GZFileIt->second);
+  return gzungetc(C, GZFileIt->second.GZ);
 }
 
 Expect<int32_t> WasmEdgeZlibGZFlush::body(const Runtime::CallingFrame &,
@@ -1675,7 +2080,7 @@ Expect<int32_t> WasmEdgeZlibGZFlush::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzflush(GZFileIt->second, Flush);
+  return gzflush(GZFileIt->second.GZ, Flush);
 }
 
 Expect<int32_t> WasmEdgeZlibGZSeek::body(const Runtime::CallingFrame &,
@@ -1688,7 +2093,16 @@ Expect<int32_t> WasmEdgeZlibGZSeek::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzseek(GZFileIt->second, Offset, Whence);
+  // WASI's capability checks never see zlib's lseek on the duplicated
+  // descriptor, so refuse repositioning when FD_SEEK was absent at open. Only
+  // read handles need the gate: write-mode gzseek never repositions the
+  // descriptor (zlib answers -1 to backward seeks and compresses zeros for
+  // forward seeks), while a read-mode seek may lseek at zlib's discretion.
+  if (unlikely(!GZFileIt->second.CanSeek && GZFileIt->second.OpenedForRead)) {
+    return static_cast<int32_t>(-1);
+  }
+
+  return gzseek(GZFileIt->second.GZ, Offset, Whence);
 }
 
 Expect<int32_t> WasmEdgeZlibGZRewind::body(const Runtime::CallingFrame &,
@@ -1700,7 +2114,14 @@ Expect<int32_t> WasmEdgeZlibGZRewind::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzrewind(GZFileIt->second);
+  // gzrewind repositions the descriptor with lseek only for read handles
+  // (zlib answers -1 in write mode before any lseek), so enforce FD_SEEK the
+  // same way as gzseek above.
+  if (unlikely(!GZFileIt->second.CanSeek && GZFileIt->second.OpenedForRead)) {
+    return static_cast<int32_t>(-1);
+  }
+
+  return gzrewind(GZFileIt->second.GZ);
 }
 
 Expect<int32_t> WasmEdgeZlibGZTell::body(const Runtime::CallingFrame &,
@@ -1712,7 +2133,7 @@ Expect<int32_t> WasmEdgeZlibGZTell::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gztell(GZFileIt->second);
+  return gztell(GZFileIt->second.GZ);
 }
 
 Expect<int32_t> WasmEdgeZlibGZOffset::body(const Runtime::CallingFrame &,
@@ -1724,7 +2145,15 @@ Expect<int32_t> WasmEdgeZlibGZOffset::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzoffset(GZFileIt->second);
+  // gzoffset queries the descriptor position with lseek; refuse when FD_TELL
+  // was absent at open. gztell stays available regardless: zlib computes it
+  // from its own counters without touching the descriptor, as on a pipe.
+  if (unlikely(!GZFileIt->second.CanTell ||
+               GZFileIt->second.RestoredAppendOffset)) {
+    return static_cast<int32_t>(-1);
+  }
+
+  return gzoffset(GZFileIt->second.GZ);
 }
 
 Expect<int32_t> WasmEdgeZlibGZEof::body(const Runtime::CallingFrame &,
@@ -1736,7 +2165,7 @@ Expect<int32_t> WasmEdgeZlibGZEof::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzeof(GZFileIt->second);
+  return gzeof(GZFileIt->second.GZ);
 }
 
 Expect<int32_t> WasmEdgeZlibGZDirect::body(const Runtime::CallingFrame &,
@@ -1748,10 +2177,10 @@ Expect<int32_t> WasmEdgeZlibGZDirect::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzdirect(GZFileIt->second);
+  return gzdirect(GZFileIt->second.GZ);
 }
 
-Expect<int32_t> WasmEdgeZlibGZClose::body(const Runtime::CallingFrame &,
+Expect<int32_t> WasmEdgeZlibGZClose::body(const Runtime::CallingFrame &Frame,
                                           uint32_t GZFile) {
   const auto GZFileIt = Env.GZFileMap.find(GZFile);
   if (GZFileIt == Env.GZFileMap.end()) {
@@ -1760,14 +2189,16 @@ Expect<int32_t> WasmEdgeZlibGZClose::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  const auto ZRes = gzclose(GZFileIt->second);
+  const int64_t OwnedWasiFd = GZFileIt->second.OwnedWasiFd;
+  const auto ZRes = gzclose(GZFileIt->second.GZ);
 
   Env.GZFileMap.erase(GZFileIt);
+  releaseOwnedWasiFd(Frame, OwnedWasiFd);
 
   return ZRes;
 }
 
-Expect<int32_t> WasmEdgeZlibGZClose_r::body(const Runtime::CallingFrame &,
+Expect<int32_t> WasmEdgeZlibGZClose_r::body(const Runtime::CallingFrame &Frame,
                                             uint32_t GZFile) {
   const auto GZFileIt = Env.GZFileMap.find(GZFile);
   if (GZFileIt == Env.GZFileMap.end()) {
@@ -1776,17 +2207,21 @@ Expect<int32_t> WasmEdgeZlibGZClose_r::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  const auto ZRes = gzclose_r(GZFileIt->second);
+  const int64_t OwnedWasiFd = GZFileIt->second.OwnedWasiFd;
+  const auto ZRes = gzclose_r(GZFileIt->second.GZ);
 
   // Z_STREAM_ERROR means the handle was the wrong mode and was NOT freed; keep
-  // it so the environment destructor can still reclaim it.
-  if (ZRes != Z_STREAM_ERROR)
+  // it (and the guest fd it owns) so the environment destructor can still
+  // reclaim it.
+  if (ZRes != Z_STREAM_ERROR) {
     Env.GZFileMap.erase(GZFileIt);
+    releaseOwnedWasiFd(Frame, OwnedWasiFd);
+  }
 
   return ZRes;
 }
 
-Expect<int32_t> WasmEdgeZlibGZClose_w::body(const Runtime::CallingFrame &,
+Expect<int32_t> WasmEdgeZlibGZClose_w::body(const Runtime::CallingFrame &Frame,
                                             uint32_t GZFile) {
   const auto GZFileIt = Env.GZFileMap.find(GZFile);
   if (GZFileIt == Env.GZFileMap.end()) {
@@ -1795,12 +2230,16 @@ Expect<int32_t> WasmEdgeZlibGZClose_w::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  const auto ZRes = gzclose_w(GZFileIt->second);
+  const int64_t OwnedWasiFd = GZFileIt->second.OwnedWasiFd;
+  const auto ZRes = gzclose_w(GZFileIt->second.GZ);
 
   // Z_STREAM_ERROR means the handle was the wrong mode and was NOT freed; keep
-  // it so the environment destructor can still reclaim it.
-  if (ZRes != Z_STREAM_ERROR)
+  // it (and the guest fd it owns) so the environment destructor can still
+  // reclaim it.
+  if (ZRes != Z_STREAM_ERROR) {
     Env.GZFileMap.erase(GZFileIt);
+    releaseOwnedWasiFd(Frame, OwnedWasiFd);
+  }
 
   return ZRes;
 }
@@ -1814,7 +2253,7 @@ Expect<void> WasmEdgeZlibGZClearerr::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  gzclearerr(GZFileIt->second);
+  gzclearerr(GZFileIt->second.GZ);
 
   return Expect<void>{};
 }
@@ -2047,7 +2486,7 @@ Expect<int32_t> WasmEdgeZlibGZGetc_::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzgetc_(GZFileIt->second);
+  return gzgetc_(GZFileIt->second.GZ);
 }
 
 Expect<int32_t>

--- a/plugins/wasmedge_zlib/zlibfunc.cpp
+++ b/plugins/wasmedge_zlib/zlibfunc.cpp
@@ -66,7 +66,9 @@ getInBoundsCString(const Runtime::Instance::MemoryInstance &MemInst,
 template <typename T>
 auto SyncRun(const std::string_view &Msg, WasmEdgeZlibEnvironment &Env,
              uint32_t ZStreamPtr, const Runtime::CallingFrame &Frame,
-             T Callback) -> Expect<int32_t> {
+             T Callback, bool ValidateInputBuffer = false,
+             bool ValidateOutputBuffer = false, bool SyncGZHeader = false)
+    -> Expect<int32_t> {
 
   MEMINST_CHECK(MemInst, Frame, 0)
   WasmZStream *ModuleZStream = MemInst->getPointer<WasmZStream *>(ZStreamPtr);
@@ -89,19 +91,28 @@ auto SyncRun(const std::string_view &Msg, WasmEdgeZlibEnvironment &Env,
 
   const auto InSpan = MemInst->getSpan<unsigned char>(ModuleZStream->NextIn,
                                                       ModuleZStream->AvailIn);
-  if (unlikely(ModuleZStream->AvailIn != 0 && InSpan.data() == nullptr)) {
-    spdlog::error("[WasmEdge-Zlib] [{}-SyncRun] "sv
-                  "Out-of-bounds input buffer."sv,
-                  Msg);
-    return Unexpect(ErrCode::Value::HostFuncError);
-  }
   const auto OutSpan = MemInst->getSpan<unsigned char>(ModuleZStream->NextOut,
                                                        ModuleZStream->AvailOut);
-  if (unlikely(ModuleZStream->AvailOut != 0 && OutSpan.data() == nullptr)) {
-    spdlog::error("[WasmEdge-Zlib] [{}-SyncRun] "sv
-                  "Out-of-bounds output buffer."sv,
-                  Msg);
-    return Unexpect(ErrCode::Value::HostFuncError);
+  // Only the streaming callbacks read next_in or write next_out, so only they
+  // must reject an out-of-bounds data buffer (inflateSync scans input but
+  // never writes output). Control operations (init, reset, end, copy, ...)
+  // ignore these fields, and zlib's contract lets a guest leave them
+  // uninitialized; trapping them would break valid init and cleanup calls.
+  if (ValidateInputBuffer) {
+    if (unlikely(ModuleZStream->AvailIn != 0 && InSpan.data() == nullptr)) {
+      spdlog::error("[WasmEdge-Zlib] [{}-SyncRun] "sv
+                    "Out-of-bounds input buffer."sv,
+                    Msg);
+      return Unexpect(ErrCode::Value::HostFuncError);
+    }
+  }
+  if (ValidateOutputBuffer) {
+    if (unlikely(ModuleZStream->AvailOut != 0 && OutSpan.data() == nullptr)) {
+      spdlog::error("[WasmEdge-Zlib] [{}-SyncRun] "sv
+                    "Out-of-bounds output buffer."sv,
+                    Msg);
+      return Unexpect(ErrCode::Value::HostFuncError);
+    }
   }
 
   HostZStream->next_in = InSpan.data();
@@ -127,78 +138,65 @@ auto SyncRun(const std::string_view &Msg, WasmEdgeZlibEnvironment &Env,
   unsigned char *PreComputeName{};
   unsigned char *PreComputeComment{};
 
-  if (GZHeaderStoreIt != Env.GZHeaderMap.end()) {
-    // Sync GZ Header
-
+  // Only inflate() syncs the header, and only the guest-owned INPUT fields:
+  // the buffer locations (extra/name/comment) and their *_max capacities,
+  // re-validated against linear memory every call; a guest null (0) location
+  // is zlib's Z_NULL ("field not requested") and must not resolve to wasm
+  // address 0. The OUTPUT fields (text/time/xflags/os/extra_len/hcrc/done)
+  // stay zlib-owned and flow guest-ward only in the write-back below;
+  // re-injecting extra_len would let a guest drive the EXTRA-state write
+  // offset out of bounds. Cleanup/reset calls skip this (SyncGZHeader=false),
+  // so a corrupted *_max never aborts a stream teardown.
+  if (SyncGZHeader && GZHeaderStoreIt != Env.GZHeaderMap.end() &&
+      GZHeaderStoreIt->second->IsInflate) {
     auto *ModuleGZHeader = MemInst->getPointer<WasmGZHeader *>(
-        GZHeaderStoreIt->second.WasmGZHeaderOffset);
+        GZHeaderStoreIt->second->WasmGZHeaderOffset);
     if (unlikely(ModuleGZHeader == nullptr)) {
       spdlog::error("[WasmEdge-Zlib] [{}-SyncRun] "sv
                     "Out-of-bounds gzip header."sv,
                     Msg);
       return Unexpect(ErrCode::Value::HostFuncError);
     }
-    auto *HostGZHeader = GZHeaderStoreIt->second.HostGZHeader.get();
-    const bool IsInflate = GZHeaderStoreIt->second.IsInflate;
+    auto *HostGZHeader = GZHeaderStoreIt->second->HostGZHeader.get();
 
-    HostGZHeader->text = ModuleGZHeader->Text;
-    HostGZHeader->time = ModuleGZHeader->Time;
-    HostGZHeader->xflags = ModuleGZHeader->XFlags;
-    HostGZHeader->os = ModuleGZHeader->OS;
-
-    // inflateGetHeader writes into the buffers (bounded by *_max); the strings
-    // are read back as-is. deflateSetHeader reads the buffers: extra spans
-    // extra_len bytes and name/comment are zlib-scanned C strings.
-    const uint32_t ExtraCap =
-        IsInflate ? ModuleGZHeader->ExtraMax : ModuleGZHeader->ExtraLen;
-    const auto ExtraSpan =
-        MemInst->getSpan<unsigned char>(ModuleGZHeader->Extra, ExtraCap);
-    if (unlikely(ExtraCap != 0 && ExtraSpan.data() == nullptr)) {
-      spdlog::error("[WasmEdge-Zlib] [{}-SyncRun] "sv
-                    "Out-of-bounds gzip header extra field."sv,
-                    Msg);
-      return Unexpect(ErrCode::Value::HostFuncError);
-    }
-    HostGZHeader->extra = ExtraSpan.data();
-    HostGZHeader->extra_len = ModuleGZHeader->ExtraLen;
-    HostGZHeader->extra_max = ModuleGZHeader->ExtraMax;
-
-    const auto BindHeaderString = [&](uint32_t FieldOffset, uint32_t MaxLen,
-                                      Bytef *&HostField) -> bool {
-      if (IsInflate) {
-        const auto FieldSpan =
-            MemInst->getSpan<unsigned char>(FieldOffset, MaxLen);
-        if (unlikely(MaxLen != 0 && FieldSpan.data() == nullptr)) {
-          return false;
-        }
-        HostField = FieldSpan.data();
-      } else if (FieldOffset != 0) {
-        const auto *FieldStr = getInBoundsCString(*MemInst, FieldOffset);
-        if (unlikely(FieldStr == nullptr)) {
-          return false;
-        }
-        HostField = reinterpret_cast<Bytef *>(const_cast<char *>(FieldStr));
-      } else {
-        HostField = nullptr;
+    bool FieldOOB = false;
+    // zlib never writes through a zero-capacity field yet still distinguishes
+    // the caller's non-null pointer from Z_NULL ("field not requested"), so a
+    // stale zero-capacity guest pointer past linear memory must stay non-null
+    // rather than read as an absent field; the shared dummy is never written
+    // (every header store is bounded by its *_max), and the delta write-back
+    // below leaves the guest offset untouched for it.
+    static unsigned char ZeroCapacityHeaderField = 0;
+    const auto ResolveField = [&](uint32_t Ptr,
+                                  uint32_t Max) -> unsigned char * {
+      if (Ptr == 0) {
+        return nullptr;
       }
-      return true;
+      const auto FieldSpan = MemInst->getSpan<unsigned char>(Ptr, Max);
+      if (FieldSpan.data() == nullptr) {
+        if (unlikely(Max != 0)) {
+          FieldOOB = true;
+        } else {
+          return &ZeroCapacityHeaderField;
+        }
+      }
+      return FieldSpan.data();
     };
-
-    if (unlikely(
-            !BindHeaderString(ModuleGZHeader->Name, ModuleGZHeader->NameMax,
-                              HostGZHeader->name) ||
-            !BindHeaderString(ModuleGZHeader->Comment, ModuleGZHeader->CommMax,
-                              HostGZHeader->comment))) {
+    HostGZHeader->extra =
+        ResolveField(ModuleGZHeader->Extra, ModuleGZHeader->ExtraMax);
+    HostGZHeader->extra_max = ModuleGZHeader->ExtraMax;
+    HostGZHeader->name =
+        ResolveField(ModuleGZHeader->Name, ModuleGZHeader->NameMax);
+    HostGZHeader->name_max = ModuleGZHeader->NameMax;
+    HostGZHeader->comment =
+        ResolveField(ModuleGZHeader->Comment, ModuleGZHeader->CommMax);
+    HostGZHeader->comm_max = ModuleGZHeader->CommMax;
+    if (unlikely(FieldOOB)) {
       spdlog::error("[WasmEdge-Zlib] [{}-SyncRun] "sv
-                    "Out-of-bounds gzip header name/comment field."sv,
+                    "Out-of-bounds gzip header buffer."sv,
                     Msg);
       return Unexpect(ErrCode::Value::HostFuncError);
     }
-    HostGZHeader->name_max = ModuleGZHeader->NameMax;
-    HostGZHeader->comm_max = ModuleGZHeader->CommMax;
-
-    HostGZHeader->hcrc = ModuleGZHeader->HCRC;
-    HostGZHeader->done = ModuleGZHeader->Done;
 
     PreComputeExtra = HostGZHeader->extra;
     PreComputeName = HostGZHeader->name;
@@ -223,30 +221,46 @@ auto SyncRun(const std::string_view &Msg, WasmEdgeZlibEnvironment &Env,
   ModuleZStream->Adler = HostZStream->adler;
   ModuleZStream->Reserved = HostZStream->reserved;
 
-  if (GZHeaderStoreIt != Env.GZHeaderMap.end()) {
-    // Sync GZ Header
-
+  if (SyncGZHeader && GZHeaderStoreIt != Env.GZHeaderMap.end() &&
+      GZHeaderStoreIt->second->IsInflate) {
     auto *ModuleGZHeader = MemInst->getPointer<WasmGZHeader *>(
-        GZHeaderStoreIt->second.WasmGZHeaderOffset);
-    auto *HostGZHeader = GZHeaderStoreIt->second.HostGZHeader.get();
+        GZHeaderStoreIt->second->WasmGZHeaderOffset);
+    if (ModuleGZHeader != nullptr) {
+      auto *HostGZHeader = GZHeaderStoreIt->second->HostGZHeader.get();
 
-    ModuleGZHeader->Text = HostGZHeader->text;
-    ModuleGZHeader->Time = HostGZHeader->time;
-    ModuleGZHeader->XFlags = HostGZHeader->xflags;
-    ModuleGZHeader->OS = HostGZHeader->os;
+      ModuleGZHeader->Text = HostGZHeader->text;
+      ModuleGZHeader->Time = HostGZHeader->time;
+      ModuleGZHeader->XFlags = HostGZHeader->xflags;
+      ModuleGZHeader->OS = HostGZHeader->os;
 
-    ModuleGZHeader->Extra += HostGZHeader->extra - PreComputeExtra;
-    ModuleGZHeader->ExtraLen = HostGZHeader->extra_len;
-    ModuleGZHeader->ExtraMax = HostGZHeader->extra_max;
+      // zlib sets an absent optional field's pointer to Z_NULL "to signal its
+      // absence" even when a buffer was supplied; surface that as guest null
+      // instead of subtracting a live pointer from null.
+      if (HostGZHeader->extra == Z_NULL) {
+        ModuleGZHeader->Extra = 0;
+      } else if (PreComputeExtra != nullptr) {
+        ModuleGZHeader->Extra += HostGZHeader->extra - PreComputeExtra;
+      }
+      ModuleGZHeader->ExtraLen = HostGZHeader->extra_len;
+      ModuleGZHeader->ExtraMax = HostGZHeader->extra_max;
 
-    ModuleGZHeader->Name += HostGZHeader->name - PreComputeName;
-    ModuleGZHeader->NameMax = HostGZHeader->name_max;
+      if (HostGZHeader->name == Z_NULL) {
+        ModuleGZHeader->Name = 0;
+      } else if (PreComputeName != nullptr) {
+        ModuleGZHeader->Name += HostGZHeader->name - PreComputeName;
+      }
+      ModuleGZHeader->NameMax = HostGZHeader->name_max;
 
-    ModuleGZHeader->Comment += HostGZHeader->comment - PreComputeComment;
-    ModuleGZHeader->CommMax = HostGZHeader->comm_max;
+      if (HostGZHeader->comment == Z_NULL) {
+        ModuleGZHeader->Comment = 0;
+      } else if (PreComputeComment != nullptr) {
+        ModuleGZHeader->Comment += HostGZHeader->comment - PreComputeComment;
+      }
+      ModuleGZHeader->CommMax = HostGZHeader->comm_max;
 
-    ModuleGZHeader->HCRC = HostGZHeader->hcrc;
-    ModuleGZHeader->Done = HostGZHeader->done;
+      ModuleGZHeader->HCRC = HostGZHeader->hcrc;
+      ModuleGZHeader->Done = HostGZHeader->done;
+    }
   }
 
   return ZRes;
@@ -278,9 +292,14 @@ WasmEdgeZlibDeflateInit::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> WasmEdgeZlibDeflate::WasmEdgeZlibDeflate::body(
     const Runtime::CallingFrame &Frame, uint32_t ZStreamPtr, int32_t Flush) {
 
+  // deflate() refuses a flush outside [Z_NO_FLUSH, Z_BLOCK] before touching
+  // next_in or next_out, so as with deflateParams validate the buffers only
+  // for a flush value zlib will service.
+  const bool FlushValid = Flush >= Z_NO_FLUSH && Flush <= Z_BLOCK;
   return SyncRun(
       "WasmEdgeZlibDeflate", Env, ZStreamPtr, Frame,
-      [&](z_stream *HostZStream) { return deflate(HostZStream, Flush); });
+      [&](z_stream *HostZStream) { return deflate(HostZStream, Flush); },
+      /*ValidateInputBuffer=*/FlushValid, /*ValidateOutputBuffer=*/FlushValid);
 }
 
 Expect<int32_t> WasmEdgeZlibDeflateEnd::body(const Runtime::CallingFrame &Frame,
@@ -290,8 +309,16 @@ Expect<int32_t> WasmEdgeZlibDeflateEnd::body(const Runtime::CallingFrame &Frame,
       SyncRun("WasmEdgeZlibDeflateEnd", Env, ZStreamPtr, Frame,
               [&](z_stream *HostZStream) { return deflateEnd(HostZStream); });
 
-  if (ZRes == Z_OK)
+  // deflateEnd frees zlib's internal state on both Z_OK and Z_DATA_ERROR (the
+  // latter when the stream is ended mid-compression), so drop the host tracking
+  // on either result. Only Z_STREAM_ERROR (an already-invalid stream) leaves
+  // it.
+  if (ZRes == Z_OK || ZRes == Z_DATA_ERROR) {
     Env.ZStreamMap.erase(ZStreamPtr);
+    // Drop the header snapshot; zlib no longer references it after deflateEnd.
+    // A deflateCopy'd stream that shares it keeps it alive via the shared_ptr.
+    Env.GZHeaderMap.erase(ZStreamPtr);
+  }
 
   return ZRes;
 }
@@ -324,7 +351,9 @@ Expect<int32_t> WasmEdgeZlibInflate::body(const Runtime::CallingFrame &Frame,
 
   return SyncRun(
       "WasmEdgeZlibInflate", Env, ZStreamPtr, Frame,
-      [&](z_stream *HostZStream) { return inflate(HostZStream, Flush); });
+      [&](z_stream *HostZStream) { return inflate(HostZStream, Flush); },
+      /*ValidateInputBuffer=*/true, /*ValidateOutputBuffer=*/true,
+      /*SyncGZHeader=*/true);
 }
 
 Expect<int32_t> WasmEdgeZlibInflateEnd::body(const Runtime::CallingFrame &Frame,
@@ -335,6 +364,9 @@ Expect<int32_t> WasmEdgeZlibInflateEnd::body(const Runtime::CallingFrame &Frame,
               [&](z_stream *HostZStream) { return inflateEnd(HostZStream); });
 
   Env.ZStreamMap.erase(ZStreamPtr);
+  // Drop the header snapshot captured by inflateGetHeader; zlib no longer
+  // references it after inflateEnd.
+  Env.GZHeaderMap.erase(ZStreamPtr);
 
   return ZRes;
 }
@@ -456,8 +488,19 @@ WasmEdgeZlibDeflateCopy::body(const Runtime::CallingFrame &Frame,
                               return deflateCopy(DestZStream, SourceZStream);
                             });
 
-  if (ZRes != Z_OK && Inserted)
-    Env.ZStreamMap.erase(It);
+  if (ZRes != Z_OK) {
+    if (Inserted)
+      Env.ZStreamMap.erase(It);
+    return ZRes;
+  }
+
+  // deflateCopy duplicated the source's internal gz_header pointer into the
+  // destination stream. Share the same reference-counted header snapshot so it
+  // stays alive for the copy even after the source later replaces or ends its
+  // own header; the deflate snapshot is immutable, so sharing is safe.
+  const auto SourceHeaderIt = Env.GZHeaderMap.find(SourcePtr);
+  if (SourceHeaderIt != Env.GZHeaderMap.end())
+    Env.GZHeaderMap.insert_or_assign(DestPtr, SourceHeaderIt->second);
 
   return ZRes;
 }
@@ -476,10 +519,22 @@ WasmEdgeZlibDeflateParams::body(const Runtime::CallingFrame &Frame,
                                 uint32_t ZStreamPtr, int32_t Level,
                                 int32_t Strategy) {
 
-  return SyncRun("WasmEdgeZlibDeflateParams", Env, ZStreamPtr, Frame,
-                 [&](z_stream *HostZStream) {
-                   return deflateParams(HostZStream, Level, Strategy);
-                 });
+  // deflateParams rejects an out-of-range level or strategy before consuming
+  // next_in or producing into next_out, so buffers only need to prove
+  // themselves for a call zlib will actually service; a rejected call still
+  // gets zlib's Z_STREAM_ERROR, and an unresolved span stays untouched
+  // because deflate() re-checks null buffers itself.
+  const bool ParamsValid =
+      (Level == Z_DEFAULT_COMPRESSION || (Level >= 0 && Level <= 9)) &&
+      Strategy >= 0 && Strategy <= Z_FIXED;
+
+  return SyncRun(
+      "WasmEdgeZlibDeflateParams", Env, ZStreamPtr, Frame,
+      [&](z_stream *HostZStream) {
+        return deflateParams(HostZStream, Level, Strategy);
+      },
+      /*ValidateInputBuffer=*/ParamsValid,
+      /*ValidateOutputBuffer=*/ParamsValid);
 }
 
 Expect<int32_t> WasmEdgeZlibDeflateTune::body(
@@ -534,15 +589,112 @@ Expect<int32_t>
 WasmEdgeZlibDeflateSetHeader::body(const Runtime::CallingFrame &Frame,
                                    uint32_t ZStreamPtr, uint32_t HeadPtr) {
 
-  auto HostGZHeader = std::make_unique<gz_header>();
-  auto HostGZHeaderPtr = HostGZHeader.get();
+  MEMINST_CHECK(MemInst, Frame, 0)
 
-  const auto [It, Inserted] = Env.GZHeaderMap.emplace(
-      std::pair<uint32_t, WasmEdgeZlibEnvironment::GZStore>{
-          ZStreamPtr, WasmEdgeZlibEnvironment::GZStore{
-                          .WasmGZHeaderOffset = HeadPtr,
-                          .IsInflate = false,
-                          .HostGZHeader = std::move(HostGZHeader)}});
+  // Native deflateSetHeader accepts Z_NULL and reverts the stream to the
+  // default gzip header; guest null (0) takes that path rather than
+  // dereferencing wasm address 0. zlib then retains no pointer into any
+  // snapshot, so a published one can be dropped.
+  if (HeadPtr == 0) {
+    const auto ZRes = SyncRun("WasmEdgeZlibDeflateSetHeader", Env, ZStreamPtr,
+                              Frame, [&](z_stream *HostZStream) {
+                                return deflateSetHeader(HostZStream, Z_NULL);
+                              });
+    if (ZRes && *ZRes == Z_OK)
+      Env.GZHeaderMap.erase(ZStreamPtr);
+    return ZRes;
+  }
+
+  // Get zlib's verdict before any guest-header work: only a gzip deflate
+  // stream accepts a header, and deflateSetHeader merely validates the stream
+  // and stores the pointer, so re-storing the currently published snapshot
+  // (or Z_NULL when none was published) changes nothing. A stream zlib
+  // rejects thus fails with its cheap Z_STREAM_ERROR before the host reads
+  // the header or snapshots a guest-sized extra/name/comment into host
+  // memory, and an invalid ZStreamPtr still traps inside SyncRun.
+  {
+    const auto StoreIt = Env.GZHeaderMap.find(ZStreamPtr);
+    gz_header *CurrentHead = StoreIt != Env.GZHeaderMap.end()
+                                 ? StoreIt->second->HostGZHeader.get()
+                                 : Z_NULL;
+    const auto ProbeRes =
+        SyncRun("WasmEdgeZlibDeflateSetHeader", Env, ZStreamPtr, Frame,
+                [&](z_stream *HostZStream) {
+                  return deflateSetHeader(HostZStream, CurrentHead);
+                });
+    if (!ProbeRes || *ProbeRes != Z_OK) {
+      return ProbeRes;
+    }
+  }
+
+  auto *ModuleGZHeader = MemInst->getPointer<WasmGZHeader *>(HeadPtr);
+  if (unlikely(ModuleGZHeader == nullptr)) {
+    spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibDeflateSetHeader] "sv
+                  "Out-of-bounds gzip header."sv);
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
+
+  // Snapshot the header into host-owned storage; deflate() emits the name and
+  // comment incrementally across calls (resuming at an internal index), so the
+  // buffers must stay stable and must not be re-read from mutable guest memory.
+  // The store is heap-allocated and reference-counted so deflateCopy can hand
+  // the same snapshot to a copied stream; its address stays stable, so the
+  // bound buffer pointers remain valid once it is inserted into the map.
+  auto Store = std::make_shared<WasmEdgeZlibEnvironment::GZStore>();
+  Store->WasmGZHeaderOffset = HeadPtr;
+  Store->IsInflate = false;
+  Store->HostGZHeader = std::make_unique<gz_header>();
+
+  const bool HasExtra =
+      ModuleGZHeader->Extra != 0 && ModuleGZHeader->ExtraLen != 0;
+  const bool HasName = ModuleGZHeader->Name != 0;
+  const bool HasComment = ModuleGZHeader->Comment != 0;
+
+  if (HasExtra) {
+    const auto ExtraSpan = MemInst->getSpan<Bytef>(ModuleGZHeader->Extra,
+                                                   ModuleGZHeader->ExtraLen);
+    if (unlikely(ExtraSpan.data() == nullptr)) {
+      spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibDeflateSetHeader] "sv
+                    "Out-of-bounds gzip header extra field."sv);
+      return Unexpect(ErrCode::Value::HostFuncError);
+    }
+    Store->Extra.assign(ExtraSpan.begin(), ExtraSpan.end());
+  }
+  if (HasName) {
+    const auto *NameStr = getInBoundsCString(*MemInst, ModuleGZHeader->Name);
+    if (unlikely(NameStr == nullptr)) {
+      spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibDeflateSetHeader] "sv
+                    "Out-of-bounds gzip header name field."sv);
+      return Unexpect(ErrCode::Value::HostFuncError);
+    }
+    Store->Name = NameStr;
+  }
+  if (HasComment) {
+    const auto *CommentStr =
+        getInBoundsCString(*MemInst, ModuleGZHeader->Comment);
+    if (unlikely(CommentStr == nullptr)) {
+      spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibDeflateSetHeader] "sv
+                    "Out-of-bounds gzip header comment field."sv);
+      return Unexpect(ErrCode::Value::HostFuncError);
+    }
+    Store->Comment = CommentStr;
+  }
+
+  Store->HostGZHeader->text = ModuleGZHeader->Text;
+  Store->HostGZHeader->time = ModuleGZHeader->Time;
+  Store->HostGZHeader->xflags = ModuleGZHeader->XFlags;
+  Store->HostGZHeader->os = ModuleGZHeader->OS;
+  Store->HostGZHeader->hcrc = ModuleGZHeader->HCRC;
+  Store->HostGZHeader->extra_len = ModuleGZHeader->ExtraLen;
+
+  // Point the gz_header at the store's own snapshot buffers. The store keeps a
+  // stable heap address, so this binding stays valid after it is inserted.
+  auto *HostGZHeaderPtr = Store->HostGZHeader.get();
+  HostGZHeaderPtr->extra = HasExtra ? Store->Extra.data() : Z_NULL;
+  HostGZHeaderPtr->name =
+      HasName ? reinterpret_cast<Bytef *>(Store->Name.data()) : Z_NULL;
+  HostGZHeaderPtr->comment =
+      HasComment ? reinterpret_cast<Bytef *>(Store->Comment.data()) : Z_NULL;
 
   const auto ZRes =
       SyncRun("WasmEdgeZlibDeflateSetHeader", Env, ZStreamPtr, Frame,
@@ -550,8 +702,11 @@ WasmEdgeZlibDeflateSetHeader::body(const Runtime::CallingFrame &Frame,
                 return deflateSetHeader(HostZStream, HostGZHeaderPtr);
               });
 
-  if (ZRes != Z_OK && Inserted)
-    Env.GZHeaderMap.erase(It);
+  // Publish the snapshot only after zlib accepts it. On any failure the
+  // previously stored header stays in place, since zlib (or a deflateCopy'd
+  // stream) may still hold a pointer into it from an earlier success.
+  if (ZRes == Z_OK)
+    Env.GZHeaderMap.insert_or_assign(ZStreamPtr, std::move(Store));
 
   return ZRes;
 }
@@ -631,7 +786,8 @@ WasmEdgeZlibInflateSync::body(const Runtime::CallingFrame &Frame,
 
   return SyncRun(
       "WasmEdgeZlibInflateSync", Env, ZStreamPtr, Frame,
-      [&](z_stream *HostZStream) { return inflateSync(HostZStream); });
+      [&](z_stream *HostZStream) { return inflateSync(HostZStream); },
+      /*ValidateInputBuffer=*/true);
 }
 
 Expect<int32_t>
@@ -663,8 +819,19 @@ WasmEdgeZlibInflateCopy::body(const Runtime::CallingFrame &Frame,
                               return inflateCopy(DestZStream, SourceZStream);
                             });
 
-  if (ZRes != Z_OK && Inserted)
-    Env.ZStreamMap.erase(It);
+  if (ZRes != Z_OK) {
+    if (Inserted)
+      Env.ZStreamMap.erase(It);
+    return ZRes;
+  }
+
+  // inflateCopy duplicated the source's internal gz_header pointer into the
+  // destination stream. Share the same reference-counted header snapshot so it
+  // stays alive for the copy even after the source later replaces or ends its
+  // own header; zlib's copied head aliases this exact host storage.
+  const auto SourceHeaderIt = Env.GZHeaderMap.find(SourcePtr);
+  if (SourceHeaderIt != Env.GZHeaderMap.end())
+    Env.GZHeaderMap.insert_or_assign(DestPtr, SourceHeaderIt->second);
 
   return ZRes;
 }
@@ -673,19 +840,37 @@ Expect<int32_t>
 WasmEdgeZlibInflateReset::body(const Runtime::CallingFrame &Frame,
                                uint32_t ZStreamPtr) {
 
-  return SyncRun(
-      "WasmEdgeZlibInflateReset", Env, ZStreamPtr, Frame,
-      [&](z_stream *HostZStream) { return inflateReset(HostZStream); });
+  const auto ZRes =
+      SyncRun("WasmEdgeZlibInflateReset", Env, ZStreamPtr, Frame,
+              [&](z_stream *HostZStream) { return inflateReset(HostZStream); });
+
+  // A successful inflate reset detaches zlib's internal gzip-header pointer
+  // (the guest must call inflateGetHeader again for the next stream), so the
+  // snapshot must be dropped with it: a stale entry would keep re-validating
+  // and rewriting a guest header zlib no longer references, failing legitimate
+  // post-reset inflate calls once the guest reuses that memory. deflate resets
+  // keep zlib's gzhead, so deflate snapshots must stay alive.
+  if (ZRes && *ZRes == Z_OK)
+    Env.GZHeaderMap.erase(ZStreamPtr);
+
+  return ZRes;
 }
 
 Expect<int32_t>
 WasmEdgeZlibInflateReset2::body(const Runtime::CallingFrame &Frame,
                                 uint32_t ZStreamPtr, int32_t WindowBits) {
 
-  return SyncRun("WasmEdgeZlibInflateReset2", Env, ZStreamPtr, Frame,
-                 [&](z_stream *HostZStream) {
-                   return inflateReset2(HostZStream, WindowBits);
-                 });
+  const auto ZRes = SyncRun("WasmEdgeZlibInflateReset2", Env, ZStreamPtr, Frame,
+                            [&](z_stream *HostZStream) {
+                              return inflateReset2(HostZStream, WindowBits);
+                            });
+
+  // inflateReset2 detaches zlib's gzip-header pointer like inflateReset; drop
+  // the stale snapshot (see WasmEdgeZlibInflateReset).
+  if (ZRes && *ZRes == Z_OK)
+    Env.GZHeaderMap.erase(ZStreamPtr);
+
+  return ZRes;
 }
 
 Expect<int32_t>
@@ -712,15 +897,22 @@ Expect<int32_t>
 WasmEdgeZlibInflateGetHeader::body(const Runtime::CallingFrame &Frame,
                                    uint32_t ZStreamPtr, uint32_t HeadPtr) {
 
-  auto HostGZHeader = std::make_unique<gz_header>();
-  auto HostGZHeaderPtr = HostGZHeader.get();
+  MEMINST_CHECK(MemInst, Frame, 0)
 
-  const auto [It, Inserted] = Env.GZHeaderMap.emplace(
-      std::pair<uint32_t, WasmEdgeZlibEnvironment::GZStore>{
-          ZStreamPtr, WasmEdgeZlibEnvironment::GZStore{
-                          .WasmGZHeaderOffset = HeadPtr,
-                          .IsInflate = true,
-                          .HostGZHeader = std::move(HostGZHeader)}});
+  // Validate the guest header pointer up front (like deflateSetHeader) so an
+  // out-of-bounds HeadPtr is rejected here instead of being stored and then
+  // failing every later inflate/cleanup call once zlib has accepted the stream.
+  if (unlikely(MemInst->getPointer<WasmGZHeader *>(HeadPtr) == nullptr)) {
+    spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibInflateGetHeader] "sv
+                  "Out-of-bounds gzip header."sv);
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
+
+  auto Store = std::make_shared<WasmEdgeZlibEnvironment::GZStore>();
+  Store->WasmGZHeaderOffset = HeadPtr;
+  Store->IsInflate = true;
+  Store->HostGZHeader = std::make_unique<gz_header>();
+  auto *HostGZHeaderPtr = Store->HostGZHeader.get();
 
   const auto ZRes =
       SyncRun("WasmEdgeZlibInflateGetHeader", Env, ZStreamPtr, Frame,
@@ -728,8 +920,12 @@ WasmEdgeZlibInflateGetHeader::body(const Runtime::CallingFrame &Frame,
                 return inflateGetHeader(HostZStream, HostGZHeaderPtr);
               });
 
-  if (ZRes != Z_OK && Inserted)
-    Env.GZHeaderMap.erase(It);
+  // Publish the snapshot only after zlib accepts it and points its internal
+  // head at it. A repeated call replaces the previous snapshot, which zlib no
+  // longer references; on failure zlib left its head untouched, so the local
+  // store is simply dropped and any previously stored header stays in place.
+  if (ZRes == Z_OK)
+    Env.GZHeaderMap.insert_or_assign(ZStreamPtr, std::move(Store));
 
   return ZRes;
 }
@@ -1220,7 +1416,10 @@ Expect<int32_t> WasmEdgeZlibGZClose_r::body(const Runtime::CallingFrame &,
 
   const auto ZRes = gzclose_r(GZFileIt->second);
 
-  Env.GZFileMap.erase(GZFileIt);
+  // Z_STREAM_ERROR means the handle was the wrong mode and was NOT freed; keep
+  // it so the environment destructor can still reclaim it.
+  if (ZRes != Z_STREAM_ERROR)
+    Env.GZFileMap.erase(GZFileIt);
 
   return ZRes;
 }
@@ -1236,7 +1435,10 @@ Expect<int32_t> WasmEdgeZlibGZClose_w::body(const Runtime::CallingFrame &,
 
   const auto ZRes = gzclose_w(GZFileIt->second);
 
-  Env.GZFileMap.erase(GZFileIt);
+  // Z_STREAM_ERROR means the handle was the wrong mode and was NOT freed; keep
+  // it so the environment destructor can still reclaim it.
+  if (ZRes != Z_STREAM_ERROR)
+    Env.GZFileMap.erase(GZFileIt);
 
   return ZRes;
 }
@@ -1573,7 +1775,14 @@ WasmEdgeZlibInflateResetKeep::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return inflateResetKeep(HostZStreamIt->second.get());
+  const auto ZRes = inflateResetKeep(HostZStreamIt->second.get());
+
+  // inflateResetKeep detaches zlib's gzip-header pointer like inflateReset;
+  // drop the stale snapshot (see WasmEdgeZlibInflateReset).
+  if (ZRes == Z_OK)
+    Env.GZHeaderMap.erase(ZStreamPtr);
+
+  return ZRes;
 }
 
 Expect<int32_t>

--- a/plugins/wasmedge_zlib/zlibfunc.cpp
+++ b/plugins/wasmedge_zlib/zlibfunc.cpp
@@ -4,6 +4,8 @@
 #include "zlibfunc.h"
 
 #include <cstring>
+#include <optional>
+#include <string_view>
 
 namespace WasmEdge {
 namespace Host {
@@ -38,10 +40,23 @@ namespace Host {
     return Unexpect(ErrCode::Value::HostFuncError);                            \
   }
 
+// zlib's versioned init entry points reject a null or major-mismatched version
+// before they examine any other argument.
+static inline bool CheckVersion(const char *Version) noexcept {
+  return Version != nullptr && Version[0] == ZLIB_VERSION[0];
+}
+
 constexpr bool CheckSize(int32_t StreamSize) {
 
   return (StreamSize == static_cast<int32_t>(sizeof(WasmZStream)));
 }
+
+constexpr uint64_t MaxGZHeaderStringLen = UINT64_C(1) << 20;
+
+// zlib's versioned initializers inspect only version[0], so cap the version
+// scan well above any real ZLIB_VERSION instead of letting a guest pointer
+// into a large non-NUL region drive an unbounded memchr over linear memory.
+constexpr uint64_t MaxZlibVersionLen = 63;
 
 // Return an in-bounds, NUL-terminated C string starting at `Offset`, or nullptr
 // when the offset is out of bounds or no terminator exists before the end of
@@ -61,6 +76,27 @@ getInBoundsCString(const Runtime::Instance::MemoryInstance &MemInst,
     return nullptr;
   }
   return Str;
+}
+
+static inline std::optional<std::string_view>
+getBoundedInBoundsCString(const Runtime::Instance::MemoryInstance &MemInst,
+                          uint32_t Offset, uint64_t MaxLen) noexcept {
+  const uint64_t MemSize = MemInst.getSize();
+  if (unlikely(Offset >= MemSize)) {
+    return std::nullopt;
+  }
+  const auto *Str = MemInst.getPointer<const char *>(Offset);
+  if (unlikely(Str == nullptr)) {
+    return std::nullopt;
+  }
+  const uint64_t Remaining = MemSize - Offset;
+  const uint64_t Bound = MaxLen == UINT64_MAX ? Remaining : MaxLen + 1;
+  const uint64_t ScanLen = Remaining < Bound ? Remaining : Bound;
+  const auto *End = static_cast<const char *>(std::memchr(Str, '\0', ScanLen));
+  if (unlikely(End == nullptr)) {
+    return std::nullopt;
+  }
+  return std::string_view(Str, static_cast<size_t>(End - Str));
 }
 
 template <typename T>
@@ -86,7 +122,7 @@ auto SyncRun(const std::string_view &Msg, WasmEdgeZlibEnvironment &Env,
                   Msg);
     return Unexpect(ErrCode::Value::HostFuncError);
   }
-  auto HostZStream = HostZStreamIt->second.get();
+  auto *HostZStream = &HostZStreamIt->second.Z;
   const auto GZHeaderStoreIt = Env.GZHeaderMap.find(ZStreamPtr);
 
   const auto InSpan = MemInst->getSpan<unsigned char>(ModuleZStream->NextIn,
@@ -205,11 +241,21 @@ auto SyncRun(const std::string_view &Msg, WasmEdgeZlibEnvironment &Env,
 
   const auto ZRes = Callback(HostZStream);
 
-  ModuleZStream->NextIn += HostZStream->next_in - PreComputeNextIn;
+  // deflateCopy/inflateCopy overwrite the host stream with the source's
+  // retained next_in/next_out, so copying onto a destination whose own buffer
+  // did not resolve can leave one side of this delta null while the other is a
+  // live pointer. Subtracting a null from a non-null pointer is undefined, so
+  // advance the guest offset only when both ends are real; every other callback
+  // keeps both ends in the same buffer, where the guard always passes.
+  if (HostZStream->next_in != nullptr && PreComputeNextIn != nullptr) {
+    ModuleZStream->NextIn += HostZStream->next_in - PreComputeNextIn;
+  }
   ModuleZStream->AvailIn = HostZStream->avail_in;
   ModuleZStream->TotalIn = HostZStream->total_in;
 
-  ModuleZStream->NextOut += HostZStream->next_out - PreComputeNextOut;
+  if (HostZStream->next_out != nullptr && PreComputeNextOut != nullptr) {
+    ModuleZStream->NextOut += HostZStream->next_out - PreComputeNextOut;
+  }
   ModuleZStream->AvailOut = HostZStream->avail_out;
   ModuleZStream->TotalOut = HostZStream->total_out;
 
@@ -266,44 +312,96 @@ auto SyncRun(const std::string_view &Msg, WasmEdgeZlibEnvironment &Env,
   return ZRes;
 }
 
-Expect<int32_t>
-WasmEdgeZlibDeflateInit::body(const Runtime::CallingFrame &Frame,
-                              uint32_t ZStreamPtr, int32_t Level) {
+// Create a fresh tracked stream, run zlib's init on it, and reject re-init over
+// a live key. Running an init on an already-initialized z_stream would let zlib
+// overwrite strm->state and leak the previous internal state (unbounded, since
+// nothing else frees it). On a failed init the (empty) entry is dropped so the
+// guest may retry.
+template <typename InitFn>
+Expect<int32_t> initStream(const std::string_view &Msg,
+                           WasmEdgeZlibEnvironment &Env, uint32_t ZStreamPtr,
+                           const Runtime::CallingFrame &Frame, ZStreamKind Kind,
+                           InitFn Init) {
+  const auto [It, Inserted] = Env.ZStreamMap.try_emplace(ZStreamPtr, Kind);
+  if (unlikely(!Inserted)) {
+    spdlog::error("[WasmEdge-Zlib] [{}] "
+                  "Re-initializing a stream that is still live."sv,
+                  Msg);
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
-  auto NewZStream = std::make_unique<z_stream>();
-  NewZStream->zalloc = Z_NULL;
-  NewZStream->zfree = Z_NULL;
-  NewZStream->opaque =
-      Z_NULL; // ignore opaque since zmalloc and zfree was ignored
+  const auto ZRes = SyncRun(Msg, Env, ZStreamPtr, Frame, Init);
 
-  const auto [It, Inserted] =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
-
-  const auto ZRes = SyncRun(
-      "WasmEdgeZlibDeflateInit", Env, ZStreamPtr, Frame,
-      [&](z_stream *HostZStream) { return deflateInit(HostZStream, Level); });
-
-  if (ZRes != Z_OK && Inserted)
+  // An errored Expect compares unequal to nothing (both == and != yield
+  // false), so test it explicitly: a SyncRun trap must also drop the entry,
+  // or the failed key would be treated as live forever.
+  if (!ZRes || *ZRes != Z_OK)
     Env.ZStreamMap.erase(It);
 
   return ZRes;
 }
 
+// zlib's stream functions verify the stream kind first (deflateStateCheck /
+// inflateStateCheck) and answer a mismatched stream with Z_STREAM_ERROR
+// before reading or writing anything else. Classic zlib decides that
+// deterministically for a deflate<->inflate mix (the punned status and mode
+// value ranges are disjoint), but zlib-ng's layouts differ enough that the
+// same probe reads arbitrary fields: a cross-kind call may pass its checks
+// and then free garbage pointers (deflateEnd), overwrite live internal state
+// (inflateReset/inflatePrime/inflateValidate), or copy past the allocation
+// (inflateCopy) -- and inflateBackEnd frees whatever state it is handed
+// without any check at all. Answer from the tracked kind instead of entering
+// zlib with a mismatched state; an untracked ZStreamPtr keeps its usual trap.
+static inline bool streamKindMismatch(const WasmEdgeZlibEnvironment &Env,
+                                      uint32_t ZStreamPtr,
+                                      ZStreamKind Expected) noexcept {
+  const auto It = Env.ZStreamMap.find(ZStreamPtr);
+  return It != Env.ZStreamMap.end() && It->second.Kind != Expected;
+}
+
+Expect<int32_t>
+WasmEdgeZlibDeflateInit::body(const Runtime::CallingFrame &Frame,
+                              uint32_t ZStreamPtr, int32_t Level) {
+  return initStream(
+      "WasmEdgeZlibDeflateInit", Env, ZStreamPtr, Frame, ZStreamKind::Deflate,
+      [&](z_stream *HostZStream) { return deflateInit(HostZStream, Level); });
+}
+
 Expect<int32_t> WasmEdgeZlibDeflate::WasmEdgeZlibDeflate::body(
     const Runtime::CallingFrame &Frame, uint32_t ZStreamPtr, int32_t Flush) {
+
+  if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::Deflate)) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
   // deflate() refuses a flush outside [Z_NO_FLUSH, Z_BLOCK] before touching
   // next_in or next_out, so as with deflateParams validate the buffers only
   // for a flush value zlib will service.
   const bool FlushValid = Flush >= Z_NO_FLUSH && Flush <= Z_BLOCK;
-  return SyncRun(
+  const auto ZRes = SyncRun(
       "WasmEdgeZlibDeflate", Env, ZStreamPtr, Frame,
       [&](z_stream *HostZStream) { return deflate(HostZStream, Flush); },
       /*ValidateInputBuffer=*/FlushValid, /*ValidateOutputBuffer=*/FlushValid);
+
+  // A deflate() that returns Z_OK/Z_STREAM_END has written the header and left
+  // INIT_STATE, the state a later deflateSetDictionary refuses; record it so
+  // that guard can answer without validating the dictionary span.
+  if (ZRes && (*ZRes == Z_OK || *ZRes == Z_STREAM_END)) {
+    if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
+        It != Env.ZStreamMap.end()) {
+      It->second.DeflateStarted = true;
+    }
+  }
+
+  return ZRes;
 }
 
 Expect<int32_t> WasmEdgeZlibDeflateEnd::body(const Runtime::CallingFrame &Frame,
                                              uint32_t ZStreamPtr) {
+
+  if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::Deflate)) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
   const auto ZRes =
       SyncRun("WasmEdgeZlibDeflateEnd", Env, ZStreamPtr, Frame,
@@ -312,8 +410,8 @@ Expect<int32_t> WasmEdgeZlibDeflateEnd::body(const Runtime::CallingFrame &Frame,
   // deflateEnd frees zlib's internal state on both Z_OK and Z_DATA_ERROR (the
   // latter when the stream is ended mid-compression), so drop the host tracking
   // on either result. Only Z_STREAM_ERROR (an already-invalid stream) leaves
-  // it.
-  if (ZRes == Z_OK || ZRes == Z_DATA_ERROR) {
+  // it, as does a SyncRun trap (zlib never ran, so nothing was freed).
+  if (ZRes && (*ZRes == Z_OK || *ZRes == Z_DATA_ERROR)) {
     Env.ZStreamMap.erase(ZStreamPtr);
     // Drop the header snapshot; zlib no longer references it after deflateEnd.
     // A deflateCopy'd stream that shares it keeps it alive via the shared_ptr.
@@ -326,47 +424,57 @@ Expect<int32_t> WasmEdgeZlibDeflateEnd::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t>
 WasmEdgeZlibInflateInit::body(const Runtime::CallingFrame &Frame,
                               uint32_t ZStreamPtr) {
-
-  auto NewZStream = std::make_unique<z_stream>();
-  NewZStream->zalloc = Z_NULL;
-  NewZStream->zfree = Z_NULL;
-  NewZStream->opaque =
-      Z_NULL; // ignore opaque since zmalloc and zfree was ignored
-
-  const auto [It, Inserted] =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
-
-  const auto ZRes =
-      SyncRun("WasmEdgeZlibInflateInit", Env, ZStreamPtr, Frame,
-              [&](z_stream *HostZStream) { return inflateInit(HostZStream); });
-
-  if (ZRes != Z_OK && Inserted)
-    Env.ZStreamMap.erase(It);
-
-  return ZRes;
+  return initStream(
+      "WasmEdgeZlibInflateInit", Env, ZStreamPtr, Frame, ZStreamKind::Inflate,
+      [&](z_stream *HostZStream) { return inflateInit(HostZStream); });
 }
 
 Expect<int32_t> WasmEdgeZlibInflate::body(const Runtime::CallingFrame &Frame,
                                           uint32_t ZStreamPtr, int32_t Flush) {
 
-  return SyncRun(
+  if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::Inflate)) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
+
+  const auto ZRes = SyncRun(
       "WasmEdgeZlibInflate", Env, ZStreamPtr, Frame,
       [&](z_stream *HostZStream) { return inflate(HostZStream, Flush); },
       /*ValidateInputBuffer=*/true, /*ValidateOutputBuffer=*/true,
       /*SyncGZHeader=*/true);
+
+  // Z_NEED_DICT is the only way into DICT mode, and only a later inflate()
+  // leaves it (a successful inflateSetDictionary keeps the mode until then),
+  // so inflate results alone track whether zlib may be awaiting a dictionary.
+  if (ZRes) {
+    if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
+        It != Env.ZStreamMap.end()) {
+      It->second.MayNeedDict = *ZRes == Z_NEED_DICT;
+    }
+  }
+
+  return ZRes;
 }
 
 Expect<int32_t> WasmEdgeZlibInflateEnd::body(const Runtime::CallingFrame &Frame,
                                              uint32_t ZStreamPtr) {
 
+  if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::Inflate)) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
+
   const auto ZRes =
       SyncRun("WasmEdgeZlibInflateEnd", Env, ZStreamPtr, Frame,
               [&](z_stream *HostZStream) { return inflateEnd(HostZStream); });
 
-  Env.ZStreamMap.erase(ZStreamPtr);
-  // Drop the header snapshot captured by inflateGetHeader; zlib no longer
-  // references it after inflateEnd.
-  Env.GZHeaderMap.erase(ZStreamPtr);
+  // Z_STREAM_ERROR means zlib did not free the stream (a wrong-type or
+  // already-invalid stream); keep the entry so its internal state is not leaked
+  // and the correct *End can still reclaim it. A SyncRun trap keeps it for the
+  // same reason. Any other result freed zlib's state, so drop the tracking and
+  // the header snapshot with it.
+  if (ZRes && *ZRes != Z_STREAM_ERROR) {
+    Env.ZStreamMap.erase(ZStreamPtr);
+    Env.GZHeaderMap.erase(ZStreamPtr);
+  }
 
   return ZRes;
 }
@@ -374,32 +482,39 @@ Expect<int32_t> WasmEdgeZlibInflateEnd::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t> WasmEdgeZlibDeflateInit2::body(
     const Runtime::CallingFrame &Frame, uint32_t ZStreamPtr, int32_t Level,
     int32_t Method, int32_t WindowBits, int32_t MemLevel, int32_t Strategy) {
-
-  auto NewZStream = std::make_unique<z_stream>();
-  NewZStream->zalloc = Z_NULL;
-  NewZStream->zfree = Z_NULL;
-  NewZStream->opaque =
-      Z_NULL; // ignore opaque since zmalloc and zfree was ignored
-
-  const auto [It, Inserted] =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
-
   const auto ZRes =
-      SyncRun("WasmEdgeZlibDeflateInit2", Env, ZStreamPtr, Frame,
-              [&](z_stream *HostZStream) {
-                return deflateInit2(HostZStream, Level, Method, WindowBits,
-                                    MemLevel, Strategy);
-              });
-
-  if (ZRes != Z_OK && Inserted)
-    Env.ZStreamMap.erase(It);
-
+      initStream("WasmEdgeZlibDeflateInit2", Env, ZStreamPtr, Frame,
+                 ZStreamKind::Deflate, [&](z_stream *HostZStream) {
+                   return deflateInit2(HostZStream, Level, Method, WindowBits,
+                                       MemLevel, Strategy);
+                 });
+  if (ZRes && *ZRes == Z_OK) {
+    if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
+        It != Env.ZStreamMap.end()) {
+      It->second.GzipWrap = WindowBits >= 16;
+      It->second.RawDeflate = WindowBits < 0;
+    }
+  }
   return ZRes;
 }
 
 Expect<int32_t> WasmEdgeZlibDeflateSetDictionary::body(
     const Runtime::CallingFrame &Frame, uint32_t ZStreamPtr,
     uint32_t DictionaryPtr, uint32_t DictLength) {
+
+  // deflateSetDictionary reads the dictionary immediately except when it
+  // rejects the request first: a wrong-kind stream fails the state check, a
+  // gzip-wrapped deflate stream refuses any preset dictionary, and a
+  // zlib-wrapped stream that has already produced output (left INIT_STATE)
+  // refuses one too, all before touching the bytes -- answer those from the
+  // tracked state. A raw deflate stream instead rejects on live lookahead,
+  // which is not tracked here, so that case still validates the buffer.
+  if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
+      It != Env.ZStreamMap.end() &&
+      (It->second.Kind != ZStreamKind::Deflate || It->second.GzipWrap ||
+       (!It->second.RawDeflate && It->second.DeflateStarted))) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
@@ -435,16 +550,30 @@ Expect<int32_t> WasmEdgeZlibDeflateGetDictionary::body(
                   "Invalid ZStreamPtr received."sv);
     return Unexpect(ErrCode::Value::HostFuncError);
   }
+  if (ZStreamIt->second.Kind != ZStreamKind::Deflate) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
   // zlib writes up to the internal window (~32 KiB) with no caller-supplied
   // cap, so query the exact length first and validate the destination for it.
   uInt NeededLen = 0;
-  deflateGetDictionary(ZStreamIt->second.get(), Z_NULL, &NeededLen);
+  deflateGetDictionary(&ZStreamIt->second.Z, Z_NULL, &NeededLen);
 
-  BUFFER_CHECK(Dictionary, MemInst, DictionaryPtr, NeededLen,
-               "WasmEdgeZlibDeflateGetDictionary")
-  PTR_CHECK(DictLength, MemInst, DictLengthPtr, uint32_t,
-            "WasmEdgeZlibDeflateGetDictionary")
+  // Both out-pointers are optional: a Z_NULL dictionary returns only the
+  // length and a Z_NULL dictLength is not set, so a guest null (0) maps to
+  // Z_NULL rather than to wasm address 0.
+  uint8_t *Dictionary = nullptr;
+  if (DictionaryPtr != 0) {
+    BUFFER_CHECK(DictionaryBuf, MemInst, DictionaryPtr, NeededLen,
+                 "WasmEdgeZlibDeflateGetDictionary")
+    Dictionary = DictionaryBuf;
+  }
+  uint32_t *DictLength = nullptr;
+  if (DictLengthPtr != 0) {
+    PTR_CHECK(DictLengthOut, MemInst, DictLengthPtr, uint32_t,
+              "WasmEdgeZlibDeflateGetDictionary")
+    DictLength = DictLengthOut;
+  }
 
   return SyncRun("WasmEdgeZlibDeflateGetDictionary", Env, ZStreamPtr, Frame,
                  [&](z_stream *HostZStream) {
@@ -468,19 +597,36 @@ WasmEdgeZlibDeflateCopy::body(const Runtime::CallingFrame &Frame,
                   "Invalid SourcePtr received."sv);
     return Unexpect(ErrCode::Value::HostFuncError);
   }
-  auto *SourceZStream = SourceZStreamIt->second.get();
+  if (SourceZStreamIt->second.Kind != ZStreamKind::Deflate) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
+  // Capture the source stream pointer before try_emplace may rehash the map;
+  // node addresses are stable across rehash, iterators are not.
+  auto *SourceZStream = &SourceZStreamIt->second.Z;
+  const bool SourceGzipWrap = SourceZStreamIt->second.GzipWrap;
+  const bool SourceRawDeflate = SourceZStreamIt->second.RawDeflate;
+  const bool SourceDeflateStarted = SourceZStreamIt->second.DeflateStarted;
 
-  auto NewZStream = std::make_unique<z_stream>();
+  MEMINST_CHECK(MemInst, Frame, 0)
+  auto *SourceModuleZStream = MemInst->getPointer<WasmZStream *>(SourcePtr);
+  auto *DestModuleZStream = MemInst->getPointer<WasmZStream *>(DestPtr);
+  if (unlikely(SourceModuleZStream == nullptr ||
+               DestModuleZStream == nullptr)) {
+    spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibDeflateCopy] "sv
+                  "Out-of-bounds ZStreamPtr received."sv);
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
 
+  // Reject copying onto a live destination (this also rejects a self-copy where
+  // DestPtr == SourcePtr): deflateCopy would overwrite the destination stream,
+  // leaking its state, and on an allocation failure leave the destination
+  // aliasing the source's internal state.
   const auto [It, Inserted] =
-      Env.ZStreamMap.emplace(std::make_pair(DestPtr, std::move(NewZStream)));
-
-  const auto Res = SyncRun("WasmEdgeZlibDeflateCopy", Env, DestPtr, Frame,
-                           [&](z_stream *) { return 0; });
-  if (!Res.has_value()) {
-    if (Inserted)
-      Env.ZStreamMap.erase(It);
-    return Res;
+      Env.ZStreamMap.try_emplace(DestPtr, ZStreamKind::Deflate);
+  if (unlikely(!Inserted)) {
+    spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibDeflateCopy] "sv
+                  "Destination stream is already live."sv);
+    return static_cast<int32_t>(Z_STREAM_ERROR);
   }
 
   const auto ZRes = SyncRun("WasmEdgeZlibDeflateCopy", Env, DestPtr, Frame,
@@ -488,11 +634,23 @@ WasmEdgeZlibDeflateCopy::body(const Runtime::CallingFrame &Frame,
                               return deflateCopy(DestZStream, SourceZStream);
                             });
 
-  if (ZRes != Z_OK) {
-    if (Inserted)
-      Env.ZStreamMap.erase(It);
+  // A SyncRun trap (errored Expect) compares unequal to nothing, so test it
+  // explicitly: the failed destination entry must be dropped, and the header
+  // sharing below is for a successful copy only.
+  if (!ZRes || *ZRes != Z_OK) {
+    // deflateCopy may have left the destination aliasing the source's internal
+    // state; detach it so erasing the entry does not free the source's state.
+    It->second.Z.state = Z_NULL;
+    Env.ZStreamMap.erase(It);
     return ZRes;
   }
+
+  // The copy inherits the source's wrapper and progress: zlib duplicated the
+  // internal state wholesale, wrap and status included, so the dictionary
+  // rejects keep answering for the copy exactly as they would for the source.
+  It->second.GzipWrap = SourceGzipWrap;
+  It->second.RawDeflate = SourceRawDeflate;
+  It->second.DeflateStarted = SourceDeflateStarted;
 
   // deflateCopy duplicated the source's internal gz_header pointer into the
   // destination stream. Share the same reference-counted header snapshot so it
@@ -502,6 +660,20 @@ WasmEdgeZlibDeflateCopy::body(const Runtime::CallingFrame &Frame,
   if (SourceHeaderIt != Env.GZHeaderMap.end())
     Env.GZHeaderMap.insert_or_assign(DestPtr, SourceHeaderIt->second);
 
+  // zlib overwrote the destination host stream with the source wholesale, but
+  // the delta write-back cannot express that against an uninitialized (legal
+  // here) destination's pre-call pointers. Copy the stream fields directly
+  // from the source's guest-visible struct instead.
+  DestModuleZStream->NextIn = SourceModuleZStream->NextIn;
+  DestModuleZStream->AvailIn = SourceModuleZStream->AvailIn;
+  DestModuleZStream->TotalIn = SourceModuleZStream->TotalIn;
+  DestModuleZStream->NextOut = SourceModuleZStream->NextOut;
+  DestModuleZStream->AvailOut = SourceModuleZStream->AvailOut;
+  DestModuleZStream->TotalOut = SourceModuleZStream->TotalOut;
+  DestModuleZStream->DataType = SourceModuleZStream->DataType;
+  DestModuleZStream->Adler = SourceModuleZStream->Adler;
+  DestModuleZStream->Reserved = SourceModuleZStream->Reserved;
+
   return ZRes;
 }
 
@@ -509,15 +681,34 @@ Expect<int32_t>
 WasmEdgeZlibDeflateReset::body(const Runtime::CallingFrame &Frame,
                                uint32_t ZStreamPtr) {
 
-  return SyncRun(
-      "WasmEdgeZlibDeflateReset", Env, ZStreamPtr, Frame,
-      [&](z_stream *HostZStream) { return deflateReset(HostZStream); });
+  if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::Deflate)) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
+
+  const auto ZRes =
+      SyncRun("WasmEdgeZlibDeflateReset", Env, ZStreamPtr, Frame,
+              [&](z_stream *HostZStream) { return deflateReset(HostZStream); });
+
+  // deflateReset returns the stream to INIT_STATE, so a preset dictionary is
+  // allowed again until the next deflate().
+  if (ZRes && *ZRes == Z_OK) {
+    if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
+        It != Env.ZStreamMap.end()) {
+      It->second.DeflateStarted = false;
+    }
+  }
+
+  return ZRes;
 }
 
 Expect<int32_t>
 WasmEdgeZlibDeflateParams::body(const Runtime::CallingFrame &Frame,
                                 uint32_t ZStreamPtr, int32_t Level,
                                 int32_t Strategy) {
+
+  if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::Deflate)) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
   // deflateParams rejects an out-of-range level or strategy before consuming
   // next_in or producing into next_out, so buffers only need to prove
@@ -541,6 +732,10 @@ Expect<int32_t> WasmEdgeZlibDeflateTune::body(
     const Runtime::CallingFrame &Frame, uint32_t ZStreamPtr, int32_t GoodLength,
     int32_t MaxLazy, int32_t NiceLength, int32_t MaxChain) {
 
+  if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::Deflate)) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
+
   return SyncRun("WasmEdgeZlibDeflateTune", Env, ZStreamPtr, Frame,
                  [&](z_stream *HostZStream) {
                    return deflateTune(HostZStream, GoodLength, MaxLazy,
@@ -552,6 +747,10 @@ Expect<int32_t>
 WasmEdgeZlibDeflateBound::body(const Runtime::CallingFrame &Frame,
                                uint32_t ZStreamPtr, uint32_t SourceLen) {
 
+  // No kind guard here: deflateBound only reads scalar fields that stay
+  // inside any tracked state's allocation and falls back to its conservative
+  // bound when the checks fail, so a wrong-kind stream is safe host-side and
+  // gets the same answer a native caller would.
   return SyncRun("WasmEdgeZlibDeflateBound", Env, ZStreamPtr, Frame,
                  [&](z_stream *HostZStream) {
                    return deflateBound(HostZStream, SourceLen);
@@ -563,10 +762,27 @@ WasmEdgeZlibDeflatePending::body(const Runtime::CallingFrame &Frame,
                                  uint32_t ZStreamPtr, uint32_t PendingPtr,
                                  uint32_t BitsPtr) {
 
+  // A wrong-kind stream is refused before zlib writes either out-parameter,
+  // so the guest pointers are validated only for a call zlib will service.
+  if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::Deflate)) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
+
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  auto *Pending = MemInst->getPointer<uint32_t *>(PendingPtr);
-  auto *Bits = MemInst->getPointer<int32_t *>(BitsPtr);
+  // Both out-pointers are optional: zlib does not set a Z_NULL pending or
+  // bits, so a guest null (0) maps to Z_NULL rather than to wasm address 0.
+  uint32_t *Pending = nullptr;
+  if (PendingPtr != 0) {
+    PTR_CHECK(PendingOut, MemInst, PendingPtr, uint32_t,
+              "WasmEdgeZlibDeflatePending")
+    Pending = PendingOut;
+  }
+  int32_t *Bits = nullptr;
+  if (BitsPtr != 0) {
+    PTR_CHECK(BitsOut, MemInst, BitsPtr, int32_t, "WasmEdgeZlibDeflatePending")
+    Bits = BitsOut;
+  }
 
   return SyncRun("WasmEdgeZlibDeflatePending", Env, ZStreamPtr, Frame,
                  [&](z_stream *HostZStream) {
@@ -579,6 +795,10 @@ WasmEdgeZlibDeflatePrime::body(const Runtime::CallingFrame &Frame,
                                uint32_t ZStreamPtr, int32_t Bits,
                                int32_t Value) {
 
+  if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::Deflate)) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
+
   return SyncRun("WasmEdgeZlibDeflatePrime", Env, ZStreamPtr, Frame,
                  [&](z_stream *HostZStream) {
                    return deflatePrime(HostZStream, Bits, Value);
@@ -588,6 +808,10 @@ WasmEdgeZlibDeflatePrime::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t>
 WasmEdgeZlibDeflateSetHeader::body(const Runtime::CallingFrame &Frame,
                                    uint32_t ZStreamPtr, uint32_t HeadPtr) {
+
+  if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::Deflate)) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
@@ -645,39 +869,53 @@ WasmEdgeZlibDeflateSetHeader::body(const Runtime::CallingFrame &Frame,
   Store->IsInflate = false;
   Store->HostGZHeader = std::make_unique<gz_header>();
 
-  const bool HasExtra =
-      ModuleGZHeader->Extra != 0 && ModuleGZHeader->ExtraLen != 0;
+  // The gzip extra field length is 16-bit: zlib writes only the low 16 bits of
+  // extra_len as XLEN and emits at most that many bytes. Snapshot (and bounds-
+  // check) only what zlib will use, so a guest-declared multi-GB ExtraLen can
+  // neither force a matching host allocation nor spuriously fail the bounds
+  // check for bytes zlib never reads.
+  const uint32_t ExtraLen16 = ModuleGZHeader->ExtraLen & UINT32_C(0xffff);
+  const bool HasExtra = ModuleGZHeader->Extra != 0;
   const bool HasName = ModuleGZHeader->Name != 0;
   const bool HasComment = ModuleGZHeader->Comment != 0;
 
   if (HasExtra) {
-    const auto ExtraSpan = MemInst->getSpan<Bytef>(ModuleGZHeader->Extra,
-                                                   ModuleGZHeader->ExtraLen);
-    if (unlikely(ExtraSpan.data() == nullptr)) {
-      spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibDeflateSetHeader] "sv
-                    "Out-of-bounds gzip header extra field."sv);
-      return Unexpect(ErrCode::Value::HostFuncError);
+    if (ExtraLen16 != 0) {
+      const auto ExtraSpan =
+          MemInst->getSpan<Bytef>(ModuleGZHeader->Extra, ExtraLen16);
+      if (unlikely(ExtraSpan.data() == nullptr)) {
+        spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibDeflateSetHeader] "sv
+                      "Out-of-bounds gzip header extra field."sv);
+        return Unexpect(ErrCode::Value::HostFuncError);
+      }
+      Store->Extra.assign(ExtraSpan.begin(), ExtraSpan.end());
+    } else {
+      // A non-null extra with a zero emitted length still makes zlib set the
+      // gzip FEXTRA flag with XLEN=0. Keep a one-byte placeholder so the
+      // published pointer stays non-null (an empty vector's data() may be
+      // null); extra_len is 0, so zlib never reads the byte.
+      Store->Extra.assign(1, 0);
     }
-    Store->Extra.assign(ExtraSpan.begin(), ExtraSpan.end());
   }
   if (HasName) {
-    const auto *NameStr = getInBoundsCString(*MemInst, ModuleGZHeader->Name);
-    if (unlikely(NameStr == nullptr)) {
+    const auto NameStr = getBoundedInBoundsCString(
+        *MemInst, ModuleGZHeader->Name, MaxGZHeaderStringLen);
+    if (unlikely(!NameStr)) {
       spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibDeflateSetHeader] "sv
                     "Out-of-bounds gzip header name field."sv);
       return Unexpect(ErrCode::Value::HostFuncError);
     }
-    Store->Name = NameStr;
+    Store->Name.assign(NameStr->data(), NameStr->size());
   }
   if (HasComment) {
-    const auto *CommentStr =
-        getInBoundsCString(*MemInst, ModuleGZHeader->Comment);
-    if (unlikely(CommentStr == nullptr)) {
+    const auto CommentStr = getBoundedInBoundsCString(
+        *MemInst, ModuleGZHeader->Comment, MaxGZHeaderStringLen);
+    if (unlikely(!CommentStr)) {
       spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibDeflateSetHeader] "sv
                     "Out-of-bounds gzip header comment field."sv);
       return Unexpect(ErrCode::Value::HostFuncError);
     }
-    Store->Comment = CommentStr;
+    Store->Comment.assign(CommentStr->data(), CommentStr->size());
   }
 
   Store->HostGZHeader->text = ModuleGZHeader->Text;
@@ -685,7 +923,7 @@ WasmEdgeZlibDeflateSetHeader::body(const Runtime::CallingFrame &Frame,
   Store->HostGZHeader->xflags = ModuleGZHeader->XFlags;
   Store->HostGZHeader->os = ModuleGZHeader->OS;
   Store->HostGZHeader->hcrc = ModuleGZHeader->HCRC;
-  Store->HostGZHeader->extra_len = ModuleGZHeader->ExtraLen;
+  Store->HostGZHeader->extra_len = ExtraLen16;
 
   // Point the gz_header at the store's own snapshot buffers. The store keeps a
   // stable heap address, so this binding stays valid after it is inserted.
@@ -702,10 +940,11 @@ WasmEdgeZlibDeflateSetHeader::body(const Runtime::CallingFrame &Frame,
                 return deflateSetHeader(HostZStream, HostGZHeaderPtr);
               });
 
-  // Publish the snapshot only after zlib accepts it. On any failure the
-  // previously stored header stays in place, since zlib (or a deflateCopy'd
-  // stream) may still hold a pointer into it from an earlier success.
-  if (ZRes == Z_OK)
+  // Publish the snapshot only after zlib accepts it. On any failure (a zlib
+  // error or a SyncRun trap) the previously stored header stays in place,
+  // since zlib (or a deflateCopy'd stream) may still hold a pointer into it
+  // from an earlier success.
+  if (ZRes && *ZRes == Z_OK)
     Env.GZHeaderMap.insert_or_assign(ZStreamPtr, std::move(Store));
 
   return ZRes;
@@ -714,29 +953,38 @@ WasmEdgeZlibDeflateSetHeader::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t>
 WasmEdgeZlibInflateInit2::body(const Runtime::CallingFrame &Frame,
                                uint32_t ZStreamPtr, int32_t WindowBits) {
-  auto NewZStream = std::make_unique<z_stream>();
-  NewZStream->zalloc = Z_NULL;
-  NewZStream->zfree = Z_NULL;
-  NewZStream->opaque =
-      Z_NULL; // ignore opaque since zmalloc and zfree was ignored
-
-  const auto [It, Inserted] =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
-
-  const auto ZRes = SyncRun("WasmEdgeZlibInflateInit2", Env, ZStreamPtr, Frame,
-                            [&](z_stream *HostZStream) {
-                              return inflateInit2(HostZStream, WindowBits);
-                            });
-
-  if (ZRes != Z_OK && Inserted)
-    Env.ZStreamMap.erase(It);
-
+  const auto ZRes =
+      initStream("WasmEdgeZlibInflateInit2", Env, ZStreamPtr, Frame,
+                 ZStreamKind::Inflate, [&](z_stream *HostZStream) {
+                   return inflateInit2(HostZStream, WindowBits);
+                 });
+  // wrap is fixed by windowBits: negative selects a raw stream and 16+
+  // enables the gzip wrapper (24..31 gzip-only, 40..47 auto-detect).
+  if (ZRes && *ZRes == Z_OK) {
+    if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
+        It != Env.ZStreamMap.end()) {
+      It->second.RawInflate = WindowBits < 0;
+      It->second.GzipWrap = WindowBits >= 16;
+    }
+  }
   return ZRes;
 }
 
 Expect<int32_t> WasmEdgeZlibInflateSetDictionary::body(
     const Runtime::CallingFrame &Frame, uint32_t ZStreamPtr,
     uint32_t DictionaryPtr, uint32_t DictLength) {
+
+  // inflateSetDictionary reads the dictionary only when the stream can accept
+  // it: raw inflate folds it into the window at once and DICT mode checksums
+  // it, but a wrapped stream that is not waiting for a dictionary (and any
+  // non-inflate stream) answers Z_STREAM_ERROR before touching the bytes, so
+  // only the reading cases validate the guest buffer.
+  if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
+      It != Env.ZStreamMap.end() &&
+      (It->second.Kind != ZStreamKind::Inflate ||
+       (!It->second.RawInflate && !It->second.MayNeedDict))) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
@@ -762,16 +1010,30 @@ Expect<int32_t> WasmEdgeZlibInflateGetDictionary::body(
                   "Invalid ZStreamPtr received."sv);
     return Unexpect(ErrCode::Value::HostFuncError);
   }
+  if (ZStreamIt->second.Kind != ZStreamKind::Inflate) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
   // zlib writes up to the internal window (~32 KiB) with no caller-supplied
   // cap, so query the exact length first and validate the destination for it.
   uInt NeededLen = 0;
-  inflateGetDictionary(ZStreamIt->second.get(), Z_NULL, &NeededLen);
+  inflateGetDictionary(&ZStreamIt->second.Z, Z_NULL, &NeededLen);
 
-  BUFFER_CHECK(Dictionary, MemInst, DictionaryPtr, NeededLen,
-               "WasmEdgeZlibInflateGetDictionary")
-  PTR_CHECK(DictLength, MemInst, DictLengthPtr, uint32_t,
-            "WasmEdgeZlibInflateGetDictionary")
+  // Both out-pointers are optional: a Z_NULL dictionary returns only the
+  // length and a Z_NULL dictLength is not set, so a guest null (0) maps to
+  // Z_NULL rather than to wasm address 0.
+  uint8_t *Dictionary = nullptr;
+  if (DictionaryPtr != 0) {
+    BUFFER_CHECK(DictionaryBuf, MemInst, DictionaryPtr, NeededLen,
+                 "WasmEdgeZlibInflateGetDictionary")
+    Dictionary = DictionaryBuf;
+  }
+  uint32_t *DictLength = nullptr;
+  if (DictLengthPtr != 0) {
+    PTR_CHECK(DictLengthOut, MemInst, DictLengthPtr, uint32_t,
+              "WasmEdgeZlibInflateGetDictionary")
+    DictLength = DictLengthOut;
+  }
 
   return SyncRun("WasmEdgeZlibInflateGetDictionary", Env, ZStreamPtr, Frame,
                  [&](z_stream *HostZStream) {
@@ -783,6 +1045,10 @@ Expect<int32_t> WasmEdgeZlibInflateGetDictionary::body(
 Expect<int32_t>
 WasmEdgeZlibInflateSync::body(const Runtime::CallingFrame &Frame,
                               uint32_t ZStreamPtr) {
+
+  if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::Inflate)) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
   return SyncRun(
       "WasmEdgeZlibInflateSync", Env, ZStreamPtr, Frame,
@@ -799,19 +1065,35 @@ WasmEdgeZlibInflateCopy::body(const Runtime::CallingFrame &Frame,
                   "Invalid SourcePtr received."sv);
     return Unexpect(ErrCode::Value::HostFuncError);
   }
-  auto *SourceZStream = SourceZStreamIt->second.get();
+  if (SourceZStreamIt->second.Kind != ZStreamKind::Inflate) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
+  // Capture the source stream pointer before try_emplace may rehash the map;
+  // node addresses are stable across rehash, iterators are not.
+  auto *SourceZStream = &SourceZStreamIt->second.Z;
+  const bool SourceGzipWrap = SourceZStreamIt->second.GzipWrap;
+  const bool SourceRawInflate = SourceZStreamIt->second.RawInflate;
+  const bool SourceMayNeedDict = SourceZStreamIt->second.MayNeedDict;
 
-  auto NewZStream = std::make_unique<z_stream>();
+  MEMINST_CHECK(MemInst, Frame, 0)
+  auto *SourceModuleZStream = MemInst->getPointer<WasmZStream *>(SourcePtr);
+  auto *DestModuleZStream = MemInst->getPointer<WasmZStream *>(DestPtr);
+  if (unlikely(SourceModuleZStream == nullptr ||
+               DestModuleZStream == nullptr)) {
+    spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibInflateCopy] "sv
+                  "Out-of-bounds ZStreamPtr received."sv);
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
 
+  // Reject copying onto a live destination (this also rejects a self-copy where
+  // DestPtr == SourcePtr): inflateCopy would overwrite the destination stream,
+  // leaking its state.
   const auto [It, Inserted] =
-      Env.ZStreamMap.emplace(std::make_pair(DestPtr, std::move(NewZStream)));
-
-  const auto Res = SyncRun("WasmEdgeZlibInflateCopy", Env, DestPtr, Frame,
-                           [&](z_stream *) { return 0; });
-  if (!Res.has_value()) {
-    if (Inserted)
-      Env.ZStreamMap.erase(It);
-    return Res;
+      Env.ZStreamMap.try_emplace(DestPtr, ZStreamKind::Inflate);
+  if (unlikely(!Inserted)) {
+    spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibInflateCopy] "sv
+                  "Destination stream is already live."sv);
+    return static_cast<int32_t>(Z_STREAM_ERROR);
   }
 
   const auto ZRes = SyncRun("WasmEdgeZlibInflateCopy", Env, DestPtr, Frame,
@@ -819,11 +1101,22 @@ WasmEdgeZlibInflateCopy::body(const Runtime::CallingFrame &Frame,
                               return inflateCopy(DestZStream, SourceZStream);
                             });
 
-  if (ZRes != Z_OK) {
-    if (Inserted)
-      Env.ZStreamMap.erase(It);
+  // A SyncRun trap (errored Expect) compares unequal to nothing, so test it
+  // explicitly: the failed destination entry must be dropped, and the header
+  // sharing below is for a successful copy only.
+  if (!ZRes || *ZRes != Z_OK) {
+    // inflateCopy allocates before touching the destination, so a failure
+    // leaves its state null; detach defensively before erasing regardless.
+    It->second.Z.state = Z_NULL;
+    Env.ZStreamMap.erase(It);
     return ZRes;
   }
+
+  // The copy inherits the source's wrapper and dictionary-wait state: zlib
+  // duplicated the internal state wholesale, wrap and mode included.
+  It->second.GzipWrap = SourceGzipWrap;
+  It->second.RawInflate = SourceRawInflate;
+  It->second.MayNeedDict = SourceMayNeedDict;
 
   // inflateCopy duplicated the source's internal gz_header pointer into the
   // destination stream. Share the same reference-counted header snapshot so it
@@ -833,12 +1126,29 @@ WasmEdgeZlibInflateCopy::body(const Runtime::CallingFrame &Frame,
   if (SourceHeaderIt != Env.GZHeaderMap.end())
     Env.GZHeaderMap.insert_or_assign(DestPtr, SourceHeaderIt->second);
 
+  // Same as deflateCopy: express the copied stream fields directly from the
+  // source's guest-visible struct instead of the delta write-back, which
+  // cannot resolve an uninitialized destination's offsets.
+  DestModuleZStream->NextIn = SourceModuleZStream->NextIn;
+  DestModuleZStream->AvailIn = SourceModuleZStream->AvailIn;
+  DestModuleZStream->TotalIn = SourceModuleZStream->TotalIn;
+  DestModuleZStream->NextOut = SourceModuleZStream->NextOut;
+  DestModuleZStream->AvailOut = SourceModuleZStream->AvailOut;
+  DestModuleZStream->TotalOut = SourceModuleZStream->TotalOut;
+  DestModuleZStream->DataType = SourceModuleZStream->DataType;
+  DestModuleZStream->Adler = SourceModuleZStream->Adler;
+  DestModuleZStream->Reserved = SourceModuleZStream->Reserved;
+
   return ZRes;
 }
 
 Expect<int32_t>
 WasmEdgeZlibInflateReset::body(const Runtime::CallingFrame &Frame,
                                uint32_t ZStreamPtr) {
+
+  if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::Inflate)) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
   const auto ZRes =
       SyncRun("WasmEdgeZlibInflateReset", Env, ZStreamPtr, Frame,
@@ -850,8 +1160,14 @@ WasmEdgeZlibInflateReset::body(const Runtime::CallingFrame &Frame,
   // and rewriting a guest header zlib no longer references, failing legitimate
   // post-reset inflate calls once the guest reuses that memory. deflate resets
   // keep zlib's gzhead, so deflate snapshots must stay alive.
-  if (ZRes && *ZRes == Z_OK)
+  if (ZRes && *ZRes == Z_OK) {
     Env.GZHeaderMap.erase(ZStreamPtr);
+    // The stream is back at the header stage, no longer awaiting a dictionary.
+    if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
+        It != Env.ZStreamMap.end()) {
+      It->second.MayNeedDict = false;
+    }
+  }
 
   return ZRes;
 }
@@ -860,6 +1176,10 @@ Expect<int32_t>
 WasmEdgeZlibInflateReset2::body(const Runtime::CallingFrame &Frame,
                                 uint32_t ZStreamPtr, int32_t WindowBits) {
 
+  if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::Inflate)) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
+
   const auto ZRes = SyncRun("WasmEdgeZlibInflateReset2", Env, ZStreamPtr, Frame,
                             [&](z_stream *HostZStream) {
                               return inflateReset2(HostZStream, WindowBits);
@@ -867,8 +1187,17 @@ WasmEdgeZlibInflateReset2::body(const Runtime::CallingFrame &Frame,
 
   // inflateReset2 detaches zlib's gzip-header pointer like inflateReset; drop
   // the stale snapshot (see WasmEdgeZlibInflateReset).
-  if (ZRes && *ZRes == Z_OK)
+  if (ZRes && *ZRes == Z_OK) {
     Env.GZHeaderMap.erase(ZStreamPtr);
+    // inflateReset2 re-derives wrap from the new windowBits and restarts at
+    // the header stage (see WasmEdgeZlibInflateInit2 for the mapping).
+    if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
+        It != Env.ZStreamMap.end()) {
+      It->second.RawInflate = WindowBits < 0;
+      It->second.GzipWrap = WindowBits >= 16;
+      It->second.MayNeedDict = false;
+    }
+  }
 
   return ZRes;
 }
@@ -877,6 +1206,10 @@ Expect<int32_t>
 WasmEdgeZlibInflatePrime::body(const Runtime::CallingFrame &Frame,
                                uint32_t ZStreamPtr, int32_t Bits,
                                int32_t Value) {
+
+  if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::Inflate)) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
   return SyncRun("WasmEdgeZlibInflatePrime", Env, ZStreamPtr, Frame,
                  [&](z_stream *HostZStream) {
@@ -888,6 +1221,11 @@ Expect<int32_t>
 WasmEdgeZlibInflateMark::body(const Runtime::CallingFrame &Frame,
                               uint32_t ZStreamPtr) {
 
+  // inflateMark's bad-state answer is -(1 << 16), not Z_STREAM_ERROR.
+  if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::Inflate)) {
+    return INT32_C(-65536);
+  }
+
   return SyncRun(
       "WasmEdgeZlibInflateMark", Env, ZStreamPtr, Frame,
       [&](z_stream *HostZStream) { return inflateMark(HostZStream); });
@@ -896,6 +1234,17 @@ WasmEdgeZlibInflateMark::body(const Runtime::CallingFrame &Frame,
 Expect<int32_t>
 WasmEdgeZlibInflateGetHeader::body(const Runtime::CallingFrame &Frame,
                                    uint32_t ZStreamPtr, uint32_t HeadPtr) {
+
+  // inflateGetHeader stores the header and writes head->done only on a
+  // gzip-capable inflate stream (wrap & 2); every other stream gets
+  // Z_STREAM_ERROR before the header is touched, so the guest pointer is
+  // validated only when zlib will actually accept it. wrap is fixed by
+  // windowBits at init/reset2 time, so the tracked flag mirrors it exactly.
+  if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
+      It != Env.ZStreamMap.end() &&
+      (It->second.Kind != ZStreamKind::Inflate || !It->second.GzipWrap)) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
@@ -922,10 +1271,19 @@ WasmEdgeZlibInflateGetHeader::body(const Runtime::CallingFrame &Frame,
 
   // Publish the snapshot only after zlib accepts it and points its internal
   // head at it. A repeated call replaces the previous snapshot, which zlib no
-  // longer references; on failure zlib left its head untouched, so the local
-  // store is simply dropped and any previously stored header stays in place.
-  if (ZRes == Z_OK)
+  // longer references; on failure (a zlib error or a SyncRun trap) zlib left
+  // its head untouched, so the local store is simply dropped and any
+  // previously stored header stays in place.
+  if (ZRes && *ZRes == Z_OK) {
+    // inflateGetHeader reset head->done to 0 as it registered the header.
+    // Deliver that now: the store was not yet published during this SyncRun,
+    // so the next inflate would otherwise be the first call to sync it back.
+    if (auto *ModuleGZHeader = MemInst->getPointer<WasmGZHeader *>(HeadPtr);
+        ModuleGZHeader != nullptr) {
+      ModuleGZHeader->Done = 0;
+    }
     Env.GZHeaderMap.insert_or_assign(ZStreamPtr, std::move(Store));
+  }
 
   return ZRes;
 }
@@ -934,16 +1292,10 @@ Expect<int32_t>
 WasmEdgeZlibInflateBackInit::body(const Runtime::CallingFrame &Frame,
                                   uint32_t ZStreamPtr, int32_t WindowBits,
                                   uint32_t WindowPtr) {
-  auto NewZStream = std::make_unique<z_stream>();
-  NewZStream->zalloc = Z_NULL;
-  NewZStream->zfree = Z_NULL;
-  NewZStream->opaque =
-      Z_NULL; // ignore opaque since zmalloc and zfree was ignored
-
   MEMINST_CHECK(MemInst, Frame, 0)
 
   uint8_t *Window = nullptr;
-  if (WindowBits >= 8 && WindowBits <= 15) {
+  if (WindowPtr != 0 && WindowBits >= 8 && WindowBits <= 15) {
     const auto WindowSpan =
         MemInst->getSpan<uint8_t>(WindowPtr, UINT64_C(1) << WindowBits);
     if (unlikely(WindowSpan.data() == nullptr)) {
@@ -953,33 +1305,37 @@ WasmEdgeZlibInflateBackInit::body(const Runtime::CallingFrame &Frame,
     }
     Window = WindowSpan.data();
   } else {
-    Window = MemInst->getPointer<unsigned char *>(WindowPtr);
+    // A guest null window is zlib's Z_NULL and an out-of-range windowBits is
+    // equally rejected before the window is touched, so neither resolves a
+    // guest pointer (wasm address 0 must not stand in for Z_NULL here).
+    Window = nullptr;
   }
 
-  const auto [It, Inserted] =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
-
-  const auto ZRes =
-      SyncRun("WasmEdgeZlibInflateBackInit", Env, ZStreamPtr, Frame,
-              [&](z_stream *HostZStream) {
-                return inflateBackInit(HostZStream, WindowBits, Window);
-              });
-
-  if (ZRes != Z_OK && Inserted)
-    Env.ZStreamMap.erase(It);
-
-  return ZRes;
+  return initStream("WasmEdgeZlibInflateBackInit", Env, ZStreamPtr, Frame,
+                    ZStreamKind::InflateBack, [&](z_stream *HostZStream) {
+                      return inflateBackInit(HostZStream, WindowBits, Window);
+                    });
 }
 
 Expect<int32_t>
 WasmEdgeZlibInflateBackEnd::body(const Runtime::CallingFrame &Frame,
                                  uint32_t ZStreamPtr) {
 
+  // inflateBackEnd frees whatever state it is handed -- it never checks the
+  // kind -- so without this a guest could free a live deflate/inflate state
+  // through it and leak that stream's separately allocated internals.
+  if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::InflateBack)) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
+
   const auto ZRes = SyncRun(
       "WasmEdgeZlibInflateBackEnd", Env, ZStreamPtr, Frame,
       [&](z_stream *HostZStream) { return inflateBackEnd(HostZStream); });
 
-  Env.ZStreamMap.erase(ZStreamPtr);
+  // Keep the entry on Z_STREAM_ERROR or a SyncRun trap (zlib did not free it);
+  // otherwise drop it.
+  if (ZRes && *ZRes != Z_STREAM_ERROR)
+    Env.ZStreamMap.erase(ZStreamPtr);
 
   return ZRes;
 }
@@ -1161,7 +1517,13 @@ Expect<int32_t> WasmEdgeZlibGZBuffer::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzbuffer(GZFileIt->second, Size);
+  // Clamp a guest-declared buffer size to a sane maximum: gzbuffer makes zlib
+  // allocate three times this size on the first I/O, so an unclamped multi-GB
+  // request would exhaust host memory (and zlib rejects sizes >= 2^31
+  // outright).
+  constexpr uint32_t MaxGZBufferSize = UINT32_C(64) * 1024 * 1024;
+  return gzbuffer(GZFileIt->second,
+                  Size > MaxGZBufferSize ? MaxGZBufferSize : Size);
 }
 
 Expect<int32_t> WasmEdgeZlibGZSetParams::body(const Runtime::CallingFrame &,
@@ -1535,29 +1897,18 @@ WasmEdgeZlibDeflateInit_::body(const Runtime::CallingFrame &Frame,
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  const auto *WasmZlibVersion = MemInst->getPointer<const char *>(VersionPtr);
-  auto NewZStream = std::make_unique<z_stream>();
+  const auto WasmZlibVersion =
+      getBoundedInBoundsCString(*MemInst, VersionPtr, MaxZlibVersionLen);
+  if (!WasmZlibVersion || !CheckVersion(WasmZlibVersion->data())) {
+    return static_cast<int32_t>(Z_VERSION_ERROR);
+  }
 
-  // ignore wasm custom allocators
-  NewZStream->zalloc = Z_NULL;
-  NewZStream->zfree = Z_NULL;
-  // Ignore opaque because zmalloc and zfree are ignored.
-  NewZStream->opaque = Z_NULL;
-
-  const auto [It, Inserted] =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
-
-  const auto ZRes =
-      SyncRun("WasmEdgeZlibDeflateInit_", Env, ZStreamPtr, Frame,
-              [&](z_stream *HostZStream) {
-                return deflateInit_(HostZStream, Level, WasmZlibVersion,
-                                    sizeof(z_stream));
-              });
-
-  if (ZRes != Z_OK && Inserted)
-    Env.ZStreamMap.erase(It);
-
-  return ZRes;
+  return initStream("WasmEdgeZlibDeflateInit_", Env, ZStreamPtr, Frame,
+                    ZStreamKind::Deflate, [&](z_stream *HostZStream) {
+                      return deflateInit_(HostZStream, Level,
+                                          WasmZlibVersion->data(),
+                                          sizeof(z_stream));
+                    });
 }
 
 Expect<int32_t>
@@ -1569,28 +1920,17 @@ WasmEdgeZlibInflateInit_::body(const Runtime::CallingFrame &Frame,
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  const auto *WasmZlibVersion = MemInst->getPointer<const char *>(VersionPtr);
-  auto NewZStream = std::make_unique<z_stream>();
+  const auto WasmZlibVersion =
+      getBoundedInBoundsCString(*MemInst, VersionPtr, MaxZlibVersionLen);
+  if (!WasmZlibVersion || !CheckVersion(WasmZlibVersion->data())) {
+    return static_cast<int32_t>(Z_VERSION_ERROR);
+  }
 
-  // ignore wasm custom allocators
-  NewZStream->zalloc = Z_NULL;
-  NewZStream->zfree = Z_NULL;
-  // Ignore opaque because zmalloc and zfree are ignored.
-  NewZStream->opaque = Z_NULL;
-
-  const auto [It, Inserted] =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
-
-  const auto ZRes = SyncRun("WasmEdgeZlibInflateInit_", Env, ZStreamPtr, Frame,
-                            [&](z_stream *HostZStream) {
-                              return inflateInit_(HostZStream, WasmZlibVersion,
-                                                  sizeof(z_stream));
-                            });
-
-  if (ZRes != Z_OK && Inserted)
-    Env.ZStreamMap.erase(It);
-
-  return ZRes;
+  return initStream("WasmEdgeZlibInflateInit_", Env, ZStreamPtr, Frame,
+                    ZStreamKind::Inflate, [&](z_stream *HostZStream) {
+                      return inflateInit_(HostZStream, WasmZlibVersion->data(),
+                                          sizeof(z_stream));
+                    });
 }
 
 Expect<int32_t> WasmEdgeZlibDeflateInit2_::body(
@@ -1602,26 +1942,26 @@ Expect<int32_t> WasmEdgeZlibDeflateInit2_::body(
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  const auto *WasmZlibVersion = MemInst->getPointer<const char *>(VersionPtr);
-  auto NewZStream = std::make_unique<z_stream>();
-  NewZStream->zalloc = Z_NULL;
-  NewZStream->zfree = Z_NULL;
-  NewZStream->opaque =
-      Z_NULL; // ignore opaque since zmalloc and zfree was ignored
+  const auto WasmZlibVersion =
+      getBoundedInBoundsCString(*MemInst, VersionPtr, MaxZlibVersionLen);
+  if (!WasmZlibVersion || !CheckVersion(WasmZlibVersion->data())) {
+    return static_cast<int32_t>(Z_VERSION_ERROR);
+  }
 
-  const auto [It, Inserted] =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
-
-  const auto ZRes = SyncRun(
-      "WasmEdgeZlibDeflateInit2_", Env, ZStreamPtr, Frame,
-      [&](z_stream *HostZStream) {
-        return deflateInit2_(HostZStream, Level, Method, WindowBits, MemLevel,
-                             Strategy, WasmZlibVersion, sizeof(z_stream));
-      });
-
-  if (ZRes != Z_OK && Inserted)
-    Env.ZStreamMap.erase(It);
-
+  const auto ZRes =
+      initStream("WasmEdgeZlibDeflateInit2_", Env, ZStreamPtr, Frame,
+                 ZStreamKind::Deflate, [&](z_stream *HostZStream) {
+                   return deflateInit2_(
+                       HostZStream, Level, Method, WindowBits, MemLevel,
+                       Strategy, WasmZlibVersion->data(), sizeof(z_stream));
+                 });
+  if (ZRes && *ZRes == Z_OK) {
+    if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
+        It != Env.ZStreamMap.end()) {
+      It->second.GzipWrap = WindowBits >= 16;
+      It->second.RawDeflate = WindowBits < 0;
+    }
+  }
   return ZRes;
 }
 
@@ -1634,26 +1974,26 @@ WasmEdgeZlibInflateInit2_::body(const Runtime::CallingFrame &Frame,
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  const auto *WasmZlibVersion = MemInst->getPointer<const char *>(VersionPtr);
-  auto NewZStream = std::make_unique<z_stream>();
-  NewZStream->zalloc = Z_NULL;
-  NewZStream->zfree = Z_NULL;
-  NewZStream->opaque =
-      Z_NULL; // ignore opaque since zmalloc and zfree was ignored
+  const auto WasmZlibVersion =
+      getBoundedInBoundsCString(*MemInst, VersionPtr, MaxZlibVersionLen);
+  if (!WasmZlibVersion || !CheckVersion(WasmZlibVersion->data())) {
+    return static_cast<int32_t>(Z_VERSION_ERROR);
+  }
 
-  const auto [It, Inserted] =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
-
-  const auto ZRes =
-      SyncRun("WasmEdgeZlibInflateInit2_", Env, ZStreamPtr, Frame,
-              [&](z_stream *HostZStream) {
-                return inflateInit2_(HostZStream, WindowBits, WasmZlibVersion,
-                                     sizeof(z_stream));
-              });
-
-  if (ZRes != Z_OK && Inserted)
-    Env.ZStreamMap.erase(It);
-
+  const auto ZRes = initStream(
+      "WasmEdgeZlibInflateInit2_", Env, ZStreamPtr, Frame, ZStreamKind::Inflate,
+      [&](z_stream *HostZStream) {
+        return inflateInit2_(HostZStream, WindowBits, WasmZlibVersion->data(),
+                             sizeof(z_stream));
+      });
+  // See WasmEdgeZlibInflateInit2 for the windowBits-to-wrap mapping.
+  if (ZRes && *ZRes == Z_OK) {
+    if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
+        It != Env.ZStreamMap.end()) {
+      It->second.RawInflate = WindowBits < 0;
+      It->second.GzipWrap = WindowBits >= 16;
+    }
+  }
   return ZRes;
 }
 
@@ -1665,9 +2005,16 @@ Expect<int32_t> WasmEdgeZlibInflateBackInit_::body(
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  const auto *WasmZlibVersion = MemInst->getPointer<const char *>(VersionPtr);
+  const auto WasmZlibVersion =
+      getBoundedInBoundsCString(*MemInst, VersionPtr, MaxZlibVersionLen);
+  // zlib rejects a null or major-mismatched version before it examines any
+  // other argument, so mirror that order and answer Z_VERSION_ERROR here
+  // rather than resolve (and possibly trap on) the window span first.
+  if (!WasmZlibVersion || !CheckVersion(WasmZlibVersion->data())) {
+    return static_cast<int32_t>(Z_VERSION_ERROR);
+  }
   uint8_t *Window = nullptr;
-  if (WindowBits >= 8 && WindowBits <= 15) {
+  if (WindowPtr != 0 && WindowBits >= 8 && WindowBits <= 15) {
     const auto WindowSpan =
         MemInst->getSpan<uint8_t>(WindowPtr, UINT64_C(1) << WindowBits);
     if (unlikely(WindowSpan.data() == nullptr)) {
@@ -1677,28 +2024,18 @@ Expect<int32_t> WasmEdgeZlibInflateBackInit_::body(
     }
     Window = WindowSpan.data();
   } else {
-    Window = MemInst->getPointer<unsigned char *>(WindowPtr);
+    // A guest null window is zlib's Z_NULL and an out-of-range windowBits is
+    // equally rejected before the window is touched, so neither resolves a
+    // guest pointer (wasm address 0 must not stand in for Z_NULL here).
+    Window = nullptr;
   }
-  auto NewZStream = std::make_unique<z_stream>();
-  NewZStream->zalloc = Z_NULL;
-  NewZStream->zfree = Z_NULL;
-  NewZStream->opaque =
-      Z_NULL; // ignore opaque since zmalloc and zfree was ignored
 
-  const auto [It, Inserted] =
-      Env.ZStreamMap.emplace(std::make_pair(ZStreamPtr, std::move(NewZStream)));
-
-  const auto ZRes =
-      SyncRun("WasmEdgeZlibInflateBackInit_", Env, ZStreamPtr, Frame,
-              [&](z_stream *HostZStream) {
-                return inflateBackInit_(HostZStream, WindowBits, Window,
-                                        WasmZlibVersion, sizeof(z_stream));
-              });
-
-  if (ZRes != Z_OK && Inserted)
-    Env.ZStreamMap.erase(It);
-
-  return ZRes;
+  return initStream("WasmEdgeZlibInflateBackInit_", Env, ZStreamPtr, Frame,
+                    ZStreamKind::InflateBack, [&](z_stream *HostZStream) {
+                      return inflateBackInit_(HostZStream, WindowBits, Window,
+                                              WasmZlibVersion->data(),
+                                              sizeof(z_stream));
+                    });
 }
 
 Expect<int32_t> WasmEdgeZlibGZGetc_::body(const Runtime::CallingFrame &,
@@ -1722,8 +2059,11 @@ WasmEdgeZlibInflateSyncPoint::body(const Runtime::CallingFrame &,
                   "Invalid ZStreamPtr received."sv);
     return Unexpect(ErrCode::Value::HostFuncError);
   }
+  if (HostZStreamIt->second.Kind != ZStreamKind::Inflate) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
-  return inflateSyncPoint(HostZStreamIt->second.get());
+  return inflateSyncPoint(&HostZStreamIt->second.Z);
 }
 
 Expect<int32_t>
@@ -1735,8 +2075,11 @@ WasmEdgeZlibInflateUndermine::body(const Runtime::CallingFrame &,
                   "Invalid ZStreamPtr received."sv);
     return Unexpect(ErrCode::Value::HostFuncError);
   }
+  if (HostZStreamIt->second.Kind != ZStreamKind::Inflate) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
-  return inflateUndermine(HostZStreamIt->second.get(), Subvert);
+  return inflateUndermine(&HostZStreamIt->second.Z, Subvert);
 }
 
 Expect<int32_t> WasmEdgeZlibInflateValidate::body(const Runtime::CallingFrame &,
@@ -1748,8 +2091,11 @@ Expect<int32_t> WasmEdgeZlibInflateValidate::body(const Runtime::CallingFrame &,
                   "Invalid ZStreamPtr received."sv);
     return Unexpect(ErrCode::Value::HostFuncError);
   }
+  if (HostZStreamIt->second.Kind != ZStreamKind::Inflate) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
-  return inflateValidate(HostZStreamIt->second.get(), Check);
+  return inflateValidate(&HostZStreamIt->second.Z, Check);
 }
 
 Expect<int32_t>
@@ -1761,8 +2107,12 @@ WasmEdgeZlibInflateCodesUsed::body(const Runtime::CallingFrame &,
                   "Invalid ZStreamPtr received."sv);
     return Unexpect(ErrCode::Value::HostFuncError);
   }
+  // inflateCodesUsed's bad-state answer is (unsigned long)-1.
+  if (HostZStreamIt->second.Kind != ZStreamKind::Inflate) {
+    return INT32_C(-1);
+  }
 
-  return inflateCodesUsed(HostZStreamIt->second.get());
+  return inflateCodesUsed(&HostZStreamIt->second.Z);
 }
 
 Expect<int32_t>
@@ -1774,13 +2124,19 @@ WasmEdgeZlibInflateResetKeep::body(const Runtime::CallingFrame &,
                   "Invalid ZStreamPtr received."sv);
     return Unexpect(ErrCode::Value::HostFuncError);
   }
+  if (HostZStreamIt->second.Kind != ZStreamKind::Inflate) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
-  const auto ZRes = inflateResetKeep(HostZStreamIt->second.get());
+  const auto ZRes = inflateResetKeep(&HostZStreamIt->second.Z);
 
   // inflateResetKeep detaches zlib's gzip-header pointer like inflateReset;
-  // drop the stale snapshot (see WasmEdgeZlibInflateReset).
-  if (ZRes == Z_OK)
+  // drop the stale snapshot (see WasmEdgeZlibInflateReset) and the
+  // dictionary-wait flag with it (the stream is back at the header stage).
+  if (ZRes == Z_OK) {
     Env.GZHeaderMap.erase(ZStreamPtr);
+    HostZStreamIt->second.MayNeedDict = false;
+  }
 
   return ZRes;
 }
@@ -1794,8 +2150,19 @@ WasmEdgeZlibDeflateResetKeep::body(const Runtime::CallingFrame &,
                   "Invalid ZStreamPtr received."sv);
     return Unexpect(ErrCode::Value::HostFuncError);
   }
+  if (HostZStreamIt->second.Kind != ZStreamKind::Deflate) {
+    return static_cast<int32_t>(Z_STREAM_ERROR);
+  }
 
-  return deflateResetKeep(HostZStreamIt->second.get());
+  const int ZRes = deflateResetKeep(&HostZStreamIt->second.Z);
+
+  // deflateResetKeep also returns the stream to INIT_STATE, so clear the
+  // started flag that gates deflateSetDictionary.
+  if (ZRes == Z_OK) {
+    HostZStreamIt->second.DeflateStarted = false;
+  }
+
+  return ZRes;
 }
 
 } // namespace Host

--- a/plugins/wasmedge_zlib/zlibfunc.cpp
+++ b/plugins/wasmedge_zlib/zlibfunc.cpp
@@ -3,9 +3,16 @@
 
 #include "zlibfunc.h"
 
+#include "host/wasi/wasimodule.h"
+
 #include <cstring>
 #include <optional>
 #include <string_view>
+
+#if !defined(_WIN32)
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 
 namespace WasmEdge {
 namespace Host {
@@ -17,10 +24,6 @@ namespace Host {
     return Unexpect(ErrCode::Value::HostFuncError);                            \
   }
 
-// Bind `Var` to a guest buffer of `Len` bytes at `Offset`, validating that the
-// whole range is in bounds (zlib may touch all of it). getPointer only checks a
-// single element, so getSpan is required here. A zero-length buffer is
-// accepted.
 #define BUFFER_CHECK(Var, MemInstPtr, Offset, Len, FuncName)                   \
   const auto Var##Span = (MemInstPtr)->getSpan<uint8_t>((Offset), (Len));      \
   if (unlikely((Len) != 0 && Var##Span.data() == nullptr)) {                   \
@@ -30,8 +33,6 @@ namespace Host {
   }                                                                            \
   auto *Var = Var##Span.data();
 
-// Bind `Var` to a single `Type` object at `Offset`, rejecting an out-of-bounds
-// offset (getPointer returns nullptr rather than trapping).
 #define PTR_CHECK(Var, MemInstPtr, Offset, Type, FuncName)                     \
   auto *Var = (MemInstPtr)->getPointer<Type *>((Offset));                      \
   if (unlikely(Var == nullptr)) {                                              \
@@ -40,8 +41,6 @@ namespace Host {
     return Unexpect(ErrCode::Value::HostFuncError);                            \
   }
 
-// zlib's versioned init entry points reject a null or major-mismatched version
-// before they examine any other argument.
 static inline bool CheckVersion(const char *Version) noexcept {
   return Version != nullptr && Version[0] == ZLIB_VERSION[0];
 }
@@ -53,30 +52,7 @@ constexpr bool CheckSize(int32_t StreamSize) {
 
 constexpr uint64_t MaxGZHeaderStringLen = UINT64_C(1) << 20;
 
-// zlib's versioned initializers inspect only version[0], so cap the version
-// scan well above any real ZLIB_VERSION instead of letting a guest pointer
-// into a large non-NUL region drive an unbounded memchr over linear memory.
 constexpr uint64_t MaxZlibVersionLen = 63;
-
-// Return an in-bounds, NUL-terminated C string starting at `Offset`, or nullptr
-// when the offset is out of bounds or no terminator exists before the end of
-// linear memory (which would make zlib's strlen/strcpy read out of bounds).
-static inline const char *
-getInBoundsCString(const Runtime::Instance::MemoryInstance &MemInst,
-                   uint32_t Offset) noexcept {
-  const uint64_t MemSize = MemInst.getSize();
-  if (unlikely(Offset >= MemSize)) {
-    return nullptr;
-  }
-  const auto *Str = MemInst.getPointer<const char *>(Offset);
-  if (unlikely(Str == nullptr)) {
-    return nullptr;
-  }
-  if (unlikely(std::memchr(Str, '\0', MemSize - Offset) == nullptr)) {
-    return nullptr;
-  }
-  return Str;
-}
 
 static inline std::optional<std::string_view>
 getBoundedInBoundsCString(const Runtime::Instance::MemoryInstance &MemInst,
@@ -129,11 +105,6 @@ auto SyncRun(const std::string_view &Msg, WasmEdgeZlibEnvironment &Env,
                                                       ModuleZStream->AvailIn);
   const auto OutSpan = MemInst->getSpan<unsigned char>(ModuleZStream->NextOut,
                                                        ModuleZStream->AvailOut);
-  // Only the streaming callbacks read next_in or write next_out, so only they
-  // must reject an out-of-bounds data buffer (inflateSync scans input but
-  // never writes output). Control operations (init, reset, end, copy, ...)
-  // ignore these fields, and zlib's contract lets a guest leave them
-  // uninitialized; trapping them would break valid init and cleanup calls.
   if (ValidateInputBuffer) {
     if (unlikely(ModuleZStream->AvailIn != 0 && InSpan.data() == nullptr)) {
       spdlog::error("[WasmEdge-Zlib] [{}-SyncRun] "sv
@@ -174,15 +145,6 @@ auto SyncRun(const std::string_view &Msg, WasmEdgeZlibEnvironment &Env,
   unsigned char *PreComputeName{};
   unsigned char *PreComputeComment{};
 
-  // Only inflate() syncs the header, and only the guest-owned INPUT fields:
-  // the buffer locations (extra/name/comment) and their *_max capacities,
-  // re-validated against linear memory every call; a guest null (0) location
-  // is zlib's Z_NULL ("field not requested") and must not resolve to wasm
-  // address 0. The OUTPUT fields (text/time/xflags/os/extra_len/hcrc/done)
-  // stay zlib-owned and flow guest-ward only in the write-back below;
-  // re-injecting extra_len would let a guest drive the EXTRA-state write
-  // offset out of bounds. Cleanup/reset calls skip this (SyncGZHeader=false),
-  // so a corrupted *_max never aborts a stream teardown.
   if (SyncGZHeader && GZHeaderStoreIt != Env.GZHeaderMap.end() &&
       GZHeaderStoreIt->second->IsInflate) {
     auto *ModuleGZHeader = MemInst->getPointer<WasmGZHeader *>(
@@ -196,12 +158,6 @@ auto SyncRun(const std::string_view &Msg, WasmEdgeZlibEnvironment &Env,
     auto *HostGZHeader = GZHeaderStoreIt->second->HostGZHeader.get();
 
     bool FieldOOB = false;
-    // zlib never writes through a zero-capacity field yet still distinguishes
-    // the caller's non-null pointer from Z_NULL ("field not requested"), so a
-    // stale zero-capacity guest pointer past linear memory must stay non-null
-    // rather than read as an absent field; the shared dummy is never written
-    // (every header store is bounded by its *_max), and the delta write-back
-    // below leaves the guest offset untouched for it.
     static unsigned char ZeroCapacityHeaderField = 0;
     const auto ResolveField = [&](uint32_t Ptr,
                                   uint32_t Max) -> unsigned char * {
@@ -241,12 +197,6 @@ auto SyncRun(const std::string_view &Msg, WasmEdgeZlibEnvironment &Env,
 
   const auto ZRes = Callback(HostZStream);
 
-  // deflateCopy/inflateCopy overwrite the host stream with the source's
-  // retained next_in/next_out, so copying onto a destination whose own buffer
-  // did not resolve can leave one side of this delta null while the other is a
-  // live pointer. Subtracting a null from a non-null pointer is undefined, so
-  // advance the guest offset only when both ends are real; every other callback
-  // keeps both ends in the same buffer, where the guard always passes.
   if (HostZStream->next_in != nullptr && PreComputeNextIn != nullptr) {
     ModuleZStream->NextIn += HostZStream->next_in - PreComputeNextIn;
   }
@@ -279,9 +229,6 @@ auto SyncRun(const std::string_view &Msg, WasmEdgeZlibEnvironment &Env,
       ModuleGZHeader->XFlags = HostGZHeader->xflags;
       ModuleGZHeader->OS = HostGZHeader->os;
 
-      // zlib sets an absent optional field's pointer to Z_NULL "to signal its
-      // absence" even when a buffer was supplied; surface that as guest null
-      // instead of subtracting a live pointer from null.
       if (HostGZHeader->extra == Z_NULL) {
         ModuleGZHeader->Extra = 0;
       } else if (PreComputeExtra != nullptr) {
@@ -312,11 +259,6 @@ auto SyncRun(const std::string_view &Msg, WasmEdgeZlibEnvironment &Env,
   return ZRes;
 }
 
-// Create a fresh tracked stream, run zlib's init on it, and reject re-init over
-// a live key. Running an init on an already-initialized z_stream would let zlib
-// overwrite strm->state and leak the previous internal state (unbounded, since
-// nothing else frees it). On a failed init the (empty) entry is dropped so the
-// guest may retry.
 template <typename InitFn>
 Expect<int32_t> initStream(const std::string_view &Msg,
                            WasmEdgeZlibEnvironment &Env, uint32_t ZStreamPtr,
@@ -332,26 +274,12 @@ Expect<int32_t> initStream(const std::string_view &Msg,
 
   const auto ZRes = SyncRun(Msg, Env, ZStreamPtr, Frame, Init);
 
-  // An errored Expect compares unequal to nothing (both == and != yield
-  // false), so test it explicitly: a SyncRun trap must also drop the entry,
-  // or the failed key would be treated as live forever.
   if (!ZRes || *ZRes != Z_OK)
     Env.ZStreamMap.erase(It);
 
   return ZRes;
 }
 
-// zlib's stream functions verify the stream kind first (deflateStateCheck /
-// inflateStateCheck) and answer a mismatched stream with Z_STREAM_ERROR
-// before reading or writing anything else. Classic zlib decides that
-// deterministically for a deflate<->inflate mix (the punned status and mode
-// value ranges are disjoint), but zlib-ng's layouts differ enough that the
-// same probe reads arbitrary fields: a cross-kind call may pass its checks
-// and then free garbage pointers (deflateEnd), overwrite live internal state
-// (inflateReset/inflatePrime/inflateValidate), or copy past the allocation
-// (inflateCopy) -- and inflateBackEnd frees whatever state it is handed
-// without any check at all. Answer from the tracked kind instead of entering
-// zlib with a mismatched state; an untracked ZStreamPtr keeps its usual trap.
 static inline bool streamKindMismatch(const WasmEdgeZlibEnvironment &Env,
                                       uint32_t ZStreamPtr,
                                       ZStreamKind Expected) noexcept {
@@ -374,18 +302,12 @@ Expect<int32_t> WasmEdgeZlibDeflate::WasmEdgeZlibDeflate::body(
     return static_cast<int32_t>(Z_STREAM_ERROR);
   }
 
-  // deflate() refuses a flush outside [Z_NO_FLUSH, Z_BLOCK] before touching
-  // next_in or next_out, so as with deflateParams validate the buffers only
-  // for a flush value zlib will service.
   const bool FlushValid = Flush >= Z_NO_FLUSH && Flush <= Z_BLOCK;
   const auto ZRes = SyncRun(
       "WasmEdgeZlibDeflate", Env, ZStreamPtr, Frame,
       [&](z_stream *HostZStream) { return deflate(HostZStream, Flush); },
       /*ValidateInputBuffer=*/FlushValid, /*ValidateOutputBuffer=*/FlushValid);
 
-  // A deflate() that returns Z_OK/Z_STREAM_END has written the header and left
-  // INIT_STATE, the state a later deflateSetDictionary refuses; record it so
-  // that guard can answer without validating the dictionary span.
   if (ZRes && (*ZRes == Z_OK || *ZRes == Z_STREAM_END)) {
     if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
         It != Env.ZStreamMap.end()) {
@@ -407,14 +329,8 @@ Expect<int32_t> WasmEdgeZlibDeflateEnd::body(const Runtime::CallingFrame &Frame,
       SyncRun("WasmEdgeZlibDeflateEnd", Env, ZStreamPtr, Frame,
               [&](z_stream *HostZStream) { return deflateEnd(HostZStream); });
 
-  // deflateEnd frees zlib's internal state on both Z_OK and Z_DATA_ERROR (the
-  // latter when the stream is ended mid-compression), so drop the host tracking
-  // on either result. Only Z_STREAM_ERROR (an already-invalid stream) leaves
-  // it, as does a SyncRun trap (zlib never ran, so nothing was freed).
   if (ZRes && (*ZRes == Z_OK || *ZRes == Z_DATA_ERROR)) {
     Env.ZStreamMap.erase(ZStreamPtr);
-    // Drop the header snapshot; zlib no longer references it after deflateEnd.
-    // A deflateCopy'd stream that shares it keeps it alive via the shared_ptr.
     Env.GZHeaderMap.erase(ZStreamPtr);
   }
 
@@ -442,9 +358,6 @@ Expect<int32_t> WasmEdgeZlibInflate::body(const Runtime::CallingFrame &Frame,
       /*ValidateInputBuffer=*/true, /*ValidateOutputBuffer=*/true,
       /*SyncGZHeader=*/true);
 
-  // Z_NEED_DICT is the only way into DICT mode, and only a later inflate()
-  // leaves it (a successful inflateSetDictionary keeps the mode until then),
-  // so inflate results alone track whether zlib may be awaiting a dictionary.
   if (ZRes) {
     if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
         It != Env.ZStreamMap.end()) {
@@ -466,11 +379,6 @@ Expect<int32_t> WasmEdgeZlibInflateEnd::body(const Runtime::CallingFrame &Frame,
       SyncRun("WasmEdgeZlibInflateEnd", Env, ZStreamPtr, Frame,
               [&](z_stream *HostZStream) { return inflateEnd(HostZStream); });
 
-  // Z_STREAM_ERROR means zlib did not free the stream (a wrong-type or
-  // already-invalid stream); keep the entry so its internal state is not leaked
-  // and the correct *End can still reclaim it. A SyncRun trap keeps it for the
-  // same reason. Any other result freed zlib's state, so drop the tracking and
-  // the header snapshot with it.
   if (ZRes && *ZRes != Z_STREAM_ERROR) {
     Env.ZStreamMap.erase(ZStreamPtr);
     Env.GZHeaderMap.erase(ZStreamPtr);
@@ -502,13 +410,6 @@ Expect<int32_t> WasmEdgeZlibDeflateSetDictionary::body(
     const Runtime::CallingFrame &Frame, uint32_t ZStreamPtr,
     uint32_t DictionaryPtr, uint32_t DictLength) {
 
-  // deflateSetDictionary reads the dictionary immediately except when it
-  // rejects the request first: a wrong-kind stream fails the state check, a
-  // gzip-wrapped deflate stream refuses any preset dictionary, and a
-  // zlib-wrapped stream that has already produced output (left INIT_STATE)
-  // refuses one too, all before touching the bytes -- answer those from the
-  // tracked state. A raw deflate stream instead rejects on live lookahead,
-  // which is not tracked here, so that case still validates the buffer.
   if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
       It != Env.ZStreamMap.end() &&
       (It->second.Kind != ZStreamKind::Deflate || It->second.GzipWrap ||
@@ -521,10 +422,6 @@ Expect<int32_t> WasmEdgeZlibDeflateSetDictionary::body(
   BUFFER_CHECK(Dictionary, MemInst, DictionaryPtr, DictLength,
                "WasmEdgeZlibDeflateSetDictionary")
 
-  // deflateSetDictionary never reads a zero-length dictionary yet still
-  // rejects Z_NULL, so preserve that contract exactly: a guest null maps to
-  // Z_NULL while any other offset stays non-null, including one past the end
-  // of memory whose zero-length span carries no pointer.
   static constexpr Bytef EmptyDictionary = 0;
   const Bytef *DictionaryArg = Dictionary;
   if (DictLength == 0) {
@@ -554,14 +451,9 @@ Expect<int32_t> WasmEdgeZlibDeflateGetDictionary::body(
     return static_cast<int32_t>(Z_STREAM_ERROR);
   }
 
-  // zlib writes up to the internal window (~32 KiB) with no caller-supplied
-  // cap, so query the exact length first and validate the destination for it.
   uInt NeededLen = 0;
   deflateGetDictionary(&ZStreamIt->second.Z, Z_NULL, &NeededLen);
 
-  // Both out-pointers are optional: a Z_NULL dictionary returns only the
-  // length and a Z_NULL dictLength is not set, so a guest null (0) maps to
-  // Z_NULL rather than to wasm address 0.
   uint8_t *Dictionary = nullptr;
   if (DictionaryPtr != 0) {
     BUFFER_CHECK(DictionaryBuf, MemInst, DictionaryPtr, NeededLen,
@@ -600,8 +492,6 @@ WasmEdgeZlibDeflateCopy::body(const Runtime::CallingFrame &Frame,
   if (SourceZStreamIt->second.Kind != ZStreamKind::Deflate) {
     return static_cast<int32_t>(Z_STREAM_ERROR);
   }
-  // Capture the source stream pointer before try_emplace may rehash the map;
-  // node addresses are stable across rehash, iterators are not.
   auto *SourceZStream = &SourceZStreamIt->second.Z;
   const bool SourceGzipWrap = SourceZStreamIt->second.GzipWrap;
   const bool SourceRawDeflate = SourceZStreamIt->second.RawDeflate;
@@ -617,10 +507,6 @@ WasmEdgeZlibDeflateCopy::body(const Runtime::CallingFrame &Frame,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  // Reject copying onto a live destination (this also rejects a self-copy where
-  // DestPtr == SourcePtr): deflateCopy would overwrite the destination stream,
-  // leaking its state, and on an allocation failure leave the destination
-  // aliasing the source's internal state.
   const auto [It, Inserted] =
       Env.ZStreamMap.try_emplace(DestPtr, ZStreamKind::Deflate);
   if (unlikely(!Inserted)) {
@@ -634,36 +520,20 @@ WasmEdgeZlibDeflateCopy::body(const Runtime::CallingFrame &Frame,
                               return deflateCopy(DestZStream, SourceZStream);
                             });
 
-  // A SyncRun trap (errored Expect) compares unequal to nothing, so test it
-  // explicitly: the failed destination entry must be dropped, and the header
-  // sharing below is for a successful copy only.
   if (!ZRes || *ZRes != Z_OK) {
-    // deflateCopy may have left the destination aliasing the source's internal
-    // state; detach it so erasing the entry does not free the source's state.
     It->second.Z.state = Z_NULL;
     Env.ZStreamMap.erase(It);
     return ZRes;
   }
 
-  // The copy inherits the source's wrapper and progress: zlib duplicated the
-  // internal state wholesale, wrap and status included, so the dictionary
-  // rejects keep answering for the copy exactly as they would for the source.
   It->second.GzipWrap = SourceGzipWrap;
   It->second.RawDeflate = SourceRawDeflate;
   It->second.DeflateStarted = SourceDeflateStarted;
 
-  // deflateCopy duplicated the source's internal gz_header pointer into the
-  // destination stream. Share the same reference-counted header snapshot so it
-  // stays alive for the copy even after the source later replaces or ends its
-  // own header; the deflate snapshot is immutable, so sharing is safe.
   const auto SourceHeaderIt = Env.GZHeaderMap.find(SourcePtr);
   if (SourceHeaderIt != Env.GZHeaderMap.end())
     Env.GZHeaderMap.insert_or_assign(DestPtr, SourceHeaderIt->second);
 
-  // zlib overwrote the destination host stream with the source wholesale, but
-  // the delta write-back cannot express that against an uninitialized (legal
-  // here) destination's pre-call pointers. Copy the stream fields directly
-  // from the source's guest-visible struct instead.
   DestModuleZStream->NextIn = SourceModuleZStream->NextIn;
   DestModuleZStream->AvailIn = SourceModuleZStream->AvailIn;
   DestModuleZStream->TotalIn = SourceModuleZStream->TotalIn;
@@ -689,8 +559,6 @@ WasmEdgeZlibDeflateReset::body(const Runtime::CallingFrame &Frame,
       SyncRun("WasmEdgeZlibDeflateReset", Env, ZStreamPtr, Frame,
               [&](z_stream *HostZStream) { return deflateReset(HostZStream); });
 
-  // deflateReset returns the stream to INIT_STATE, so a preset dictionary is
-  // allowed again until the next deflate().
   if (ZRes && *ZRes == Z_OK) {
     if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
         It != Env.ZStreamMap.end()) {
@@ -710,11 +578,6 @@ WasmEdgeZlibDeflateParams::body(const Runtime::CallingFrame &Frame,
     return static_cast<int32_t>(Z_STREAM_ERROR);
   }
 
-  // deflateParams rejects an out-of-range level or strategy before consuming
-  // next_in or producing into next_out, so buffers only need to prove
-  // themselves for a call zlib will actually service; a rejected call still
-  // gets zlib's Z_STREAM_ERROR, and an unresolved span stays untouched
-  // because deflate() re-checks null buffers itself.
   const bool ParamsValid =
       (Level == Z_DEFAULT_COMPRESSION || (Level >= 0 && Level <= 9)) &&
       Strategy >= 0 && Strategy <= Z_FIXED;
@@ -747,10 +610,6 @@ Expect<int32_t>
 WasmEdgeZlibDeflateBound::body(const Runtime::CallingFrame &Frame,
                                uint32_t ZStreamPtr, uint32_t SourceLen) {
 
-  // No kind guard here: deflateBound only reads scalar fields that stay
-  // inside any tracked state's allocation and falls back to its conservative
-  // bound when the checks fail, so a wrong-kind stream is safe host-side and
-  // gets the same answer a native caller would.
   return SyncRun("WasmEdgeZlibDeflateBound", Env, ZStreamPtr, Frame,
                  [&](z_stream *HostZStream) {
                    return deflateBound(HostZStream, SourceLen);
@@ -762,16 +621,12 @@ WasmEdgeZlibDeflatePending::body(const Runtime::CallingFrame &Frame,
                                  uint32_t ZStreamPtr, uint32_t PendingPtr,
                                  uint32_t BitsPtr) {
 
-  // A wrong-kind stream is refused before zlib writes either out-parameter,
-  // so the guest pointers are validated only for a call zlib will service.
   if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::Deflate)) {
     return static_cast<int32_t>(Z_STREAM_ERROR);
   }
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  // Both out-pointers are optional: zlib does not set a Z_NULL pending or
-  // bits, so a guest null (0) maps to Z_NULL rather than to wasm address 0.
   uint32_t *Pending = nullptr;
   if (PendingPtr != 0) {
     PTR_CHECK(PendingOut, MemInst, PendingPtr, uint32_t,
@@ -815,10 +670,6 @@ WasmEdgeZlibDeflateSetHeader::body(const Runtime::CallingFrame &Frame,
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  // Native deflateSetHeader accepts Z_NULL and reverts the stream to the
-  // default gzip header; guest null (0) takes that path rather than
-  // dereferencing wasm address 0. zlib then retains no pointer into any
-  // snapshot, so a published one can be dropped.
   if (HeadPtr == 0) {
     const auto ZRes = SyncRun("WasmEdgeZlibDeflateSetHeader", Env, ZStreamPtr,
                               Frame, [&](z_stream *HostZStream) {
@@ -829,13 +680,6 @@ WasmEdgeZlibDeflateSetHeader::body(const Runtime::CallingFrame &Frame,
     return ZRes;
   }
 
-  // Get zlib's verdict before any guest-header work: only a gzip deflate
-  // stream accepts a header, and deflateSetHeader merely validates the stream
-  // and stores the pointer, so re-storing the currently published snapshot
-  // (or Z_NULL when none was published) changes nothing. A stream zlib
-  // rejects thus fails with its cheap Z_STREAM_ERROR before the host reads
-  // the header or snapshots a guest-sized extra/name/comment into host
-  // memory, and an invalid ZStreamPtr still traps inside SyncRun.
   {
     const auto StoreIt = Env.GZHeaderMap.find(ZStreamPtr);
     gz_header *CurrentHead = StoreIt != Env.GZHeaderMap.end()
@@ -858,22 +702,11 @@ WasmEdgeZlibDeflateSetHeader::body(const Runtime::CallingFrame &Frame,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  // Snapshot the header into host-owned storage; deflate() emits the name and
-  // comment incrementally across calls (resuming at an internal index), so the
-  // buffers must stay stable and must not be re-read from mutable guest memory.
-  // The store is heap-allocated and reference-counted so deflateCopy can hand
-  // the same snapshot to a copied stream; its address stays stable, so the
-  // bound buffer pointers remain valid once it is inserted into the map.
   auto Store = std::make_shared<WasmEdgeZlibEnvironment::GZStore>();
   Store->WasmGZHeaderOffset = HeadPtr;
   Store->IsInflate = false;
   Store->HostGZHeader = std::make_unique<gz_header>();
 
-  // The gzip extra field length is 16-bit: zlib writes only the low 16 bits of
-  // extra_len as XLEN and emits at most that many bytes. Snapshot (and bounds-
-  // check) only what zlib will use, so a guest-declared multi-GB ExtraLen can
-  // neither force a matching host allocation nor spuriously fail the bounds
-  // check for bytes zlib never reads.
   const uint32_t ExtraLen16 = ModuleGZHeader->ExtraLen & UINT32_C(0xffff);
   const bool HasExtra = ModuleGZHeader->Extra != 0;
   const bool HasName = ModuleGZHeader->Name != 0;
@@ -890,10 +723,6 @@ WasmEdgeZlibDeflateSetHeader::body(const Runtime::CallingFrame &Frame,
       }
       Store->Extra.assign(ExtraSpan.begin(), ExtraSpan.end());
     } else {
-      // A non-null extra with a zero emitted length still makes zlib set the
-      // gzip FEXTRA flag with XLEN=0. Keep a one-byte placeholder so the
-      // published pointer stays non-null (an empty vector's data() may be
-      // null); extra_len is 0, so zlib never reads the byte.
       Store->Extra.assign(1, 0);
     }
   }
@@ -925,8 +754,6 @@ WasmEdgeZlibDeflateSetHeader::body(const Runtime::CallingFrame &Frame,
   Store->HostGZHeader->hcrc = ModuleGZHeader->HCRC;
   Store->HostGZHeader->extra_len = ExtraLen16;
 
-  // Point the gz_header at the store's own snapshot buffers. The store keeps a
-  // stable heap address, so this binding stays valid after it is inserted.
   auto *HostGZHeaderPtr = Store->HostGZHeader.get();
   HostGZHeaderPtr->extra = HasExtra ? Store->Extra.data() : Z_NULL;
   HostGZHeaderPtr->name =
@@ -940,10 +767,6 @@ WasmEdgeZlibDeflateSetHeader::body(const Runtime::CallingFrame &Frame,
                 return deflateSetHeader(HostZStream, HostGZHeaderPtr);
               });
 
-  // Publish the snapshot only after zlib accepts it. On any failure (a zlib
-  // error or a SyncRun trap) the previously stored header stays in place,
-  // since zlib (or a deflateCopy'd stream) may still hold a pointer into it
-  // from an earlier success.
   if (ZRes && *ZRes == Z_OK)
     Env.GZHeaderMap.insert_or_assign(ZStreamPtr, std::move(Store));
 
@@ -958,8 +781,6 @@ WasmEdgeZlibInflateInit2::body(const Runtime::CallingFrame &Frame,
                  ZStreamKind::Inflate, [&](z_stream *HostZStream) {
                    return inflateInit2(HostZStream, WindowBits);
                  });
-  // wrap is fixed by windowBits: negative selects a raw stream and 16+
-  // enables the gzip wrapper (24..31 gzip-only, 40..47 auto-detect).
   if (ZRes && *ZRes == Z_OK) {
     if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
         It != Env.ZStreamMap.end()) {
@@ -974,11 +795,6 @@ Expect<int32_t> WasmEdgeZlibInflateSetDictionary::body(
     const Runtime::CallingFrame &Frame, uint32_t ZStreamPtr,
     uint32_t DictionaryPtr, uint32_t DictLength) {
 
-  // inflateSetDictionary reads the dictionary only when the stream can accept
-  // it: raw inflate folds it into the window at once and DICT mode checksums
-  // it, but a wrapped stream that is not waiting for a dictionary (and any
-  // non-inflate stream) answers Z_STREAM_ERROR before touching the bytes, so
-  // only the reading cases validate the guest buffer.
   if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
       It != Env.ZStreamMap.end() &&
       (It->second.Kind != ZStreamKind::Inflate ||
@@ -1014,14 +830,9 @@ Expect<int32_t> WasmEdgeZlibInflateGetDictionary::body(
     return static_cast<int32_t>(Z_STREAM_ERROR);
   }
 
-  // zlib writes up to the internal window (~32 KiB) with no caller-supplied
-  // cap, so query the exact length first and validate the destination for it.
   uInt NeededLen = 0;
   inflateGetDictionary(&ZStreamIt->second.Z, Z_NULL, &NeededLen);
 
-  // Both out-pointers are optional: a Z_NULL dictionary returns only the
-  // length and a Z_NULL dictLength is not set, so a guest null (0) maps to
-  // Z_NULL rather than to wasm address 0.
   uint8_t *Dictionary = nullptr;
   if (DictionaryPtr != 0) {
     BUFFER_CHECK(DictionaryBuf, MemInst, DictionaryPtr, NeededLen,
@@ -1068,8 +879,6 @@ WasmEdgeZlibInflateCopy::body(const Runtime::CallingFrame &Frame,
   if (SourceZStreamIt->second.Kind != ZStreamKind::Inflate) {
     return static_cast<int32_t>(Z_STREAM_ERROR);
   }
-  // Capture the source stream pointer before try_emplace may rehash the map;
-  // node addresses are stable across rehash, iterators are not.
   auto *SourceZStream = &SourceZStreamIt->second.Z;
   const bool SourceGzipWrap = SourceZStreamIt->second.GzipWrap;
   const bool SourceRawInflate = SourceZStreamIt->second.RawInflate;
@@ -1085,9 +894,6 @@ WasmEdgeZlibInflateCopy::body(const Runtime::CallingFrame &Frame,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  // Reject copying onto a live destination (this also rejects a self-copy where
-  // DestPtr == SourcePtr): inflateCopy would overwrite the destination stream,
-  // leaking its state.
   const auto [It, Inserted] =
       Env.ZStreamMap.try_emplace(DestPtr, ZStreamKind::Inflate);
   if (unlikely(!Inserted)) {
@@ -1101,34 +907,20 @@ WasmEdgeZlibInflateCopy::body(const Runtime::CallingFrame &Frame,
                               return inflateCopy(DestZStream, SourceZStream);
                             });
 
-  // A SyncRun trap (errored Expect) compares unequal to nothing, so test it
-  // explicitly: the failed destination entry must be dropped, and the header
-  // sharing below is for a successful copy only.
   if (!ZRes || *ZRes != Z_OK) {
-    // inflateCopy allocates before touching the destination, so a failure
-    // leaves its state null; detach defensively before erasing regardless.
     It->second.Z.state = Z_NULL;
     Env.ZStreamMap.erase(It);
     return ZRes;
   }
 
-  // The copy inherits the source's wrapper and dictionary-wait state: zlib
-  // duplicated the internal state wholesale, wrap and mode included.
   It->second.GzipWrap = SourceGzipWrap;
   It->second.RawInflate = SourceRawInflate;
   It->second.MayNeedDict = SourceMayNeedDict;
 
-  // inflateCopy duplicated the source's internal gz_header pointer into the
-  // destination stream. Share the same reference-counted header snapshot so it
-  // stays alive for the copy even after the source later replaces or ends its
-  // own header; zlib's copied head aliases this exact host storage.
   const auto SourceHeaderIt = Env.GZHeaderMap.find(SourcePtr);
   if (SourceHeaderIt != Env.GZHeaderMap.end())
     Env.GZHeaderMap.insert_or_assign(DestPtr, SourceHeaderIt->second);
 
-  // Same as deflateCopy: express the copied stream fields directly from the
-  // source's guest-visible struct instead of the delta write-back, which
-  // cannot resolve an uninitialized destination's offsets.
   DestModuleZStream->NextIn = SourceModuleZStream->NextIn;
   DestModuleZStream->AvailIn = SourceModuleZStream->AvailIn;
   DestModuleZStream->TotalIn = SourceModuleZStream->TotalIn;
@@ -1154,15 +946,8 @@ WasmEdgeZlibInflateReset::body(const Runtime::CallingFrame &Frame,
       SyncRun("WasmEdgeZlibInflateReset", Env, ZStreamPtr, Frame,
               [&](z_stream *HostZStream) { return inflateReset(HostZStream); });
 
-  // A successful inflate reset detaches zlib's internal gzip-header pointer
-  // (the guest must call inflateGetHeader again for the next stream), so the
-  // snapshot must be dropped with it: a stale entry would keep re-validating
-  // and rewriting a guest header zlib no longer references, failing legitimate
-  // post-reset inflate calls once the guest reuses that memory. deflate resets
-  // keep zlib's gzhead, so deflate snapshots must stay alive.
   if (ZRes && *ZRes == Z_OK) {
     Env.GZHeaderMap.erase(ZStreamPtr);
-    // The stream is back at the header stage, no longer awaiting a dictionary.
     if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
         It != Env.ZStreamMap.end()) {
       It->second.MayNeedDict = false;
@@ -1185,12 +970,8 @@ WasmEdgeZlibInflateReset2::body(const Runtime::CallingFrame &Frame,
                               return inflateReset2(HostZStream, WindowBits);
                             });
 
-  // inflateReset2 detaches zlib's gzip-header pointer like inflateReset; drop
-  // the stale snapshot (see WasmEdgeZlibInflateReset).
   if (ZRes && *ZRes == Z_OK) {
     Env.GZHeaderMap.erase(ZStreamPtr);
-    // inflateReset2 re-derives wrap from the new windowBits and restarts at
-    // the header stage (see WasmEdgeZlibInflateInit2 for the mapping).
     if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
         It != Env.ZStreamMap.end()) {
       It->second.RawInflate = WindowBits < 0;
@@ -1221,7 +1002,6 @@ Expect<int32_t>
 WasmEdgeZlibInflateMark::body(const Runtime::CallingFrame &Frame,
                               uint32_t ZStreamPtr) {
 
-  // inflateMark's bad-state answer is -(1 << 16), not Z_STREAM_ERROR.
   if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::Inflate)) {
     return INT32_C(-65536);
   }
@@ -1235,11 +1015,6 @@ Expect<int32_t>
 WasmEdgeZlibInflateGetHeader::body(const Runtime::CallingFrame &Frame,
                                    uint32_t ZStreamPtr, uint32_t HeadPtr) {
 
-  // inflateGetHeader stores the header and writes head->done only on a
-  // gzip-capable inflate stream (wrap & 2); every other stream gets
-  // Z_STREAM_ERROR before the header is touched, so the guest pointer is
-  // validated only when zlib will actually accept it. wrap is fixed by
-  // windowBits at init/reset2 time, so the tracked flag mirrors it exactly.
   if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
       It != Env.ZStreamMap.end() &&
       (It->second.Kind != ZStreamKind::Inflate || !It->second.GzipWrap)) {
@@ -1248,9 +1023,6 @@ WasmEdgeZlibInflateGetHeader::body(const Runtime::CallingFrame &Frame,
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  // Validate the guest header pointer up front (like deflateSetHeader) so an
-  // out-of-bounds HeadPtr is rejected here instead of being stored and then
-  // failing every later inflate/cleanup call once zlib has accepted the stream.
   if (unlikely(MemInst->getPointer<WasmGZHeader *>(HeadPtr) == nullptr)) {
     spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibInflateGetHeader] "sv
                   "Out-of-bounds gzip header."sv);
@@ -1269,15 +1041,7 @@ WasmEdgeZlibInflateGetHeader::body(const Runtime::CallingFrame &Frame,
                 return inflateGetHeader(HostZStream, HostGZHeaderPtr);
               });
 
-  // Publish the snapshot only after zlib accepts it and points its internal
-  // head at it. A repeated call replaces the previous snapshot, which zlib no
-  // longer references; on failure (a zlib error or a SyncRun trap) zlib left
-  // its head untouched, so the local store is simply dropped and any
-  // previously stored header stays in place.
   if (ZRes && *ZRes == Z_OK) {
-    // inflateGetHeader reset head->done to 0 as it registered the header.
-    // Deliver that now: the store was not yet published during this SyncRun,
-    // so the next inflate would otherwise be the first call to sync it back.
     if (auto *ModuleGZHeader = MemInst->getPointer<WasmGZHeader *>(HeadPtr);
         ModuleGZHeader != nullptr) {
       ModuleGZHeader->Done = 0;
@@ -1305,9 +1069,6 @@ WasmEdgeZlibInflateBackInit::body(const Runtime::CallingFrame &Frame,
     }
     Window = WindowSpan.data();
   } else {
-    // A guest null window is zlib's Z_NULL and an out-of-range windowBits is
-    // equally rejected before the window is touched, so neither resolves a
-    // guest pointer (wasm address 0 must not stand in for Z_NULL here).
     Window = nullptr;
   }
 
@@ -1321,9 +1082,6 @@ Expect<int32_t>
 WasmEdgeZlibInflateBackEnd::body(const Runtime::CallingFrame &Frame,
                                  uint32_t ZStreamPtr) {
 
-  // inflateBackEnd frees whatever state it is handed -- it never checks the
-  // kind -- so without this a guest could free a live deflate/inflate state
-  // through it and leak that stream's separately allocated internals.
   if (streamKindMismatch(Env, ZStreamPtr, ZStreamKind::InflateBack)) {
     return static_cast<int32_t>(Z_STREAM_ERROR);
   }
@@ -1332,8 +1090,6 @@ WasmEdgeZlibInflateBackEnd::body(const Runtime::CallingFrame &Frame,
       "WasmEdgeZlibInflateBackEnd", Env, ZStreamPtr, Frame,
       [&](z_stream *HostZStream) { return inflateBackEnd(HostZStream); });
 
-  // Keep the entry on Z_STREAM_ERROR or a SyncRun trap (zlib did not free it);
-  // otherwise drop it.
   if (ZRes && *ZRes != Z_STREAM_ERROR)
     Env.ZStreamMap.erase(ZStreamPtr);
 
@@ -1345,13 +1101,6 @@ WasmEdgeZlibZlibCompilerFlags::body(const Runtime::CallingFrame &) {
   return zlibCompileFlags();
 }
 
-// compress/compress2 reject a null destination (Z_STREAM_ERROR) yet answer a
-// non-null one that merely lacks capacity with Z_BUF_ERROR, all without
-// writing a byte, so mirror deflateSetDictionary's contract: a guest null
-// maps to Z_NULL while any other offset stays non-null, including one whose
-// zero-length span carries no pointer. uncompress/uncompress2 need no such
-// care -- at zero capacity they swap in an internal probe buffer and never
-// look at the caller's pointer.
 static Bytef ZeroCapacityDest;
 static inline Bytef *resolveDestArg(uint8_t *Dest, uint32_t DestPtr,
                                     uint32_t DstCap) noexcept {
@@ -1389,10 +1138,6 @@ Expect<int32_t> WasmEdgeZlibCompress2::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0)
 
   PTR_CHECK(DestLen, MemInst, DestLenPtr, uint32_t, "WasmEdgeZlibCompress2")
-  // An out-of-range level fails compress2's deflateInit before any source
-  // byte is read or dest byte written -- though only after *destLen has been
-  // zeroed -- so answer the same way instead of validating spans the
-  // rejected call would never touch.
   if (Level != Z_DEFAULT_COMPRESSION && (Level < 0 || Level > 9)) {
     *DestLen = 0;
     return Z_STREAM_ERROR;
@@ -1449,63 +1194,301 @@ WasmEdgeZlibUncompress2::body(const Runtime::CallingFrame &Frame,
 
   unsigned long HostDestLen = DstCap, HostSourceLen = SrcLen;
   const auto ZRes = uncompress2(Dest, &HostDestLen, Source, &HostSourceLen);
-  // Write the source length before the destination length so an aliased guest
-  // (DestLenPtr == SourceLenPtr) is left with the produced length, matching
-  // native uncompress2, which writes *destLen last into the shared slot.
   *SourceLen = static_cast<uint32_t>(HostSourceLen);
   *DestLen = static_cast<uint32_t>(HostDestLen);
 
   return ZRes;
 }
 
+static WASI::Environ *
+getWasiEnviron(const Runtime::CallingFrame &Frame) noexcept {
+  const auto *WasiMod = Frame.getWASIModule();
+  if (WasiMod == nullptr) {
+    return nullptr;
+  }
+  const auto *Typed = dynamic_cast<const WasiModule *>(WasiMod);
+  if (Typed == nullptr) {
+    return nullptr;
+  }
+  return const_cast<WASI::Environ *>(Typed->getEnv());
+}
+
+static void releaseOwnedWasiFd(const Runtime::CallingFrame &Frame,
+                               int64_t OwnedWasiFd) noexcept {
+  if (OwnedWasiFd < 0) {
+    return;
+  }
+  if (auto *WasiEnv = getWasiEnviron(Frame); WasiEnv != nullptr) {
+    WasiEnv->fdClose(static_cast<__wasi_fd_t>(OwnedWasiFd));
+  }
+}
+
+#if defined(_WIN32)
+// TODO(zlib): Bridge Windows HANDLEs to CRT descriptors.
+static int dupNativeHandle(uint64_t) noexcept { return -1; }
+static void closeNativeFd(int) noexcept {}
+static int64_t tellNativeFd(int) noexcept { return -1; }
+static void seekNativeFd(int, int64_t) noexcept {}
+#else
+static int dupNativeHandle(uint64_t Native) noexcept {
+  return ::fcntl(static_cast<int>(Native), F_DUPFD_CLOEXEC, 0);
+}
+static void closeNativeFd(int Fd) noexcept { ::close(Fd); }
+static int64_t tellNativeFd(int Fd) noexcept {
+  return static_cast<int64_t>(::lseek(Fd, 0, SEEK_CUR));
+}
+static void seekNativeFd(int Fd, int64_t Offset) noexcept {
+  ::lseek(Fd, static_cast<off_t>(Offset), SEEK_SET);
+}
+#endif
+
+enum class GZOpenDir { None, Read, Write, Append };
+enum class GZOpenDirect { Auto, Transparent, ForceGzip };
+
+struct GZOpenMode {
+  GZOpenDir Dir = GZOpenDir::None;
+  bool Exclusive = false;
+  bool NonBlock = false;
+  GZOpenDirect Direct = GZOpenDirect::Auto;
+};
+
+static std::optional<GZOpenMode>
+parseGZOpenMode(std::string_view Mode) noexcept {
+  GZOpenMode Parsed;
+  for (const char C : Mode) {
+    switch (C) {
+    case 'r':
+      Parsed.Dir = GZOpenDir::Read;
+      break;
+    case 'w':
+      Parsed.Dir = GZOpenDir::Write;
+      break;
+    case 'a':
+      Parsed.Dir = GZOpenDir::Append;
+      break;
+    case 'x':
+      Parsed.Exclusive = true;
+      break;
+    case 'N':
+      Parsed.NonBlock = true;
+      break;
+    case 'T':
+      Parsed.Direct = GZOpenDirect::Transparent;
+      break;
+    case 'G':
+      Parsed.Direct = GZOpenDirect::ForceGzip;
+      break;
+    case '+':
+      return std::nullopt;
+    default:
+      break;
+    }
+  }
+  if (Parsed.Dir == GZOpenDir::None) {
+    return std::nullopt;
+  }
+  if (Parsed.Dir == GZOpenDir::Read &&
+      Parsed.Direct == GZOpenDirect::Transparent) {
+    return std::nullopt;
+  }
+  if (Parsed.Dir != GZOpenDir::Read &&
+      Parsed.Direct == GZOpenDirect::ForceGzip) {
+    return std::nullopt;
+  }
+  return Parsed;
+}
+
+static WasmEdgeZlibEnvironment::GZFileEntry
+wasiFdToGZ(WASI::Environ &WasiEnv, __wasi_fd_t WasiFd, const char *Mode,
+           bool OwnWasiFd) noexcept {
+  const auto Parsed = parseGZOpenMode(Mode);
+  if (!Parsed) {
+    spdlog::error("[WasmEdge-Zlib] [wasiFdToGZ] "sv
+                  "Unsupported gz mode \"{}\"."sv,
+                  Mode);
+    if (OwnWasiFd) {
+      WasiEnv.fdClose(WasiFd);
+    }
+    return {};
+  }
+  const __wasi_rights_t RequiredRights = Parsed->Dir == GZOpenDir::Read
+                                             ? __WASI_RIGHTS_FD_READ
+                                             : __WASI_RIGHTS_FD_WRITE;
+  if (!WasiEnv.canFd(WasiFd, RequiredRights)) {
+    spdlog::error("[WasmEdge-Zlib] [wasiFdToGZ] "sv
+                  "WASI fd lacks the rights required by mode \"{}\"."sv,
+                  Mode);
+    if (OwnWasiFd) {
+      WasiEnv.fdClose(WasiFd);
+    }
+    return {};
+  }
+  const bool CanSeek = WasiEnv.canFd(WasiFd, __WASI_RIGHTS_FD_SEEK);
+  const bool CanTell = WasiEnv.canFd(WasiFd, __WASI_RIGHTS_FD_TELL);
+  if (Parsed->Dir == GZOpenDir::Append && !CanSeek) {
+    __wasi_fdstat_t FdStat;
+    const bool AppendOnly = WasiEnv.fdFdstatGet(WasiFd, FdStat).has_value() &&
+                            (FdStat.fs_flags & __WASI_FDFLAGS_APPEND) != 0;
+    if (!AppendOnly) {
+      spdlog::error("[WasmEdge-Zlib] [wasiFdToGZ] "sv
+                    "Append mode needs FD_SEEK on a non-append-only fd."sv);
+      if (OwnWasiFd) {
+        WasiEnv.fdClose(WasiFd);
+      }
+      return {};
+    }
+  }
+  auto HandleRes = WasiEnv.getNativeHandler(WasiFd);
+  if (!HandleRes) {
+    if (OwnWasiFd) {
+      WasiEnv.fdClose(WasiFd);
+    }
+    return {};
+  }
+  const int DupFd = dupNativeHandle(*HandleRes);
+  if (OwnWasiFd) {
+    WasiEnv.fdClose(WasiFd);
+  }
+  if (DupFd < 0) {
+    spdlog::error("[WasmEdge-Zlib] [wasiFdToGZ] "sv
+                  "Failed to duplicate the host descriptor for zlib."sv);
+    return {};
+  }
+  const bool RestoreOffset =
+      !OwnWasiFd && Parsed->Dir == GZOpenDir::Append && !CanSeek;
+  const int64_t SavedOffset = RestoreOffset ? tellNativeFd(DupFd) : -1;
+  gzFile GZ = gzdopen(DupFd, Mode);
+  bool RestoredAppendOffset = false;
+  if (RestoreOffset && SavedOffset >= 0) {
+    seekNativeFd(DupFd, SavedOffset);
+    RestoredAppendOffset = true;
+  }
+  if (GZ == nullptr) {
+    closeNativeFd(DupFd);
+    return {};
+  }
+  return {GZ, CanSeek, CanTell, RestoredAppendOffset,
+          Parsed->Dir == GZOpenDir::Read};
+}
+
+static WasmEdgeZlibEnvironment::GZFileEntry
+wasiGZOpen(WASI::Environ &WasiEnv, const char *Path,
+           const char *Mode) noexcept {
+  const auto Parsed = parseGZOpenMode(Mode);
+  if (!Parsed) {
+    return {};
+  }
+#if defined(_WIN32)
+  static_cast<void>(WasiEnv);
+  static_cast<void>(Path);
+  spdlog::error("[WasmEdge-Zlib] [wasiGZOpen] "sv
+                "WASI-mediated gzopen is not supported on Windows yet; "sv
+                "returning a null handle for mode \"{}\"."sv,
+                Mode);
+  return {};
+#else
+  auto OpenFlags = static_cast<__wasi_oflags_t>(0);
+  auto FdFlags = static_cast<__wasi_fdflags_t>(0);
+  __wasi_rights_t Rights = static_cast<__wasi_rights_t>(0);
+  switch (Parsed->Dir) {
+  case GZOpenDir::Read:
+    Rights = __WASI_RIGHTS_FD_READ;
+    break;
+  case GZOpenDir::Write:
+    OpenFlags = __WASI_OFLAGS_CREAT | __WASI_OFLAGS_TRUNC;
+    Rights = __WASI_RIGHTS_FD_WRITE;
+    break;
+  case GZOpenDir::Append:
+    OpenFlags = __WASI_OFLAGS_CREAT;
+    FdFlags = __WASI_FDFLAGS_APPEND;
+    Rights = __WASI_RIGHTS_FD_WRITE;
+    break;
+  case GZOpenDir::None:
+    return {};
+  }
+  if (Parsed->NonBlock) {
+    FdFlags = static_cast<__wasi_fdflags_t>(FdFlags | __WASI_FDFLAGS_NONBLOCK);
+  }
+  __wasi_rights_t OptionalRights =
+      __WASI_RIGHTS_FD_SEEK | __WASI_RIGHTS_FD_TELL;
+  __wasi_fdstat_t DirStat;
+  if (WasiEnv.fdFdstatGet(3, DirStat).has_value()) {
+    __wasi_rights_t Inheriting = DirStat.fs_rights_inheriting;
+    if ((Inheriting & __WASI_RIGHTS_FD_SEEK) != 0) {
+      Inheriting |= __WASI_RIGHTS_FD_TELL;
+    }
+    OptionalRights &= Inheriting;
+  }
+  Rights |= OptionalRights;
+  auto LookupFlags = __WASI_LOOKUPFLAGS_SYMLINK_FOLLOW;
+  if (Parsed->Exclusive && Parsed->Dir != GZOpenDir::Read) {
+    OpenFlags |= __WASI_OFLAGS_EXCL;
+    LookupFlags = static_cast<__wasi_lookupflags_t>(0);
+  }
+  while (Path[0] == '/' || (Path[0] == '.' && Path[1] == '/') ||
+         (Path[0] == '.' && Path[1] == '\0')) {
+    Path += (Path[0] == '.' && Path[1] == '/') ? 2 : 1;
+  }
+  auto FdRes = WasiEnv.pathOpen(3, Path, LookupFlags, OpenFlags, Rights, Rights,
+                                FdFlags);
+  if (!FdRes) {
+    return {};
+  }
+  return wasiFdToGZ(WasiEnv, *FdRes, Mode, /*OwnWasiFd=*/true);
+#endif
+}
+
+constexpr uint64_t MaxGZOpenPathLen = 4096;
+constexpr uint64_t MaxGZOpenModeLen = 63;
+
 Expect<uint32_t> WasmEdgeZlibGZOpen::body(const Runtime::CallingFrame &Frame,
                                           uint32_t PathPtr, uint32_t ModePtr) {
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  const auto *Path = getInBoundsCString(*MemInst, PathPtr);
-  const auto *Mode = getInBoundsCString(*MemInst, ModePtr);
-  if (unlikely(Path == nullptr || Mode == nullptr)) {
-    spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibGZOpen] "sv
-                  "Out-of-bounds path or mode string."sv);
-    return Unexpect(ErrCode::Value::HostFuncError);
+  if (PathPtr == 0) {
+    return UINT32_C(0);
   }
 
-  auto ZRes = gzopen(Path, Mode);
-  if (unlikely(ZRes == nullptr)) {
-    // A null gzFile is zlib's ordinary open failure (e.g. a missing file);
-    // surface it to the guest as a null handle instead of trapping. No live
-    // handle is ever 0 because NextGZFile starts at sizeof(gzFile).
+  const auto PathStr =
+      getBoundedInBoundsCString(*MemInst, PathPtr, MaxGZOpenPathLen);
+  const auto ModeStr =
+      getBoundedInBoundsCString(*MemInst, ModePtr, MaxGZOpenModeLen);
+  if (unlikely(!PathStr || !ModeStr)) {
+    spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibGZOpen] "sv
+                  "Out-of-bounds or oversized path or mode string."sv);
+    return Unexpect(ErrCode::Value::HostFuncError);
+  }
+  const std::string Path(PathStr->data(), PathStr->size());
+  const std::string Mode(ModeStr->data(), ModeStr->size());
+
+  WasmEdgeZlibEnvironment::GZFileEntry Entry{};
+  if (Frame.getWASIModule() == nullptr) {
+    Entry = {gzopen(Path.c_str(), Mode.c_str()), /*CanSeek=*/true,
+             /*CanTell=*/true, /*RestoredAppendOffset=*/false};
+  } else if (auto *WasiEnv = getWasiEnviron(Frame); WasiEnv != nullptr) {
+    Entry = wasiGZOpen(*WasiEnv, Path.c_str(), Mode.c_str());
+  } else {
+    spdlog::error(
+        "[WasmEdge-Zlib] [WasmEdgeZlibGZOpen] "sv
+        "A WASI module is configured but is not one this plugin can "sv
+        "read capabilities from; refusing to open outside the "sv
+        "capability layer."sv);
+    return UINT32_C(0);
+  }
+  if (unlikely(Entry.GZ == nullptr)) {
     return UINT32_C(0);
   }
 
   const uint32_t NewWasmGZFile = Env.NextGZFile++;
-  Env.GZFileMap.emplace(NewWasmGZFile, ZRes);
+  Env.GZFileMap.emplace(NewWasmGZFile, Entry);
 
   return NewWasmGZFile;
 }
 
-Expect<uint32_t> WasmEdgeZlibGZDOpen::body(const Runtime::CallingFrame &Frame,
-                                           int32_t FD, uint32_t ModePtr) {
-  MEMINST_CHECK(MemInst, Frame, 0)
-
-  const auto *Mode = getInBoundsCString(*MemInst, ModePtr);
-  if (unlikely(Mode == nullptr)) {
-    spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibGZDOpen] "sv
-                  "Out-of-bounds mode string."sv);
-    return Unexpect(ErrCode::Value::HostFuncError);
-  }
-
-  auto ZRes = gzdopen(FD, Mode);
-  if (unlikely(ZRes == nullptr)) {
-    // Match gzopen: a null gzFile is an ordinary failure handed back to the
-    // guest as a null handle, not a host trap.
-    return UINT32_C(0);
-  }
-
-  const uint32_t NewWasmGZFile = Env.NextGZFile++;
-  Env.GZFileMap.emplace(NewWasmGZFile, ZRes);
-
-  return NewWasmGZFile;
+Expect<uint32_t> WasmEdgeZlibGZDOpen::body(const Runtime::CallingFrame &,
+                                           int32_t, uint32_t) {
+  // TODO(zlib): Re-enable gzdopen after WASI fd ownership is safe at teardown.
+  return UINT32_C(0);
 }
 
 Expect<int32_t> WasmEdgeZlibGZBuffer::body(const Runtime::CallingFrame &,
@@ -1517,12 +1500,11 @@ Expect<int32_t> WasmEdgeZlibGZBuffer::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  // Clamp a guest-declared buffer size to a sane maximum: gzbuffer makes zlib
-  // allocate three times this size on the first I/O, so an unclamped multi-GB
-  // request would exhaust host memory (and zlib rejects sizes >= 2^31
-  // outright).
+  if (Size >= UINT32_C(0x80000000)) {
+    return INT32_C(-1);
+  }
   constexpr uint32_t MaxGZBufferSize = UINT32_C(64) * 1024 * 1024;
-  return gzbuffer(GZFileIt->second,
+  return gzbuffer(GZFileIt->second.GZ,
                   Size > MaxGZBufferSize ? MaxGZBufferSize : Size);
 }
 
@@ -1536,7 +1518,7 @@ Expect<int32_t> WasmEdgeZlibGZSetParams::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzsetparams(GZFileIt->second, Level, Strategy);
+  return gzsetparams(GZFileIt->second.GZ, Level, Strategy);
 }
 
 Expect<int32_t> WasmEdgeZlibGZRead::body(const Runtime::CallingFrame &Frame,
@@ -1551,9 +1533,13 @@ Expect<int32_t> WasmEdgeZlibGZRead::body(const Runtime::CallingFrame &Frame,
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
+  if (Len > UINT32_C(0x7fffffff)) {
+    return gzread(GZFileIt->second.GZ, nullptr, Len);
+  }
+
   BUFFER_CHECK(Buf, MemInst, BufPtr, Len, "WasmEdgeZlibGZRead")
 
-  return gzread(GZFileIt->second, Buf, Len);
+  return gzread(GZFileIt->second.GZ, Buf, Len);
 }
 
 Expect<int32_t> WasmEdgeZlibGZFread::body(const Runtime::CallingFrame &Frame,
@@ -1569,9 +1555,12 @@ Expect<int32_t> WasmEdgeZlibGZFread::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0)
 
   const uint64_t Bytes = static_cast<uint64_t>(Size) * NItems;
+  if (Bytes > UINT32_MAX) {
+    return gzfread(nullptr, static_cast<z_size_t>(-1), 2, GZFileIt->second.GZ);
+  }
   BUFFER_CHECK(Buf, MemInst, BufPtr, Bytes, "WasmEdgeZlibGZFread")
 
-  return gzfread(Buf, Size, NItems, GZFileIt->second);
+  return gzfread(Buf, Size, NItems, GZFileIt->second.GZ);
 }
 
 Expect<int32_t> WasmEdgeZlibGZWrite::body(const Runtime::CallingFrame &Frame,
@@ -1586,9 +1575,13 @@ Expect<int32_t> WasmEdgeZlibGZWrite::body(const Runtime::CallingFrame &Frame,
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
+  if (Len > UINT32_C(0x7fffffff)) {
+    return gzwrite(GZFileIt->second.GZ, nullptr, Len);
+  }
+
   BUFFER_CHECK(Buf, MemInst, BufPtr, Len, "WasmEdgeZlibGZWrite")
 
-  return gzwrite(GZFileIt->second, Buf, Len);
+  return gzwrite(GZFileIt->second.GZ, Buf, Len);
 }
 
 Expect<int32_t> WasmEdgeZlibGZFwrite::body(const Runtime::CallingFrame &Frame,
@@ -1604,9 +1597,12 @@ Expect<int32_t> WasmEdgeZlibGZFwrite::body(const Runtime::CallingFrame &Frame,
   MEMINST_CHECK(MemInst, Frame, 0)
 
   const uint64_t Bytes = static_cast<uint64_t>(Size) * NItems;
+  if (Bytes > UINT32_MAX) {
+    return gzfwrite(nullptr, static_cast<z_size_t>(-1), 2, GZFileIt->second.GZ);
+  }
   BUFFER_CHECK(Buf, MemInst, BufPtr, Bytes, "WasmEdgeZlibGZFwrite")
 
-  return gzfwrite(Buf, Size, NItems, GZFileIt->second);
+  return gzfwrite(Buf, Size, NItems, GZFileIt->second.GZ);
 }
 
 Expect<int32_t> WasmEdgeZlibGZPuts::body(const Runtime::CallingFrame &Frame,
@@ -1620,14 +1616,21 @@ Expect<int32_t> WasmEdgeZlibGZPuts::body(const Runtime::CallingFrame &Frame,
 
   MEMINST_CHECK(MemInst, Frame, 0)
 
-  const auto *String = getInBoundsCString(*MemInst, StringPtr);
-  if (unlikely(String == nullptr)) {
+  const auto String =
+      getBoundedInBoundsCString(*MemInst, StringPtr, UINT64_MAX);
+  if (unlikely(!String)) {
     spdlog::error("[WasmEdge-Zlib] [WasmEdgeZlibGZPuts] "sv
                   "Out-of-bounds string."sv);
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzputs(GZFileIt->second, String);
+  if (String->empty()) {
+    return gzputs(GZFileIt->second.GZ, "");
+  }
+  const int Written = gzwrite(GZFileIt->second.GZ, String->data(),
+                              static_cast<unsigned>(String->size()));
+  return Written > 0 && static_cast<size_t>(Written) == String->size() ? Written
+                                                                       : -1;
 }
 
 Expect<int32_t> WasmEdgeZlibGZPutc::body(const Runtime::CallingFrame &,
@@ -1639,7 +1642,7 @@ Expect<int32_t> WasmEdgeZlibGZPutc::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzputc(GZFileIt->second, C);
+  return gzputc(GZFileIt->second.GZ, C);
 }
 
 Expect<int32_t> WasmEdgeZlibGZGetc::body(const Runtime::CallingFrame &,
@@ -1651,7 +1654,7 @@ Expect<int32_t> WasmEdgeZlibGZGetc::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzgetc(GZFileIt->second);
+  return gzgetc(GZFileIt->second.GZ);
 }
 
 Expect<int32_t> WasmEdgeZlibGZUngetc::body(const Runtime::CallingFrame &,
@@ -1663,7 +1666,7 @@ Expect<int32_t> WasmEdgeZlibGZUngetc::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzungetc(C, GZFileIt->second);
+  return gzungetc(C, GZFileIt->second.GZ);
 }
 
 Expect<int32_t> WasmEdgeZlibGZFlush::body(const Runtime::CallingFrame &,
@@ -1675,7 +1678,7 @@ Expect<int32_t> WasmEdgeZlibGZFlush::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzflush(GZFileIt->second, Flush);
+  return gzflush(GZFileIt->second.GZ, Flush);
 }
 
 Expect<int32_t> WasmEdgeZlibGZSeek::body(const Runtime::CallingFrame &,
@@ -1688,7 +1691,11 @@ Expect<int32_t> WasmEdgeZlibGZSeek::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzseek(GZFileIt->second, Offset, Whence);
+  if (unlikely(!GZFileIt->second.CanSeek && GZFileIt->second.OpenedForRead)) {
+    return static_cast<int32_t>(-1);
+  }
+
+  return gzseek(GZFileIt->second.GZ, Offset, Whence);
 }
 
 Expect<int32_t> WasmEdgeZlibGZRewind::body(const Runtime::CallingFrame &,
@@ -1700,7 +1707,11 @@ Expect<int32_t> WasmEdgeZlibGZRewind::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzrewind(GZFileIt->second);
+  if (unlikely(!GZFileIt->second.CanSeek && GZFileIt->second.OpenedForRead)) {
+    return static_cast<int32_t>(-1);
+  }
+
+  return gzrewind(GZFileIt->second.GZ);
 }
 
 Expect<int32_t> WasmEdgeZlibGZTell::body(const Runtime::CallingFrame &,
@@ -1712,7 +1723,7 @@ Expect<int32_t> WasmEdgeZlibGZTell::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gztell(GZFileIt->second);
+  return gztell(GZFileIt->second.GZ);
 }
 
 Expect<int32_t> WasmEdgeZlibGZOffset::body(const Runtime::CallingFrame &,
@@ -1724,7 +1735,12 @@ Expect<int32_t> WasmEdgeZlibGZOffset::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzoffset(GZFileIt->second);
+  if (unlikely(!GZFileIt->second.CanTell ||
+               GZFileIt->second.RestoredAppendOffset)) {
+    return static_cast<int32_t>(-1);
+  }
+
+  return gzoffset(GZFileIt->second.GZ);
 }
 
 Expect<int32_t> WasmEdgeZlibGZEof::body(const Runtime::CallingFrame &,
@@ -1736,7 +1752,7 @@ Expect<int32_t> WasmEdgeZlibGZEof::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzeof(GZFileIt->second);
+  return gzeof(GZFileIt->second.GZ);
 }
 
 Expect<int32_t> WasmEdgeZlibGZDirect::body(const Runtime::CallingFrame &,
@@ -1748,10 +1764,10 @@ Expect<int32_t> WasmEdgeZlibGZDirect::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzdirect(GZFileIt->second);
+  return gzdirect(GZFileIt->second.GZ);
 }
 
-Expect<int32_t> WasmEdgeZlibGZClose::body(const Runtime::CallingFrame &,
+Expect<int32_t> WasmEdgeZlibGZClose::body(const Runtime::CallingFrame &Frame,
                                           uint32_t GZFile) {
   const auto GZFileIt = Env.GZFileMap.find(GZFile);
   if (GZFileIt == Env.GZFileMap.end()) {
@@ -1760,14 +1776,16 @@ Expect<int32_t> WasmEdgeZlibGZClose::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  const auto ZRes = gzclose(GZFileIt->second);
+  const int64_t OwnedWasiFd = GZFileIt->second.OwnedWasiFd;
+  const auto ZRes = gzclose(GZFileIt->second.GZ);
 
   Env.GZFileMap.erase(GZFileIt);
+  releaseOwnedWasiFd(Frame, OwnedWasiFd);
 
   return ZRes;
 }
 
-Expect<int32_t> WasmEdgeZlibGZClose_r::body(const Runtime::CallingFrame &,
+Expect<int32_t> WasmEdgeZlibGZClose_r::body(const Runtime::CallingFrame &Frame,
                                             uint32_t GZFile) {
   const auto GZFileIt = Env.GZFileMap.find(GZFile);
   if (GZFileIt == Env.GZFileMap.end()) {
@@ -1776,17 +1794,18 @@ Expect<int32_t> WasmEdgeZlibGZClose_r::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  const auto ZRes = gzclose_r(GZFileIt->second);
+  const int64_t OwnedWasiFd = GZFileIt->second.OwnedWasiFd;
+  const auto ZRes = gzclose_r(GZFileIt->second.GZ);
 
-  // Z_STREAM_ERROR means the handle was the wrong mode and was NOT freed; keep
-  // it so the environment destructor can still reclaim it.
-  if (ZRes != Z_STREAM_ERROR)
+  if (ZRes != Z_STREAM_ERROR) {
     Env.GZFileMap.erase(GZFileIt);
+    releaseOwnedWasiFd(Frame, OwnedWasiFd);
+  }
 
   return ZRes;
 }
 
-Expect<int32_t> WasmEdgeZlibGZClose_w::body(const Runtime::CallingFrame &,
+Expect<int32_t> WasmEdgeZlibGZClose_w::body(const Runtime::CallingFrame &Frame,
                                             uint32_t GZFile) {
   const auto GZFileIt = Env.GZFileMap.find(GZFile);
   if (GZFileIt == Env.GZFileMap.end()) {
@@ -1795,12 +1814,13 @@ Expect<int32_t> WasmEdgeZlibGZClose_w::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  const auto ZRes = gzclose_w(GZFileIt->second);
+  const int64_t OwnedWasiFd = GZFileIt->second.OwnedWasiFd;
+  const auto ZRes = gzclose_w(GZFileIt->second.GZ);
 
-  // Z_STREAM_ERROR means the handle was the wrong mode and was NOT freed; keep
-  // it so the environment destructor can still reclaim it.
-  if (ZRes != Z_STREAM_ERROR)
+  if (ZRes != Z_STREAM_ERROR) {
     Env.GZFileMap.erase(GZFileIt);
+    releaseOwnedWasiFd(Frame, OwnedWasiFd);
+  }
 
   return ZRes;
 }
@@ -1814,18 +1834,11 @@ Expect<void> WasmEdgeZlibGZClearerr::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  gzclearerr(GZFileIt->second);
+  gzclearerr(GZFileIt->second.GZ);
 
   return Expect<void>{};
 }
 
-// adler32/crc32 read Z_NULL as a request for the checksum's initial value and
-// any non-null zero-length buffer as "leave the running value unchanged",
-// mirroring deflateSetDictionary's contract above. getSpan yields a null
-// pointer for an out-of-bounds zero-length slice (which would reset the
-// caller's checksum) and a non-null pointer for guest offset 0 -- the guest's
-// Z_NULL -- (which would suppress the reset it asked for). Map a guest null to
-// Z_NULL and every other zero-length request to a non-null empty buffer.
 static inline const Bytef *
 normalizeChecksumBuf(const Bytef *Buf, uint32_t BufPtr, uint32_t Len) noexcept {
   if (Len != 0) {
@@ -1986,7 +1999,6 @@ WasmEdgeZlibInflateInit2_::body(const Runtime::CallingFrame &Frame,
         return inflateInit2_(HostZStream, WindowBits, WasmZlibVersion->data(),
                              sizeof(z_stream));
       });
-  // See WasmEdgeZlibInflateInit2 for the windowBits-to-wrap mapping.
   if (ZRes && *ZRes == Z_OK) {
     if (const auto It = Env.ZStreamMap.find(ZStreamPtr);
         It != Env.ZStreamMap.end()) {
@@ -2007,9 +2019,6 @@ Expect<int32_t> WasmEdgeZlibInflateBackInit_::body(
 
   const auto WasmZlibVersion =
       getBoundedInBoundsCString(*MemInst, VersionPtr, MaxZlibVersionLen);
-  // zlib rejects a null or major-mismatched version before it examines any
-  // other argument, so mirror that order and answer Z_VERSION_ERROR here
-  // rather than resolve (and possibly trap on) the window span first.
   if (!WasmZlibVersion || !CheckVersion(WasmZlibVersion->data())) {
     return static_cast<int32_t>(Z_VERSION_ERROR);
   }
@@ -2024,9 +2033,6 @@ Expect<int32_t> WasmEdgeZlibInflateBackInit_::body(
     }
     Window = WindowSpan.data();
   } else {
-    // A guest null window is zlib's Z_NULL and an out-of-range windowBits is
-    // equally rejected before the window is touched, so neither resolves a
-    // guest pointer (wasm address 0 must not stand in for Z_NULL here).
     Window = nullptr;
   }
 
@@ -2047,7 +2053,7 @@ Expect<int32_t> WasmEdgeZlibGZGetc_::body(const Runtime::CallingFrame &,
     return Unexpect(ErrCode::Value::HostFuncError);
   }
 
-  return gzgetc_(GZFileIt->second);
+  return gzgetc_(GZFileIt->second.GZ);
 }
 
 Expect<int32_t>
@@ -2107,7 +2113,6 @@ WasmEdgeZlibInflateCodesUsed::body(const Runtime::CallingFrame &,
                   "Invalid ZStreamPtr received."sv);
     return Unexpect(ErrCode::Value::HostFuncError);
   }
-  // inflateCodesUsed's bad-state answer is (unsigned long)-1.
   if (HostZStreamIt->second.Kind != ZStreamKind::Inflate) {
     return INT32_C(-1);
   }
@@ -2130,9 +2135,6 @@ WasmEdgeZlibInflateResetKeep::body(const Runtime::CallingFrame &,
 
   const auto ZRes = inflateResetKeep(&HostZStreamIt->second.Z);
 
-  // inflateResetKeep detaches zlib's gzip-header pointer like inflateReset;
-  // drop the stale snapshot (see WasmEdgeZlibInflateReset) and the
-  // dictionary-wait flag with it (the stream is back at the header stage).
   if (ZRes == Z_OK) {
     Env.GZHeaderMap.erase(ZStreamPtr);
     HostZStreamIt->second.MayNeedDict = false;
@@ -2156,8 +2158,6 @@ WasmEdgeZlibDeflateResetKeep::body(const Runtime::CallingFrame &,
 
   const int ZRes = deflateResetKeep(&HostZStreamIt->second.Z);
 
-  // deflateResetKeep also returns the stream to INIT_STATE, so clear the
-  // started flag that gates deflateSetDictionary.
   if (ZRes == Z_OK) {
     HostZStreamIt->second.DeflateStarted = false;
   }

--- a/test/plugins/wasmedge_zlib/wasmedge_zlib.cpp
+++ b/test/plugins/wasmedge_zlib/wasmedge_zlib.cpp
@@ -10,6 +10,8 @@
 #include <array>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
+#include <filesystem>
 #include <gtest/gtest.h>
 #include <memory>
 #include <string>
@@ -131,26 +133,28 @@ TEST(WasmEdgeZlibTest, DeflateInflateCycle) {
 
   // deflateInit_ Test
   // WASM z_stream size Mismatch
-  EXPECT_TRUE(DeflateInit_.run(CallFrame,
-                               std::initializer_list<WasmEdge::ValVariant>{
-                                   ModuleZStream, INT32_C(-1), WasmZlibVersion,
-                                   sizeof(WasmZStream) + 16},
-                               RetVal));
+  EXPECT_TRUE(
+      DeflateInit_.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           ModuleZStream, INT32_C(-1), WasmZlibVersion,
+                           static_cast<uint32_t>(sizeof(WasmZStream) + 16)},
+                       RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_VERSION_ERROR);
 
   // Version Mismatch
-  EXPECT_TRUE(DeflateInit_.run(
-      CallFrame,
-      std::initializer_list<WasmEdge::ValVariant>{
-          ModuleZStream, INT32_C(-1), WasmZlibVersion + 2, sizeof(WasmZStream)},
-      RetVal));
+  EXPECT_TRUE(
+      DeflateInit_.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           ModuleZStream, INT32_C(-1), WasmZlibVersion + 2,
+                           static_cast<uint32_t>(sizeof(WasmZStream))},
+                       RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_VERSION_ERROR);
 
-  EXPECT_TRUE(DeflateInit_.run(
-      CallFrame,
-      std::initializer_list<WasmEdge::ValVariant>{
-          ModuleZStream, INT32_C(-1), WasmZlibVersion, sizeof(WasmZStream)},
-      RetVal));
+  EXPECT_TRUE(DeflateInit_.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   ModuleZStream, INT32_C(-1), WasmZlibVersion,
+                                   static_cast<uint32_t>(sizeof(WasmZStream))},
+                               RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
   WasmCompressedData = WasmHP;
@@ -191,26 +195,27 @@ TEST(WasmEdgeZlibTest, DeflateInflateCycle) {
 
   // inflateInit_ Test
   // WASM z_stream size Mismatch
-  EXPECT_TRUE(InflateInit_.run(
-      CallFrame,
-      std::initializer_list<WasmEdge::ValVariant>{
-          ModuleZStream, WasmZlibVersion, sizeof(WasmZStream) + 16},
-      RetVal));
-  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_VERSION_ERROR);
-
-  // Version Mismatch
-  EXPECT_TRUE(InflateInit_.run(
-      CallFrame,
-      std::initializer_list<WasmEdge::ValVariant>{
-          ModuleZStream, WasmZlibVersion + 2, sizeof(WasmZStream)},
-      RetVal));
-  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_VERSION_ERROR);
-
   EXPECT_TRUE(
       InflateInit_.run(CallFrame,
                        std::initializer_list<WasmEdge::ValVariant>{
-                           ModuleZStream, WasmZlibVersion, sizeof(WasmZStream)},
+                           ModuleZStream, WasmZlibVersion,
+                           static_cast<uint32_t>(sizeof(WasmZStream) + 16)},
                        RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_VERSION_ERROR);
+
+  // Version Mismatch
+  EXPECT_TRUE(InflateInit_.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   ModuleZStream, WasmZlibVersion + 2,
+                                   static_cast<uint32_t>(sizeof(WasmZStream))},
+                               RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_VERSION_ERROR);
+
+  EXPECT_TRUE(InflateInit_.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   ModuleZStream, WasmZlibVersion,
+                                   static_cast<uint32_t>(sizeof(WasmZStream))},
+                               RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
   WasmDecompressedData = WasmHP;
@@ -252,6 +257,556 @@ TEST(WasmEdgeZlibTest, DeflateInflateCycle) {
                          MemInst.getPointer<uint8_t *>(
                              WasmDecompressedData + WasmDecompressedDataSize),
                          MemInst.getPointer<uint8_t *>(WasmData)));
+}
+
+#define GET_ZLIB_FUNC(Var, Name)                                               \
+  auto *Var##Inst = ZlibMod->findFuncExports(Name);                            \
+  ASSERT_NE(Var##Inst, nullptr);                                               \
+  auto &Var = Var##Inst->getHostFunc();
+
+TEST(WasmEdgeZlibTest, HardeningBounds) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  // Out-of-bounds z_stream pointer must fail instead of dereferencing NULL:
+  // 65530 + sizeof(WasmZStream) exceeds the single memory page.
+  {
+    GET_ZLIB_FUNC(DeflateInit, "deflateInit")
+    EXPECT_FALSE(DeflateInit.run(CallFrame,
+                                 std::initializer_list<WasmEdge::ValVariant>{
+                                     UINT32_C(65530), INT32_C(-1)},
+                                 RetVal));
+  }
+
+  // A guest-controlled avail_out larger than linear memory must be rejected
+  // rather than letting zlib write past the end of memory.
+  {
+    GET_ZLIB_FUNC(DeflateInit, "deflateInit")
+    GET_ZLIB_FUNC(Deflate, "deflate")
+    const uint32_t ZS = 0;
+    std::fill_n(MemInst.getPointer<uint8_t *>(ZS), sizeof(WasmZStream), 0);
+    ASSERT_TRUE(DeflateInit.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-1)},
+        RetVal));
+    ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+    auto *Strm = MemInst.getPointer<WasmZStream *>(ZS);
+    Strm->NextIn = 1000;
+    Strm->AvailIn = 4;
+    Strm->NextOut = 2000;
+    Strm->AvailOut = UINT32_C(0xFFFFFFFF);
+    EXPECT_FALSE(Deflate.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(0)},
+        RetVal));
+  }
+
+  // compress with an out-of-bounds destination-length pointer must fail.
+  {
+    GET_ZLIB_FUNC(Compress, "compress")
+    EXPECT_FALSE(Compress.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            UINT32_C(0), UINT32_C(65534), UINT32_C(100), UINT32_C(10)},
+        RetVal));
+  }
+
+  // compress with a valid destination but an out-of-bounds source length must
+  // fail rather than let zlib read past the end of memory.
+  {
+    GET_ZLIB_FUNC(Compress, "compress")
+    *MemInst.getPointer<uint32_t *>(0) = 100;
+    EXPECT_FALSE(Compress.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            UINT32_C(8), UINT32_C(0), UINT32_C(4000), UINT32_C(0xFFFFFFF0)},
+        RetVal));
+  }
+
+  // uncompress with an out-of-bounds destination-length pointer must fail.
+  {
+    GET_ZLIB_FUNC(Uncompress, "uncompress")
+    EXPECT_FALSE(Uncompress.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            UINT32_C(0), UINT32_C(65535), UINT32_C(100), UINT32_C(10)},
+        RetVal));
+  }
+
+  // adler32 / crc32 with a length larger than memory must fail rather than
+  // read out of bounds.
+  {
+    GET_ZLIB_FUNC(Adler32, "adler32")
+    EXPECT_FALSE(
+        Adler32.run(CallFrame,
+                    std::initializer_list<WasmEdge::ValVariant>{
+                        UINT32_C(1), UINT32_C(100), UINT32_C(0xFFFFFFFF)},
+                    RetVal));
+    GET_ZLIB_FUNC(CRC32, "crc32")
+    EXPECT_FALSE(
+        CRC32.run(CallFrame,
+                  std::initializer_list<WasmEdge::ValVariant>{
+                      UINT32_C(0), UINT32_C(100), UINT32_C(0xFFFFFFFF)},
+                  RetVal));
+  }
+
+  // An unknown gz file handle must be rejected, not dereferenced.
+  {
+    GET_ZLIB_FUNC(GZRead, "gzread")
+    EXPECT_FALSE(GZRead.run(CallFrame,
+                            std::initializer_list<WasmEdge::ValVariant>{
+                                UINT32_C(9999), UINT32_C(0), UINT32_C(10)},
+                            RetVal));
+  }
+}
+
+TEST(WasmEdgeZlibTest, HardeningCompress2AnswersInvalidLevelBeforeBounds) {
+  // An out-of-range level fails compress2's deflateInit before any source
+  // byte is read or dest byte written -- though only after *destLen has been
+  // zeroed -- so the wrapper must surface that Z_STREAM_ERROR instead of
+  // trapping on data spans the rejected call would never touch. A level zlib
+  // accepts keeps the bounds check.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(Compress2, "compress2")
+
+  // A garbage *destLen makes the dest span run far past linear memory.
+  const uint32_t DestLenPtr = 0;
+  *MemInst.getPointer<uint32_t *>(DestLenPtr) = UINT32_C(0xFFFFFFF0);
+  ASSERT_TRUE(Compress2.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          UINT32_C(8), DestLenPtr, UINT32_C(4096), UINT32_C(64), INT32_C(10)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+  EXPECT_EQ(*MemInst.getPointer<uint32_t *>(DestLenPtr), UINT32_C(0));
+
+  // With an accepted level the same out-of-bounds span must keep trapping.
+  *MemInst.getPointer<uint32_t *>(DestLenPtr) = UINT32_C(0xFFFFFFF0);
+  EXPECT_FALSE(Compress2.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          UINT32_C(8), DestLenPtr, UINT32_C(4096), UINT32_C(64), INT32_C(-1)},
+      RetVal));
+}
+
+TEST(WasmEdgeZlibTest, HardeningUncompress2AliasedLengthMatchesNative) {
+  // Native uncompress2 writes *destLen last, so when a guest aliases the two
+  // length pointers (DestLenPtr == SourceLenPtr) the shared slot ends holding
+  // the produced (uncompressed) length, not the consumed source length. The
+  // wrapper snapshots into separate host variables, so it must write them back
+  // in the same order to leave the guest the value native would.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(Compress, "compress")
+  GET_ZLIB_FUNC(Uncompress2, "uncompress2")
+
+  // A highly compressible payload, compressed to a zlib stream.
+  const uint32_t RawPtr = 4096;
+  const uint32_t RawLen = 100;
+  fillMemContent(MemInst, RawPtr, RawLen, static_cast<uint8_t>('A'));
+
+  const uint32_t CompPtr = 256;
+  const uint32_t CompCap = 512;
+  const uint32_t CompLenPtr = 128;
+  fillMemContent(MemInst, CompPtr, CompCap);
+  *MemInst.getPointer<uint32_t *>(CompLenPtr) = CompCap;
+  ASSERT_TRUE(Compress.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               CompPtr, CompLenPtr, RawPtr, RawLen},
+                           RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  const uint32_t CompLen = *MemInst.getPointer<uint32_t *>(CompLenPtr);
+  ASSERT_GT(CompLen, 0U);
+
+  // Aliased call: the single slot is both dest capacity and source length. A
+  // capacity that covers the produced and compressed sizes lets the decode
+  // finish; the wrapper bounds the source by this length, and inflate stops at
+  // the stream end long before consuming the zero-filled tail.
+  const uint32_t Cap = 256;
+  ASSERT_GE(Cap, RawLen);
+  ASSERT_GT(Cap, CompLen);
+  const uint32_t OutPtr = 8192;
+  const uint32_t AliasLenPtr = 64;
+  fillMemContent(MemInst, OutPtr, Cap);
+  *MemInst.getPointer<uint32_t *>(AliasLenPtr) = Cap;
+  ASSERT_TRUE(Uncompress2.run(CallFrame,
+                              std::initializer_list<WasmEdge::ValVariant>{
+                                  OutPtr, AliasLenPtr, CompPtr, AliasLenPtr},
+                              RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_EQ(*MemInst.getPointer<uint32_t *>(AliasLenPtr), RawLen);
+  EXPECT_EQ(0, std::memcmp(MemInst.getPointer<char *>(OutPtr),
+                           MemInst.getPointer<char *>(RawPtr), RawLen));
+
+  // Non-aliased control: each slot keeps its own result.
+  const uint32_t DestLenPtr = 32;
+  const uint32_t SrcLenPtr = 48;
+  fillMemContent(MemInst, OutPtr, Cap);
+  *MemInst.getPointer<uint32_t *>(DestLenPtr) = Cap;
+  *MemInst.getPointer<uint32_t *>(SrcLenPtr) = CompLen;
+  ASSERT_TRUE(Uncompress2.run(CallFrame,
+                              std::initializer_list<WasmEdge::ValVariant>{
+                                  OutPtr, DestLenPtr, CompPtr, SrcLenPtr},
+                              RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_EQ(*MemInst.getPointer<uint32_t *>(DestLenPtr), RawLen);
+  EXPECT_EQ(*MemInst.getPointer<uint32_t *>(SrcLenPtr), CompLen);
+}
+
+TEST(WasmEdgeZlibTest, HardeningZeroCapacityDestMatchesZlib) {
+  // compress distinguishes a null destination (Z_STREAM_ERROR) from a
+  // non-null one with no capacity (Z_BUF_ERROR) without writing a byte, so
+  // the wrapper must not turn either answer into the other: a guest null maps
+  // to Z_NULL while a nonzero offset stays non-null even when its zero-length
+  // span carries no pointer (one out of bounds included).
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(Compress, "compress")
+
+  const uint32_t DestLenPtr = 0;
+  const uint32_t SourcePtr = 4096;
+  const char *const Payload = "zero capacity destination";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(SourcePtr), Payload);
+
+  // A guest-null destination with no capacity is zlib's Z_STREAM_ERROR.
+  *MemInst.getPointer<uint32_t *>(DestLenPtr) = 0;
+  ASSERT_TRUE(Compress.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               UINT32_C(0), DestLenPtr, SourcePtr, PayloadLen},
+                           RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+
+  // A nonzero destination offset past the end of linear memory still answers
+  // Z_BUF_ERROR at zero capacity; the pointer is never dereferenced.
+  *MemInst.getPointer<uint32_t *>(DestLenPtr) = 0;
+  ASSERT_TRUE(
+      Compress.run(CallFrame,
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       UINT32_C(0xFFFF0000), DestLenPtr, SourcePtr, PayloadLen},
+                   RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_BUF_ERROR);
+
+  // An in-bounds destination with no capacity keeps the same answer.
+  *MemInst.getPointer<uint32_t *>(DestLenPtr) = 0;
+  ASSERT_TRUE(Compress.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               UINT32_C(8), DestLenPtr, SourcePtr, PayloadLen},
+                           RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_BUF_ERROR);
+}
+
+TEST(WasmEdgeZlibTest, HardeningZeroLengthDictionaryMatchesZlib) {
+  // deflateSetDictionary never reads a zero-length dictionary yet still
+  // rejects Z_NULL, so the wrapper must not turn either case into the other:
+  // any nonzero guest offset stays acceptable at length zero, while a guest
+  // null keeps failing with Z_STREAM_ERROR the way it does natively.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit, "deflateInit")
+  GET_ZLIB_FUNC(DeflateSetDictionary, "deflateSetDictionary")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+
+  const uint32_t ZS = 0;
+  std::fill_n(MemInst.getPointer<uint8_t *>(ZS), sizeof(WasmZStream), 0);
+  ASSERT_TRUE(DeflateInit.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-1)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // Beyond the single memory page, so the zero-length span has no pointer.
+  ASSERT_TRUE(
+      DeflateSetDictionary.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   ZS, UINT32_C(0xFFFF0000), UINT32_C(0)},
+                               RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  ASSERT_TRUE(DeflateSetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, UINT32_C(0), UINT32_C(0)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+
+  // A nonzero length keeps the bounds check: the same wild offset must fail.
+  EXPECT_FALSE(
+      DeflateSetDictionary.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   ZS, UINT32_C(0xFFFF0000), UINT32_C(64)},
+                               RetVal));
+
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+}
+
+TEST(WasmEdgeZlibTest, HardeningZeroLengthChecksumMatchesZlib) {
+  // adler32/crc32 read Z_NULL as "return the initial value" and any non-null
+  // zero-length buffer as "return the running value unchanged". A guest null
+  // (offset 0) must map to Z_NULL, while any other zero-length offset -- even a
+  // wild one past the end of memory whose span carries no pointer -- must
+  // preserve the caller's checksum instead of resetting it to the seed.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(Adler32, "adler32")
+  GET_ZLIB_FUNC(CRC32, "crc32")
+
+  const uint32_t Running = 999;
+  const uint32_t WildOffset = 0xFFFF0000;
+
+  // Guest Z_NULL (offset 0, length 0) returns the checksum's initial value.
+  // zlib defines adler32(0, Z_NULL, 0) == 1 and crc32(0, Z_NULL, 0) == 0.
+  ASSERT_TRUE(Adler32.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              Running, UINT32_C(0), UINT32_C(0)},
+                          RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(1));
+
+  // A non-null zero-length buffer, including a wild offset past memory whose
+  // span has no pointer, preserves the running value rather than seeding.
+  ASSERT_TRUE(Adler32.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              Running, WildOffset, UINT32_C(0)},
+                          RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(Running));
+
+  // The same wild offset with a nonzero length still fails the bounds check.
+  EXPECT_FALSE(Adler32.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               Running, WildOffset, UINT32_C(1)},
+                           RetVal));
+
+  // crc32 shares the contract; its initial value is 0 rather than 1.
+  ASSERT_TRUE(CRC32.run(CallFrame,
+                        std::initializer_list<WasmEdge::ValVariant>{
+                            Running, UINT32_C(0), UINT32_C(0)},
+                        RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(0));
+
+  ASSERT_TRUE(CRC32.run(CallFrame,
+                        std::initializer_list<WasmEdge::ValVariant>{
+                            Running, WildOffset, UINT32_C(0)},
+                        RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(Running));
+}
+
+TEST(WasmEdgeZlibTest, HardeningUnterminatedString) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  // Fill every byte of linear memory with a non-NUL value so any C string
+  // starting inside it has no terminator before the end of memory.
+  std::fill_n(MemInst.getPointer<uint8_t *>(0),
+              static_cast<size_t>(MemInst.getSize()),
+              static_cast<uint8_t>(0xFF));
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  EXPECT_FALSE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0), UINT32_C(100)},
+      RetVal));
+}
+
+TEST(WasmEdgeZlibTest, GZFileRoundTrip) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const std::string TmpPath = (std::filesystem::temp_directory_path() /
+                               "wasmedge_zlib_hardening_test.gz")
+                                  .string();
+  ASSERT_LT(TmpPath.size() + 1, 1024U);
+
+  const uint32_t PathPtr = 0;
+  std::strcpy(MemInst.getPointer<char *>(PathPtr), TmpPath.c_str());
+  const uint32_t ModeWPtr = 1024;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+  const uint32_t ModeRPtr = 1040;
+  std::strcpy(MemInst.getPointer<char *>(ModeRPtr), "rb");
+  const uint32_t DataPtr = 1100;
+  const char *const Payload = "hello zlib hardening";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  GET_ZLIB_FUNC(GZWrite, "gzwrite")
+  GET_ZLIB_FUNC(GZRead, "gzread")
+  GET_ZLIB_FUNC(GZClose, "gzclose")
+
+  if (!GZOpen.run(
+          CallFrame,
+          std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWPtr},
+          RetVal)) {
+    GTEST_SKIP() << "cannot create temporary file: " << TmpPath;
+  }
+  const uint32_t WHandle = RetVal[0].get<uint32_t>();
+
+  EXPECT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, DataPtr, PayloadLen},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+
+  // Closing must free the zlib handle exactly once (no double-free).
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, RetVal));
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeRPtr},
+      RetVal));
+  const uint32_t RHandle = RetVal[0].get<uint32_t>();
+  EXPECT_NE(RHandle, WHandle);
+
+  // gzread with an out-of-bounds length must fail rather than overflow the
+  // buffer.
+  EXPECT_FALSE(GZRead.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              RHandle, UINT32_C(60000), UINT32_C(0xFFFFFFFF)},
+                          RetVal));
+
+  const uint32_t ReadBuf = 4096;
+  EXPECT_TRUE(GZRead.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             RHandle, ReadBuf, UINT32_C(256)},
+                         RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_EQ(
+      0, std::memcmp(MemInst.getPointer<char *>(ReadBuf), Payload, PayloadLen));
+
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
+
+  // A double close must be rejected gracefully; the handle is already gone.
+  EXPECT_FALSE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
+
+  std::remove(TmpPath.c_str());
+}
+
+TEST(WasmEdgeZlibTest, GZOpenFailureReturnsNullHandle) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  // A gzopen that fails for an ordinary I/O reason (a missing file) must return
+  // a null handle (0) so guest code can handle the usual gzopen(...) == NULL
+  // case, rather than trapping the whole Wasm call.
+  const std::string MissingPath =
+      (std::filesystem::temp_directory_path() / "wasmedge_zlib_absent_dir_zzz" /
+       "definitely_absent.gz")
+          .string();
+  ASSERT_LT(MissingPath.size() + 1, 900U);
+  const uint32_t PathPtr = 0;
+  std::strcpy(MemInst.getPointer<char *>(PathPtr), MissingPath.c_str());
+  const uint32_t ModePtr = 1000;
+  std::strcpy(MemInst.getPointer<char *>(ModePtr), "rb");
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModePtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+
+  // gzdopen on an invalid file descriptor is likewise an ordinary failure.
+  const uint32_t ModeDPtr = 1010;
+  std::strcpy(MemInst.getPointer<char *>(ModeDPtr), "rb");
+  GET_ZLIB_FUNC(GZDOpen, "gzdopen")
+  EXPECT_TRUE(GZDOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{INT32_C(-1), ModeDPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
 }
 
 TEST(WasmEdgeZlibTest, Module) {

--- a/test/plugins/wasmedge_zlib/wasmedge_zlib.cpp
+++ b/test/plugins/wasmedge_zlib/wasmedge_zlib.cpp
@@ -765,6 +765,123 @@ TEST(WasmEdgeZlibTest, GZFileRoundTrip) {
   std::remove(TmpPath.c_str());
 }
 
+TEST(WasmEdgeZlibTest, GZHeaderSnapshot) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(16, 16)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(DeflateSetHeader, "deflateSetHeader")
+  GET_ZLIB_FUNC(Deflate, "deflate")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(InflateGetHeader, "inflateGetHeader")
+  GET_ZLIB_FUNC(Inflate, "inflate")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  const uint32_t DZS = 0x100;
+  const uint32_t DHdr = 0x200;
+  const uint32_t NamePtr = 0x300;
+  const uint32_t DataPtr = 0x500;
+  const uint32_t CompPtr = 0x1000;
+  const uint32_t CompCap = 0x2000;
+  const char *const OrigName = "original-header-name";
+  const char *const Payload = "payload-to-compress-through-gzip";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(NamePtr), OrigName);
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+  std::fill_n(MemInst.getPointer<uint8_t *>(DZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(DHdr), sizeof(WasmGZHeader), 0);
+
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           DZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(31),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *DHeader = MemInst.getPointer<WasmGZHeader *>(DHdr);
+  DHeader->Name = NamePtr;
+  ASSERT_TRUE(DeflateSetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS, DHdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // After the header is captured, corrupt the guest name and repoint the header
+  // field to an unterminated region at the end of memory. With the snapshot the
+  // emitted name must stay "original-header-name"; without it, deflate would
+  // re-read this and run off the end of linear memory.
+  std::strcpy(MemInst.getPointer<char *>(NamePtr), "CORRUPTED-VALUE");
+  DHeader->Name = static_cast<uint32_t>(MemInst.getSize()) - 3;
+  std::fill_n(MemInst.getPointer<uint8_t *>(
+                  static_cast<uint32_t>(MemInst.getSize()) - 3),
+              3, static_cast<uint8_t>(0xFF));
+
+  auto *DStrm = MemInst.getPointer<WasmZStream *>(DZS);
+  DStrm->NextIn = DataPtr;
+  DStrm->AvailIn = PayloadLen;
+  DStrm->NextOut = CompPtr;
+  DStrm->AvailOut = CompCap;
+  ASSERT_TRUE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  const uint32_t CompLen = CompCap - DStrm->AvailOut;
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS}, RetVal));
+
+  const uint32_t IZS = 0x4000;
+  const uint32_t IHdr = 0x4100;
+  const uint32_t INameBuf = 0x4200;
+  const uint32_t INameMax = 128;
+  const uint32_t DecPtr = 0x5000;
+  const uint32_t DecCap = 0x1000;
+  std::fill_n(MemInst.getPointer<uint8_t *>(IZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(IHdr), sizeof(WasmGZHeader), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(INameBuf), INameMax, 0);
+
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(31)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *IHeader = MemInst.getPointer<WasmGZHeader *>(IHdr);
+  IHeader->Name = INameBuf;
+  IHeader->NameMax = INameMax;
+  ASSERT_TRUE(InflateGetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, IHdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *IStrm = MemInst.getPointer<WasmZStream *>(IZS);
+  IStrm->NextIn = CompPtr;
+  IStrm->AvailIn = CompLen;
+  IStrm->NextOut = DecPtr;
+  IStrm->AvailOut = DecCap;
+  ASSERT_TRUE(Inflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+
+  // The round-tripped header name is the snapshot taken at set-header time, not
+  // the corrupted guest value.
+  EXPECT_STREQ(MemInst.getPointer<char *>(INameBuf), OrigName);
+}
+
 TEST(WasmEdgeZlibTest, GZOpenFailureReturnsNullHandle) {
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
@@ -807,6 +924,896 @@ TEST(WasmEdgeZlibTest, GZOpenFailureReturnsNullHandle) {
       std::initializer_list<WasmEdge::ValVariant>{INT32_C(-1), ModeDPtr},
       RetVal));
   EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+}
+
+TEST(WasmEdgeZlibTest, DeflateSetHeaderKeepsHeaderOnFailedReplace) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(16, 16)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(DeflateSetHeader, "deflateSetHeader")
+
+  const uint32_t DZS = 0x100;
+  const uint32_t DHdr = 0x200;
+  const uint32_t Name1Ptr = 0x300;
+  const char *const Name1 = "original-header-name";
+  std::strcpy(MemInst.getPointer<char *>(Name1Ptr), Name1);
+  std::fill_n(MemInst.getPointer<uint8_t *>(DZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(DHdr), sizeof(WasmGZHeader), 0);
+
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           DZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(31),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // The first set-header succeeds and is captured into host storage; zlib now
+  // holds a pointer into that stored header.
+  auto *DHeader = MemInst.getPointer<WasmGZHeader *>(DHdr);
+  DHeader->Name = Name1Ptr;
+  ASSERT_TRUE(DeflateSetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS, DHdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // The second set-header names a header whose name runs off the end of linear
+  // memory, so the snapshot is rejected. The failed replacement must not
+  // clobber the previously stored, still-referenced header.
+  DHeader->Name = static_cast<uint32_t>(MemInst.getSize()) - 3;
+  std::fill_n(MemInst.getPointer<uint8_t *>(
+                  static_cast<uint32_t>(MemInst.getSize()) - 3),
+              3, static_cast<uint8_t>(0xFF));
+  EXPECT_FALSE(DeflateSetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS, DHdr},
+      RetVal));
+
+  // The stored header is still the first one, not the failed replacement.
+  const auto &HeaderMap = ZlibMod->getEnv().GZHeaderMap;
+  const auto StoreIt = HeaderMap.find(DZS);
+  ASSERT_NE(StoreIt, HeaderMap.end());
+  EXPECT_EQ(StoreIt->second->Name, Name1);
+}
+
+TEST(WasmEdgeZlibTest, HardeningDeflateSetHeaderNonGzipSkipsSnapshot) {
+  // zlib only accepts deflateSetHeader on a gzip deflate stream and answers
+  // Z_STREAM_ERROR for anything else without reading the header. The host must
+  // obtain that verdict before doing any guest-header work: on a zlib-format
+  // stream, even a header whose name would fail the snapshot's bounds check
+  // (or force a guest-sized host copy) surfaces zlib's Z_STREAM_ERROR instead
+  // of trapping or copying.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(16, 16)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(DeflateSetHeader, "deflateSetHeader")
+
+  const uint32_t DZS = 0x100;
+  const uint32_t DHdr = 0x200;
+  std::fill_n(MemInst.getPointer<uint8_t *>(DZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(DHdr), sizeof(WasmGZHeader), 0);
+
+  // windowBits 15 requests the zlib wrapper, not gzip, so zlib will refuse
+  // the header on this stream.
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           DZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(15),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // The header name runs unterminated to the end of linear memory; on a gzip
+  // stream this snapshot would trap. zlib's verdict comes first, so the call
+  // reports Z_STREAM_ERROR and stores nothing.
+  auto *DHeader = MemInst.getPointer<WasmGZHeader *>(DHdr);
+  DHeader->Name = static_cast<uint32_t>(MemInst.getSize()) - 3;
+  std::fill_n(MemInst.getPointer<uint8_t *>(
+                  static_cast<uint32_t>(MemInst.getSize()) - 3),
+              3, static_cast<uint8_t>(0xFF));
+  ASSERT_TRUE(DeflateSetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS, DHdr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+  EXPECT_EQ(ZlibMod->getEnv().GZHeaderMap.count(DZS), 0U);
+}
+
+TEST(WasmEdgeZlibTest, EndErasesGzipHeaderSnapshot) {
+  // deflateEnd / inflateEnd must drop the per-stream gzip-header snapshot.
+  // Leaving it in GZHeaderMap lets a guest accumulate host allocations by
+  // cycling stream pointers, and would keep a copied stream's shared header
+  // alive past the point zlib still needs it.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(16, 16)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(DeflateSetHeader, "deflateSetHeader")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(InflateGetHeader, "inflateGetHeader")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  const auto &HeaderMap = ZlibMod->getEnv().GZHeaderMap;
+
+  const uint32_t DZS = 0x100;
+  const uint32_t DHdr = 0x200;
+  const uint32_t NamePtr = 0x300;
+  std::strcpy(MemInst.getPointer<char *>(NamePtr), "deflate-header-name");
+  std::fill_n(MemInst.getPointer<uint8_t *>(DZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(DHdr), sizeof(WasmGZHeader), 0);
+
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           DZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(31),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  MemInst.getPointer<WasmGZHeader *>(DHdr)->Name = NamePtr;
+  ASSERT_TRUE(DeflateSetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS, DHdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  ASSERT_NE(HeaderMap.find(DZS), HeaderMap.end());
+
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS}, RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_EQ(HeaderMap.find(DZS), HeaderMap.end());
+
+  const uint32_t IZS = 0x2000;
+  const uint32_t IHdr = 0x2100;
+  const uint32_t INameBuf = 0x2200;
+  const uint32_t INameMax = 128;
+  std::fill_n(MemInst.getPointer<uint8_t *>(IZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(IHdr), sizeof(WasmGZHeader), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(INameBuf), INameMax, 0);
+
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(31)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *IHeader = MemInst.getPointer<WasmGZHeader *>(IHdr);
+  IHeader->Name = INameBuf;
+  IHeader->NameMax = INameMax;
+  ASSERT_TRUE(InflateGetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, IHdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  ASSERT_NE(HeaderMap.find(IZS), HeaderMap.end());
+
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_EQ(HeaderMap.find(IZS), HeaderMap.end());
+}
+
+TEST(WasmEdgeZlibTest, InflateResetDropsGzipHeaderSnapshot) {
+  // Every inflate reset detaches zlib's internal gzip-header pointer (the
+  // guest must call inflateGetHeader again for the next stream), so the host
+  // snapshot must be dropped with it. A stale entry keeps re-validating and
+  // rewriting the guest header on every inflate call, trapping legitimate
+  // post-reset use once the guest reuses that memory.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(16, 16)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(Deflate, "deflate")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(InflateGetHeader, "inflateGetHeader")
+  GET_ZLIB_FUNC(InflateReset, "inflateReset")
+  GET_ZLIB_FUNC(InflateReset2, "inflateReset2")
+  GET_ZLIB_FUNC(InflateResetKeep, "inflateResetKeep")
+  GET_ZLIB_FUNC(Inflate, "inflate")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  // Build a small gzip stream to decode after the resets.
+  const uint32_t DZS = 0x100;
+  const uint32_t DataPtr = 0x300;
+  const uint32_t CompPtr = 0x1000;
+  const uint32_t CompCap = 0x2000;
+  const char *const Payload = "payload-for-inflate-reset";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::fill_n(MemInst.getPointer<uint8_t *>(DZS), sizeof(WasmZStream), 0);
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           DZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(31),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  auto *DStrm = MemInst.getPointer<WasmZStream *>(DZS);
+  DStrm->NextIn = DataPtr;
+  DStrm->AvailIn = PayloadLen;
+  DStrm->NextOut = CompPtr;
+  DStrm->AvailOut = CompCap;
+  ASSERT_TRUE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  const uint32_t CompLen = CompCap - DStrm->AvailOut;
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS}, RetVal));
+
+  const auto &HeaderMap = ZlibMod->getEnv().GZHeaderMap;
+
+  const uint32_t IZS = 0x4000;
+  const uint32_t IHdr = 0x4100;
+  const uint32_t NameBuf = 0x4200;
+  const uint32_t NameMax = 64;
+  std::fill_n(MemInst.getPointer<uint8_t *>(IZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(IHdr), sizeof(WasmGZHeader), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(NameBuf), NameMax, 0);
+
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(31)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *IHeader = MemInst.getPointer<WasmGZHeader *>(IHdr);
+  const auto RegisterHeader = [&]() {
+    IHeader->Name = NameBuf;
+    IHeader->NameMax = NameMax;
+    ASSERT_TRUE(InflateGetHeader.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, IHdr},
+        RetVal));
+    ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+    ASSERT_NE(HeaderMap.find(IZS), HeaderMap.end());
+  };
+
+  RegisterHeader();
+  ASSERT_TRUE(InflateReset.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_EQ(HeaderMap.find(IZS), HeaderMap.end());
+
+  RegisterHeader();
+  ASSERT_TRUE(InflateReset2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(31)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_EQ(HeaderMap.find(IZS), HeaderMap.end());
+
+  RegisterHeader();
+  ASSERT_TRUE(InflateResetKeep.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_EQ(HeaderMap.find(IZS), HeaderMap.end());
+
+  // After a reset the guest may legitimately reuse the header memory; inflate
+  // must not trap on the discarded registration.
+  RegisterHeader();
+  ASSERT_TRUE(InflateReset.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  IHeader->Name = 0xFFFFFF00;
+  IHeader->NameMax = 0xFFFFFFFF;
+
+  const uint32_t DecPtr = 0x5000;
+  const uint32_t DecCap = 0x1000;
+  auto *IStrm = MemInst.getPointer<WasmZStream *>(IZS);
+  IStrm->NextIn = CompPtr;
+  IStrm->AvailIn = CompLen;
+  IStrm->NextOut = DecPtr;
+  IStrm->AvailOut = DecCap;
+  ASSERT_TRUE(Inflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(Z_FINISH)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  EXPECT_EQ(
+      std::memcmp(MemInst.getPointer<char *>(DecPtr), Payload, PayloadLen), 0);
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+}
+
+TEST(WasmEdgeZlibTest, DeflateCopyKeepsCopiedHeaderAlive) {
+  // deflateCopy duplicates zlib's internal gz_header pointer into the copied
+  // stream. Replacing (or ending) the source header must not free the storage
+  // the copy still references, otherwise a later deflate on the copy reads
+  // freed host memory.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(16, 16)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(DeflateSetHeader, "deflateSetHeader")
+  GET_ZLIB_FUNC(DeflateCopy, "deflateCopy")
+  GET_ZLIB_FUNC(Deflate, "deflate")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(InflateGetHeader, "inflateGetHeader")
+  GET_ZLIB_FUNC(Inflate, "inflate")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  const uint32_t SrcZS = 0x100;
+  const uint32_t DstZS = 0x180;
+  const uint32_t Hdr = 0x200;
+  const uint32_t NamePtr = 0x300;
+  const uint32_t Name2Ptr = 0x340;
+  const uint32_t DataPtr = 0x400;
+  const uint32_t CompPtr = 0x1000;
+  const uint32_t CompCap = 0x3000;
+  const char *const OrigName = "original-header-name";
+  const char *const NewName = "replacement-header-name";
+  const char *const Payload = "payload-through-copied-gzip-stream";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(NamePtr), OrigName);
+  std::strcpy(MemInst.getPointer<char *>(Name2Ptr), NewName);
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+  std::fill_n(MemInst.getPointer<uint8_t *>(SrcZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(DstZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(Hdr), sizeof(WasmGZHeader), 0);
+
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           SrcZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(31),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *DHeader = MemInst.getPointer<WasmGZHeader *>(Hdr);
+  DHeader->Name = NamePtr;
+  ASSERT_TRUE(DeflateSetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{SrcZS, Hdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // Copy the freshly configured source stream.
+  ASSERT_TRUE(DeflateCopy.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DstZS, SrcZS},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  const auto &HeaderMap = ZlibMod->getEnv().GZHeaderMap;
+  // The copy must own an independent, live header snapshot.
+  {
+    const auto DstIt = HeaderMap.find(DstZS);
+    ASSERT_NE(DstIt, HeaderMap.end());
+    EXPECT_EQ(DstIt->second->Name, OrigName);
+  }
+
+  // Replace the source header; on the buggy code this frees the storage the
+  // copied stream still points at.
+  DHeader->Name = Name2Ptr;
+  ASSERT_TRUE(DeflateSetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{SrcZS, Hdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // The copy still carries its own original header, independent of the source.
+  {
+    const auto DstIt = HeaderMap.find(DstZS);
+    ASSERT_NE(DstIt, HeaderMap.end());
+    EXPECT_EQ(DstIt->second->Name, OrigName);
+  }
+
+  // Drive the copied stream to completion; it must emit the original name
+  // without reading freed memory.
+  auto *DStrm = MemInst.getPointer<WasmZStream *>(DstZS);
+  DStrm->NextIn = DataPtr;
+  DStrm->AvailIn = PayloadLen;
+  DStrm->NextOut = CompPtr;
+  DStrm->AvailOut = CompCap;
+  ASSERT_TRUE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DstZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  const uint32_t CompLen = CompCap - DStrm->AvailOut;
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DstZS}, RetVal));
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{SrcZS}, RetVal));
+
+  // Round-trip the copy's output and confirm the header name survived.
+  const uint32_t IZS = 0x5000;
+  const uint32_t IHdr = 0x5100;
+  const uint32_t INameBuf = 0x5200;
+  const uint32_t INameMax = 128;
+  const uint32_t DecPtr = 0x6000;
+  const uint32_t DecCap = 0x2000;
+  std::fill_n(MemInst.getPointer<uint8_t *>(IZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(IHdr), sizeof(WasmGZHeader), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(INameBuf), INameMax, 0);
+
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(31)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *IHeader = MemInst.getPointer<WasmGZHeader *>(IHdr);
+  IHeader->Name = INameBuf;
+  IHeader->NameMax = INameMax;
+  ASSERT_TRUE(InflateGetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, IHdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *IStrm = MemInst.getPointer<WasmZStream *>(IZS);
+  IStrm->NextIn = CompPtr;
+  IStrm->AvailIn = CompLen;
+  IStrm->NextOut = DecPtr;
+  IStrm->AvailOut = DecCap;
+  ASSERT_TRUE(Inflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+
+  EXPECT_STREQ(MemInst.getPointer<char *>(INameBuf), OrigName);
+}
+
+TEST(WasmEdgeZlibTest, InflateCopyKeepsCopiedHeaderAlive) {
+  // inflateCopy duplicates zlib's internal gz_header pointer into the copied
+  // stream, exactly like deflateCopy. Ending the source stream must not free
+  // the header snapshot the copy still points at, otherwise a later inflate on
+  // the copy writes the parsed gzip header through freed host memory.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(16, 16)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(InflateGetHeader, "inflateGetHeader")
+  GET_ZLIB_FUNC(InflateCopy, "inflateCopy")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  const uint32_t SrcZS = 0x100;
+  const uint32_t DstZS = 0x180;
+  const uint32_t Hdr = 0x200;
+  const uint32_t NameBuf = 0x300;
+  const uint32_t NameMax = 128;
+  std::fill_n(MemInst.getPointer<uint8_t *>(SrcZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(DstZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(Hdr), sizeof(WasmGZHeader), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(NameBuf), NameMax, 0);
+
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{SrcZS, INT32_C(31)}, RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *IHeader = MemInst.getPointer<WasmGZHeader *>(Hdr);
+  IHeader->Name = NameBuf;
+  IHeader->NameMax = NameMax;
+  ASSERT_TRUE(InflateGetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{SrcZS, Hdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  ASSERT_TRUE(InflateCopy.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DstZS, SrcZS},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // The copy must share the source's live header snapshot; its internal head
+  // pointer now aliases the same host storage.
+  const auto &HeaderMap = ZlibMod->getEnv().GZHeaderMap;
+  const auto SrcIt = HeaderMap.find(SrcZS);
+  const auto DstIt = HeaderMap.find(DstZS);
+  ASSERT_NE(SrcIt, HeaderMap.end());
+  ASSERT_NE(DstIt, HeaderMap.end());
+  EXPECT_EQ(DstIt->second, SrcIt->second);
+
+  // Ending the source must keep the shared snapshot alive for the copy.
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{SrcZS}, RetVal));
+  EXPECT_EQ(HeaderMap.find(SrcZS), HeaderMap.end());
+  EXPECT_NE(HeaderMap.find(DstZS), HeaderMap.end());
+
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DstZS}, RetVal));
+}
+
+TEST(WasmEdgeZlibTest, InflateGetHeaderReplacesStoredHeaderOnSuccess) {
+  // A second inflateGetHeader on the same stream re-points zlib's internal head
+  // at the new host snapshot. The stored snapshot must be replaced (and kept
+  // alive), otherwise a later inflate writes the header through freed memory.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(16, 16)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(InflateGetHeader, "inflateGetHeader")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  const uint32_t IZS = 0x100;
+  const uint32_t Hdr1 = 0x200;
+  const uint32_t Hdr2 = 0x280;
+  std::fill_n(MemInst.getPointer<uint8_t *>(IZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(Hdr1), sizeof(WasmGZHeader), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(Hdr2), sizeof(WasmGZHeader), 0);
+
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(31)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  ASSERT_TRUE(InflateGetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, Hdr1},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  const auto &HeaderMap = ZlibMod->getEnv().GZHeaderMap;
+  {
+    const auto It = HeaderMap.find(IZS);
+    ASSERT_NE(It, HeaderMap.end());
+    EXPECT_EQ(It->second->WasmGZHeaderOffset, Hdr1);
+  }
+
+  // Re-register a different guest header. zlib now points at the second
+  // snapshot, so the stored entry must become the second one.
+  ASSERT_TRUE(InflateGetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, Hdr2},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  {
+    const auto It = HeaderMap.find(IZS);
+    ASSERT_NE(It, HeaderMap.end());
+    EXPECT_EQ(It->second->WasmGZHeaderOffset, Hdr2);
+  }
+
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+}
+
+TEST(WasmEdgeZlibTest, DeflateEndEarlyAbortErasesState) {
+  // deflateEnd frees all of zlib's internal state even when it returns
+  // Z_DATA_ERROR for a stream ended mid-compression. The host tracking (stream
+  // entry and gzip-header snapshot) must be dropped on that path too, otherwise
+  // a guest can accumulate host allocations by cycling stream pointers.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(16, 16)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(DeflateSetHeader, "deflateSetHeader")
+  GET_ZLIB_FUNC(Deflate, "deflate")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+
+  const uint32_t DZS = 0x100;
+  const uint32_t Hdr = 0x200;
+  const uint32_t NamePtr = 0x300;
+  const uint32_t DataPtr = 0x400;
+  const uint32_t CompPtr = 0x1000;
+  const uint32_t CompCap = 0x1000;
+  const char *const Payload = "partial-payload";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(NamePtr), "aborted-stream-name");
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+  std::fill_n(MemInst.getPointer<uint8_t *>(DZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(Hdr), sizeof(WasmGZHeader), 0);
+
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           DZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(31),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  MemInst.getPointer<WasmGZHeader *>(Hdr)->Name = NamePtr;
+  ASSERT_TRUE(DeflateSetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS, Hdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  const auto &Env = ZlibMod->getEnv();
+  ASSERT_NE(Env.ZStreamMap.find(DZS), Env.ZStreamMap.end());
+  ASSERT_NE(Env.GZHeaderMap.find(DZS), Env.GZHeaderMap.end());
+
+  // Compress part of the input without finishing; the stream is now mid-flight.
+  auto *DStrm = MemInst.getPointer<WasmZStream *>(DZS);
+  DStrm->NextIn = DataPtr;
+  DStrm->AvailIn = PayloadLen;
+  DStrm->NextOut = CompPtr;
+  DStrm->AvailOut = CompCap;
+  ASSERT_TRUE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DZS, INT32_C(Z_NO_FLUSH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // deflateEnd on a mid-compression stream returns Z_DATA_ERROR but still frees
+  // zlib's state; the host entries must be erased on that path too.
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS}, RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_DATA_ERROR);
+  EXPECT_EQ(Env.ZStreamMap.find(DZS), Env.ZStreamMap.end());
+  EXPECT_EQ(Env.GZHeaderMap.find(DZS), Env.GZHeaderMap.end());
+}
+
+TEST(WasmEdgeZlibTest, InflateSyncAllowsDirtyOutputBuffer) {
+  // inflateSync consumes input but never writes output ("No output is
+  // provided"), so a stale/out-of-bounds next_out must not trap the call. The
+  // input buffer is still validated because inflateSync scans next_in.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(InflateSync, "inflateSync")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  const uint32_t IZS = 0x100;
+  const uint32_t InPtr = 0x200;
+  std::fill_n(MemInst.getPointer<uint8_t *>(IZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(InPtr), 8,
+              static_cast<uint8_t>(0xFF));
+
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(31)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // Valid input, but next_out points one past the end of linear memory with a
+  // nonzero avail_out. inflateSync must still run rather than trap.
+  auto *IStrm = MemInst.getPointer<WasmZStream *>(IZS);
+  IStrm->NextIn = InPtr;
+  IStrm->AvailIn = 8;
+  IStrm->NextOut = static_cast<uint32_t>(MemInst.getSize());
+  IStrm->AvailOut = 16;
+  EXPECT_TRUE(InflateSync.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_DATA_ERROR);
+
+  // The input buffer stays guarded: an out-of-bounds next_in with nonzero
+  // avail_in must still trap.
+  IStrm->NextIn = static_cast<uint32_t>(MemInst.getSize());
+  IStrm->AvailIn = 8;
+  IStrm->NextOut = 0;
+  IStrm->AvailOut = 0;
+  EXPECT_FALSE(InflateSync.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+
+  IStrm->NextIn = InPtr;
+  IStrm->AvailIn = 0;
+  IStrm->NextOut = 0;
+  IStrm->AvailOut = 0;
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+}
+
+TEST(WasmEdgeZlibTest, ControlCallsIgnoreDirtyDataBuffers) {
+  // zlib's contract lets a guest call deflateInit / reset / end with
+  // uninitialized next_in/avail_in (only zalloc/zfree/opaque must be set).
+  // Those control operations do not consume the data buffers, so an
+  // out-of-bounds next_in/next_out must not trap them; only the streaming
+  // operations validate the buffers.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit, "deflateInit")
+  GET_ZLIB_FUNC(DeflateReset, "deflateReset")
+  GET_ZLIB_FUNC(Deflate, "deflate")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+
+  const uint32_t MemBytes = static_cast<uint32_t>(MemInst.getSize());
+  const uint32_t ZS = 0;
+  std::fill_n(MemInst.getPointer<uint8_t *>(ZS), sizeof(WasmZStream), 0);
+
+  auto SetDirtyBuffers = [&]() {
+    auto *Strm = MemInst.getPointer<WasmZStream *>(ZS);
+    // next_in + avail_in runs off the end of linear memory.
+    Strm->NextIn = MemBytes - 4;
+    Strm->AvailIn = 0x10000;
+    Strm->NextOut = MemBytes - 4;
+    Strm->AvailOut = 0x10000;
+  };
+
+  // Initialize the stream with dirty, out-of-bounds buffer fields present.
+  SetDirtyBuffers();
+  ASSERT_TRUE(DeflateInit.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-1)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // reset ignores the data buffers too.
+  SetDirtyBuffers();
+  ASSERT_TRUE(DeflateReset.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // The streaming path must still reject an out-of-bounds output buffer.
+  {
+    auto *Strm = MemInst.getPointer<WasmZStream *>(ZS);
+    Strm->NextIn = 0;
+    Strm->AvailIn = 0;
+    Strm->NextOut = MemBytes - 4;
+    Strm->AvailOut = 0x10000;
+  }
+  EXPECT_FALSE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(Z_NO_FLUSH)},
+      RetVal));
+
+  // End cleans up even with dirty buffer fields.
+  SetDirtyBuffers();
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+}
+
+TEST(WasmEdgeZlibTest, HardeningRejectedParamsIgnoreDirtyDataBuffers) {
+  // deflateParams rejects an out-of-range level or strategy -- and deflate()
+  // an out-of-range flush -- before consuming next_in or producing into
+  // next_out, so a call zlib refuses must surface its Z_STREAM_ERROR instead
+  // of trapping on dirty buffer fields; serviceable parameters keep the
+  // bounds check.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit, "deflateInit")
+  GET_ZLIB_FUNC(DeflateParams, "deflateParams")
+  GET_ZLIB_FUNC(Deflate, "deflate")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+
+  const uint32_t MemBytes = static_cast<uint32_t>(MemInst.getSize());
+  const uint32_t ZS = 0;
+  std::fill_n(MemInst.getPointer<uint8_t *>(ZS), sizeof(WasmZStream), 0);
+
+  ASSERT_TRUE(DeflateInit.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-1)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto SetDirtyBuffers = [&]() {
+    auto *Strm = MemInst.getPointer<WasmZStream *>(ZS);
+    Strm->NextIn = MemBytes - 4;
+    Strm->AvailIn = 0x10000;
+    Strm->NextOut = MemBytes - 4;
+    Strm->AvailOut = 0x10000;
+  };
+
+  // An out-of-range level is zlib's Z_STREAM_ERROR, not a trap.
+  SetDirtyBuffers();
+  ASSERT_TRUE(DeflateParams.run(CallFrame,
+                                std::initializer_list<WasmEdge::ValVariant>{
+                                    ZS, INT32_C(10), INT32_C(Z_FILTERED)},
+                                RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+
+  // An out-of-range strategy behaves the same.
+  SetDirtyBuffers();
+  ASSERT_TRUE(DeflateParams.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-1), INT32_C(99)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+
+  // deflate() with a flush beyond Z_BLOCK is rejected the same way.
+  SetDirtyBuffers();
+  ASSERT_TRUE(Deflate.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(99)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+
+  // Parameters zlib would service must still reject the dirty buffers.
+  SetDirtyBuffers();
+  EXPECT_FALSE(DeflateParams.run(CallFrame,
+                                 std::initializer_list<WasmEdge::ValVariant>{
+                                     ZS, INT32_C(1), INT32_C(Z_FILTERED)},
+                                 RetVal));
+
+  SetDirtyBuffers();
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 }
 
 TEST(WasmEdgeZlibTest, Module) {
@@ -894,6 +1901,668 @@ TEST(WasmEdgeZlibTest, Module) {
   EXPECT_NE(ZlibMod->findFuncExports("inflateResetKeep"), nullptr);
   EXPECT_NE(ZlibMod->findFuncExports("deflateResetKeep"), nullptr);
 }
+
+TEST(WasmEdgeZlibTest, HardeningInflateGetHeaderValidatesHeadPtr) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(InflateGetHeader, "inflateGetHeader")
+
+  const uint32_t IZS = 0;
+  std::fill_n(MemInst.getPointer<uint8_t *>(IZS), sizeof(WasmZStream), 0);
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(31)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // An out-of-bounds HeadPtr must be rejected up front (like deflateSetHeader)
+  // rather than stored and dereferenced on later inflate/cleanup calls:
+  // 65530 + sizeof(WasmGZHeader) exceeds the single 64 KiB page.
+  EXPECT_FALSE(InflateGetHeader.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{IZS, UINT32_C(65530)},
+      RetVal));
+}
+
+TEST(WasmEdgeZlibTest, HardeningInflateEndToleratesCorruptHeaderMax) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(InflateGetHeader, "inflateGetHeader")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  const uint32_t IZS = 0;
+  const uint32_t IHdr = 0x100;
+  const uint32_t NameBuf = 0x200;
+  std::fill_n(MemInst.getPointer<uint8_t *>(IZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(IHdr), sizeof(WasmGZHeader), 0);
+
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(31)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *IHeader = MemInst.getPointer<WasmGZHeader *>(IHdr);
+  IHeader->Name = NameBuf;
+  IHeader->NameMax = 64;
+  ASSERT_TRUE(InflateGetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, IHdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // The guest corrupts NameMax to an out-of-bounds span after registering the
+  // header. inflateEnd is a cleanup call that never writes the gzip header, so
+  // it must still run zlib's inflateEnd and release the stream rather than
+  // aborting on header-buffer validation (which would leak the internal state).
+  IHeader->NameMax = UINT32_C(0xFFFFFFFF);
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+}
+
+TEST(WasmEdgeZlibTest, GZHeaderAbsentOptionalFieldsSurfaceAsNull) {
+  // zlib clears gz_header.extra/name/comment to Z_NULL when the stream lacks
+  // the field even though the caller supplied buffers. The write-back must
+  // surface that as guest null (0) instead of subtracting a live host pointer
+  // from null, which poisoned the guest header and made every later inflate
+  // call on the stream trap.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(16, 16)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(Deflate, "deflate")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(InflateGetHeader, "inflateGetHeader")
+  GET_ZLIB_FUNC(Inflate, "inflate")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  const uint32_t DZS = 0x100;
+  const uint32_t DataPtr = 0x500;
+  const uint32_t CompPtr = 0x1000;
+  const uint32_t CompCap = 0x2000;
+  const char *const Payload = "absent-header-fields-payload";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+  std::fill_n(MemInst.getPointer<uint8_t *>(DZS), sizeof(WasmZStream), 0);
+
+  // The default gzip header carries no extra, name, or comment field.
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           DZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(31),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  auto *DStrm = MemInst.getPointer<WasmZStream *>(DZS);
+  DStrm->NextIn = DataPtr;
+  DStrm->AvailIn = PayloadLen;
+  DStrm->NextOut = CompPtr;
+  DStrm->AvailOut = CompCap;
+  ASSERT_TRUE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  const uint32_t CompLen = CompCap - DStrm->AvailOut;
+  ASSERT_GT(CompLen, 12U);
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS}, RetVal));
+
+  const uint32_t IZS = 0x4000;
+  const uint32_t IHdr = 0x4100;
+  const uint32_t ExtraBuf = 0x4200;
+  const uint32_t NameBuf = 0x4300;
+  const uint32_t CommBuf = 0x4400;
+  const uint32_t DecPtr = 0x5000;
+  const uint32_t DecCap = 0x1000;
+  std::fill_n(MemInst.getPointer<uint8_t *>(IZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(IHdr), sizeof(WasmGZHeader), 0);
+
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(31)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *IHeader = MemInst.getPointer<WasmGZHeader *>(IHdr);
+  IHeader->Extra = ExtraBuf;
+  IHeader->ExtraMax = 64;
+  IHeader->Name = NameBuf;
+  IHeader->NameMax = 64;
+  IHeader->Comment = CommBuf;
+  IHeader->CommMax = 64;
+  ASSERT_TRUE(InflateGetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, IHdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // The first 12 bytes cover the whole field-free header, so zlib completes it
+  // and clears the absent optional fields within this call.
+  auto *IStrm = MemInst.getPointer<WasmZStream *>(IZS);
+  IStrm->NextIn = CompPtr;
+  IStrm->AvailIn = 12;
+  IStrm->NextOut = DecPtr;
+  IStrm->AvailOut = DecCap;
+  ASSERT_TRUE(Inflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(Z_NO_FLUSH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_EQ(IHeader->Extra, 0U);
+  EXPECT_EQ(IHeader->Name, 0U);
+  EXPECT_EQ(IHeader->Comment, 0U);
+  EXPECT_EQ(IHeader->Done, 1);
+
+  // The stream must stay usable after the header write-back.
+  IStrm->NextIn = CompPtr + 12;
+  IStrm->AvailIn = CompLen - 12;
+  ASSERT_TRUE(Inflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  EXPECT_EQ(
+      0, std::memcmp(MemInst.getPointer<char *>(DecPtr), Payload, PayloadLen));
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+}
+
+TEST(WasmEdgeZlibTest, GZHeaderNullFieldPointersMapToZNull) {
+  // A guest null (0) extra/name/comment pointer means the field is not
+  // requested (zlib's Z_NULL contract) and must not resolve to wasm address 0:
+  // with a nonzero *Max, zlib would copy header contents into guest memory
+  // the guest never offered.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(16, 16)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(DeflateSetHeader, "deflateSetHeader")
+  GET_ZLIB_FUNC(Deflate, "deflate")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(InflateGetHeader, "inflateGetHeader")
+  GET_ZLIB_FUNC(Inflate, "inflate")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  fillMemContent(MemInst, 0, 64, 0xAB);
+
+  const uint32_t DZS = 0x100;
+  const uint32_t DHdr = 0x200;
+  const uint32_t ExtraSrc = 0x300;
+  const uint32_t NameSrc = 0x340;
+  const uint32_t CommSrc = 0x380;
+  const uint32_t DataPtr = 0x500;
+  const uint32_t CompPtr = 0x1000;
+  const uint32_t CompCap = 0x2000;
+  const char *const Payload = "null-field-pointer-payload";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::fill_n(MemInst.getPointer<uint8_t *>(DZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(DHdr), sizeof(WasmGZHeader), 0);
+  std::memcpy(MemInst.getPointer<uint8_t *>(ExtraSrc), "abcd", 4);
+  std::strcpy(MemInst.getPointer<char *>(NameSrc), "gz-name");
+  std::strcpy(MemInst.getPointer<char *>(CommSrc), "gz-comment");
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           DZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(31),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  auto *DHeader = MemInst.getPointer<WasmGZHeader *>(DHdr);
+  DHeader->Extra = ExtraSrc;
+  DHeader->ExtraLen = 4;
+  DHeader->Name = NameSrc;
+  DHeader->Comment = CommSrc;
+  ASSERT_TRUE(DeflateSetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS, DHdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  auto *DStrm = MemInst.getPointer<WasmZStream *>(DZS);
+  DStrm->NextIn = DataPtr;
+  DStrm->AvailIn = PayloadLen;
+  DStrm->NextOut = CompPtr;
+  DStrm->AvailOut = CompCap;
+  ASSERT_TRUE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  const uint32_t CompLen = CompCap - DStrm->AvailOut;
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS}, RetVal));
+
+  const uint32_t IZS = 0x4000;
+  const uint32_t IHdr = 0x4100;
+  const uint32_t DecPtr = 0x5000;
+  const uint32_t DecCap = 0x1000;
+  std::fill_n(MemInst.getPointer<uint8_t *>(IZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(IHdr), sizeof(WasmGZHeader), 0);
+
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(31)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *IHeader = MemInst.getPointer<WasmGZHeader *>(IHdr);
+  IHeader->Extra = 0;
+  IHeader->ExtraMax = 64;
+  IHeader->Name = 0;
+  IHeader->NameMax = 64;
+  IHeader->Comment = 0;
+  IHeader->CommMax = 64;
+  ASSERT_TRUE(InflateGetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, IHdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *IStrm = MemInst.getPointer<WasmZStream *>(IZS);
+  IStrm->NextIn = CompPtr;
+  IStrm->AvailIn = CompLen;
+  IStrm->NextOut = DecPtr;
+  IStrm->AvailOut = DecCap;
+  ASSERT_TRUE(Inflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+
+  EXPECT_EQ(IHeader->Done, 1);
+  EXPECT_EQ(IHeader->ExtraLen, 4U);
+  EXPECT_EQ(IHeader->Extra, 0U);
+  EXPECT_EQ(IHeader->Name, 0U);
+  EXPECT_EQ(IHeader->Comment, 0U);
+
+  // Nothing may have been written through the null field pointers.
+  const std::vector<uint8_t> Expected(64, 0xAB);
+  EXPECT_EQ(0,
+            std::memcmp(MemInst.getPointer<uint8_t *>(0), Expected.data(), 64));
+
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+}
+
+TEST(WasmEdgeZlibTest, DeflateSetHeaderNullRevertsToDefaultHeader) {
+  // Native deflateSetHeader accepts Z_NULL and reverts the stream to the
+  // default gzip header; guest 0 must take that path instead of snapshotting
+  // whatever bytes sit at wasm address 0 (and trapping on garbage there).
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(16, 16)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(DeflateSetHeader, "deflateSetHeader")
+  GET_ZLIB_FUNC(Deflate, "deflate")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+
+  const uint32_t DZS = 0x100;
+  const uint32_t DHdr = 0x200;
+  const uint32_t NamePtr = 0x300;
+  const uint32_t DataPtr = 0x500;
+  const uint32_t CompPtr = 0x1000;
+  const uint32_t CompCap = 0x2000;
+  const char *const Payload = "default-header-payload";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::fill_n(MemInst.getPointer<uint8_t *>(DZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(DHdr), sizeof(WasmGZHeader), 0);
+  std::strcpy(MemInst.getPointer<char *>(NamePtr), "hdr-name");
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+  // Poison wasm address 0: a wrapper that dereferences the null header would
+  // read a header full of out-of-bounds pointers and trap.
+  fillMemContent(MemInst, 0, sizeof(WasmGZHeader), 0xFF);
+
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           DZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(31),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  auto *DHeader = MemInst.getPointer<WasmGZHeader *>(DHdr);
+  DHeader->Name = NamePtr;
+  ASSERT_TRUE(DeflateSetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS, DHdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  const auto &HeaderMap = ZlibMod->getEnv().GZHeaderMap;
+  EXPECT_EQ(HeaderMap.count(DZS), 1U);
+
+  ASSERT_TRUE(DeflateSetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS, UINT32_C(0)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_EQ(HeaderMap.count(DZS), 0U);
+
+  auto *DStrm = MemInst.getPointer<WasmZStream *>(DZS);
+  DStrm->NextIn = DataPtr;
+  DStrm->AvailIn = PayloadLen;
+  DStrm->NextOut = CompPtr;
+  DStrm->AvailOut = CompCap;
+  ASSERT_TRUE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS}, RetVal));
+}
+
+TEST(WasmEdgeZlibTest, HardeningInflateHeaderExtraLenIsZlibOwned) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(16, 16)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(DeflateSetHeader, "deflateSetHeader")
+  GET_ZLIB_FUNC(Deflate, "deflate")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(InflateGetHeader, "inflateGetHeader")
+  GET_ZLIB_FUNC(Inflate, "inflate")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  // Build a gzip stream carrying a 100-byte extra field with distinctive,
+  // non-zero content so a misplaced copy is detectable.
+  const uint32_t DZS = 0x100;
+  const uint32_t DHdr = 0x200;
+  const uint32_t ExtraSrc = 0x300;
+  const uint32_t DataPtr = 0x500;
+  const uint32_t CompPtr = 0x1000;
+  const uint32_t CompCap = 0x2000;
+  const uint32_t ExtraFieldLen = 100;
+  const char *const Payload = "payload-to-compress-through-gzip";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::fill_n(MemInst.getPointer<uint8_t *>(DZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(DHdr), sizeof(WasmGZHeader), 0);
+  for (uint32_t I = 0; I < ExtraFieldLen; ++I) {
+    *MemInst.getPointer<uint8_t *>(ExtraSrc + I) =
+        static_cast<uint8_t>((I % 251) + 1);
+  }
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           DZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(31),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *DHeader = MemInst.getPointer<WasmGZHeader *>(DHdr);
+  DHeader->Extra = ExtraSrc;
+  DHeader->ExtraLen = ExtraFieldLen;
+  ASSERT_TRUE(DeflateSetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS, DHdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *DStrm = MemInst.getPointer<WasmZStream *>(DZS);
+  DStrm->NextIn = DataPtr;
+  DStrm->AvailIn = PayloadLen;
+  DStrm->NextOut = CompPtr;
+  DStrm->AvailOut = CompCap;
+  ASSERT_TRUE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  const uint32_t CompLen = CompCap - DStrm->AvailOut;
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS}, RetVal));
+
+  // Inflate it in two chunks, injecting a bogus ExtraLen between them.
+  const uint32_t IZS = 0x4000;
+  const uint32_t IHdr = 0x4100;
+  const uint32_t ExtraDst = 0x4200;
+  const uint32_t ExtraMax = 200;
+  const uint32_t DecPtr = 0x5000;
+  const uint32_t DecCap = 0x1000;
+  std::fill_n(MemInst.getPointer<uint8_t *>(IZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(IHdr), sizeof(WasmGZHeader), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(ExtraDst), ExtraMax, 0);
+
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(31)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *IHeader = MemInst.getPointer<WasmGZHeader *>(IHdr);
+  IHeader->Extra = ExtraDst;
+  IHeader->ExtraMax = ExtraMax;
+  ASSERT_TRUE(InflateGetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, IHdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // First chunk: exactly the 10-byte gzip base header + 2-byte XLEN, so zlib
+  // parses EXLEN (setting extra_len = 100 from the stream) and parks in the
+  // EXTRA state before copying any extra bytes.
+  auto *IStrm = MemInst.getPointer<WasmZStream *>(IZS);
+  IStrm->NextIn = CompPtr;
+  IStrm->AvailIn = 12;
+  IStrm->NextOut = DecPtr;
+  IStrm->AvailOut = DecCap;
+  ASSERT_TRUE(Inflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(Z_NO_FLUSH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // extra_len is an OUTPUT field owned by zlib (true XLEN is 100). A malicious
+  // guest overwrites it before the continuation call. The plugin must not push
+  // this back into zlib's header, or the guest controls the EXTRA-state write
+  // offset (len = extra_len - state->length) -- CVE-2022-37434 territory on
+  // zlib <= 1.2.12.
+  IHeader->ExtraLen = 150;
+
+  IStrm->AvailIn = CompLen - 12;
+  ASSERT_TRUE(Inflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+
+  // zlib's parsed extra_len (100) must survive rather than the injected 150,
+  // and the extra bytes must land at offset 0 (len == 0), not offset 50.
+  EXPECT_EQ(IHeader->ExtraLen, ExtraFieldLen);
+  EXPECT_EQ(*MemInst.getPointer<uint8_t *>(ExtraDst), static_cast<uint8_t>(1));
+}
+
+TEST(WasmEdgeZlibTest, HardeningInflateHeaderZeroCapacityKeepsGuestPointers) {
+  // zlib never writes through a zero-capacity extra/name/comment buffer, yet
+  // still distinguishes the caller's non-null pointer from Z_NULL ("field not
+  // requested"): the pointer survives untouched and only an absent stream
+  // field nulls it. A stale zero-capacity guest pointer past linear memory is
+  // therefore legal input -- the header sync must not misread it as Z_NULL
+  // and write guest NULL back over it.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(16, 16)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(DeflateSetHeader, "deflateSetHeader")
+  GET_ZLIB_FUNC(Deflate, "deflate")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(InflateGetHeader, "inflateGetHeader")
+  GET_ZLIB_FUNC(Inflate, "inflate")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  // Build a gzip stream that carries all three optional header fields.
+  const uint32_t DZS = 0x100;
+  const uint32_t DHdr = 0x200;
+  const uint32_t ExtraSrc = 0x300;
+  const uint32_t NameSrc = 0x380;
+  const uint32_t CommSrc = 0x400;
+  const uint32_t DataPtr = 0x500;
+  const uint32_t CompPtr = 0x1000;
+  const uint32_t CompCap = 0x2000;
+  const uint32_t ExtraFieldLen = 8;
+  const char *const Payload = "zero-capacity header fields";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::fill_n(MemInst.getPointer<uint8_t *>(DZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(DHdr), sizeof(WasmGZHeader), 0);
+  for (uint32_t I = 0; I < ExtraFieldLen; ++I) {
+    *MemInst.getPointer<uint8_t *>(ExtraSrc + I) = static_cast<uint8_t>(I + 1);
+  }
+  std::strcpy(MemInst.getPointer<char *>(NameSrc), "stream-name");
+  std::strcpy(MemInst.getPointer<char *>(CommSrc), "stream-comment");
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           DZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(31),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  auto *DHeader = MemInst.getPointer<WasmGZHeader *>(DHdr);
+  DHeader->Extra = ExtraSrc;
+  DHeader->ExtraLen = ExtraFieldLen;
+  DHeader->Name = NameSrc;
+  DHeader->Comment = CommSrc;
+  ASSERT_TRUE(DeflateSetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS, DHdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  auto *DStrm = MemInst.getPointer<WasmZStream *>(DZS);
+  DStrm->NextIn = DataPtr;
+  DStrm->AvailIn = PayloadLen;
+  DStrm->NextOut = CompPtr;
+  DStrm->AvailOut = CompCap;
+  ASSERT_TRUE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  const uint32_t CompLen = CompCap - DStrm->AvailOut;
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS}, RetVal));
+
+  // Inflate with non-null zero-capacity pointers that lie outside linear
+  // memory: legal for zlib (never dereferenced at *_max == 0), so they must
+  // come back untouched, with the output fields still populated.
+  const uint32_t IZS = 0x4000;
+  const uint32_t IHdr = 0x4100;
+  const uint32_t OOBExtra = 0xFFFF0000;
+  const uint32_t OOBName = 0xFFFF0100;
+  const uint32_t OOBComment = 0xFFFF0200;
+  const uint32_t DecPtr = 0x5000;
+  const uint32_t DecCap = 0x1000;
+  std::fill_n(MemInst.getPointer<uint8_t *>(IZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(IHdr), sizeof(WasmGZHeader), 0);
+
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(31)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  auto *IHeader = MemInst.getPointer<WasmGZHeader *>(IHdr);
+  IHeader->Extra = OOBExtra;
+  IHeader->ExtraMax = 0;
+  IHeader->Name = OOBName;
+  IHeader->NameMax = 0;
+  IHeader->Comment = OOBComment;
+  IHeader->CommMax = 0;
+  ASSERT_TRUE(InflateGetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, IHdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *IStrm = MemInst.getPointer<WasmZStream *>(IZS);
+  IStrm->NextIn = CompPtr;
+  IStrm->AvailIn = CompLen;
+  IStrm->NextOut = DecPtr;
+  IStrm->AvailOut = DecCap;
+  ASSERT_TRUE(Inflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+
+  // The guest's pointers survive; the stream's fields still surface through
+  // the zlib-owned outputs.
+  EXPECT_EQ(IHeader->Extra, OOBExtra);
+  EXPECT_EQ(IHeader->Name, OOBName);
+  EXPECT_EQ(IHeader->Comment, OOBComment);
+  EXPECT_EQ(IHeader->ExtraLen, ExtraFieldLen);
+  EXPECT_EQ(IHeader->Done, INT32_C(1));
+
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+}
+
 
 GTEST_API_ int main(int ArgC, char **ArgV) {
   testing::InitGoogleTest(&ArgC, ArgV);

--- a/test/plugins/wasmedge_zlib/wasmedge_zlib.cpp
+++ b/test/plugins/wasmedge_zlib/wasmedge_zlib.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "common/defines.h"
+#include "host/wasi/wasimodule.h"
 #include "runtime/instance/module.h"
 #include "zlibfunc.h"
 #include "zlibmodule.h"
@@ -12,10 +13,15 @@
 #include <cstdio>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <gtest/gtest.h>
 #include <memory>
 #include <string>
 #include <vector>
+
+#if !defined(_WIN32)
+#include <sys/stat.h>
+#endif
 
 namespace {
 
@@ -44,6 +50,14 @@ std::unique_ptr<WasmEdge::Host::WasmEdgeZlibModule> createModule() {
   }
   return {};
 }
+
+// Exposes ModuleInstance's protected setWASIModule so a test can wire a WASI
+// module without going through full module instantiation.
+class WasiWiredModule : public WasmEdge::Runtime::Instance::ModuleInstance {
+public:
+  using ModuleInstance::ModuleInstance;
+  void wireWASIModule(const ModuleInstance *M) noexcept { setWASIModule(M); }
+};
 
 } // namespace
 
@@ -1114,7 +1128,62 @@ TEST(WasmEdgeZlibTest, HardeningUnterminatedString) {
   GET_ZLIB_FUNC(GZOpen, "gzopen")
   EXPECT_FALSE(GZOpen.run(
       CallFrame,
-      std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0), UINT32_C(100)},
+      std::initializer_list<WasmEdge::ValVariant>{UINT32_C(1), UINT32_C(100)},
+      RetVal));
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZOpenRejectsOversizedPathOrMode) {
+  // gzopen bounds its path and mode snapshots, so a terminator that exists only
+  // beyond the cap is rejected rather than scanned to and copied -- otherwise a
+  // guest could put the NUL at the far end of a huge memory and force a
+  // matching host allocation.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+
+  // Oversized path: fill memory with a non-NUL byte so the only terminators are
+  // the ones placed here. The path's NUL sits past the 4096 cap, so the scan
+  // gives up; a short valid mode isolates the failure to the path.
+  std::fill_n(MemInst.getPointer<uint8_t *>(0),
+              static_cast<size_t>(MemInst.getSize()),
+              static_cast<uint8_t>('A'));
+  MemInst.getPointer<char *>(1)[5000] = '\0';
+  std::strcpy(MemInst.getPointer<char *>(6000), "rb");
+  EXPECT_FALSE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{UINT32_C(1), UINT32_C(6000)},
+      RetVal));
+
+  // A guest-null path is gz_open's own pre-open failure (a null handle):
+  // wasm address 0 is NULL, not the start of a path string, so nothing at
+  // offset 0 may be scanned or opened.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0), UINT32_C(6000)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+
+  // Oversized mode: a short valid path, but the mode's NUL sits past the
+  // 63-byte cap.
+  std::fill_n(MemInst.getPointer<uint8_t *>(0),
+              static_cast<size_t>(MemInst.getSize()),
+              static_cast<uint8_t>('A'));
+  std::strcpy(MemInst.getPointer<char *>(1), "/tmp/x");
+  MemInst.getPointer<char *>(100)[200] = '\0';
+  EXPECT_FALSE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{UINT32_C(1), UINT32_C(100)},
       RetVal));
 }
 
@@ -1135,9 +1204,9 @@ TEST(WasmEdgeZlibTest, GZFileRoundTrip) {
   const std::string TmpPath = (std::filesystem::temp_directory_path() /
                                "wasmedge_zlib_hardening_test.gz")
                                   .string();
-  ASSERT_LT(TmpPath.size() + 1, 1024U);
+  ASSERT_LT(TmpPath.size() + 1, 1000U);
 
-  const uint32_t PathPtr = 0;
+  const uint32_t PathPtr = 16;
   std::strcpy(MemInst.getPointer<char *>(PathPtr), TmpPath.c_str());
   const uint32_t ModeWPtr = 1024;
   std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
@@ -1177,11 +1246,13 @@ TEST(WasmEdgeZlibTest, GZFileRoundTrip) {
   const uint32_t RHandle = RetVal[0].get<uint32_t>();
   EXPECT_NE(RHandle, WHandle);
 
-  // gzread with an out-of-bounds length must fail rather than overflow the
-  // buffer.
+  // gzread with an out-of-bounds length that still fits in an int must trap
+  // rather than overflow the buffer (a length that does not fit in an int is
+  // instead answered by zlib itself; see
+  // HardeningGZOversizedRequestsMatchZlib).
   EXPECT_FALSE(GZRead.run(CallFrame,
                           std::initializer_list<WasmEdge::ValVariant>{
-                              RHandle, UINT32_C(60000), UINT32_C(0xFFFFFFFF)},
+                              RHandle, UINT32_C(60000), UINT32_C(0x40000000)},
                           RetVal));
 
   const uint32_t ReadBuf = 4096;
@@ -1200,6 +1271,258 @@ TEST(WasmEdgeZlibTest, GZFileRoundTrip) {
   EXPECT_FALSE(GZClose.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
 
+  std::remove(TmpPath.c_str());
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZOversizedRequestsMatchZlib) {
+  // zlib answers oversized gz I/O with a documented error rather than OOB
+  // access, and the wrappers must surface that instead of trapping:
+  //   - gzread returns -1 for a length that does not fit in a signed int;
+  //   - gzwrite returns 0 for a length that does not fit in a signed int;
+  //   - gzfread/gzfwrite return 0 when size*nitems overflows the guest's
+  //     32-bit z_size_t, and like native zlib they leave a sticky
+  //     Z_STREAM_ERROR on the handle that blocks further I/O until
+  //     gzclearerr.
+  // gzputs is now written through gzwrite, so also confirm it round-trips.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const std::string TmpPath = (std::filesystem::temp_directory_path() /
+                               "wasmedge_zlib_oversized_test.gz")
+                                  .string();
+  ASSERT_LT(TmpPath.size() + 1, 1000U);
+  const uint32_t PathPtr = 16;
+  std::strcpy(MemInst.getPointer<char *>(PathPtr), TmpPath.c_str());
+  const uint32_t ModeWPtr = 1024;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+  const uint32_t ModeRPtr = 1040;
+  std::strcpy(MemInst.getPointer<char *>(ModeRPtr), "rb");
+  const uint32_t StrPtr = 1100;
+  const char *const Payload = "gzputs through gzwrite";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(StrPtr), Payload);
+  // A guest offset holding a zero byte is an empty string.
+  const uint32_t EmptyStrPtr = 2048;
+  MemInst.getPointer<char *>(EmptyStrPtr)[0] = '\0';
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  GET_ZLIB_FUNC(GZPuts, "gzputs")
+  GET_ZLIB_FUNC(GZWrite, "gzwrite")
+  GET_ZLIB_FUNC(GZFwrite, "gzfwrite")
+  GET_ZLIB_FUNC(GZRead, "gzread")
+  GET_ZLIB_FUNC(GZFread, "gzfread")
+  GET_ZLIB_FUNC(GZClearerr, "gzclearerr")
+  GET_ZLIB_FUNC(GZClose, "gzclose")
+
+  // > INT_MAX, and 0x80000000 * 2 also overflows a 32-bit z_size_t.
+  const uint32_t Oversized = UINT32_C(0x80000000);
+
+  if (!GZOpen.run(
+          CallFrame,
+          std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWPtr},
+          RetVal)) {
+    GTEST_SKIP() << "cannot create temporary file: " << TmpPath;
+  }
+  const uint32_t WHandle = RetVal[0].get<uint32_t>();
+
+  // gzputs writes the measured string and returns the byte count.
+  ASSERT_TRUE(GZPuts.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle, StrPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+
+  // An empty string writes nothing and returns 0, not -1.
+  ASSERT_TRUE(GZPuts.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, EmptyStrPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(0));
+
+  // gzfwrite whose size*nitems overflows a 32-bit product returns 0 and, as
+  // in native zlib, records a sticky Z_STREAM_ERROR: even an empty gzputs is
+  // refused (-1) until gzclearerr lifts it. The empty probe writes no bytes,
+  // so the payload read back below stays unchanged.
+  ASSERT_TRUE(GZFwrite.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               StrPtr, Oversized, UINT32_C(2), WHandle},
+                           RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(0));
+  ASSERT_TRUE(GZPuts.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, EmptyStrPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(-1));
+  ASSERT_TRUE(GZClearerr.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, {}));
+  ASSERT_TRUE(GZPuts.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, EmptyStrPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(0));
+
+  // gzwrite with a length that does not fit in an int returns 0 instead of
+  // trapping; like native zlib it leaves a sticky Z_DATA_ERROR, so probe it
+  // last in the write phase.
+  ASSERT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, StrPtr, Oversized},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(0));
+
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, RetVal));
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeRPtr},
+      RetVal));
+  const uint32_t RHandle = RetVal[0].get<uint32_t>();
+
+  // A normal read returns the payload gzputs wrote, confirming the
+  // gzwrite-backed gzputs round-trips. Do this before the oversized probes
+  // below, which -- like native zlib -- leave a sticky Z_STREAM_ERROR.
+  const uint32_t ReadBuf = 4096;
+  ASSERT_TRUE(GZRead.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             RHandle, ReadBuf, UINT32_C(256)},
+                         RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_EQ(
+      0, std::memcmp(MemInst.getPointer<char *>(ReadBuf), Payload, PayloadLen));
+
+  // gzfread whose size*nitems overflows a 32-bit product returns 0 and, as in
+  // native zlib, records a sticky Z_STREAM_ERROR: a normal gzread answers -1
+  // until gzclearerr lifts it (after which the drained stream reads 0 at EOF).
+  ASSERT_TRUE(GZFread.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              ReadBuf, Oversized, UINT32_C(2), RHandle},
+                          RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(0));
+  ASSERT_TRUE(GZRead.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             RHandle, ReadBuf, UINT32_C(8)},
+                         RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(-1));
+  ASSERT_TRUE(GZClearerr.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, {}));
+  ASSERT_TRUE(GZRead.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             RHandle, ReadBuf, UINT32_C(8)},
+                         RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(0));
+
+  // gzread with a length that does not fit in an int returns -1 instead of
+  // trapping (zlib also sets the sticky Z_STREAM_ERROR).
+  ASSERT_TRUE(GZRead.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{RHandle, ReadBuf, Oversized},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(-1));
+
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
+  std::remove(TmpPath.c_str());
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZPutsEmptyStringHonorsMode) {
+  // gzputs refuses a handle that is not writing before accepting even a
+  // zero-length string, so an empty write on a read handle must answer -1
+  // like native gzputs instead of a hardcoded no-op 0.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const std::string TmpPath =
+      (std::filesystem::temp_directory_path() / "wasmedge_zlib_gzputs_mode.gz")
+          .string();
+  ASSERT_LT(TmpPath.size() + 1, 1000U);
+
+  const uint32_t PathPtr = 16;
+  std::strcpy(MemInst.getPointer<char *>(PathPtr), TmpPath.c_str());
+  const uint32_t ModeWPtr = 1024;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+  const uint32_t ModeRPtr = 1040;
+  std::strcpy(MemInst.getPointer<char *>(ModeRPtr), "rb");
+  const uint32_t EmptyPtr = 1060;
+  MemInst.getPointer<char *>(EmptyPtr)[0] = '\0';
+  const uint32_t DataPtr = 1100;
+  const char *const Payload = "gzputs mode probe";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  GET_ZLIB_FUNC(GZPuts, "gzputs")
+  GET_ZLIB_FUNC(GZRead, "gzread")
+  GET_ZLIB_FUNC(GZClose, "gzclose")
+
+  if (!GZOpen.run(
+          CallFrame,
+          std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWPtr},
+          RetVal)) {
+    GTEST_SKIP() << "cannot create temporary file: " << TmpPath;
+  }
+  const uint32_t WHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(WHandle, 0U);
+
+  // On a write handle an empty string is an accepted no-op.
+  EXPECT_TRUE(GZPuts.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle, EmptyPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), 0);
+  EXPECT_TRUE(GZPuts.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle, DataPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, RetVal));
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeRPtr},
+      RetVal));
+  const uint32_t RHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(RHandle, 0U);
+
+  // On a read handle gzputs answers -1 for the empty and non-empty string
+  // alike; neither may be reported as a successful no-op.
+  EXPECT_TRUE(GZPuts.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle, EmptyPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), -1);
+  EXPECT_TRUE(GZPuts.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle, DataPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), -1);
+
+  // The rejected writes did not disturb the handle: the payload reads back.
+  const uint32_t ReadBuf = 4096;
+  EXPECT_TRUE(GZRead.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             RHandle, ReadBuf, UINT32_C(256)},
+                         RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_EQ(
+      0, std::memcmp(MemInst.getPointer<char *>(ReadBuf), Payload, PayloadLen));
+
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
   std::remove(TmpPath.c_str());
 }
 
@@ -1342,7 +1665,7 @@ TEST(WasmEdgeZlibTest, GZOpenFailureReturnsNullHandle) {
        "definitely_absent.gz")
           .string();
   ASSERT_LT(MissingPath.size() + 1, 900U);
-  const uint32_t PathPtr = 0;
+  const uint32_t PathPtr = 16;
   std::strcpy(MemInst.getPointer<char *>(PathPtr), MissingPath.c_str());
   const uint32_t ModePtr = 1000;
   std::strcpy(MemInst.getPointer<char *>(ModePtr), "rb");
@@ -3799,8 +4122,8 @@ TEST(WasmEdgeZlibTest, HardeningGZBufferClampsSize) {
   const std::string TmpPath = (std::filesystem::temp_directory_path() /
                                "wasmedge_zlib_gzbuffer_test.gz")
                                   .string();
-  ASSERT_LT(TmpPath.size() + 1, 1024U);
-  const uint32_t PathPtr = 0;
+  ASSERT_LT(TmpPath.size() + 1, 1000U);
+  const uint32_t PathPtr = 16;
   std::strcpy(MemInst.getPointer<char *>(PathPtr), TmpPath.c_str());
   const uint32_t ModeWPtr = 1024;
   std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
@@ -3817,13 +4140,21 @@ TEST(WasmEdgeZlibTest, HardeningGZBufferClampsSize) {
   }
   const uint32_t WHandle = RetVal[0].get<uint32_t>();
 
-  // A guest-declared ~4 GB buffer size must be clamped to a sane cap rather
-  // than forwarded verbatim: zlib rejects sizes >= 2^31 (returning -1) and
-  // otherwise allocates three times the size on first I/O. After clamping, an
-  // absurd request is accepted (returns 0) with a bounded host allocation.
+  // A size zlib itself refuses (>= 2^31, it must be able to double it) keeps
+  // its native -1 answer instead of being clamped into an accepted request.
   EXPECT_TRUE(GZBuffer.run(CallFrame,
                            std::initializer_list<WasmEdge::ValVariant>{
                                WHandle, UINT32_C(0xFFFFFFFF)},
+                           RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), -1);
+
+  // Below that, a guest-declared buffer size must be clamped to a sane cap
+  // rather than forwarded verbatim, since zlib allocates three times the size
+  // on first I/O: an absurd request is accepted (returns 0) with a bounded
+  // host allocation.
+  EXPECT_TRUE(GZBuffer.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               WHandle, UINT32_C(0x40000000)},
                            RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), 0);
 
@@ -4215,6 +4546,914 @@ TEST(WasmEdgeZlibTest, HardeningDeflateInitValidatesVersionString) {
                                    static_cast<int32_t>(sizeof(WasmZStream))},
                                RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_VERSION_ERROR);
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZOpenMediatedByWasi) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasiWiredModule Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+
+  // Stand up a WASI sandbox with a single preopened directory (becomes fd 3).
+  const std::filesystem::path SandboxDir =
+      std::filesystem::temp_directory_path() / "wasmedge_zlib_wasi_sandbox";
+  std::error_code EC;
+  std::filesystem::create_directories(SandboxDir, EC);
+  std::filesystem::remove(SandboxDir / "wasi.gz", EC);
+
+  WasmEdge::Host::WasiModule WasiMod;
+  WasiMod.init(std::vector<std::string>{SandboxDir.string()}, "test", {}, {});
+  Mod.wireWASIModule(&WasiMod);
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const uint32_t PathPtr = 16;
+  std::strcpy(MemInst.getPointer<char *>(PathPtr), "wasi.gz");
+  const uint32_t ModeWPtr = 64;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+  const uint32_t ModeRPtr = 96;
+  std::strcpy(MemInst.getPointer<char *>(ModeRPtr), "rb");
+  const uint32_t EscapePtr = 128;
+  std::strcpy(MemInst.getPointer<char *>(EscapePtr), "../wasi_escape.gz");
+  const uint32_t DataPtr = 256;
+  const char *const Payload = "hello wasi-mediated gzip";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  GET_ZLIB_FUNC(GZWrite, "gzwrite")
+  GET_ZLIB_FUNC(GZRead, "gzread")
+  GET_ZLIB_FUNC(GZClose, "gzclose")
+
+  // A relative path is resolved through WASI, inside the preopened directory.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWPtr},
+      RetVal));
+  const uint32_t WHandle = RetVal[0].get<uint32_t>();
+  if (WHandle == 0) {
+    GTEST_SKIP() << "WASI preopen unavailable in this environment";
+  }
+  EXPECT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, DataPtr, PayloadLen},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, RetVal));
+
+  // The file must land inside the sandbox host directory, proving the open went
+  // through the WASI preopen rather than the process working directory.
+  EXPECT_TRUE(std::filesystem::exists(SandboxDir / "wasi.gz"));
+
+  // Round-trip read back through WASI mediation.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeRPtr},
+      RetVal));
+  const uint32_t RHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(RHandle, 0U);
+  const uint32_t ReadBuf = 512;
+  EXPECT_TRUE(GZRead.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             RHandle, ReadBuf, UINT32_C(256)},
+                         RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_EQ(
+      0, std::memcmp(MemInst.getPointer<char *>(ReadBuf), Payload, PayloadLen));
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
+
+  // A path escaping the preopened directory is denied by WASI (null handle),
+  // rather than opened on the host as raw gzopen would.
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{EscapePtr, ModeWPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+
+  std::filesystem::remove(SandboxDir / "wasi.gz", EC);
+  std::filesystem::remove(SandboxDir / "wasi_escape.gz", EC);
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZOpenWasiAcceptsAbsoluteGuestPaths) {
+  // wasi-libc's open() strips leading '/' and './' runs before matching the
+  // preopen table (its default cwd is '/'), so "/f.gz" and "f.gz" name the
+  // same sandbox entry for a guest. resolvePath instead rejects absolute
+  // paths outright, so gzopen must normalize the same way before pathOpen or
+  // every absolute guest path fails with a null handle. Stripping only
+  // removes leading no-ops: ".." still cannot climb out of the preopen.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasiWiredModule Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+
+  const std::filesystem::path SandboxDir =
+      std::filesystem::temp_directory_path() / "wasmedge_zlib_wasi_abs";
+  std::error_code EC;
+  std::filesystem::create_directories(SandboxDir, EC);
+  std::filesystem::remove(SandboxDir / "wasi_probe.gz", EC);
+  std::filesystem::remove(SandboxDir / "wasi_abs.gz", EC);
+
+  WasmEdge::Host::WasiModule WasiMod;
+  WasiMod.init(std::vector<std::string>{SandboxDir.string()}, "test", {}, {});
+  Mod.wireWASIModule(&WasiMod);
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const uint32_t ProbePtr = 16;
+  std::strcpy(MemInst.getPointer<char *>(ProbePtr), "wasi_probe.gz");
+  const uint32_t AbsPtr = 96;
+  std::strcpy(MemInst.getPointer<char *>(AbsPtr), "/wasi_abs.gz");
+  const uint32_t DotPtr = 176;
+  std::strcpy(MemInst.getPointer<char *>(DotPtr), "./wasi_abs.gz");
+  const uint32_t MixedPtr = 256;
+  std::strcpy(MemInst.getPointer<char *>(MixedPtr), "//./wasi_abs.gz");
+  const uint32_t EscapePtr = 336;
+  std::strcpy(MemInst.getPointer<char *>(EscapePtr), "/../wasi_abs_escape.gz");
+  const uint32_t ModeWPtr = 512;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+  const uint32_t ModeRPtr = 544;
+  std::strcpy(MemInst.getPointer<char *>(ModeRPtr), "rb");
+  const uint32_t DataPtr = 1024;
+  const char *const Payload = "absolute path through the preopen";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  GET_ZLIB_FUNC(GZWrite, "gzwrite")
+  GET_ZLIB_FUNC(GZRead, "gzread")
+  GET_ZLIB_FUNC(GZClose, "gzclose")
+
+  // Baseline relative open, which also detects environments without the WASI
+  // bridge.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ProbePtr, ModeWPtr}, RetVal));
+  const uint32_t ProbeHandle = RetVal[0].get<uint32_t>();
+  if (ProbeHandle == 0) {
+    GTEST_SKIP() << "WASI preopen unavailable in this environment";
+  }
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ProbeHandle},
+      RetVal));
+
+  // An absolute guest path lands on the same sandbox entry as its relative
+  // spelling, the way wasi-libc resolves it.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{AbsPtr, ModeWPtr},
+      RetVal));
+  const uint32_t WHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(WHandle, 0U);
+  EXPECT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, DataPtr, PayloadLen},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, RetVal));
+  EXPECT_TRUE(std::filesystem::exists(SandboxDir / "wasi_abs.gz"));
+
+  // "./" and mixed "//./" spellings normalize to the same entry too.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DotPtr, ModeRPtr},
+      RetVal));
+  const uint32_t RHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(RHandle, 0U);
+  const uint32_t ReadBuf = 2048;
+  EXPECT_TRUE(GZRead.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             RHandle, ReadBuf, UINT32_C(256)},
+                         RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_EQ(
+      0, std::memcmp(MemInst.getPointer<char *>(ReadBuf), Payload, PayloadLen));
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{MixedPtr, ModeRPtr}, RetVal));
+  const uint32_t MHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(MHandle, 0U);
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{MHandle}, RetVal));
+
+  // Stripping must not open an escape hatch: a normalized path that then
+  // climbs with ".." is still denied by the resolver.
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{EscapePtr, ModeWPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+
+  std::filesystem::remove(SandboxDir / "wasi_probe.gz", EC);
+  std::filesystem::remove(SandboxDir / "wasi_abs.gz", EC);
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZOpenUnrecognizedWasiFailsClosed) {
+  // A wasi_snapshot_preview1 import can be satisfied by a module that is not
+  // WasmEdge's Host::WasiModule (a custom or stub WASI). getWasiEnviron cannot
+  // read its capabilities, so gzopen must fail closed with a null handle rather
+  // than fall back to a raw host open that would reach files outside the
+  // sandbox the guest expects.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasiWiredModule Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+
+  // Wire a plain module instance (not a WasiModule) as the WASI module, the way
+  // an embedder supplying a custom wasi_snapshot_preview1 would.
+  WasmEdge::Runtime::Instance::ModuleInstance StubWasi(
+      "wasi_snapshot_preview1");
+  Mod.wireWASIModule(&StubWasi);
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  // A real host file that a raw gzopen(..., "rb") would open transparently, so
+  // a non-zero handle here would prove the capability layer was bypassed.
+  const std::filesystem::path HostFile =
+      std::filesystem::temp_directory_path() /
+      "wasmedge_zlib_unrecognized_wasi.txt";
+  {
+    std::ofstream OFS(HostFile, std::ios::binary | std::ios::trunc);
+    if (!OFS) {
+      GTEST_SKIP() << "cannot create host probe file";
+    }
+    OFS << "not a gzip file, but gzopen reads it transparently";
+  }
+
+  const uint32_t PathPtr = 16;
+  const std::string HostPathStr = HostFile.string();
+  std::strcpy(MemInst.getPointer<char *>(PathPtr), HostPathStr.c_str());
+  const uint32_t ModePtr = 2048;
+  std::strcpy(MemInst.getPointer<char *>(ModePtr), "rb");
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+
+  // The open runs without trapping but is refused (null handle).
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModePtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+
+  std::error_code EC;
+  std::filesystem::remove(HostFile, EC);
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZOpenWasiHonorsOpenModes) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasiWiredModule Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+
+  const std::filesystem::path SandboxDir =
+      std::filesystem::temp_directory_path() / "wasmedge_zlib_wasi_modes";
+  std::error_code EC;
+  std::filesystem::create_directories(SandboxDir, EC);
+  std::filesystem::remove(SandboxDir / "modes.gz", EC);
+  std::filesystem::remove(SandboxDir / "fresh.gz", EC);
+  std::filesystem::remove(SandboxDir / "transparent.gz", EC);
+  std::filesystem::remove(SandboxDir / "gfresh.gz", EC);
+
+  WasmEdge::Host::WasiModule WasiMod;
+  WasiMod.init(std::vector<std::string>{SandboxDir.string()}, "test", {}, {});
+  Mod.wireWASIModule(&WasiMod);
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const uint32_t PathPtr = 16;
+  std::strcpy(MemInst.getPointer<char *>(PathPtr), "modes.gz");
+  const uint32_t FreshPtr = 32;
+  std::strcpy(MemInst.getPointer<char *>(FreshPtr), "fresh.gz");
+  const uint32_t ModeWPtr = 64;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+  const uint32_t ModeWPlusPtr = 96;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPlusPtr), "w+");
+  const uint32_t ModeNoDirPtr = 128;
+  std::strcpy(MemInst.getPointer<char *>(ModeNoDirPtr), "b");
+  const uint32_t ModeWxPtr = 160;
+  std::strcpy(MemInst.getPointer<char *>(ModeWxPtr), "wx");
+  const uint32_t ModeWrPtr = 192;
+  std::strcpy(MemInst.getPointer<char *>(ModeWrPtr), "wr");
+  const uint32_t ModeAPtr = 224;
+  std::strcpy(MemInst.getPointer<char *>(ModeAPtr), "a");
+  const uint32_t ModeRTPtr = 288;
+  std::strcpy(MemInst.getPointer<char *>(ModeRTPtr), "rT");
+  const uint32_t ModeWTPtr = 320;
+  std::strcpy(MemInst.getPointer<char *>(ModeWTPtr), "wT");
+  const uint32_t TransPathPtr = 352;
+  std::strcpy(MemInst.getPointer<char *>(TransPathPtr), "transparent.gz");
+  const uint32_t ModeWGPtr = 368;
+  std::strcpy(MemInst.getPointer<char *>(ModeWGPtr), "wG");
+  const uint32_t ModeAGPtr = 384;
+  std::strcpy(MemInst.getPointer<char *>(ModeAGPtr), "aG");
+  const uint32_t ModeWTGPtr = 400;
+  std::strcpy(MemInst.getPointer<char *>(ModeWTGPtr), "wTG");
+  const uint32_t ModeWGTPtr = 416;
+  std::strcpy(MemInst.getPointer<char *>(ModeWGTPtr), "wGT");
+  const uint32_t ModeRGPtr = 432;
+  std::strcpy(MemInst.getPointer<char *>(ModeRGPtr), "rG");
+  const uint32_t ModeRNPtr = 448;
+  std::strcpy(MemInst.getPointer<char *>(ModeRNPtr), "rN");
+  const uint32_t GFreshPtr = 464;
+  std::strcpy(MemInst.getPointer<char *>(GFreshPtr), "gfresh.gz");
+  const uint32_t FifoPtr = 480;
+  std::strcpy(MemInst.getPointer<char *>(FifoPtr), "fifo.gz");
+  const uint32_t ModeWNPtr = 496;
+  std::strcpy(MemInst.getPointer<char *>(ModeWNPtr), "wN");
+  const uint32_t DataPtr = 256;
+  const char *const Payload = "gzopen mode fidelity";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+  const uint32_t ReadBuf = 512;
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  GET_ZLIB_FUNC(GZWrite, "gzwrite")
+  GET_ZLIB_FUNC(GZRead, "gzread")
+  GET_ZLIB_FUNC(GZClose, "gzclose")
+
+  // Baseline write, which also detects environments without the WASI bridge.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWPtr},
+      RetVal));
+  const uint32_t WHandle = RetVal[0].get<uint32_t>();
+  if (WHandle == 0) {
+    GTEST_SKIP() << "WASI preopen unavailable in this environment";
+  }
+  ASSERT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, DataPtr, PayloadLen},
+      RetVal));
+  ASSERT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, RetVal));
+  const auto BaselineSize = std::filesystem::file_size(SandboxDir / "modes.gz");
+
+  // zlib rejects any '+' mode before touching the file; mediated through WASI
+  // the open must equally fail without truncating the existing file.
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWPlusPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+  // A mode without any r/w/a direction is rejected the same way.
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeNoDirPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+  // A transparent read ("rT") is another mode gz_open refuses before opening
+  // ("can't force transparent read"), so it must fail without reaching the
+  // file -- native zlib never opens it, not even to fail later.
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeRTPtr}, RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+  // zlib 1.3.2 defines 'G' as the forced-gzip counterpart of 'T' and refuses
+  // it for write and append before opening ("G" has no meaning when writing);
+  // earlier zlib ignores the letter. Refusing it up front keeps the failure
+  // side-effect-free on every zlib: no truncation of an existing file and no
+  // creation of a missing one.
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWGPtr}, RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{GFreshPtr, ModeWGPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_FALSE(std::filesystem::exists(SandboxDir / "gfresh.gz"));
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeAGPtr}, RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+  // The last of 'T'/'G' wins exactly as in zlib's parse: "wTG" ends forced
+  // gzip and is refused the same way.
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWTGPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+  // Transparent write stays a valid mode: 'T' alone must not be rejected.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{TransPathPtr, ModeWTPtr},
+      RetVal));
+  const uint32_t THandle = RetVal[0].get<uint32_t>();
+  EXPECT_NE(THandle, 0U);
+  if (THandle != 0) {
+    EXPECT_TRUE(GZClose.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{THandle},
+        RetVal));
+  }
+
+  // "wGT" ends transparent, so it stays as valid as "wT" itself.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{TransPathPtr, ModeWGTPtr},
+      RetVal));
+  const uint32_t GTHandle = RetVal[0].get<uint32_t>();
+  EXPECT_NE(GTHandle, 0U);
+  if (GTHandle != 0) {
+    EXPECT_TRUE(GZClose.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{GTHandle},
+        RetVal));
+  }
+
+  // An exclusive create over an existing file must fail and leave it intact
+  // instead of truncating it.
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWxPtr}, RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+  // The last of r/w/a wins, exactly as in zlib's own parse: "wr" is a read
+  // open and must neither create nor truncate.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWrPtr}, RetVal));
+  const uint32_t RHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(RHandle, 0U);
+  EXPECT_TRUE(GZRead.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             RHandle, ReadBuf, UINT32_C(256)},
+                         RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_EQ(
+      0, std::memcmp(MemInst.getPointer<char *>(ReadBuf), Payload, PayloadLen));
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+  // A forced-gzip read ("rG", zlib >= 1.3.2) and a nonblocking read ("rN",
+  // ignored by earlier zlib) both stay valid open modes for a regular file.
+  for (const uint32_t ModePtr : {ModeRGPtr, ModeRNPtr}) {
+    ASSERT_TRUE(GZOpen.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModePtr}, RetVal));
+    const uint32_t Handle = RetVal[0].get<uint32_t>();
+    EXPECT_NE(Handle, 0U);
+    if (Handle == 0) {
+      continue;
+    }
+    EXPECT_TRUE(GZRead.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               Handle, ReadBuf, UINT32_C(256)},
+                           RetVal));
+    EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+    EXPECT_EQ(0, std::memcmp(MemInst.getPointer<char *>(ReadBuf), Payload,
+                             PayloadLen));
+    EXPECT_TRUE(GZClose.run(CallFrame,
+                            std::initializer_list<WasmEdge::ValVariant>{Handle},
+                            RetVal));
+  }
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+#if !defined(_WIN32)
+  // 'N' must reach pathOpen as NONBLOCK, because with zlib >= 1.3.2 the
+  // native gzopen carries O_NONBLOCK in open(2) itself: a "wN" open of a
+  // FIFO with no reader fails with ENXIO instead of blocking the host, and
+  // an "rN" open with no writer returns a handle immediately.
+  const std::filesystem::path FifoPath = SandboxDir / "fifo.gz";
+  std::filesystem::remove(FifoPath, EC);
+  ASSERT_EQ(::mkfifo(FifoPath.c_str(), 0600), 0);
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FifoPtr, ModeWNPtr}, RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FifoPtr, ModeRNPtr}, RetVal));
+  const uint32_t NHandle = RetVal[0].get<uint32_t>();
+  EXPECT_NE(NHandle, 0U);
+  if (NHandle != 0) {
+    EXPECT_TRUE(GZClose.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{NHandle},
+        RetVal));
+  }
+  std::filesystem::remove(FifoPath, EC);
+#endif
+
+  // Append mode extends the existing file rather than truncating it.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeAPtr},
+      RetVal));
+  const uint32_t AHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(AHandle, 0U);
+  EXPECT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{AHandle, DataPtr, PayloadLen},
+      RetVal));
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{AHandle}, RetVal));
+  EXPECT_GT(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+  // An exclusive create of a missing file succeeds.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FreshPtr, ModeWxPtr},
+      RetVal));
+  const uint32_t XHandle = RetVal[0].get<uint32_t>();
+  EXPECT_NE(XHandle, 0U);
+  if (XHandle != 0) {
+    EXPECT_TRUE(GZClose.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{XHandle},
+        RetVal));
+  }
+  EXPECT_TRUE(std::filesystem::exists(SandboxDir / "fresh.gz"));
+
+  std::filesystem::remove(SandboxDir / "modes.gz", EC);
+  std::filesystem::remove(SandboxDir / "fresh.gz", EC);
+  std::filesystem::remove(SandboxDir / "transparent.gz", EC);
+  std::filesystem::remove(SandboxDir / "gfresh.gz", EC);
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZOpenWasiFollowsSandboxSymlinks) {
+  // wasi-libc's open() follows a final symlink by default and so does a
+  // native gzopen, so a WASI-mediated gzopen must too -- the resolver
+  // re-walks the target with the same preopen-escape checks -- while a
+  // symlink that leaves the sandbox stays denied and an exclusive create
+  // keeps native O_EXCL's refusal to follow, dangling links included.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasiWiredModule Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+
+  const std::filesystem::path SandboxDir =
+      std::filesystem::temp_directory_path() / "wasmedge_zlib_wasi_symlink";
+  const std::filesystem::path OutsideFile =
+      std::filesystem::temp_directory_path() /
+      "wasmedge_zlib_wasi_symlink_outside.gz";
+  std::error_code EC;
+  std::filesystem::remove_all(SandboxDir, EC);
+  std::filesystem::create_directories(SandboxDir, EC);
+  std::filesystem::remove(OutsideFile, EC);
+
+  WasmEdge::Host::WasiModule WasiMod;
+  WasiMod.init(std::vector<std::string>{SandboxDir.string()}, "test", {}, {});
+  Mod.wireWASIModule(&WasiMod);
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const uint32_t TargetPtr = 16;
+  std::strcpy(MemInst.getPointer<char *>(TargetPtr), "target.gz");
+  const uint32_t LinkPtr = 32;
+  std::strcpy(MemInst.getPointer<char *>(LinkPtr), "link.gz");
+  const uint32_t EscLinkPtr = 64;
+  std::strcpy(MemInst.getPointer<char *>(EscLinkPtr), "escape.gz");
+  const uint32_t AbsLinkPtr = 96;
+  std::strcpy(MemInst.getPointer<char *>(AbsLinkPtr), "abslink.gz");
+  const uint32_t DangLinkPtr = 128;
+  std::strcpy(MemInst.getPointer<char *>(DangLinkPtr), "dangling.gz");
+  const uint32_t ModeWPtr = 160;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+  const uint32_t ModeRPtr = 192;
+  std::strcpy(MemInst.getPointer<char *>(ModeRPtr), "rb");
+  const uint32_t ModeWxPtr = 224;
+  std::strcpy(MemInst.getPointer<char *>(ModeWxPtr), "wx");
+  const uint32_t DataPtr = 256;
+  const char *const Payload = "symlinked gzip payload";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+  const uint32_t ReadBuf = 512;
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  GET_ZLIB_FUNC(GZWrite, "gzwrite")
+  GET_ZLIB_FUNC(GZRead, "gzread")
+  GET_ZLIB_FUNC(GZClose, "gzclose")
+
+  // Baseline write, which also detects environments without the WASI bridge.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{TargetPtr, ModeWPtr},
+      RetVal));
+  const uint32_t WHandle = RetVal[0].get<uint32_t>();
+  if (WHandle == 0) {
+    GTEST_SKIP() << "WASI preopen unavailable in this environment";
+  }
+  ASSERT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, DataPtr, PayloadLen},
+      RetVal));
+  ASSERT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, RetVal));
+
+  // A real file outside the sandbox, so a resolver that leaked through the
+  // escaping links below would loudly succeed in opening it.
+  {
+    std::ofstream(OutsideFile) << "outside";
+  }
+  std::filesystem::create_symlink("target.gz", SandboxDir / "link.gz", EC);
+  if (EC) {
+    GTEST_SKIP() << "cannot create symlinks in this environment";
+  }
+  std::filesystem::create_symlink(OutsideFile, SandboxDir / "abslink.gz", EC);
+  std::filesystem::create_symlink(std::filesystem::path("..") /
+                                      OutsideFile.filename(),
+                                  SandboxDir / "escape.gz", EC);
+  std::filesystem::create_symlink("missing.gz", SandboxDir / "dangling.gz", EC);
+
+  // A symlink to an in-sandbox file reads like the file itself.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{LinkPtr, ModeRPtr},
+      RetVal));
+  const uint32_t RHandle = RetVal[0].get<uint32_t>();
+  EXPECT_NE(RHandle, 0U);
+  if (RHandle != 0) {
+    EXPECT_TRUE(GZRead.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               RHandle, ReadBuf, UINT32_C(256)},
+                           RetVal));
+    EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+    EXPECT_EQ(0, std::memcmp(MemInst.getPointer<char *>(ReadBuf), Payload,
+                             PayloadLen));
+    EXPECT_TRUE(GZClose.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle},
+        RetVal));
+  }
+
+  // Writing through the symlink follows it rather than replacing the link.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{LinkPtr, ModeWPtr},
+      RetVal));
+  const uint32_t LWHandle = RetVal[0].get<uint32_t>();
+  EXPECT_NE(LWHandle, 0U);
+  if (LWHandle != 0) {
+    EXPECT_TRUE(GZClose.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{LWHandle},
+        RetVal));
+  }
+  EXPECT_TRUE(std::filesystem::is_symlink(SandboxDir / "link.gz"));
+  EXPECT_TRUE(std::filesystem::exists(SandboxDir / "target.gz"));
+
+  // A symlink whose target steps out of the preopen stays denied, whether it
+  // escapes relatively or names the outside file by absolute path.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{EscLinkPtr, ModeRPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{AbsLinkPtr, ModeRPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+
+  // An exclusive create refuses an existing symlink -- even a dangling one --
+  // rather than following it to create the target, matching native O_EXCL.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DangLinkPtr, ModeWxPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_FALSE(std::filesystem::exists(SandboxDir / "missing.gz"));
+
+  std::filesystem::remove_all(SandboxDir, EC);
+  std::filesystem::remove(OutsideFile, EC);
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZDOpenTemporarilyDisabled) {
+  // gzdopen is temporarily disabled while its bridged-descriptor fd lifecycle
+  // is reworked (an owned WASI fd cannot be released safely at environment
+  // teardown yet). It must refuse every call with a null handle -- even a
+  // valid, fully-writable descriptor -- and must not consume the guest's fd.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasiWiredModule Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+
+  const std::filesystem::path SandboxDir =
+      std::filesystem::temp_directory_path() / "wasmedge_zlib_gzdopen_disabled";
+  std::error_code EC;
+  std::filesystem::create_directories(SandboxDir, EC);
+  std::filesystem::remove(SandboxDir / "disabled.gz", EC);
+
+  WasmEdge::Host::WasiModule WasiMod;
+  WasiMod.init(std::vector<std::string>{SandboxDir.string()}, "test", {}, {});
+  Mod.wireWASIModule(&WasiMod);
+  auto *Env = const_cast<WasmEdge::Host::WASI::Environ *>(WasiMod.getEnv());
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const uint32_t ModeWPtr = 0;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+
+  GET_ZLIB_FUNC(GZDOpen, "gzdopen")
+
+  const __wasi_rights_t FullRights =
+      __WASI_RIGHTS_FD_READ | __WASI_RIGHTS_FD_WRITE | __WASI_RIGHTS_FD_SEEK |
+      __WASI_RIGHTS_FD_TELL;
+  auto Fd =
+      Env->pathOpen(3, "disabled.gz", static_cast<__wasi_lookupflags_t>(0),
+                    __WASI_OFLAGS_CREAT | __WASI_OFLAGS_TRUNC, FullRights,
+                    FullRights, static_cast<__wasi_fdflags_t>(0));
+  if (!Fd.has_value()) {
+    GTEST_SKIP() << "WASI preopen unavailable in this environment";
+  }
+
+  // Even a descriptor that would previously have bridged is refused now.
+  ASSERT_TRUE(GZDOpen.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              static_cast<int32_t>(*Fd), ModeWPtr},
+                          RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+
+  // The refused call left the descriptor untouched, so the guest still owns it.
+  __wasi_fdstat_t FdStat;
+  EXPECT_TRUE(Env->fdFdstatGet(*Fd, FdStat).has_value());
+  Env->fdClose(*Fd);
+
+  std::filesystem::remove(SandboxDir / "disabled.gz", EC);
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZOpenWasiStreamingWithoutSeekTellRights) {
+  // A guest that narrowed the preopen's rights to plain read/write must still
+  // gzopen for streaming: FD_SEEK/FD_TELL stay optional (recorded on the
+  // handle and gated at gzseek/gzrewind/gzoffset), matching gzdopen's
+  // documented design.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasiWiredModule Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+
+  const std::filesystem::path SandboxDir =
+      std::filesystem::temp_directory_path() / "wasmedge_zlib_wasi_narrowed";
+  std::error_code EC;
+  std::filesystem::create_directories(SandboxDir, EC);
+  std::filesystem::remove(SandboxDir / "stream.gz", EC);
+  std::filesystem::remove(SandboxDir / "fresh.gz", EC);
+  std::filesystem::remove(SandboxDir / "append.gz", EC);
+
+  WasmEdge::Host::WasiModule WasiMod;
+  WasiMod.init(std::vector<std::string>{SandboxDir.string()}, "test", {}, {});
+  Mod.wireWASIModule(&WasiMod);
+  auto *Env = const_cast<WasmEdge::Host::WASI::Environ *>(WasiMod.getEnv());
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const uint32_t PathPtr = 16;
+  std::strcpy(MemInst.getPointer<char *>(PathPtr), "stream.gz");
+  const uint32_t FreshPtr = 32;
+  std::strcpy(MemInst.getPointer<char *>(FreshPtr), "fresh.gz");
+  const uint32_t AppendPtr = 64;
+  std::strcpy(MemInst.getPointer<char *>(AppendPtr), "append.gz");
+  const uint32_t ModeWPtr = 96;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+  const uint32_t ModeRPtr = 112;
+  std::strcpy(MemInst.getPointer<char *>(ModeRPtr), "rb");
+  const uint32_t ModeAPtr = 128;
+  std::strcpy(MemInst.getPointer<char *>(ModeAPtr), "ab");
+  const uint32_t DataPtr = 256;
+  const char *const Payload = "streaming without seek rights";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+  const uint32_t ReadPtr = 512;
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  GET_ZLIB_FUNC(GZWrite, "gzwrite")
+  GET_ZLIB_FUNC(GZRead, "gzread")
+  GET_ZLIB_FUNC(GZClose, "gzclose")
+  GET_ZLIB_FUNC(GZSeek, "gzseek")
+  GET_ZLIB_FUNC(GZOffset, "gzoffset")
+  GET_ZLIB_FUNC(GZTell, "gztell")
+
+  // Seed the file while the preopen still holds its full rights.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWPtr},
+      RetVal));
+  const uint32_t WHandle = RetVal[0].get<uint32_t>();
+  if (WHandle == 0) {
+    GTEST_SKIP() << "WASI-mediated gzopen unavailable in this environment";
+  }
+  ASSERT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, DataPtr, PayloadLen},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  ASSERT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, RetVal));
+
+  // Narrow the preopen the way a guest would via fd_fdstat_set_rights.
+  __wasi_fdstat_t DirStat;
+  ASSERT_TRUE(Env->fdFdstatGet(3, DirStat).has_value());
+  const __wasi_rights_t NoSeekTell =
+      ~(__WASI_RIGHTS_FD_SEEK | __WASI_RIGHTS_FD_TELL);
+  ASSERT_TRUE(Env->fdFdstatSetRights(3, DirStat.fs_rights_base & NoSeekTell,
+                                     DirStat.fs_rights_inheriting & NoSeekTell)
+                  .has_value());
+
+  // Streaming read still opens; repositioning is refused on the handle.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeRPtr},
+      RetVal));
+  const uint32_t RHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(RHandle, 0U);
+  ASSERT_TRUE(GZRead.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{RHandle, ReadPtr, PayloadLen},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_EQ(
+      0, std::memcmp(MemInst.getPointer<char *>(ReadPtr), Payload, PayloadLen));
+  ASSERT_TRUE(GZSeek.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             RHandle, INT32_C(6), INT32_C(SEEK_SET)},
+                         RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), -1);
+  ASSERT_TRUE(GZOffset.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), -1);
+  ASSERT_TRUE(GZTell.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  ASSERT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
+
+  // Streaming write and append open under the narrowed preopen as well.
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FreshPtr, ModeWPtr}, RetVal));
+  const uint32_t FHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(FHandle, 0U);
+  ASSERT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FHandle, DataPtr, PayloadLen},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  ASSERT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FHandle}, RetVal));
+  EXPECT_TRUE(std::filesystem::exists(SandboxDir / "fresh.gz"));
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{AppendPtr, ModeAPtr},
+      RetVal));
+  const uint32_t AHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(AHandle, 0U);
+  ASSERT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{AHandle, DataPtr, PayloadLen},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  ASSERT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{AHandle}, RetVal));
+
+  std::filesystem::remove(SandboxDir / "stream.gz", EC);
+  std::filesystem::remove(SandboxDir / "fresh.gz", EC);
+  std::filesystem::remove(SandboxDir / "append.gz", EC);
 }
 
 GTEST_API_ int main(int ArgC, char **ArgV) {

--- a/test/plugins/wasmedge_zlib/wasmedge_zlib.cpp
+++ b/test/plugins/wasmedge_zlib/wasmedge_zlib.cpp
@@ -118,7 +118,9 @@ TEST(WasmEdgeZlibTest, DeflateInflateCycle) {
   WasmZlibVersion = WasmHP;
   std::snprintf(MemInst.getPointer<char *>(WasmHP),
                 std::strlen(ZLIB_VERSION) + 1, ZLIB_VERSION);
-  WasmHP += std::strlen(ZLIB_VERSION);
+  // Reserve the terminator too so the version stays a NUL-terminated in-bounds
+  // C string; the wrapper rejects an unterminated version.
+  WasmHP += std::strlen(ZLIB_VERSION) + 1;
 
   WasmData = WasmHP;
   std::generate_n(MemInst.getPointer<char *>(WasmHP), DataSize, RandChar);
@@ -593,6 +595,442 @@ TEST(WasmEdgeZlibTest, HardeningZeroLengthDictionaryMatchesZlib) {
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 }
 
+TEST(WasmEdgeZlibTest,
+     HardeningInflateSetDictionaryValidatesOnlyWhenZlibReads) {
+  // inflateSetDictionary reads the dictionary only from a raw stream or a
+  // stream waiting in DICT mode; a wrapped stream that is not waiting answers
+  // Z_STREAM_ERROR before touching the bytes, so an unreadable guest buffer
+  // must surface that error rather than a trap -- and must keep trapping in
+  // the states where zlib does read it.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit, "deflateInit")
+  GET_ZLIB_FUNC(DeflateSetDictionary, "deflateSetDictionary")
+  GET_ZLIB_FUNC(Deflate, "deflate")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+  GET_ZLIB_FUNC(InflateInit, "inflateInit")
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(InflateSetDictionary, "inflateSetDictionary")
+  GET_ZLIB_FUNC(Inflate, "inflate")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  const uint32_t OOBPtr = 0xFFFF0000;
+  const uint32_t DictPtr = 0x100;
+  const char *const Dict = "the quick brown fox jumps over the lazy dog";
+  const uint32_t DictLen = static_cast<uint32_t>(std::strlen(Dict));
+  std::strcpy(MemInst.getPointer<char *>(DictPtr), Dict);
+  const uint32_t WrongDictPtr = 0x180;
+  const char *const WrongDict = "an entirely different preset dictionary";
+  const uint32_t WrongDictLen = static_cast<uint32_t>(std::strlen(WrongDict));
+  std::strcpy(MemInst.getPointer<char *>(WrongDictPtr), WrongDict);
+
+  // A zlib-wrapped stream that never saw Z_NEED_DICT: zlib rejects before
+  // reading, so even an out-of-bounds dictionary gets the soft error.
+  const uint32_t ZS = 0x40;
+  fillMemContent(MemInst, ZS, sizeof(WasmZStream));
+  ASSERT_TRUE(InflateInit.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_TRUE(InflateSetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, OOBPtr, UINT32_C(0x100)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+
+  // A raw stream folds the dictionary into the window immediately, so the
+  // unreadable buffer must keep trapping and a readable one must be accepted.
+  fillMemContent(MemInst, ZS, sizeof(WasmZStream));
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-15)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_FALSE(InflateSetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, OOBPtr, UINT32_C(0x100)},
+      RetVal));
+  EXPECT_TRUE(InflateSetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, DictPtr, DictLen},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+
+  // Produce an FDICT stream so inflate really enters DICT mode.
+  const uint32_t DataPtr = 0x200;
+  const char *const Payload = "the quick brown fox jumps over the lazy dog!";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+  const uint32_t CompPtr = 0x1000;
+  const uint32_t CompCap = 0x1000;
+  const uint32_t DZS = 0x80;
+  fillMemContent(MemInst, DZS, sizeof(WasmZStream));
+  ASSERT_TRUE(DeflateInit.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS, INT32_C(-1)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  ASSERT_TRUE(DeflateSetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DZS, DictPtr, DictLen},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  auto *DStrm = MemInst.getPointer<WasmZStream *>(DZS);
+  DStrm->NextIn = DataPtr;
+  DStrm->AvailIn = PayloadLen;
+  DStrm->NextOut = CompPtr;
+  DStrm->AvailOut = CompCap;
+  ASSERT_TRUE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  const uint32_t CompLen = CompCap - DStrm->AvailOut;
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS}, RetVal));
+
+  const uint32_t DecPtr = 0x2000;
+  const uint32_t DecCap = 0x1000;
+  fillMemContent(MemInst, ZS, sizeof(WasmZStream));
+  ASSERT_TRUE(InflateInit.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  auto *IStrm = MemInst.getPointer<WasmZStream *>(ZS);
+  IStrm->NextIn = CompPtr;
+  IStrm->AvailIn = CompLen;
+  IStrm->NextOut = DecPtr;
+  IStrm->AvailOut = DecCap;
+  ASSERT_TRUE(Inflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(Z_NO_FLUSH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_NEED_DICT);
+
+  // Waiting in DICT mode, zlib checksums the bytes: unreadable memory traps,
+  // a wrong dictionary gets Z_DATA_ERROR and leaves the stream waiting.
+  EXPECT_FALSE(InflateSetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, OOBPtr, UINT32_C(0x100)},
+      RetVal));
+  EXPECT_TRUE(
+      InflateSetDictionary.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   ZS, WrongDictPtr, WrongDictLen},
+                               RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_DATA_ERROR);
+  EXPECT_TRUE(InflateSetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, DictPtr, DictLen},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // The stream leaves DICT mode only inside the next inflate call, so a
+  // repeated set still checksums (and so still traps on unreadable memory).
+  EXPECT_FALSE(InflateSetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, OOBPtr, UINT32_C(0x10)},
+      RetVal));
+
+  ASSERT_TRUE(Inflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  EXPECT_EQ(
+      0, std::memcmp(MemInst.getPointer<char *>(DecPtr), Payload, PayloadLen));
+
+  // Done inflating, the stream is no longer waiting: back to the soft error.
+  EXPECT_TRUE(InflateSetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, OOBPtr, UINT32_C(0x10)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+}
+
+TEST(WasmEdgeZlibTest, HardeningDeflateSetDictionaryGzipStreamAnswersFirst) {
+  // A gzip-wrapped deflate stream refuses any preset dictionary before
+  // reading it, so an unreadable guest buffer surfaces Z_STREAM_ERROR there;
+  // a zlib-wrapped stream at INIT does read it and must keep trapping.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(DeflateSetDictionary, "deflateSetDictionary")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+
+  const uint32_t OOBPtr = 0xFFFF0000;
+  const uint32_t ZS = 0;
+  fillMemContent(MemInst, ZS, sizeof(WasmZStream));
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           ZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(31),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_TRUE(DeflateSetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, OOBPtr, UINT32_C(0x100)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+
+  const uint32_t ZS2 = 0x40;
+  fillMemContent(MemInst, ZS2, sizeof(WasmZStream));
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           ZS2, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(15),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_FALSE(DeflateSetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS2, OOBPtr, UINT32_C(0x100)},
+      RetVal));
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS2}, RetVal));
+}
+
+TEST(WasmEdgeZlibTest, HardeningDeflateSetDictionaryStartedStreamAnswersFirst) {
+  // Once a zlib-wrapped deflate stream has produced output (left INIT_STATE),
+  // deflateSetDictionary returns Z_STREAM_ERROR before reading the dictionary,
+  // so an unreadable guest buffer must surface that error rather than trap. The
+  // same stream still at INIT reads the dictionary and keeps trapping, and a
+  // raw stream (which rejects on live lookahead, untracked here) keeps trapping
+  // too.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(Deflate, "deflate")
+  GET_ZLIB_FUNC(DeflateSetDictionary, "deflateSetDictionary")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+
+  const uint32_t OOBPtr = 0xFFFF0000;
+  const uint32_t InPtr = 256;
+  const uint32_t OutPtr = 1024;
+  const char *const Input = "the quick brown fox jumps over the lazy dog";
+  const uint32_t InLen = static_cast<uint32_t>(std::strlen(Input));
+  std::strcpy(MemInst.getPointer<char *>(InPtr), Input);
+
+  // A zlib-wrapped (wrap == 1) stream still at INIT_STATE reads the dictionary,
+  // so an OOB buffer traps.
+  const uint32_t ZS = 0;
+  fillMemContent(MemInst, ZS, sizeof(WasmZStream));
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           ZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(15),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_FALSE(DeflateSetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, OOBPtr, UINT32_C(0x100)},
+      RetVal));
+
+  // Advance the stream past INIT_STATE with one deflate() call.
+  auto *Strm = MemInst.getPointer<WasmZStream *>(ZS);
+  Strm->NextIn = InPtr;
+  Strm->AvailIn = InLen;
+  Strm->NextOut = OutPtr;
+  Strm->AvailOut = 256;
+  ASSERT_TRUE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(Z_NO_FLUSH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // The started stream now answers an OOB dictionary with Z_STREAM_ERROR
+  // instead of trapping on the span.
+  EXPECT_TRUE(DeflateSetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, OOBPtr, UINT32_C(0x100)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+
+  // A raw stream rejects on live lookahead, which is not tracked, so a started
+  // raw stream keeps trapping on an OOB dictionary (documented residual).
+  const uint32_t ZSRaw = 0x40;
+  fillMemContent(MemInst, ZSRaw, sizeof(WasmZStream));
+  ASSERT_TRUE(DeflateInit2.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   ZSRaw, INT32_C(-1), INT32_C(Z_DEFLATED),
+                                   INT32_C(-15), INT32_C(8),
+                                   INT32_C(Z_DEFAULT_STRATEGY)},
+                               RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  auto *RawStrm = MemInst.getPointer<WasmZStream *>(ZSRaw);
+  RawStrm->NextIn = InPtr;
+  RawStrm->AvailIn = InLen;
+  RawStrm->NextOut = OutPtr;
+  RawStrm->AvailOut = 256;
+  ASSERT_TRUE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZSRaw, INT32_C(Z_NO_FLUSH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_FALSE(
+      DeflateSetDictionary.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   ZSRaw, OOBPtr, UINT32_C(0x100)},
+                               RetVal));
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZSRaw}, RetVal));
+}
+
+TEST(WasmEdgeZlibTest, HardeningDeflateCopyInheritsDictionaryState) {
+  // deflateCopy duplicates zlib's internal state wholesale, wrap and progress
+  // included, so the tracked facts must follow the copy. A copy of a started
+  // zlib-wrapped stream answers an OOB dictionary with Z_STREAM_ERROR before
+  // validating the span, exactly as the source would; and a copy of a raw
+  // stream stays raw, so after its own deflate() it still accepts a preset
+  // dictionary the way native zlib does (raw rejects depend on live lookahead,
+  // not on having started).
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(Deflate, "deflate")
+  GET_ZLIB_FUNC(DeflateCopy, "deflateCopy")
+  GET_ZLIB_FUNC(DeflateSetDictionary, "deflateSetDictionary")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+
+  const uint32_t OOBPtr = 0xFFFF0000;
+  const uint32_t InPtr = 256;
+  const uint32_t OutPtr = 1024;
+  const uint32_t DictPtr = 2048;
+  const char *const Input = "the quick brown fox jumps over the lazy dog";
+  const uint32_t InLen = static_cast<uint32_t>(std::strlen(Input));
+  std::strcpy(MemInst.getPointer<char *>(InPtr), Input);
+  const char *const Dict = "sample preset dictionary";
+  const uint32_t DictLen = static_cast<uint32_t>(std::strlen(Dict));
+  std::strcpy(MemInst.getPointer<char *>(DictPtr), Dict);
+
+  // A copy of a started zlib-wrapped stream inherits the started fact: the
+  // dictionary refusal is answered before the span is validated, so an OOB
+  // buffer yields Z_STREAM_ERROR rather than a trap.
+  const uint32_t ZS = 0;
+  const uint32_t ZC = 0x40;
+  fillMemContent(MemInst, ZS, sizeof(WasmZStream));
+  fillMemContent(MemInst, ZC, sizeof(WasmZStream));
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           ZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(15),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  auto *Strm = MemInst.getPointer<WasmZStream *>(ZS);
+  Strm->NextIn = InPtr;
+  Strm->AvailIn = InLen;
+  Strm->NextOut = OutPtr;
+  Strm->AvailOut = 512;
+  ASSERT_TRUE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(Z_NO_FLUSH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  ASSERT_TRUE(DeflateCopy.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZC, ZS}, RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_TRUE(DeflateSetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZC, OOBPtr, UINT32_C(0x100)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZC}, RetVal));
+
+  // A copy of a raw stream inherits rawness: after the copy's own deflate()
+  // drains the lookahead with a sync flush, native zlib still accepts a preset
+  // dictionary, so the started fact must not misfile the copy as zlib-wrapped.
+  const uint32_t ZSRaw = 0x80;
+  const uint32_t ZCRaw = 0xC0;
+  fillMemContent(MemInst, ZSRaw, sizeof(WasmZStream));
+  fillMemContent(MemInst, ZCRaw, sizeof(WasmZStream));
+  ASSERT_TRUE(DeflateInit2.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   ZSRaw, INT32_C(-1), INT32_C(Z_DEFLATED),
+                                   INT32_C(-15), INT32_C(8),
+                                   INT32_C(Z_DEFAULT_STRATEGY)},
+                               RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  ASSERT_TRUE(DeflateCopy.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZCRaw, ZSRaw},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  auto *RawStrm = MemInst.getPointer<WasmZStream *>(ZCRaw);
+  RawStrm->NextIn = InPtr;
+  RawStrm->AvailIn = InLen;
+  RawStrm->NextOut = OutPtr;
+  RawStrm->AvailOut = 512;
+  ASSERT_TRUE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZCRaw, INT32_C(Z_SYNC_FLUSH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_TRUE(DeflateSetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZCRaw, DictPtr, DictLen},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZSRaw}, RetVal));
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZCRaw}, RetVal));
+}
+
 TEST(WasmEdgeZlibTest, HardeningZeroLengthChecksumMatchesZlib) {
   // adler32/crc32 read Z_NULL as "return the initial value" and any non-null
   // zero-length buffer as "return the running value unchanged". A guest null
@@ -984,6 +1422,73 @@ TEST(WasmEdgeZlibTest, DeflateSetHeaderKeepsHeaderOnFailedReplace) {
   const auto StoreIt = HeaderMap.find(DZS);
   ASSERT_NE(StoreIt, HeaderMap.end());
   EXPECT_EQ(StoreIt->second->Name, Name1);
+}
+
+TEST(WasmEdgeZlibTest, DeflateSetHeaderRejectsOversizedNameAndComment) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(18, 18)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(DeflateSetHeader, "deflateSetHeader")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+
+  constexpr uint32_t TooLongHeaderStringLen = (UINT32_C(1) << 20) + 1;
+  const uint32_t LongStringPtr = 0x1000;
+  std::fill_n(MemInst.getPointer<char *>(LongStringPtr), TooLongHeaderStringLen,
+              'h');
+  *MemInst.getPointer<char *>(LongStringPtr + TooLongHeaderStringLen) = '\0';
+
+  const auto InitGzipStream = [&](uint32_t ZS) {
+    std::fill_n(MemInst.getPointer<uint8_t *>(ZS), sizeof(WasmZStream), 0);
+    ASSERT_TRUE(
+        DeflateInit2.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             ZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(31),
+                             INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                         RetVal));
+    ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  };
+
+  const uint32_t NameZS = 0x100;
+  const uint32_t NameHdr = 0x200;
+  InitGzipStream(NameZS);
+  std::fill_n(MemInst.getPointer<uint8_t *>(NameHdr), sizeof(WasmGZHeader), 0);
+  auto *NameHeader = MemInst.getPointer<WasmGZHeader *>(NameHdr);
+  NameHeader->Name = LongStringPtr;
+  EXPECT_FALSE(DeflateSetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{NameZS, NameHdr},
+      RetVal));
+  EXPECT_EQ(ZlibMod->getEnv().GZHeaderMap.count(NameZS), 0U);
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{NameZS}, RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  const uint32_t CommentZS = 0x300;
+  const uint32_t CommentHdr = 0x400;
+  InitGzipStream(CommentZS);
+  std::fill_n(MemInst.getPointer<uint8_t *>(CommentHdr), sizeof(WasmGZHeader),
+              0);
+  auto *CommentHeader = MemInst.getPointer<WasmGZHeader *>(CommentHdr);
+  CommentHeader->Comment = LongStringPtr;
+  EXPECT_FALSE(DeflateSetHeader.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{CommentZS, CommentHdr},
+      RetVal));
+  EXPECT_EQ(ZlibMod->getEnv().GZHeaderMap.count(CommentZS), 0U);
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{CommentZS},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 }
 
 TEST(WasmEdgeZlibTest, HardeningDeflateSetHeaderNonGzipSkipsSnapshot) {
@@ -1473,6 +1978,171 @@ TEST(WasmEdgeZlibTest, InflateCopyKeepsCopiedHeaderAlive) {
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{DstZS}, RetVal));
 }
 
+TEST(WasmEdgeZlibTest, CopyInitializesDirtyDestinationStream) {
+  // deflateCopy/inflateCopy must make the destination a complete copy of the
+  // source. The generic write-back moves buffer offsets by deltas against the
+  // destination's own pre-call pointers, which an uninitialized destination
+  // (legal per zlib's contract) cannot provide, so the copies must publish the
+  // source's stream fields directly; otherwise the destination keeps garbage
+  // offsets alongside the source's counts and traps on its next use.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(16, 16)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(Deflate, "deflate")
+  GET_ZLIB_FUNC(DeflateCopy, "deflateCopy")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(Inflate, "inflate")
+  GET_ZLIB_FUNC(InflateCopy, "inflateCopy")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  const uint32_t DataPtr = 0x300;
+  const char *const Payload = "payload-for-copy-write-back";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+
+  // A gzip blob for the inflate half.
+  const uint32_t AZS = 0x200;
+  const uint32_t BlobPtr = 0x3000;
+  const uint32_t BlobCap = 0x1000;
+  std::fill_n(MemInst.getPointer<uint8_t *>(AZS), sizeof(WasmZStream), 0);
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           AZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(31),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  auto *AStrm = MemInst.getPointer<WasmZStream *>(AZS);
+  AStrm->NextIn = DataPtr;
+  AStrm->AvailIn = PayloadLen;
+  AStrm->NextOut = BlobPtr;
+  AStrm->AvailOut = BlobCap;
+  ASSERT_TRUE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{AZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  const uint32_t BlobLen = BlobCap - AStrm->AvailOut;
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{AZS}, RetVal));
+
+  // deflateCopy onto an uninitialized (all-0xFF) destination struct, with the
+  // source mid-stream and input restaged the way a guest does between calls.
+  const uint32_t SZS = 0x100;
+  const uint32_t DCopyZS = 0x180;
+  const uint32_t CompPtr = 0x1000;
+  const uint32_t CompCap = 0x2000;
+  std::fill_n(MemInst.getPointer<uint8_t *>(SZS), sizeof(WasmZStream), 0);
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           SZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(15),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  auto *SStrm = MemInst.getPointer<WasmZStream *>(SZS);
+  SStrm->NextIn = DataPtr;
+  SStrm->AvailIn = PayloadLen;
+  SStrm->NextOut = CompPtr;
+  SStrm->AvailOut = CompCap;
+  ASSERT_TRUE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{SZS, INT32_C(Z_NO_FLUSH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  SStrm->NextIn = DataPtr;
+  SStrm->AvailIn = PayloadLen;
+
+  std::fill_n(MemInst.getPointer<uint8_t *>(DCopyZS), sizeof(WasmZStream),
+              0xFF);
+  ASSERT_TRUE(DeflateCopy.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DCopyZS, SZS},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *DCopyStrm = MemInst.getPointer<WasmZStream *>(DCopyZS);
+  EXPECT_EQ(DCopyStrm->NextIn, SStrm->NextIn);
+  EXPECT_EQ(DCopyStrm->AvailIn, SStrm->AvailIn);
+  EXPECT_EQ(DCopyStrm->TotalIn, SStrm->TotalIn);
+  EXPECT_EQ(DCopyStrm->NextOut, SStrm->NextOut);
+  EXPECT_EQ(DCopyStrm->AvailOut, SStrm->AvailOut);
+  EXPECT_EQ(DCopyStrm->TotalOut, SStrm->TotalOut);
+
+  // The copy must be usable as-is: finishing it may not trap on leftover
+  // garbage offsets.
+  ASSERT_TRUE(Deflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DCopyZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DCopyZS}, RetVal));
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{SZS}, RetVal));
+
+  // inflateCopy: park the source inside the gzip stream, stage the rest of the
+  // input, then copy onto an all-0xFF destination struct.
+  const uint32_t IZS = 0x4000;
+  const uint32_t ICopyZS = 0x4080;
+  const uint32_t DecPtr = 0x5000;
+  const uint32_t DecCap = 0x1000;
+  std::fill_n(MemInst.getPointer<uint8_t *>(IZS), sizeof(WasmZStream), 0);
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(31)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  auto *IStrm = MemInst.getPointer<WasmZStream *>(IZS);
+  IStrm->NextIn = BlobPtr;
+  IStrm->AvailIn = 12;
+  IStrm->NextOut = DecPtr;
+  IStrm->AvailOut = DecCap;
+  ASSERT_TRUE(Inflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(Z_NO_FLUSH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  IStrm->AvailIn = BlobLen - 12;
+
+  std::fill_n(MemInst.getPointer<uint8_t *>(ICopyZS), sizeof(WasmZStream),
+              0xFF);
+  ASSERT_TRUE(InflateCopy.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ICopyZS, IZS},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *ICopyStrm = MemInst.getPointer<WasmZStream *>(ICopyZS);
+  EXPECT_EQ(ICopyStrm->NextIn, IStrm->NextIn);
+  EXPECT_EQ(ICopyStrm->AvailIn, IStrm->AvailIn);
+  EXPECT_EQ(ICopyStrm->TotalIn, IStrm->TotalIn);
+  EXPECT_EQ(ICopyStrm->NextOut, IStrm->NextOut);
+  EXPECT_EQ(ICopyStrm->AvailOut, IStrm->AvailOut);
+  EXPECT_EQ(ICopyStrm->TotalOut, IStrm->TotalOut);
+
+  ASSERT_TRUE(Inflate.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ICopyZS, INT32_C(Z_FINISH)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+  EXPECT_EQ(
+      std::memcmp(MemInst.getPointer<char *>(DecPtr), Payload, PayloadLen), 0);
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ICopyZS}, RetVal));
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+}
+
 TEST(WasmEdgeZlibTest, InflateGetHeaderReplacesStoredHeaderOnSuccess) {
   // A second inflateGetHeader on the same stream re-points zlib's internal head
   // at the new host snapshot. The stored snapshot must be replaced (and kept
@@ -1933,6 +2603,73 @@ TEST(WasmEdgeZlibTest, HardeningInflateGetHeaderValidatesHeadPtr) {
       CallFrame,
       std::initializer_list<WasmEdge::ValVariant>{IZS, UINT32_C(65530)},
       RetVal));
+}
+
+TEST(WasmEdgeZlibTest, HardeningInflateGetHeaderAnswersNonGzipStreams) {
+  // inflateGetHeader touches the header only on a gzip-capable inflate stream
+  // (wrap & 2); a zlib-wrapped or raw stream gets Z_STREAM_ERROR before any
+  // dereference, so an out-of-bounds HeadPtr must surface that soft error
+  // there and keep trapping only where zlib would accept the registration.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(InflateInit, "inflateInit")
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(InflateGetHeader, "inflateGetHeader")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  const uint32_t OOBHeadPtr = 65530;
+
+  // Plain inflateInit: zlib wrapper only, the header request is refused.
+  const uint32_t ZS = 0;
+  fillMemContent(MemInst, ZS, sizeof(WasmZStream));
+  ASSERT_TRUE(InflateInit.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_TRUE(InflateGetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, OOBHeadPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+
+  // Raw inflate: no wrapper at all, same soft answer.
+  fillMemContent(MemInst, ZS, sizeof(WasmZStream));
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-15)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_TRUE(InflateGetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, OOBHeadPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+
+  // Auto-detect (windowBits 47) is gzip-capable: zlib would store the header
+  // and reset head->done, so the unreadable pointer keeps failing hard (the
+  // gzip-only windowBits 31 case is covered in
+  // HardeningInflateGetHeaderValidatesHeadPtr).
+  fillMemContent(MemInst, ZS, sizeof(WasmZStream));
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(47)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_FALSE(InflateGetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, OOBHeadPtr},
+      RetVal));
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
 }
 
 TEST(WasmEdgeZlibTest, HardeningInflateEndToleratesCorruptHeaderMax) {
@@ -2563,6 +3300,922 @@ TEST(WasmEdgeZlibTest, HardeningInflateHeaderZeroCapacityKeepsGuestPointers) {
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
 }
 
+TEST(WasmEdgeZlibTest, HardeningReinitRejectsLiveStream) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit, "deflateInit")
+
+  const uint32_t ZS = 0;
+  std::fill_n(MemInst.getPointer<uint8_t *>(ZS), sizeof(WasmZStream), 0);
+  ASSERT_TRUE(DeflateInit.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-1)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // Re-initializing an already-live stream must be rejected. Running zlib's
+  // init on the existing z_stream would overwrite strm->state and leak the
+  // previous internal state (window/hash/pending buffers), unbounded.
+  ASSERT_TRUE(DeflateInit.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-1)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+}
+
+TEST(WasmEdgeZlibTest, HardeningWrongTypeEndKeepsStream) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit, "deflateInit")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+
+  const uint32_t ZS = 0;
+  std::fill_n(MemInst.getPointer<uint8_t *>(ZS), sizeof(WasmZStream), 0);
+  ASSERT_TRUE(DeflateInit.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-1)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // inflateEnd on a deflate stream is the wrong cleanup: zlib returns
+  // Z_STREAM_ERROR without freeing. The wrapper must keep the stream tracked
+  // rather than drop the only handle (which would leak the internal state), so
+  // the correct deflateEnd still frees it afterwards.
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+}
+
+TEST(WasmEdgeZlibTest, HardeningWrongKindStreamAnswersLikeZlib) {
+  // Every kind-specific entry point answers a stream of the other kind with
+  // its documented bad-state result before reading or writing anything, so
+  // stale or out-of-bounds buffer fields on the guest stream must not trap,
+  // out-parameters must not be validated, and the mismatched host state must
+  // never be entered (on zlib-ng a cross-kind call could otherwise free
+  // garbage pointers or overwrite live internal state).
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit, "deflateInit")
+  GET_ZLIB_FUNC(Deflate, "deflate")
+  GET_ZLIB_FUNC(DeflateParams, "deflateParams")
+  GET_ZLIB_FUNC(DeflateTune, "deflateTune")
+  GET_ZLIB_FUNC(DeflatePending, "deflatePending")
+  GET_ZLIB_FUNC(DeflatePrime, "deflatePrime")
+  GET_ZLIB_FUNC(DeflateSetHeader, "deflateSetHeader")
+  GET_ZLIB_FUNC(DeflateGetDictionary, "deflateGetDictionary")
+  GET_ZLIB_FUNC(DeflateReset, "deflateReset")
+  GET_ZLIB_FUNC(DeflateResetKeep, "deflateResetKeep")
+  GET_ZLIB_FUNC(DeflateCopy, "deflateCopy")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+  GET_ZLIB_FUNC(InflateInit, "inflateInit")
+  GET_ZLIB_FUNC(Inflate, "inflate")
+  GET_ZLIB_FUNC(InflateSync, "inflateSync")
+  GET_ZLIB_FUNC(InflateMark, "inflateMark")
+  GET_ZLIB_FUNC(InflateGetDictionary, "inflateGetDictionary")
+  GET_ZLIB_FUNC(InflateValidate, "inflateValidate")
+  GET_ZLIB_FUNC(InflateCodesUsed, "inflateCodesUsed")
+  GET_ZLIB_FUNC(InflateSyncPoint, "inflateSyncPoint")
+  GET_ZLIB_FUNC(InflateUndermine, "inflateUndermine")
+  GET_ZLIB_FUNC(InflatePrime, "inflatePrime")
+  GET_ZLIB_FUNC(InflateReset, "inflateReset")
+  GET_ZLIB_FUNC(InflateReset2, "inflateReset2")
+  GET_ZLIB_FUNC(InflateResetKeep, "inflateResetKeep")
+  GET_ZLIB_FUNC(InflateCopy, "inflateCopy")
+  GET_ZLIB_FUNC(InflateBackEnd, "inflateBackEnd")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  const uint32_t OOBPtr = 0xFFFF0000;
+  const uint32_t DZS = 0x40;
+  const uint32_t IZS = 0x100;
+  fillMemContent(MemInst, DZS, sizeof(WasmZStream));
+  fillMemContent(MemInst, IZS, sizeof(WasmZStream));
+  ASSERT_TRUE(DeflateInit.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS, INT32_C(-1)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  ASSERT_TRUE(InflateInit.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // Poison both guest streams' buffer fields; a wrong-kind call must answer
+  // without ever validating them.
+  for (const uint32_t ZS : {DZS, IZS}) {
+    auto *Strm = MemInst.getPointer<WasmZStream *>(ZS);
+    Strm->NextIn = OOBPtr;
+    Strm->AvailIn = 0x1000;
+    Strm->NextOut = OOBPtr;
+    Strm->AvailOut = 0x1000;
+  }
+
+  const auto ExpectI32 = [&](auto &Func,
+                             std::initializer_list<WasmEdge::ValVariant> Args,
+                             int32_t Expected) {
+    EXPECT_TRUE(Func.run(CallFrame, Args, RetVal));
+    EXPECT_EQ(RetVal[0].get<int32_t>(), Expected);
+  };
+
+  // deflate family on the live inflate stream.
+  ExpectI32(Deflate, {IZS, INT32_C(Z_NO_FLUSH)}, Z_STREAM_ERROR);
+  ExpectI32(DeflateParams, {IZS, INT32_C(9), INT32_C(Z_DEFAULT_STRATEGY)},
+            Z_STREAM_ERROR);
+  ExpectI32(DeflateTune,
+            {IZS, INT32_C(8), INT32_C(16), INT32_C(32), INT32_C(128)},
+            Z_STREAM_ERROR);
+  ExpectI32(DeflatePending, {IZS, OOBPtr, OOBPtr}, Z_STREAM_ERROR);
+  ExpectI32(DeflatePrime, {IZS, INT32_C(5), INT32_C(21)}, Z_STREAM_ERROR);
+  ExpectI32(DeflateSetHeader, {IZS, UINT32_C(0x300)}, Z_STREAM_ERROR);
+  ExpectI32(DeflateGetDictionary, {IZS, OOBPtr, OOBPtr}, Z_STREAM_ERROR);
+  ExpectI32(DeflateReset, {IZS}, Z_STREAM_ERROR);
+  ExpectI32(DeflateResetKeep, {IZS}, Z_STREAM_ERROR);
+  ExpectI32(DeflateEnd, {IZS}, Z_STREAM_ERROR);
+
+  // inflate family on the live deflate stream.
+  ExpectI32(Inflate, {DZS, INT32_C(Z_NO_FLUSH)}, Z_STREAM_ERROR);
+  ExpectI32(InflateSync, {DZS}, Z_STREAM_ERROR);
+  ExpectI32(InflateMark, {DZS}, INT32_C(-65536));
+  ExpectI32(InflateGetDictionary, {DZS, OOBPtr, OOBPtr}, Z_STREAM_ERROR);
+  ExpectI32(InflateValidate, {DZS, INT32_C(1)}, Z_STREAM_ERROR);
+  ExpectI32(InflateCodesUsed, {DZS}, INT32_C(-1));
+  ExpectI32(InflateSyncPoint, {DZS}, Z_STREAM_ERROR);
+  ExpectI32(InflateUndermine, {DZS, INT32_C(1)}, Z_STREAM_ERROR);
+  ExpectI32(InflatePrime, {DZS, INT32_C(5), INT32_C(21)}, Z_STREAM_ERROR);
+  ExpectI32(InflateReset, {DZS}, Z_STREAM_ERROR);
+  ExpectI32(InflateReset2, {DZS, INT32_C(-15)}, Z_STREAM_ERROR);
+  ExpectI32(InflateResetKeep, {DZS}, Z_STREAM_ERROR);
+  ExpectI32(InflateBackEnd, {DZS}, Z_STREAM_ERROR);
+
+  // A rejected copy must not leave a destination entry behind.
+  const uint32_t CopyPtr = 0x200;
+  fillMemContent(MemInst, CopyPtr, sizeof(WasmZStream));
+  ExpectI32(InflateCopy, {CopyPtr, DZS}, Z_STREAM_ERROR);
+  ExpectI32(DeflateCopy, {CopyPtr, IZS}, Z_STREAM_ERROR);
+  ExpectI32(DeflateInit, {CopyPtr, INT32_C(-1)}, Z_OK);
+  ExpectI32(DeflateEnd, {CopyPtr}, Z_OK);
+
+  // None of the rejected calls entered zlib: the deflate stream still
+  // compresses (inflateBackEnd in particular must not have freed its state).
+  const uint32_t DataPtr = 0x300;
+  const char *const Payload = "wrong-kind guard leaves streams intact";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+  auto *DStrm = MemInst.getPointer<WasmZStream *>(DZS);
+  DStrm->NextIn = DataPtr;
+  DStrm->AvailIn = PayloadLen;
+  DStrm->NextOut = 0x1000;
+  DStrm->AvailOut = 0x1000;
+  ExpectI32(Deflate, {DZS, INT32_C(Z_FINISH)}, Z_STREAM_END);
+  ExpectI32(DeflateEnd, {DZS}, Z_OK);
+  ExpectI32(InflateEnd, {IZS}, Z_OK);
+}
+
+TEST(WasmEdgeZlibTest, HardeningDeflateCopyRejectsLiveDest) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit, "deflateInit")
+  GET_ZLIB_FUNC(DeflateCopy, "deflateCopy")
+
+  const uint32_t Dest = 0;
+  const uint32_t Source = 0x100;
+  std::fill_n(MemInst.getPointer<uint8_t *>(Dest), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(Source), sizeof(WasmZStream), 0);
+  ASSERT_TRUE(DeflateInit.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{Dest, INT32_C(-1)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  ASSERT_TRUE(DeflateInit.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{Source, INT32_C(-1)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // Copying onto an already-live destination must be rejected: zlib's
+  // deflateCopy overwrites the dest z_stream (leaking its state) and, on an
+  // allocation failure, leaves dest aliasing the source's state.
+  ASSERT_TRUE(DeflateCopy.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{Dest, Source},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+}
+
+TEST(WasmEdgeZlibTest, HardeningFailedInitLeavesKeyReusable) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 2)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit, "deflateInit")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+
+  // An out-of-bounds z_stream pointer traps after the tracking entry was
+  // already created; the failed init must drop that entry again.
+  const uint32_t ZS = UINT32_C(65536);
+  ASSERT_FALSE(DeflateInit.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-1)},
+      RetVal));
+
+  // Once the same address becomes valid (after a grow), the key must accept a
+  // fresh stream instead of being reported as still live by the dead entry.
+  ASSERT_TRUE(MemInst.growPage(1));
+  std::fill_n(MemInst.getPointer<uint8_t *>(ZS), sizeof(WasmZStream), 0);
+  ASSERT_TRUE(DeflateInit.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-1)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+}
+
+TEST(WasmEdgeZlibTest, HardeningFailedCopyLeavesKeyReusable) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 2)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit, "deflateInit")
+  GET_ZLIB_FUNC(DeflateCopy, "deflateCopy")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+  GET_ZLIB_FUNC(InflateInit, "inflateInit")
+  GET_ZLIB_FUNC(InflateCopy, "inflateCopy")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  const uint32_t DeflateSrc = 0;
+  const uint32_t InflateSrc = 0x100;
+  const uint32_t DeflateDest = UINT32_C(65536);
+  const uint32_t InflateDest = UINT32_C(65536) + 0x100;
+  std::fill_n(MemInst.getPointer<uint8_t *>(DeflateSrc), sizeof(WasmZStream),
+              0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(InflateSrc), sizeof(WasmZStream),
+              0);
+  ASSERT_TRUE(DeflateInit.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DeflateSrc, INT32_C(-1)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  ASSERT_TRUE(InflateInit.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{InflateSrc},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // An out-of-bounds destination traps after its tracking entry was created;
+  // the failed copy must drop that entry again.
+  ASSERT_FALSE(DeflateCopy.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DeflateDest, DeflateSrc},
+      RetVal));
+  ASSERT_FALSE(InflateCopy.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{InflateDest, InflateSrc},
+      RetVal));
+
+  // Once the same addresses become valid (after a grow), the keys must accept
+  // the copies instead of being reported as already-live destinations.
+  ASSERT_TRUE(MemInst.growPage(1));
+  std::fill_n(MemInst.getPointer<uint8_t *>(DeflateDest), sizeof(WasmZStream),
+              0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(InflateDest), sizeof(WasmZStream),
+              0);
+  ASSERT_TRUE(DeflateCopy.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DeflateDest, DeflateSrc},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  ASSERT_TRUE(InflateCopy.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{InflateDest, InflateSrc},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  for (const uint32_t ZS : {DeflateSrc, DeflateDest}) {
+    ASSERT_TRUE(DeflateEnd.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+    EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  }
+  for (const uint32_t ZS : {InflateSrc, InflateDest}) {
+    ASSERT_TRUE(InflateEnd.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+    EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  }
+}
+
+TEST(WasmEdgeZlibTest, HardeningDeflateSetHeaderClampsExtra) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(2, 2)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(DeflateSetHeader, "deflateSetHeader")
+
+  const uint32_t DZS = 0;
+  const uint32_t DHdr = 0x100;
+  std::fill_n(MemInst.getPointer<uint8_t *>(DZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(DHdr), sizeof(WasmGZHeader), 0);
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           DZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(31),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // Place an 8-byte extra field at the very end of memory and declare an
+  // ExtraLen whose low 16 bits are 8 but whose full value (0x10008) runs far
+  // out of bounds. zlib emits only (ExtraLen & 0xffff) = 8 bytes, all in
+  // bounds, so the wrapper must snapshot only those 8 bytes: it must neither
+  // fail the full-length bounds check nor allocate the full 0x10008 on the
+  // host.
+  const uint32_t MemBytes = static_cast<uint32_t>(MemInst.getSize());
+  const uint32_t ExtraOff = MemBytes - 8;
+  for (uint32_t I = 0; I < 8; ++I) {
+    *MemInst.getPointer<uint8_t *>(ExtraOff + I) = static_cast<uint8_t>(I + 1);
+  }
+  auto *DHeader = MemInst.getPointer<WasmGZHeader *>(DHdr);
+  DHeader->Extra = ExtraOff;
+  DHeader->ExtraLen = UINT32_C(0x10008);
+
+  ASSERT_TRUE(DeflateSetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS, DHdr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+}
+
+TEST(WasmEdgeZlibTest, DeflateSetHeaderKeepsEmptyExtraField) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(2, 2)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(DeflateSetHeader, "deflateSetHeader")
+  GET_ZLIB_FUNC(Deflate, "deflate")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+
+  // zlib keys the gzip FEXTRA flag on the extra pointer alone: a non-null
+  // extra whose emitted length (the low 16 bits of extra_len) is zero still
+  // yields FLG.FEXTRA with XLEN=0. The wrapper must preserve that instead of
+  // silently dropping the flag from the emitted header.
+  const std::array<uint32_t, 2> ZeroEmittedLens = {UINT32_C(0),
+                                                   UINT32_C(0x10000)};
+  for (const uint32_t ExtraLen : ZeroEmittedLens) {
+    const uint32_t DZS = 0x100;
+    const uint32_t DHdr = 0x200;
+    const uint32_t ExtraPtr = 0x300;
+    const uint32_t DataPtr = 0x500;
+    const uint32_t CompPtr = 0x1000;
+    const uint32_t CompCap = 0x1000;
+    const char *const Payload = "payload";
+    std::fill_n(MemInst.getPointer<uint8_t *>(DZS), sizeof(WasmZStream), 0);
+    std::fill_n(MemInst.getPointer<uint8_t *>(DHdr), sizeof(WasmGZHeader), 0);
+    std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+
+    ASSERT_TRUE(
+        DeflateInit2.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             DZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(31),
+                             INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                         RetVal));
+    ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+    auto *DHeader = MemInst.getPointer<WasmGZHeader *>(DHdr);
+    DHeader->Extra = ExtraPtr;
+    DHeader->ExtraLen = ExtraLen;
+    ASSERT_TRUE(DeflateSetHeader.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS, DHdr},
+        RetVal));
+    ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+    auto *DStrm = MemInst.getPointer<WasmZStream *>(DZS);
+    DStrm->NextIn = DataPtr;
+    DStrm->AvailIn = static_cast<uint32_t>(std::strlen(Payload));
+    DStrm->NextOut = CompPtr;
+    DStrm->AvailOut = CompCap;
+    ASSERT_TRUE(Deflate.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{DZS, INT32_C(Z_FINISH)},
+        RetVal));
+    ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
+    ASSERT_TRUE(DeflateEnd.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS}, RetVal));
+
+    const auto *Out = MemInst.getPointer<const uint8_t *>(CompPtr);
+    EXPECT_NE(Out[3] & 0x04, 0) << "FEXTRA dropped for ExtraLen " << ExtraLen;
+    EXPECT_EQ(Out[10], 0) << "XLEN low byte for ExtraLen " << ExtraLen;
+    EXPECT_EQ(Out[11], 0) << "XLEN high byte for ExtraLen " << ExtraLen;
+  }
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZBufferClampsSize) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const std::string TmpPath = (std::filesystem::temp_directory_path() /
+                               "wasmedge_zlib_gzbuffer_test.gz")
+                                  .string();
+  ASSERT_LT(TmpPath.size() + 1, 1024U);
+  const uint32_t PathPtr = 0;
+  std::strcpy(MemInst.getPointer<char *>(PathPtr), TmpPath.c_str());
+  const uint32_t ModeWPtr = 1024;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  GET_ZLIB_FUNC(GZBuffer, "gzbuffer")
+  GET_ZLIB_FUNC(GZClose, "gzclose")
+
+  if (!GZOpen.run(
+          CallFrame,
+          std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWPtr},
+          RetVal)) {
+    GTEST_SKIP() << "cannot create temporary file: " << TmpPath;
+  }
+  const uint32_t WHandle = RetVal[0].get<uint32_t>();
+
+  // A guest-declared ~4 GB buffer size must be clamped to a sane cap rather
+  // than forwarded verbatim: zlib rejects sizes >= 2^31 (returning -1) and
+  // otherwise allocates three times the size on first I/O. After clamping, an
+  // absurd request is accepted (returns 0) with a bounded host allocation.
+  EXPECT_TRUE(GZBuffer.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               WHandle, UINT32_C(0xFFFFFFFF)},
+                           RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), 0);
+
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, RetVal));
+  std::remove(TmpPath.c_str());
+}
+
+TEST(WasmEdgeZlibTest, HardeningDeflatePendingRejectsOOBPointer) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit, "deflateInit")
+  GET_ZLIB_FUNC(DeflatePending, "deflatePending")
+
+  const uint32_t ZS = 0;
+  std::fill_n(MemInst.getPointer<uint8_t *>(ZS), sizeof(WasmZStream), 0);
+  ASSERT_TRUE(DeflateInit.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-1)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // An out-of-bounds pending out-pointer must be rejected outright, not left
+  // for zlib to silently drop via its internal NULL tolerance (65534 + 4 bytes
+  // exceeds the single 64 KiB page; the bits pointer at 0x100 is valid).
+  EXPECT_FALSE(DeflatePending.run(CallFrame,
+                                  std::initializer_list<WasmEdge::ValVariant>{
+                                      ZS, UINT32_C(65534), UINT32_C(0x100)},
+                                  RetVal));
+}
+
+TEST(WasmEdgeZlibTest, InflateGetHeaderSyncsImmediateDoneReset) {
+  // inflateGetHeader resets head->done to 0 as it registers the header; the
+  // guest must observe that immediately, not only after the next inflate call
+  // happens to sync the header back.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(16, 16)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(InflateGetHeader, "inflateGetHeader")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  const uint32_t IZS = 0x100;
+  const uint32_t IHdr = 0x200;
+  std::fill_n(MemInst.getPointer<uint8_t *>(IZS), sizeof(WasmZStream), 0);
+  std::fill_n(MemInst.getPointer<uint8_t *>(IHdr), sizeof(WasmGZHeader), 0);
+
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(31)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  auto *IHeader = MemInst.getPointer<WasmGZHeader *>(IHdr);
+  IHeader->Done = 1;
+  ASSERT_TRUE(InflateGetHeader.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, IHdr},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_EQ(IHeader->Done, 0);
+
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+}
+
+TEST(WasmEdgeZlibTest, GetDictionaryAndPendingHonorNullOutPointers) {
+  // deflateGetDictionary/inflateGetDictionary/deflatePending document Z_NULL
+  // out-pointers as "skip": a null dictionary returns only the length, and a
+  // null dictLength/pending/bits is not set. Guest 0 must map to Z_NULL
+  // rather than to a live pointer at wasm address 0.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(16, 16)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit2, "deflateInit2")
+  GET_ZLIB_FUNC(DeflateSetDictionary, "deflateSetDictionary")
+  GET_ZLIB_FUNC(DeflateGetDictionary, "deflateGetDictionary")
+  GET_ZLIB_FUNC(DeflatePending, "deflatePending")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+  GET_ZLIB_FUNC(InflateInit2, "inflateInit2")
+  GET_ZLIB_FUNC(InflateGetDictionary, "inflateGetDictionary")
+  GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
+
+  fillMemContent(MemInst, 0, 64, 0xCD);
+  const std::vector<uint8_t> Expected(64, 0xCD);
+
+  const uint32_t DZS = 0x100;
+  const uint32_t DictSrc = 0x200;
+  const uint32_t DictOut = 0x240;
+  const uint32_t LenPtr = 0x280;
+  const uint32_t BitsPtr = 0x290;
+  const uint32_t PendPtr = 0x2A0;
+  const char *const Dict = "0123456789abcdef";
+  const uint32_t DictLen = 16;
+  std::memcpy(MemInst.getPointer<uint8_t *>(DictSrc), Dict, DictLen);
+  std::fill_n(MemInst.getPointer<uint8_t *>(DZS), sizeof(WasmZStream), 0);
+
+  ASSERT_TRUE(
+      DeflateInit2.run(CallFrame,
+                       std::initializer_list<WasmEdge::ValVariant>{
+                           DZS, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(15),
+                           INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY)},
+                       RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  ASSERT_TRUE(DeflateSetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DZS, DictSrc, DictLen},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  // dictionary == Z_NULL: only the length is returned.
+  ASSERT_TRUE(DeflateGetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DZS, UINT32_C(0), LenPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_EQ(*MemInst.getPointer<uint32_t *>(LenPtr), DictLen);
+
+  // dictLength == Z_NULL: the dictionary is copied, the length is not set.
+  ASSERT_TRUE(DeflateGetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DZS, DictOut, UINT32_C(0)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_EQ(0,
+            std::memcmp(MemInst.getPointer<uint8_t *>(DictOut), Dict, DictLen));
+
+  // pending / bits == Z_NULL: the other value is still delivered.
+  ASSERT_TRUE(DeflatePending.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DZS, UINT32_C(0), BitsPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  ASSERT_TRUE(DeflatePending.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DZS, PendPtr, UINT32_C(0)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+
+  EXPECT_EQ(0,
+            std::memcmp(MemInst.getPointer<uint8_t *>(0), Expected.data(), 64));
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS}, RetVal));
+
+  const uint32_t IZS = 0x400;
+  std::fill_n(MemInst.getPointer<uint8_t *>(IZS), sizeof(WasmZStream), 0);
+  ASSERT_TRUE(InflateInit2.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, INT32_C(15)},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  ASSERT_TRUE(InflateGetDictionary.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{IZS, DictOut, UINT32_C(0)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  EXPECT_EQ(0,
+            std::memcmp(MemInst.getPointer<uint8_t *>(0), Expected.data(), 64));
+  ASSERT_TRUE(InflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
+}
+
+TEST(WasmEdgeZlibTest, HardeningInflateBackInitVersionErrorSkipsWindow) {
+  // inflateBackInit_ answers Z_VERSION_ERROR for a null or major-mismatched
+  // version before it examines any other argument, so a bad version paired
+  // with an out-of-bounds window must surface that soft error rather than a
+  // window-validation trap.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(InflateBackInit_, "inflateBackInit_")
+
+  const uint32_t ZS = 0;
+  std::fill_n(MemInst.getPointer<uint8_t *>(ZS), sizeof(WasmZStream), 0);
+  const uint32_t OOBWindowPtr = 0xFFFF0000;
+
+  const uint32_t BadVersionPtr = 0x100;
+  std::strcpy(MemInst.getPointer<char *>(BadVersionPtr), "0.0.0");
+  ASSERT_TRUE(
+      InflateBackInit_.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               ZS, INT32_C(15), OOBWindowPtr, BadVersionPtr,
+                               static_cast<int32_t>(sizeof(WasmZStream))},
+                           RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_VERSION_ERROR);
+
+  // With a matching version the same out-of-bounds window keeps failing hard.
+  const uint32_t VersionPtr = 0x140;
+  std::strcpy(MemInst.getPointer<char *>(VersionPtr), ZLIB_VERSION);
+  EXPECT_FALSE(
+      InflateBackInit_.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               ZS, INT32_C(15), OOBWindowPtr, VersionPtr,
+                               static_cast<int32_t>(sizeof(WasmZStream))},
+                           RetVal));
+}
+
+TEST(WasmEdgeZlibTest, HardeningInflateBackInitNullWindowMatchesZlib) {
+  // inflateBackInit rejects a Z_NULL window before touching it, so a guest
+  // null must take that path instead of resolving to wasm address 0 -- and
+  // the failed init must leave the key reusable.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(InflateBackInit, "inflateBackInit")
+  GET_ZLIB_FUNC(InflateBackEnd, "inflateBackEnd")
+
+  const uint32_t ZS = 0;
+  fillMemContent(MemInst, ZS, sizeof(WasmZStream));
+  ASSERT_TRUE(InflateBackInit.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(15), UINT32_C(0)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+
+  // A 32 KiB window at a real offset succeeds on the same key afterwards.
+  ASSERT_TRUE(InflateBackInit.run(CallFrame,
+                                  std::initializer_list<WasmEdge::ValVariant>{
+                                      ZS, INT32_C(15), UINT32_C(0x1000)},
+                                  RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  ASSERT_TRUE(InflateBackEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+}
+
+TEST(WasmEdgeZlibTest, HardeningVersionedInitAnswersVersionErrorFirst) {
+  // The versioned init wrappers answer Z_VERSION_ERROR for a null or
+  // major-mismatched version before they examine the stream argument, like
+  // native zlib: a bad version paired with an out-of-bounds z_stream or an
+  // already-live key surfaces the version error instead of a trap or
+  // Z_STREAM_ERROR.
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit_, "deflateInit_")
+  GET_ZLIB_FUNC(InflateInit_, "inflateInit_")
+  GET_ZLIB_FUNC(DeflateInit2_, "deflateInit2_")
+  GET_ZLIB_FUNC(InflateInit2_, "inflateInit2_")
+  GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
+
+  const int32_t StreamSize = static_cast<int32_t>(sizeof(WasmZStream));
+  const uint32_t BadVersionPtr = 0x100;
+  std::strcpy(MemInst.getPointer<char *>(BadVersionPtr), "0.0.0");
+  const uint32_t OOBZStreamPtr = 0xFFFF0000;
+
+  // Out-of-bounds stream, bad version: the version error must win in every
+  // versioned wrapper rather than a stream-resolution trap.
+  ASSERT_TRUE(DeflateInit_.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{OOBZStreamPtr, INT32_C(-1),
+                                                  BadVersionPtr, StreamSize},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_VERSION_ERROR);
+  ASSERT_TRUE(InflateInit_.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   OOBZStreamPtr, BadVersionPtr, StreamSize},
+                               RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_VERSION_ERROR);
+  ASSERT_TRUE(DeflateInit2_.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          OOBZStreamPtr, INT32_C(-1), INT32_C(Z_DEFLATED), INT32_C(15),
+          INT32_C(8), INT32_C(Z_DEFAULT_STRATEGY), BadVersionPtr, StreamSize},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_VERSION_ERROR);
+  ASSERT_TRUE(InflateInit2_.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{OOBZStreamPtr, INT32_C(15),
+                                                  BadVersionPtr, StreamSize},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_VERSION_ERROR);
+
+  // Live key, bad version: still the version error, and the live stream
+  // survives for a matching-version re-init to reject and an end to free.
+  const uint32_t ZS = 0;
+  fillMemContent(MemInst, ZS, sizeof(WasmZStream));
+  const uint32_t VersionPtr = 0x140;
+  std::strcpy(MemInst.getPointer<char *>(VersionPtr), ZLIB_VERSION);
+  ASSERT_TRUE(DeflateInit_.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   ZS, INT32_C(-1), VersionPtr, StreamSize},
+                               RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+  ASSERT_TRUE(DeflateInit_.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   ZS, INT32_C(-1), BadVersionPtr, StreamSize},
+                               RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_VERSION_ERROR);
+  ASSERT_TRUE(DeflateInit_.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   ZS, INT32_C(-1), VersionPtr, StreamSize},
+                               RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
+  ASSERT_TRUE(DeflateEnd.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
+}
+
+TEST(WasmEdgeZlibTest, HardeningDeflateInitValidatesVersionString) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(DeflateInit_, "deflateInit_")
+
+  const uint32_t ZS = 0;
+  std::fill_n(MemInst.getPointer<uint8_t *>(ZS), sizeof(WasmZStream), 0);
+
+  // Point the version at the last 4 bytes of memory, filled with the real
+  // ZLIB_VERSION first byte but with no NUL terminator before the end of linear
+  // memory. zlib only reads version[0] today, but the wrapper must validate the
+  // whole in-bounds C string so an unterminated version cannot be accepted (and
+  // a future zlib that compares more of the string cannot read out of bounds).
+  const uint32_t MemBytes = static_cast<uint32_t>(MemInst.getSize());
+  const uint32_t VersionPtr = MemBytes - 4;
+  std::fill_n(MemInst.getPointer<uint8_t *>(VersionPtr), 4,
+              static_cast<uint8_t>(ZLIB_VERSION[0]));
+
+  ASSERT_TRUE(DeflateInit_.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   ZS, INT32_C(-1), VersionPtr,
+                                   static_cast<int32_t>(sizeof(WasmZStream))},
+                               RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), Z_VERSION_ERROR);
+}
 
 GTEST_API_ int main(int ArgC, char **ArgV) {
   testing::InitGoogleTest(&ArgC, ArgV);

--- a/test/plugins/wasmedge_zlib/wasmedge_zlib.cpp
+++ b/test/plugins/wasmedge_zlib/wasmedge_zlib.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "common/defines.h"
+#include "host/wasi/wasimodule.h"
 #include "runtime/instance/module.h"
 #include "zlibfunc.h"
 #include "zlibmodule.h"
@@ -12,10 +13,15 @@
 #include <cstdio>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <gtest/gtest.h>
 #include <memory>
 #include <string>
 #include <vector>
+
+#if !defined(_WIN32)
+#include <sys/stat.h>
+#endif
 
 namespace {
 
@@ -44,6 +50,12 @@ std::unique_ptr<WasmEdge::Host::WasmEdgeZlibModule> createModule() {
   }
   return {};
 }
+
+class WasiWiredModule : public WasmEdge::Runtime::Instance::ModuleInstance {
+public:
+  using ModuleInstance::ModuleInstance;
+  void wireWASIModule(const ModuleInstance *M) noexcept { setWASIModule(M); }
+};
 
 } // namespace
 
@@ -118,8 +130,6 @@ TEST(WasmEdgeZlibTest, DeflateInflateCycle) {
   WasmZlibVersion = WasmHP;
   std::snprintf(MemInst.getPointer<char *>(WasmHP),
                 std::strlen(ZLIB_VERSION) + 1, ZLIB_VERSION);
-  // Reserve the terminator too so the version stays a NUL-terminated in-bounds
-  // C string; the wrapper rejects an unterminated version.
   WasmHP += std::strlen(ZLIB_VERSION) + 1;
 
   WasmData = WasmHP;
@@ -280,8 +290,6 @@ TEST(WasmEdgeZlibTest, HardeningBounds) {
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
   std::array<WasmEdge::ValVariant, 1> RetVal;
 
-  // Out-of-bounds z_stream pointer must fail instead of dereferencing NULL:
-  // 65530 + sizeof(WasmZStream) exceeds the single memory page.
   {
     GET_ZLIB_FUNC(DeflateInit, "deflateInit")
     EXPECT_FALSE(DeflateInit.run(CallFrame,
@@ -290,8 +298,6 @@ TEST(WasmEdgeZlibTest, HardeningBounds) {
                                  RetVal));
   }
 
-  // A guest-controlled avail_out larger than linear memory must be rejected
-  // rather than letting zlib write past the end of memory.
   {
     GET_ZLIB_FUNC(DeflateInit, "deflateInit")
     GET_ZLIB_FUNC(Deflate, "deflate")
@@ -311,7 +317,6 @@ TEST(WasmEdgeZlibTest, HardeningBounds) {
         RetVal));
   }
 
-  // compress with an out-of-bounds destination-length pointer must fail.
   {
     GET_ZLIB_FUNC(Compress, "compress")
     EXPECT_FALSE(Compress.run(
@@ -321,8 +326,6 @@ TEST(WasmEdgeZlibTest, HardeningBounds) {
         RetVal));
   }
 
-  // compress with a valid destination but an out-of-bounds source length must
-  // fail rather than let zlib read past the end of memory.
   {
     GET_ZLIB_FUNC(Compress, "compress")
     *MemInst.getPointer<uint32_t *>(0) = 100;
@@ -333,7 +336,6 @@ TEST(WasmEdgeZlibTest, HardeningBounds) {
         RetVal));
   }
 
-  // uncompress with an out-of-bounds destination-length pointer must fail.
   {
     GET_ZLIB_FUNC(Uncompress, "uncompress")
     EXPECT_FALSE(Uncompress.run(
@@ -343,8 +345,6 @@ TEST(WasmEdgeZlibTest, HardeningBounds) {
         RetVal));
   }
 
-  // adler32 / crc32 with a length larger than memory must fail rather than
-  // read out of bounds.
   {
     GET_ZLIB_FUNC(Adler32, "adler32")
     EXPECT_FALSE(
@@ -360,7 +360,6 @@ TEST(WasmEdgeZlibTest, HardeningBounds) {
                   RetVal));
   }
 
-  // An unknown gz file handle must be rejected, not dereferenced.
   {
     GET_ZLIB_FUNC(GZRead, "gzread")
     EXPECT_FALSE(GZRead.run(CallFrame,
@@ -371,11 +370,6 @@ TEST(WasmEdgeZlibTest, HardeningBounds) {
 }
 
 TEST(WasmEdgeZlibTest, HardeningCompress2AnswersInvalidLevelBeforeBounds) {
-  // An out-of-range level fails compress2's deflateInit before any source
-  // byte is read or dest byte written -- though only after *destLen has been
-  // zeroed -- so the wrapper must surface that Z_STREAM_ERROR instead of
-  // trapping on data spans the rejected call would never touch. A level zlib
-  // accepts keeps the bounds check.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -391,7 +385,6 @@ TEST(WasmEdgeZlibTest, HardeningCompress2AnswersInvalidLevelBeforeBounds) {
 
   GET_ZLIB_FUNC(Compress2, "compress2")
 
-  // A garbage *destLen makes the dest span run far past linear memory.
   const uint32_t DestLenPtr = 0;
   *MemInst.getPointer<uint32_t *>(DestLenPtr) = UINT32_C(0xFFFFFFF0);
   ASSERT_TRUE(Compress2.run(
@@ -402,7 +395,6 @@ TEST(WasmEdgeZlibTest, HardeningCompress2AnswersInvalidLevelBeforeBounds) {
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
   EXPECT_EQ(*MemInst.getPointer<uint32_t *>(DestLenPtr), UINT32_C(0));
 
-  // With an accepted level the same out-of-bounds span must keep trapping.
   *MemInst.getPointer<uint32_t *>(DestLenPtr) = UINT32_C(0xFFFFFFF0);
   EXPECT_FALSE(Compress2.run(
       CallFrame,
@@ -412,11 +404,6 @@ TEST(WasmEdgeZlibTest, HardeningCompress2AnswersInvalidLevelBeforeBounds) {
 }
 
 TEST(WasmEdgeZlibTest, HardeningUncompress2AliasedLengthMatchesNative) {
-  // Native uncompress2 writes *destLen last, so when a guest aliases the two
-  // length pointers (DestLenPtr == SourceLenPtr) the shared slot ends holding
-  // the produced (uncompressed) length, not the consumed source length. The
-  // wrapper snapshots into separate host variables, so it must write them back
-  // in the same order to leave the guest the value native would.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -433,7 +420,6 @@ TEST(WasmEdgeZlibTest, HardeningUncompress2AliasedLengthMatchesNative) {
   GET_ZLIB_FUNC(Compress, "compress")
   GET_ZLIB_FUNC(Uncompress2, "uncompress2")
 
-  // A highly compressible payload, compressed to a zlib stream.
   const uint32_t RawPtr = 4096;
   const uint32_t RawLen = 100;
   fillMemContent(MemInst, RawPtr, RawLen, static_cast<uint8_t>('A'));
@@ -451,10 +437,6 @@ TEST(WasmEdgeZlibTest, HardeningUncompress2AliasedLengthMatchesNative) {
   const uint32_t CompLen = *MemInst.getPointer<uint32_t *>(CompLenPtr);
   ASSERT_GT(CompLen, 0U);
 
-  // Aliased call: the single slot is both dest capacity and source length. A
-  // capacity that covers the produced and compressed sizes lets the decode
-  // finish; the wrapper bounds the source by this length, and inflate stops at
-  // the stream end long before consuming the zero-filled tail.
   const uint32_t Cap = 256;
   ASSERT_GE(Cap, RawLen);
   ASSERT_GT(Cap, CompLen);
@@ -471,7 +453,6 @@ TEST(WasmEdgeZlibTest, HardeningUncompress2AliasedLengthMatchesNative) {
   EXPECT_EQ(0, std::memcmp(MemInst.getPointer<char *>(OutPtr),
                            MemInst.getPointer<char *>(RawPtr), RawLen));
 
-  // Non-aliased control: each slot keeps its own result.
   const uint32_t DestLenPtr = 32;
   const uint32_t SrcLenPtr = 48;
   fillMemContent(MemInst, OutPtr, Cap);
@@ -487,11 +468,6 @@ TEST(WasmEdgeZlibTest, HardeningUncompress2AliasedLengthMatchesNative) {
 }
 
 TEST(WasmEdgeZlibTest, HardeningZeroCapacityDestMatchesZlib) {
-  // compress distinguishes a null destination (Z_STREAM_ERROR) from a
-  // non-null one with no capacity (Z_BUF_ERROR) without writing a byte, so
-  // the wrapper must not turn either answer into the other: a guest null maps
-  // to Z_NULL while a nonzero offset stays non-null even when its zero-length
-  // span carries no pointer (one out of bounds included).
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -513,7 +489,6 @@ TEST(WasmEdgeZlibTest, HardeningZeroCapacityDestMatchesZlib) {
   const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
   std::strcpy(MemInst.getPointer<char *>(SourcePtr), Payload);
 
-  // A guest-null destination with no capacity is zlib's Z_STREAM_ERROR.
   *MemInst.getPointer<uint32_t *>(DestLenPtr) = 0;
   ASSERT_TRUE(Compress.run(CallFrame,
                            std::initializer_list<WasmEdge::ValVariant>{
@@ -521,8 +496,6 @@ TEST(WasmEdgeZlibTest, HardeningZeroCapacityDestMatchesZlib) {
                            RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
 
-  // A nonzero destination offset past the end of linear memory still answers
-  // Z_BUF_ERROR at zero capacity; the pointer is never dereferenced.
   *MemInst.getPointer<uint32_t *>(DestLenPtr) = 0;
   ASSERT_TRUE(
       Compress.run(CallFrame,
@@ -531,7 +504,6 @@ TEST(WasmEdgeZlibTest, HardeningZeroCapacityDestMatchesZlib) {
                    RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_BUF_ERROR);
 
-  // An in-bounds destination with no capacity keeps the same answer.
   *MemInst.getPointer<uint32_t *>(DestLenPtr) = 0;
   ASSERT_TRUE(Compress.run(CallFrame,
                            std::initializer_list<WasmEdge::ValVariant>{
@@ -541,10 +513,6 @@ TEST(WasmEdgeZlibTest, HardeningZeroCapacityDestMatchesZlib) {
 }
 
 TEST(WasmEdgeZlibTest, HardeningZeroLengthDictionaryMatchesZlib) {
-  // deflateSetDictionary never reads a zero-length dictionary yet still
-  // rejects Z_NULL, so the wrapper must not turn either case into the other:
-  // any nonzero guest offset stays acceptable at length zero, while a guest
-  // null keeps failing with Z_STREAM_ERROR the way it does natively.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -569,7 +537,6 @@ TEST(WasmEdgeZlibTest, HardeningZeroLengthDictionaryMatchesZlib) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // Beyond the single memory page, so the zero-length span has no pointer.
   ASSERT_TRUE(
       DeflateSetDictionary.run(CallFrame,
                                std::initializer_list<WasmEdge::ValVariant>{
@@ -583,7 +550,6 @@ TEST(WasmEdgeZlibTest, HardeningZeroLengthDictionaryMatchesZlib) {
       RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
 
-  // A nonzero length keeps the bounds check: the same wild offset must fail.
   EXPECT_FALSE(
       DeflateSetDictionary.run(CallFrame,
                                std::initializer_list<WasmEdge::ValVariant>{
@@ -597,11 +563,6 @@ TEST(WasmEdgeZlibTest, HardeningZeroLengthDictionaryMatchesZlib) {
 
 TEST(WasmEdgeZlibTest,
      HardeningInflateSetDictionaryValidatesOnlyWhenZlibReads) {
-  // inflateSetDictionary reads the dictionary only from a raw stream or a
-  // stream waiting in DICT mode; a wrapped stream that is not waiting answers
-  // Z_STREAM_ERROR before touching the bytes, so an unreadable guest buffer
-  // must surface that error rather than a trap -- and must keep trapping in
-  // the states where zlib does read it.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -635,8 +596,6 @@ TEST(WasmEdgeZlibTest,
   const uint32_t WrongDictLen = static_cast<uint32_t>(std::strlen(WrongDict));
   std::strcpy(MemInst.getPointer<char *>(WrongDictPtr), WrongDict);
 
-  // A zlib-wrapped stream that never saw Z_NEED_DICT: zlib rejects before
-  // reading, so even an out-of-bounds dictionary gets the soft error.
   const uint32_t ZS = 0x40;
   fillMemContent(MemInst, ZS, sizeof(WasmZStream));
   ASSERT_TRUE(InflateInit.run(
@@ -650,8 +609,6 @@ TEST(WasmEdgeZlibTest,
   ASSERT_TRUE(InflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
 
-  // A raw stream folds the dictionary into the window immediately, so the
-  // unreadable buffer must keep trapping and a readable one must be accepted.
   fillMemContent(MemInst, ZS, sizeof(WasmZStream));
   ASSERT_TRUE(InflateInit2.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-15)},
@@ -669,7 +626,6 @@ TEST(WasmEdgeZlibTest,
   ASSERT_TRUE(InflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
 
-  // Produce an FDICT stream so inflate really enters DICT mode.
   const uint32_t DataPtr = 0x200;
   const char *const Payload = "the quick brown fox jumps over the lazy dog!";
   const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
@@ -718,8 +674,6 @@ TEST(WasmEdgeZlibTest,
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_NEED_DICT);
 
-  // Waiting in DICT mode, zlib checksums the bytes: unreadable memory traps,
-  // a wrong dictionary gets Z_DATA_ERROR and leaves the stream waiting.
   EXPECT_FALSE(InflateSetDictionary.run(
       CallFrame,
       std::initializer_list<WasmEdge::ValVariant>{ZS, OOBPtr, UINT32_C(0x100)},
@@ -736,8 +690,6 @@ TEST(WasmEdgeZlibTest,
       RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // The stream leaves DICT mode only inside the next inflate call, so a
-  // repeated set still checksums (and so still traps on unreadable memory).
   EXPECT_FALSE(InflateSetDictionary.run(
       CallFrame,
       std::initializer_list<WasmEdge::ValVariant>{ZS, OOBPtr, UINT32_C(0x10)},
@@ -751,7 +703,6 @@ TEST(WasmEdgeZlibTest,
   EXPECT_EQ(
       0, std::memcmp(MemInst.getPointer<char *>(DecPtr), Payload, PayloadLen));
 
-  // Done inflating, the stream is no longer waiting: back to the soft error.
   EXPECT_TRUE(InflateSetDictionary.run(
       CallFrame,
       std::initializer_list<WasmEdge::ValVariant>{ZS, OOBPtr, UINT32_C(0x10)},
@@ -762,9 +713,6 @@ TEST(WasmEdgeZlibTest,
 }
 
 TEST(WasmEdgeZlibTest, HardeningDeflateSetDictionaryGzipStreamAnswersFirst) {
-  // A gzip-wrapped deflate stream refuses any preset dictionary before
-  // reading it, so an unreadable guest buffer surfaces Z_STREAM_ERROR there;
-  // a zlib-wrapped stream at INIT does read it and must keep trapping.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -818,12 +766,6 @@ TEST(WasmEdgeZlibTest, HardeningDeflateSetDictionaryGzipStreamAnswersFirst) {
 }
 
 TEST(WasmEdgeZlibTest, HardeningDeflateSetDictionaryStartedStreamAnswersFirst) {
-  // Once a zlib-wrapped deflate stream has produced output (left INIT_STATE),
-  // deflateSetDictionary returns Z_STREAM_ERROR before reading the dictionary,
-  // so an unreadable guest buffer must surface that error rather than trap. The
-  // same stream still at INIT reads the dictionary and keeps trapping, and a
-  // raw stream (which rejects on live lookahead, untracked here) keeps trapping
-  // too.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -849,8 +791,6 @@ TEST(WasmEdgeZlibTest, HardeningDeflateSetDictionaryStartedStreamAnswersFirst) {
   const uint32_t InLen = static_cast<uint32_t>(std::strlen(Input));
   std::strcpy(MemInst.getPointer<char *>(InPtr), Input);
 
-  // A zlib-wrapped (wrap == 1) stream still at INIT_STATE reads the dictionary,
-  // so an OOB buffer traps.
   const uint32_t ZS = 0;
   fillMemContent(MemInst, ZS, sizeof(WasmZStream));
   ASSERT_TRUE(
@@ -865,7 +805,6 @@ TEST(WasmEdgeZlibTest, HardeningDeflateSetDictionaryStartedStreamAnswersFirst) {
       std::initializer_list<WasmEdge::ValVariant>{ZS, OOBPtr, UINT32_C(0x100)},
       RetVal));
 
-  // Advance the stream past INIT_STATE with one deflate() call.
   auto *Strm = MemInst.getPointer<WasmZStream *>(ZS);
   Strm->NextIn = InPtr;
   Strm->AvailIn = InLen;
@@ -877,8 +816,6 @@ TEST(WasmEdgeZlibTest, HardeningDeflateSetDictionaryStartedStreamAnswersFirst) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // The started stream now answers an OOB dictionary with Z_STREAM_ERROR
-  // instead of trapping on the span.
   EXPECT_TRUE(DeflateSetDictionary.run(
       CallFrame,
       std::initializer_list<WasmEdge::ValVariant>{ZS, OOBPtr, UINT32_C(0x100)},
@@ -887,8 +824,6 @@ TEST(WasmEdgeZlibTest, HardeningDeflateSetDictionaryStartedStreamAnswersFirst) {
   ASSERT_TRUE(DeflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
 
-  // A raw stream rejects on live lookahead, which is not tracked, so a started
-  // raw stream keeps trapping on an OOB dictionary (documented residual).
   const uint32_t ZSRaw = 0x40;
   fillMemContent(MemInst, ZSRaw, sizeof(WasmZStream));
   ASSERT_TRUE(DeflateInit2.run(CallFrame,
@@ -918,13 +853,6 @@ TEST(WasmEdgeZlibTest, HardeningDeflateSetDictionaryStartedStreamAnswersFirst) {
 }
 
 TEST(WasmEdgeZlibTest, HardeningDeflateCopyInheritsDictionaryState) {
-  // deflateCopy duplicates zlib's internal state wholesale, wrap and progress
-  // included, so the tracked facts must follow the copy. A copy of a started
-  // zlib-wrapped stream answers an OOB dictionary with Z_STREAM_ERROR before
-  // validating the span, exactly as the source would; and a copy of a raw
-  // stream stays raw, so after its own deflate() it still accepts a preset
-  // dictionary the way native zlib does (raw rejects depend on live lookahead,
-  // not on having started).
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -955,9 +883,6 @@ TEST(WasmEdgeZlibTest, HardeningDeflateCopyInheritsDictionaryState) {
   const uint32_t DictLen = static_cast<uint32_t>(std::strlen(Dict));
   std::strcpy(MemInst.getPointer<char *>(DictPtr), Dict);
 
-  // A copy of a started zlib-wrapped stream inherits the started fact: the
-  // dictionary refusal is answered before the span is validated, so an OOB
-  // buffer yields Z_STREAM_ERROR rather than a trap.
   const uint32_t ZS = 0;
   const uint32_t ZC = 0x40;
   fillMemContent(MemInst, ZS, sizeof(WasmZStream));
@@ -992,9 +917,6 @@ TEST(WasmEdgeZlibTest, HardeningDeflateCopyInheritsDictionaryState) {
   ASSERT_TRUE(DeflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZC}, RetVal));
 
-  // A copy of a raw stream inherits rawness: after the copy's own deflate()
-  // drains the lookahead with a sync flush, native zlib still accepts a preset
-  // dictionary, so the started fact must not misfile the copy as zlib-wrapped.
   const uint32_t ZSRaw = 0x80;
   const uint32_t ZCRaw = 0xC0;
   fillMemContent(MemInst, ZSRaw, sizeof(WasmZStream));
@@ -1032,11 +954,6 @@ TEST(WasmEdgeZlibTest, HardeningDeflateCopyInheritsDictionaryState) {
 }
 
 TEST(WasmEdgeZlibTest, HardeningZeroLengthChecksumMatchesZlib) {
-  // adler32/crc32 read Z_NULL as "return the initial value" and any non-null
-  // zero-length buffer as "return the running value unchanged". A guest null
-  // (offset 0) must map to Z_NULL, while any other zero-length offset -- even a
-  // wild one past the end of memory whose span carries no pointer -- must
-  // preserve the caller's checksum instead of resetting it to the seed.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -1055,29 +972,23 @@ TEST(WasmEdgeZlibTest, HardeningZeroLengthChecksumMatchesZlib) {
   const uint32_t Running = 999;
   const uint32_t WildOffset = 0xFFFF0000;
 
-  // Guest Z_NULL (offset 0, length 0) returns the checksum's initial value.
-  // zlib defines adler32(0, Z_NULL, 0) == 1 and crc32(0, Z_NULL, 0) == 0.
   ASSERT_TRUE(Adler32.run(CallFrame,
                           std::initializer_list<WasmEdge::ValVariant>{
                               Running, UINT32_C(0), UINT32_C(0)},
                           RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(1));
 
-  // A non-null zero-length buffer, including a wild offset past memory whose
-  // span has no pointer, preserves the running value rather than seeding.
   ASSERT_TRUE(Adler32.run(CallFrame,
                           std::initializer_list<WasmEdge::ValVariant>{
                               Running, WildOffset, UINT32_C(0)},
                           RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(Running));
 
-  // The same wild offset with a nonzero length still fails the bounds check.
   EXPECT_FALSE(Adler32.run(CallFrame,
                            std::initializer_list<WasmEdge::ValVariant>{
                                Running, WildOffset, UINT32_C(1)},
                            RetVal));
 
-  // crc32 shares the contract; its initial value is 0 rather than 1.
   ASSERT_TRUE(CRC32.run(CallFrame,
                         std::initializer_list<WasmEdge::ValVariant>{
                             Running, UINT32_C(0), UINT32_C(0)},
@@ -1105,8 +1016,6 @@ TEST(WasmEdgeZlibTest, HardeningUnterminatedString) {
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
   std::array<WasmEdge::ValVariant, 1> RetVal;
 
-  // Fill every byte of linear memory with a non-NUL value so any C string
-  // starting inside it has no terminator before the end of memory.
   std::fill_n(MemInst.getPointer<uint8_t *>(0),
               static_cast<size_t>(MemInst.getSize()),
               static_cast<uint8_t>(0xFF));
@@ -1114,7 +1023,50 @@ TEST(WasmEdgeZlibTest, HardeningUnterminatedString) {
   GET_ZLIB_FUNC(GZOpen, "gzopen")
   EXPECT_FALSE(GZOpen.run(
       CallFrame,
-      std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0), UINT32_C(100)},
+      std::initializer_list<WasmEdge::ValVariant>{UINT32_C(1), UINT32_C(100)},
+      RetVal));
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZOpenRejectsOversizedPathOrMode) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+
+  std::fill_n(MemInst.getPointer<uint8_t *>(0),
+              static_cast<size_t>(MemInst.getSize()),
+              static_cast<uint8_t>('A'));
+  MemInst.getPointer<char *>(1)[5000] = '\0';
+  std::strcpy(MemInst.getPointer<char *>(6000), "rb");
+  EXPECT_FALSE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{UINT32_C(1), UINT32_C(6000)},
+      RetVal));
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0), UINT32_C(6000)},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+
+  std::fill_n(MemInst.getPointer<uint8_t *>(0),
+              static_cast<size_t>(MemInst.getSize()),
+              static_cast<uint8_t>('A'));
+  std::strcpy(MemInst.getPointer<char *>(1), "/tmp/x");
+  MemInst.getPointer<char *>(100)[200] = '\0';
+  EXPECT_FALSE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{UINT32_C(1), UINT32_C(100)},
       RetVal));
 }
 
@@ -1135,9 +1087,9 @@ TEST(WasmEdgeZlibTest, GZFileRoundTrip) {
   const std::string TmpPath = (std::filesystem::temp_directory_path() /
                                "wasmedge_zlib_hardening_test.gz")
                                   .string();
-  ASSERT_LT(TmpPath.size() + 1, 1024U);
+  ASSERT_LT(TmpPath.size() + 1, 1000U);
 
-  const uint32_t PathPtr = 0;
+  const uint32_t PathPtr = 16;
   std::strcpy(MemInst.getPointer<char *>(PathPtr), TmpPath.c_str());
   const uint32_t ModeWPtr = 1024;
   std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
@@ -1167,7 +1119,6 @@ TEST(WasmEdgeZlibTest, GZFileRoundTrip) {
       RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
 
-  // Closing must free the zlib handle exactly once (no double-free).
   EXPECT_TRUE(GZClose.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, RetVal));
 
@@ -1177,11 +1128,9 @@ TEST(WasmEdgeZlibTest, GZFileRoundTrip) {
   const uint32_t RHandle = RetVal[0].get<uint32_t>();
   EXPECT_NE(RHandle, WHandle);
 
-  // gzread with an out-of-bounds length must fail rather than overflow the
-  // buffer.
   EXPECT_FALSE(GZRead.run(CallFrame,
                           std::initializer_list<WasmEdge::ValVariant>{
-                              RHandle, UINT32_C(60000), UINT32_C(0xFFFFFFFF)},
+                              RHandle, UINT32_C(60000), UINT32_C(0x40000000)},
                           RetVal));
 
   const uint32_t ReadBuf = 4096;
@@ -1196,10 +1145,226 @@ TEST(WasmEdgeZlibTest, GZFileRoundTrip) {
   EXPECT_TRUE(GZClose.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
 
-  // A double close must be rejected gracefully; the handle is already gone.
   EXPECT_FALSE(GZClose.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
 
+  std::remove(TmpPath.c_str());
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZOversizedRequestsMatchZlib) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const std::string TmpPath = (std::filesystem::temp_directory_path() /
+                               "wasmedge_zlib_oversized_test.gz")
+                                  .string();
+  ASSERT_LT(TmpPath.size() + 1, 1000U);
+  const uint32_t PathPtr = 16;
+  std::strcpy(MemInst.getPointer<char *>(PathPtr), TmpPath.c_str());
+  const uint32_t ModeWPtr = 1024;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+  const uint32_t ModeRPtr = 1040;
+  std::strcpy(MemInst.getPointer<char *>(ModeRPtr), "rb");
+  const uint32_t StrPtr = 1100;
+  const char *const Payload = "gzputs through gzwrite";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(StrPtr), Payload);
+  const uint32_t EmptyStrPtr = 2048;
+  MemInst.getPointer<char *>(EmptyStrPtr)[0] = '\0';
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  GET_ZLIB_FUNC(GZPuts, "gzputs")
+  GET_ZLIB_FUNC(GZWrite, "gzwrite")
+  GET_ZLIB_FUNC(GZFwrite, "gzfwrite")
+  GET_ZLIB_FUNC(GZRead, "gzread")
+  GET_ZLIB_FUNC(GZFread, "gzfread")
+  GET_ZLIB_FUNC(GZClearerr, "gzclearerr")
+  GET_ZLIB_FUNC(GZClose, "gzclose")
+
+  const uint32_t Oversized = UINT32_C(0x80000000);
+
+  if (!GZOpen.run(
+          CallFrame,
+          std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWPtr},
+          RetVal)) {
+    GTEST_SKIP() << "cannot create temporary file: " << TmpPath;
+  }
+  const uint32_t WHandle = RetVal[0].get<uint32_t>();
+
+  ASSERT_TRUE(GZPuts.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle, StrPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+
+  ASSERT_TRUE(GZPuts.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, EmptyStrPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(0));
+
+  ASSERT_TRUE(GZFwrite.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               StrPtr, Oversized, UINT32_C(2), WHandle},
+                           RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(0));
+  ASSERT_TRUE(GZPuts.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, EmptyStrPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(-1));
+  ASSERT_TRUE(GZClearerr.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, {}));
+  ASSERT_TRUE(GZPuts.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, EmptyStrPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(0));
+
+  ASSERT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, StrPtr, Oversized},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(0));
+
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, RetVal));
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeRPtr},
+      RetVal));
+  const uint32_t RHandle = RetVal[0].get<uint32_t>();
+
+  const uint32_t ReadBuf = 4096;
+  ASSERT_TRUE(GZRead.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             RHandle, ReadBuf, UINT32_C(256)},
+                         RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_EQ(
+      0, std::memcmp(MemInst.getPointer<char *>(ReadBuf), Payload, PayloadLen));
+
+  ASSERT_TRUE(GZFread.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              ReadBuf, Oversized, UINT32_C(2), RHandle},
+                          RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(0));
+  ASSERT_TRUE(GZRead.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             RHandle, ReadBuf, UINT32_C(8)},
+                         RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(-1));
+  ASSERT_TRUE(GZClearerr.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, {}));
+  ASSERT_TRUE(GZRead.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             RHandle, ReadBuf, UINT32_C(8)},
+                         RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(0));
+
+  ASSERT_TRUE(GZRead.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{RHandle, ReadBuf, Oversized},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), INT32_C(-1));
+
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
+  std::remove(TmpPath.c_str());
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZPutsEmptyStringHonorsMode) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const std::string TmpPath =
+      (std::filesystem::temp_directory_path() / "wasmedge_zlib_gzputs_mode.gz")
+          .string();
+  ASSERT_LT(TmpPath.size() + 1, 1000U);
+
+  const uint32_t PathPtr = 16;
+  std::strcpy(MemInst.getPointer<char *>(PathPtr), TmpPath.c_str());
+  const uint32_t ModeWPtr = 1024;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+  const uint32_t ModeRPtr = 1040;
+  std::strcpy(MemInst.getPointer<char *>(ModeRPtr), "rb");
+  const uint32_t EmptyPtr = 1060;
+  MemInst.getPointer<char *>(EmptyPtr)[0] = '\0';
+  const uint32_t DataPtr = 1100;
+  const char *const Payload = "gzputs mode probe";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  GET_ZLIB_FUNC(GZPuts, "gzputs")
+  GET_ZLIB_FUNC(GZRead, "gzread")
+  GET_ZLIB_FUNC(GZClose, "gzclose")
+
+  if (!GZOpen.run(
+          CallFrame,
+          std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWPtr},
+          RetVal)) {
+    GTEST_SKIP() << "cannot create temporary file: " << TmpPath;
+  }
+  const uint32_t WHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(WHandle, 0U);
+
+  EXPECT_TRUE(GZPuts.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle, EmptyPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), 0);
+  EXPECT_TRUE(GZPuts.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle, DataPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, RetVal));
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeRPtr},
+      RetVal));
+  const uint32_t RHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(RHandle, 0U);
+
+  EXPECT_TRUE(GZPuts.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle, EmptyPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), -1);
+  EXPECT_TRUE(GZPuts.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle, DataPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), -1);
+
+  const uint32_t ReadBuf = 4096;
+  EXPECT_TRUE(GZRead.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             RHandle, ReadBuf, UINT32_C(256)},
+                         RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_EQ(
+      0, std::memcmp(MemInst.getPointer<char *>(ReadBuf), Payload, PayloadLen));
+
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
   std::remove(TmpPath.c_str());
 }
 
@@ -1255,10 +1420,6 @@ TEST(WasmEdgeZlibTest, GZHeaderSnapshot) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // After the header is captured, corrupt the guest name and repoint the header
-  // field to an unterminated region at the end of memory. With the snapshot the
-  // emitted name must stay "original-header-name"; without it, deflate would
-  // re-read this and run off the end of linear memory.
   std::strcpy(MemInst.getPointer<char *>(NamePtr), "CORRUPTED-VALUE");
   DHeader->Name = static_cast<uint32_t>(MemInst.getSize()) - 3;
   std::fill_n(MemInst.getPointer<uint8_t *>(
@@ -1315,8 +1476,6 @@ TEST(WasmEdgeZlibTest, GZHeaderSnapshot) {
   ASSERT_TRUE(InflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
 
-  // The round-tripped header name is the snapshot taken at set-header time, not
-  // the corrupted guest value.
   EXPECT_STREQ(MemInst.getPointer<char *>(INameBuf), OrigName);
 }
 
@@ -1334,15 +1493,12 @@ TEST(WasmEdgeZlibTest, GZOpenFailureReturnsNullHandle) {
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
   std::array<WasmEdge::ValVariant, 1> RetVal;
 
-  // A gzopen that fails for an ordinary I/O reason (a missing file) must return
-  // a null handle (0) so guest code can handle the usual gzopen(...) == NULL
-  // case, rather than trapping the whole Wasm call.
   const std::string MissingPath =
       (std::filesystem::temp_directory_path() / "wasmedge_zlib_absent_dir_zzz" /
        "definitely_absent.gz")
           .string();
   ASSERT_LT(MissingPath.size() + 1, 900U);
-  const uint32_t PathPtr = 0;
+  const uint32_t PathPtr = 16;
   std::strcpy(MemInst.getPointer<char *>(PathPtr), MissingPath.c_str());
   const uint32_t ModePtr = 1000;
   std::strcpy(MemInst.getPointer<char *>(ModePtr), "rb");
@@ -1353,7 +1509,6 @@ TEST(WasmEdgeZlibTest, GZOpenFailureReturnsNullHandle) {
       RetVal));
   EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
 
-  // gzdopen on an invalid file descriptor is likewise an ordinary failure.
   const uint32_t ModeDPtr = 1010;
   std::strcpy(MemInst.getPointer<char *>(ModeDPtr), "rb");
   GET_ZLIB_FUNC(GZDOpen, "gzdopen")
@@ -1397,8 +1552,6 @@ TEST(WasmEdgeZlibTest, DeflateSetHeaderKeepsHeaderOnFailedReplace) {
                        RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // The first set-header succeeds and is captured into host storage; zlib now
-  // holds a pointer into that stored header.
   auto *DHeader = MemInst.getPointer<WasmGZHeader *>(DHdr);
   DHeader->Name = Name1Ptr;
   ASSERT_TRUE(DeflateSetHeader.run(
@@ -1406,9 +1559,6 @@ TEST(WasmEdgeZlibTest, DeflateSetHeaderKeepsHeaderOnFailedReplace) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // The second set-header names a header whose name runs off the end of linear
-  // memory, so the snapshot is rejected. The failed replacement must not
-  // clobber the previously stored, still-referenced header.
   DHeader->Name = static_cast<uint32_t>(MemInst.getSize()) - 3;
   std::fill_n(MemInst.getPointer<uint8_t *>(
                   static_cast<uint32_t>(MemInst.getSize()) - 3),
@@ -1417,7 +1567,6 @@ TEST(WasmEdgeZlibTest, DeflateSetHeaderKeepsHeaderOnFailedReplace) {
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS, DHdr},
       RetVal));
 
-  // The stored header is still the first one, not the failed replacement.
   const auto &HeaderMap = ZlibMod->getEnv().GZHeaderMap;
   const auto StoreIt = HeaderMap.find(DZS);
   ASSERT_NE(StoreIt, HeaderMap.end());
@@ -1492,12 +1641,6 @@ TEST(WasmEdgeZlibTest, DeflateSetHeaderRejectsOversizedNameAndComment) {
 }
 
 TEST(WasmEdgeZlibTest, HardeningDeflateSetHeaderNonGzipSkipsSnapshot) {
-  // zlib only accepts deflateSetHeader on a gzip deflate stream and answers
-  // Z_STREAM_ERROR for anything else without reading the header. The host must
-  // obtain that verdict before doing any guest-header work: on a zlib-format
-  // stream, even a header whose name would fail the snapshot's bounds check
-  // (or force a guest-sized host copy) surfaces zlib's Z_STREAM_ERROR instead
-  // of trapping or copying.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -1519,8 +1662,6 @@ TEST(WasmEdgeZlibTest, HardeningDeflateSetHeaderNonGzipSkipsSnapshot) {
   std::fill_n(MemInst.getPointer<uint8_t *>(DZS), sizeof(WasmZStream), 0);
   std::fill_n(MemInst.getPointer<uint8_t *>(DHdr), sizeof(WasmGZHeader), 0);
 
-  // windowBits 15 requests the zlib wrapper, not gzip, so zlib will refuse
-  // the header on this stream.
   ASSERT_TRUE(
       DeflateInit2.run(CallFrame,
                        std::initializer_list<WasmEdge::ValVariant>{
@@ -1529,9 +1670,6 @@ TEST(WasmEdgeZlibTest, HardeningDeflateSetHeaderNonGzipSkipsSnapshot) {
                        RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // The header name runs unterminated to the end of linear memory; on a gzip
-  // stream this snapshot would trap. zlib's verdict comes first, so the call
-  // reports Z_STREAM_ERROR and stores nothing.
   auto *DHeader = MemInst.getPointer<WasmGZHeader *>(DHdr);
   DHeader->Name = static_cast<uint32_t>(MemInst.getSize()) - 3;
   std::fill_n(MemInst.getPointer<uint8_t *>(
@@ -1545,10 +1683,6 @@ TEST(WasmEdgeZlibTest, HardeningDeflateSetHeaderNonGzipSkipsSnapshot) {
 }
 
 TEST(WasmEdgeZlibTest, EndErasesGzipHeaderSnapshot) {
-  // deflateEnd / inflateEnd must drop the per-stream gzip-header snapshot.
-  // Leaving it in GZHeaderMap lets a guest accumulate host allocations by
-  // cycling stream pointers, and would keep a copied stream's shared header
-  // alive past the point zlib still needs it.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -1627,11 +1761,6 @@ TEST(WasmEdgeZlibTest, EndErasesGzipHeaderSnapshot) {
 }
 
 TEST(WasmEdgeZlibTest, InflateResetDropsGzipHeaderSnapshot) {
-  // Every inflate reset detaches zlib's internal gzip-header pointer (the
-  // guest must call inflateGetHeader again for the next stream), so the host
-  // snapshot must be dropped with it. A stale entry keeps re-validating and
-  // rewriting the guest header on every inflate call, trapping legitimate
-  // post-reset use once the guest reuses that memory.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -1656,7 +1785,6 @@ TEST(WasmEdgeZlibTest, InflateResetDropsGzipHeaderSnapshot) {
   GET_ZLIB_FUNC(Inflate, "inflate")
   GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
 
-  // Build a small gzip stream to decode after the resets.
   const uint32_t DZS = 0x100;
   const uint32_t DataPtr = 0x300;
   const uint32_t CompPtr = 0x1000;
@@ -1732,8 +1860,6 @@ TEST(WasmEdgeZlibTest, InflateResetDropsGzipHeaderSnapshot) {
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
   EXPECT_EQ(HeaderMap.find(IZS), HeaderMap.end());
 
-  // After a reset the guest may legitimately reuse the header memory; inflate
-  // must not trap on the discarded registration.
   RegisterHeader();
   ASSERT_TRUE(InflateReset.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
@@ -1760,10 +1886,6 @@ TEST(WasmEdgeZlibTest, InflateResetDropsGzipHeaderSnapshot) {
 }
 
 TEST(WasmEdgeZlibTest, DeflateCopyKeepsCopiedHeaderAlive) {
-  // deflateCopy duplicates zlib's internal gz_header pointer into the copied
-  // stream. Replacing (or ending) the source header must not free the storage
-  // the copy still references, otherwise a later deflate on the copy reads
-  // freed host memory.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -1821,37 +1943,30 @@ TEST(WasmEdgeZlibTest, DeflateCopyKeepsCopiedHeaderAlive) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // Copy the freshly configured source stream.
   ASSERT_TRUE(DeflateCopy.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{DstZS, SrcZS},
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
   const auto &HeaderMap = ZlibMod->getEnv().GZHeaderMap;
-  // The copy must own an independent, live header snapshot.
   {
     const auto DstIt = HeaderMap.find(DstZS);
     ASSERT_NE(DstIt, HeaderMap.end());
     EXPECT_EQ(DstIt->second->Name, OrigName);
   }
 
-  // Replace the source header; on the buggy code this frees the storage the
-  // copied stream still points at.
   DHeader->Name = Name2Ptr;
   ASSERT_TRUE(DeflateSetHeader.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{SrcZS, Hdr},
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // The copy still carries its own original header, independent of the source.
   {
     const auto DstIt = HeaderMap.find(DstZS);
     ASSERT_NE(DstIt, HeaderMap.end());
     EXPECT_EQ(DstIt->second->Name, OrigName);
   }
 
-  // Drive the copied stream to completion; it must emit the original name
-  // without reading freed memory.
   auto *DStrm = MemInst.getPointer<WasmZStream *>(DstZS);
   DStrm->NextIn = DataPtr;
   DStrm->AvailIn = PayloadLen;
@@ -1868,7 +1983,6 @@ TEST(WasmEdgeZlibTest, DeflateCopyKeepsCopiedHeaderAlive) {
   ASSERT_TRUE(DeflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{SrcZS}, RetVal));
 
-  // Round-trip the copy's output and confirm the header name survived.
   const uint32_t IZS = 0x5000;
   const uint32_t IHdr = 0x5100;
   const uint32_t INameBuf = 0x5200;
@@ -1909,10 +2023,6 @@ TEST(WasmEdgeZlibTest, DeflateCopyKeepsCopiedHeaderAlive) {
 }
 
 TEST(WasmEdgeZlibTest, InflateCopyKeepsCopiedHeaderAlive) {
-  // inflateCopy duplicates zlib's internal gz_header pointer into the copied
-  // stream, exactly like deflateCopy. Ending the source stream must not free
-  // the header snapshot the copy still points at, otherwise a later inflate on
-  // the copy writes the parsed gzip header through freed host memory.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -1959,8 +2069,6 @@ TEST(WasmEdgeZlibTest, InflateCopyKeepsCopiedHeaderAlive) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // The copy must share the source's live header snapshot; its internal head
-  // pointer now aliases the same host storage.
   const auto &HeaderMap = ZlibMod->getEnv().GZHeaderMap;
   const auto SrcIt = HeaderMap.find(SrcZS);
   const auto DstIt = HeaderMap.find(DstZS);
@@ -1968,7 +2076,6 @@ TEST(WasmEdgeZlibTest, InflateCopyKeepsCopiedHeaderAlive) {
   ASSERT_NE(DstIt, HeaderMap.end());
   EXPECT_EQ(DstIt->second, SrcIt->second);
 
-  // Ending the source must keep the shared snapshot alive for the copy.
   ASSERT_TRUE(InflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{SrcZS}, RetVal));
   EXPECT_EQ(HeaderMap.find(SrcZS), HeaderMap.end());
@@ -1979,12 +2086,6 @@ TEST(WasmEdgeZlibTest, InflateCopyKeepsCopiedHeaderAlive) {
 }
 
 TEST(WasmEdgeZlibTest, CopyInitializesDirtyDestinationStream) {
-  // deflateCopy/inflateCopy must make the destination a complete copy of the
-  // source. The generic write-back moves buffer offsets by deltas against the
-  // destination's own pre-call pointers, which an uninitialized destination
-  // (legal per zlib's contract) cannot provide, so the copies must publish the
-  // source's stream fields directly; otherwise the destination keeps garbage
-  // offsets alongside the source's counts and traps on its next use.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -2012,7 +2113,6 @@ TEST(WasmEdgeZlibTest, CopyInitializesDirtyDestinationStream) {
   const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
   std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
 
-  // A gzip blob for the inflate half.
   const uint32_t AZS = 0x200;
   const uint32_t BlobPtr = 0x3000;
   const uint32_t BlobCap = 0x1000;
@@ -2038,8 +2138,6 @@ TEST(WasmEdgeZlibTest, CopyInitializesDirtyDestinationStream) {
   ASSERT_TRUE(DeflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{AZS}, RetVal));
 
-  // deflateCopy onto an uninitialized (all-0xFF) destination struct, with the
-  // source mid-stream and input restaged the way a guest does between calls.
   const uint32_t SZS = 0x100;
   const uint32_t DCopyZS = 0x180;
   const uint32_t CompPtr = 0x1000;
@@ -2080,8 +2178,6 @@ TEST(WasmEdgeZlibTest, CopyInitializesDirtyDestinationStream) {
   EXPECT_EQ(DCopyStrm->AvailOut, SStrm->AvailOut);
   EXPECT_EQ(DCopyStrm->TotalOut, SStrm->TotalOut);
 
-  // The copy must be usable as-is: finishing it may not trap on leftover
-  // garbage offsets.
   ASSERT_TRUE(Deflate.run(
       CallFrame,
       std::initializer_list<WasmEdge::ValVariant>{DCopyZS, INT32_C(Z_FINISH)},
@@ -2092,8 +2188,6 @@ TEST(WasmEdgeZlibTest, CopyInitializesDirtyDestinationStream) {
   ASSERT_TRUE(DeflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{SZS}, RetVal));
 
-  // inflateCopy: park the source inside the gzip stream, stage the rest of the
-  // input, then copy onto an all-0xFF destination struct.
   const uint32_t IZS = 0x4000;
   const uint32_t ICopyZS = 0x4080;
   const uint32_t DecPtr = 0x5000;
@@ -2144,9 +2238,6 @@ TEST(WasmEdgeZlibTest, CopyInitializesDirtyDestinationStream) {
 }
 
 TEST(WasmEdgeZlibTest, InflateGetHeaderReplacesStoredHeaderOnSuccess) {
-  // A second inflateGetHeader on the same stream re-points zlib's internal head
-  // at the new host snapshot. The stored snapshot must be replaced (and kept
-  // alive), otherwise a later inflate writes the header through freed memory.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -2188,8 +2279,6 @@ TEST(WasmEdgeZlibTest, InflateGetHeaderReplacesStoredHeaderOnSuccess) {
     EXPECT_EQ(It->second->WasmGZHeaderOffset, Hdr1);
   }
 
-  // Re-register a different guest header. zlib now points at the second
-  // snapshot, so the stored entry must become the second one.
   ASSERT_TRUE(InflateGetHeader.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS, Hdr2},
       RetVal));
@@ -2205,10 +2294,6 @@ TEST(WasmEdgeZlibTest, InflateGetHeaderReplacesStoredHeaderOnSuccess) {
 }
 
 TEST(WasmEdgeZlibTest, DeflateEndEarlyAbortErasesState) {
-  // deflateEnd frees all of zlib's internal state even when it returns
-  // Z_DATA_ERROR for a stream ended mid-compression. The host tracking (stream
-  // entry and gzip-header snapshot) must be dropped on that path too, otherwise
-  // a guest can accumulate host allocations by cycling stream pointers.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -2258,7 +2343,6 @@ TEST(WasmEdgeZlibTest, DeflateEndEarlyAbortErasesState) {
   ASSERT_NE(Env.ZStreamMap.find(DZS), Env.ZStreamMap.end());
   ASSERT_NE(Env.GZHeaderMap.find(DZS), Env.GZHeaderMap.end());
 
-  // Compress part of the input without finishing; the stream is now mid-flight.
   auto *DStrm = MemInst.getPointer<WasmZStream *>(DZS);
   DStrm->NextIn = DataPtr;
   DStrm->AvailIn = PayloadLen;
@@ -2270,8 +2354,6 @@ TEST(WasmEdgeZlibTest, DeflateEndEarlyAbortErasesState) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // deflateEnd on a mid-compression stream returns Z_DATA_ERROR but still frees
-  // zlib's state; the host entries must be erased on that path too.
   ASSERT_TRUE(DeflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS}, RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_DATA_ERROR);
@@ -2280,9 +2362,6 @@ TEST(WasmEdgeZlibTest, DeflateEndEarlyAbortErasesState) {
 }
 
 TEST(WasmEdgeZlibTest, InflateSyncAllowsDirtyOutputBuffer) {
-  // inflateSync consumes input but never writes output ("No output is
-  // provided"), so a stale/out-of-bounds next_out must not trap the call. The
-  // input buffer is still validated because inflateSync scans next_in.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -2311,8 +2390,6 @@ TEST(WasmEdgeZlibTest, InflateSyncAllowsDirtyOutputBuffer) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // Valid input, but next_out points one past the end of linear memory with a
-  // nonzero avail_out. inflateSync must still run rather than trap.
   auto *IStrm = MemInst.getPointer<WasmZStream *>(IZS);
   IStrm->NextIn = InPtr;
   IStrm->AvailIn = 8;
@@ -2322,8 +2399,6 @@ TEST(WasmEdgeZlibTest, InflateSyncAllowsDirtyOutputBuffer) {
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_DATA_ERROR);
 
-  // The input buffer stays guarded: an out-of-bounds next_in with nonzero
-  // avail_in must still trap.
   IStrm->NextIn = static_cast<uint32_t>(MemInst.getSize());
   IStrm->AvailIn = 8;
   IStrm->NextOut = 0;
@@ -2340,11 +2415,6 @@ TEST(WasmEdgeZlibTest, InflateSyncAllowsDirtyOutputBuffer) {
 }
 
 TEST(WasmEdgeZlibTest, ControlCallsIgnoreDirtyDataBuffers) {
-  // zlib's contract lets a guest call deflateInit / reset / end with
-  // uninitialized next_in/avail_in (only zalloc/zfree/opaque must be set).
-  // Those control operations do not consume the data buffers, so an
-  // out-of-bounds next_in/next_out must not trap them; only the streaming
-  // operations validate the buffers.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -2369,27 +2439,23 @@ TEST(WasmEdgeZlibTest, ControlCallsIgnoreDirtyDataBuffers) {
 
   auto SetDirtyBuffers = [&]() {
     auto *Strm = MemInst.getPointer<WasmZStream *>(ZS);
-    // next_in + avail_in runs off the end of linear memory.
     Strm->NextIn = MemBytes - 4;
     Strm->AvailIn = 0x10000;
     Strm->NextOut = MemBytes - 4;
     Strm->AvailOut = 0x10000;
   };
 
-  // Initialize the stream with dirty, out-of-bounds buffer fields present.
   SetDirtyBuffers();
   ASSERT_TRUE(DeflateInit.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-1)},
       RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // reset ignores the data buffers too.
   SetDirtyBuffers();
   ASSERT_TRUE(DeflateReset.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // The streaming path must still reject an out-of-bounds output buffer.
   {
     auto *Strm = MemInst.getPointer<WasmZStream *>(ZS);
     Strm->NextIn = 0;
@@ -2402,7 +2468,6 @@ TEST(WasmEdgeZlibTest, ControlCallsIgnoreDirtyDataBuffers) {
       std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(Z_NO_FLUSH)},
       RetVal));
 
-  // End cleans up even with dirty buffer fields.
   SetDirtyBuffers();
   ASSERT_TRUE(DeflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
@@ -2410,11 +2475,6 @@ TEST(WasmEdgeZlibTest, ControlCallsIgnoreDirtyDataBuffers) {
 }
 
 TEST(WasmEdgeZlibTest, HardeningRejectedParamsIgnoreDirtyDataBuffers) {
-  // deflateParams rejects an out-of-range level or strategy -- and deflate()
-  // an out-of-range flush -- before consuming next_in or producing into
-  // next_out, so a call zlib refuses must surface its Z_STREAM_ERROR instead
-  // of trapping on dirty buffer fields; serviceable parameters keep the
-  // bounds check.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -2450,7 +2510,6 @@ TEST(WasmEdgeZlibTest, HardeningRejectedParamsIgnoreDirtyDataBuffers) {
     Strm->AvailOut = 0x10000;
   };
 
-  // An out-of-range level is zlib's Z_STREAM_ERROR, not a trap.
   SetDirtyBuffers();
   ASSERT_TRUE(DeflateParams.run(CallFrame,
                                 std::initializer_list<WasmEdge::ValVariant>{
@@ -2458,7 +2517,6 @@ TEST(WasmEdgeZlibTest, HardeningRejectedParamsIgnoreDirtyDataBuffers) {
                                 RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
 
-  // An out-of-range strategy behaves the same.
   SetDirtyBuffers();
   ASSERT_TRUE(DeflateParams.run(
       CallFrame,
@@ -2466,14 +2524,12 @@ TEST(WasmEdgeZlibTest, HardeningRejectedParamsIgnoreDirtyDataBuffers) {
       RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
 
-  // deflate() with a flush beyond Z_BLOCK is rejected the same way.
   SetDirtyBuffers();
   ASSERT_TRUE(Deflate.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(99)},
       RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
 
-  // Parameters zlib would service must still reject the dirty buffers.
   SetDirtyBuffers();
   EXPECT_FALSE(DeflateParams.run(CallFrame,
                                  std::initializer_list<WasmEdge::ValVariant>{
@@ -2487,7 +2543,6 @@ TEST(WasmEdgeZlibTest, HardeningRejectedParamsIgnoreDirtyDataBuffers) {
 }
 
 TEST(WasmEdgeZlibTest, Module) {
-  // Create the wasmedge_zlib module instance.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -2596,9 +2651,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateGetHeaderValidatesHeadPtr) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // An out-of-bounds HeadPtr must be rejected up front (like deflateSetHeader)
-  // rather than stored and dereferenced on later inflate/cleanup calls:
-  // 65530 + sizeof(WasmGZHeader) exceeds the single 64 KiB page.
   EXPECT_FALSE(InflateGetHeader.run(
       CallFrame,
       std::initializer_list<WasmEdge::ValVariant>{IZS, UINT32_C(65530)},
@@ -2606,10 +2658,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateGetHeaderValidatesHeadPtr) {
 }
 
 TEST(WasmEdgeZlibTest, HardeningInflateGetHeaderAnswersNonGzipStreams) {
-  // inflateGetHeader touches the header only on a gzip-capable inflate stream
-  // (wrap & 2); a zlib-wrapped or raw stream gets Z_STREAM_ERROR before any
-  // dereference, so an out-of-bounds HeadPtr must surface that soft error
-  // there and keep trapping only where zlib would accept the registration.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -2630,7 +2678,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateGetHeaderAnswersNonGzipStreams) {
 
   const uint32_t OOBHeadPtr = 65530;
 
-  // Plain inflateInit: zlib wrapper only, the header request is refused.
   const uint32_t ZS = 0;
   fillMemContent(MemInst, ZS, sizeof(WasmZStream));
   ASSERT_TRUE(InflateInit.run(
@@ -2643,7 +2690,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateGetHeaderAnswersNonGzipStreams) {
   ASSERT_TRUE(InflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
 
-  // Raw inflate: no wrapper at all, same soft answer.
   fillMemContent(MemInst, ZS, sizeof(WasmZStream));
   ASSERT_TRUE(InflateInit2.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-15)},
@@ -2656,10 +2702,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateGetHeaderAnswersNonGzipStreams) {
   ASSERT_TRUE(InflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
 
-  // Auto-detect (windowBits 47) is gzip-capable: zlib would store the header
-  // and reset head->done, so the unreadable pointer keeps failing hard (the
-  // gzip-only windowBits 31 case is covered in
-  // HardeningInflateGetHeaderValidatesHeadPtr).
   fillMemContent(MemInst, ZS, sizeof(WasmZStream));
   ASSERT_TRUE(InflateInit2.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(47)},
@@ -2709,10 +2751,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateEndToleratesCorruptHeaderMax) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // The guest corrupts NameMax to an out-of-bounds span after registering the
-  // header. inflateEnd is a cleanup call that never writes the gzip header, so
-  // it must still run zlib's inflateEnd and release the stream rather than
-  // aborting on header-buffer validation (which would leak the internal state).
   IHeader->NameMax = UINT32_C(0xFFFFFFFF);
   ASSERT_TRUE(InflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
@@ -2720,11 +2758,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateEndToleratesCorruptHeaderMax) {
 }
 
 TEST(WasmEdgeZlibTest, GZHeaderAbsentOptionalFieldsSurfaceAsNull) {
-  // zlib clears gz_header.extra/name/comment to Z_NULL when the stream lacks
-  // the field even though the caller supplied buffers. The write-back must
-  // surface that as guest null (0) instead of subtracting a live host pointer
-  // from null, which poisoned the guest header and made every later inflate
-  // call on the stream trap.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -2755,7 +2788,6 @@ TEST(WasmEdgeZlibTest, GZHeaderAbsentOptionalFieldsSurfaceAsNull) {
   std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
   std::fill_n(MemInst.getPointer<uint8_t *>(DZS), sizeof(WasmZStream), 0);
 
-  // The default gzip header carries no extra, name, or comment field.
   ASSERT_TRUE(
       DeflateInit2.run(CallFrame,
                        std::initializer_list<WasmEdge::ValVariant>{
@@ -2805,8 +2837,6 @@ TEST(WasmEdgeZlibTest, GZHeaderAbsentOptionalFieldsSurfaceAsNull) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // The first 12 bytes cover the whole field-free header, so zlib completes it
-  // and clears the absent optional fields within this call.
   auto *IStrm = MemInst.getPointer<WasmZStream *>(IZS);
   IStrm->NextIn = CompPtr;
   IStrm->AvailIn = 12;
@@ -2822,7 +2852,6 @@ TEST(WasmEdgeZlibTest, GZHeaderAbsentOptionalFieldsSurfaceAsNull) {
   EXPECT_EQ(IHeader->Comment, 0U);
   EXPECT_EQ(IHeader->Done, 1);
 
-  // The stream must stay usable after the header write-back.
   IStrm->NextIn = CompPtr + 12;
   IStrm->AvailIn = CompLen - 12;
   ASSERT_TRUE(Inflate.run(
@@ -2837,10 +2866,6 @@ TEST(WasmEdgeZlibTest, GZHeaderAbsentOptionalFieldsSurfaceAsNull) {
 }
 
 TEST(WasmEdgeZlibTest, GZHeaderNullFieldPointersMapToZNull) {
-  // A guest null (0) extra/name/comment pointer means the field is not
-  // requested (zlib's Z_NULL contract) and must not resolve to wasm address 0:
-  // with a nonzero *Max, zlib would copy header contents into guest memory
-  // the guest never offered.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -2953,7 +2978,6 @@ TEST(WasmEdgeZlibTest, GZHeaderNullFieldPointersMapToZNull) {
   EXPECT_EQ(IHeader->Name, 0U);
   EXPECT_EQ(IHeader->Comment, 0U);
 
-  // Nothing may have been written through the null field pointers.
   const std::vector<uint8_t> Expected(64, 0xAB);
   EXPECT_EQ(0,
             std::memcmp(MemInst.getPointer<uint8_t *>(0), Expected.data(), 64));
@@ -2963,9 +2987,6 @@ TEST(WasmEdgeZlibTest, GZHeaderNullFieldPointersMapToZNull) {
 }
 
 TEST(WasmEdgeZlibTest, DeflateSetHeaderNullRevertsToDefaultHeader) {
-  // Native deflateSetHeader accepts Z_NULL and reverts the stream to the
-  // default gzip header; guest 0 must take that path instead of snapshotting
-  // whatever bytes sit at wasm address 0 (and trapping on garbage there).
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -2996,8 +3017,6 @@ TEST(WasmEdgeZlibTest, DeflateSetHeaderNullRevertsToDefaultHeader) {
   std::fill_n(MemInst.getPointer<uint8_t *>(DHdr), sizeof(WasmGZHeader), 0);
   std::strcpy(MemInst.getPointer<char *>(NamePtr), "hdr-name");
   std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
-  // Poison wasm address 0: a wrapper that dereferences the null header would
-  // read a header full of out-of-bounds pointers and trap.
   fillMemContent(MemInst, 0, sizeof(WasmGZHeader), 0xFF);
 
   ASSERT_TRUE(
@@ -3059,8 +3078,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateHeaderExtraLenIsZlibOwned) {
   GET_ZLIB_FUNC(Inflate, "inflate")
   GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
 
-  // Build a gzip stream carrying a 100-byte extra field with distinctive,
-  // non-zero content so a misplaced copy is detectable.
   const uint32_t DZS = 0x100;
   const uint32_t DHdr = 0x200;
   const uint32_t ExtraSrc = 0x300;
@@ -3108,7 +3125,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateHeaderExtraLenIsZlibOwned) {
   ASSERT_TRUE(DeflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS}, RetVal));
 
-  // Inflate it in two chunks, injecting a bogus ExtraLen between them.
   const uint32_t IZS = 0x4000;
   const uint32_t IHdr = 0x4100;
   const uint32_t ExtraDst = 0x4200;
@@ -3132,9 +3148,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateHeaderExtraLenIsZlibOwned) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // First chunk: exactly the 10-byte gzip base header + 2-byte XLEN, so zlib
-  // parses EXLEN (setting extra_len = 100 from the stream) and parks in the
-  // EXTRA state before copying any extra bytes.
   auto *IStrm = MemInst.getPointer<WasmZStream *>(IZS);
   IStrm->NextIn = CompPtr;
   IStrm->AvailIn = 12;
@@ -3146,11 +3159,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateHeaderExtraLenIsZlibOwned) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // extra_len is an OUTPUT field owned by zlib (true XLEN is 100). A malicious
-  // guest overwrites it before the continuation call. The plugin must not push
-  // this back into zlib's header, or the guest controls the EXTRA-state write
-  // offset (len = extra_len - state->length) -- CVE-2022-37434 territory on
-  // zlib <= 1.2.12.
   IHeader->ExtraLen = 150;
 
   IStrm->AvailIn = CompLen - 12;
@@ -3162,19 +3170,11 @@ TEST(WasmEdgeZlibTest, HardeningInflateHeaderExtraLenIsZlibOwned) {
   ASSERT_TRUE(InflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
 
-  // zlib's parsed extra_len (100) must survive rather than the injected 150,
-  // and the extra bytes must land at offset 0 (len == 0), not offset 50.
   EXPECT_EQ(IHeader->ExtraLen, ExtraFieldLen);
   EXPECT_EQ(*MemInst.getPointer<uint8_t *>(ExtraDst), static_cast<uint8_t>(1));
 }
 
 TEST(WasmEdgeZlibTest, HardeningInflateHeaderZeroCapacityKeepsGuestPointers) {
-  // zlib never writes through a zero-capacity extra/name/comment buffer, yet
-  // still distinguishes the caller's non-null pointer from Z_NULL ("field not
-  // requested"): the pointer survives untouched and only an absent stream
-  // field nulls it. A stale zero-capacity guest pointer past linear memory is
-  // therefore legal input -- the header sync must not misread it as Z_NULL
-  // and write guest NULL back over it.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -3197,7 +3197,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateHeaderZeroCapacityKeepsGuestPointers) {
   GET_ZLIB_FUNC(Inflate, "inflate")
   GET_ZLIB_FUNC(InflateEnd, "inflateEnd")
 
-  // Build a gzip stream that carries all three optional header fields.
   const uint32_t DZS = 0x100;
   const uint32_t DHdr = 0x200;
   const uint32_t ExtraSrc = 0x300;
@@ -3248,9 +3247,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateHeaderZeroCapacityKeepsGuestPointers) {
   ASSERT_TRUE(DeflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{DZS}, RetVal));
 
-  // Inflate with non-null zero-capacity pointers that lie outside linear
-  // memory: legal for zlib (never dereferenced at *_max == 0), so they must
-  // come back untouched, with the output fields still populated.
   const uint32_t IZS = 0x4000;
   const uint32_t IHdr = 0x4100;
   const uint32_t OOBExtra = 0xFFFF0000;
@@ -3288,8 +3284,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateHeaderZeroCapacityKeepsGuestPointers) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_END);
 
-  // The guest's pointers survive; the stream's fields still surface through
-  // the zlib-owned outputs.
   EXPECT_EQ(IHeader->Extra, OOBExtra);
   EXPECT_EQ(IHeader->Name, OOBName);
   EXPECT_EQ(IHeader->Comment, OOBComment);
@@ -3323,9 +3317,6 @@ TEST(WasmEdgeZlibTest, HardeningReinitRejectsLiveStream) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // Re-initializing an already-live stream must be rejected. Running zlib's
-  // init on the existing z_stream would overwrite strm->state and leak the
-  // previous internal state (window/hash/pending buffers), unbounded.
   ASSERT_TRUE(DeflateInit.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-1)},
       RetVal));
@@ -3357,10 +3348,6 @@ TEST(WasmEdgeZlibTest, HardeningWrongTypeEndKeepsStream) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // inflateEnd on a deflate stream is the wrong cleanup: zlib returns
-  // Z_STREAM_ERROR without freeing. The wrapper must keep the stream tracked
-  // rather than drop the only handle (which would leak the internal state), so
-  // the correct deflateEnd still frees it afterwards.
   ASSERT_TRUE(InflateEnd.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS}, RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
@@ -3370,12 +3357,6 @@ TEST(WasmEdgeZlibTest, HardeningWrongTypeEndKeepsStream) {
 }
 
 TEST(WasmEdgeZlibTest, HardeningWrongKindStreamAnswersLikeZlib) {
-  // Every kind-specific entry point answers a stream of the other kind with
-  // its documented bad-state result before reading or writing anything, so
-  // stale or out-of-bounds buffer fields on the guest stream must not trap,
-  // out-parameters must not be validated, and the mismatched host state must
-  // never be entered (on zlib-ng a cross-kind call could otherwise free
-  // garbage pointers or overwrite live internal state).
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -3431,8 +3412,6 @@ TEST(WasmEdgeZlibTest, HardeningWrongKindStreamAnswersLikeZlib) {
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{IZS}, RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // Poison both guest streams' buffer fields; a wrong-kind call must answer
-  // without ever validating them.
   for (const uint32_t ZS : {DZS, IZS}) {
     auto *Strm = MemInst.getPointer<WasmZStream *>(ZS);
     Strm->NextIn = OOBPtr;
@@ -3448,7 +3427,6 @@ TEST(WasmEdgeZlibTest, HardeningWrongKindStreamAnswersLikeZlib) {
     EXPECT_EQ(RetVal[0].get<int32_t>(), Expected);
   };
 
-  // deflate family on the live inflate stream.
   ExpectI32(Deflate, {IZS, INT32_C(Z_NO_FLUSH)}, Z_STREAM_ERROR);
   ExpectI32(DeflateParams, {IZS, INT32_C(9), INT32_C(Z_DEFAULT_STRATEGY)},
             Z_STREAM_ERROR);
@@ -3463,7 +3441,6 @@ TEST(WasmEdgeZlibTest, HardeningWrongKindStreamAnswersLikeZlib) {
   ExpectI32(DeflateResetKeep, {IZS}, Z_STREAM_ERROR);
   ExpectI32(DeflateEnd, {IZS}, Z_STREAM_ERROR);
 
-  // inflate family on the live deflate stream.
   ExpectI32(Inflate, {DZS, INT32_C(Z_NO_FLUSH)}, Z_STREAM_ERROR);
   ExpectI32(InflateSync, {DZS}, Z_STREAM_ERROR);
   ExpectI32(InflateMark, {DZS}, INT32_C(-65536));
@@ -3478,7 +3455,6 @@ TEST(WasmEdgeZlibTest, HardeningWrongKindStreamAnswersLikeZlib) {
   ExpectI32(InflateResetKeep, {DZS}, Z_STREAM_ERROR);
   ExpectI32(InflateBackEnd, {DZS}, Z_STREAM_ERROR);
 
-  // A rejected copy must not leave a destination entry behind.
   const uint32_t CopyPtr = 0x200;
   fillMemContent(MemInst, CopyPtr, sizeof(WasmZStream));
   ExpectI32(InflateCopy, {CopyPtr, DZS}, Z_STREAM_ERROR);
@@ -3486,8 +3462,6 @@ TEST(WasmEdgeZlibTest, HardeningWrongKindStreamAnswersLikeZlib) {
   ExpectI32(DeflateInit, {CopyPtr, INT32_C(-1)}, Z_OK);
   ExpectI32(DeflateEnd, {CopyPtr}, Z_OK);
 
-  // None of the rejected calls entered zlib: the deflate stream still
-  // compresses (inflateBackEnd in particular must not have freed its state).
   const uint32_t DataPtr = 0x300;
   const char *const Payload = "wrong-kind guard leaves streams intact";
   const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
@@ -3533,9 +3507,6 @@ TEST(WasmEdgeZlibTest, HardeningDeflateCopyRejectsLiveDest) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // Copying onto an already-live destination must be rejected: zlib's
-  // deflateCopy overwrites the dest z_stream (leaking its state) and, on an
-  // allocation failure, leaves dest aliasing the source's state.
   ASSERT_TRUE(DeflateCopy.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{Dest, Source},
       RetVal));
@@ -3559,15 +3530,11 @@ TEST(WasmEdgeZlibTest, HardeningFailedInitLeavesKeyReusable) {
   GET_ZLIB_FUNC(DeflateInit, "deflateInit")
   GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
 
-  // An out-of-bounds z_stream pointer traps after the tracking entry was
-  // already created; the failed init must drop that entry again.
   const uint32_t ZS = UINT32_C(65536);
   ASSERT_FALSE(DeflateInit.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{ZS, INT32_C(-1)},
       RetVal));
 
-  // Once the same address becomes valid (after a grow), the key must accept a
-  // fresh stream instead of being reported as still live by the dead entry.
   ASSERT_TRUE(MemInst.growPage(1));
   std::fill_n(MemInst.getPointer<uint8_t *>(ZS), sizeof(WasmZStream), 0);
   ASSERT_TRUE(DeflateInit.run(
@@ -3618,8 +3585,6 @@ TEST(WasmEdgeZlibTest, HardeningFailedCopyLeavesKeyReusable) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // An out-of-bounds destination traps after its tracking entry was created;
-  // the failed copy must drop that entry again.
   ASSERT_FALSE(DeflateCopy.run(
       CallFrame,
       std::initializer_list<WasmEdge::ValVariant>{DeflateDest, DeflateSrc},
@@ -3629,8 +3594,6 @@ TEST(WasmEdgeZlibTest, HardeningFailedCopyLeavesKeyReusable) {
       std::initializer_list<WasmEdge::ValVariant>{InflateDest, InflateSrc},
       RetVal));
 
-  // Once the same addresses become valid (after a grow), the keys must accept
-  // the copies instead of being reported as already-live destinations.
   ASSERT_TRUE(MemInst.growPage(1));
   std::fill_n(MemInst.getPointer<uint8_t *>(DeflateDest), sizeof(WasmZStream),
               0);
@@ -3688,12 +3651,6 @@ TEST(WasmEdgeZlibTest, HardeningDeflateSetHeaderClampsExtra) {
                        RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // Place an 8-byte extra field at the very end of memory and declare an
-  // ExtraLen whose low 16 bits are 8 but whose full value (0x10008) runs far
-  // out of bounds. zlib emits only (ExtraLen & 0xffff) = 8 bytes, all in
-  // bounds, so the wrapper must snapshot only those 8 bytes: it must neither
-  // fail the full-length bounds check nor allocate the full 0x10008 on the
-  // host.
   const uint32_t MemBytes = static_cast<uint32_t>(MemInst.getSize());
   const uint32_t ExtraOff = MemBytes - 8;
   for (uint32_t I = 0; I < 8; ++I) {
@@ -3728,10 +3685,6 @@ TEST(WasmEdgeZlibTest, DeflateSetHeaderKeepsEmptyExtraField) {
   GET_ZLIB_FUNC(Deflate, "deflate")
   GET_ZLIB_FUNC(DeflateEnd, "deflateEnd")
 
-  // zlib keys the gzip FEXTRA flag on the extra pointer alone: a non-null
-  // extra whose emitted length (the low 16 bits of extra_len) is zero still
-  // yields FLG.FEXTRA with XLEN=0. The wrapper must preserve that instead of
-  // silently dropping the flag from the emitted header.
   const std::array<uint32_t, 2> ZeroEmittedLens = {UINT32_C(0),
                                                    UINT32_C(0x10000)};
   for (const uint32_t ExtraLen : ZeroEmittedLens) {
@@ -3799,8 +3752,8 @@ TEST(WasmEdgeZlibTest, HardeningGZBufferClampsSize) {
   const std::string TmpPath = (std::filesystem::temp_directory_path() /
                                "wasmedge_zlib_gzbuffer_test.gz")
                                   .string();
-  ASSERT_LT(TmpPath.size() + 1, 1024U);
-  const uint32_t PathPtr = 0;
+  ASSERT_LT(TmpPath.size() + 1, 1000U);
+  const uint32_t PathPtr = 16;
   std::strcpy(MemInst.getPointer<char *>(PathPtr), TmpPath.c_str());
   const uint32_t ModeWPtr = 1024;
   std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
@@ -3817,13 +3770,15 @@ TEST(WasmEdgeZlibTest, HardeningGZBufferClampsSize) {
   }
   const uint32_t WHandle = RetVal[0].get<uint32_t>();
 
-  // A guest-declared ~4 GB buffer size must be clamped to a sane cap rather
-  // than forwarded verbatim: zlib rejects sizes >= 2^31 (returning -1) and
-  // otherwise allocates three times the size on first I/O. After clamping, an
-  // absurd request is accepted (returns 0) with a bounded host allocation.
   EXPECT_TRUE(GZBuffer.run(CallFrame,
                            std::initializer_list<WasmEdge::ValVariant>{
                                WHandle, UINT32_C(0xFFFFFFFF)},
+                           RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), -1);
+
+  EXPECT_TRUE(GZBuffer.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               WHandle, UINT32_C(0x40000000)},
                            RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), 0);
 
@@ -3856,9 +3811,6 @@ TEST(WasmEdgeZlibTest, HardeningDeflatePendingRejectsOOBPointer) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // An out-of-bounds pending out-pointer must be rejected outright, not left
-  // for zlib to silently drop via its internal NULL tolerance (65534 + 4 bytes
-  // exceeds the single 64 KiB page; the bits pointer at 0x100 is valid).
   EXPECT_FALSE(DeflatePending.run(CallFrame,
                                   std::initializer_list<WasmEdge::ValVariant>{
                                       ZS, UINT32_C(65534), UINT32_C(0x100)},
@@ -3866,9 +3818,6 @@ TEST(WasmEdgeZlibTest, HardeningDeflatePendingRejectsOOBPointer) {
 }
 
 TEST(WasmEdgeZlibTest, InflateGetHeaderSyncsImmediateDoneReset) {
-  // inflateGetHeader resets head->done to 0 as it registers the header; the
-  // guest must observe that immediately, not only after the next inflate call
-  // happens to sync the header back.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -3909,10 +3858,6 @@ TEST(WasmEdgeZlibTest, InflateGetHeaderSyncsImmediateDoneReset) {
 }
 
 TEST(WasmEdgeZlibTest, GetDictionaryAndPendingHonorNullOutPointers) {
-  // deflateGetDictionary/inflateGetDictionary/deflatePending document Z_NULL
-  // out-pointers as "skip": a null dictionary returns only the length, and a
-  // null dictLength/pending/bits is not set. Guest 0 must map to Z_NULL
-  // rather than to a live pointer at wasm address 0.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -3962,7 +3907,6 @@ TEST(WasmEdgeZlibTest, GetDictionaryAndPendingHonorNullOutPointers) {
       RetVal));
   ASSERT_EQ(RetVal[0].get<int32_t>(), Z_OK);
 
-  // dictionary == Z_NULL: only the length is returned.
   ASSERT_TRUE(DeflateGetDictionary.run(
       CallFrame,
       std::initializer_list<WasmEdge::ValVariant>{DZS, UINT32_C(0), LenPtr},
@@ -3970,7 +3914,6 @@ TEST(WasmEdgeZlibTest, GetDictionaryAndPendingHonorNullOutPointers) {
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_OK);
   EXPECT_EQ(*MemInst.getPointer<uint32_t *>(LenPtr), DictLen);
 
-  // dictLength == Z_NULL: the dictionary is copied, the length is not set.
   ASSERT_TRUE(DeflateGetDictionary.run(
       CallFrame,
       std::initializer_list<WasmEdge::ValVariant>{DZS, DictOut, UINT32_C(0)},
@@ -3979,7 +3922,6 @@ TEST(WasmEdgeZlibTest, GetDictionaryAndPendingHonorNullOutPointers) {
   EXPECT_EQ(0,
             std::memcmp(MemInst.getPointer<uint8_t *>(DictOut), Dict, DictLen));
 
-  // pending / bits == Z_NULL: the other value is still delivered.
   ASSERT_TRUE(DeflatePending.run(
       CallFrame,
       std::initializer_list<WasmEdge::ValVariant>{DZS, UINT32_C(0), BitsPtr},
@@ -4014,10 +3956,6 @@ TEST(WasmEdgeZlibTest, GetDictionaryAndPendingHonorNullOutPointers) {
 }
 
 TEST(WasmEdgeZlibTest, HardeningInflateBackInitVersionErrorSkipsWindow) {
-  // inflateBackInit_ answers Z_VERSION_ERROR for a null or major-mismatched
-  // version before it examines any other argument, so a bad version paired
-  // with an out-of-bounds window must surface that soft error rather than a
-  // window-validation trap.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -4047,7 +3985,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateBackInitVersionErrorSkipsWindow) {
                            RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_VERSION_ERROR);
 
-  // With a matching version the same out-of-bounds window keeps failing hard.
   const uint32_t VersionPtr = 0x140;
   std::strcpy(MemInst.getPointer<char *>(VersionPtr), ZLIB_VERSION);
   EXPECT_FALSE(
@@ -4059,9 +3996,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateBackInitVersionErrorSkipsWindow) {
 }
 
 TEST(WasmEdgeZlibTest, HardeningInflateBackInitNullWindowMatchesZlib) {
-  // inflateBackInit rejects a Z_NULL window before touching it, so a guest
-  // null must take that path instead of resolving to wasm address 0 -- and
-  // the failed init must leave the key reusable.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -4086,7 +4020,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateBackInitNullWindowMatchesZlib) {
       RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_STREAM_ERROR);
 
-  // A 32 KiB window at a real offset succeeds on the same key afterwards.
   ASSERT_TRUE(InflateBackInit.run(CallFrame,
                                   std::initializer_list<WasmEdge::ValVariant>{
                                       ZS, INT32_C(15), UINT32_C(0x1000)},
@@ -4098,11 +4031,6 @@ TEST(WasmEdgeZlibTest, HardeningInflateBackInitNullWindowMatchesZlib) {
 }
 
 TEST(WasmEdgeZlibTest, HardeningVersionedInitAnswersVersionErrorFirst) {
-  // The versioned init wrappers answer Z_VERSION_ERROR for a null or
-  // major-mismatched version before they examine the stream argument, like
-  // native zlib: a bad version paired with an out-of-bounds z_stream or an
-  // already-live key surfaces the version error instead of a trap or
-  // Z_STREAM_ERROR.
   auto ZlibMod = createModule();
   ASSERT_TRUE(ZlibMod);
 
@@ -4127,8 +4055,6 @@ TEST(WasmEdgeZlibTest, HardeningVersionedInitAnswersVersionErrorFirst) {
   std::strcpy(MemInst.getPointer<char *>(BadVersionPtr), "0.0.0");
   const uint32_t OOBZStreamPtr = 0xFFFF0000;
 
-  // Out-of-bounds stream, bad version: the version error must win in every
-  // versioned wrapper rather than a stream-resolution trap.
   ASSERT_TRUE(DeflateInit_.run(
       CallFrame,
       std::initializer_list<WasmEdge::ValVariant>{OOBZStreamPtr, INT32_C(-1),
@@ -4154,8 +4080,6 @@ TEST(WasmEdgeZlibTest, HardeningVersionedInitAnswersVersionErrorFirst) {
       RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_VERSION_ERROR);
 
-  // Live key, bad version: still the version error, and the live stream
-  // survives for a matching-version re-init to reject and an end to free.
   const uint32_t ZS = 0;
   fillMemContent(MemInst, ZS, sizeof(WasmZStream));
   const uint32_t VersionPtr = 0x140;
@@ -4199,11 +4123,6 @@ TEST(WasmEdgeZlibTest, HardeningDeflateInitValidatesVersionString) {
   const uint32_t ZS = 0;
   std::fill_n(MemInst.getPointer<uint8_t *>(ZS), sizeof(WasmZStream), 0);
 
-  // Point the version at the last 4 bytes of memory, filled with the real
-  // ZLIB_VERSION first byte but with no NUL terminator before the end of linear
-  // memory. zlib only reads version[0] today, but the wrapper must validate the
-  // whole in-bounds C string so an unterminated version cannot be accepted (and
-  // a future zlib that compares more of the string cannot read out of bounds).
   const uint32_t MemBytes = static_cast<uint32_t>(MemInst.getSize());
   const uint32_t VersionPtr = MemBytes - 4;
   std::fill_n(MemInst.getPointer<uint8_t *>(VersionPtr), 4,
@@ -4215,6 +4134,828 @@ TEST(WasmEdgeZlibTest, HardeningDeflateInitValidatesVersionString) {
                                    static_cast<int32_t>(sizeof(WasmZStream))},
                                RetVal));
   EXPECT_EQ(RetVal[0].get<int32_t>(), Z_VERSION_ERROR);
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZOpenMediatedByWasi) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasiWiredModule Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+
+  const std::filesystem::path SandboxDir =
+      std::filesystem::temp_directory_path() / "wasmedge_zlib_wasi_sandbox";
+  std::error_code EC;
+  std::filesystem::create_directories(SandboxDir, EC);
+  std::filesystem::remove(SandboxDir / "wasi.gz", EC);
+
+  WasmEdge::Host::WasiModule WasiMod;
+  WasiMod.init(std::vector<std::string>{SandboxDir.string()}, "test", {}, {});
+  Mod.wireWASIModule(&WasiMod);
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const uint32_t PathPtr = 16;
+  std::strcpy(MemInst.getPointer<char *>(PathPtr), "wasi.gz");
+  const uint32_t ModeWPtr = 64;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+  const uint32_t ModeRPtr = 96;
+  std::strcpy(MemInst.getPointer<char *>(ModeRPtr), "rb");
+  const uint32_t EscapePtr = 128;
+  std::strcpy(MemInst.getPointer<char *>(EscapePtr), "../wasi_escape.gz");
+  const uint32_t DataPtr = 256;
+  const char *const Payload = "hello wasi-mediated gzip";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  GET_ZLIB_FUNC(GZWrite, "gzwrite")
+  GET_ZLIB_FUNC(GZRead, "gzread")
+  GET_ZLIB_FUNC(GZClose, "gzclose")
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWPtr},
+      RetVal));
+  const uint32_t WHandle = RetVal[0].get<uint32_t>();
+  if (WHandle == 0) {
+    GTEST_SKIP() << "WASI preopen unavailable in this environment";
+  }
+  EXPECT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, DataPtr, PayloadLen},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, RetVal));
+
+  EXPECT_TRUE(std::filesystem::exists(SandboxDir / "wasi.gz"));
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeRPtr},
+      RetVal));
+  const uint32_t RHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(RHandle, 0U);
+  const uint32_t ReadBuf = 512;
+  EXPECT_TRUE(GZRead.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             RHandle, ReadBuf, UINT32_C(256)},
+                         RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_EQ(
+      0, std::memcmp(MemInst.getPointer<char *>(ReadBuf), Payload, PayloadLen));
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
+
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{EscapePtr, ModeWPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+
+  std::filesystem::remove(SandboxDir / "wasi.gz", EC);
+  std::filesystem::remove(SandboxDir / "wasi_escape.gz", EC);
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZOpenWasiAcceptsAbsoluteGuestPaths) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasiWiredModule Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+
+  const std::filesystem::path SandboxDir =
+      std::filesystem::temp_directory_path() / "wasmedge_zlib_wasi_abs";
+  std::error_code EC;
+  std::filesystem::create_directories(SandboxDir, EC);
+  std::filesystem::remove(SandboxDir / "wasi_probe.gz", EC);
+  std::filesystem::remove(SandboxDir / "wasi_abs.gz", EC);
+
+  WasmEdge::Host::WasiModule WasiMod;
+  WasiMod.init(std::vector<std::string>{SandboxDir.string()}, "test", {}, {});
+  Mod.wireWASIModule(&WasiMod);
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const uint32_t ProbePtr = 16;
+  std::strcpy(MemInst.getPointer<char *>(ProbePtr), "wasi_probe.gz");
+  const uint32_t AbsPtr = 96;
+  std::strcpy(MemInst.getPointer<char *>(AbsPtr), "/wasi_abs.gz");
+  const uint32_t DotPtr = 176;
+  std::strcpy(MemInst.getPointer<char *>(DotPtr), "./wasi_abs.gz");
+  const uint32_t MixedPtr = 256;
+  std::strcpy(MemInst.getPointer<char *>(MixedPtr), "//./wasi_abs.gz");
+  const uint32_t EscapePtr = 336;
+  std::strcpy(MemInst.getPointer<char *>(EscapePtr), "/../wasi_abs_escape.gz");
+  const uint32_t ModeWPtr = 512;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+  const uint32_t ModeRPtr = 544;
+  std::strcpy(MemInst.getPointer<char *>(ModeRPtr), "rb");
+  const uint32_t DataPtr = 1024;
+  const char *const Payload = "absolute path through the preopen";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  GET_ZLIB_FUNC(GZWrite, "gzwrite")
+  GET_ZLIB_FUNC(GZRead, "gzread")
+  GET_ZLIB_FUNC(GZClose, "gzclose")
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{ProbePtr, ModeWPtr}, RetVal));
+  const uint32_t ProbeHandle = RetVal[0].get<uint32_t>();
+  if (ProbeHandle == 0) {
+    GTEST_SKIP() << "WASI preopen unavailable in this environment";
+  }
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{ProbeHandle},
+      RetVal));
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{AbsPtr, ModeWPtr},
+      RetVal));
+  const uint32_t WHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(WHandle, 0U);
+  EXPECT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, DataPtr, PayloadLen},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, RetVal));
+  EXPECT_TRUE(std::filesystem::exists(SandboxDir / "wasi_abs.gz"));
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{DotPtr, ModeRPtr},
+      RetVal));
+  const uint32_t RHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(RHandle, 0U);
+  const uint32_t ReadBuf = 2048;
+  EXPECT_TRUE(GZRead.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             RHandle, ReadBuf, UINT32_C(256)},
+                         RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_EQ(
+      0, std::memcmp(MemInst.getPointer<char *>(ReadBuf), Payload, PayloadLen));
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{MixedPtr, ModeRPtr}, RetVal));
+  const uint32_t MHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(MHandle, 0U);
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{MHandle}, RetVal));
+
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{EscapePtr, ModeWPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+
+  std::filesystem::remove(SandboxDir / "wasi_probe.gz", EC);
+  std::filesystem::remove(SandboxDir / "wasi_abs.gz", EC);
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZOpenUnrecognizedWasiFailsClosed) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasiWiredModule Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+
+  WasmEdge::Runtime::Instance::ModuleInstance StubWasi(
+      "wasi_snapshot_preview1");
+  Mod.wireWASIModule(&StubWasi);
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const std::filesystem::path HostFile =
+      std::filesystem::temp_directory_path() /
+      "wasmedge_zlib_unrecognized_wasi.txt";
+  {
+    std::ofstream OFS(HostFile, std::ios::binary | std::ios::trunc);
+    if (!OFS) {
+      GTEST_SKIP() << "cannot create host probe file";
+    }
+    OFS << "not a gzip file, but gzopen reads it transparently";
+  }
+
+  const uint32_t PathPtr = 16;
+  const std::string HostPathStr = HostFile.string();
+  std::strcpy(MemInst.getPointer<char *>(PathPtr), HostPathStr.c_str());
+  const uint32_t ModePtr = 2048;
+  std::strcpy(MemInst.getPointer<char *>(ModePtr), "rb");
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModePtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+
+  std::error_code EC;
+  std::filesystem::remove(HostFile, EC);
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZOpenWasiHonorsOpenModes) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasiWiredModule Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+
+  const std::filesystem::path SandboxDir =
+      std::filesystem::temp_directory_path() / "wasmedge_zlib_wasi_modes";
+  std::error_code EC;
+  std::filesystem::create_directories(SandboxDir, EC);
+  std::filesystem::remove(SandboxDir / "modes.gz", EC);
+  std::filesystem::remove(SandboxDir / "fresh.gz", EC);
+  std::filesystem::remove(SandboxDir / "transparent.gz", EC);
+  std::filesystem::remove(SandboxDir / "gfresh.gz", EC);
+
+  WasmEdge::Host::WasiModule WasiMod;
+  WasiMod.init(std::vector<std::string>{SandboxDir.string()}, "test", {}, {});
+  Mod.wireWASIModule(&WasiMod);
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const uint32_t PathPtr = 16;
+  std::strcpy(MemInst.getPointer<char *>(PathPtr), "modes.gz");
+  const uint32_t FreshPtr = 32;
+  std::strcpy(MemInst.getPointer<char *>(FreshPtr), "fresh.gz");
+  const uint32_t ModeWPtr = 64;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+  const uint32_t ModeWPlusPtr = 96;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPlusPtr), "w+");
+  const uint32_t ModeNoDirPtr = 128;
+  std::strcpy(MemInst.getPointer<char *>(ModeNoDirPtr), "b");
+  const uint32_t ModeWxPtr = 160;
+  std::strcpy(MemInst.getPointer<char *>(ModeWxPtr), "wx");
+  const uint32_t ModeWrPtr = 192;
+  std::strcpy(MemInst.getPointer<char *>(ModeWrPtr), "wr");
+  const uint32_t ModeAPtr = 224;
+  std::strcpy(MemInst.getPointer<char *>(ModeAPtr), "a");
+  const uint32_t ModeRTPtr = 288;
+  std::strcpy(MemInst.getPointer<char *>(ModeRTPtr), "rT");
+  const uint32_t ModeWTPtr = 320;
+  std::strcpy(MemInst.getPointer<char *>(ModeWTPtr), "wT");
+  const uint32_t TransPathPtr = 352;
+  std::strcpy(MemInst.getPointer<char *>(TransPathPtr), "transparent.gz");
+  const uint32_t ModeWGPtr = 368;
+  std::strcpy(MemInst.getPointer<char *>(ModeWGPtr), "wG");
+  const uint32_t ModeAGPtr = 384;
+  std::strcpy(MemInst.getPointer<char *>(ModeAGPtr), "aG");
+  const uint32_t ModeWTGPtr = 400;
+  std::strcpy(MemInst.getPointer<char *>(ModeWTGPtr), "wTG");
+  const uint32_t ModeWGTPtr = 416;
+  std::strcpy(MemInst.getPointer<char *>(ModeWGTPtr), "wGT");
+  const uint32_t ModeRGPtr = 432;
+  std::strcpy(MemInst.getPointer<char *>(ModeRGPtr), "rG");
+  const uint32_t ModeRNPtr = 448;
+  std::strcpy(MemInst.getPointer<char *>(ModeRNPtr), "rN");
+  const uint32_t GFreshPtr = 464;
+  std::strcpy(MemInst.getPointer<char *>(GFreshPtr), "gfresh.gz");
+  const uint32_t FifoPtr = 480;
+  std::strcpy(MemInst.getPointer<char *>(FifoPtr), "fifo.gz");
+  const uint32_t ModeWNPtr = 496;
+  std::strcpy(MemInst.getPointer<char *>(ModeWNPtr), "wN");
+  const uint32_t DataPtr = 256;
+  const char *const Payload = "gzopen mode fidelity";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+  const uint32_t ReadBuf = 512;
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  GET_ZLIB_FUNC(GZWrite, "gzwrite")
+  GET_ZLIB_FUNC(GZRead, "gzread")
+  GET_ZLIB_FUNC(GZClose, "gzclose")
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWPtr},
+      RetVal));
+  const uint32_t WHandle = RetVal[0].get<uint32_t>();
+  if (WHandle == 0) {
+    GTEST_SKIP() << "WASI preopen unavailable in this environment";
+  }
+  ASSERT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, DataPtr, PayloadLen},
+      RetVal));
+  ASSERT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, RetVal));
+  const auto BaselineSize = std::filesystem::file_size(SandboxDir / "modes.gz");
+
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWPlusPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeNoDirPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeRTPtr}, RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWGPtr}, RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{GFreshPtr, ModeWGPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_FALSE(std::filesystem::exists(SandboxDir / "gfresh.gz"));
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeAGPtr}, RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWTGPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{TransPathPtr, ModeWTPtr},
+      RetVal));
+  const uint32_t THandle = RetVal[0].get<uint32_t>();
+  EXPECT_NE(THandle, 0U);
+  if (THandle != 0) {
+    EXPECT_TRUE(GZClose.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{THandle},
+        RetVal));
+  }
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{TransPathPtr, ModeWGTPtr},
+      RetVal));
+  const uint32_t GTHandle = RetVal[0].get<uint32_t>();
+  EXPECT_NE(GTHandle, 0U);
+  if (GTHandle != 0) {
+    EXPECT_TRUE(GZClose.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{GTHandle},
+        RetVal));
+  }
+
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWxPtr}, RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWrPtr}, RetVal));
+  const uint32_t RHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(RHandle, 0U);
+  EXPECT_TRUE(GZRead.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             RHandle, ReadBuf, UINT32_C(256)},
+                         RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_EQ(
+      0, std::memcmp(MemInst.getPointer<char *>(ReadBuf), Payload, PayloadLen));
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+  for (const uint32_t ModePtr : {ModeRGPtr, ModeRNPtr}) {
+    ASSERT_TRUE(GZOpen.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModePtr}, RetVal));
+    const uint32_t Handle = RetVal[0].get<uint32_t>();
+    EXPECT_NE(Handle, 0U);
+    if (Handle == 0) {
+      continue;
+    }
+    EXPECT_TRUE(GZRead.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               Handle, ReadBuf, UINT32_C(256)},
+                           RetVal));
+    EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+    EXPECT_EQ(0, std::memcmp(MemInst.getPointer<char *>(ReadBuf), Payload,
+                             PayloadLen));
+    EXPECT_TRUE(GZClose.run(CallFrame,
+                            std::initializer_list<WasmEdge::ValVariant>{Handle},
+                            RetVal));
+  }
+  EXPECT_EQ(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+#if !defined(_WIN32)
+  const std::filesystem::path FifoPath = SandboxDir / "fifo.gz";
+  std::filesystem::remove(FifoPath, EC);
+  ASSERT_EQ(::mkfifo(FifoPath.c_str(), 0600), 0);
+  EXPECT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FifoPtr, ModeWNPtr}, RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FifoPtr, ModeRNPtr}, RetVal));
+  const uint32_t NHandle = RetVal[0].get<uint32_t>();
+  EXPECT_NE(NHandle, 0U);
+  if (NHandle != 0) {
+    EXPECT_TRUE(GZClose.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{NHandle},
+        RetVal));
+  }
+  std::filesystem::remove(FifoPath, EC);
+#endif
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeAPtr},
+      RetVal));
+  const uint32_t AHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(AHandle, 0U);
+  EXPECT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{AHandle, DataPtr, PayloadLen},
+      RetVal));
+  EXPECT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{AHandle}, RetVal));
+  EXPECT_GT(std::filesystem::file_size(SandboxDir / "modes.gz"), BaselineSize);
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FreshPtr, ModeWxPtr},
+      RetVal));
+  const uint32_t XHandle = RetVal[0].get<uint32_t>();
+  EXPECT_NE(XHandle, 0U);
+  if (XHandle != 0) {
+    EXPECT_TRUE(GZClose.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{XHandle},
+        RetVal));
+  }
+  EXPECT_TRUE(std::filesystem::exists(SandboxDir / "fresh.gz"));
+
+  std::filesystem::remove(SandboxDir / "modes.gz", EC);
+  std::filesystem::remove(SandboxDir / "fresh.gz", EC);
+  std::filesystem::remove(SandboxDir / "transparent.gz", EC);
+  std::filesystem::remove(SandboxDir / "gfresh.gz", EC);
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZOpenWasiFollowsSandboxSymlinks) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasiWiredModule Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+
+  const std::filesystem::path SandboxDir =
+      std::filesystem::temp_directory_path() / "wasmedge_zlib_wasi_symlink";
+  const std::filesystem::path OutsideFile =
+      std::filesystem::temp_directory_path() /
+      "wasmedge_zlib_wasi_symlink_outside.gz";
+  std::error_code EC;
+  std::filesystem::remove_all(SandboxDir, EC);
+  std::filesystem::create_directories(SandboxDir, EC);
+  std::filesystem::remove(OutsideFile, EC);
+
+  WasmEdge::Host::WasiModule WasiMod;
+  WasiMod.init(std::vector<std::string>{SandboxDir.string()}, "test", {}, {});
+  Mod.wireWASIModule(&WasiMod);
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const uint32_t TargetPtr = 16;
+  std::strcpy(MemInst.getPointer<char *>(TargetPtr), "target.gz");
+  const uint32_t LinkPtr = 32;
+  std::strcpy(MemInst.getPointer<char *>(LinkPtr), "link.gz");
+  const uint32_t EscLinkPtr = 64;
+  std::strcpy(MemInst.getPointer<char *>(EscLinkPtr), "escape.gz");
+  const uint32_t AbsLinkPtr = 96;
+  std::strcpy(MemInst.getPointer<char *>(AbsLinkPtr), "abslink.gz");
+  const uint32_t DangLinkPtr = 128;
+  std::strcpy(MemInst.getPointer<char *>(DangLinkPtr), "dangling.gz");
+  const uint32_t ModeWPtr = 160;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+  const uint32_t ModeRPtr = 192;
+  std::strcpy(MemInst.getPointer<char *>(ModeRPtr), "rb");
+  const uint32_t ModeWxPtr = 224;
+  std::strcpy(MemInst.getPointer<char *>(ModeWxPtr), "wx");
+  const uint32_t DataPtr = 256;
+  const char *const Payload = "symlinked gzip payload";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+  const uint32_t ReadBuf = 512;
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  GET_ZLIB_FUNC(GZWrite, "gzwrite")
+  GET_ZLIB_FUNC(GZRead, "gzread")
+  GET_ZLIB_FUNC(GZClose, "gzclose")
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{TargetPtr, ModeWPtr},
+      RetVal));
+  const uint32_t WHandle = RetVal[0].get<uint32_t>();
+  if (WHandle == 0) {
+    GTEST_SKIP() << "WASI preopen unavailable in this environment";
+  }
+  ASSERT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, DataPtr, PayloadLen},
+      RetVal));
+  ASSERT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, RetVal));
+
+  {
+    std::ofstream(OutsideFile) << "outside";
+  }
+  std::filesystem::create_symlink("target.gz", SandboxDir / "link.gz", EC);
+  if (EC) {
+    GTEST_SKIP() << "cannot create symlinks in this environment";
+  }
+  std::filesystem::create_symlink(OutsideFile, SandboxDir / "abslink.gz", EC);
+  std::filesystem::create_symlink(std::filesystem::path("..") /
+                                      OutsideFile.filename(),
+                                  SandboxDir / "escape.gz", EC);
+  std::filesystem::create_symlink("missing.gz", SandboxDir / "dangling.gz", EC);
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{LinkPtr, ModeRPtr},
+      RetVal));
+  const uint32_t RHandle = RetVal[0].get<uint32_t>();
+  EXPECT_NE(RHandle, 0U);
+  if (RHandle != 0) {
+    EXPECT_TRUE(GZRead.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               RHandle, ReadBuf, UINT32_C(256)},
+                           RetVal));
+    EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+    EXPECT_EQ(0, std::memcmp(MemInst.getPointer<char *>(ReadBuf), Payload,
+                             PayloadLen));
+    EXPECT_TRUE(GZClose.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle},
+        RetVal));
+  }
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{LinkPtr, ModeWPtr},
+      RetVal));
+  const uint32_t LWHandle = RetVal[0].get<uint32_t>();
+  EXPECT_NE(LWHandle, 0U);
+  if (LWHandle != 0) {
+    EXPECT_TRUE(GZClose.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{LWHandle},
+        RetVal));
+  }
+  EXPECT_TRUE(std::filesystem::is_symlink(SandboxDir / "link.gz"));
+  EXPECT_TRUE(std::filesystem::exists(SandboxDir / "target.gz"));
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{EscLinkPtr, ModeRPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{AbsLinkPtr, ModeRPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{DangLinkPtr, ModeWxPtr},
+      RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+  EXPECT_FALSE(std::filesystem::exists(SandboxDir / "missing.gz"));
+
+  std::filesystem::remove_all(SandboxDir, EC);
+  std::filesystem::remove(OutsideFile, EC);
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZDOpenTemporarilyDisabled) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasiWiredModule Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+
+  const std::filesystem::path SandboxDir =
+      std::filesystem::temp_directory_path() / "wasmedge_zlib_gzdopen_disabled";
+  std::error_code EC;
+  std::filesystem::create_directories(SandboxDir, EC);
+  std::filesystem::remove(SandboxDir / "disabled.gz", EC);
+
+  WasmEdge::Host::WasiModule WasiMod;
+  WasiMod.init(std::vector<std::string>{SandboxDir.string()}, "test", {}, {});
+  Mod.wireWASIModule(&WasiMod);
+  auto *Env = const_cast<WasmEdge::Host::WASI::Environ *>(WasiMod.getEnv());
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const uint32_t ModeWPtr = 0;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+
+  GET_ZLIB_FUNC(GZDOpen, "gzdopen")
+
+  const __wasi_rights_t FullRights =
+      __WASI_RIGHTS_FD_READ | __WASI_RIGHTS_FD_WRITE | __WASI_RIGHTS_FD_SEEK |
+      __WASI_RIGHTS_FD_TELL;
+  auto Fd =
+      Env->pathOpen(3, "disabled.gz", static_cast<__wasi_lookupflags_t>(0),
+                    __WASI_OFLAGS_CREAT | __WASI_OFLAGS_TRUNC, FullRights,
+                    FullRights, static_cast<__wasi_fdflags_t>(0));
+  if (!Fd.has_value()) {
+    GTEST_SKIP() << "WASI preopen unavailable in this environment";
+  }
+
+  ASSERT_TRUE(GZDOpen.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              static_cast<int32_t>(*Fd), ModeWPtr},
+                          RetVal));
+  EXPECT_EQ(RetVal[0].get<uint32_t>(), 0U);
+
+  __wasi_fdstat_t FdStat;
+  EXPECT_TRUE(Env->fdFdstatGet(*Fd, FdStat).has_value());
+  Env->fdClose(*Fd);
+
+  std::filesystem::remove(SandboxDir / "disabled.gz", EC);
+}
+
+TEST(WasmEdgeZlibTest, HardeningGZOpenWasiStreamingWithoutSeekTellRights) {
+  auto ZlibMod = createModule();
+  ASSERT_TRUE(ZlibMod);
+
+  WasiWiredModule Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1, 1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_NE(MemInstPtr, nullptr);
+  auto &MemInst = *MemInstPtr;
+
+  const std::filesystem::path SandboxDir =
+      std::filesystem::temp_directory_path() / "wasmedge_zlib_wasi_narrowed";
+  std::error_code EC;
+  std::filesystem::create_directories(SandboxDir, EC);
+  std::filesystem::remove(SandboxDir / "stream.gz", EC);
+  std::filesystem::remove(SandboxDir / "fresh.gz", EC);
+  std::filesystem::remove(SandboxDir / "append.gz", EC);
+
+  WasmEdge::Host::WasiModule WasiMod;
+  WasiMod.init(std::vector<std::string>{SandboxDir.string()}, "test", {}, {});
+  Mod.wireWASIModule(&WasiMod);
+  auto *Env = const_cast<WasmEdge::Host::WASI::Environ *>(WasiMod.getEnv());
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> RetVal;
+
+  const uint32_t PathPtr = 16;
+  std::strcpy(MemInst.getPointer<char *>(PathPtr), "stream.gz");
+  const uint32_t FreshPtr = 32;
+  std::strcpy(MemInst.getPointer<char *>(FreshPtr), "fresh.gz");
+  const uint32_t AppendPtr = 64;
+  std::strcpy(MemInst.getPointer<char *>(AppendPtr), "append.gz");
+  const uint32_t ModeWPtr = 96;
+  std::strcpy(MemInst.getPointer<char *>(ModeWPtr), "wb");
+  const uint32_t ModeRPtr = 112;
+  std::strcpy(MemInst.getPointer<char *>(ModeRPtr), "rb");
+  const uint32_t ModeAPtr = 128;
+  std::strcpy(MemInst.getPointer<char *>(ModeAPtr), "ab");
+  const uint32_t DataPtr = 256;
+  const char *const Payload = "streaming without seek rights";
+  const uint32_t PayloadLen = static_cast<uint32_t>(std::strlen(Payload));
+  std::strcpy(MemInst.getPointer<char *>(DataPtr), Payload);
+  const uint32_t ReadPtr = 512;
+
+  GET_ZLIB_FUNC(GZOpen, "gzopen")
+  GET_ZLIB_FUNC(GZWrite, "gzwrite")
+  GET_ZLIB_FUNC(GZRead, "gzread")
+  GET_ZLIB_FUNC(GZClose, "gzclose")
+  GET_ZLIB_FUNC(GZSeek, "gzseek")
+  GET_ZLIB_FUNC(GZOffset, "gzoffset")
+  GET_ZLIB_FUNC(GZTell, "gztell")
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeWPtr},
+      RetVal));
+  const uint32_t WHandle = RetVal[0].get<uint32_t>();
+  if (WHandle == 0) {
+    GTEST_SKIP() << "WASI-mediated gzopen unavailable in this environment";
+  }
+  ASSERT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{WHandle, DataPtr, PayloadLen},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  ASSERT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{WHandle}, RetVal));
+
+  __wasi_fdstat_t DirStat;
+  ASSERT_TRUE(Env->fdFdstatGet(3, DirStat).has_value());
+  const __wasi_rights_t NoSeekTell =
+      ~(__WASI_RIGHTS_FD_SEEK | __WASI_RIGHTS_FD_TELL);
+  ASSERT_TRUE(Env->fdFdstatSetRights(3, DirStat.fs_rights_base & NoSeekTell,
+                                     DirStat.fs_rights_inheriting & NoSeekTell)
+                  .has_value());
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{PathPtr, ModeRPtr},
+      RetVal));
+  const uint32_t RHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(RHandle, 0U);
+  ASSERT_TRUE(GZRead.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{RHandle, ReadPtr, PayloadLen},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  EXPECT_EQ(
+      0, std::memcmp(MemInst.getPointer<char *>(ReadPtr), Payload, PayloadLen));
+  ASSERT_TRUE(GZSeek.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             RHandle, INT32_C(6), INT32_C(SEEK_SET)},
+                         RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), -1);
+  ASSERT_TRUE(GZOffset.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), -1);
+  ASSERT_TRUE(GZTell.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
+  EXPECT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  ASSERT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{RHandle}, RetVal));
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FreshPtr, ModeWPtr}, RetVal));
+  const uint32_t FHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(FHandle, 0U);
+  ASSERT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FHandle, DataPtr, PayloadLen},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  ASSERT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FHandle}, RetVal));
+  EXPECT_TRUE(std::filesystem::exists(SandboxDir / "fresh.gz"));
+
+  ASSERT_TRUE(GZOpen.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{AppendPtr, ModeAPtr},
+      RetVal));
+  const uint32_t AHandle = RetVal[0].get<uint32_t>();
+  ASSERT_NE(AHandle, 0U);
+  ASSERT_TRUE(GZWrite.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{AHandle, DataPtr, PayloadLen},
+      RetVal));
+  ASSERT_EQ(RetVal[0].get<int32_t>(), static_cast<int32_t>(PayloadLen));
+  ASSERT_TRUE(GZClose.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{AHandle}, RetVal));
+
+  std::filesystem::remove(SandboxDir / "stream.gz", EC);
+  std::filesystem::remove(SandboxDir / "fresh.gz", EC);
+  std::filesystem::remove(SandboxDir / "append.gz", EC);
 }
 
 GTEST_API_ int main(int ArgC, char **ArgV) {


### PR DESCRIPTION
## Description

#5022 attempts to harden against a potential null pointer dereference. This PR is a follow-up that reinforces every guest-reachable path in the `wasmedge_zlib` plugin.

The plugin passed guest-controlled linear-memory offsets, lengths, paths, and file descriptors to zlib after only a single-element `getPointer()` check. A malicious or buggy Wasm guest could drive out-of-bounds reads/writes into host memory, dereference NULL, over-read unbounded C strings, trigger a `gzFile` double-free, disclose host memory through the streaming gzip header, leak zlib's internal state without bound, and open host files/descriptors outside the Wasm sandbox.

The work is organized into four commits:

### 1. Bounds, string, struct, and handle safety (`fix`)

- **Buffer validation**: every guest buffer is validated against its full length with `getSpan()`, and length out-pointers are null-checked (`compress`/`uncompress`, `deflate`/`inflate` via `SyncRun`, `adler32`/`crc32`, `set`/`getDictionary`, `gzread`/`gzwrite`/`gzfread`/`gzfwrite`).
- **Bounded strings**: the C strings handed to zlib (`gzopen` path/mode, `gzputs`) are kept in bounds so `strlen` cannot read past the end of linear memory.
- **Struct validation**: `z_stream` and `gz_header` are null-checked in `SyncRun`, with direction-aware bounds on the header buffers.
- **gzFile lifetime**: handles are stored raw (not in a `unique_ptr<gzFile_s>` that default-deleted a zlib-owned, `gzclose`-freed allocation), freed only via `gzclose` plus an environment destructor, and handed out as monotonic IDs; failure paths erase the correct map entry.

### 2. gz-header out-of-bounds and use-after-free (`fix`)

- `deflateSetHeader` snapshots `name`/`comment`/`extra` into host-owned storage once; the `SyncRun` header sync is inflate-only, so a guest can no longer repoint the name mid-stream and make zlib scan off the end of linear memory.
- `deflateCopy`/`inflateCopy` share the source's reference-counted header snapshot, so a later `setHeader`/`getHeader`/`end` on the source cannot free storage the copy still references.
- Only guest-owned INPUT fields (`extra`/`name`/`comment` and their `*_max`) are synced into zlib before `inflate()`; the zlib-owned OUTPUT fields (notably `extra_len`) flow back only. Re-injecting `extra_len` let a guest drive the `EXTRA`-state write offset out of bounds mid-stream &mdash; a CVE-2022-37434-class host heap write on zlib &le; 1.2.12.

### 3. Stream lifecycle, guest sizes, and pointer accessors (`fix`)

- Streams are owned by a typed RAII wrapper that ends each exactly once. Re-initializing or copying onto a still-live stream is rejected (`Z_STREAM_ERROR`) instead of leaking zlib's internal state (~256&nbsp;KB per deflate, unbounded).
- Guest-declared sizes are bounded: `deflateSetHeader` caps the extra field at the 16 bits zlib emits and rejects name/comment strings over 1&nbsp;MiB before snapshotting them; `gzbuffer` clamps the requested size to 64&nbsp;MiB, since zlib allocates three times it on first I/O.
- `deflatePending` validates its out-pointers; the versioned `*Init_` entry points validate the version string as a bounded in-bounds C string (an unbounded terminator scan let a guest drive a multi-GB `memchr` over linear memory); the `inflateBack` window path no longer leans on zlib's internal NULL tolerance; and the `SyncRun` write-back delta is guarded against undefined null-pointer subtraction on the copy path.

### 4. WASI-mediated `gz*` file access (`feat`)

- `gzopen` no longer passes a guest-controlled host path straight to zlib. When a WASI module is configured, the path is resolved through its capability layer &mdash; `pathOpen` under the preopened directory, after parsing the mode the way zlib's `gz_open` does &mdash; so the guest can only reach files WASI granted: escaping paths are denied, and a rejected mode or an exclusive `"wx"` create cannot touch the file. The resulting descriptor is bridged to zlib as an independent close-on-exec duplicate (`F_DUPFD_CLOEXEC`). Without WASI the functions fall back to a direct host open, matching the `FStream` convention used by the wasi_nn plugins.
- The path and mode are snapshotted into bounded host copies (4&nbsp;KiB / 63 bytes) before any parse, closing a shared-memory TOCTOU between the rights check and zlib's re-parse; `gzputs` likewise writes its validated bytes through `gzwrite` instead of letting zlib re-scan guest memory.
- `FD_SEEK`/`FD_TELL` stay optional at open so streaming `gzopen` works under a narrowed preopen; they are recorded on the handle and enforced at the calls that would `lseek` the duplicated descriptor (`gzseek`/`gzrewind` on read handles, `gzoffset`). A new `Environ::canFd` exposes the capability probe.
- **`gzdopen` is disabled for now**: bridging a guest descriptor transfers fd ownership to the `gzFile`, and that owned WASI fd cannot yet be released safely at environment teardown without an explicit `gzclose`. The export stays registered and fails with a null handle &mdash; zlib's ordinary `gzdopen(...) == NULL` failure &mdash; without consuming the guest's fd. A `TODO` marks the re-enable path.
- **Behavior note**: under WASI, `gzopen` now requires the path to resolve within a preopened directory. On Windows the WASI&rarr;CRT bridge is not implemented yet, so the path fails closed (null handle) and logs the limitation, with a `TODO` tracking the `DuplicateHandle` + `_open_osfhandle` bridge and Windows CI coverage.

The three Codex review threads on this PR have been addressed and resolved.

> This contribution was developed with assistance from Claude (Anthropic) and OpenAI Codex.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

Run on macOS (arm64) &mdash; full `wasmedge_zlib` suite, 47 tests. The `[error]` log lines in a full run are the hardening rejection paths being exercised.

```text
[----------] 47 tests from WasmEdgeZlibTest
...
[       OK ] WasmEdgeZlibTest.HardeningGZOpenMediatedByWasi (0 ms)
[       OK ] WasmEdgeZlibTest.HardeningGZOpenWasiHonorsOpenModes (0 ms)
[       OK ] WasmEdgeZlibTest.HardeningGZDOpenTemporarilyDisabled (0 ms)
[       OK ] WasmEdgeZlibTest.HardeningGZOpenWasiStreamingWithoutSeekTellRights (0 ms)
[----------] 47 tests from WasmEdgeZlibTest (34 ms total)
[==========] 47 tests from 1 test suite ran. (34 ms total)
[  PASSED  ] 47 tests.
```

WASI-mediated cases: `HardeningGZOpenMediatedByWasi` (preopen round trip + escape denial), `HardeningGZOpenWasiHonorsOpenModes` (gz open-mode semantics under WASI), `HardeningGZOpenWasiStreamingWithoutSeekTellRights` (streaming under a narrowed preopen), and `HardeningGZDOpenTemporarilyDisabled` (`gzdopen` refuses even a fully-writable descriptor and leaves it open).
