### PR TITLE
ci: add lib/executor and include/executor to wasi-testsuite.yml path …

### DIFF
--- a/.github/workflows/wasi-testsuite.yml
+++ b/.github/workflows/wasi-testsuite.yml
@@ -14,6 +14,8 @@ on:
       - "lib/host/wasi/**"
       - "include/host/wasi/**"
       - "thirdparty/wasi/**"
+      - "lib/executor/**"
+      - "include/executor/**"
   pull_request:
     branches:
       - master
@@ -23,6 +25,8 @@ on:
       - "lib/host/wasi/**"
       - "include/host/wasi/**"
       - "thirdparty/wasi/**"
+      - "lib/executor/**"
+      - "include/executor/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

The `wasi-testsuite.yml` workflow path filter did not include `lib/executor/**` or `include/executor/**`. Changes to the executor's import resolution code — which directly handles WASI host function dispatch — would not trigger the WASI compliance testsuite, creating a silent gap in CI coverage.

`lib/executor/instantiate/import.cpp` contains WASI module-name matching logic for `wasi_snapshot_preview1`, `wasi_nn`, and `wasi_crypto_*` namespaces, and calls `setWASIModule()` to register the WASI host instance during module instantiation. A regression in this file can break WASI compliance without the testsuite being triggered.

This commit adds `lib/executor/**` and `include/executor/**` to the `paths` filter for both `push` and `pull_request` triggers.

fixes #5105 

## Checklist

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`).
- [x] **Commit Messages**: Validated with `commitlint` — 0 problems, 0 warnings.
- [x] **Local Tests Passed**: This is a YAML-only workflow path filter change with no C++
  source modification. No test targets are affected. Build binary confirmed present at
  `build/tools/wasmedge/wasmedge`.
- [x] **AI Disclosure**: Disclosed via `Assisted-by:` trailer in commits and noted above.
- [x] **Human-in-the-loop**: Reviewed and submitted by human contributor.

## Test Evidence

This change only modifies which file paths trigger the `Test Wasi Testsuite` workflow — no runtime code is changed and no C++ compilation is needed.

**commitlint output:**
