### PR TITLE
ci: disable s390x and OpenWrt auto CI triage

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -92,9 +92,11 @@ filter.
 | **CodeQL** (`codeql-analysis.yml`) | Security analysis of C/C++ sources (excludes `docs/`, `.github/`, `utils/`); also runs weekly. | Address the flagged security finding. |
 | **IWYU checker** (`IWYU_scan.yml`) | Include-what-you-use scan on Fedora and macOS; reports header suggestions as logs/artifacts. | Review the log and tidy includes where applicable. |
 | **Static Code Analysis** (`static-code-analysis.yml`) | Meta **Infer** analysis; uploads a report artifact. | Review the report for genuine defects (e.g. null dereferences). |
-| **riscv64 / s390x** (`build_for_riscv.yml`, `build_for_s390x.yml`) | Emulated build and test on these architectures. | Fix the architecture-specific failure. |
+| **riscv64** (`build_for_riscv.yml`) | Emulated build and test on riscv64. | Fix the architecture-specific failure. |
 | **Nix** (`build_for_nix.yml`) | `nix build` and `nix flake check` (also triggered by `flake.nix` / `flake.lock`). | Fix the Nix build or flake check. |
-| **OpenWrt** (`build_for_openwrt.yml`) | Build and test on OpenWrt (also triggered by `plugins/**` and `utils/openwrt/**`). | Fix the OpenWrt build failure. |
+
+The s390x (`build_for_s390x.yml`) and OpenWrt (`build_for_openwrt.yml`) workflows
+are manual-only (`workflow_dispatch`) and do not run on pushes or pull requests.
 
 ### Plugins
 
@@ -103,9 +105,9 @@ Triggered by changes under `plugins/` or `test/plugins/`.
 | Workflow | What it does | If it fails |
 | -------- | ------------ | ----------- |
 | **Extensions** (`build-extensions.yml`) | Runs a path-filtered plugin build matrix for changed plugins, plus unconditional WASI-NN GGML RPC and Windows WASI-NN jobs. | Fix failures in changed plugin builds and in WASI-NN jobs when related to your change; for clearly unrelated WASI-NN, flaky, or upstream failures, see [Interpreting failures](#interpreting-failures). |
-| **IWYU checker**, **Static Code Analysis**, **CodeQL**, **OpenWrt** | Also triggered by plugin sources (see the Core engine table above). | As above. |
+| **IWYU checker**, **Static Code Analysis**, **CodeQL** | Also triggered by plugin sources (see the Core engine table above). | As above. |
 
-Plugin-only changes do **not** trigger `Core`, `riscv64`, `s390x`, or `Nix`.
+Plugin-only changes do **not** trigger `Core`, `riscv64`, or `Nix`.
 
 ### WASI host implementation
 
@@ -170,8 +172,8 @@ workflows are called by the entries below and are not listed here; see
 | Installers | `test-installers.yml` | `push` (`master`), `pull_request` (`master`); paths: workflow, `utils/install.sh`, `utils/install_v2.sh`, `utils/install.py`, `utils/uninstall.sh` | black check + installer/uninstaller tests |
 | docker | `docker.yml` | `push` (`master`), `pull_request`, periodic `schedule` (days 1/8/15/22/29 of each month); paths: workflow, `utils/docker/`, `utils/ffmpeg/`, `utils/opencvmini/`, `utils/wasi-crypto/`, `utils/wasi-nn/` | builds the affected base/CI images |
 | Build and Test WasmEdge on riscv64 arch | `build_for_riscv.yml` | `push` (`master`), `pull_request` (`master`, `proposal/**`); paths: core engine paths (not `test/plugins/`) | emulated build/test |
-| Build and Test WasmEdge on s390x arch | `build_for_s390x.yml` | `push` (`master`), `pull_request` (`master`, `proposal/**`); paths: core engine paths (not `test/plugins/`) | emulated build/test |
-| Test WasmEdge on OpenWrt | `build_for_openwrt.yml` | `push` (`master`), `pull_request` (`master`, `proposal/**`); paths: core engine paths + `plugins/`, `utils/openwrt/` | build/test on OpenWrt |
+| Build and Test WasmEdge on s390x arch | `build_for_s390x.yml` | `workflow_dispatch` only | emulated build/test; run manually from the Actions tab |
+| Test WasmEdge on OpenWrt | `build_for_openwrt.yml` | `workflow_dispatch` only | build/test on OpenWrt; run manually from the Actions tab |
 | Build WasmEdge on Nix | `build_for_nix.yml` | `push` (`master`), `pull_request` (`master`, `proposal/**`); paths: workflow, `flake.nix`, `flake.lock`, `include/`, `lib/`, `thirdparty/`, `tools/`, `cmake/`, `CMakeLists.txt` | `nix build` + `nix flake check` |
 | Pull Request Labeler | `labeler.yml` | `pull_request_target` (opened/synchronize/reopened/closed); no path filter | auto-labels by path; runs in base-repo context |
 | release | `release.yml` | `workflow_dispatch`, `push` tags `X.Y.Z*` | creates release, tarball, release builds |

--- a/.github/workflows/build_for_openwrt.yml
+++ b/.github/workflows/build_for_openwrt.yml
@@ -5,35 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - ".github/workflows/build_for_openwrt.yml"
-      - "include/**"
-      - "lib/**"
-      - "plugins/**"
-      - "test/**"
-      - "thirdparty/**"
-      - "tools/**"
-      - "CMakeLists.txt"
-      - "cmake/**"
-      - "utils/openwrt/**"
-  pull_request:
-    branches:
-      - master
-      - 'proposal/**'
-    paths:
-      - ".github/workflows/build_for_openwrt.yml"
-      - "include/**"
-      - "lib/**"
-      - "plugins/**"
-      - "test/**"
-      - "thirdparty/**"
-      - "tools/**"
-      - "CMakeLists.txt"
-      - "cmake/**"
-      - "utils/openwrt/**"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/build_for_s390x.yml
+++ b/.github/workflows/build_for_s390x.yml
@@ -5,33 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - ".github/workflows/build_for_s390x.yml"
-      - "include/**"
-      - "lib/**"
-      - "test/**"
-      - "!test/plugins/**"
-      - "thirdparty/**"
-      - "tools/**"
-      - "CMakeLists.txt"
-      - "cmake/**"
-  pull_request:
-    branches:
-      - master
-      - 'proposal/**'
-    paths:
-      - ".github/workflows/build_for_s390x.yml"
-      - "include/**"
-      - "lib/**"
-      - "test/**"
-      - "!test/plugins/**"
-      - "thirdparty/**"
-      - "tools/**"
-      - "CMakeLists.txt"
-      - "cmake/**"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

Currently, s390x and OpenWrt CI jobs are triaged automatically. However, they do take a significant amount of time. Since we are not shipping pre-built assets for these hardware and platforms, I would like to trigger them only when a `workflow_dispatch` is sent. Especially, we should run them before the release as the final gate, rather than spending a lot of time waiting for these two CI jobs on each PR.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
