### PR TITLE
ci: fix RISC-V64 cross-compile libedit installation failure

### DIFF
--- a/.github/workflows/build_for_riscv.yml
+++ b/.github/workflows/build_for_riscv.yml
@@ -77,17 +77,28 @@ jobs:
           cmake g++ dpkg-dev make \
           gcc-riscv64-linux-gnu g++-riscv64-linux-gnu \
           zlib1g-dev:riscv64 libzstd-dev:riscv64 \
-          libffi-dev:riscv64 libedit-dev:riscv64 libxml2-dev:riscv64
+          libffi-dev:riscv64 libxml2-dev:riscv64
 
-        # llvm-20-dev:riscv64 cannot be fully installed because:
-        # 1. python3-minimal:riscv64 postinst tries to run a riscv64 binary
-        # 2. llvm-20/llvm-20-tools pull in libcurl4t64 -> libssh-4, which
-        #    fails when noble-security has a newer Multi-Arch:same version
-        #    of libssh-4:amd64 than what riscv64 ports provide.
+        # Several riscv64 packages cannot be fully installed via apt because
+        # noble-security ships newer Multi-Arch:same versions for amd64 that
+        # conflict with the older riscv64 versions on noble-ports:
+        # 1. libedit-dev -> libedit2 -> libtinfo6 (version conflict)
+        # 2. llvm-20-dev -> llvm-20-tools -> libcurl4t64 -> libssh-4 (version conflict)
+        # 3. python3-minimal:riscv64 postinst tries to run a riscv64 binary
         # Workaround: download only the dev/lib packages needed for
         # cross-compilation (skip tools), then extract without postinst.
+        # libbsd0/libmd0 are runtime deps of libedit2 that the linker needs
+        # to resolve libedit.so.2 when linking against libLLVM.
         mkdir -p /tmp/riscv64-debs && cd /tmp/riscv64-debs
         apt-get download \
+          libedit-dev:riscv64 \
+          libedit2:riscv64 \
+          libbsd0:riscv64 \
+          libmd0:riscv64 \
+          libncurses-dev:riscv64 \
+          libncurses6:riscv64 \
+          libncursesw6:riscv64 \
+          libtinfo6:riscv64 \
           llvm-20-dev:riscv64 \
           llvm-20:riscv64 \
           llvm-20-runtime:riscv64 \
@@ -173,12 +184,30 @@ jobs:
           libgcc-s1-riscv64-cross \
           libatomic1-riscv64-cross
 
-        # Install riscv64 LLVM/LLD runtime libraries (these do NOT depend on
-        # python3:riscv64, so apt-get install works without postinst issues)
-        apt-get install -y --no-install-recommends \
+        # Install riscv64 LLVM/LLD runtime libraries and their dependency
+        # closure via download+extract instead of apt-get install: libllvm20
+        # depends on libedit2 -> libtinfo6, which hits the same noble-security
+        # vs noble-ports Multi-Arch:same version skew as the cross_compile
+        # job. The extracted libraries land in /usr/lib/riscv64-linux-gnu,
+        # where LD_LIBRARY_PATH and the sysroot symlinks below resolve them
+        # without needing postinst or ldconfig.
+        mkdir -p /tmp/riscv64-debs && cd /tmp/riscv64-debs
+        apt-get download \
           libllvm20:riscv64 \
           liblld-20:riscv64 \
+          libedit2:riscv64 \
+          libbsd0:riscv64 \
+          libmd0:riscv64 \
+          libtinfo6:riscv64 \
+          libffi8:riscv64 \
+          libxml2:riscv64 \
+          libicu74:riscv64 \
+          liblzma5:riscv64 \
+          libzstd1:riscv64 \
           zlib1g:riscv64
+        for deb in *.deb; do
+          dpkg-deb -x "$deb" /
+        done
 
         # Create symlinks so QEMU sysroot can find multi-arch libraries.
         # With -L /usr/riscv64-linux-gnu, QEMU translates guest absolute paths


### PR DESCRIPTION
## Description

The `Build and Test WasmEdge on riscv64 arch` workflow failed on master (e.g.
[run 28610507597](https://github.com/WasmEdge/WasmEdge/actions/runs/28610507597))
because `noble-security` published a newer Multi-Arch:same `libtinfo6` for amd64
(`6.4+20240113-1ubuntu2.1`) before riscv64 `noble-ports` caught up
(`6.4+20240113-1ubuntu2`), so apt refused to co-install the riscv64 variant:

```
libedit2:riscv64 : Depends: libtinfo6:riscv64 (>= 6) but it is not going to be installed
libncurses-dev:riscv64 : Depends: libtinfo6:riscv64 (= 6.4+20240113-1ubuntu2) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

This is the same failure class as the existing `libssh-4` workaround for the
LLVM packages. The ports archive has since caught up (which is why the latest
master run is green again), but the skew recurs every time a security update
lands, so this hardens the workflow against the next occurrence.

Changes:

- Move `libedit-dev:riscv64` and its transitive deps (`libedit2`, `libbsd0`,
  `libmd0`, `libncurses-dev`, `libncurses6`, `libncursesw6`, `libtinfo6`) from
  `apt-get install` to the existing `apt-get download` + `dpkg-deb -x` pattern,
  bypassing apt's cross-arch version checks.
- `libbsd0`/`libmd0` are required in the download list: they were previously
  pulled in implicitly by apt, and without them linking against libLLVM fails
  with `libbsd.so.0, needed by libedit.so.2, not found` /
  `undefined reference to 'vis@LIBBSD_0.0'` (caught during local verification).

> This contribution was developed with assistance from Claude Fable 5 (Anthropic).

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

Replicated both workflow jobs locally in an `ubuntu:24.04` container
(native arm64 with the host-arch pin adapted, since amd64 emulation on Apple
Silicon hits an unrelated gcc-13 LTO ICE; the apt/download/extract phases were
additionally verified in the CI-exact amd64 container):

Toolchain install (fixed step) + full cross-build:

```
=== PHASE 2 OK: toolchain installed ===
[100%] Built target wasmedgeAPIUnitTests
=== PHASE 4 OK: BUILD SUCCEEDED ===
```

Quick test suite under QEMU (`.github/scripts/run-riscv64-quick-tests.sh`):

```
PASSED: wasmedgeCommonTests
PASSED: wasmedgeErrinfoTests
PASSED: expectedTests
PASSED: poTests
PASSED: spanTests
PASSED: wasmedgeLoaderFileMgrTests
PASSED: wasmedgeLoaderASTTests
PASSED: wasmedgeLoaderSerializerTests
PASSED: wasmedgeRuntimeInstanceTests
PASSED: wasmedgeExternrefTests
PASSED: wasmedgeHostMockTests
PASSED: wasmedgeAPIUnitTests
PASSED: wasmedgeAOTBlake3Tests
=== Quick Test Suite Complete ===
All quick tests passed
```

CLI verification under QEMU:

```
$ qemu-riscv64-static -L /usr/riscv64-linux-gnu build/tools/wasmedge/wasmedge -v
build/tools/wasmedge/wasmedge version 0.0.0-unreleased
 (plugin "wasi_logging") version 0.1.0.0
$ qemu-riscv64-static ... wasmedge --reactor fibonacci.wasm fib 30
1346269
```

Since this PR touches `.github/workflows/build_for_riscv.yml`, the RISC-V
workflow also runs on this PR itself for end-to-end validation.
