### PR TITLE
ci: deduplicate GitHub Actions caches to stay under the 10 GB quota

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -180,6 +180,7 @@ workflows are called by the entries below and are not listed here; see
 | Test WasmEdge on OpenWrt | `build_for_openwrt.yml` | `workflow_dispatch` only | build/test on OpenWrt; run manually from the Actions tab |
 | Build WasmEdge on Nix | `build_for_nix.yml` | `push` (`master`), `pull_request` (`master`, `proposal/**`); paths: workflow, `flake.nix`, `flake.lock`, `include/`, `lib/`, `thirdparty/`, `tools/`, `cmake/`, `CMakeLists.txt` | `nix build` + `nix flake check` |
 | Pull Request Labeler | `labeler.yml` | `pull_request_target` (opened/synchronize/reopened/closed); no path filter | auto-labels by path; runs in base-repo context |
+| Cleanup PR caches | `cleanup-pr-caches.yml` | `pull_request_target` (closed); no path filter | deletes the closed PR's Actions caches to free the repository cache quota; runs in base-repo context |
 | release | `release.yml` | `workflow_dispatch`, `push` tags `X.Y.Z*` | creates release, tarball, release builds |
 | Submit WasmEdge MSI package to the Windows Package Manager Community Repository | `winget-submit.yml` | `workflow_dispatch`, `release` (released) | submits the MSI to the Windows Package Manager |
 

--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -152,8 +152,9 @@ jobs:
       - name: Ensure git safe directory
         run: |
           git config --global --add safe.directory $(pwd)
-      - name: Cache ML model fixtures
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Restore ML model fixtures
+        id: ml-fixtures
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: build_rpc/test/plugins/wasi_nn/wasinn_*_fixtures
           key: ml-fixtures-wasi_nn-ggml-rpc-${{ hashFiles('test/plugins/wasi_nn/CMakeLists.txt') }}
@@ -193,6 +194,12 @@ jobs:
           sleep 3
           (cd ${nnrpc_test_dir} && ./${test_bin} --gtest_filter=WasiNNTest.GGMLBackendComputeSingleWithRPC)
           kill -9 "$RPC_SERVER_PID"
+      - name: Save ML model fixtures
+        if: ${{ github.ref == 'refs/heads/master' && steps.ml-fixtures.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: build_rpc/test/plugins/wasi_nn/wasinn_*_fixtures
+          key: ml-fixtures-wasi_nn-ggml-rpc-${{ hashFiles('test/plugins/wasi_nn/CMakeLists.txt') }}
 
   build_windows_wasi_nn:
     permissions:
@@ -225,14 +232,15 @@ jobs:
       - uses: GuillaumeFalourd/setup-windows10-sdk-action@d4f23d08ae372a72e47dc2616c9ec8c951f853ec # v2.5
         with:
           sdk-version: 26100
-      - name: Cache LLVM
+      - name: Restore LLVM
         id: llvm-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: LLVM-21.1.3-win64-MultiThreadedDLL
           key: llvm-21.1.3-windows-2025
-      - name: Cache ML model fixtures
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Restore ML model fixtures
+        id: ml-fixtures
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: build/test/plugins/wasi_nn/wasinn_*_fixtures
           key: ml-fixtures-wasi_nn-ggml-windows-${{ hashFiles('test/plugins/wasi_nn/CMakeLists.txt') }}
@@ -244,6 +252,12 @@ jobs:
           Invoke-WebRequest -Uri $uri -HttpVersion 2.0 -OutFile $llvm
           Expand-Archive -Path $llvm
           Remove-Item -Path $llvm
+      - name: Save LLVM
+        if: ${{ github.ref == 'refs/heads/master' && steps.llvm-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: LLVM-21.1.3-win64-MultiThreadedDLL
+          key: llvm-21.1.3-windows-2025
       - name: Build WasmEdge
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -271,6 +285,12 @@ jobs:
           Write-Output "Compress-Archive -Path $Env:output_bin -DestinationPath plugin_${Env:tar_names}.zip -CompressionLevel Optimal"
           Compress-Archive -Path "$Env:output_bin" -DestinationPath "plugin_${Env:tar_names}.zip" -CompressionLevel Optimal
           ls "plugin_${Env:tar_names}.zip"
+      - name: Save ML model fixtures
+        if: ${{ github.ref == 'refs/heads/master' && steps.ml-fixtures.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: build/test/plugins/wasi_nn/wasinn_*_fixtures
+          key: ml-fixtures-wasi_nn-ggml-windows-${{ hashFiles('test/plugins/wasi_nn/CMakeLists.txt') }}
       - name: Upload artifact - wasi_nn-ggml
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -26,11 +26,17 @@ jobs:
           REPO: ${{ github.repository }}
           REF: refs/pull/${{ github.event.pull_request.number }}/merge
         run: |
-          while :; do
+          for pass in 1 2 3 4 5 6 7 8 9 10; do
             ids=$(gh cache list --repo "$REPO" --ref "$REF" --limit 100 --json id --jq '.[].id')
             [ -z "$ids" ] && break
+            echo "Delete pass ${pass}"
             for id in $ids; do
               gh cache delete "$id" --repo "$REPO" || true
             done
           done
-          echo "All caches on $REF are deleted."
+          remaining=$(gh cache list --repo "$REPO" --ref "$REF" --limit 1 --json id --jq 'length')
+          if [ "$remaining" -gt 0 ]; then
+            echo "::warning::Caches remain on $REF after 10 delete passes; they expire automatically within 7 days."
+          else
+            echo "All caches on $REF are deleted."
+          fi

--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -1,0 +1,36 @@
+name: Cleanup PR caches
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    name: Delete caches of the closed PR
+    permissions:
+      actions: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Delete caches on the merge ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          while :; do
+            ids=$(gh cache list --repo "$REPO" --ref "$REF" --limit 100 --json id --jq '.[].id')
+            [ -z "$ids" ] && break
+            for id in $ids; do
+              gh cache delete "$id" --repo "$REPO" || true
+            done
+          done
+          echo "All caches on $REF are deleted."

--- a/.github/workflows/reusable-build-extensions-on-linux.yml
+++ b/.github/workflows/reusable-build-extensions-on-linux.yml
@@ -84,14 +84,15 @@ jobs:
       - name: Ensure git safe directory
         run: |
           git config --global --add safe.directory $(pwd)
-      # Cache the ML models downloaded at configure time, keyed per plugin
+      # Restore the ML models downloaded at configure time, keyed per plugin
       # (per backend for wasi_nn, with the bitnet variants sharing one model)
       # so flaky upstream downloads only hit on cache misses. Only the
-      # downloaded files are cached, not test byproducts. The same key may
-      # appear once per compression toolchain (gzip/zstd) across job images.
+      # downloaded files are cached, not test byproducts, and only master
+      # runs save the cache so PR runs never create per-ref duplicates.
       - if: ${{ !inputs.release && (matrix.dir == 'wasi_nn' || matrix.dir == 'wasmedge_stablediffusion') }}
-        name: Cache ML model fixtures
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        name: Restore ML model fixtures
+        id: ml-fixtures
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             build/test/plugins/wasi_nn/wasinn_*_fixtures
@@ -117,6 +118,14 @@ jobs:
 
           cp -f ${output_dir}/${bin_name} ${bin_name}
           tar -zcvf ${{ steps.var.outputs.artifact }} ${bin_name}
+      - if: ${{ !inputs.release && (matrix.dir == 'wasi_nn' || matrix.dir == 'wasmedge_stablediffusion') && github.ref == 'refs/heads/master' && steps.ml-fixtures.outputs.cache-hit != 'true' }}
+        name: Save ML model fixtures
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            build/test/plugins/wasi_nn/wasinn_*_fixtures
+            build/test/plugins/wasmedge_stablediffusion/stableDiffusion/sd-v1-5-fp16.safetensors
+          key: ml-fixtures-${{ matrix.dir == 'wasi_nn' && (contains(matrix.plugin, 'bitnet') && 'wasi_nn-bitnet' || matrix.plugin) || matrix.dir }}-${{ hashFiles(format('test/plugins/{0}/CMakeLists.txt', matrix.dir)) }}
       - if: ${{ !inputs.release && matrix.plugin == 'wasm_bpf' }}
         name: Prepare test env
         shell: bash

--- a/.github/workflows/reusable-build-extensions-on-macos.yml
+++ b/.github/workflows/reusable-build-extensions-on-macos.yml
@@ -50,14 +50,15 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      # Cache the ML models downloaded at configure time, keyed per plugin
+      # Restore the ML models downloaded at configure time, keyed per plugin
       # (per backend for wasi_nn, with the bitnet variants sharing one model)
       # so flaky upstream downloads only hit on cache misses. Only the
-      # downloaded files are cached, not test byproducts. The same key may
-      # appear once per compression toolchain (gzip/zstd) across job images.
+      # downloaded files are cached, not test byproducts, and only master
+      # runs save the cache so PR runs never create per-ref duplicates.
       - if: ${{ !inputs.release && (matrix.dir == 'wasi_nn' || matrix.dir == 'wasmedge_stablediffusion') }}
-        name: Cache ML model fixtures
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        name: Restore ML model fixtures
+        id: ml-fixtures
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             build/test/plugins/wasi_nn/wasinn_*_fixtures
@@ -93,6 +94,14 @@ jobs:
             -DOPENSSL_ROOT_DIR=${OpenSSL_DIR} \
             ${{ matrix.options }}
           cmake --build build --target ${target}
+      - if: ${{ !inputs.release && (matrix.dir == 'wasi_nn' || matrix.dir == 'wasmedge_stablediffusion') && github.ref == 'refs/heads/master' && steps.ml-fixtures.outputs.cache-hit != 'true' }}
+        name: Save ML model fixtures
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            build/test/plugins/wasi_nn/wasinn_*_fixtures
+            build/test/plugins/wasmedge_stablediffusion/stableDiffusion/sd-v1-5-fp16.safetensors
+          key: ml-fixtures-${{ matrix.dir == 'wasi_nn' && (contains(matrix.plugin, 'bitnet') && 'wasi_nn-bitnet' || matrix.plugin) || matrix.dir }}-${{ hashFiles(format('test/plugins/{0}/CMakeLists.txt', matrix.dir)) }}
       - id: var
         run: |
           export prefix="WasmEdge-plugin-${{ matrix.plugin }}"

--- a/.github/workflows/reusable-build-on-android.yml
+++ b/.github/workflows/reusable-build-on-android.yml
@@ -31,9 +31,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - name: Cache Android NDK and CMake
+      - name: Restore Android NDK and CMake
         id: cache-android
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             cmake-3.22.2-linux-x86_64.tar.gz
@@ -49,6 +49,14 @@ jobs:
           cp -r cmake-3.22.2-linux-x86_64/share /usr/local
           [ -f android-ndk-r23b-linux.zip ] || curl -sLO https://dl.google.com/android/repository/android-ndk-r23b-linux.zip
           unzip -q android-ndk-r23b-linux.zip
+      - name: Save Android NDK and CMake
+        if: ${{ github.ref == 'refs/heads/master' && steps.cache-android.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            cmake-3.22.2-linux-x86_64.tar.gz
+            android-ndk-r23b-linux.zip
+          key: android-ndk-r23b-cmake-3.22.2
       - name: Grant the safe directory for git
         run: |
           git config --global --add safe.directory $(pwd)

--- a/.github/workflows/reusable-build-on-windows-msvc.yml
+++ b/.github/workflows/reusable-build-on-windows-msvc.yml
@@ -52,6 +52,20 @@ jobs:
         with:
           path: LLVM-21.1.3-win64-MultiThreadedDLL
           key: llvm-21.1.3-windows-2025
+      - name: Download LLVM for Windows
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: |
+          $uri = "https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-21.1.3/LLVM-21.1.3-win64-MultiThreadedDLL.zip"
+          $llvm = "LLVM-21.1.3-win64-MultiThreadedDLL.zip"
+          Invoke-WebRequest -Uri $uri -HttpVersion 2.0 -OutFile $llvm
+          Expand-Archive -Path $llvm
+          Remove-Item -Path $llvm
+      - name: Save LLVM for Windows
+        if: ${{ github.ref == 'refs/heads/master' && steps.cache-llvm.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: LLVM-21.1.3-win64-MultiThreadedDLL
+          key: llvm-21.1.3-windows-2025
       - name: Ensure git safe directory
         run: |
           git config --global --add safe.directory $(pwd)
@@ -72,22 +86,10 @@ jobs:
           $vsPath = (vswhere -latest -property installationPath)
           Import-Module (Join-Path $vsPath Common7\Tools\Microsoft.VisualStudio.DevShell.dll)
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.26100.0"
-          if (-not (Test-Path "LLVM-21.1.3-win64-MultiThreadedDLL")) {
-            $uri = "https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-21.1.3/LLVM-21.1.3-win64-MultiThreadedDLL.zip"
-            $llvm = "LLVM-21.1.3-win64-MultiThreadedDLL.zip"
-            Invoke-WebRequest -Uri $uri -HttpVersion 2.0 -OutFile $llvm
-            Expand-Archive -Path $llvm
-          }
           $llvm_dir = "$pwd\LLVM-21.1.3-win64-MultiThreadedDLL\LLVM-21.1.3-win64\lib\cmake\llvm"
           $cmake_sys_version = "10.0.26100.0"
           cmake -Bbuild -GNinja -DCMAKE_SYSTEM_VERSION="$cmake_sys_version" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL -DCMAKE_POLICY_DEFAULT_CMP0141=NEW -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded -DLLVM_DIR:PATH="$llvm_dir" -DWASMEDGE_BUILD_TESTS="$Env:build_tests" -DWASMEDGE_BUILD_PACKAGE=ZIP .
           cmake --build build
-      - name: Save LLVM for Windows
-        if: ${{ github.ref == 'refs/heads/master' && steps.cache-llvm.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: LLVM-21.1.3-win64-MultiThreadedDLL
-          key: llvm-21.1.3-windows-2025
       - name: Test WasmEdge
         run: |
           $vsPath = (vswhere -latest -property installationPath)

--- a/.github/workflows/reusable-build-on-windows-msvc.yml
+++ b/.github/workflows/reusable-build-on-windows-msvc.yml
@@ -46,12 +46,12 @@ jobs:
           }
           Write-Error "sccache server did not become ready; aborting before the long build"
           exit 1
-      - name: Cache LLVM for Windows
+      - name: Restore LLVM for Windows
         id: cache-llvm
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: LLVM-21.1.3-win64-MultiThreadedDLL
-          key: llvm-21.1.3-windows-2025-msvc
+          key: llvm-21.1.3-windows-2025
       - name: Ensure git safe directory
         run: |
           git config --global --add safe.directory $(pwd)
@@ -82,6 +82,12 @@ jobs:
           $cmake_sys_version = "10.0.26100.0"
           cmake -Bbuild -GNinja -DCMAKE_SYSTEM_VERSION="$cmake_sys_version" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL -DCMAKE_POLICY_DEFAULT_CMP0141=NEW -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded -DLLVM_DIR:PATH="$llvm_dir" -DWASMEDGE_BUILD_TESTS="$Env:build_tests" -DWASMEDGE_BUILD_PACKAGE=ZIP .
           cmake --build build
+      - name: Save LLVM for Windows
+        if: ${{ github.ref == 'refs/heads/master' && steps.cache-llvm.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: LLVM-21.1.3-win64-MultiThreadedDLL
+          key: llvm-21.1.3-windows-2025
       - name: Test WasmEdge
         run: |
           $vsPath = (vswhere -latest -property installationPath)

--- a/.github/workflows/reusable-build-on-windows.yml
+++ b/.github/workflows/reusable-build-on-windows.yml
@@ -52,6 +52,20 @@ jobs:
         with:
           path: LLVM-21.1.3-win64-MultiThreadedDLL
           key: llvm-21.1.3-windows-2025
+      - name: Download LLVM for Windows
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: |
+          $uri = "https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-21.1.3/LLVM-21.1.3-win64-MultiThreadedDLL.zip"
+          $llvm = "LLVM-21.1.3-win64-MultiThreadedDLL.zip"
+          Invoke-WebRequest -Uri $uri -HttpVersion 2.0 -OutFile $llvm
+          Expand-Archive -Path $llvm
+          Remove-Item -Path $llvm
+      - name: Save LLVM for Windows
+        if: ${{ github.ref == 'refs/heads/master' && steps.cache-llvm.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: LLVM-21.1.3-win64-MultiThreadedDLL
+          key: llvm-21.1.3-windows-2025
       - name: Ensure git safe directory
         run: |
           git config --global --add safe.directory $(pwd)
@@ -76,12 +90,6 @@ jobs:
           $vsPath = (vswhere -latest -property installationPath)
           Import-Module (Join-Path $vsPath Common7\Tools\Microsoft.VisualStudio.DevShell.dll)
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64 -winsdk=10.0.26100.0"
-          if (-not (Test-Path "LLVM-21.1.3-win64-MultiThreadedDLL")) {
-            $uri = "https://github.com/WasmEdge/llvm-windows/releases/download/llvmorg-21.1.3/LLVM-21.1.3-win64-MultiThreadedDLL.zip"
-            $llvm = "LLVM-21.1.3-win64-MultiThreadedDLL.zip"
-            Invoke-WebRequest -Uri $uri -HttpVersion 2.0 -OutFile $llvm
-            Expand-Archive -Path $llvm
-          }
           $llvm_dir = "$pwd\LLVM-21.1.3-win64-MultiThreadedDLL\LLVM-21.1.3-win64\lib\cmake\llvm"
           $Env:CC = "$pwd\LLVM-21.1.3-win64-MultiThreadedDLL\LLVM-21.1.3-win64\bin\clang-cl.exe"
           $Env:CXX = "$pwd\LLVM-21.1.3-win64-MultiThreadedDLL\LLVM-21.1.3-win64\bin\clang-cl.exe"
@@ -89,12 +97,6 @@ jobs:
           $cmake_sys_version = "10.0.26100.0"
           cmake -Bbuild -GNinja -DCMAKE_SYSTEM_VERSION="$cmake_sys_version" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL -DCMAKE_MT="$llvm_mt" -DLLVM_DIR="$llvm_dir" -DWASMEDGE_BUILD_TESTS="$Env:build_tests" -DWASMEDGE_BUILD_PACKAGE=ZIP .
           cmake --build build
-      - name: Save LLVM for Windows
-        if: ${{ github.ref == 'refs/heads/master' && steps.cache-llvm.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: LLVM-21.1.3-win64-MultiThreadedDLL
-          key: llvm-21.1.3-windows-2025
       - name: Test WasmEdge
         run: |
           $Env:PATH += ";$pwd\build\lib\api"

--- a/.github/workflows/reusable-build-on-windows.yml
+++ b/.github/workflows/reusable-build-on-windows.yml
@@ -46,9 +46,9 @@ jobs:
           }
           Write-Error "sccache server did not become ready; aborting before the long build"
           exit 1
-      - name: Cache LLVM for Windows
+      - name: Restore LLVM for Windows
         id: cache-llvm
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: LLVM-21.1.3-win64-MultiThreadedDLL
           key: llvm-21.1.3-windows-2025
@@ -89,6 +89,12 @@ jobs:
           $cmake_sys_version = "10.0.26100.0"
           cmake -Bbuild -GNinja -DCMAKE_SYSTEM_VERSION="$cmake_sys_version" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL -DCMAKE_MT="$llvm_mt" -DLLVM_DIR="$llvm_dir" -DWASMEDGE_BUILD_TESTS="$Env:build_tests" -DWASMEDGE_BUILD_PACKAGE=ZIP .
           cmake --build build
+      - name: Save LLVM for Windows
+        if: ${{ github.ref == 'refs/heads/master' && steps.cache-llvm.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: LLVM-21.1.3-win64-MultiThreadedDLL
+          key: llvm-21.1.3-windows-2025
       - name: Test WasmEdge
         run: |
           $Env:PATH += ";$pwd\build\lib\api"

--- a/utils/docker/Dockerfile.manylinux_2_28-plugins-deps
+++ b/utils/docker/Dockerfile.manylinux_2_28-plugins-deps
@@ -6,7 +6,7 @@ WORKDIR /root
 ### deps for x86_64 ###
 FROM base AS deps-amd64
 RUN cd && (yum check-update || true) && \
-  yum install -y wget unzip zlib-devel zlib-static elfutils-libelf-devel
+  yum install -y wget unzip zlib-devel zlib-static elfutils-libelf-devel zstd
 
 COPY wasi-nn/install-pytorch.sh .
 ENV PYTORCH_VERSION="2.5.1"
@@ -17,7 +17,7 @@ RUN [ "/bin/bash", "install-pytorch.sh", "--disable-cxx11-abi" ]
 ### deps for aarch64 ###
 FROM base AS deps-arm64
 RUN cd && (yum check-update || true) && \
-  yum install -y wget unzip zlib-devel zlib-static
+  yum install -y wget unzip zlib-devel zlib-static zstd
 
 ### deps for all ###
 FROM deps-${TARGETARCH} AS final

--- a/utils/docker/Dockerfile.ubuntu-base
+++ b/utils/docker/Dockerfile.ubuntu-base
@@ -13,7 +13,8 @@ RUN apt-get update && \
         ninja-build \
         software-properties-common \
         wget \
-        zlib1g-dev
+        zlib1g-dev \
+        zstd
 
 ### deps for ubuntu 20.04 ###
 FROM base AS deps-20


### PR DESCRIPTION
## Description

After shipping the #5112, we are caching the WASI-NN models to avoid re-downloading these large files repeatedly and to resolve the flaky issues. However, the repository's actions cache is limited to a hard 10GB quota. This means that GitHub's LRU eviction policy keeps deleting the master-seeded caches. As a result, every PR run misses the cache, re-downloads the files, and saves a duplicate copy onto their own `refs/pull/<PR Number>/merge` ref, which can never be shared with other PRs. Worse yet, this process causes evictions of even more cache entries on the master seeds.

Observed duplication before this change:

| Cache | Waste | Cause |
| ----- | ----- | ----- |
| `ml-fixtures-wasmedge_stablediffusion-*` twice on master | ~2.0 GB | same key, two cache *versions*: zstd (hosted macOS runners) vs gzip (Linux containers without zstd) |
| `android-ndk-r23b-cmake-3.22.2` per PR ref | ~760 MB × N PRs | PR-side `actions/cache` save after the master seed was evicted |
| `llvm-21.1.3-windows-2025` + `llvm-21.1.3-windows-2025-msvc` | ~980 MB | two keys for the identical extracted LLVM zip |
| ML fixtures on PR refs (e.g. bitnet, 520 MB) | ~0.5 GB × N PRs | PR-side save |

Expected steady state: roughly 10.5 GB → 6 GB, master seeds stop being evicted, and the PR cache hit rate recovers.

One commit per fix:

1. `ci: save heavy caches only on master and unify the Windows LLVM key` —  
   Split every large `actions/cache` usage into `actions/cache/restore` plus  
   an explicit `actions/cache/save` gated on `github.ref == 'refs/heads/master'` and a cache miss (Android NDK, Windows LLVM in three jobs; ML model fixtures in four jobs). PR runs still restore the master-seeded entries; a miss now costs a re-download instead of a duplicated cache entry. The `-msvc` key suffix is dropped so all three Windows jobs share one LLVM entry, and the split actions are pinned to the `actions/cache` v6.1.0 revision already used elsewhere.

2. `ci: install zstd in Linux build images for consistent cache compression` —  
   `actions/cache` versions entries by compression method and falls back to gzip inside containers without zstd. Installing zstd in the Ubuntu base image and the manylinux_2_28 plugins images makes container jobs produce the same cache version as the hosted runners, collapsing the double-stored fixture caches into a single shared entry per key.

3. `ci: delete a pull request's Actions caches when it closes` —  
   New `cleanup-pr-caches.yml` on `pull_request_target` (closed): deletes the closed PR's merge-ref caches so they stop occupying quota for up to a week. The job checks out nothing and runs no PR-controlled code; the base-repo token is needed for the `actions: write` scope on fork PRs.


Verification of the compression split: `actions/cache` computes the cache version as `sha256(paths | compressionMethod | salt)`. Recomputing this for all four observed version hashes matches exactly (4/4)—see Test Evidence—and the pinned v6.1.0 source selects zstd purely based on the presence of the `zstd` binary on Linux.

Note on the coding style and local test checklist items: this PR touches only workflow YAML files and Dockerfiles, so there is no C/C++ code for `clang-format` or the test suites to cover; `actionlint`, `lineguard`, and `commitlint` runs are attached as Test Evidence instead.

This contribution was developed with assistance from Claude Fable 5 (Anthropic) via GitHub Copilot CLI.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

`commitlint` on all three commits:

```console
=== ci: delete a pull request's Actions caches when it closes
PASS
=== ci: install zstd in Linux build images for consistent cache compression
PASS
=== ci: save heavy caches only on master and unify the Windows LLVM key
PASS
```

`actionlint` parity with master (only pre-existing shellcheck notes in
untouched scripts; the new workflow reports nothing):

```console
$ actionlint <master copies of edited workflows> | grep -c shellcheck
41
$ actionlint <edited workflows> | grep -c shellcheck
41
$ actionlint .github/workflows/cleanup-pr-caches.yml
(no output)
```

`lineguard` on all edited files:

```console
✓ All files passed lint checks!
```

Cache-version hash verification — recomputed
`sha256(paths | compression | salt)` against the four versions observed via
`GET /repos/WasmEdge/WasmEdge/actions/caches`:

```console
MATCH a193326089346c3a  computed as [fixtures + gzip]               == observed [SD/bitnet fixtures (linux container jobs)]
MATCH 63e10b2d4bc8cf29  computed as [android + gzip]                == observed [android NDK (container)]
MATCH 2cb93949004e5135  computed as [fixtures + zstd-without-long]  == observed [SD/mlx fixtures (macOS jobs)]
MATCH 2e557480df06ee1d  computed as [llvm + zstd-without-long + windows-only] == observed [windows LLVM (hosted runner)]
```

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
