### PR TITLE
fix(loader,component): bound loader recursion depth to prevent stack overflow

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -977,6 +977,8 @@ E(UnknownCanonicalOption, 0x01AB, "unknown canonical option")
 E(MalformedName, 0x01AC, "malformed name")
 // Component model not implemented
 E(ComponentNotImplLoader, 0x01AD, "component model (loader) not implemented")
+// Component model nesting level exceeded
+E(ComponentNestLevelExceeded, 0x01AE, "component nesting level exceeded")
 // @}
 
 // Validation phase

--- a/include/loader/loader.h
+++ b/include/loader/loader.h
@@ -515,6 +515,21 @@ private:
   std::recursive_mutex Mutex;
   bool HasDataSection;
 
+  /// Maximum component model loader recursion depth; deeper input is rejected
+  /// to avoid native stack overflow.
+  static inline constexpr uint32_t MaxComponentNestLevel = 256;
+  /// Current component model loader recursion depth.
+  uint32_t ComponentNestLevel = 0;
+
+  /// Scoped increment/decrement of ComponentNestLevel.
+  struct ComponentNestGuard {
+    uint32_t &Level;
+    explicit ComponentNestGuard(uint32_t &L) noexcept : Level(L) { ++Level; }
+    ~ComponentNestGuard() noexcept { --Level; }
+    ComponentNestGuard(const ComponentNestGuard &) = delete;
+    ComponentNestGuard &operator=(const ComponentNestGuard &) = delete;
+  };
+
   /// Input data type enumeration.
   enum class InputType : uint8_t { WASM, UniversalWASM, SharedLibrary };
   InputType WASMType = InputType::WASM;

--- a/lib/loader/ast/component/component.cpp
+++ b/lib/loader/ast/component/component.cpp
@@ -42,6 +42,11 @@ Expect<std::pair<std::vector<Byte>, std::vector<Byte>>> Loader::loadPreamble() {
 
 Expect<void> Loader::loadComponent(AST::Component::Component &Comp,
                                    std::optional<uint64_t> Bound) {
+  ComponentNestGuard NestGuard(ComponentNestLevel);
+  if (unlikely(ComponentNestLevel > MaxComponentNestLevel)) {
+    return logLoadError(ErrCode::Value::ComponentNestLevelExceeded,
+                        FMgr.getLastOffset(), ASTNodeAttr::Component);
+  }
   auto ReportError = [](auto E) {
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Component));
     return E;

--- a/lib/loader/ast/component/component_type.cpp
+++ b/lib/loader/ast/component/component_type.cpp
@@ -9,6 +9,11 @@ namespace WasmEdge {
 namespace Loader {
 
 Expect<void> Loader::loadType(AST::Component::CoreDefType &Ty) {
+  ComponentNestGuard NestGuard(ComponentNestLevel);
+  if (unlikely(ComponentNestLevel > MaxComponentNestLevel)) {
+    return logLoadError(ErrCode::Value::ComponentNestLevelExceeded,
+                        FMgr.getLastOffset(), ASTNodeAttr::Comp_CoreDefType);
+  }
   auto ReportError = [](auto E) {
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_CoreDefType));
     return E;
@@ -82,6 +87,11 @@ Expect<void> Loader::loadType(AST::Component::CoreDefType &Ty) {
 }
 
 Expect<void> Loader::loadType(AST::Component::DefType &Ty) {
+  ComponentNestGuard NestGuard(ComponentNestLevel);
+  if (unlikely(ComponentNestLevel > MaxComponentNestLevel)) {
+    return logLoadError(ErrCode::Value::ComponentNestLevelExceeded,
+                        FMgr.getLastOffset(), ASTNodeAttr::Comp_DefType);
+  }
   auto ReportError = [](auto E) {
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_DefType));
     return E;

--- a/test/component/ComponentLoaderTest.cpp
+++ b/test/component/ComponentLoaderTest.cpp
@@ -18,6 +18,71 @@ namespace {
 using namespace WasmEdge;
 using namespace std::literals;
 
+std::vector<uint8_t> leb128U32(uint32_t N) {
+  std::vector<uint8_t> Out;
+  do {
+    uint8_t B = static_cast<uint8_t>(N & 0x7F);
+    N >>= 7;
+    if (N != 0) {
+      B = static_cast<uint8_t>(B | 0x80);
+    }
+    Out.push_back(B);
+  } while (N != 0);
+  return Out;
+}
+
+const std::vector<uint8_t> ComponentPreamble = {0x00, 0x61, 0x73, 0x6d,
+                                                0x0d, 0x00, 0x01, 0x00};
+
+std::vector<uint8_t> makeTypeSection(uint8_t SecId,
+                                     const std::vector<uint8_t> &TypeBody) {
+  std::vector<uint8_t> Payload = {0x01};
+  Payload.insert(Payload.end(), TypeBody.begin(), TypeBody.end());
+  std::vector<uint8_t> Vec = ComponentPreamble;
+  Vec.push_back(SecId);
+  const auto Size = leb128U32(static_cast<uint32_t>(Payload.size()));
+  Vec.insert(Vec.end(), Size.begin(), Size.end());
+  Vec.insert(Vec.end(), Payload.begin(), Payload.end());
+  return Vec;
+}
+
+// Component type nested `Depth` levels: `41 01 01` per level, `41 00` last.
+std::vector<uint8_t> makeNestedComponentType(uint32_t Depth) {
+  std::vector<uint8_t> Body;
+  for (uint32_t I = 0; I + 1 < Depth; ++I) {
+    Body.insert(Body.end(), {0x41, 0x01, 0x01});
+  }
+  Body.insert(Body.end(), {0x41, 0x00});
+  return makeTypeSection(0x07, Body);
+}
+
+// Core module type nested `Depth` levels: `50 01 01` per level, `50 00` last.
+std::vector<uint8_t> makeNestedCoreModuleType(uint32_t Depth) {
+  std::vector<uint8_t> Body;
+  for (uint32_t I = 0; I + 1 < Depth; ++I) {
+    Body.insert(Body.end(), {0x50, 0x01, 0x01});
+  }
+  Body.insert(Body.end(), {0x50, 0x00});
+  return makeTypeSection(0x03, Body);
+}
+
+// `Depth` components nested via component sections (0x04), innermost empty.
+std::vector<uint8_t> makeNestedComponents(uint32_t Depth) {
+  std::vector<uint8_t> Body;
+  for (uint32_t I = 0; I < Depth; ++I) {
+    std::vector<uint8_t> Content = ComponentPreamble;
+    Content.insert(Content.end(), Body.begin(), Body.end());
+    std::vector<uint8_t> Sec = {0x04};
+    const auto Size = leb128U32(static_cast<uint32_t>(Content.size()));
+    Sec.insert(Sec.end(), Size.begin(), Size.end());
+    Sec.insert(Sec.end(), Content.begin(), Content.end());
+    Body = std::move(Sec);
+  }
+  std::vector<uint8_t> Vec = ComponentPreamble;
+  Vec.insert(Vec.end(), Body.begin(), Body.end());
+  return Vec;
+}
+
 TEST(ComponentNameParserTest, Parse) {
   {
     auto CName = Validator::ComponentName::parse("[constructor]my-class"sv);
@@ -574,6 +639,55 @@ TEST(ComponentLoaderTest, AsyncI64ResourceRepWithMemory64) {
   EXPECT_EQ(*RT.getDestructor(), 0U);
   // Callback is absent in this payload.
   EXPECT_FALSE(RT.getCallback().has_value());
+}
+
+TEST(ComponentLoaderTest, DeeplyNestedComponentTypeRejected) {
+  WasmEdge::Configure Conf;
+  Conf.addProposal(WasmEdge::Proposal::Component);
+  WasmEdge::Loader::Loader Loader(Conf);
+
+  // Over the limit: rejected, not a stack overflow.
+  auto Res = Loader.parseWasmUnit(makeNestedComponentType(1000));
+  ASSERT_FALSE(Res);
+  EXPECT_EQ(Res.error().getEnum(),
+            WasmEdge::ErrCode::Value::ComponentNestLevelExceeded);
+}
+
+TEST(ComponentLoaderTest, ModeratelyNestedComponentTypeAccepted) {
+  WasmEdge::Configure Conf;
+  Conf.addProposal(WasmEdge::Proposal::Component);
+  WasmEdge::Loader::Loader Loader(Conf);
+
+  // Within the limit: still loads.
+  auto Res = Loader.parseWasmUnit(makeNestedComponentType(200));
+  ASSERT_TRUE(Res);
+  EXPECT_NE(
+      std::get_if<std::unique_ptr<WasmEdge::AST::Component::Component>>(&*Res),
+      nullptr);
+}
+
+TEST(ComponentLoaderTest, DeeplyNestedCoreModuleTypeRejected) {
+  WasmEdge::Configure Conf;
+  Conf.addProposal(WasmEdge::Proposal::Component);
+  WasmEdge::Loader::Loader Loader(Conf);
+
+  // Core module types share the guard.
+  auto Res = Loader.parseWasmUnit(makeNestedCoreModuleType(1000));
+  ASSERT_FALSE(Res);
+  EXPECT_EQ(Res.error().getEnum(),
+            WasmEdge::ErrCode::Value::ComponentNestLevelExceeded);
+}
+
+TEST(ComponentLoaderTest, DeeplyNestedComponentRejected) {
+  WasmEdge::Configure Conf;
+  Conf.addProposal(WasmEdge::Proposal::Component);
+  WasmEdge::Loader::Loader Loader(Conf);
+
+  // Nested components share the guard.
+  auto Res = Loader.parseWasmUnit(makeNestedComponents(300));
+  ASSERT_FALSE(Res);
+  EXPECT_EQ(Res.error().getEnum(),
+            WasmEdge::ErrCode::Value::ComponentNestLevelExceeded);
 }
 
 } // namespace


### PR DESCRIPTION
## Description

The Component Model loader can overflow the native stack while parsing a crafted
deeply-nested component, because its mutually-recursive type, declaration, and
nested-component parsers had **no recursion-depth limit** — one native stack
frame is consumed per nesting level, unbounded. The recursion is:

```
loadType(DefType) [0x41/0x42]
  -> loadType(ComponentType/InstanceType)
  -> loadDecl(ComponentDecl) -> loadDecl(InstanceDecl) [0x01]
  -> loadType(DefType) -> ...
```

with equivalent unbounded cycles through `loadType(CoreDefType)` [0x50] ->
`loadDecl(CoreModuleDecl)` [0x01], and through nested components
(`loadComponent` -> component section `0x04` -> `loadComponent`). (Component
*value* types are not affected: `loadType(ComponentValType)` reads an `s33` leaf,
so records/lists/tuples/etc. are already bounded.)

**Fix.** Add a single shared recursion-depth counter (`ComponentNestLevel`) with
an RAII guard (`ComponentNestGuard`), bounded by `MaxComponentNestLevel = 256`,
checked at every recursion entry point of the component loader:
`loadType(DefType)`, `loadType(CoreDefType)`, and `loadComponent`. One shared
counter bounds the *total* native stack depth across interleaved component and
type nesting. Exceeding the limit returns a new, dedicated error code
`ComponentNestLevelExceeded` (`0x01AE`) instead of crashing. The limit is far
beyond any realistic component (which nest only a handful of levels) yet safe
under an 8&nbsp;MB stack.

**Files changed**

- `include/common/enum.inc` — new `ComponentNestLevelExceeded` (0x01AE) error.
- `include/loader/loader.h` — `ComponentNestLevel` counter, `MaxComponentNestLevel`, and the `ComponentNestGuard` RAII helper.
- `lib/loader/ast/component/component_type.cpp` — guard `loadType(DefType)` and `loadType(CoreDefType)`.
- `lib/loader/ast/component/component.cpp` — guard `loadComponent`.
- `test/component/ComponentLoaderTest.cpp` — 4 regression tests (added to the existing target; no new test binary).

> This contribution was developed with assistance from Claude (Anthropic). AI
> assistance is disclosed via the `Assisted-by:` trailer in the commit.

## Checklist

- [x] **DCO Signed-off**: commit is signed off (`Signed-off-by: Shen-Ta Hsieh <beststeve@secondstate.io>`, matches author).
- [x] **Commit Messages**: follows Conventional Commits (`fix(loader,component): …`, header 77 chars). `commitlint` could not be run offline locally — will be validated by CI.
- [x] **Coding Style**: `clang-format` produces no changes; `lineguard --config .lineguardrc` passes.
- [x] **Local Tests Passed**: see Test Evidence below.
- [x] **AI Disclosure**: `Assisted-by: Claude (Anthropic)` trailer in the commit and noted above.
- [x] **Human-in-the-loop**: changes reviewed and verified by the author before submission.

## Test Evidence

### Unit tests

New + existing component loader tests (all pass):

```
[ RUN      ] ComponentLoaderTest.DeeplyNestedComponentTypeRejected
[       OK ] ComponentLoaderTest.DeeplyNestedComponentTypeRejected
[ RUN      ] ComponentLoaderTest.ModeratelyNestedComponentTypeAccepted
[       OK ] ComponentLoaderTest.ModeratelyNestedComponentTypeAccepted
[ RUN      ] ComponentLoaderTest.DeeplyNestedCoreModuleTypeRejected
[       OK ] ComponentLoaderTest.DeeplyNestedCoreModuleTypeRejected
[ RUN      ] ComponentLoaderTest.DeeplyNestedComponentRejected
[       OK ] ComponentLoaderTest.DeeplyNestedComponentRejected
...
[==========] 112 tests from 4 test suites ran.
[  PASSED  ] 112 tests.
```

### Hand-written reproducer

A component whose single type is a component type nested N levels deep — in the
component text format:

```wat
;; depth 6
(component (type (component (type (component (type
  (component (type (component (type (component)))))))))))
```

`wasm-tools` caps text nesting at 49, so depths past the loader limit are
produced with the small assembler below, which reproduces `wasm-tools`' exact
binary encoding (verified byte-identical for every depth `wasm-tools` accepts,
1..49). This script is provided here for reproduction only; it is not part of
the change:

```python
#!/usr/bin/env python3
# Assemble a component whose single type is a component type nested `depth`
# levels deep: (component (type (component (type ... (component))))).
import sys

def leb128_u32(n):
    out = bytearray()
    while True:
        b = n & 0x7F
        n >>= 7
        out.append(b | 0x80 if n else b)
        if not n:
            return bytes(out)

def nested_component_type(depth):
    pre = bytes([0x00, 0x61, 0x73, 0x6D, 0x0D, 0x00, 0x01, 0x00])  # component preamble
    body = bytearray()
    for _ in range(depth - 1):
        body += bytes([0x41, 0x01, 0x01])   # componenttype, 1 decl, instancedecl(type)
    body += bytes([0x41, 0x00])             # innermost componenttype, 0 decls
    payload = bytes([0x01]) + bytes(body)   # 1 type in the type section
    return pre + bytes([0x07]) + leb128_u32(len(payload)) + payload

if __name__ == "__main__":
    open(sys.argv[2], "wb").write(nested_component_type(int(sys.argv[1])))
```

Each nesting level consumes one native stack frame in the loader; without a
depth limit this is unbounded. On a default 8&nbsp;MB stack an unpatched release
build overflows above ~10,000–11,000 levels (build-dependent — ASan/debug builds
overflow far shallower); the reproducer uses 50000 for margin.

```console
$ python3 assemble.py 50000 nested.wasm

# Unpatched loader — native stack overflow:
$ wasmedge --enable-component nested.wasm
Segmentation fault (core dumped)                                       # exit 139

# Patched loader — graceful rejection, no crash:
$ wasmedge --enable-component nested.wasm
[error] loading failed: component nesting level exceeded, Code: 0x1ae   # exit 1

# A component nested within the limit still loads:
$ python3 assemble.py 200 shallow.wasm && wasmedge --enable-component shallow.wasm
```
