### PR TITLE
ci(docker): fix ChatTTS install failure on Ubuntu 24.04 plugins image

### DIFF
--- a/utils/wasi-nn/install-chattts.sh
+++ b/utils/wasi-nn/install-chattts.sh
@@ -14,6 +14,11 @@ pip install --upgrade pip
 
 # Install PyTorch CPU version to save space
 pip --python /usr/bin/python3 install --break-system-packages --index-url https://download.pytorch.org/whl/cpu 'torch<=2.6.0' 'torchaudio<=2.6.0'
+
+# The Debian-provided numpy has no RECORD file, so pip cannot uninstall it
+# when resolving a newer version. Shadow it with a pip-managed copy instead.
+pip --python /usr/bin/python3 install --break-system-packages --ignore-installed 'numpy<3.0.0'
+
 pip --python /usr/bin/python3 install --break-system-packages chattts==0.2.4, transformers==4.46.3
 
 # Remove wheel cache


### PR DESCRIPTION
## Description

The weekly `docker` workflow has been failing on `master` since 2026-06-22
(runs on 06-22, 06-29, and 07-01, e.g.
https://github.com/WasmEdge/WasmEdge/actions/runs/28485892675), with the
`Ubuntu (default)` job failing at the `plugins-2404` target:

```
#98 [plugins-2404 deps-all 18/18] RUN [ "/bin/bash", "install-chattts.sh" ]
× Cannot uninstall numpy 1.26.4
╰─> The package's contents are unknown: no RECORD file was found for numpy.
```

### Root cause

No repository change is involved; it is an upstream PyPI change:

1. In the Ubuntu 24.04 plugins image, `install-openvino.sh` pulls in the
   Debian package `python3-numpy` 1.26.4 as a dependency of the OpenVINO apt
   packages. Debian packages ship no pip `RECORD` file.
2. `install-chattts.sh` installs `chattts==0.2.4` into the system Python
   without pinning transitive dependencies.
3. scipy 1.18.0 (released 2026-06-19) requires `numpy>=2.0.0`, so pip now has
   to replace the apt-installed numpy. The uninstall aborts with
   `uninstall-no-record-file`.
4. The last successful run (06-15) resolved scipy 1.17.1, which was satisfied
   with the existing numpy 1.26.4, so nothing needed uninstalling.

### Fix

Shadow the apt-installed numpy with a pip-managed copy in `/usr/local` via
`pip install --ignore-installed 'numpy<3.0.0'` before installing ChatTTS.
The pip-managed copy has a proper `RECORD` file and takes precedence on
`sys.path`, so pip can freely resolve, upgrade, or downgrade numpy afterwards
without touching the Debian package.

This contribution was developed with assistance from Claude Fable 5
(GitHub Copilot CLI).

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines. (Shell script only; `lineguard` passed.)
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

Reproduced the CI failure and verified the fix locally with Docker
(`--platform linux/amd64`), simulating the CI image state
(`ubuntu:24.04` + apt `python3-numpy`, as pulled in by OpenVINO):

**Before the fix — identical error to CI:**

```
error: uninstall-no-record-file

× Cannot uninstall numpy 1.26.4
╰─> The package's contents are unknown: no RECORD file was found for numpy.
```

**After the fix — patched `install-chattts.sh` end-to-end on ubuntu:24.04:**

```
=== install script: EXIT 0
Successfully installed certifi-2026.6.17 cffi-2.0.0 charset_normalizer-3.4.7
chattts-0.2.4 ... numpy-2.4.6 ... scipy-1.18.0 ... transformers-4.46.3 ...
=== VERIFY: import ChatTTS with system python
numpy 2.4.6
torch 2.6.0+cpu
transformers 4.46.3
ChatTTS.Chat OK: <class 'ChatTTS.core.Chat'>
```

**Regression check on ubuntu:20.04 / 22.04 (unaffected paths):**

```
ubuntu:20.04 → final numpy: 1.24.4 (pip-managed, resolves as before)
ubuntu:22.04 → final numpy: 2.2.6  (pip-managed, resolves as before)
```