### PR TITLE
fix(common): join the async worker thread instead of detaching it

### DIFF
--- a/include/common/async.h
+++ b/include/common/async.h
@@ -35,7 +35,6 @@ public:
                          &TargetInst, std::forward<ArgsT>(Args)...)]() mutable {
           P.set_value(std::apply(FPtr, Tuple));
         });
-    Thread.detach();
   }
   Async(const Async &) noexcept = delete;
   Async(Async &&Other) noexcept : Async() { swap(*this, Other); }
@@ -43,6 +42,11 @@ public:
   Async &operator=(Async &&Other) noexcept {
     swap(*this, Other);
     return *this;
+  }
+  ~Async() noexcept {
+    if (Thread.joinable()) {
+      Thread.join();
+    }
   }
 
   bool valid() const noexcept { return Future.valid(); }
@@ -71,6 +75,9 @@ public:
   void cancel() noexcept {
     if (likely(StopFunc.operator bool())) {
       StopFunc();
+    }
+    if (Thread.joinable()) {
+      Thread.join();
     }
   }
 


### PR DESCRIPTION
## Description

`Async` runs `VM::runWasmFile` / `Executor::invoke` on a **detached** `std::thread` that captures a raw pointer to the target VM or Executor. Because the thread is detached, neither `~Async()` nor `cancel()` waits for it, so the target can be destroyed while the worker is still running:

- `WasmEdge_AsyncCancel` followed by `WasmEdge_VMDelete`: `cancel()` returns before the interpreter reaches its next stop checkpoint, so the VM (Executor, StoreManager, module instances, linear memory) is freed underneath the worker.
- `WasmEdge_AsyncDelete` while the worker is still running: the detached thread outlives the `Async` wrapper.

Both leave the worker dereferencing freed memory.

This PR keeps the thread joinable and joins it in the destructor, and joins after signalling stop in `cancel()`, so the worker has finished before the target is released. The stop token is checked and cleared at each function entry, so for interruptible execution `cancel()` still returns promptly. The existing async interrupt tests already `cancel()` and then `get()`, so their behavior is unchanged.

## Checklist

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`).
- [x] **Commit Messages**: Conventional Commit format (`fix(common): ...`).
- [x] **Local Tests Passed**: See Test Evidence below.
- [x] **Human-in-the-loop**: Every change in this PR was reviewed and verified by the author.

## Test Evidence

<img width="1470" height="956" alt="Screenshot 2026-07-05 at 3 05 46 PM" src="https://github.com/user-attachments/assets/cb9ff5be-98c4-4575-b5eb-60e01defb855" />

