### PR TITLE
feat(component): implement instantiate and execute support for core tags

### DIFF
--- a/include/runtime/instance/component/component.h
+++ b/include/runtime/instance/component/component.h
@@ -20,6 +20,7 @@
 #include "common/types.h"
 #include "runtime/instance/component/function.h"
 #include "runtime/instance/module.h"
+#include "runtime/instance/tag.h"
 
 #include <atomic>
 #include <functional>
@@ -329,6 +330,18 @@ public:
     return findExport(ExpCoreGlobInsts, Name);
   }
 
+  // Index space: core tag.
+  void addCoreTag(TagInstance *Inst) noexcept { CoreTagInsts.push_back(Inst); }
+  TagInstance *getCoreTag(uint32_t Index) const noexcept {
+    return CoreTagInsts[Index];
+  }
+  void exportCoreTag(std::string_view Name, uint32_t Idx) noexcept {
+    ExpCoreTagInsts.insert_or_assign(std::string(Name), CoreTagInsts[Idx]);
+  }
+  TagInstance *findCoreTag(std::string_view Name) const noexcept {
+    return findExport(ExpCoreTagInsts, Name);
+  }
+
   // Index space: core type.
   // TODO: deep copy the type
   void addCoreType(const AST::Component::CoreDefType &Ty) noexcept {
@@ -379,6 +392,7 @@ private:
   std::vector<MemoryInstance *> CoreMemInsts;
   std::vector<GlobalInstance *> CoreGlobInsts;
   std::vector<const AST::Component::CoreDefType *> CoreTypes;
+  std::vector<TagInstance *> CoreTagInsts;
   std::vector<const ModuleInstance *> CoreModInsts;
   std::vector<const AST::Module *> CoreMods;
 
@@ -405,6 +419,7 @@ private:
   std::map<std::string, TableInstance *, std::less<>> ExpCoreTabInsts;
   std::map<std::string, MemoryInstance *, std::less<>> ExpCoreMemInsts;
   std::map<std::string, GlobalInstance *, std::less<>> ExpCoreGlobInsts;
+  std::map<std::string, TagInstance *, std::less<>> ExpCoreTagInsts;
   // TODO: ExpCoreTypes
   std::map<std::string, const ModuleInstance *, std::less<>> ExpCoreModInsts;
   // TODO: ExpCoreMods

--- a/lib/executor/instantiate/component/component_alias.cpp
+++ b/lib/executor/instantiate/component/component_alias.cpp
@@ -75,6 +75,11 @@ Executor::instantiate(Runtime::Instance::ComponentInstance &CompInst,
         CompInst.addCoreGlobal(GlobInst);
         break;
       }
+      case AST::Component::Sort::CoreSortType::Tag: {
+        auto *TagInst = ModInst->getTagExports(FindExports);
+        CompInst.addCoreTag(TagInst);
+        break;
+      }
       case AST::Component::Sort::CoreSortType::Type:
       case AST::Component::Sort::CoreSortType::Module:
       case AST::Component::Sort::CoreSortType::Instance:

--- a/lib/executor/instantiate/component/component_instance.cpp
+++ b/lib/executor/instantiate/component/component_instance.cpp
@@ -34,7 +34,7 @@ Executor::instantiate(Runtime::Instance::ComponentInstance &CompInst,
       // Inline exports case.
       // Create a core module instance with the exports.
       auto Mod = std::make_unique<Runtime::Instance::ModuleInstance>("");
-      uint32_t ExpIdx[4] = {0, 0, 0, 0};
+      uint32_t ExpIdx[5] = {0, 0, 0, 0, 0};
 
       for (const auto &Exp : Expr.getInlineExports()) {
         const auto &SortIdx = Exp.getSortIdx();
@@ -68,6 +68,11 @@ Executor::instantiate(Runtime::Instance::ComponentInstance &CompInst,
           Mod->importGlobal(CompInst.getCoreGlobal(Idx));
           Mod->exportGlobal(Exp.getName(), ExpIdx[3]);
           ExpIdx[3]++;
+          break;
+        case AST::Component::Sort::CoreSortType::Tag:
+          Mod->importTag(CompInst.getCoreTag(Idx));
+          Mod->exportTag(Exp.getName(), ExpIdx[4]);
+          ExpIdx[4]++;
           break;
         case AST::Component::Sort::CoreSortType::Type:
         case AST::Component::Sort::CoreSortType::Module:
@@ -191,6 +196,11 @@ Executor::instantiate(Runtime::Instance::ComponentInstance &CompInst,
             Comp->addCoreGlobal(CompInst.getCoreGlobal(Idx));
             Comp->exportCoreGlobal(Exp.getName(), CoreExpIdx[3]);
             CoreExpIdx[3]++;
+            break;
+          case AST::Component::Sort::CoreSortType::Tag:
+            Comp->addCoreTag(CompInst.getCoreTag(Idx));
+            Comp->exportCoreTag(Exp.getName(), CoreExpIdx[4]);
+            CoreExpIdx[4]++;
             break;
           case AST::Component::Sort::CoreSortType::Type:
           case AST::Component::Sort::CoreSortType::Module:

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -341,7 +341,7 @@ std::map<std::string, ComponentModelSupport> ComponentModelFolders = {
     {"naming",                  {true, true,  false, false}},
     {"nested-modules",          {true, false, false, false}},
     {"resources",               {true, false, false, false}},
-    {"tags",                    {true, true,  false, false}},
+    {"tags",                    {true, true,  true, true}},
     {"type-export-restrictions",{true, false, false, false}},
     {"types",                   {true, false, false, false}},
     {"very-nested",             {true, false, false, false}},


### PR DESCRIPTION
## Description

this pr implements executor support for core tag exports/aliases in the component model, enabling tags.wast to fully pass (load, validate, instantiate, and execute).

 note : i checked tags.wast itself, and it contains zero invoke/assert_return commands , no test in that file actually calls a function or exercises runtime behavior. It only declares, aliases, and exports tags. So there's nothing for the "Execute" phase of the test harness to do for this specific file. Flipping Execute to true was safe and correct because it doesn't turn on any code path that isn't already covered by the Instantiate fix , it just tells the harness "this file is fully done," which is accurate.

Part of #4711
Related to #4236

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [ ] **AI Disclosure**: na
- [ ] **Human-in-the-loop**: na

## Test Evidence
<!-- Paste your test output screenshot or logs here -->
note: the current wasmedge-spectest version of tags.wast expects specific validator error strings ("export `` for core instance 0 is not a tag" and "unknown tag 0"), while WasmEdge's validator currently reports a more generic "unknown tag" message for both cases. The wast test harness only asserts that validation fails, not the exact message text, so this doesn't affect test results. Per point 5 of this #4711 issue, standardizing these trap messages is optional and could be addressed in a follow-up PR to the wasmedge-spectest repo if desired.

> <img width="830" height="382" alt="image" src="https://github.com/user-attachments/assets/1cd32424-81da-4ada-9458-782b2fbc1f7c" />

> <img width="796" height="431" alt="image" src="https://github.com/user-attachments/assets/6292214a-d630-4fd8-b34b-e2e08eb390a3" />


---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
