### PR TITLE
chore: pin FetchContent dependencies to commit hashes

### DIFF
--- a/cmake/Helper.cmake
+++ b/cmake/Helper.cmake
@@ -425,7 +425,7 @@ function(wasmedge_setup_simdjson)
     FetchContent_Declare(
       simdjson
       GIT_REPOSITORY https://github.com/simdjson/simdjson.git
-      GIT_TAG  tags/v3.10.0
+      GIT_TAG  ccf8694510bcf3d7d53fd58cd574d5b78bcc28aa  # v3.10.0
       GIT_SHALLOW TRUE
     )
     set(SIMDJSON_DEVELOPER_MODE OFF CACHE BOOL "SIMDJSON developer mode" FORCE)
@@ -479,7 +479,7 @@ function(wasmedge_setup_spdlog)
     FetchContent_Declare(
       fmt
       GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-      GIT_TAG        11.0.2
+      GIT_TAG        0c9fce2ffefecfdce794e1859584e25877b7b592  # 11.0.2
       GIT_SHALLOW    TRUE
     )
     set(FMT_INSTALL OFF CACHE BOOL "Generate the install target." FORCE)
@@ -509,7 +509,7 @@ function(wasmedge_setup_spdlog)
     FetchContent_Declare(
       spdlog
       GIT_REPOSITORY https://github.com/gabime/spdlog.git
-      GIT_TAG        v1.13.0
+      GIT_TAG        7c02e204c92545f869e2f04edaab1f19fe8b19fd  # v1.13.0
       GIT_SHALLOW    TRUE
     )
     set(SPDLOG_BUILD_SHARED OFF CACHE BOOL "Build shared library" FORCE)

--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -357,7 +357,7 @@ function(wasmedge_setup_llama_target target)
     FetchContent_Declare(
       llama
       GIT_REPOSITORY https://github.com/ggml-org/llama.cpp.git
-      GIT_TAG        b8757
+      GIT_TAG        a29e4c0b7b23e020107058480dabbe03b7cba6e1  # b8757
       GIT_SHALLOW    FALSE
     )
     FetchContent_MakeAvailable(llama)
@@ -515,7 +515,7 @@ function(wasmedge_setup_mlx_target target)
       FetchContent_Declare(
         mlx
         GIT_REPOSITORY https://github.com/ml-explore/mlx.git
-        GIT_TAG        v0.24.1
+        GIT_TAG        aba899cef8c9188f92eb12b173fbe5a7ef62d4aa  # v0.24.1
         GIT_SHALLOW    FALSE
       )
       set(MLX_BUILD_GGUF OFF)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
   FetchContent_Declare(
     GTest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG v1.15.2
+    GIT_TAG b514bdc898e2951020cbdca1304b75f5950d1f59  # v1.15.2
     GIT_SHALLOW TRUE
   )
   set(BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject" FORCE)

--- a/test/spec/CMakeLists.txt
+++ b/test/spec/CMakeLists.txt
@@ -9,7 +9,7 @@ message(STATUS "Downloading the WASM spec test suite")
 FetchContent_Declare(
   wasmedge_unit_test
   GIT_REPOSITORY https://github.com/WasmEdge/wasmedge-spectest
-  GIT_TAG        wasm-core-20260322
+  GIT_TAG        e1b86257eac83f3bfa643814d593e7651d5f4c28  # wasm-core-20260322
 )
 FetchContent_MakeAvailable(wasmedge_unit_test)
 message(STATUS "Downloading the WASM spec test suite -- done")


### PR DESCRIPTION
## Description

Seven `FetchContent_Declare` entries pinned their dependency with a **mutable git tag** (e.g. `GIT_TAG v1.15.2`). A tag can be force-moved or deleted upstream, so the same source tree could resolve to different code over time — a reproducibility and supply-chain hazard. This PR pins each entry to the **immutable commit the tag currently resolves to**, keeping the tag name in a trailing comment for readability:

| File | Dependency | Before | After |
|------|------------|--------|-------|
| `test/CMakeLists.txt` | googletest | `v1.15.2` | `b514bdc898e2951020cbdca1304b75f5950d1f59  # v1.15.2` |
| `test/spec/CMakeLists.txt` | wasmedge-spectest | `wasm-core-20260322` | `e1b86257eac83f3bfa643814d593e7651d5f4c28  # wasm-core-20260322` |
| `cmake/Helper.cmake` | simdjson | `tags/v3.10.0` | `ccf8694510bcf3d7d53fd58cd574d5b78bcc28aa  # v3.10.0` |
| `cmake/Helper.cmake` | fmt | `11.0.2` | `0c9fce2ffefecfdce794e1859584e25877b7b592  # 11.0.2` |
| `cmake/Helper.cmake` | spdlog | `v1.13.0` | `7c02e204c92545f869e2f04edaab1f19fe8b19fd  # v1.13.0` |
| `cmake/WASINNDeps.cmake` | llama.cpp | `b8757` | `a29e4c0b7b23e020107058480dabbe03b7cba6e1  # b8757` |
| `cmake/WASINNDeps.cmake` | mlx | `v0.24.1` | `aba899cef8c9188f92eb12b173fbe5a7ef62d4aa  # v0.24.1` |

Each hash was resolved with `git ls-remote`, peeling annotated tags with `^{}` (`wasm-core-20260322` was annotated; the rest are lightweight). **No build output changes** — each pinned commit is byte-identical to what its tag checks out today. `GIT_SHALLOW` lines are left unchanged: the pinned commit is the tag tip, so the shallow + SHA fetch path still works (already relied on by `plugins/wasmedge_stablediffusion`, which pins a full commit under `GIT_SHALLOW TRUE`).

**Deliberately left unchanged:** the 8 entries already pinned to full hashes; the 2 abbreviated-hash pins (`tokenizers-cpp 55d53aa`, `BitNet 404980e`, which are commits, not tags); and `${WASMEDGE_DEPS_VERSION}` (a variable). GitHub Actions (already SHA-pinned with version comments) and the Nix flake (pinned via `flake.lock`) were audited and need no change.

> This contribution was developed with assistance from Claude (Anthropic).

## Checklist

- [x] **DCO Signed-off**: single commit, `git commit -s`; `Signed-off-by:` matches the author.
- [x] **Commit Messages**: Conventional Commit (`chore: pin FetchContent dependencies to commit hashes`, 53-char header).
- [x] **Coding Style**: N/A — CMake-only change, no C/C++ modified (`clang-format` not applicable).
- [x] **Local Tests Passed**: see Test Evidence below.

AI-assisted tooling:

- [x] **AI Disclosure**: `Assisted-by: Claude (Anthropic)` trailer in the commit and noted in this description.
- [x] **Human-in-the-loop**: reviewed by the author (@ibmibmibm) before submission.

## Test Evidence

`lineguard` clean on all 4 changed files:

```
Checking 4 files...
✓ All files passed lint checks!
  Files checked: 4
```

Targeted configure exercising the fetch-by-hash path:

```
$ cmake -S . -B build-verify -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_USE_LLVM=OFF -DWASMEDGE_BUILD_TOOLS=OFF
-- Configuring done
-- Generating done
-- Build files have been written to: .../build-verify   (exit 0)
```

Inspecting `build-verify/_deps/*-src` HEADs confirmed each fetched dependency checked out the exact newly pinned hash (i.e. no system package short-circuited the pin):

- `gtest-src` → `b514bdc898e2951020cbdca1304b75f5950d1f59` (fetched under `GIT_SHALLOW TRUE`, confirming the shallow + SHA path works)
- `wasmedge_unit_test-src` → `e1b86257eac83f3bfa643814d593e7651d5f4c28`
- `simdjson-src` → `ccf8694510bcf3d7d53fd58cd574d5b78bcc28aa`
- `fmt-src` → `0c9fce2ffefecfdce794e1859584e25877b7b592`
- `spdlog-src` → `7c02e204c92545f869e2f04edaab1f19fe8b19fd`

(`llama.cpp` and `mlx` are gated behind WASI-NN GGML/MLX backend flags not enabled by this configure; their pinned hashes are the exact commits their tags resolve to.)
