### PR TITLE
feat(component): enforce case-insensitive parameter validation

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1171,7 +1171,10 @@ E(ElemSegDoesNotFit, 0x0304, "elements segment does not fit")
 // Invalid core sort for component export
 E(InvalidCoreSort, 0x03A0, "invalid core sort")
 // Canonical option lifting failed
-E(InvalidCanonOption, 0x03A1, "invalid canonical option")
+E(InvalidCanonOption, 0x02C2, "canonical option")
+// Function parameter name conflict
+E(FuncParamNameConflict, 0x02C3,
+  "function parameter name conflicts with previous parameter name")
 // Invalid export core exports
 E(CoreInvalidExport, 0x03A2, "invalid export in core module")
 // Invalid resource.drop args

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -2908,7 +2908,7 @@ Validator::validate(const AST::Component::DefValType &DVT) noexcept {
 
 Expect<void> Validator::validate(const AST::Component::FuncType &FT) noexcept {
   // Validate param names: kebab-case + unique
-  std::unordered_set<std::string_view> ParamNames;
+  std::unordered_map<std::string, std::string> ParamNames;
   for (const auto &P : FT.getParamList()) {
     if (!P.getLabel().empty()) {
       if (!isKebabString(P.getLabel())) {
@@ -2918,11 +2918,15 @@ Expect<void> Validator::validate(const AST::Component::FuncType &FT) noexcept {
             P.getLabel());
         return Unexpect(ErrCode::Value::ComponentNameNotKebab);
       }
-      if (!ParamNames.insert(P.getLabel()).second) {
-        spdlog::error(ErrCode::Value::ComponentDuplicateName);
-        spdlog::error("    FuncType: duplicate parameter name '{}'"sv,
-                      P.getLabel());
-        return Unexpect(ErrCode::Value::ComponentDuplicateName);
+      auto Normalized = toLowerStr(P.getLabel());
+      auto [It, Inserted] =
+          ParamNames.emplace(Normalized, std::string(P.getLabel()));
+      if (!Inserted) {
+        spdlog::error(ErrCode::Value::FuncParamNameConflict);
+        spdlog::error(
+            "    function parameter name `{}` conflicts with previous parameter name `{}`"sv,
+            P.getLabel(), It->second);
+        return Unexpect(ErrCode::Value::FuncParamNameConflict);
       }
     }
     EXPECTED_TRY(validate(P.getValType()));

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -325,7 +325,7 @@ std::map<std::string, ComponentModelSupport> ComponentModelFolders = {
     {"export",                  {true, true,  false, false}},
     {"export-ascription",       {true, true,  false, false}},
     {"export-introduces-alias", {true, true,  true,  false}},
-    {"func",                    {true, false, false, false}},
+    {"func",                    {true, true,  true,  true}},
     {"import",                  {true, false, false, false}},
     {"imports-exports",         {true, true,  false, false}},
     {"inline-exports",          {true, true,  true,  false}},


### PR DESCRIPTION
## Description
addresses the executor implementation tracking issue #4711 by completing the underlying validation logic and enabling the full compliance pipeline for the `func` spec test entry.

Part of https://github.com/WasmEdge/WasmEdge/issues/4711
Related to https://github.com/WasmEdge/WasmEdge/issues/4236

notes: 

- Set the phase flags for the func section to {true, true, true, true}, fully enabling all stages: Load, Validate, Instantiate, and Execute across the entire func.wast test suite.

-  Implemented case-insensitive uniqueness constraints on function type parameter names using std::unordered_map to track normalized lowercase keys while maintaining diagnostic fidelity.

- Error Specifications (enum.inc): Added spec-compliant error definitions for InvalidCanonOption (0x02C2) and FuncParamNameConflict (0x02C3) to match expected assertion failures.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [ ] **AI Disclosure**:  na
- [ ] **Human-in-the-loop**:  na

## Test Evidence
<img width="819" height="535" alt="image" src="https://github.com/user-attachments/assets/4664c01e-a37c-44fb-b911-b3ee442a743e" />

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
