### PR TITLE
fix(utils): prevent sed syntax error in uninstall.sh on duplicate env…

### DIFF
--- a/.github/scripts/installer-test-helpers.sh
+++ b/.github/scripts/installer-test-helpers.sh
@@ -54,3 +54,17 @@ verify_shell_config() {
     echo "✓ --no-modify-shell-profile works"
   fi
 }
+
+test_uninstall_duplicates() {
+  printf "\n=== Test: Uninstall duplicate env configs ===\n"
+  bash utils/install.sh -D
+  echo ". \"$HOME/.wasmedge/env\"" >> ~/.bashrc
+  echo ". \"$HOME/.wasmedge/env\"" >> ~/.bashrc
+  bash utils/uninstall.sh -q -V
+  if grep -q ". \"$HOME/.wasmedge/env\"" ~/.bashrc 2>/dev/null; then
+    echo "✗ Duplicate entries were not successfully removed"
+    exit 1
+  else
+    echo "✓ Duplicate entries removed successfully"
+  fi
+}

--- a/.github/scripts/installer-test-helpers.sh
+++ b/.github/scripts/installer-test-helpers.sh
@@ -55,16 +55,23 @@ verify_shell_config() {
   fi
 }
 
-test_uninstall_duplicates() {
-  printf "\n=== Test: Uninstall duplicate env configs ===\n"
+# Verify uninstaller successfully handles duplicate env configurations
+verify_uninstall_duplicate_env() {
+  local config_file="$HOME/.bashrc"
+  
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    config_file="$HOME/.bash_profile"
+  fi
+
   bash utils/install.sh -D
-  echo ". \"$HOME/.wasmedge/env\"" >> ~/.bashrc
-  echo ". \"$HOME/.wasmedge/env\"" >> ~/.bashrc
+  echo ". \"$HOME/.wasmedge/env\"" >> "$config_file"
+  echo ". \"$HOME/.wasmedge/env\"" >> "$config_file"
   bash utils/uninstall.sh -q -V
-  if grep -q ". \"$HOME/.wasmedge/env\"" ~/.bashrc 2>/dev/null; then
-    echo "✗ Duplicate entries were not successfully removed"
+  
+  if [ -f "$config_file" ] && grep -q ". \"$HOME/.wasmedge/env\"" "$config_file"; then
+    echo "✗ Duplicate entries were not successfully removed from $config_file"
     exit 1
   else
-    echo "✓ Duplicate entries removed successfully"
+    echo "✓ Duplicate entries removed successfully from $config_file"
   fi
 }

--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -141,6 +141,17 @@ jobs:
         verify_version "${LATEST_VERSION}"
         bash utils/uninstall.sh -q -V
 
+        # Test uninstall with duplicate env configurations (PR #5140)
+        printf "\n=== Test 1.5: Uninstall duplicate env configs ===\n"
+        bash utils/install.sh -D
+        echo ". \"\$HOME/.wasmedge/env\"" >> ~/.bashrc
+        echo ". \"\$HOME/.wasmedge/env\"" >> ~/.bashrc
+        bash utils/uninstall.sh -q -V
+        if grep -q ". \"\$HOME/.wasmedge/env\"" ~/.bashrc; then
+          echo "[FAIL] Duplicate entries were not successfully removed"
+          exit 1
+        fi
+
         # Test plugin installation
         printf "\n=== Test 2: Specific version with plugin ===\n"
         bash utils/install.sh -v ${TEST_VERSION} --plugins wasi_nn-ggml -D

--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -142,15 +142,7 @@ jobs:
         bash utils/uninstall.sh -q -V
 
         # Test uninstall with duplicate env configurations (PR #5140)
-        printf "\n=== Test 1.5: Uninstall duplicate env configs ===\n"
-        bash utils/install.sh -D
-        echo ". \"\$HOME/.wasmedge/env\"" >> ~/.bashrc
-        echo ". \"\$HOME/.wasmedge/env\"" >> ~/.bashrc
-        bash utils/uninstall.sh -q -V
-        if grep -q ". \"\$HOME/.wasmedge/env\"" ~/.bashrc; then
-          echo "[FAIL] Duplicate entries were not successfully removed"
-          exit 1
-        fi
+        test_uninstall_duplicates
 
         # Test plugin installation
         printf "\n=== Test 2: Specific version with plugin ===\n"

--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -142,7 +142,8 @@ jobs:
         bash utils/uninstall.sh -q -V
 
         # Test uninstall with duplicate env configurations (PR #5140)
-        test_uninstall_duplicates
+        printf "\n=== Test: Uninstall duplicate env configs ===\n"
+        verify_uninstall_duplicate_env
 
         # Test plugin installation
         printf "\n=== Test 2: Specific version with plugin ===\n"

--- a/utils/uninstall.sh
+++ b/utils/uninstall.sh
@@ -260,11 +260,10 @@ main() {
 
     for file in "${__HOME__}/${_shell_rc}" "${__HOME__}/.profile" "${__HOME__}/.bash_profile"; do
       [[ -f "$file" ]] || continue
-      line_num="$(grep -n ". \"${IPATH}/env\"" "$file" | cut -d : -f 1)"
-      [[ -n "$line_num" ]] || continue
+      grep -q ". \"${IPATH}/env\"" "$file" || continue
       real_file="$(resolve_path "$file")"
       cp "$real_file" "$real_file.bak"
-      sed "${line_num}d" "$real_file.bak" > "$real_file"
+      sed "\#\. \"${IPATH}/env\"#d" "$real_file.bak" > "$real_file"
       rm -f "$real_file.bak"
     done
 


### PR DESCRIPTION
## Description
This PR resolves a syntax error in the uninstaller script (`utils/uninstall.sh`) that causes it to crash when a user's shell profile (such as `.bashrc` or `.profile`) contains duplicate WasmEdge env config entries. 

Currently, the script uses `grep -n` to find the line numbers of `. "${IPATH}/env"` and feeds them into `sed`. If multiple entries are found, `line_num` holds multiple lines separated by newlines (e.g., `25\n28`), causing `sed` to fail with:
`sed: -e expression # 1, char 5: unknown command: '\n'`

This PR replaces the line-number-based deletion with direct pattern-based deletion in `sed`:
`sed "\#\. \"${IPATH}/env\"#d"`

This safely removes all duplicate configurations in a single pass without crashing.

This contribution was developed with assistance from Gemini (Google).

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
Verified manually by creating a mock profile with multiple env lines and running the uninstaller loop:

```bash
# Before running uninstaller:
# Some other configs
export PATH=/usr/local/bin:$PATH
. "/home/norway-02/.wasmedge/env"
export FOO=bar
. "/home/norway-02/.wasmedge/env"
# End of configs

# After running fixed uninstaller:
# Some other configs
export PATH=/usr/local/bin:$PATH
export FOO=bar
# End of configs