### PR TITLE
chore: scope third-party warning suppressions to their own sources

### DIFF
--- a/cmake/Helper.cmake
+++ b/cmake/Helper.cmake
@@ -408,6 +408,22 @@ if((WASMEDGE_LINK_LLVM_STATIC OR WASMEDGE_BUILD_STATIC_LIB) AND WASMEDGE_USE_LLV
   endif()
 endif()
 
+# Re-export a target's interface include directories as system includes, so that
+# consumers reach its headers through -isystem / -external:I instead of -I and
+# never compile them with the project warning flags. The SYSTEM target property
+# would do this directly, but it needs CMake 3.25 and the floor here is 3.18.
+function(wasmedge_mark_system_includes target)
+  if(NOT TARGET ${target})
+    return()
+  endif()
+  get_target_property(WASMEDGE_SYSTEM_INCLUDE_DIRS
+    ${target} INTERFACE_INCLUDE_DIRECTORIES)
+  if(WASMEDGE_SYSTEM_INCLUDE_DIRS)
+    set_property(TARGET ${target} PROPERTY
+      INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${WASMEDGE_SYSTEM_INCLUDE_DIRS})
+  endif()
+endfunction()
+
 function(wasmedge_setup_simdjson)
   if(TARGET simdjson::simdjson)
     return()
@@ -435,16 +451,14 @@ function(wasmedge_setup_simdjson)
 
     # Consumers pull in simdjson through -isystem / -external:I so that its
     # headers are never compiled with the project warning flags, the same way
-    # gtest is already treated.
-    get_target_property(SIMDJSON_INCLUDE_DIRS simdjson INTERFACE_INCLUDE_DIRECTORIES)
-    if(SIMDJSON_INCLUDE_DIRS)
-      set_property(TARGET simdjson PROPERTY
-        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${SIMDJSON_INCLUDE_DIRS})
-    endif()
+    # gtest is already treated. The suppressions below then only have to cover
+    # simdjson's own sources, which inherit WASMEDGE_CFLAGS from the enclosing
+    # directory scope.
+    wasmedge_mark_system_includes(simdjson)
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       target_compile_options(simdjson
-        PUBLIC
+        PRIVATE
         -Wno-undef
         -Wno-suggest-override
         -Wno-documentation
@@ -465,7 +479,7 @@ function(wasmedge_setup_simdjson)
       )
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
       target_compile_options(simdjson
-        PUBLIC
+        PRIVATE
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4100> # unreferenced formal parameter
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4505> # unreferenced local function has been removed
       )

--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -371,6 +371,15 @@ function(wasmedge_setup_llama_target target)
     if(WASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_CUBLAS)
       set_property(TARGET ggml-cuda PROPERTY POSITION_INDEPENDENT_CODE ON)
     endif()
+
+    # Reach llama.cpp's headers through -isystem / -external:I. They are pulled
+    # into this plugin's own translation units, so without this they compile
+    # under WASMEDGE_CFLAGS and trip -Werror on clang-cl, where -Wall means
+    # -Weverything.
+    foreach(LLAMA_TARGET IN ITEMS
+        common ggml ggml-base ggml-cpu ggml-cuda llama mtmd)
+      wasmedge_mark_system_includes(${LLAMA_TARGET})
+    endforeach()
   endif()
   # Ignore unused function warnings in common.h in llama.cpp.
   if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
@@ -379,12 +388,16 @@ function(wasmedge_setup_llama_target target)
       -Wno-error=unused-function
     )
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # The GGML sources index vectors with int, which clang-cl reports under
+    # -Weverything. Keep the diagnostics, but do not fail the build on them.
     target_compile_options(${target}
       PRIVATE
       -Wno-error=unused-function
       -Wno-error=implicit-float-conversion
       -Wno-error=documentation
       -Wno-error=unused-template
+      -Wno-error=sign-conversion
+      -Wno-error=extra-semi-stmt
     )
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     target_compile_options(${target}

--- a/plugins/wasi_nn/GGML/core/ggml_core.cpp
+++ b/plugins/wasi_nn/GGML/core/ggml_core.cpp
@@ -127,7 +127,8 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, WASINN::Graph &G,
                 "\"ggml-model.bin\" and passing this filename as a "sv
                 "parameter to the ggml llama library."sv)
     }
-    TempFile.write(BinModel.data(), BinModel.size());
+    TempFile.write(BinModel.data(),
+                   static_cast<std::streamsize>(BinModel.size()));
     TempFile.close();
     LOG_DEBUG(GraphRef.EnableDebugLog,
               "load: Write model into a tmpfile...Done"sv)

--- a/plugins/wasi_nn/wasinnenv.cpp
+++ b/plugins/wasi_nn/wasinnenv.cpp
@@ -55,8 +55,13 @@ bool load(const std::filesystem::path &Path, std::vector<uint8_t> &Data) {
   File.seekg(0, std::ios::end);
   std::streampos FileSize = File.tellg();
   File.seekg(0, std::ios::beg);
-  Data.resize(FileSize);
-  File.read(reinterpret_cast<char *>(Data.data()), FileSize);
+  if (FileSize < 0) {
+    spdlog::error("[WASI-NN] Preload model fail."sv);
+    return false;
+  }
+  Data.resize(static_cast<size_t>(FileSize));
+  File.read(reinterpret_cast<char *>(Data.data()),
+            static_cast<std::streamsize>(FileSize));
   File.close();
   return true;
 }

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -48,7 +48,7 @@ void resolveRegister(std::map<std::string, std::string> &Alias,
                      simdjson::dom::array &CmdArray) {
   std::string_view OrgName;
   uint64_t LastModLine = 0;
-  for (const simdjson::dom::object &Cmd : CmdArray) {
+  for (const simdjson::dom::object Cmd : CmdArray) {
     std::string_view CmdType = Cmd["type"];
     if (CmdType == "module"sv) {
       // Record last module in order
@@ -127,7 +127,7 @@ parseValueList(const simdjson::dom::array &Args) {
   std::vector<WasmEdge::ValType> ResultTypes;
   Result.reserve(Args.size());
   ResultTypes.reserve(Args.size());
-  for (const simdjson::dom::object &Element : Args) {
+  for (const simdjson::dom::object Element : Args) {
     std::string_view Type = Element["type"];
     simdjson::dom::element Value = Element["value"];
     if (Value.type() == simdjson::dom::element_type::ARRAY) {
@@ -203,7 +203,7 @@ std::vector<std::pair<std::string, std::string>>
 parseExpectedList(const simdjson::dom::array &Args) {
   std::vector<std::pair<std::string, std::string>> Result;
   Result.reserve(Args.size());
-  for (const simdjson::dom::object &Element : Args) {
+  for (const simdjson::dom::object Element : Args) {
     std::string_view Type = Element["type"];
     simdjson::dom::element Value;
     auto NoValue = Element["value"].get(Value);
@@ -1157,7 +1157,7 @@ void SpecTest::processCommands(ContextHandle Ctx, std::string_view Proposal,
         // and the register commands inside the thread tell us what names
         // to register them under.
         std::map<std::string, std::string> SharedRegisterMap;
-        for (const simdjson::dom::object &SubCmd : ThreadCmds) {
+        for (const simdjson::dom::object SubCmd : ThreadCmds) {
           std::string_view SubType;
           if (!SubCmd["type"].get(SubType) && SubType == "register"sv) {
             std::string_view RegName, RegAs;
@@ -1171,7 +1171,7 @@ void SpecTest::processCommands(ContextHandle Ctx, std::string_view Proposal,
         std::vector<std::pair<std::string, std::string>> SharedModules;
         simdjson::dom::array SharedArray;
         if (!Cmd["shared"].get(SharedArray)) {
-          for (const simdjson::dom::object &SharedEntry : SharedArray) {
+          for (const simdjson::dom::object SharedEntry : SharedArray) {
             std::string_view ModRef = SharedEntry["module"];
             std::string OrigName(ModRef);
             // Resolve parent store name through alias.
@@ -1228,7 +1228,7 @@ void SpecTest::processCommands(ContextHandle Ctx, std::string_view Proposal,
   };
 
   // Iterate commands.
-  for (const simdjson::dom::object &Cmd : CmdArray) {
+  for (const simdjson::dom::object Cmd : CmdArray) {
     RunCommand(Cmd);
   }
 


### PR DESCRIPTION
## Description

> **Ready for review.** CI is green (`codecov/patch` is the only red — a coverage-delta on two plugin lines that execute only under a loaded model, which the coverage suite does not run; `codecov/project` passes). The wasi_nn surface here is worth a careful look — see **What CI still has to decide** and the two flagged items at the end.

Follow-up to #5131, which upgraded simdjson to v4.6.4 and exposed simdjson's interface include directories as **system includes** (`-isystem`, or `-external:I` on MSVC).

The two per-compiler suppression lists on the `simdjson` target are attached as `PUBLIC`. CMake therefore appends them to the command line of **every source of every target that links simdjson** — not merely to files that `#include` it. That silently disabled 17 warnings (`-Wno-sign-conversion`, `-Wno-old-style-cast`, `-Wno-implicit-int-conversion`, `/wd4100`, …) across `test/spec/spectest.cpp` and the whole `plugins/wasi_nn` target, for those targets' **own code**. That was never the intent.

This PR narrows both lists to `PRIVATE`. Now that consumers reach simdjson's headers through `-isystem`, the lists only have to cover simdjson's own sources, which they still do.

### What the leak was hiding

Removing it surfaced three real problems. All three are invisible on Linux, because the warnings involved are not in `-Wall -Wextra`. They are visible on the Windows job because **clang-cl treats `-Wall` as MSVC's `/Wall`, which expands to `-Weverything`**. (That is also why `WASMEDGE_CFLAGS` carries `-Weverything`-only suppressions such as `-Wno-c++98-compat` and `-Wno-padded`, even though `-Weverything` appears nowhere in the CMake.)

**1. `spectest.cpp` bound loop variables to temporaries** — six sites:

```cpp
for (const simdjson::dom::object &Cmd : CmdArray) {   // binds to a temporary
```

`simdjson::dom::array` iteration yields elements **by value**, so the `const&` binds to a temporary (`-Wrange-loop-bind-reference`). `dom::object` is a lightweight handle (a tape pointer plus an index), so the reference bought nothing and misstated the lifetime. Fixed by iterating by value.

**2. Two unchecked narrowings in the wasi_nn plugin** (`-Wsign-conversion`):

```
plugins\wasi_nn\wasinnenv.cpp(58,15):            'streamoff' -> 'size_type'
plugins\wasi_nn\GGML\core\ggml_core.cpp(130,46): 'size_type' -> 'std::streamsize'
```

Neither file includes simdjson. They were covered only because their *target* links it. Fixed with explicit `static_cast`s, matching the surrounding style.

**3. llama.cpp's headers were compiled under our warning flags.** `common/base64.hpp` reaches the plugin's own translation units through plain `-I`, so it was compiled with `WASMEDGE_CFLAGS` and survived `-Werror` only because simdjson leaked `-Wno-sign-conversion` and `-Wno-implicit-int-conversion` onto the plugin target. Eight errors, in a vendored third-party header we do not control.

The fix is the same one #5131 applied to simdjson: mark llama.cpp's interface include directories as system includes, so consumers get `-isystem` / `-external:I`. Since two dependencies now need this, it is factored into `wasmedge_mark_system_includes()`. (`INTERFACE_SYSTEM_INCLUDE_DIRECTORIES` rather than CMake 3.25's `SYSTEM` property, because the floor here is 3.18.)

The existing `-Wno-error=` block for llama.cpp is left untouched — this PR does not try to prove it dead.

### Verified

Locally on GCC 15.2.0 and Clang 21.1.8: `simdjson` and both consuming test suites build with zero warnings under `-Wall -Wextra -Werror`, and both suites pass.

Scoping was checked against `compile_commands.json` rather than assumed:

| TU | simdjson suppression flags | `-isystem` simdjson |
|---|---|---|
| `simdjson.cpp` (own source) | all retained | no |
| `spectest.cpp` (consumer) | none | yes |

The `-Wno-` flags still on `spectest.cpp` come from `test/CMakeLists.txt`, not from simdjson.

Because Linux cannot see these warnings, each consumer was recompiled with all 17 formerly-leaked warnings re-enabled:

- `spectest.cpp`: 6 × `-Wrange-loop-bind-reference` before the fix, **0** after.
- `wasinnenv.cpp`, `wasinnfunc.cpp`, `wasinnmodule.cpp`, `ggml_core.cpp`, `GGML/utils.cpp`, `GGML/metadata/metadata_parser.cpp`: **0 errors, 0 warnings** after the fixes.
- `base64.hpp` reached from `ggml_core.cpp`: **12** warnings with llama on `-I`, **0** with llama on `-isystem`. Verified both directions, so the suppression is attributable to the change rather than to the probe missing the header.

No warning is attributed to any simdjson or llama.cpp header, confirming the system includes do their job.

### CI history on this branch

| Run | Change | Result |
|---|---|---|
| 1 | delete both suppression lists | `Windows` + `Windows-MSVC` red — the lists are load-bearing for simdjson's own sources |
| 2 | `PRIVATE` + `spectest.cpp` loop fix | `Windows`, `Windows-MSVC`, all `macOS` **green**; `WASI-NN (Windows)` red on `wasinnenv.cpp` |
| 3 | + `wasinnenv.cpp` cast | 92 checks green; `WASI-NN (Windows)` red on `base64.hpp` + `ggml_core.cpp` |
| 4 | + llama system includes, `ggml_core.cpp` cast | 107 green; whole plugin backend matrix passed; `WASI-NN (Windows)` red on 51 masked `-Wsign-conversion` sites in GGML's own sources |
| 5 | + `-Wno-error=sign-conversion` / `extra-semi-stmt` on the plugin target | `WASI-NN (Windows)` **green**; whole matrix green |
| 6 | + negative-`tellg()` guard in `load()` (Copilot review) | green (one OpenVINO clang job flaked, passed on rerun) |

### Reviewer notes — two things worth a close look

1. **`-Wno-error=sign-conversion` / `-Wno-error=extra-semi-stmt` on the wasi_nn target.** These demote (do not silence) 51 real sites in GGML's own sources, 40 of them `int`-indexed `std::vector` access in `GGML/tts/tts_core.cpp`'s FFT routines. They keep the build green without reworking signed index arithmetic in code that cannot be runtime-tested here. A follow-up should burn these down and remove the two flags.
2. **llama.cpp `-isystem` treatment.** `wasmedge_mark_system_includes()` re-exports llama's interface include dirs as system includes so its headers stop compiling under `-Werror`. This is the same fix #5131 applied to simdjson; the existing `-Wno-error=` block for llama is left untouched rather than assumed dead.

### The GGML sign-conversion sites (run 4 → 5)

Run 4 turned the entire plugin backend matrix green — whisper, piper, mlx, chattts, openvino, pytorch, bitnet, tensorflow, across manylinux / ubuntu / darwin — and confirmed no warning comes from any llama.cpp or simdjson header. The only remaining failure was `WASI-NN (Windows)`, and every error was now in **WasmEdge's own GGML sources**: 51 unique `-Wsign-conversion` / `-Wextra-semi-stmt` sites, 40 of them in `GGML/tts/tts_core.cpp`, which index `std::vector` with `int` loop counters in FFT routines.

These are the last thing the leak was hiding. Fixing all 51 means reworking signed index arithmetic in DSP code, which does not belong in a build-scoping change. Instead they are added to the plugin target's **existing** `-Wno-error=` block — the one already carrying `-Wno-error=unused-function`, `-Wno-error=documentation`, `-Wno-error=unused-template` for llama.cpp. `-Wno-error=` demotes without silencing: the diagnostics still print, the build no longer fails. Verified on the configured `tts_core.cpp` command line — 50 warnings / 0 errors with the flags, 50 errors / exit 1 without — and a full re-sweep of all 23 plugin TUs now passes with `-Werror` still on. A follow-up should burn the sites down and remove the two flags.

Still unverified locally: AppleClang and CI's clang 15 / 16 / 18, though all `macOS` jobs passed from run 2 onward.

> This contribution was developed with assistance from Claude (Anthropic). The commit carries the `Assisted-by: Claude (Anthropic)` trailer, and a human verified the change and test results.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

```
$ g++ --version | head -1
g++ (Ubuntu 15.2.0-16ubuntu1) 15.2.0
$ cmake --build build --target simdjson wasmedgeExecutorCoreTests wasmedgeComponentRegressionTests
gcc: warnings = 0, errors = 0
$ ctest -R 'wasmedgeExecutorCoreTests|wasmedgeComponentRegressionTests'
100% tests passed, 0 tests failed out of 2

$ clang++ --version | head -1
Ubuntu clang version 21.1.8 (6ubuntu1)
$ cmake --build build-clang --target simdjson wasmedgeExecutorCoreTests wasmedgeComponentRegressionTests
clang: warnings = 0, errors = 0
$ ctest -R 'wasmedgeExecutorCoreTests|wasmedgeComponentRegressionTests'
100% tests passed, 0 tests failed out of 2

$ clang-format --dry-run -Werror test/spec/spectest.cpp plugins/wasi_nn/wasinnenv.cpp \
    plugins/wasi_nn/GGML/core/ggml_core.cpp    # exit 0
$ lineguard --config .lineguardrc <all 5 changed files>
✓ All files passed lint checks!
```

wasi_nn plugin TUs recompiled with the 17 formerly-leaked warnings re-enabled (GGML backend configured, llama.cpp fetched):

```
  utils.cpp             errors=0 warnings=0
  wasinnenv.cpp         errors=0 warnings=0
  wasinnfunc.cpp        errors=0 warnings=0
  wasinnmodule.cpp      errors=0 warnings=0
  ggml_core.cpp         errors=0 warnings=0
  metadata_parser.cpp   errors=0 warnings=0

base64.hpp warnings with llama on -I:       12
base64.hpp warnings with llama on -isystem:  0
```

(The two `-Wimplicit-int-conversion` hits in `include/common/int128.h` seen during probing are a Linux-only artifact of the `unsigned __int128` path; core lib TUs include that header on Windows without simdjson's flags and are green, so it cannot regress there.)
