### PR TITLE
examples(capi): add minimal fibonacci C API example

### DIFF
--- a/examples/capi/fibonacci/Makefile
+++ b/examples/capi/fibonacci/Makefile
@@ -1,0 +1,10 @@
+CXX = g++
+WASMEDGE ?= $(HOME)/.local/wasmedge
+CXXFLAGS = -I$(WASMEDGE)/include
+LDFLAGS = -L$(WASMEDGE)/lib64 -lwasmedge -Wl,-rpath,$(WASMEDGE)/lib64
+
+run_fib: run_fib.cpp
+	$(CXX) $(CXXFLAGS) $^ $(LDFLAGS) -o $@
+
+clean:
+	rm -f run_fib

--- a/examples/capi/fibonacci/README.md
+++ b/examples/capi/fibonacci/README.md
@@ -1,0 +1,31 @@
+# Fibonacci example with WasmEdge C API
+
+Load `fibonacci.wasm` and call the exported `fib` function.
+
+The WASM module is built from [`../../wasm/fibonacci.wat`](../../wasm/fibonacci.wat). See [`../../wasm/README.md`](../../wasm/README.md) for `wat2wasm` instructions.
+
+## Prerequisites
+
+- WasmEdge installed (tested with 0.17.x)
+- `g++` and the WasmEdge C API headers/library
+
+## Build and run
+
+```bash
+cd examples/capi/fibonacci
+make
+./run_fib 8
+```
+
+Expected output:
+
+```text
+fib(8) = 34
+```
+
+If WasmEdge is not in the default library path:
+
+```bash
+export LD_LIBRARY_PATH="$HOME/.local/wasmedge/lib64:$LD_LIBRARY_PATH"
+make WASMEDGE=$HOME/.local/wasmedge
+```

--- a/examples/capi/fibonacci/run_fib.cpp
+++ b/examples/capi/fibonacci/run_fib.cpp
@@ -1,0 +1,32 @@
+#include <cstdio>
+#include <cstdlib>
+#include <wasmedge/wasmedge.h>
+
+int main(int Argc, const char *Argv[]) {
+  const char *WasmFile = "../../wasm/fibonacci.wasm";
+  int N = 8;
+  if (Argc > 1) {
+    N = std::atoi(Argv[1]);
+  }
+
+  WasmEdge_VMContext *VMCxt = WasmEdge_VMCreate(nullptr, nullptr);
+  WasmEdge_Value Params[1] = {WasmEdge_ValueGenI32(N)};
+  WasmEdge_Value Returns[1];
+  WasmEdge_String FuncName = WasmEdge_StringCreateByCString("fib");
+
+  WasmEdge_Result Res = WasmEdge_VMRunWasmFromFile(
+      VMCxt, WasmFile, FuncName, Params, 1, Returns, 1);
+
+  if (WasmEdge_ResultOK(Res)) {
+    printf("fib(%d) = %d\n", N, WasmEdge_ValueGetI32(Returns[0]));
+  } else {
+    printf("Error: %s\n", WasmEdge_ResultGetMessage(Res));
+    WasmEdge_StringDelete(FuncName);
+    WasmEdge_VMDelete(VMCxt);
+    return 1;
+  }
+
+  WasmEdge_StringDelete(FuncName);
+  WasmEdge_VMDelete(VMCxt);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- Add `examples/capi/fibonacci/` with a small C API host program
- Reuses `examples/wasm/fibonacci.wasm` from `fibonacci.wat`
- Makefile targets a preinstalled WasmEdge (tested with 0.17.1)

## Why
`embed_cxx` needs a full cmake/wasi-sdk build. This is a lighter entry point for learning `WasmEdge_VMRunWasmFromFile`.

## Test plan
- [x] `wat2wasm ../../wasm/fibonacci.wat -o ../../wasm/fibonacci.wasm`
- [x] `make && ./run_fib 8` → `fib(8) = 34`

Related docs work: https://github.com/WasmEdge/docs/pull/310