### PR TITLE
fix(coredump): bound corestack value serialization

### DIFF
--- a/lib/executor/coredump.cpp
+++ b/lib/executor/coredump.cpp
@@ -6,6 +6,7 @@
 #include "common/types.h"
 #include "runtime/stackmgr.h"
 #include "spdlog/spdlog.h"
+#include <array>
 #include <cstdint>
 #include <cstring>
 #include <vector>
@@ -14,6 +15,18 @@ using namespace std::literals;
 
 namespace WasmEdge {
 namespace Coredump {
+namespace {
+
+std::array<Byte, sizeof(uint32_t)>
+serializeCoreStackValue(const Runtime::StackManager::Value &Value) noexcept {
+  std::array<Byte, sizeof(uint32_t)> ValueBytes{};
+  const auto RawValue = Value.unwrap();
+  std::memcpy(ValueBytes.data(), &RawValue, ValueBytes.size());
+  return ValueBytes;
+}
+
+} // namespace
+
 void generateCoredump(const Runtime::StackManager &StackMgr,
                       bool ForWasmgdb) noexcept {
   spdlog::info("Generating coredump..."sv);
@@ -128,9 +141,7 @@ AST::CustomSection createCorestack(
       // 0x7F implies i32. i128 is not supported here, and wasmgdb does not
       // support i64.
       Content.push_back(0x7F);
-      auto Value = Iter.unwrap();
-      std::vector<Byte> ValueBytes(4);
-      std::memcpy(ValueBytes.data(), &Value, sizeof(int64_t));
+      auto ValueBytes = serializeCoreStackValue(Iter);
       Content.insert(Content.end(), ValueBytes.begin(), ValueBytes.end());
     }
     if (!ForWasmgdb) {
@@ -138,9 +149,7 @@ AST::CustomSection createCorestack(
         // 0x7F implies i32. i128 is not supported here, and wasmgdb does not
         // support i64.
         Content.push_back(0x7F);
-        auto Value = Iter.unwrap();
-        std::vector<Byte> ValueBytes(4);
-        std::memcpy(ValueBytes.data(), &Value, sizeof(int64_t));
+        auto ValueBytes = serializeCoreStackValue(Iter);
         Content.insert(Content.end(), ValueBytes.begin(), ValueBytes.end());
       }
     }

--- a/test/executor/ExecutorTest.cpp
+++ b/test/executor/ExecutorTest.cpp
@@ -20,6 +20,7 @@
 #include "../spec/hostfunc.h"
 #include "../spec/spectest.h"
 
+#include <algorithm>
 #include <gtest/gtest.h>
 
 #include <array>
@@ -39,6 +40,24 @@ namespace {
 using namespace std::literals;
 using namespace WasmEdge;
 static SpecTest T(std::filesystem::u8path("../spec/testSuites"sv));
+
+class ScopedWorkingDirectory {
+public:
+  explicit ScopedWorkingDirectory(std::filesystem::path Dir)
+      : Original(std::filesystem::current_path()), Current(std::move(Dir)) {
+    std::filesystem::create_directories(Current);
+    std::filesystem::current_path(Current);
+  }
+
+  ~ScopedWorkingDirectory() {
+    std::filesystem::current_path(Original);
+    std::filesystem::remove_all(Current);
+  }
+
+private:
+  std::filesystem::path Original;
+  std::filesystem::path Current;
+};
 
 // Parameterized testing class.
 class CoreTest : public testing::TestWithParam<std::string> {};
@@ -307,6 +326,11 @@ TEST(VM, MultipleVM) {
 }
 
 TEST(Coredump, generateCoredump) {
+  ScopedWorkingDirectory WorkingDir(
+      std::filesystem::temp_directory_path() /
+      ("wasmedge-coredump-test-" +
+       std::to_string(
+           std::chrono::steady_clock::now().time_since_epoch().count())));
   WasmEdge::Configure Conf;
   Conf.getRuntimeConfigure().setEnableCoredump(true);
   Conf.getRuntimeConfigure().setCoredumpWasmgdb(false);
@@ -321,15 +345,60 @@ TEST(Coredump, generateCoredump) {
   ASSERT_TRUE(VM.loadWasm(Wasm));
   ASSERT_TRUE(VM.validate());
   ASSERT_TRUE(VM.instantiate());
-  VM.execute("access_out_of_bounds");
-  bool FindCoredump = false;
+  EXPECT_FALSE(VM.execute("access_out_of_bounds"));
+  std::filesystem::path CoredumpPath;
   for (const auto &Entry : std::filesystem::directory_iterator("./")) {
     if (Entry.path().string().find("coredump.") != std::string::npos) {
-      FindCoredump = true;
-      break;
+      ASSERT_TRUE(CoredumpPath.empty());
+      CoredumpPath = Entry.path();
     }
   }
-  EXPECT_TRUE(FindCoredump);
+  ASSERT_FALSE(CoredumpPath.empty());
+
+  Loader::Loader LoadEngine(Conf);
+  auto CoredumpModule = LoadEngine.parseModule(CoredumpPath);
+  ASSERT_TRUE(CoredumpModule);
+  const auto &Module = *(*CoredumpModule);
+
+  const auto CoreStackIt = std::find_if(
+      Module.getCustomSections().begin(), Module.getCustomSections().end(),
+      [](const auto &Section) { return Section.getName() == "corestack"; });
+  ASSERT_NE(CoreStackIt, Module.getCustomSections().end());
+
+  const auto Content = CoreStackIt->getContent();
+  size_t Offset = 0;
+  const auto ReadU32 = [&Content, &Offset]() {
+    uint32_t Result = 0;
+    uint32_t Shift = 0;
+    while (true) {
+      EXPECT_LT(Offset, Content.size());
+      if (Offset >= Content.size()) {
+        return 0U;
+      }
+      const uint8_t Byte = Content[Offset++];
+      Result |= static_cast<uint32_t>(Byte & 0x7FU) << Shift;
+      if ((Byte & 0x80U) == 0) {
+        return Result;
+      }
+      Shift += 7U;
+    }
+  };
+
+  ASSERT_GE(Content.size(), 6U);
+  EXPECT_EQ(Content[Offset++], 0x00U);
+  EXPECT_EQ(Content[Offset++], 0x04U);
+  EXPECT_EQ(
+      std::string_view(reinterpret_cast<const char *>(&Content[Offset]), 4),
+      "main");
+  Offset += 4U;
+  EXPECT_EQ(ReadU32(), 1U);
+  EXPECT_EQ(Content[Offset++], 0x00U);
+  static_cast<void>(ReadU32());
+  static_cast<void>(ReadU32());
+  const auto LocalCount = ReadU32();
+  const auto StackCount = ReadU32();
+  EXPECT_EQ(Content.size(),
+            Offset + static_cast<size_t>(LocalCount + StackCount) * 5U);
 }
 
 } // namespace


### PR DESCRIPTION
## Summary
- prevent `createCorestack` from copying past the temporary 4-byte value buffer
- add a coredump regression that validates the generated `corestack` custom section payload
- keep the change scoped to coredump serialization and its existing executor test target

## Linked Issue
Fixes #5160

## What Changed
- replace the unsafe 8-byte copy into a 4-byte buffer with a helper that serializes exactly 4 bytes for each emitted `i32` corestack value
- update `Coredump.generateCoredump` to run in an isolated temp directory, reload the emitted coredump module, and validate the `corestack` section structure and encoded value payload size

## Verification
- `bash ./.github/scripts/clang-format.sh /Library/Developer/CommandLineTools/usr/bin/clang-format` — passed
- `cmake -S . -B build -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_USE_LLVM=OFF` — passed
- `cmake --build build --target wasmedgeExecutorCoreTests -j$(sysctl -n hw.logicalcpu)` — passed
- `ctest -R wasmedgeExecutorCoreTests --output-on-failure` — passed
- `./wasmedgeExecutorCoreTests --gtest_filter=Coredump.generateCoredump` (in `build/test/executor`) — passed
- `/Users/rootp1/.cargo/bin/lineguard --config .lineguardrc --verbose lib/executor/coredump.cpp test/executor/ExecutorTest.cpp` — passed
- `git ls-files | grep -v '^thirdparty' | grep -v '/thirdparty/' | grep -v '/dist/' | xargs codespell --ignore-words .github/workflows/ignore_words 2>/dev/null` — passed
- `cmake -S . -B build-asan -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_USE_LLVM=OFF -DCMAKE_C_FLAGS='-fsanitize=address -fno-omit-frame-pointer' -DCMAKE_CXX_FLAGS='-fsanitize=address -fno-omit-frame-pointer' -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address' -DCMAKE_SHARED_LINKER_FLAGS='-fsanitize=address'` — passed
- `cmake --build build-asan --target wasmedgeExecutorCoreTests -j$(sysctl -n hw.logicalcpu)` — passed
- `./wasmedgeExecutorCoreTests --gtest_filter=Coredump.generateCoredump` (in `build-asan/test/executor`) — passed
- `cd build-asan && ctest -R wasmedgeExecutorCoreTests --output-on-failure` — passed
- `npx --yes -p commitlint@20.2.0 -p @commitlint/config-conventional@20.2.0 commitlint --extends @commitlint/config-conventional --from HEAD~1 --to HEAD --verbose` — passed

## Scope
- only `lib/executor/coredump.cpp` and `test/executor/ExecutorTest.cpp` are included in the branch diff against `upstream/master`
