### PR TITLE
ci(commitlint): set footer-max-line-length to warning level

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -5,5 +5,8 @@ module.exports = {
     // that we have no control.
     "header-max-length": [1, "always", 100],
     "body-max-line-length": [1, "always", 100],
+    // Squash-merge concatenates commit bodies, and every line after a
+    // `Fixes #N` reference is parsed as footer, so relax this too.
+    "footer-max-line-length": [1, "always", 100],
   },
 };


### PR DESCRIPTION
## Description

Check this squashed commit: f1f2cdbea4824a09cc46a93573b7695a5da99140.  
It will fail the commitlint check once the maintainers use the "Update branch" button.

The reason is that any line after "Fixes #N" will be treated as a footer, which will cause the commitlint check to fail.  
I believe this issue will recur whenever we have a squashed commit with one line exceeding 100 characters and one of the previous commits contains the "Fixes #N" pattern.

Therefore, I'm relaxing this check from an error to a warning. 

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
