### PR TITLE
 fix(coredump): bound corestack value serialization

### DIFF
--- a/lib/executor/coredump.cpp
+++ b/lib/executor/coredump.cpp
@@ -6,6 +6,7 @@
 #include "common/types.h"
 #include "runtime/stackmgr.h"
 #include "spdlog/spdlog.h"
+#include <array>
 #include <cstdint>
 #include <cstring>
 #include <vector>
@@ -14,6 +15,18 @@ using namespace std::literals;
 
 namespace WasmEdge {
 namespace Coredump {
+namespace {
+
+std::array<Byte, sizeof(uint32_t)>
+serializeCoreStackValue(const Runtime::StackManager::Value &Value) noexcept {
+  std::array<Byte, sizeof(uint32_t)> ValueBytes{};
+  const auto RawValue = Value.unwrap();
+  std::memcpy(ValueBytes.data(), &RawValue, ValueBytes.size());
+  return ValueBytes;
+}
+
+} // namespace
+
 void generateCoredump(const Runtime::StackManager &StackMgr,
                       bool ForWasmgdb) noexcept {
   spdlog::info("Generating coredump..."sv);
@@ -128,9 +141,7 @@ AST::CustomSection createCorestack(
       // 0x7F implies i32. i128 is not supported here, and wasmgdb does not
       // support i64.
       Content.push_back(0x7F);
-      auto Value = Iter.unwrap();
-      std::vector<Byte> ValueBytes(4);
-      std::memcpy(ValueBytes.data(), &Value, sizeof(int64_t));
+      auto ValueBytes = serializeCoreStackValue(Iter);
       Content.insert(Content.end(), ValueBytes.begin(), ValueBytes.end());
     }
     if (!ForWasmgdb) {
@@ -138,9 +149,7 @@ AST::CustomSection createCorestack(
         // 0x7F implies i32. i128 is not supported here, and wasmgdb does not
         // support i64.
         Content.push_back(0x7F);
-        auto Value = Iter.unwrap();
-        std::vector<Byte> ValueBytes(4);
-        std::memcpy(ValueBytes.data(), &Value, sizeof(int64_t));
+        auto ValueBytes = serializeCoreStackValue(Iter);
         Content.insert(Content.end(), ValueBytes.begin(), ValueBytes.end());
       }
     }

--- a/test/executor/ExecutorTest.cpp
+++ b/test/executor/ExecutorTest.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "common/spdlog.h"
+#include "experimental/scope.hpp"
 #include "vm/vm.h"
 
 #include "../spec/hostfunc.h"
@@ -40,24 +41,6 @@ namespace {
 using namespace std::literals;
 using namespace WasmEdge;
 static SpecTest T(std::filesystem::u8path("../spec/testSuites"sv));
-
-class ScopedWorkingDirectory {
-public:
-  explicit ScopedWorkingDirectory(std::filesystem::path Dir)
-      : Original(std::filesystem::current_path()), Current(std::move(Dir)) {
-    std::filesystem::create_directories(Current);
-    std::filesystem::current_path(Current);
-  }
-
-  ~ScopedWorkingDirectory() {
-    std::filesystem::current_path(Original);
-    std::filesystem::remove_all(Current);
-  }
-
-private:
-  std::filesystem::path Original;
-  std::filesystem::path Current;
-};
 
 // Parameterized testing class.
 class CoreTest : public testing::TestWithParam<std::string> {};
@@ -326,11 +309,19 @@ TEST(VM, MultipleVM) {
 }
 
 TEST(Coredump, generateCoredump) {
-  ScopedWorkingDirectory WorkingDir(
+  const auto OriginalPath = std::filesystem::current_path();
+  const auto CurrentPath =
       std::filesystem::temp_directory_path() /
       ("wasmedge-coredump-test-" +
        std::to_string(
-           std::chrono::steady_clock::now().time_since_epoch().count())));
+           std::chrono::steady_clock::now().time_since_epoch().count()));
+  std::filesystem::create_directories(CurrentPath);
+  std::filesystem::current_path(CurrentPath);
+  const cxx20::scope_exit WorkingDir([OriginalPath, CurrentPath]() noexcept {
+    std::error_code Error;
+    std::filesystem::current_path(OriginalPath, Error);
+    std::filesystem::remove_all(CurrentPath, Error);
+  });
   WasmEdge::Configure Conf;
   Conf.getRuntimeConfigure().setEnableCoredump(true);
   Conf.getRuntimeConfigure().setCoredumpWasmgdb(false);

--- a/test/executor/ExecutorTest.cpp
+++ b/test/executor/ExecutorTest.cpp
@@ -20,6 +20,7 @@
 #include "../spec/hostfunc.h"
 #include "../spec/spectest.h"
 
+#include <algorithm>
 #include <gtest/gtest.h>
 
 #include <array>
@@ -39,6 +40,24 @@ namespace {
 using namespace std::literals;
 using namespace WasmEdge;
 static SpecTest T(std::filesystem::u8path("../spec/testSuites"sv));
+
+class ScopedWorkingDirectory {
+public:
+  explicit ScopedWorkingDirectory(std::filesystem::path Dir)
+      : Original(std::filesystem::current_path()), Current(std::move(Dir)) {
+    std::filesystem::create_directories(Current);
+    std::filesystem::current_path(Current);
+  }
+
+  ~ScopedWorkingDirectory() {
+    std::filesystem::current_path(Original);
+    std::filesystem::remove_all(Current);
+  }
+
+private:
+  std::filesystem::path Original;
+  std::filesystem::path Current;
+};
 
 // Parameterized testing class.
 class CoreTest : public testing::TestWithParam<std::string> {};
@@ -307,6 +326,11 @@ TEST(VM, MultipleVM) {
 }
 
 TEST(Coredump, generateCoredump) {
+  ScopedWorkingDirectory WorkingDir(
+      std::filesystem::temp_directory_path() /
+      ("wasmedge-coredump-test-" +
+       std::to_string(
+           std::chrono::steady_clock::now().time_since_epoch().count())));
   WasmEdge::Configure Conf;
   Conf.getRuntimeConfigure().setEnableCoredump(true);
   Conf.getRuntimeConfigure().setCoredumpWasmgdb(false);
@@ -321,15 +345,60 @@ TEST(Coredump, generateCoredump) {
   ASSERT_TRUE(VM.loadWasm(Wasm));
   ASSERT_TRUE(VM.validate());
   ASSERT_TRUE(VM.instantiate());
-  VM.execute("access_out_of_bounds");
-  bool FindCoredump = false;
+  EXPECT_FALSE(VM.execute("access_out_of_bounds"));
+  std::filesystem::path CoredumpPath;
   for (const auto &Entry : std::filesystem::directory_iterator("./")) {
     if (Entry.path().string().find("coredump.") != std::string::npos) {
-      FindCoredump = true;
-      break;
+      ASSERT_TRUE(CoredumpPath.empty());
+      CoredumpPath = Entry.path();
     }
   }
-  EXPECT_TRUE(FindCoredump);
+  ASSERT_FALSE(CoredumpPath.empty());
+
+  Loader::Loader LoadEngine(Conf);
+  auto CoredumpModule = LoadEngine.parseModule(CoredumpPath);
+  ASSERT_TRUE(CoredumpModule);
+  const auto &Module = *(*CoredumpModule);
+
+  const auto CoreStackIt = std::find_if(
+      Module.getCustomSections().begin(), Module.getCustomSections().end(),
+      [](const auto &Section) { return Section.getName() == "corestack"; });
+  ASSERT_NE(CoreStackIt, Module.getCustomSections().end());
+
+  const auto Content = CoreStackIt->getContent();
+  size_t Offset = 0;
+  const auto ReadU32 = [&Content, &Offset]() {
+    uint32_t Result = 0;
+    uint32_t Shift = 0;
+    while (true) {
+      EXPECT_LT(Offset, Content.size());
+      if (Offset >= Content.size()) {
+        return 0U;
+      }
+      const uint8_t Byte = Content[Offset++];
+      Result |= static_cast<uint32_t>(Byte & 0x7FU) << Shift;
+      if ((Byte & 0x80U) == 0) {
+        return Result;
+      }
+      Shift += 7U;
+    }
+  };
+
+  ASSERT_GE(Content.size(), 6U);
+  EXPECT_EQ(Content[Offset++], 0x00U);
+  EXPECT_EQ(Content[Offset++], 0x04U);
+  EXPECT_EQ(
+      std::string_view(reinterpret_cast<const char *>(&Content[Offset]), 4),
+      "main");
+  Offset += 4U;
+  EXPECT_EQ(ReadU32(), 1U);
+  EXPECT_EQ(Content[Offset++], 0x00U);
+  static_cast<void>(ReadU32());
+  static_cast<void>(ReadU32());
+  const auto LocalCount = ReadU32();
+  const auto StackCount = ReadU32();
+  EXPECT_EQ(Content.size(),
+            Offset + static_cast<size_t>(LocalCount + StackCount) * 5U);
 }
 
 } // namespace

--- a/test/executor/ExecutorTest.cpp
+++ b/test/executor/ExecutorTest.cpp
@@ -360,8 +360,7 @@ TEST(Coredump, generateCoredump) {
   size_t Offset = 0;
   const auto ReadU32 = [&Content, &Offset]() {
     uint32_t Result = 0;
-    uint32_t Shift = 0;
-    while (true) {
+    for (uint32_t Shift = 0; Shift < 35U; Shift += 7U) {
       EXPECT_LT(Offset, Content.size());
       if (Offset >= Content.size()) {
         return 0U;
@@ -371,8 +370,9 @@ TEST(Coredump, generateCoredump) {
       if ((Byte & 0x80U) == 0) {
         return Result;
       }
-      Shift += 7U;
     }
+    ADD_FAILURE() << "LEB128 u32 encoding exceeds 5 bytes";
+    return 0U;
   };
 
   ASSERT_GE(Content.size(), 6U);


### PR DESCRIPTION
Closes #5162

## Description
Fixes a heap buffer overflow in coredump corestack serialization.

The coredump path was allocating a 4-byte temporary buffer for each serialized corestack value but copying `sizeof(int64_t)` bytes into it. This change makes the serializer write exactly the emitted 32-bit payload width and adds a regression test that reloads the generated coredump and validates the `corestack` section structure.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [ ] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

<img width="649" height="291" alt="image" src="https://github.com/user-attachments/assets/a1d531d4-26c6-44da-9eb3-f64d83ffda99" />
<img width="538" height="117" alt="image" src="https://github.com/user-attachments/assets/f2b5b0c4-7d0f-4ef3-b42b-6efe31c457c4" />
