### PR TITLE
fix(serializer): encode DataSegment memory index as u32 LEB128

### DIFF
--- a/lib/loader/serialize/serial_segment.cpp
+++ b/lib/loader/serialize/serial_segment.cpp
@@ -173,7 +173,7 @@ Serializer::serializeSegment(const AST::DataSegment &Seg,
   case AST::DataSegment::DataMode::Active:
     if (Seg.getIdx() != 0) {
       OutVec.push_back(0x02);
-      serializeU64(Seg.getIdx(), OutVec);
+      serializeU32(Seg.getIdx(), OutVec);
     } else {
       OutVec.push_back(0x00);
     }

--- a/test/loader/serializeSegmentTest.cpp
+++ b/test/loader/serializeSegmentTest.cpp
@@ -606,5 +606,39 @@ TEST(SerializeSegmentTest, SerializeDataSegment) {
   EXPECT_EQ(Output, Expected);
 
   EXPECT_FALSE(SerWASM1.serializeSection(DataSec, Output));
+
+  // 5. Active data segment with memidx >= 128 must encode the index as u32
+  //    LEB128, not u64. Values below 128 are single-byte in both encodings so
+  //    the bug is only visible at the boundary. memidx = 128 (0x80 0x01 in
+  //    u32 LEB128) produces exactly two bytes; a u64 LEB128 would emit the
+  //    same two bytes followed by five zero-continuation bytes, corrupting
+  //    any compliant parser.
+  {
+    WasmEdge::Configure ConfMultiMem;
+    ConfMultiMem.addProposal(WasmEdge::Proposal::MultiMemories);
+    WasmEdge::Loader::Serializer SerMultiMem(ConfMultiMem);
+
+    WasmEdge::AST::DataSection DataSecMM;
+    WasmEdge::AST::DataSegment DataSegMM;
+    DataSegMM.setMode(WasmEdge::AST::DataSegment::DataMode::Active);
+    DataSegMM.setIdx(128U);
+    DataSegMM.getExpr().getInstrs() = {End};
+    DataSegMM.getData() = {0xAAU};
+    DataSecMM.getContent() = {DataSegMM};
+
+    Output = {};
+    EXPECT_TRUE(SerMultiMem.serializeSection(DataSecMM, Output));
+    Expected = {
+        0x0BU,        // Data section
+        0x07U,        // Content size = 7
+        0x01U,        // Vector length = 1
+        0x02U,        // Prefix byte: active + non-zero memidx
+        0x80U, 0x01U, // memidx = 128 as u32 LEB128 (2 bytes, not 9)
+        0x0BU,        // Offset expression (End)
+        0x01U,        // Data vector length = 1
+        0xAAU         // Data byte
+    };
+    EXPECT_EQ(Output, Expected);
+  }
 }
 } // namespace


### PR DESCRIPTION
## Summary

Closes #5171

Active data segments with a non-zero memory index were being serialized using `serializeU64` instead of `serializeU32`.

`DataSegment::getIdx()` returns a `uint32_t`, and according to the WebAssembly binary specification (§5.5.12), the memory index must be encoded as a `u32` LEB128. Using `serializeU64` produces an incorrect encoding once the memory index reaches `128` or higher, resulting in binaries that cannot be parsed by compliant WebAssembly runtimes.

The equivalent element segment serialization path already uses `serializeU32` for table indices, so this change makes the data segment serializer consistent with that implementation.

The issue went unnoticed because the existing tests only covered memory indices `0` and `1`, where both serializers produce the same single-byte encoding. The difference only becomes visible for values `>= 128`.

## Changes

- Replaced `serializeU64` with `serializeU32` when serializing the memory index in `lib/loader/serialize/serial_segment.cpp`.
- Added a regression test in `test/loader/serializeSegmentTest.cpp` using `memidx = 128` to verify that the memory index is encoded as the expected 2-byte `u32` LEB128 value.

## Testing

```bash
cmake -S . -B build -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_USE_LLVM=OFF
cmake --build build -j$(nproc) --target wasmedgeLoaderSerializerTests
cd build && ctest -R wasmedgeLoaderSerializerTests --output-on-failure
```

Result:

```text
1/1 Test #4: wasmedgeLoaderSerializerTests .... Passed  0.01 sec
100% tests passed, 0 tests failed out of 1
```