### PR TITLE
chore: upgrade stb_image to newest version

### DIFF
--- a/cmake/Helper.cmake
+++ b/cmake/Helper.cmake
@@ -589,11 +589,12 @@ function(wasmedge_setup_stb_image)
   FetchContent_Declare(
     stb
     GIT_REPOSITORY https://github.com/nothings/stb.git
-    GIT_TAG        2dfbe86bef853be33cbbda07abcb4db58c7f817d
+    GIT_TAG        31c1ad37456438565541f4919958214b6e762fb4  # stb_image v2.30, stb_image_resize2 v2.18
     GIT_SHALLOW    FALSE
   )
   FetchContent_MakeAvailable(stb)
   message(STATUS "Downloading stb_image source -- done")
   add_library(wasmedgeDepsSTBImage INTERFACE)
   target_include_directories(wasmedgeDepsSTBImage SYSTEM INTERFACE ${stb_SOURCE_DIR})
+  wasmedge_mark_system_includes(wasmedgeDepsSTBImage)
 endfunction()


### PR DESCRIPTION
## Description

Upgrade the WasmEdge-owned `stb_image` dependency to the newest upstream version and adopt the project's system-include convention for its headers.

`cmake/Helper.cmake` (`wasmedge_setup_stb_image()`):

- Bump the `nothings/stb` FetchContent pin `2dfbe86` → `31c1ad3` (latest `master`, Apr 2026). This moves `stb_image_resize2.h` **v2.14 → v2.18** (SIMD/bug-fix work, no API break); `stb_image.h` stays **v2.30**. Every symbol the `wasmedge_image` plugin uses — `stbi_load_from_memory`, `stbi_loadf_from_memory`, `stbi_image_free`, `stbir_resize_uint8_linear`, `stbir_resize_float_linear`, and `STBIR_RGB` — is unchanged.
- Add `wasmedge_mark_system_includes(wasmedgeDepsSTBImage)`, matching the convention already applied to `fmt`, `spdlog`, `simdjson`, and `llama` (stb was the only header dependency missing it).

The `wasmedge_image` plugin is the only consumer of this pin. The stb copies vendored inside `llama.cpp` (already `stb_image.h` v2.30) and `stable-diffusion.cpp` (upstream-controlled, and coupled to the deprecated v1 `stb_image_resize.h` API in `sd_func.cpp`) are intentionally left untouched — moving those would mean bumping those whole dependencies, which is out of scope here.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). Author and `Signed-off-by` emails match (`beststeve@secondstate.io`).
- [x] **Commit Messages**: Conventional Commit format (`chore: upgrade stb_image to newest version`).
- [x] **Coding Style**: CMake-only change (no C++ touched); `lineguard --config .lineguardrc cmake/Helper.cmake` passes.
- [x] **Local Tests Passed**: See Test Evidence below.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclosed via the `Assisted-by: Claude (Anthropic)` trailer in the commit. This contribution was developed with assistance from Claude Code (Anthropic).
- [x] **Human-in-the-loop**: Change and results were human-reviewed before submission.

## Test Evidence

Configured with `-DWASMEDGE_PLUGIN_IMAGE=ON -DWASMEDGE_BUILD_TESTS=ON`. FetchContent checked out the new pin:

```
$ git -C build/_deps/stb-src rev-parse HEAD
31c1ad37456438565541f4919958214b6e762fb4
```

Plugin builds warning-clean (a grep of the build log for `stb_image|warning:|error:` returns nothing):

```
[144/153] Building CXX object plugins/wasmedge_image/.../image_env.cpp.o
[145/153] Building CXX object plugins/wasmedge_image/.../image_func.cpp.o
[146/153] Building CXX object plugins/wasmedge_image/.../image_module.cpp.o
...
[153/153] Linking CXX shared library plugins/wasmedge_image/libwasmedgePluginWasmEdgeImage.so
```

Image plugin test passes:

```
$ ctest -R '^wasmedgeImageTests$'
    Start 23: wasmedgeImageTests
1/1 Test #23: wasmedgeImageTests ...............   Passed    0.01 sec

100% tests passed, 0 tests failed out of 1
```

---

> This is a **draft** while GitHub CI runs.
