### PR TITLE
fix(plugin/image): harden decodeImgToSize size handling and error paths

### DIFF
--- a/plugins/wasmedge_image/image_func.cpp
+++ b/plugins/wasmedge_image/image_func.cpp
@@ -11,6 +11,7 @@
 #define STB_IMAGE_RESIZE_IMPLEMENTATION
 #include <stb_image_resize2.h>
 
+#include <limits>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -42,6 +43,32 @@ bool decodeImgToSize(Span<const uint8_t> Buf, uint32_t W, uint32_t H,
     return false;
   }
 
+  // The stb loader and resizer take the buffer sizes, dimensions, and strides
+  // as int. Reject the values outside the int range before converting.
+  constexpr uint64_t MaxInt =
+      static_cast<uint64_t>(std::numeric_limits<int>::max());
+  if (unlikely(Buf.size() > MaxInt)) {
+    spdlog::error("[WasmEdge-Image] Input buffer size {} is too large."sv,
+                  Buf.size());
+    return false;
+  }
+  const uint64_t BytesPerPixel = 3 * (IsU8 ? sizeof(uint8_t) : sizeof(float));
+  const uint64_t NumPixels = static_cast<uint64_t>(W) * H;
+  if (unlikely(W == 0 || H == 0)) {
+    spdlog::error("[WasmEdge-Image] Output size {}x{} is invalid."sv, W, H);
+    return false;
+  }
+  if (unlikely(W > MaxInt / BytesPerPixel || H > MaxInt)) {
+    spdlog::error("[WasmEdge-Image] Output size {}x{} is too large."sv, W, H);
+    return false;
+  }
+  if (unlikely(DstBuf.size() / BytesPerPixel < NumPixels)) {
+    spdlog::error("[WasmEdge-Image] Output buffer size {} not enough. "sv
+                  "At least need {}x{}x{} bytes."sv,
+                  DstBuf.size(), W, H, BytesPerPixel);
+    return false;
+  }
+
   // Load and decode the image from buffer.
   union RawImagePtr {
     uint8_t *U8;
@@ -51,10 +78,11 @@ bool decodeImgToSize(Span<const uint8_t> Buf, uint32_t W, uint32_t H,
   RawImg.U8 = nullptr;
   int IW, IH, IC;
   if (IsU8) {
-    RawImg.U8 = stbi_load_from_memory(Buf.data(), Buf.size(), &IW, &IH, &IC, 3);
+    RawImg.U8 = stbi_load_from_memory(Buf.data(), static_cast<int>(Buf.size()),
+                                      &IW, &IH, &IC, 3);
   } else {
-    RawImg.F32 =
-        stbi_loadf_from_memory(Buf.data(), Buf.size(), &IW, &IH, &IC, 3);
+    RawImg.F32 = stbi_loadf_from_memory(
+        Buf.data(), static_cast<int>(Buf.size()), &IW, &IH, &IC, 3);
   }
   if (RawImg.U8 == nullptr) {
     spdlog::error("[WasmEdge-Image] Load image failed."sv);
@@ -62,39 +90,37 @@ bool decodeImgToSize(Span<const uint8_t> Buf, uint32_t W, uint32_t H,
   }
 
   // Resize.
-  const uint64_t BytesPerPixel = 3 * (IsU8 ? sizeof(uint8_t) : sizeof(float));
-  const uint64_t NumPixels = static_cast<uint64_t>(W) * H;
-  if (unlikely(DstBuf.size() / BytesPerPixel < NumPixels)) {
-    spdlog::error("[WasmEdge-Image] Output buffer size {} not enough. "sv
-                  "At least need {}x{}x{} bytes."sv,
-                  DstBuf.size(), W, H, BytesPerPixel);
-    return false;
-  }
+  bool Resized = false;
   if (IsU8) {
-    stbir_resize_uint8_linear(RawImg.U8, IW, IH, 0, DstBuf.data(),
-                              static_cast<int>(W), static_cast<int>(H), 0,
-                              STBIR_RGB);
+    Resized = stbir_resize_uint8_linear(
+                  RawImg.U8, IW, IH, 0, DstBuf.data(), static_cast<int>(W),
+                  static_cast<int>(H), 0, STBIR_RGB) != nullptr;
   } else {
-    stbir_resize_float_linear(
-        RawImg.F32, IW, IH, 0, reinterpret_cast<float *>(DstBuf.data()),
-        static_cast<int>(W), static_cast<int>(H), 0, STBIR_RGB);
+    Resized =
+        stbir_resize_float_linear(
+            RawImg.F32, IW, IH, 0, reinterpret_cast<float *>(DstBuf.data()),
+            static_cast<int>(W), static_cast<int>(H), 0, STBIR_RGB) != nullptr;
+  }
+  stbi_image_free(RawImg.U8);
+  if (unlikely(!Resized)) {
+    spdlog::error("[WasmEdge-Image] Resize image failed."sv);
+    return false;
   }
 
   // Handle BGR case.
   if (!IsRGB) {
     if (IsU8) {
-      for (uint32_t I = 0; I < W * H; I++) {
+      for (uint64_t I = 0; I < NumPixels; I++) {
         std::swap(DstBuf[I * 3], DstBuf[I * 3 + 2]);
       }
     } else {
       auto F32DstBuf = Span<float>(reinterpret_cast<float *>(DstBuf.data()),
                                    DstBuf.size() / sizeof(float));
-      for (uint32_t I = 0; I < W * H; I++) {
+      for (uint64_t I = 0; I < NumPixels; I++) {
         std::swap(F32DstBuf[I * 3], F32DstBuf[I * 3 + 2]);
       }
     }
   }
-  stbi_image_free(RawImg.U8);
   return true;
 }
 

--- a/test/plugins/wasmedge_image/wasmedge_image.cpp
+++ b/test/plugins/wasmedge_image/wasmedge_image.cpp
@@ -511,6 +511,135 @@ TEST(WasmEdgeImageTest, LoadImage) {
   EXPECT_TRUE(std::fabs(OutSpanF32[Position * 3 + 2] - 0.0f) < 0.00001f);
 }
 
+TEST(WasmEdgeImageTest, InvalidParams) {
+  // Create the wasmedge_image module instance.
+  auto ImgMod = createModule();
+  ASSERT_TRUE(ImgMod);
+
+  // Create the calling frame with memory instance.
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "memory", std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+                    WasmEdge::AST::MemoryType(1)));
+  auto *MemInstPtr = Mod.findMemoryExports("memory");
+  ASSERT_TRUE(MemInstPtr != nullptr);
+  auto &MemInst = *MemInstPtr;
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+  std::array<WasmEdge::ValVariant, 1> Errno = {UINT32_C(0)};
+
+  // Input payload offset.
+  uint32_t InOffset = 0;
+  // Input payload size.
+  uint32_t InSize = static_cast<uint32_t>(TestRedPNG.size());
+  // Output image data offset.
+  uint32_t OutOffset = 1024;
+  // Output buffer size for the 50x60 RGB u8 format.
+  uint32_t OutSize = 50 * 60 * 3;
+
+  // Get the function "load_image".
+  auto *FuncInst = ImgMod->findFuncExports("load_image");
+  EXPECT_NE(FuncInst, nullptr);
+  EXPECT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncInst = FuncInst->getHostFunc();
+
+  // Set the memory[0, 158] as the PNG image payload.
+  fillMemContent(MemInst, 0, 32768);
+  fillMemContent(MemInst, 0, TestRedPNG);
+
+  // Test: Zero output width should fail.
+  EXPECT_TRUE(HostFuncInst.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   InOffset,  // Payload offset.
+                                   InSize,    // Payload size.
+                                   0U, 60U,   // Target width and height.
+                                   0U,        // Target type: RGB8.
+                                   OutOffset, // Output buffer offset.
+                                   OutSize    // Output buffer size.
+                               },
+                               Errno));
+  EXPECT_EQ(Errno[0].get<uint32_t>(), static_cast<uint32_t>(ErrNo::Fail));
+
+  // Test: Zero output height should fail.
+  EXPECT_TRUE(HostFuncInst.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   InOffset,  // Payload offset.
+                                   InSize,    // Payload size.
+                                   50U, 0U,   // Target width and height.
+                                   1U,        // Target type: BGR8.
+                                   OutOffset, // Output buffer offset.
+                                   OutSize    // Output buffer size.
+                               },
+                               Errno));
+  EXPECT_EQ(Errno[0].get<uint32_t>(), static_cast<uint32_t>(ErrNo::Fail));
+
+  // Test: Output width with the row size exceeding INT32_MAX should fail
+  // because the resizer takes the dimensions and strides as int.
+  EXPECT_TRUE(HostFuncInst.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   InOffset,       // Payload offset.
+                                   InSize,         // Payload size.
+                                   800000000U, 1U, // Target width and height.
+                                   0U,             // Target type: RGB8.
+                                   OutOffset,      // Output buffer offset.
+                                   OutSize         // Output buffer size.
+                               },
+                               Errno));
+  EXPECT_EQ(Errno[0].get<uint32_t>(), static_cast<uint32_t>(ErrNo::Fail));
+
+  // Test: Output height exceeding INT32_MAX should fail because the resizer
+  // takes the dimensions as int.
+  EXPECT_TRUE(HostFuncInst.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   InOffset,        // Payload offset.
+                                   InSize,          // Payload size.
+                                   1U, 2147483648U, // Target width and height.
+                                   0U,              // Target type: RGB8.
+                                   OutOffset,       // Output buffer offset.
+                                   OutSize          // Output buffer size.
+                               },
+                               Errno));
+  EXPECT_EQ(Errno[0].get<uint32_t>(), static_cast<uint32_t>(ErrNo::Fail));
+
+  // Test: Insufficient output buffer should fail.
+  EXPECT_TRUE(HostFuncInst.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   InOffset,    // Payload offset.
+                                   InSize,      // Payload size.
+                                   50U, 60U,    // Target width and height.
+                                   0U,          // Target type: RGB8.
+                                   OutOffset,   // Output buffer offset.
+                                   OutSize - 1U // Output buffer size.
+                               },
+                               Errno));
+  EXPECT_EQ(Errno[0].get<uint32_t>(), static_cast<uint32_t>(ErrNo::Fail));
+
+  // Test: Unknown output data type should fail.
+  EXPECT_TRUE(HostFuncInst.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   InOffset,  // Payload offset.
+                                   InSize,    // Payload size.
+                                   50U, 60U,  // Target width and height.
+                                   4U,        // Target type: unknown.
+                                   OutOffset, // Output buffer offset.
+                                   OutSize    // Output buffer size.
+                               },
+                               Errno));
+  EXPECT_EQ(Errno[0].get<uint32_t>(), static_cast<uint32_t>(ErrNo::Fail));
+
+  // Test: Empty input payload should fail.
+  EXPECT_TRUE(HostFuncInst.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   InOffset,  // Payload offset.
+                                   0U,        // Payload size.
+                                   50U, 60U,  // Target width and height.
+                                   0U,        // Target type: RGB8.
+                                   OutOffset, // Output buffer offset.
+                                   OutSize    // Output buffer size.
+                               },
+                               Errno));
+  EXPECT_EQ(Errno[0].get<uint32_t>(), static_cast<uint32_t>(ErrNo::Fail));
+}
+
 GTEST_API_ int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
## Description

Fixes #5174

This PR hardens `decodeImgToSize` in the `wasmedge_image` plugin. Instead of only patching the two loops reported in #5174, it audits and fixes the whole function in one pass, since all three host functions (`load_jpg`, `load_png`, `load_image`) funnel through this single callee:

- **BGR swap loops (#5174)**: the loop bounds were computed as `W * H` in 32-bit with a 32-bit counter. They now reuse the 64-bit `NumPixels` with a `uint64_t` counter. Note on severity: this truncation is not reachable through the host-function API — the output buffer length is a `u32`, and the existing 64-bit buffer check (#4914) guarantees `NumPixels <= UINT32_MAX / 3` whenever the loops run — so this part is a consistency fix rather than an observable bug fix.
- **Decoded image leak**: the early return on the output-buffer-size check leaked the decoded stb image (up to ~2 GiB of host memory per failed call, repeatable by the guest). Validation now happens before decoding, and the decoded image is freed on all paths.
- **Ignored resize result**: the `stbir_resize_*` return value was discarded, so a zero output dimension (or an internal stbir failure such as allocation failure) reported success while writing no pixel data. The result is now checked. Behavior change: `W == 0` or `H == 0` now returns `Fail` instead of silently succeeding with an untouched buffer.
- **stb int-domain guards**: `Buf.size()` was implicitly narrowed to `int` for the stb loaders, and `W`/`H` were cast to `int` for the resizer without range checks. A guest buffer over 2 GiB could feed a negative length into the loaders or overflow the resizer's `int` row pitch (`W * 3`), which is signed-overflow UB inside stbir. The input length and output dimensions are now validated against the `int` domain before any conversion.

The new `WasmEdgeImageTest.InvalidParams` covers the failure paths (zero dimensions, dimensions exceeding the resizer's `int` domain, insufficient output buffer, unknown data type, and empty payload). The zero-dimension cases were verified red before the fix (they previously returned `Success`) and green after. The existing BGR8/BGR32F tests guard the swap-loop rewrite.

> This contribution was developed with assistance from Claude (Anthropic).

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

`wasmedgeImageTests` (macOS, `-DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_PLUGIN_IMAGE=ON`):

```text
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from WasmEdgeImageTest
[ RUN      ] WasmEdgeImageTest.Module
[       OK ] WasmEdgeImageTest.Module (3 ms)
[ RUN      ] WasmEdgeImageTest.LoadJPG
[       OK ] WasmEdgeImageTest.LoadJPG (1 ms)
[ RUN      ] WasmEdgeImageTest.LoadPNG
[       OK ] WasmEdgeImageTest.LoadPNG (0 ms)
[ RUN      ] WasmEdgeImageTest.LoadImage
[       OK ] WasmEdgeImageTest.LoadImage (0 ms)
[ RUN      ] WasmEdgeImageTest.InvalidParams
[       OK ] WasmEdgeImageTest.InvalidParams (1 ms)
[----------] 5 tests from WasmEdgeImageTest (6 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (6 ms total)
[  PASSED  ] 5 tests.
```

Additional local checks:

- Full build with tests: 0 errors / 0 warnings.
- `clang-format` (v22) applied to the changed files.
- `lineguard`: all files passed.
- `commitlint` (`commitlint@20.2.0` + `@commitlint/config-conventional@20.2.0`): 0 problems, 1 warning (`footer-leading-blank`, warning level).