### PR TITLE
docs: fix "the recommend skills" grammar in mentorship idea templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/gsoc_idea.yml
+++ b/.github/ISSUE_TEMPLATE/gsoc_idea.yml
@@ -31,9 +31,9 @@ body:
   - type: textarea
     id: recommend-skills
     attributes:
-      label: "Recommend skills"
-      description: Please shortly describe the recommend skills for the project you want to propose for the GSoC program.
-      placeholder: Describe in several bullet points about the recommend skills. E.g. C++, Rust, WebAssembly, etc.
+      label: "Recommended skills"
+      description: Please shortly describe the recommended skills for the project you want to propose for the GSoC program.
+      placeholder: Describe in several bullet points about the recommended skills. E.g. C++, Rust, WebAssembly, etc.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/lfx_mentorship_idea.yml
+++ b/.github/ISSUE_TEMPLATE/lfx_mentorship_idea.yml
@@ -31,9 +31,9 @@ body:
   - type: textarea
     id: recommend-skills
     attributes:
-      label: "Recommend skills"
-      description: Please shortly describe the recommend skills for the project you want to propose for the LFX Mentorship program.
-      placeholder: Describe in several bullet points about the recommend skills. E.g. C++, Rust, WebAssembly, etc.
+      label: "Recommended skills"
+      description: Please shortly describe the recommended skills for the project you want to propose for the LFX Mentorship program.
+      placeholder: Describe in several bullet points about the recommended skills. E.g. C++, Rust, WebAssembly, etc.
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION


## Description

The GSoC and LFX mentorship idea issue templates describe their skills field as "the recommend skills", which should read "the recommended skills".

**Where it was found:**

- `.github/ISSUE_TEMPLATE/gsoc_idea.yml` — lines 34, 35, 36
- `.github/ISSUE_TEMPLATE/lfx_mentorship_idea.yml` — lines 34, 35, 36

Both files carried the same error in three places each: the field `label`, its `description`, and its `placeholder`. These strings are user-facing — they render on the "GSoC Idea" and "LFX Mentorship Idea" forms that prospective mentees fill in.

**What the fix does:**

Changes `recommend skills` to `recommended skills` in the `description` and `placeholder` of both templates, and updates the `label` from `"Recommend skills"` to `"Recommended skills"` for consistency across the three strings.

The `id: recommend-skills` field key is intentionally left unchanged, since it is an internal identifier rather than display text and altering it would change the form's response key.

This is a text-only change to two GitHub issue-template YAML files. No C++, CMake, or other build input is touched, so no runtime, library, or tool behavior changes.
fixes #5181 
## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines. — Not applicable: no C/C++ files are changed. `lineguard` and `codespell` pass.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.



## Test Evidence

This change touches only two GitHub issue-template YAML files and no build input, so the compiled test suite cannot exercise it. The applicable CI linters were run locally against the changed files, along with a YAML parse to confirm both templates remain well-formed.

