### PR TITLE
fix(wasi): prevent fd_allocate overflow from truncating files on macOS

### DIFF
--- a/lib/host/wasi/inode-macos.cpp
+++ b/lib/host/wasi/inode-macos.cpp
@@ -174,8 +174,10 @@ WasiExpect<void> INode::fdAdvise(__wasi_filesize_t, __wasi_filesize_t,
 
 WasiExpect<void> INode::fdAllocate(__wasi_filesize_t Offset,
                                    __wasi_filesize_t Len) const noexcept {
-  if (Len > std::numeric_limits<int64_t>::max()) {
-    return WasiUnexpect(__WASI_ERRNO_NOSPC);
+  constexpr auto MaxFileSize =
+      static_cast<__wasi_filesize_t>(std::numeric_limits<int64_t>::max());
+  if (Len > MaxFileSize || Offset > MaxFileSize - Len) {
+    return WasiUnexpect(__WASI_ERRNO_FBIG);
   }
   const auto OldOffset = ::lseek(Fd, 0, SEEK_CUR);
   if (OldOffset < 0) {
@@ -201,7 +203,8 @@ WasiExpect<void> INode::fdAllocate(__wasi_filesize_t Offset,
       return WasiUnexpect(fromErrNo(errno));
     }
   }
-  if (auto Res = ::ftruncate(Fd, Offset + Len); unlikely(Res < 0)) {
+  if (auto Res = ::ftruncate(Fd, static_cast<int64_t>(Offset + Len));
+      unlikely(Res < 0)) {
     return WasiUnexpect(fromErrNo(errno));
   }
 

--- a/test/host/wasi/wasi.cpp
+++ b/test/host/wasi/wasi.cpp
@@ -4319,6 +4319,44 @@ bool isValidFd(int Fd) {
 }
 } // namespace
 
+#if WASMEDGE_OS_MACOS
+TEST(WasiTest, FdAllocateRejectsOffsetLenOverflowMacOS) {
+  WasmEdge::Host::WASI::Environ Env;
+  const fs::path TempPath = fs::u8path("wasi_fd_allocate_overflow.tmp");
+  const std::string_view Content = "wasmedge fd_allocate overflow guard"sv;
+
+  {
+    std::ofstream Out(TempPath, std::ios::binary);
+    ASSERT_TRUE(Out.is_open());
+    Out << Content;
+  }
+
+  Env.init({"/:."s}, "test"s, {}, {});
+  const auto Fd = Env.pathOpen(
+      3, TempPath.u8string(), static_cast<__wasi_lookupflags_t>(0),
+      static_cast<__wasi_oflags_t>(0), __WASI_RIGHTS_FD_ALLOCATE,
+      static_cast<__wasi_rights_t>(0), static_cast<__wasi_fdflags_t>(0));
+  ASSERT_TRUE(Fd);
+
+  const auto Res = Env.fdAllocate(*Fd, UINT64_MAX, UINT64_C(1));
+  ASSERT_FALSE(Res);
+  EXPECT_EQ(Res.error(), __WASI_ERRNO_FBIG);
+
+  EXPECT_TRUE(Env.fdClose(*Fd));
+  Env.fini();
+
+  std::ifstream In(TempPath, std::ios::binary);
+  ASSERT_TRUE(In.is_open());
+  const std::string Actual((std::istreambuf_iterator<char>(In)),
+                           std::istreambuf_iterator<char>());
+  EXPECT_EQ(std::string_view(Actual.data(), Actual.size()), Content);
+
+  std::error_code Ec;
+  fs::remove(TempPath, Ec);
+  EXPECT_FALSE(Ec);
+}
+#endif
+
 TEST(WasiTest, CustomFds) {
   WasmEdge::Host::WASI::Environ Env;
   WasmEdge::Runtime::Instance::ModuleInstance Mod("");


### PR DESCRIPTION
## Description

Fixes an integer overflow in the macOS WASI `INode::fdAllocate` backend
(`lib/host/wasi/inode-macos.cpp`).

The function computed the requested end position `Offset + Len` as an unsigned
64-bit value and passed the result straight to `ftruncate()`. A guest holding
`fd_allocate` rights could call `fd_allocate(offset = UINT64_MAX, len = 1)`,
wrapping the sum to `0`. The call then became `ftruncate(Fd, 0)`, silently
truncating the backing file to zero bytes — a data-loss / integrity bug.

### Fix

Reject any request whose end position `Offset + Len` does not fit in an
`int64_t` **before** performing any file operation, returning
`__WASI_ERRNO_FBIG`:

```cpp
constexpr auto MaxFileSize =
    static_cast<__wasi_filesize_t>(std::numeric_limits<int64_t>::max());
if (Len > MaxFileSize || Offset > MaxFileSize - Len) {
  return WasiUnexpect(__WASI_ERRNO_FBIG);
}
```

The `Len > MaxFileSize` check short-circuits, so `MaxFileSize - Len` can never
underflow; the second check then catches the wrap-around. After the guard,
`Offset + Len <= INT64_MAX`, so the value passed to `ftruncate()` is now also
cast explicitly to `int64_t`.

`__WASI_ERRNO_FBIG` is chosen deliberately over `EINVAL`: the Linux backend
(`inode-linux.cpp`) uses `posix_fallocate()`, which returns `EFBIG` when
`offset + len` exceeds the maximum file size. Returning `FBIG` here keeps
`fd_allocate` behaviour consistent across the macOS and Linux backends for the
same input.

### Test

Adds a macOS-only regression test `FdAllocateRejectsOffsetLenOverflowMacOS` in
`test/host/wasi/wasi.cpp` that opens a file with known contents, drives the
`UINT64_MAX + 1` case, asserts the error is `__WASI_ERRNO_FBIG`, and verifies
the file is left byte-for-byte untouched (i.e. not truncated).

close #5179

## Checklist

- [x] **DCO Signed-off**: commit is signed off (`git commit -s`).
- [x] **Commit Messages**: Conventional Commits format, header under 100 chars.
- [x] **Coding Style**: change follows the surrounding style (LLVM/`clang-format`
      conventions). Note: `clang-format` was not available in my environment, so
      the formatting was matched by hand — please flag if anything is off.
- [x] **Local Tests Passed**: Built `wasiTests` and ran the full WASI unit-test
      suite locally against this branch — **60/60 tests passed**, clean build,
      no regressions (log under *Test Evidence*). Transparency note: the added
      regression test is guarded by `#if WASMEDGE_OS_MACOS`, so on my Linux host
      it is compiled out and does **not** execute locally — it runs under macOS
      CI. I do not have a macOS machine, so I could not run that specific case
      locally. To compensate, the overflow arithmetic and the resulting
      `ftruncate` truncation were reproduced against a **real file / real
      `ftruncate`** (see below), confirming that before the guard the file is
      zeroed and after the guard the request is rejected with the file left
      intact.

### AI assistance

- [ ] **AI Disclosure**: ..
- [x] **Human-in-the-loop**: The change was reviewed by me before submission.

## Test Evidence

**1. Full WASI unit-test suite (Linux, this branch) — 60/60 passed, clean build:**

```
$ git log -1 --oneline
e848c66a fix(wasi): prevent fd_allocate overflow from truncating files on macOS

$ cmake --build build --target wasiTests -j$(nproc)
[1/2] Building CXX object test/host/wasi/CMakeFiles/wasiTests.dir/wasi.cpp.o
[2/2] Linking CXX executable test/host/wasi/wasiTests

$ ctest -R wasiTests --output-on-failure
    Start 26: wasiTests
1/1 Test #26: wasiTests ........................   Passed    1.99 sec
100% tests passed, 0 tests failed out of 1

$ ./build/test/host/wasi/wasiTests
[==========] Running 60 tests from 5 test suites.
[==========] 60 tests from 5 test suites ran. (2009 ms total)
[  PASSED  ] 60 tests.
```

The suite builds and passes with the new test file present; the new
`FdAllocateRejectsOffsetLenOverflowMacOS` case is `#if WASMEDGE_OS_MACOS`-gated
and therefore not part of the Linux binary (verified via `--gtest_list_tests`),
so it is exercised by macOS CI rather than this run.

**2. Fix logic reproduced against a real file / real `ftruncate` (before vs. after):**

A standalone harness replays `fdAllocate`'s exact guard/arithmetic against a
real on-disk file, with the overflow guard toggled off (pre-fix) and on
(post-fix):

```
BEFORE FIX (guard off):
  offset=0xffffffffffffffff len=1 -> Offset+Len wraps to 0 -> ftruncate(fd,0)
  file size: 4096 -> 0            **data loss reproduced**

AFTER FIX (guard on):
  offset=0xffffffffffffffff len=1 -> rejected before any file op
  file size: 4096 -> 4096         file untouched
  legit grow 0->1000              accepted, size 1000
  legit grow off=1MiB len=4096    accepted, size 1MiB+4096
  already-large-enough no-op      size unchanged
  offset+len == INT64_MAX         accepted (boundary)
  offset+len == INT64_MAX + 1     rejected (boundary)
```
