### PR TITLE
feat(wasi-nn,ggml): upgrade llama.cpp version to v0.4.0

### DIFF
--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -301,15 +301,21 @@ function(wasmedge_setup_llama_target target)
     # llama.cpp options
     # Disable warnings and debug messages
     set(LLAMA_ALL_WARNINGS OFF)
-    # Disable curl dependency
-    set(LLAMA_CURL OFF)
+    # Disable openssl dependency
+    set(LLAMA_OPENSSL OFF)
     set(LLAMA_METAL_NDEBUG ON)
     set(LLAMA_BUILD_COMMON ON)
-    set(LLAMA_BUILD_TOOLS ON)
+    # Build the mtmd library only instead of the whole llama.cpp tools tree
+    set(LLAMA_BUILD_TOOLS OFF)
+    set(LLAMA_BUILD_MTMD ON)
+    # Disable the ffmpeg-based video input support in mtmd
+    set(MTMD_VIDEO OFF CACHE BOOL "enable video support in mtmd" FORCE)
     set(GGML_ACCELERATE OFF)
     set(GGML_AMX OFF)
     set(GGML_OPENMP OFF)
     set(BUILD_SHARED_LIBS OFF)
+    # All fetched static libraries are linked into the shared plugin library.
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
     if(WASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_NATIVE)
       message(STATUS "WASI-NN GGML LLAMA backend: Enable GGML_NATIVE(AVX/AVX2/FMA/F16C)")
@@ -357,27 +363,17 @@ function(wasmedge_setup_llama_target target)
     FetchContent_Declare(
       llama
       GIT_REPOSITORY https://github.com/ggml-org/llama.cpp.git
-      GIT_TAG        a29e4c0b7b23e020107058480dabbe03b7cba6e1  # b8757
+      GIT_TAG        2ed3c1abbb8e155226b0b2cbeb9e9efad77fbb02  # b9952
       GIT_SHALLOW    FALSE
     )
     FetchContent_MakeAvailable(llama)
     message(STATUS "Downloading llama.cpp source -- done")
-    set_property(TARGET common PROPERTY POSITION_INDEPENDENT_CODE ON)
-    set_property(TARGET ggml PROPERTY POSITION_INDEPENDENT_CODE ON)
-    set_property(TARGET ggml-base PROPERTY POSITION_INDEPENDENT_CODE ON)
-    set_property(TARGET ggml-cpu PROPERTY POSITION_INDEPENDENT_CODE ON)
-    set_property(TARGET llama PROPERTY POSITION_INDEPENDENT_CODE ON)
-    set_property(TARGET mtmd PROPERTY POSITION_INDEPENDENT_CODE ON)
-    if(WASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_CUBLAS)
-      set_property(TARGET ggml-cuda PROPERTY POSITION_INDEPENDENT_CODE ON)
-    endif()
-
     # Reach llama.cpp's headers through -isystem / -external:I. They are pulled
     # into this plugin's own translation units, so without this they compile
     # under WASMEDGE_CFLAGS and trip -Werror on clang-cl, where -Wall means
     # -Weverything.
     foreach(LLAMA_TARGET IN ITEMS
-        common ggml ggml-base ggml-cpu ggml-cuda llama mtmd)
+        llama-common ggml ggml-base ggml-cpu ggml-cuda llama mtmd)
       wasmedge_mark_system_includes(${LLAMA_TARGET})
     endforeach()
   endif()
@@ -411,7 +407,7 @@ function(wasmedge_setup_llama_target target)
     wasmedge_setup_simdjson()
     target_link_libraries(${target}
       PRIVATE
-      common
+      llama-common
       simdjson::simdjson
       mtmd
     )

--- a/cmake/wasi_nn/ggml.cmake
+++ b/cmake/wasi_nn/ggml.cmake
@@ -11,15 +11,21 @@ function(wasmedge_setup_llama_target target)
     # llama.cpp options
     # Disable warnings and debug messages
     set(LLAMA_ALL_WARNINGS OFF)
-    # Disable curl dependency
-    set(LLAMA_CURL OFF)
+    # Disable openssl dependency
+    set(LLAMA_OPENSSL OFF)
     set(LLAMA_METAL_NDEBUG ON)
     set(LLAMA_BUILD_COMMON ON)
-    set(LLAMA_BUILD_TOOLS ON)
+    # Build the mtmd library only instead of the whole llama.cpp tools tree
+    set(LLAMA_BUILD_TOOLS OFF)
+    set(LLAMA_BUILD_MTMD ON)
+    # Disable the ffmpeg-based video input support in mtmd
+    set(MTMD_VIDEO OFF CACHE BOOL "enable video support in mtmd" FORCE)
     set(GGML_ACCELERATE OFF)
     set(GGML_AMX OFF)
     set(GGML_OPENMP OFF)
     set(BUILD_SHARED_LIBS OFF)
+    # All fetched static libraries are linked into the shared plugin library.
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
     if(WASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_NATIVE)
       message(STATUS "WASI-NN GGML LLAMA backend: Enable GGML_NATIVE(AVX/AVX2/FMA/F16C)")
@@ -67,27 +73,17 @@ function(wasmedge_setup_llama_target target)
     FetchContent_Declare(
       llama
       GIT_REPOSITORY https://github.com/ggml-org/llama.cpp.git
-      GIT_TAG        a29e4c0b7b23e020107058480dabbe03b7cba6e1  # b8757
+      GIT_TAG        5266f24da75dc449bd56cbed7addb9c8e4a6a73e  # v0.4.0
       GIT_SHALLOW    FALSE
     )
     FetchContent_MakeAvailable(llama)
     message(STATUS "Downloading llama.cpp source -- done")
-    set_property(TARGET common PROPERTY POSITION_INDEPENDENT_CODE ON)
-    set_property(TARGET ggml PROPERTY POSITION_INDEPENDENT_CODE ON)
-    set_property(TARGET ggml-base PROPERTY POSITION_INDEPENDENT_CODE ON)
-    set_property(TARGET ggml-cpu PROPERTY POSITION_INDEPENDENT_CODE ON)
-    set_property(TARGET llama PROPERTY POSITION_INDEPENDENT_CODE ON)
-    set_property(TARGET mtmd PROPERTY POSITION_INDEPENDENT_CODE ON)
-    if(WASMEDGE_PLUGIN_WASI_NN_GGML_LLAMA_CUBLAS)
-      set_property(TARGET ggml-cuda PROPERTY POSITION_INDEPENDENT_CODE ON)
-    endif()
-
     # Reach llama.cpp's headers through -isystem / -external:I. They are pulled
     # into this plugin's own translation units, so without this they compile
     # under WASMEDGE_CFLAGS and trip -Werror on clang-cl, where -Wall means
     # -Weverything.
     foreach(LLAMA_TARGET IN ITEMS
-        common ggml ggml-base ggml-cpu ggml-cuda llama mtmd)
+        llama-common ggml ggml-base ggml-cpu ggml-cuda llama mtmd)
       wasmedge_mark_system_includes(${LLAMA_TARGET})
     endforeach()
   endif()
@@ -121,7 +117,7 @@ function(wasmedge_setup_llama_target target)
     wasmedge_setup_simdjson()
     target_link_libraries(${target}
       PRIVATE
-      common
+      llama-common
       simdjson::simdjson
       mtmd
     )

--- a/plugins/wasi_nn/GGML/core/ggml_core.cpp
+++ b/plugins/wasi_nn/GGML/core/ggml_core.cpp
@@ -12,11 +12,10 @@
 #include "GGML/metadata/metadata_parser.h"
 #include "wasinn_ggml_log.h"
 #include <base64.hpp>
+#include <build-info.h>
 #include <common.h>
 #include <cstdlib>
 #include <fmt/ranges.h>
-#include <json-partial.h>
-#include <json-schema-to-grammar.h>
 #include <llama.h>
 #include <mtmd-helper.h>
 #include <mtmd.h>
@@ -100,8 +99,8 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, WASINN::Graph &G,
 
   // Logging.
   LOG_DEBUG(GraphRef.EnableDebugLog, "load"sv)
-  LOG_INFO(GraphRef.EnableLog, "LLAMA_COMMIT {}"sv, LLAMA_COMMIT)
-  LOG_INFO(GraphRef.EnableLog, "LLAMA_BUILD_NUMBER {}"sv, LLAMA_BUILD_NUMBER)
+  LOG_INFO(GraphRef.EnableLog, "LLAMA_COMMIT {}"sv, llama_commit())
+  LOG_INFO(GraphRef.EnableLog, "LLAMA_BUILD_NUMBER {}"sv, llama_build_number())
 
   // Handle the model path.
   LOG_DEBUG(GraphRef.EnableDebugLog, "load: handling model path."sv)
@@ -208,8 +207,16 @@ Expect<ErrNo> initExecCtx(WasiNNEnvironment &, WASINN::Graph &G,
   CxtRef.OutputBatch = allocBatch(1);
 
   // Allocate sampler.
-  CxtRef.LlamaSampler =
-      common_sampler_init(GraphRef.LlamaModel.get(), GraphRef.Params.sampling);
+  try {
+    CxtRef.LlamaSampler = common_sampler_init(GraphRef.LlamaModel.get(),
+                                              GraphRef.Params.sampling);
+  } catch (const std::exception &E) {
+    RET_ERROR(ErrNo::InvalidArgument,
+              "initExecCtx: unable to init sampler: {}"sv, E.what())
+  }
+  if (CxtRef.LlamaSampler == nullptr) {
+    RET_ERROR(ErrNo::InvalidArgument, "initExecCtx: unable to init sampler."sv)
+  }
 
   LOG_DEBUG(GraphRef.EnableDebugLog, "initExecCtx...Done"sv)
   return ErrNo::Success;

--- a/plugins/wasi_nn/GGML/core/ggml_core.cpp
+++ b/plugins/wasi_nn/GGML/core/ggml_core.cpp
@@ -12,11 +12,10 @@
 #include "GGML/metadata/metadata_parser.h"
 #include "wasinn_ggml_log.h"
 #include <base64.hpp>
+#include <build-info.h>
 #include <common.h>
 #include <cstdlib>
 #include <fmt/ranges.h>
-#include <json-partial.h>
-#include <json-schema-to-grammar.h>
 #include <llama.h>
 #include <mtmd-helper.h>
 #include <mtmd.h>
@@ -100,8 +99,8 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, WASINN::Graph &G,
 
   // Logging.
   LOG_DEBUG(GraphRef.EnableDebugLog, "load"sv)
-  LOG_INFO(GraphRef.EnableLog, "LLAMA_COMMIT {}"sv, LLAMA_COMMIT)
-  LOG_INFO(GraphRef.EnableLog, "LLAMA_BUILD_NUMBER {}"sv, LLAMA_BUILD_NUMBER)
+  LOG_INFO(GraphRef.EnableLog, "LLAMA_COMMIT {}"sv, llama_commit())
+  LOG_INFO(GraphRef.EnableLog, "LLAMA_BUILD_NUMBER {}"sv, llama_build_number())
 
   // Handle the model path.
   LOG_DEBUG(GraphRef.EnableDebugLog, "load: handling model path."sv)
@@ -172,7 +171,7 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, WASINN::Graph &G,
   // Initialize the TTS related model and context.
   if (GraphRef.TextToSpeech) {
     LOG_DEBUG(GraphRef.EnableDebugLog, "load: initialize TTS model."sv)
-    Params.model = GraphRef.Params.vocoder.model;
+    Params.model = GraphRef.VocoderModel;
     Params.embedding = true;
     llama_model_params TTSModelParams = common_model_params_to_llama(Params);
     GraphRef.TTSModel = llama_model_ptr(
@@ -208,8 +207,16 @@ Expect<ErrNo> initExecCtx(WasiNNEnvironment &, WASINN::Graph &G,
   CxtRef.OutputBatch = allocBatch(1);
 
   // Allocate sampler.
-  CxtRef.LlamaSampler =
-      common_sampler_init(GraphRef.LlamaModel.get(), GraphRef.Params.sampling);
+  try {
+    CxtRef.LlamaSampler = common_sampler_init(GraphRef.LlamaModel.get(),
+                                              GraphRef.Params.sampling);
+  } catch (const std::exception &E) {
+    RET_ERROR(ErrNo::InvalidArgument,
+              "initExecCtx: unable to init sampler: {}"sv, E.what())
+  }
+  if (CxtRef.LlamaSampler == nullptr) {
+    RET_ERROR(ErrNo::InvalidArgument, "initExecCtx: unable to init sampler."sv)
+  }
 
   LOG_DEBUG(GraphRef.EnableDebugLog, "initExecCtx...Done"sv)
   return ErrNo::Success;

--- a/plugins/wasi_nn/GGML/core/ggml_type.h
+++ b/plugins/wasi_nn/GGML/core/ggml_type.h
@@ -62,6 +62,7 @@ struct Graph {
   bool TextToSpeech = false;
   std::string TTSOutputFilePath = "output.wav";
   std::string TTSSpeakerFilePath;
+  common_params_model VocoderModel;
   llama_model_ptr TTSModel = nullptr;
   llama_context_ptr TTSContext = nullptr;
   // Configs.

--- a/plugins/wasi_nn/GGML/core/input_processor.cpp
+++ b/plugins/wasi_nn/GGML/core/input_processor.cpp
@@ -13,6 +13,21 @@
 
 namespace WasmEdge::Host::WASINN::GGML {
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
+namespace {
+
+// Take the ownership of both wrapper members. Video input is not supported:
+// the lazy video bitmap is released before the video context it refers to,
+// and a null bitmap is returned so that callers report a load failure.
+mtmd::bitmap adoptBitmapWrapper(mtmd_helper_bitmap_wrapper Wrapper) noexcept {
+  mtmd_helper::video_ptr VideoContext(Wrapper.video_ctx);
+  mtmd::bitmap Bitmap(Wrapper.bitmap);
+  if (VideoContext != nullptr) {
+    Bitmap.ptr.reset();
+  }
+  return Bitmap;
+}
+
+} // namespace
 
 Expect<ErrNo> setInput(WasiNNEnvironment &Env, WASINN::Graph &G,
                        WASINN::Context &C, uint32_t Index,
@@ -95,10 +110,17 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, WASINN::Graph &G,
                "setInput: Reallocate llama sampler due to parameters change."sv)
       if (CxtRef.LlamaSampler) {
         common_sampler_free(CxtRef.LlamaSampler);
+        CxtRef.LlamaSampler = nullptr;
       }
-      CxtRef.LlamaSampler = common_sampler_init(GraphRef.LlamaModel.get(),
-                                                GraphRef.Params.sampling);
-      if (GraphRef.LlamaContext == nullptr) {
+      try {
+        CxtRef.LlamaSampler = common_sampler_init(GraphRef.LlamaModel.get(),
+                                                  GraphRef.Params.sampling);
+      } catch (const std::exception &E) {
+        G.setInvalid();
+        RET_ERROR(ErrNo::InvalidArgument,
+                  "setInput: unable to init sampler: {}"sv, E.what())
+      }
+      if (CxtRef.LlamaSampler == nullptr) {
         G.setInvalid();
         RET_ERROR(ErrNo::InvalidArgument, "setInput: unable to init sampler."sv)
       }
@@ -195,13 +217,15 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, WASINN::Graph &G,
                                       VisionPromptImagePlaceholder);
         if (Payload.has_value()) {
           // Create the new image bitmap.
-          mtmd::bitmap Bitmap(mtmd_helper_bitmap_init_from_buf(
-              GraphRef.VisionContext.get(), Payload->first.data(),
-              Payload->first.size()));
+          mtmd::bitmap Bitmap =
+              adoptBitmapWrapper(mtmd_helper_bitmap_init_from_buf(
+                  GraphRef.VisionContext.get(), Payload->first.data(),
+                  Payload->first.size(), false));
           if (Bitmap.ptr == nullptr) {
-            RET_ERROR(
-                ErrNo::InvalidArgument,
-                "setInput: unable to load the image from base64 paylaod."sv)
+            RET_ERROR(ErrNo::InvalidArgument,
+                      "setInput: unable to load the image from base64 "sv
+                      "payload. The data may be corrupt, in an unsupported "sv
+                      "format, or a video, which is not supported."sv)
           }
           Bitmaps.entries.push_back(std::move(Bitmap));
         }
@@ -212,13 +236,16 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, WASINN::Graph &G,
         LOG_DEBUG(GraphRef.EnableDebugLog,
                   "setInput: load the image bitmap from file: {}"sv,
                   CxtRef.Conf.ImagePath)
-        mtmd::bitmap Bitmap(mtmd_helper_bitmap_init_from_file(
-            GraphRef.VisionContext.get(), CxtRef.Conf.ImagePath.c_str()));
+        mtmd::bitmap Bitmap =
+            adoptBitmapWrapper(mtmd_helper_bitmap_init_from_file(
+                GraphRef.VisionContext.get(), CxtRef.Conf.ImagePath.c_str(),
+                false));
         if (Bitmap.ptr == nullptr) {
-          RET_ERROR(
-              ErrNo::InvalidArgument,
-              "setInput: unable to load the image bitmap from file: {}."sv,
-              CxtRef.Conf.ImagePath)
+          RET_ERROR(ErrNo::InvalidArgument,
+                    "setInput: unable to load the image bitmap from file: "sv
+                    "{}. The file may be corrupt, in an unsupported "sv
+                    "format, or a video, which is not supported."sv,
+                    CxtRef.Conf.ImagePath)
         }
         Bitmaps.entries.push_back(std::move(Bitmap));
         LOG_DEBUG(GraphRef.EnableDebugLog,

--- a/plugins/wasi_nn/GGML/core/input_processor.cpp
+++ b/plugins/wasi_nn/GGML/core/input_processor.cpp
@@ -13,6 +13,21 @@
 
 namespace WasmEdge::Host::WASINN::GGML {
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
+namespace {
+
+// Take the ownership of both wrapper members. Video input is not supported:
+// the lazy video bitmap is released before the video context it refers to,
+// and a null bitmap is returned so that callers report a load failure.
+mtmd::bitmap adoptBitmapWrapper(mtmd_helper_bitmap_wrapper Wrapper) noexcept {
+  mtmd_helper::video_ptr VideoContext(Wrapper.video_ctx);
+  mtmd::bitmap Bitmap(Wrapper.bitmap);
+  if (VideoContext != nullptr) {
+    Bitmap.ptr.reset();
+  }
+  return Bitmap;
+}
+
+} // namespace
 
 Expect<ErrNo> setInput(WasiNNEnvironment &Env, WASINN::Graph &G,
                        WASINN::Context &C, uint32_t Index,
@@ -95,10 +110,17 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, WASINN::Graph &G,
                "setInput: Reallocate llama sampler due to parameters change."sv)
       if (CxtRef.LlamaSampler) {
         common_sampler_free(CxtRef.LlamaSampler);
+        CxtRef.LlamaSampler = nullptr;
       }
-      CxtRef.LlamaSampler = common_sampler_init(GraphRef.LlamaModel.get(),
-                                                GraphRef.Params.sampling);
-      if (GraphRef.LlamaContext == nullptr) {
+      try {
+        CxtRef.LlamaSampler = common_sampler_init(GraphRef.LlamaModel.get(),
+                                                  GraphRef.Params.sampling);
+      } catch (const std::exception &E) {
+        G.setInvalid();
+        RET_ERROR(ErrNo::InvalidArgument,
+                  "setInput: unable to init sampler: {}"sv, E.what())
+      }
+      if (CxtRef.LlamaSampler == nullptr) {
         G.setInvalid();
         RET_ERROR(ErrNo::InvalidArgument, "setInput: unable to init sampler."sv)
       }
@@ -195,13 +217,16 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, WASINN::Graph &G,
                                       VisionPromptImagePlaceholder);
         if (Payload.has_value()) {
           // Create the new image bitmap.
-          mtmd::bitmap Bitmap(mtmd_helper_bitmap_init_from_buf(
-              GraphRef.VisionContext.get(), Payload->first.data(),
-              Payload->first.size()));
+          mtmd::bitmap Bitmap =
+              adoptBitmapWrapper(mtmd_helper_bitmap_init_from_buf(
+                  GraphRef.VisionContext.get(), Payload->first.data(),
+                  Payload->first.size(), false,
+                  mtmd_helper_init_opt_default()));
           if (Bitmap.ptr == nullptr) {
-            RET_ERROR(
-                ErrNo::InvalidArgument,
-                "setInput: unable to load the image from base64 paylaod."sv)
+            RET_ERROR(ErrNo::InvalidArgument,
+                      "setInput: unable to load the image from base64 "sv
+                      "payload. The data may be corrupt, in an unsupported "sv
+                      "format, or a video, which is not supported."sv)
           }
           Bitmaps.entries.push_back(std::move(Bitmap));
         }
@@ -212,13 +237,16 @@ Expect<ErrNo> setInput(WasiNNEnvironment &Env, WASINN::Graph &G,
         LOG_DEBUG(GraphRef.EnableDebugLog,
                   "setInput: load the image bitmap from file: {}"sv,
                   CxtRef.Conf.ImagePath)
-        mtmd::bitmap Bitmap(mtmd_helper_bitmap_init_from_file(
-            GraphRef.VisionContext.get(), CxtRef.Conf.ImagePath.c_str()));
+        mtmd::bitmap Bitmap =
+            adoptBitmapWrapper(mtmd_helper_bitmap_init_from_file(
+                GraphRef.VisionContext.get(), CxtRef.Conf.ImagePath.c_str(),
+                false, mtmd_helper_init_opt_default()));
         if (Bitmap.ptr == nullptr) {
-          RET_ERROR(
-              ErrNo::InvalidArgument,
-              "setInput: unable to load the image bitmap from file: {}."sv,
-              CxtRef.Conf.ImagePath)
+          RET_ERROR(ErrNo::InvalidArgument,
+                    "setInput: unable to load the image bitmap from file: "sv
+                    "{}. The file may be corrupt, in an unsupported "sv
+                    "format, or a video, which is not supported."sv,
+                    CxtRef.Conf.ImagePath)
         }
         Bitmaps.entries.push_back(std::move(Bitmap));
         LOG_DEBUG(GraphRef.EnableDebugLog,

--- a/plugins/wasi_nn/GGML/core/output_generator.cpp
+++ b/plugins/wasi_nn/GGML/core/output_generator.cpp
@@ -3,6 +3,10 @@
 
 #include "ggml_core.h"
 
+#ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
+#include <build-info.h>
+#endif
+
 namespace WasmEdge::Host::WASINN::GGML {
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
 namespace {
@@ -13,7 +17,7 @@ std::string buildOutputMetadata(Context &CxtRef) noexcept {
                      R"("llama_build_number": {}, )"
                      R"("llama_commit": "{}"}})"sv,
                      CxtRef.LlamaNInputs, CxtRef.LlamaOutputTokens.size(),
-                     LLAMA_BUILD_NUMBER, LLAMA_COMMIT);
+                     llama_build_number(), llama_commit());
 }
 } // namespace
 

--- a/plugins/wasi_nn/GGML/metadata/metadata_parser.cpp
+++ b/plugins/wasi_nn/GGML/metadata/metadata_parser.cpp
@@ -6,12 +6,27 @@
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
 #include <common.h>
 #include <fmt/ranges.h>
-#include <json-partial.h>
 #include <json-schema-to-grammar.h>
+#include <nlohmann/json.hpp>
 #endif
 
 namespace WasmEdge::Host::WASINN::GGML {
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
+namespace {
+
+// Warn about options removed from llama.cpp instead of silently ignoring
+// them.
+void warnRemovedKey(const simdjson::dom::element &Doc, std::string_view Key) {
+  if (Doc.at_key(Key).error() == simdjson::SUCCESS) {
+    LOG_WARN(
+        "metadata: the \"{}\" option is no longer supported by llama.cpp "sv
+        "and is ignored."sv,
+        Key)
+  }
+}
+
+} // namespace
+
 // Parse metadata from JSON.
 ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
                     const std::string &Metadata, bool *IsModelUpdated,
@@ -269,27 +284,32 @@ ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
     parseJsonWithProcessorAuto<std::string_view>(
         Doc, "json-schema",
         [&GraphRef](const std::string_view &JsonSchema) -> bool {
-          GraphRef.Params.sampling.grammar =
-              common_grammar(COMMON_GRAMMAR_TYPE_OUTPUT_FORMAT,
-                             json_schema_to_grammar(
-                                 nlohmann::ordered_json::parse(JsonSchema)));
+          try {
+            GraphRef.Params.sampling.grammar =
+                common_grammar(COMMON_GRAMMAR_TYPE_OUTPUT_FORMAT,
+                               json_schema_to_grammar(
+                                   nlohmann::ordered_json::parse(JsonSchema)));
+          } catch (const std::exception &E) {
+            LOG_ERROR("Invalid json-schema option: {}"sv, E.what())
+            return false;
+          }
           return true;
         });
     parseJsonWithCastAuto<int64_t>(Doc, "seed", GraphRef.Params.sampling.seed);
 
     // The speculative parameters.
-    parseJsonWithCastAuto<int64_t>(Doc, "n-ctx-speculative",
-                                   GraphRef.Params.speculative.n_ctx);
+    warnRemovedKey(Doc, "n-ctx-speculative"sv);
     parseJsonWithCastAuto<int64_t>(Doc, "n-max-speculative",
-                                   GraphRef.Params.speculative.n_max);
+                                   GraphRef.Params.speculative.draft.n_max);
     parseJsonWithCastAuto<int64_t>(Doc, "n-min-speculative",
-                                   GraphRef.Params.speculative.n_min);
-    parseJsonWithCastAuto<int64_t>(Doc, "n-gpu-layers-speculative",
-                                   GraphRef.Params.speculative.n_gpu_layers);
+                                   GraphRef.Params.speculative.draft.n_min);
+    parseJsonWithCastAuto<int64_t>(
+        Doc, "n-gpu-layers-speculative",
+        GraphRef.Params.speculative.draft.n_gpu_layers);
     parseJsonWithCastAuto<double>(Doc, "p-split-speculative",
-                                  GraphRef.Params.speculative.p_split);
+                                  GraphRef.Params.speculative.draft.p_split);
     parseJsonWithCastAuto<double>(Doc, "p-min-speculative",
-                                  GraphRef.Params.speculative.p_min);
+                                  GraphRef.Params.speculative.draft.p_min);
     // The vocoder parameters.
     parseJsonWithCastAuto<std::string_view>(
         Doc, "hf-repo-vocoder", GraphRef.Params.vocoder.model.hf_repo);
@@ -330,10 +350,10 @@ ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
                                             GraphRef.Params.input_suffix);
     parseJsonWithCastAuto<std::string_view>(
         Doc, "lookup-cache-static",
-        GraphRef.Params.speculative.lookup_cache_static);
+        GraphRef.Params.speculative.ngram_cache.lookup_cache_static);
     parseJsonWithCastAuto<std::string_view>(
         Doc, "lookup-cache-dynamic",
-        GraphRef.Params.speculative.lookup_cache_dynamic);
+        GraphRef.Params.speculative.ngram_cache.lookup_cache_dynamic);
     parseJsonWithCastAuto<std::string_view>(Doc, "logits-file",
                                             GraphRef.Params.logits_file);
     parseJsonAuto<bool>(Doc, "lora-init-without-apply",
@@ -440,7 +460,7 @@ ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
                                             GraphRef.Params.ssl_file_key);
     parseJsonWithCastAuto<std::string_view>(Doc, "ssl-file-cert",
                                             GraphRef.Params.ssl_file_cert);
-    parseJsonAuto<bool>(Doc, "webui", GraphRef.Params.webui);
+    parseJsonAuto<bool>(Doc, "webui", GraphRef.Params.ui);
     parseJsonAuto<bool>(Doc, "endpoint-slots", GraphRef.Params.endpoint_slots);
     parseJsonAuto<bool>(Doc, "endpoint-props", GraphRef.Params.endpoint_props);
     parseJsonAuto<bool>(Doc, "endpoint-metrics",
@@ -520,6 +540,10 @@ ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
                         GraphRef.Params.batched_bench_output_jsonl);
   } catch (const ErrNo &Error) {
     return Error;
+  } catch (const std::exception &E) {
+    RET_ERROR(ErrNo::InvalidArgument,
+              "metadata: unexpected exception while applying options: {}"sv,
+              E.what())
   }
   // The tensor buffer overrides should be terminated with an empty pattern.
   if (!GraphRef.TensorBuftOverrides.empty()) {

--- a/plugins/wasi_nn/GGML/metadata/metadata_parser.cpp
+++ b/plugins/wasi_nn/GGML/metadata/metadata_parser.cpp
@@ -6,12 +6,26 @@
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
 #include <common.h>
 #include <fmt/ranges.h>
-#include <json-partial.h>
 #include <json-schema-to-grammar.h>
 #endif
 
 namespace WasmEdge::Host::WASINN::GGML {
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
+namespace {
+
+// Warn about options removed from llama.cpp instead of silently ignoring
+// them.
+void warnRemovedKey(const simdjson::dom::element &Doc, std::string_view Key) {
+  if (Doc.at_key(Key).error() == simdjson::SUCCESS) {
+    LOG_WARN(
+        "metadata: the \"{}\" option is no longer supported by llama.cpp "sv
+        "and is ignored."sv,
+        Key)
+  }
+}
+
+} // namespace
+
 // Parse metadata from JSON.
 ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
                     const std::string &Metadata, bool *IsModelUpdated,
@@ -116,7 +130,7 @@ ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
     // The TTS parameters using macros
     parseJsonAuto<bool>(Doc, "tts", GraphRef.TextToSpeech);
     parseJsonWithCastAuto<std::string_view>(Doc, "model-vocoder",
-                                            GraphRef.Params.vocoder.model.path);
+                                            GraphRef.VocoderModel.path);
     parseJsonWithCastAuto<std::string_view>(Doc, "tts-output-file",
                                             GraphRef.TTSOutputFilePath);
 
@@ -269,34 +283,39 @@ ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
     parseJsonWithProcessorAuto<std::string_view>(
         Doc, "json-schema",
         [&GraphRef](const std::string_view &JsonSchema) -> bool {
-          GraphRef.Params.sampling.grammar =
-              common_grammar(COMMON_GRAMMAR_TYPE_OUTPUT_FORMAT,
-                             json_schema_to_grammar(
-                                 nlohmann::ordered_json::parse(JsonSchema)));
+          try {
+            GraphRef.Params.sampling.grammar =
+                common_grammar(COMMON_GRAMMAR_TYPE_OUTPUT_FORMAT,
+                               json_schema_to_grammar(common_json::parse(
+                                   std::string(JsonSchema))));
+          } catch (const std::exception &E) {
+            LOG_ERROR("Invalid json-schema option: {}"sv, E.what())
+            return false;
+          }
           return true;
         });
     parseJsonWithCastAuto<int64_t>(Doc, "seed", GraphRef.Params.sampling.seed);
 
     // The speculative parameters.
-    parseJsonWithCastAuto<int64_t>(Doc, "n-ctx-speculative",
-                                   GraphRef.Params.speculative.n_ctx);
+    warnRemovedKey(Doc, "n-ctx-speculative"sv);
     parseJsonWithCastAuto<int64_t>(Doc, "n-max-speculative",
-                                   GraphRef.Params.speculative.n_max);
+                                   GraphRef.Params.speculative.draft.n_max);
     parseJsonWithCastAuto<int64_t>(Doc, "n-min-speculative",
-                                   GraphRef.Params.speculative.n_min);
-    parseJsonWithCastAuto<int64_t>(Doc, "n-gpu-layers-speculative",
-                                   GraphRef.Params.speculative.n_gpu_layers);
+                                   GraphRef.Params.speculative.draft.n_min);
+    parseJsonWithCastAuto<int64_t>(
+        Doc, "n-gpu-layers-speculative",
+        GraphRef.Params.speculative.draft.n_gpu_layers);
     parseJsonWithCastAuto<double>(Doc, "p-split-speculative",
-                                  GraphRef.Params.speculative.p_split);
+                                  GraphRef.Params.speculative.draft.p_split);
     parseJsonWithCastAuto<double>(Doc, "p-min-speculative",
-                                  GraphRef.Params.speculative.p_min);
+                                  GraphRef.Params.speculative.draft.p_min);
     // The vocoder parameters.
-    parseJsonWithCastAuto<std::string_view>(
-        Doc, "hf-repo-vocoder", GraphRef.Params.vocoder.model.hf_repo);
-    parseJsonWithCastAuto<std::string_view>(
-        Doc, "hf-file-vocoder", GraphRef.Params.vocoder.model.hf_file);
+    parseJsonWithCastAuto<std::string_view>(Doc, "hf-repo-vocoder",
+                                            GraphRef.VocoderModel.hf_repo);
+    parseJsonWithCastAuto<std::string_view>(Doc, "hf-file-vocoder",
+                                            GraphRef.VocoderModel.hf_file);
     parseJsonWithCastAuto<std::string_view>(Doc, "model-url-vocoder",
-                                            GraphRef.Params.vocoder.model.url);
+                                            GraphRef.VocoderModel.url);
 
     // The config parameters.
     parseJsonAuto<bool>(Doc, "stream-stdout", ConfRef.StreamStdout);
@@ -330,10 +349,10 @@ ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
                                             GraphRef.Params.input_suffix);
     parseJsonWithCastAuto<std::string_view>(
         Doc, "lookup-cache-static",
-        GraphRef.Params.speculative.lookup_cache_static);
+        GraphRef.Params.speculative.ngram_cache.lookup_cache_static);
     parseJsonWithCastAuto<std::string_view>(
         Doc, "lookup-cache-dynamic",
-        GraphRef.Params.speculative.lookup_cache_dynamic);
+        GraphRef.Params.speculative.ngram_cache.lookup_cache_dynamic);
     parseJsonWithCastAuto<std::string_view>(Doc, "logits-file",
                                             GraphRef.Params.logits_file);
     parseJsonAuto<bool>(Doc, "lora-init-without-apply",
@@ -394,8 +413,57 @@ ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
     parseJsonAuto<bool>(Doc, "ctx-shift", GraphRef.Params.ctx_shift);
     parseJsonAuto<bool>(Doc, "input-prefix-bos",
                         GraphRef.Params.input_prefix_bos);
-    parseJsonAuto<bool>(Doc, "use-mlock", GraphRef.Params.use_mlock);
-    parseJsonAuto<bool>(Doc, "use-mmap", GraphRef.Params.use_mmap);
+    // llama.cpp merged the mmap and mlock switches into the load-mode
+    // parameter. Map the legacy boolean keys onto it for compatibility.
+    {
+      bool UseMmap = true;
+      bool UseMlock = false;
+      bool LegacyLoadKeyUsed = false;
+      parseJsonWithProcessorAuto<bool>(
+          Doc, "use-mlock", [&UseMlock, &LegacyLoadKeyUsed](const bool &Value) {
+            UseMlock = Value;
+            LegacyLoadKeyUsed = true;
+            return true;
+          });
+      parseJsonWithProcessorAuto<bool>(
+          Doc, "use-mmap", [&UseMmap, &LegacyLoadKeyUsed](const bool &Value) {
+            UseMmap = Value;
+            LegacyLoadKeyUsed = true;
+            return true;
+          });
+      if (LegacyLoadKeyUsed) {
+        if (UseMlock) {
+          GraphRef.Params.load_mode =
+              UseMmap ? LLAMA_LOAD_MODE_MMAP_MLOCK : LLAMA_LOAD_MODE_MLOCK;
+        } else {
+          GraphRef.Params.load_mode =
+              UseMmap ? LLAMA_LOAD_MODE_MMAP : LLAMA_LOAD_MODE_NONE;
+        }
+      }
+    }
+    parseJsonWithProcessorAuto<std::string_view>(
+        Doc, "load-mode",
+        [&GraphRef](const std::string_view &LoadMode) -> bool {
+          if (LoadMode == "auto"sv) {
+            GraphRef.Params.load_mode = LLAMA_LOAD_MODE_AUTO;
+          } else if (LoadMode == "none"sv) {
+            GraphRef.Params.load_mode = LLAMA_LOAD_MODE_NONE;
+          } else if (LoadMode == "mmap"sv) {
+            GraphRef.Params.load_mode = LLAMA_LOAD_MODE_MMAP;
+          } else if (LoadMode == "mlock"sv) {
+            GraphRef.Params.load_mode = LLAMA_LOAD_MODE_MLOCK;
+          } else if (LoadMode == "mmap+mlock"sv) {
+            GraphRef.Params.load_mode = LLAMA_LOAD_MODE_MMAP_MLOCK;
+          } else if (LoadMode == "dio"sv) {
+            GraphRef.Params.load_mode = LLAMA_LOAD_MODE_DIRECT_IO;
+          } else {
+            spdlog::error(
+                "[WASI-NN] GGML backend: The load-mode option must be "
+                "one of: auto, none, mmap, mlock, mmap+mlock, dio."sv);
+            return false;
+          }
+          return true;
+        });
     parseJsonAuto<bool>(Doc, "verbose-prompt", GraphRef.Params.verbose_prompt);
     parseJsonAuto<bool>(Doc, "display-prompt", GraphRef.Params.display_prompt);
     parseJsonAuto<bool>(Doc, "no-kv-offload", GraphRef.Params.no_kv_offload);
@@ -440,7 +508,7 @@ ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
                                             GraphRef.Params.ssl_file_key);
     parseJsonWithCastAuto<std::string_view>(Doc, "ssl-file-cert",
                                             GraphRef.Params.ssl_file_cert);
-    parseJsonAuto<bool>(Doc, "webui", GraphRef.Params.webui);
+    parseJsonAuto<bool>(Doc, "webui", GraphRef.Params.ui);
     parseJsonAuto<bool>(Doc, "endpoint-slots", GraphRef.Params.endpoint_slots);
     parseJsonAuto<bool>(Doc, "endpoint-props", GraphRef.Params.endpoint_props);
     parseJsonAuto<bool>(Doc, "endpoint-metrics",
@@ -520,6 +588,10 @@ ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
                         GraphRef.Params.batched_bench_output_jsonl);
   } catch (const ErrNo &Error) {
     return Error;
+  } catch (const std::exception &E) {
+    RET_ERROR(ErrNo::InvalidArgument,
+              "metadata: unexpected exception while applying options: {}"sv,
+              E.what())
   }
   // The tensor buffer overrides should be terminated with an empty pattern.
   if (!GraphRef.TensorBuftOverrides.empty()) {

--- a/plugins/wasi_nn/GGML/metadata/metadata_parser.cpp
+++ b/plugins/wasi_nn/GGML/metadata/metadata_parser.cpp
@@ -413,11 +413,13 @@ ErrNo parseMetadata(Graph &GraphRef, LocalConfig &ConfRef,
     parseJsonAuto<bool>(Doc, "ctx-shift", GraphRef.Params.ctx_shift);
     parseJsonAuto<bool>(Doc, "input-prefix-bos",
                         GraphRef.Params.input_prefix_bos);
-    // llama.cpp merged the mmap and mlock switches into the load-mode
-    // parameter. Map the legacy boolean keys onto it for compatibility.
     {
-      bool UseMmap = true;
-      bool UseMlock = false;
+      const auto LoadMode = GraphRef.Params.load_mode;
+      bool UseMmap = LoadMode == LLAMA_LOAD_MODE_AUTO ||
+                     LoadMode == LLAMA_LOAD_MODE_MMAP ||
+                     LoadMode == LLAMA_LOAD_MODE_MMAP_MLOCK;
+      bool UseMlock = LoadMode == LLAMA_LOAD_MODE_MLOCK ||
+                      LoadMode == LLAMA_LOAD_MODE_MMAP_MLOCK;
       bool LegacyLoadKeyUsed = false;
       parseJsonWithProcessorAuto<bool>(
           Doc, "use-mlock", [&UseMlock, &LegacyLoadKeyUsed](const bool &Value) {

--- a/plugins/wasi_nn/GGML/tts/tts_core.cpp
+++ b/plugins/wasi_nn/GGML/tts/tts_core.cpp
@@ -5,8 +5,7 @@
 #include "host/wasi/vfs_io.h"
 
 #ifdef WASMEDGE_PLUGIN_WASI_NN_BACKEND_GGML
-#include <json-partial.h>
-#include <json-schema-to-grammar.h>
+#include <nlohmann/json.hpp>
 #include <regex>
 #endif
 
@@ -381,35 +380,41 @@ getSpeakerProfileFromFile(const std::string &FilePath, WasiNNEnvironment &Env) {
   if (!JsonFile.is_open()) {
     return std::nullopt;
   }
-  nlohmann::json JsonData;
-  JsonFile >> JsonData;
-  JsonFile.close();
+  try {
+    nlohmann::json JsonData;
+    JsonFile >> JsonData;
+    JsonFile.close();
 
-  // Initialize the outputs.
-  std::string AudioOutputText = "<|audio_start|>\n";
-  std::string TextOutput = "<|text_start|>";
+    // Initialize the outputs.
+    std::string AudioOutputText = "<|audio_start|>\n";
+    std::string TextOutput = "<|text_start|>";
 
-  // Iterate through each word in the JSON data
-  for (const auto &WordData : JsonData["words"]) {
-    std::string Word = WordData["word"];
-    double Duration = WordData["duration"];
-    std::vector<int> Codes = WordData["codes"];
+    // Iterate through each word in the JSON data
+    for (const auto &WordData : JsonData.at("words")) {
+      std::string Word = WordData.at("word");
+      double Duration = WordData.at("duration");
+      std::vector<int> Codes = WordData.at("codes");
 
-    // Create the audio output entry
-    std::ostringstream WordEntry;
-    WordEntry << Word << "<|t_" << std::fixed << std::setprecision(2)
-              << Duration << "|><|code_start|>";
-    for (const auto &Code : Codes) {
-      WordEntry << "<|" << Code << "|>";
+      // Create the audio output entry
+      std::ostringstream WordEntry;
+      WordEntry << Word << "<|t_" << std::fixed << std::setprecision(2)
+                << Duration << "|><|code_start|>";
+      for (const auto &Code : Codes) {
+        WordEntry << "<|" << Code << "|>";
+      }
+      WordEntry << "<|code_end|>\n";
+      AudioOutputText += WordEntry.str();
+
+      // Create the text output entry
+      TextOutput += Word + "<|text_sep|>";
     }
-    WordEntry << "<|code_end|>\n";
-    AudioOutputText += WordEntry.str();
 
-    // Create the text output entry
-    TextOutput += Word + "<|text_sep|>";
+    return TTSSpeakerProfile{TextOutput, AudioOutputText};
+  } catch (const std::exception &E) {
+    LOG_ERROR("getSpeakerProfileFromFile: invalid speaker profile: {}"sv,
+              E.what())
+    return std::nullopt;
   }
-
-  return TTSSpeakerProfile{TextOutput, AudioOutputText};
 }
 
 // TextToSpeech function that generates voice data from codes.

--- a/test/plugins/wasi_nn/CMakeLists.txt
+++ b/test/plugins/wasi_nn/CMakeLists.txt
@@ -233,13 +233,6 @@ target_link_libraries(wasiNNTests
   ${GTEST_BOTH_LIBRARIES}
 )
 
-if(TARGET build_info)
-  target_link_libraries(wasiNNTests
-    PRIVATE
-    build_info
-  )
-endif()
-
 # Link to the WasmEdge library
 if(WASMEDGE_LINK_PLUGINS_STATIC)
   target_link_libraries(wasiNNTests

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -1487,6 +1487,57 @@ TEST(WasiNNTest, GGMLBackend) {
   }
 
   // GGML WASI-NN set_input tests.
+  {
+    auto Graph = NNMod->getEnv().NNGraph.get(0);
+    ASSERT_NE(Graph, nullptr);
+    const auto &Params =
+        Graph->get<WasmEdge::Host::WASINN::GGML::Graph>().Params;
+    struct LoadModeCase {
+      std::string_view Metadata;
+      llama_load_mode Expected;
+    };
+    const LoadModeCase Cases[] = {
+        {R"({"use-mmap":false})", LLAMA_LOAD_MODE_NONE},
+        {R"({"use-mlock":true})", LLAMA_LOAD_MODE_MLOCK},
+        {R"({})", LLAMA_LOAD_MODE_MLOCK},
+        {R"({"use-mmap":true})", LLAMA_LOAD_MODE_MMAP_MLOCK},
+        {R"({"use-mlock":false})", LLAMA_LOAD_MODE_MMAP},
+        {R"({"use-mlock":true})", LLAMA_LOAD_MODE_MMAP_MLOCK},
+        {R"({"use-mmap":false})", LLAMA_LOAD_MODE_MLOCK},
+        {R"({"use-mlock":false})", LLAMA_LOAD_MODE_NONE},
+        {R"({"load-mode":"mmap+mlock"})", LLAMA_LOAD_MODE_MMAP_MLOCK},
+        {R"({"use-mmap":false})", LLAMA_LOAD_MODE_MLOCK},
+        {R"({"load-mode":"auto"})", LLAMA_LOAD_MODE_AUTO},
+        {R"({})", LLAMA_LOAD_MODE_AUTO},
+        {R"({"use-mlock":true})", LLAMA_LOAD_MODE_MMAP_MLOCK},
+        {R"({"load-mode":"dio"})", LLAMA_LOAD_MODE_DIRECT_IO},
+        {R"({})", LLAMA_LOAD_MODE_DIRECT_IO},
+        {R"({"use-mlock":true})", LLAMA_LOAD_MODE_MLOCK},
+        {R"({"use-mmap":true,"use-mlock":false,"load-mode":"none"})",
+         LLAMA_LOAD_MODE_NONE},
+        {R"({"load-mode":"auto"})", LLAMA_LOAD_MODE_AUTO},
+    };
+    for (const auto &Case : Cases) {
+      SCOPED_TRACE(Case.Metadata);
+      std::vector<uint8_t> MetadataData(Case.Metadata.begin(),
+                                        Case.Metadata.end());
+      uint32_t EntryPtr = BuilderPtr;
+      writeFatPointer(MemInst, StorePtr, UINT32_C(1), EntryPtr);
+      writeUInt32(MemInst, static_cast<uint32_t>(TensorType::U8), EntryPtr);
+      writeFatPointer(MemInst, StorePtr + UINT32_C(4),
+                      static_cast<uint32_t>(MetadataData.size()), EntryPtr);
+      writeBinaries<uint32_t>(MemInst, TensorDim, StorePtr);
+      writeBinaries<uint8_t>(MemInst, MetadataData, StorePtr + UINT32_C(4));
+      ASSERT_TRUE(
+          HostFuncSetInput.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   UINT32_C(0), UINT32_C(1), BuilderPtr},
+                               Errno));
+      ASSERT_EQ(Errno[0].get<int32_t>(), static_cast<uint32_t>(ErrNo::Success));
+      EXPECT_EQ(Params.load_mode, Case.Expected);
+    }
+  }
+
   SetInputEntryPtr = BuilderPtr;
   writeFatPointer(MemInst, StorePtr, static_cast<uint32_t>(TensorDim.size()),
                   BuilderPtr);


### PR DESCRIPTION
## Description

Upgrade the WASI-NN GGML backend from llama.cpp b8757 to the official v0.4.0 release, pinned to commit `5266f24da75dc449bd56cbed7addb9c8e4a6a73e`. Adapt the integration to the upstream API and build-system changes.

- Use the renamed `llama-common` target, build-info functions, `common_json`, and restructured speculative parameters.
- Adapt MTMD bitmap ownership and pass default initialization options to both file and buffer image loaders. Disable MTMD video support and reject unsupported video inputs.
- Keep vocoder model settings in the graph, map legacy `use-mmap` and `use-mlock` metadata to `load_mode`, and accept the `load-mode` key. Map `webui` to `ui` and warn for the removed `n-ctx-speculative` option.
- Disable OpenSSL, build only the required MTMD library, enable position-independent code for fetched static libraries, and remove obsolete test linkage.
- Convert JSON schema, TTS speaker profile, and sampler initialization exceptions into `InvalidArgument` errors, and correct the sampler reallocation null check.

This contribution was developed with assistance from Claude (Anthropic) and Codex (OpenAI).

## Checklist

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`).
- [x] **Commit Messages**: Validate commit messages and the PR title with `commitlint`.
- [x] **Coding Style**: Validate the changed C++ files with `clang-format` and the changed files with `lineguard`.
- [x] **Local Tests Passed**: Build and test evidence is recorded below.
- [x] **AI Disclosure**: Include `Assisted-by:` trailers and disclose AI assistance in this description.
- [x] **Human-in-the-loop**: The contributor reviewed the reported changes and authorized updating this PR.

## Test Evidence

Environment: macOS arm64, Release build, GGML backend with native CPU optimizations and Metal enabled; LLVM disabled. The Metal tests passed outside the agent sandbox.

```console
$ cmake -S . -B build
-- ggml version: 0.23.0
-- ggml commit:  5266f24da
-- Configuring done
-- Generating done

$ cmake --build build --target wasiNNTests -j8
[ 98%] Built target wasmedgePluginWasiNN
[100%] Built target wasiNNTests

$ ctest --test-dir build -R '^wasiNNTests$' --output-on-failure
1/1 Test #19: wasiNNTests ......................   Passed   14.72 sec
100% tests passed out of 1
```

The test log reports 22 tests from 2 test suites, all passed.

`clang-format --dry-run --Werror` passed for all six changed C++ files. `lineguard` passed for all eight changed files, and `git diff --check` passed.

Linux, Windows, CUDA, and other backend validation is left to CI.
