### PR TITLE
fix(aot): run compiled cross-module calls with the callee's module context

### DIFF
--- a/include/common/executable.h
+++ b/include/common/executable.h
@@ -36,8 +36,8 @@ public:
   virtual ~Executable() noexcept = default;
 
   /// Function type wrapper for symbols.
-  using Wrapper = void(void *ExecCtx, void *Function, const ValVariant *Args,
-                       ValVariant *Rets);
+  using Wrapper = void(void *ModCtx, void *ExecCtx, void *Function,
+                       const ValVariant *Args, ValVariant *Rets);
 
   enum class Intrinsics : uint32_t {
     kTrap,

--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -27,6 +27,7 @@
 #include "runtime/instance/module.h"
 #include "runtime/stackmgr.h"
 #include "runtime/storemgr.h"
+#include "system/stacktrace.h"
 
 #include <atomic>
 #include <csignal>
@@ -220,6 +221,12 @@ public:
   invoke(const Runtime::Instance::Component::FunctionInstance *FuncInst,
          Span<const ComponentValVariant> Params,
          Span<const ComponentValType> ParamTypes);
+
+  /// Module-qualified stack trace of the most recent failed invocation on this
+  /// thread. Valid right after an invocation returns an error, else stale.
+  static Span<const StackTraceEntry> getRecordedStackTrace() noexcept {
+    return Span<const StackTraceEntry>{StackTrace}.first(StackTraceSize);
+  }
 
   /// Asynchronous invoke a WASM function by function instance.
   Async<Expect<std::vector<std::pair<ValVariant, ValType>>>>
@@ -1224,7 +1231,7 @@ private:
   /// Pending exception for compiled functions
   static thread_local PendingExnStruct PendingExn;
   /// Record stack trace on error
-  static thread_local std::array<uint32_t, 256> StackTrace;
+  static thread_local std::array<StackTraceEntry, 256> StackTrace;
   static thread_local size_t StackTraceSize;
 
   /// WasmEdge configuration

--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -424,48 +424,51 @@ private:
 
   /// \name Helper Functions for GC instructions.
   /// @{
-  Expect<RefVariant> structNew(Runtime::StackManager &StackMgr,
+  Expect<RefVariant> structNew(const Runtime::Instance::ModuleInstance *ModInst,
                                const uint32_t TypeIdx,
                                Span<const ValVariant> Args = {}) const noexcept;
-  Expect<ValVariant> structGet(Runtime::StackManager &StackMgr,
+  Expect<ValVariant> structGet(const Runtime::Instance::ModuleInstance *ModInst,
                                const RefVariant Ref, const uint32_t TypeIdx,
                                const uint32_t Off,
                                const bool IsSigned = false) const noexcept;
-  Expect<void> structSet(Runtime::StackManager &StackMgr, const RefVariant Ref,
-                         const ValVariant Val, const uint32_t TypeIdx,
+  Expect<void> structSet(const Runtime::Instance::ModuleInstance *ModInst,
+                         const RefVariant Ref, const ValVariant Val,
+                         const uint32_t TypeIdx,
                          const uint32_t Off) const noexcept;
-  Expect<RefVariant> arrayNew(Runtime::StackManager &StackMgr,
+  Expect<RefVariant> arrayNew(const Runtime::Instance::ModuleInstance *ModInst,
                               const uint32_t TypeIdx, const uint32_t Length,
                               Span<const ValVariant> Args = {}) const noexcept;
-  Expect<RefVariant> arrayNewData(Runtime::StackManager &StackMgr,
-                                  const uint32_t TypeIdx,
-                                  const uint32_t DataIdx, const uint32_t Start,
-                                  const uint32_t Length) const noexcept;
-  Expect<RefVariant> arrayNewElem(Runtime::StackManager &StackMgr,
-                                  const uint32_t TypeIdx,
-                                  const uint32_t ElemIdx, const uint32_t Start,
-                                  const uint32_t Length) const noexcept;
-  Expect<ValVariant> arrayGet(Runtime::StackManager &StackMgr,
+  Expect<RefVariant>
+  arrayNewData(const Runtime::Instance::ModuleInstance *ModInst,
+               const uint32_t TypeIdx, const uint32_t DataIdx,
+               const uint32_t Start, const uint32_t Length) const noexcept;
+  Expect<RefVariant>
+  arrayNewElem(const Runtime::Instance::ModuleInstance *ModInst,
+               const uint32_t TypeIdx, const uint32_t ElemIdx,
+               const uint32_t Start, const uint32_t Length) const noexcept;
+  Expect<ValVariant> arrayGet(const Runtime::Instance::ModuleInstance *ModInst,
                               const RefVariant &Ref, const uint32_t TypeIdx,
                               const uint32_t Idx,
                               const bool IsSigned = false) const noexcept;
-  Expect<void> arraySet(Runtime::StackManager &StackMgr, const RefVariant &Ref,
-                        const ValVariant &Val, const uint32_t TypeIdx,
+  Expect<void> arraySet(const Runtime::Instance::ModuleInstance *ModInst,
+                        const RefVariant &Ref, const ValVariant &Val,
+                        const uint32_t TypeIdx,
                         const uint32_t Idx) const noexcept;
-  Expect<void> arrayFill(Runtime::StackManager &StackMgr, const RefVariant &Ref,
-                         const ValVariant &Val, const uint32_t TypeIdx,
-                         const uint32_t Idx, const uint32_t Cnt) const noexcept;
-  Expect<void> arrayInitData(Runtime::StackManager &StackMgr,
+  Expect<void> arrayFill(const Runtime::Instance::ModuleInstance *ModInst,
+                         const RefVariant &Ref, const ValVariant &Val,
+                         const uint32_t TypeIdx, const uint32_t Idx,
+                         const uint32_t Cnt) const noexcept;
+  Expect<void> arrayInitData(const Runtime::Instance::ModuleInstance *ModInst,
                              const RefVariant &Ref, const uint32_t TypeIdx,
                              const uint32_t DataIdx, const uint32_t DstIdx,
                              const uint32_t SrcIdx,
                              const uint32_t Cnt) const noexcept;
-  Expect<void> arrayInitElem(Runtime::StackManager &StackMgr,
+  Expect<void> arrayInitElem(const Runtime::Instance::ModuleInstance *ModInst,
                              const RefVariant &Ref, const uint32_t TypeIdx,
                              const uint32_t ElemIdx, const uint32_t DstIdx,
                              const uint32_t SrcIdx,
                              const uint32_t Cnt) const noexcept;
-  Expect<void> arrayCopy(Runtime::StackManager &StackMgr,
+  Expect<void> arrayCopy(const Runtime::Instance::ModuleInstance *ModInst,
                          const RefVariant &DstRef, const uint32_t DstTypeIdx,
                          const uint32_t DstIdx, const RefVariant &SrcRef,
                          const uint32_t SrcTypeIdx, const uint32_t SrcIdx,

--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -409,6 +409,12 @@ private:
       bool IsNativeEntry = false,
       const Runtime::Instance::ModuleInstance *CallerModInst = nullptr);
 
+  /// Live module instances whose compiled code may be on the native stack at
+  /// fault time: the current frame-stack modules plus every instance in a store
+  /// reachable through their linked-module back-links. Rebuilt on each fault.
+  std::vector<const Runtime::Instance::ModuleInstance *>
+  collectLiveModules(const Runtime::StackManager &StackMgr) const noexcept;
+
   /// Helper function for branching to label.
   Expect<void> branchToLabel(Runtime::StackManager &StackMgr,
                              const AST::Instruction::JumpDescriptor &JumpDesc,

--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -963,7 +963,7 @@ public:
   Expect<void> proxyCallIndirect(Runtime::StackManager &StackMgr,
                                  const uint32_t TableIdx,
                                  const uint32_t FuncTypeIdx,
-                                 const uint32_t FuncIdx, const ValVariant *Args,
+                                 const uint64_t FuncIdx, const ValVariant *Args,
                                  ValVariant *Rets) noexcept;
   Expect<void> proxyCallRef(Runtime::StackManager &StackMgr,
                             const RefVariant Ref, const ValVariant *Args,
@@ -1077,7 +1077,7 @@ public:
   Expect<void *> proxyTableGetFuncSymbol(Runtime::StackManager &StackMgr,
                                          const uint32_t TableIdx,
                                          const uint32_t FuncTypeIdx,
-                                         const uint32_t FuncIdx) noexcept;
+                                         const uint64_t FuncIdx) noexcept;
   Expect<void *> proxyRefGetFuncSymbol(Runtime::StackManager &StackMgr,
                                        const RefVariant Ref) noexcept;
   Expect<void *> proxyFuncGetFuncSymbol(Runtime::StackManager &StackMgr,

--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -1120,12 +1120,15 @@ public:
                      const uint32_t MemIdx, const uint64_t Offset,
                      const uint64_t Expected, const int64_t Timeout,
                      const uint32_t BitWidth) noexcept;
-  Expect<void *> proxyTableGetFuncSymbol(Runtime::StackManager &StackMgr,
-                                         const uint32_t TableIdx,
-                                         const uint32_t FuncTypeIdx,
-                                         const uint64_t FuncIdx) noexcept;
-  Expect<void *> proxyRefGetFuncSymbol(Runtime::StackManager &StackMgr,
-                                       const RefVariant Ref) noexcept;
+  Expect<void *> proxyTableGetFuncSymbol(
+      Runtime::StackManager &StackMgr,
+      const Runtime::Instance::ModuleInstance *ModInst, const uint32_t TableIdx,
+      const uint32_t FuncTypeIdx, const uint64_t FuncIdx,
+      Runtime::Instance::ModuleInstance::ModuleContext **CalleeCtxOut) noexcept;
+  Expect<void *> proxyRefGetFuncSymbol(
+      Runtime::StackManager &StackMgr,
+      const Runtime::Instance::ModuleInstance *ModInst, const RefVariant Ref,
+      Runtime::Instance::ModuleInstance::ModuleContext **CalleeCtxOut) noexcept;
   Expect<void *>
   proxyFuncGetFuncSymbol(Runtime::StackManager &StackMgr,
                          const Runtime::Instance::ModuleInstance *ModInst,

--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -395,11 +395,12 @@ private:
   /// @{
   /// Helper function for calling functions. Return the continuation iterator.
   /// Set `IsNativeEntry` when entering from the native code.
-  Expect<AST::InstrView::iterator>
-  enterFunction(Runtime::StackManager &StackMgr,
-                const Runtime::Instance::FunctionInstance &Func,
-                const AST::InstrView::iterator RetIt, bool IsTailCall = false,
-                bool IsNativeEntry = false);
+  Expect<AST::InstrView::iterator> enterFunction(
+      Runtime::StackManager &StackMgr,
+      const Runtime::Instance::FunctionInstance &Func,
+      const AST::InstrView::iterator RetIt, bool IsTailCall = false,
+      bool IsNativeEntry = false,
+      const Runtime::Instance::ModuleInstance *CallerModInst = nullptr);
 
   /// Helper function for branching to label.
   Expect<void> branchToLabel(Runtime::StackManager &StackMgr,

--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -486,53 +486,63 @@ private:
   /// \name Helper Functions for getting instances or types.
   /// @{
   /// Helper function for getting defined type by index.
-  const AST::SubType *getDefTypeByIdx(Runtime::StackManager &StackMgr,
-                                      const uint32_t Idx) const;
+  const AST::SubType *
+  getDefTypeByIdx(const Runtime::Instance::ModuleInstance *ModInst,
+                  const uint32_t Idx) const;
 
   /// Helper function for getting composite type by index. Assuming validated.
   const WasmEdge::AST::CompositeType &
-  getCompositeTypeByIdx(Runtime::StackManager &StackMgr,
+  getCompositeTypeByIdx(const Runtime::Instance::ModuleInstance *ModInst,
                         const uint32_t Idx) const noexcept;
 
   /// Helper function for getting struct storage type by index.
-  const ValType &getStructStorageTypeByIdx(Runtime::StackManager &StackMgr,
-                                           const uint32_t Idx,
-                                           const uint32_t Off) const noexcept;
+  const ValType &
+  getStructStorageTypeByIdx(const Runtime::Instance::ModuleInstance *ModInst,
+                            const uint32_t Idx,
+                            const uint32_t Off) const noexcept;
 
   /// Helper function for getting array storage type by index.
-  const ValType &getArrayStorageTypeByIdx(Runtime::StackManager &StackMgr,
-                                          const uint32_t Idx) const noexcept;
+  const ValType &
+  getArrayStorageTypeByIdx(const Runtime::Instance::ModuleInstance *ModInst,
+                           const uint32_t Idx) const noexcept;
 
   /// Helper function for getting function instance by index.
   Runtime::Instance::FunctionInstance *
-  getFuncInstByIdx(Runtime::StackManager &StackMgr, const uint32_t Idx) const;
+  getFuncInstByIdx(const Runtime::Instance::ModuleInstance *ModInst,
+                   const uint32_t Idx) const;
 
   /// Helper function for getting table instance by index.
   Runtime::Instance::TableInstance *
-  getTabInstByIdx(Runtime::StackManager &StackMgr, const uint32_t Idx) const;
+  getTabInstByIdx(const Runtime::Instance::ModuleInstance *ModInst,
+                  const uint32_t Idx) const;
 
   /// Helper function for getting memory instance by index.
   Runtime::Instance::MemoryInstance *
-  getMemInstByIdx(Runtime::StackManager &StackMgr, const uint32_t Idx) const;
+  getMemInstByIdx(const Runtime::Instance::ModuleInstance *ModInst,
+                  const uint32_t Idx) const;
 
   /// Helper function for getting tag instance by index.
   Runtime::Instance::TagInstance *
-  getTagInstByIdx(Runtime::StackManager &StackMgr, const uint32_t Idx) const;
+  getTagInstByIdx(const Runtime::Instance::ModuleInstance *ModInst,
+                  const uint32_t Idx) const;
 
   /// Helper function for getting global instance by index.
   Runtime::Instance::GlobalInstance *
-  getGlobInstByIdx(Runtime::StackManager &StackMgr, const uint32_t Idx) const;
+  getGlobInstByIdx(const Runtime::Instance::ModuleInstance *ModInst,
+                   const uint32_t Idx) const;
 
   /// Helper function for getting element instance by index.
   Runtime::Instance::ElementInstance *
-  getElemInstByIdx(Runtime::StackManager &StackMgr, const uint32_t Idx) const;
+  getElemInstByIdx(const Runtime::Instance::ModuleInstance *ModInst,
+                   const uint32_t Idx) const;
 
   /// Helper function for getting data instance by index.
   Runtime::Instance::DataInstance *
-  getDataInstByIdx(Runtime::StackManager &StackMgr, const uint32_t Idx) const;
+  getDataInstByIdx(const Runtime::Instance::ModuleInstance *ModInst,
+                   const uint32_t Idx) const;
 
   /// Helper function for converting into bottom abstract heap type.
-  TypeCode toBottomType(Runtime::StackManager &StackMgr,
+  TypeCode toBottomType(const Runtime::Instance::ModuleInstance *ModInst,
                         const ValType &Type) const;
 
   /// Helper function for cleaning unused bits of numeric values in ValVariant.

--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -972,137 +972,172 @@ public:
   Expect<void> proxyTrap(Runtime::StackManager &StackMgr,
                          const uint32_t Code) noexcept;
   Expect<void> proxyCall(Runtime::StackManager &StackMgr,
+                         const Runtime::Instance::ModuleInstance *ModInst,
                          const uint32_t FuncIdx, const ValVariant *Args,
                          ValVariant *Rets) noexcept;
-  Expect<void> proxyCallIndirect(Runtime::StackManager &StackMgr,
-                                 const uint32_t TableIdx,
-                                 const uint32_t FuncTypeIdx,
-                                 const uint64_t FuncIdx, const ValVariant *Args,
-                                 ValVariant *Rets) noexcept;
+  Expect<void>
+  proxyCallIndirect(Runtime::StackManager &StackMgr,
+                    const Runtime::Instance::ModuleInstance *ModInst,
+                    const uint32_t TableIdx, const uint32_t FuncTypeIdx,
+                    const uint64_t FuncIdx, const ValVariant *Args,
+                    ValVariant *Rets) noexcept;
   Expect<void> proxyCallRef(Runtime::StackManager &StackMgr,
+                            const Runtime::Instance::ModuleInstance *ModInst,
                             const RefVariant Ref, const ValVariant *Args,
                             ValVariant *Rets) noexcept;
-  Expect<RefVariant> proxyRefFunc(Runtime::StackManager &StackMgr,
-                                  const uint32_t FuncIdx) noexcept;
-  Expect<RefVariant> proxyStructNew(Runtime::StackManager &StackMgr,
-                                    const uint32_t TypeIdx,
-                                    const ValVariant *Args,
-                                    const uint32_t ArgSize) noexcept;
+  Expect<RefVariant>
+  proxyRefFunc(Runtime::StackManager &StackMgr,
+               const Runtime::Instance::ModuleInstance *ModInst,
+               const uint32_t FuncIdx) noexcept;
+  Expect<RefVariant>
+  proxyStructNew(Runtime::StackManager &StackMgr,
+                 const Runtime::Instance::ModuleInstance *ModInst,
+                 const uint32_t TypeIdx, const ValVariant *Args,
+                 const uint32_t ArgSize) noexcept;
   Expect<void> proxyStructGet(Runtime::StackManager &StackMgr,
+                              const Runtime::Instance::ModuleInstance *ModInst,
                               const RefVariant Ref, const uint32_t TypeIdx,
                               const uint32_t Off, const bool IsSigned,
                               ValVariant *Ret) noexcept;
   Expect<void> proxyStructSet(Runtime::StackManager &StackMgr,
+                              const Runtime::Instance::ModuleInstance *ModInst,
                               const RefVariant Ref, const uint32_t TypeIdx,
                               const uint32_t Off,
                               const ValVariant *Val) noexcept;
-  Expect<RefVariant> proxyArrayNew(Runtime::StackManager &StackMgr,
-                                   const uint32_t TypeIdx,
-                                   const uint32_t Length,
-                                   const ValVariant *Args,
-                                   const uint32_t ArgSize) noexcept;
-  Expect<RefVariant> proxyArrayNewData(Runtime::StackManager &StackMgr,
-                                       const uint32_t TypeIdx,
-                                       const uint32_t DataIdx,
-                                       const uint32_t Start,
-                                       const uint32_t Length) noexcept;
-  Expect<RefVariant> proxyArrayNewElem(Runtime::StackManager &StackMgr,
-                                       const uint32_t TypeIdx,
-                                       const uint32_t ElemIdx,
-                                       const uint32_t Start,
-                                       const uint32_t Length) noexcept;
+  Expect<RefVariant>
+  proxyArrayNew(Runtime::StackManager &StackMgr,
+                const Runtime::Instance::ModuleInstance *ModInst,
+                const uint32_t TypeIdx, const uint32_t Length,
+                const ValVariant *Args, const uint32_t ArgSize) noexcept;
+  Expect<RefVariant>
+  proxyArrayNewData(Runtime::StackManager &StackMgr,
+                    const Runtime::Instance::ModuleInstance *ModInst,
+                    const uint32_t TypeIdx, const uint32_t DataIdx,
+                    const uint32_t Start, const uint32_t Length) noexcept;
+  Expect<RefVariant>
+  proxyArrayNewElem(Runtime::StackManager &StackMgr,
+                    const Runtime::Instance::ModuleInstance *ModInst,
+                    const uint32_t TypeIdx, const uint32_t ElemIdx,
+                    const uint32_t Start, const uint32_t Length) noexcept;
   Expect<void> proxyArrayGet(Runtime::StackManager &StackMgr,
+                             const Runtime::Instance::ModuleInstance *ModInst,
                              const RefVariant Ref, const uint32_t TypeIdx,
                              const uint32_t Idx, const bool IsSigned,
                              ValVariant *Ret) noexcept;
   Expect<void> proxyArraySet(Runtime::StackManager &StackMgr,
+                             const Runtime::Instance::ModuleInstance *ModInst,
                              const RefVariant Ref, const uint32_t TypeIdx,
                              const uint32_t Idx,
                              const ValVariant *Val) noexcept;
   Expect<uint32_t> proxyArrayLen(Runtime::StackManager &StackMgr,
                                  const RefVariant Ref) noexcept;
   Expect<void> proxyArrayFill(Runtime::StackManager &StackMgr,
+                              const Runtime::Instance::ModuleInstance *ModInst,
                               const RefVariant Ref, const uint32_t TypeIdx,
                               const uint32_t Idx, const uint32_t Cnt,
                               const ValVariant *Val) noexcept;
   Expect<void> proxyArrayCopy(Runtime::StackManager &StackMgr,
+                              const Runtime::Instance::ModuleInstance *ModInst,
                               const RefVariant DstRef,
                               const uint32_t DstTypeIdx, const uint32_t DstIdx,
                               const RefVariant SrcRef,
                               const uint32_t SrcTypeIdx, const uint32_t SrcIdx,
                               const uint32_t Cnt) noexcept;
-  Expect<void> proxyArrayInitData(Runtime::StackManager &StackMgr,
-                                  const RefVariant Ref, const uint32_t TypeIdx,
-                                  const uint32_t DataIdx, const uint32_t DstIdx,
-                                  const uint32_t SrcIdx,
-                                  const uint32_t Cnt) noexcept;
-  Expect<void> proxyArrayInitElem(Runtime::StackManager &StackMgr,
-                                  const RefVariant Ref, const uint32_t TypeIdx,
-                                  const uint32_t ElemIdx, const uint32_t DstIdx,
-                                  const uint32_t SrcIdx,
-                                  const uint32_t Cnt) noexcept;
-  Expect<uint32_t> proxyRefTest(Runtime::StackManager &StackMgr,
-                                const RefVariant Ref, ValType VTTest) noexcept;
-  Expect<RefVariant> proxyRefCast(Runtime::StackManager &StackMgr,
-                                  const RefVariant Ref,
-                                  ValType VTCast) noexcept;
+  Expect<void>
+  proxyArrayInitData(Runtime::StackManager &StackMgr,
+                     const Runtime::Instance::ModuleInstance *ModInst,
+                     const RefVariant Ref, const uint32_t TypeIdx,
+                     const uint32_t DataIdx, const uint32_t DstIdx,
+                     const uint32_t SrcIdx, const uint32_t Cnt) noexcept;
+  Expect<void>
+  proxyArrayInitElem(Runtime::StackManager &StackMgr,
+                     const Runtime::Instance::ModuleInstance *ModInst,
+                     const RefVariant Ref, const uint32_t TypeIdx,
+                     const uint32_t ElemIdx, const uint32_t DstIdx,
+                     const uint32_t SrcIdx, const uint32_t Cnt) noexcept;
+  Expect<uint32_t>
+  proxyRefTest(Runtime::StackManager &StackMgr,
+               const Runtime::Instance::ModuleInstance *ModInst,
+               const RefVariant Ref, ValType VTTest) noexcept;
+  Expect<RefVariant>
+  proxyRefCast(Runtime::StackManager &StackMgr,
+               const Runtime::Instance::ModuleInstance *ModInst,
+               const RefVariant Ref, ValType VTCast) noexcept;
   Expect<void> proxyTableInit(Runtime::StackManager &StackMgr,
+                              const Runtime::Instance::ModuleInstance *ModInst,
                               const uint32_t TableIdx, const uint32_t ElemIdx,
                               const uint64_t DstOff, const uint32_t SrcOff,
                               const uint32_t Len) noexcept;
   Expect<void> proxyElemDrop(Runtime::StackManager &StackMgr,
+                             const Runtime::Instance::ModuleInstance *ModInst,
                              const uint32_t ElemIdx) noexcept;
   Expect<void> proxyTableCopy(Runtime::StackManager &StackMgr,
+                              const Runtime::Instance::ModuleInstance *ModInst,
                               const uint32_t TableIdxDst,
                               const uint32_t TableIdxSrc, const uint64_t DstOff,
                               const uint64_t SrcOff,
                               const uint64_t Len) noexcept;
-  Expect<uint64_t> proxyTableGrow(Runtime::StackManager &StackMgr,
-                                  const uint32_t TableIdx, const RefVariant Val,
-                                  const uint64_t NewSize) noexcept;
+  Expect<uint64_t>
+  proxyTableGrow(Runtime::StackManager &StackMgr,
+                 const Runtime::Instance::ModuleInstance *ModInst,
+                 const uint32_t TableIdx, const RefVariant Val,
+                 const uint64_t NewSize) noexcept;
   Expect<void> proxyTableFill(Runtime::StackManager &StackMgr,
+                              const Runtime::Instance::ModuleInstance *ModInst,
                               const uint32_t TableIdx, const uint64_t Off,
                               const RefVariant Ref,
                               const uint64_t Len) noexcept;
-  Expect<uint64_t> proxyMemGrow(Runtime::StackManager &StackMgr,
-                                const uint32_t MemIdx,
-                                const uint64_t NewSize) noexcept;
+  Expect<uint64_t>
+  proxyMemGrow(Runtime::StackManager &StackMgr,
+               const Runtime::Instance::ModuleInstance *ModInst,
+               const uint32_t MemIdx, const uint64_t NewSize) noexcept;
   Expect<void> proxyMemInit(Runtime::StackManager &StackMgr,
+                            const Runtime::Instance::ModuleInstance *ModInst,
                             const uint32_t MemIdx, const uint32_t DataIdx,
                             const uint64_t DstOff, const uint32_t SrcOff,
                             const uint32_t Len) noexcept;
   Expect<void> proxyDataDrop(Runtime::StackManager &StackMgr,
+                             const Runtime::Instance::ModuleInstance *ModInst,
                              const uint32_t DataIdx) noexcept;
   Expect<void> proxyMemCopy(Runtime::StackManager &StackMgr,
+                            const Runtime::Instance::ModuleInstance *ModInst,
                             const uint32_t DstMemIdx, const uint32_t SrcMemIdx,
                             const uint64_t DstOff, const uint64_t SrcOff,
                             const uint64_t Len) noexcept;
   Expect<void> proxyMemFill(Runtime::StackManager &StackMgr,
+                            const Runtime::Instance::ModuleInstance *ModInst,
                             const uint32_t MemIdx, const uint64_t Off,
                             const uint8_t Val, const uint64_t Len) noexcept;
-  Expect<uint64_t> proxyMemAtomicNotify(Runtime::StackManager &StackMgr,
-                                        const uint32_t MemIdx,
-                                        const uint64_t Offset,
-                                        const uint64_t Count) noexcept;
   Expect<uint64_t>
-  proxyMemAtomicWait(Runtime::StackManager &StackMgr, const uint32_t MemIdx,
-                     const uint64_t Offset, const uint64_t Expected,
-                     const int64_t Timeout, const uint32_t BitWidth) noexcept;
+  proxyMemAtomicNotify(Runtime::StackManager &StackMgr,
+                       const Runtime::Instance::ModuleInstance *ModInst,
+                       const uint32_t MemIdx, const uint64_t Offset,
+                       const uint64_t Count) noexcept;
+  Expect<uint64_t>
+  proxyMemAtomicWait(Runtime::StackManager &StackMgr,
+                     const Runtime::Instance::ModuleInstance *ModInst,
+                     const uint32_t MemIdx, const uint64_t Offset,
+                     const uint64_t Expected, const int64_t Timeout,
+                     const uint32_t BitWidth) noexcept;
   Expect<void *> proxyTableGetFuncSymbol(Runtime::StackManager &StackMgr,
                                          const uint32_t TableIdx,
                                          const uint32_t FuncTypeIdx,
                                          const uint64_t FuncIdx) noexcept;
   Expect<void *> proxyRefGetFuncSymbol(Runtime::StackManager &StackMgr,
                                        const RefVariant Ref) noexcept;
-  Expect<void *> proxyFuncGetFuncSymbol(Runtime::StackManager &StackMgr,
-                                        const uint32_t FuncIdx) noexcept;
+  Expect<void *>
+  proxyFuncGetFuncSymbol(Runtime::StackManager &StackMgr,
+                         const Runtime::Instance::ModuleInstance *ModInst,
+                         const uint32_t FuncIdx) noexcept;
   Expect<void> proxyThrow(Runtime::StackManager &StackMgr,
+                          const Runtime::Instance::ModuleInstance *ModInst,
                           const uint32_t TagIdx, const ValVariant *Vals,
                           const uint32_t Num) noexcept;
   Expect<void> proxyThrowRef(Runtime::StackManager &StackMgr,
                              const RefVariant Ref) noexcept;
-  Expect<void> proxyCatchPop(Runtime::StackManager &StackMgr, ValVariant *Out,
-                             const uint32_t PopPayload,
+  Expect<void> proxyCatchPop(Runtime::StackManager &StackMgr,
+                             const Runtime::Instance::ModuleInstance *ModInst,
+                             ValVariant *Out, const uint32_t PopPayload,
                              const uint32_t NeedRef) noexcept;
   /// @}
 

--- a/include/executor/executor.h
+++ b/include/executor/executor.h
@@ -30,6 +30,7 @@
 
 #include <atomic>
 #include <csignal>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -1099,30 +1100,35 @@ public:
 
 private:
   /// Execution context for compiled functions.
-  struct ExecutionContextStruct {
-#if WASMEDGE_ALLOCATOR_IS_STABLE
-    uint8_t *const *Memories;
-#else
-    uint8_t **const *Memories;
-#endif
-    const uint64_t *const *MemorySizes;
-    RefVariant **const *TableRefs;
-    const uint64_t *const *TableSizes;
-    ValVariant *const *Globals;
-    void *const *Tags;
-    void *const *PendingExnTagAddr;
+  struct ExecutorContext {
     std::atomic_uint64_t *InstrCount;
     uint64_t *CostTable;
     std::atomic_uint64_t *Gas;
     uint64_t GasLimit;
     std::atomic_uint32_t *StopToken;
-    const void *ModuleInst;
+    void *const *PendingExnTagAddr;
   };
+
+  /// Compiled code reads this struct by field index through the mirrored
+  /// ExecCtx type built in lib/llvm/compiler/context.cpp. Keep both in the same
+  /// order.
+  static_assert(offsetof(ExecutorContext, InstrCount) == 0);
+  static_assert(offsetof(ExecutorContext, InstrCount) <
+                offsetof(ExecutorContext, CostTable));
+  static_assert(offsetof(ExecutorContext, CostTable) <
+                offsetof(ExecutorContext, Gas));
+  static_assert(offsetof(ExecutorContext, Gas) <
+                offsetof(ExecutorContext, GasLimit));
+  static_assert(offsetof(ExecutorContext, GasLimit) <
+                offsetof(ExecutorContext, StopToken));
+  static_assert(offsetof(ExecutorContext, StopToken) <
+                offsetof(ExecutorContext, PendingExnTagAddr));
 
   /// Restores thread local VM reference after overwriting it.
   struct SavedThreadLocal {
     SavedThreadLocal(Executor &Ex, Runtime::StackManager &StackMgr,
-                     const Runtime::Instance::FunctionInstance &Func) noexcept;
+                     [[maybe_unused]] const Runtime::Instance::FunctionInstance
+                         &Func) noexcept;
 
     SavedThreadLocal(const SavedThreadLocal &) = delete;
     SavedThreadLocal(SavedThreadLocal &&) = delete;
@@ -1131,7 +1137,7 @@ private:
 
     Executor *SavedThis;
     Runtime::StackManager *SavedCurrentStack;
-    ExecutionContextStruct SavedExecutionContext;
+    ExecutorContext SavedExecutionContext;
   };
 
   /// Pending exception passing across the compiled and the native-entered
@@ -1162,7 +1168,7 @@ private:
   /// Stack passed into compiled functions
   static thread_local Runtime::StackManager *CurrentStack;
   /// Execution context for compiled functions
-  static thread_local ExecutionContextStruct ExecutionContext;
+  static thread_local ExecutorContext ExecutionContext;
   /// Pending exception for compiled functions
   static thread_local PendingExnStruct PendingExn;
   /// Record stack trace on error

--- a/include/runtime/instance/module.h
+++ b/include/runtime/instance/module.h
@@ -522,10 +522,13 @@ protected:
     return WASIModInst;
   }
 
-  /// Unsafely import an instance into this module.
+  /// Unsafely import an instance into this module. Only valid before
+  /// finalization: buildContext() caches the instance vectors' buffers, which a
+  /// later push_back may reallocate.
   template <typename T>
   std::enable_if_t<IsEntityV<T>, void>
   unsafeImportInstance(std::vector<T *> &Vec, T *Ptr) {
+    assuming(!isInstantiateFinalized());
     Vec.push_back(Ptr);
   }
 
@@ -536,11 +539,14 @@ protected:
         ->setTypeIndex(static_cast<uint32_t>(Types.size()) - 1);
   }
 
-  /// Unsafely create and add the instance to this module.
+  /// Unsafely create and add the instance to this module. Only valid before
+  /// finalization: buildContext() caches the instance vectors' buffers, which a
+  /// later push_back may reallocate.
   template <typename T, typename... Args>
   std::enable_if_t<IsInstanceV<T>, void>
   unsafeAddInstance(std::vector<std::unique_ptr<T>> &OwnedInstsVec,
                     std::vector<T *> &InstsVec, Args &&...Values) {
+    assuming(!isInstantiateFinalized());
     OwnedInstsVec.push_back(std::make_unique<T>(std::forward<Args>(Values)...));
     InstsVec.push_back(OwnedInstsVec.back().get());
   }
@@ -582,6 +588,33 @@ protected:
   std::vector<RefVariant **> TableRefPtrs;
   std::vector<ValVariant *> GlobalPtrs;
   /// @}
+
+  struct ModuleContext {
+#if WASMEDGE_ALLOCATOR_IS_STABLE
+    uint8_t *const *Memories;
+#else
+    uint8_t **const *Memories;
+#endif
+    const uint64_t *const *MemorySizes;
+    RefVariant **const *TableRefs;
+    const uint64_t *const *TableSizes;
+    ValVariant *const *Globals;
+    const void *ModuleInst;
+  };
+
+  ModuleContext ModCtx{};
+
+  /// Snapshot the instance vectors' buffers for compiled code. Call once, after
+  /// the last instance is added and before the start function runs; adding an
+  /// instance afterwards may reallocate and leave the context dangling.
+  void buildContext() noexcept {
+    ModCtx.Memories = MemoryPtrs.data();
+    ModCtx.MemorySizes = MemorySizePtrs.data();
+    ModCtx.TableRefs = TableRefPtrs.data();
+    ModCtx.TableSizes = TableSizePtrs.data();
+    ModCtx.Globals = GlobalPtrs.data();
+    ModCtx.ModuleInst = this;
+  }
 
   friend class Runtime::StoreManager;
   using LinkedStoreKey = std::pair<StoreManager *, std::string>;

--- a/include/runtime/instance/module.h
+++ b/include/runtime/instance/module.h
@@ -30,6 +30,7 @@
 #include "runtime/instance/tag.h"
 
 #include <atomic>
+#include <cstddef>
 #include <functional>
 #include <map>
 #include <memory>
@@ -600,7 +601,19 @@ protected:
     const uint64_t *const *TableSizes;
     ValVariant *const *Globals;
     const void *ModuleInst;
+    void *const *Tags;
   };
+
+  /// Compiled code reads this struct by field index through the mirrored ModCtx
+  /// type built in lib/llvm/compiler/context.cpp. Keep both in the same order.
+  static_assert(sizeof(ModuleContext) == 7 * sizeof(void *));
+  static_assert(offsetof(ModuleContext, Memories) == 0 * sizeof(void *));
+  static_assert(offsetof(ModuleContext, MemorySizes) == 1 * sizeof(void *));
+  static_assert(offsetof(ModuleContext, TableRefs) == 2 * sizeof(void *));
+  static_assert(offsetof(ModuleContext, TableSizes) == 3 * sizeof(void *));
+  static_assert(offsetof(ModuleContext, Globals) == 4 * sizeof(void *));
+  static_assert(offsetof(ModuleContext, ModuleInst) == 5 * sizeof(void *));
+  static_assert(offsetof(ModuleContext, Tags) == 6 * sizeof(void *));
 
   ModuleContext ModCtx{};
 
@@ -614,6 +627,7 @@ protected:
     ModCtx.TableSizes = TableSizePtrs.data();
     ModCtx.Globals = GlobalPtrs.data();
     ModCtx.ModuleInst = this;
+    ModCtx.Tags = reinterpret_cast<void *const *>(TagInsts.data());
   }
 
   friend class Runtime::StoreManager;

--- a/include/system/stacktrace.h
+++ b/include/system/stacktrace.h
@@ -37,11 +37,7 @@ interpreterStackTrace(const Runtime::StackManager &StackMgr,
                       Span<StackTraceEntry> Buffer) noexcept;
 
 Span<const StackTraceEntry>
-compiledStackTrace(const Runtime::StackManager &StackMgr,
-                   Span<StackTraceEntry> Buffer) noexcept;
-
-Span<const StackTraceEntry>
-compiledStackTrace(const Runtime::StackManager &StackMgr,
+compiledStackTrace(Span<const Runtime::Instance::ModuleInstance *const> Modules,
                    Span<void *const> Stack,
                    Span<StackTraceEntry> Buffer) noexcept;
 

--- a/include/system/stacktrace.h
+++ b/include/system/stacktrace.h
@@ -19,19 +19,30 @@
 
 namespace WasmEdge {
 
+namespace Runtime::Instance {
+class ModuleInstance;
+} // namespace Runtime::Instance
+
+/// One frame of a recorded stack trace: the function's defining module and its
+/// index within that module.
+struct StackTraceEntry {
+  const Runtime::Instance::ModuleInstance *Module;
+  uint32_t FuncIndex;
+};
+
 Span<void *const> stackTrace(Span<void *> Buffer) noexcept;
 
-Span<const uint32_t>
+Span<const StackTraceEntry>
 interpreterStackTrace(const Runtime::StackManager &StackMgr,
-                      Span<uint32_t> Buffer) noexcept;
+                      Span<StackTraceEntry> Buffer) noexcept;
 
-Span<const uint32_t> compiledStackTrace(const Runtime::StackManager &StackMgr,
-                                        Span<uint32_t> Buffer) noexcept;
+Span<const StackTraceEntry>
+compiledStackTrace(const Runtime::StackManager &StackMgr,
+                   Span<StackTraceEntry> Buffer) noexcept;
 
-Span<const uint32_t> compiledStackTrace(const Runtime::StackManager &StackMgr,
-                                        Span<void *const> Stack,
-                                        Span<uint32_t> Buffer) noexcept;
-
-void dumpStackTrace(Span<const uint32_t>) noexcept;
+Span<const StackTraceEntry>
+compiledStackTrace(const Runtime::StackManager &StackMgr,
+                   Span<void *const> Stack,
+                   Span<StackTraceEntry> Buffer) noexcept;
 
 } // namespace WasmEdge

--- a/lib/executor/engine/controlInstr.cpp
+++ b/lib/executor/engine/controlInstr.cpp
@@ -36,7 +36,7 @@ Expect<void> Executor::runIfElseOp(Runtime::StackManager &StackMgr,
 Expect<void> Executor::runThrowOp(Runtime::StackManager &StackMgr,
                                   const AST::Instruction &Instr,
                                   AST::InstrView::iterator &PC) noexcept {
-  auto *TagInst = getTagInstByIdx(StackMgr, Instr.getTargetIndex());
+  auto *TagInst = getTagInstByIdx(StackMgr.getModule(), Instr.getTargetIndex());
   // The arguments will be popped from the stack in the throw function.
   return throwException(StackMgr, *TagInst, PC);
 }
@@ -160,7 +160,8 @@ Expect<void> Executor::runCallOp(Runtime::StackManager &StackMgr,
                                  AST::InstrView::iterator &PC,
                                  bool IsTailCall) noexcept {
   // Get Function address.
-  const auto *FuncInst = getFuncInstByIdx(StackMgr, Instr.getTargetIndex());
+  const auto *FuncInst =
+      getFuncInstByIdx(StackMgr.getModule(), Instr.getTargetIndex());
   EXPECTED_TRY(auto NextPC,
                enterFunction(StackMgr, *FuncInst, PC + 1, IsTailCall));
   PC = NextPC - 1;
@@ -192,7 +193,8 @@ Expect<void> Executor::runCallIndirectOp(Runtime::StackManager &StackMgr,
                                          AST::InstrView::iterator &PC,
                                          bool IsTailCall) noexcept {
   // Get Table Instance.
-  const auto *TabInst = getTabInstByIdx(StackMgr, Instr.getSourceIndex());
+  const auto *TabInst =
+      getTabInstByIdx(StackMgr.getModule(), Instr.getSourceIndex());
 
   // Get function type at index x.
   const auto *ModInst = StackMgr.getModule();

--- a/lib/executor/engine/engine.cpp
+++ b/lib/executor/engine/engine.cpp
@@ -299,119 +299,185 @@ Expect<void> Executor::execute(Runtime::StackManager &StackMgr,
     // Table Instructions
     case OpCode::Table__get:
       return runTableGetOp(
-          StackMgr, *getTabInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getTabInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::Table__set:
       return runTableSetOp(
-          StackMgr, *getTabInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getTabInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::Table__init:
       return runTableInitOp(
-          StackMgr, *getTabInstByIdx(StackMgr, Instr.getTargetIndex()),
-          *getElemInstByIdx(StackMgr, Instr.getSourceIndex()), Instr);
+          StackMgr,
+          *getTabInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          *getElemInstByIdx(StackMgr.getModule(), Instr.getSourceIndex()),
+          Instr);
     case OpCode::Elem__drop:
-      return runElemDropOp(*getElemInstByIdx(StackMgr, Instr.getTargetIndex()));
+      return runElemDropOp(
+          *getElemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()));
     case OpCode::Table__copy:
       return runTableCopyOp(
-          StackMgr, *getTabInstByIdx(StackMgr, Instr.getTargetIndex()),
-          *getTabInstByIdx(StackMgr, Instr.getSourceIndex()), Instr);
+          StackMgr,
+          *getTabInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          *getTabInstByIdx(StackMgr.getModule(), Instr.getSourceIndex()),
+          Instr);
     case OpCode::Table__grow:
-      return runTableGrowOp(StackMgr,
-                            *getTabInstByIdx(StackMgr, Instr.getTargetIndex()));
+      return runTableGrowOp(StackMgr, *getTabInstByIdx(StackMgr.getModule(),
+                                                       Instr.getTargetIndex()));
     case OpCode::Table__size:
-      return runTableSizeOp(StackMgr,
-                            *getTabInstByIdx(StackMgr, Instr.getTargetIndex()));
+      return runTableSizeOp(StackMgr, *getTabInstByIdx(StackMgr.getModule(),
+                                                       Instr.getTargetIndex()));
     case OpCode::Table__fill:
       return runTableFillOp(
-          StackMgr, *getTabInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getTabInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
 
     // Memory Instructions
     case OpCode::I32__load:
       return runLoadOp<uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__load:
       return runLoadOp<uint64_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::F32__load:
       return runLoadOp<float>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::F64__load:
       return runLoadOp<double>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__load8_s:
       return runLoadOp<int32_t, 8>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__load8_u:
       return runLoadOp<uint32_t, 8>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__load16_s:
       return runLoadOp<int32_t, 16>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__load16_u:
       return runLoadOp<uint32_t, 16>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__load8_s:
       return runLoadOp<int64_t, 8>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__load8_u:
       return runLoadOp<uint64_t, 8>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__load16_s:
       return runLoadOp<int64_t, 16>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__load16_u:
       return runLoadOp<uint64_t, 16>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__load32_s:
       return runLoadOp<int64_t, 32>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__load32_u:
       return runLoadOp<uint64_t, 32>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__store:
       return runStoreOp<uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__store:
       return runStoreOp<uint64_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::F32__store:
       return runStoreOp<float>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::F64__store:
       return runStoreOp<double>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__store8:
       return runStoreOp<uint32_t, 8>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__store16:
       return runStoreOp<uint32_t, 16>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__store8:
       return runStoreOp<uint64_t, 8>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__store16:
       return runStoreOp<uint64_t, 16>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__store32:
       return runStoreOp<uint64_t, 32>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::Memory__grow:
       return runMemoryGrowOp(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()));
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()));
     case OpCode::Memory__size:
       return runMemorySizeOp(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()));
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()));
     case OpCode::Memory__init:
       return runMemoryInitOp(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()),
-          *getDataInstByIdx(StackMgr, Instr.getSourceIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          *getDataInstByIdx(StackMgr.getModule(), Instr.getSourceIndex()),
+          Instr);
     case OpCode::Data__drop:
-      return runDataDropOp(*getDataInstByIdx(StackMgr, Instr.getTargetIndex()));
+      return runDataDropOp(
+          *getDataInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()));
     case OpCode::Memory__copy:
       return runMemoryCopyOp(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()),
-          *getMemInstByIdx(StackMgr, Instr.getSourceIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getSourceIndex()),
+          Instr);
     case OpCode::Memory__fill:
       return runMemoryFillOp(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
 
     // Const Numeric Instructions
     case OpCode::I32__const:
@@ -854,70 +920,114 @@ Expect<void> Executor::execute(Runtime::StackManager &StackMgr,
     // SIMD Memory Instructions
     case OpCode::V128__load:
       return runLoadOp<uint128_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__load8x8_s:
       return runLoadExpandOp<int8_t, int16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__load8x8_u:
       return runLoadExpandOp<uint8_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__load16x4_s:
       return runLoadExpandOp<int16_t, int32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__load16x4_u:
       return runLoadExpandOp<uint16_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__load32x2_s:
       return runLoadExpandOp<int32_t, int64_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__load32x2_u:
       return runLoadExpandOp<uint32_t, uint64_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__load8_splat:
       return runLoadSplatOp<uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__load16_splat:
       return runLoadSplatOp<uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__load32_splat:
       return runLoadSplatOp<uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__load64_splat:
       return runLoadSplatOp<uint64_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__load32_zero:
       return runLoadOp<uint128_t, 32>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__load64_zero:
       return runLoadOp<uint128_t, 64>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__store:
       return runStoreOp<uint128_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__load8_lane:
       return runLoadLaneOp<uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__load16_lane:
       return runLoadLaneOp<uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__load32_lane:
       return runLoadLaneOp<uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__load64_lane:
       return runLoadLaneOp<uint64_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__store8_lane:
       return runStoreLaneOp<uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__store16_lane:
       return runStoreLaneOp<uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__store32_lane:
       return runStoreLaneOp<uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::V128__store64_lane:
       return runStoreLaneOp<uint64_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
 
     // SIMD Const Instructions
     case OpCode::V128__const:
@@ -1898,202 +2008,334 @@ Expect<void> Executor::execute(Runtime::StackManager &StackMgr,
       return runMemoryFenceOp();
     case OpCode::Memory__atomic__notify:
       return runAtomicNotifyOp(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::Memory__atomic__wait32:
       return runAtomicWaitOp<int32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::Memory__atomic__wait64:
       return runAtomicWaitOp<int64_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__load:
       return runAtomicLoadOp<int32_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__load:
       return runAtomicLoadOp<int64_t, uint64_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__load8_u:
       return runAtomicLoadOp<uint32_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__load16_u:
       return runAtomicLoadOp<uint32_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__load8_u:
       return runAtomicLoadOp<uint64_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__load16_u:
       return runAtomicLoadOp<uint64_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__load32_u:
       return runAtomicLoadOp<uint64_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__store:
       return runAtomicStoreOp<int32_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__store:
       return runAtomicStoreOp<int64_t, uint64_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__store8:
       return runAtomicStoreOp<uint32_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__store16:
       return runAtomicStoreOp<uint32_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__store8:
       return runAtomicStoreOp<uint64_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__store16:
       return runAtomicStoreOp<uint64_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__store32:
       return runAtomicStoreOp<uint64_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw__add:
       return runAtomicAddOp<int32_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw__add:
       return runAtomicAddOp<int64_t, uint64_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw8__add_u:
       return runAtomicAddOp<uint32_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw16__add_u:
       return runAtomicAddOp<uint32_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw8__add_u:
       return runAtomicAddOp<uint64_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw16__add_u:
       return runAtomicAddOp<uint64_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw32__add_u:
       return runAtomicAddOp<uint64_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw__sub:
       return runAtomicSubOp<int32_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw__sub:
       return runAtomicSubOp<int64_t, uint64_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw8__sub_u:
       return runAtomicSubOp<uint32_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw16__sub_u:
       return runAtomicSubOp<uint32_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw8__sub_u:
       return runAtomicSubOp<uint64_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw16__sub_u:
       return runAtomicSubOp<uint64_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw32__sub_u:
       return runAtomicSubOp<uint64_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw__and:
       return runAtomicAndOp<int32_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw__and:
       return runAtomicAndOp<int64_t, uint64_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw8__and_u:
       return runAtomicAndOp<uint32_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw16__and_u:
       return runAtomicAndOp<uint32_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw8__and_u:
       return runAtomicAndOp<uint64_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw16__and_u:
       return runAtomicAndOp<uint64_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw32__and_u:
       return runAtomicAndOp<uint64_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw__or:
       return runAtomicOrOp<int32_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw__or:
       return runAtomicOrOp<int64_t, uint64_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw8__or_u:
       return runAtomicOrOp<uint32_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw16__or_u:
       return runAtomicOrOp<uint32_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw8__or_u:
       return runAtomicOrOp<uint64_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw16__or_u:
       return runAtomicOrOp<uint64_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw32__or_u:
       return runAtomicOrOp<uint64_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw__xor:
       return runAtomicXorOp<int32_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw__xor:
       return runAtomicXorOp<int64_t, uint64_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw8__xor_u:
       return runAtomicXorOp<uint32_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw16__xor_u:
       return runAtomicXorOp<uint32_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw8__xor_u:
       return runAtomicXorOp<uint64_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw16__xor_u:
       return runAtomicXorOp<uint64_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw32__xor_u:
       return runAtomicXorOp<uint64_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw__xchg:
       return runAtomicExchangeOp<int32_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw__xchg:
       return runAtomicExchangeOp<int64_t, uint64_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw8__xchg_u:
       return runAtomicExchangeOp<uint32_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw16__xchg_u:
       return runAtomicExchangeOp<uint32_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw8__xchg_u:
       return runAtomicExchangeOp<uint64_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw16__xchg_u:
       return runAtomicExchangeOp<uint64_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw32__xchg_u:
       return runAtomicExchangeOp<uint64_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw__cmpxchg:
       return runAtomicCompareExchangeOp<int32_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw__cmpxchg:
       return runAtomicCompareExchangeOp<int64_t, uint64_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw8__cmpxchg_u:
       return runAtomicCompareExchangeOp<uint32_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I32__atomic__rmw16__cmpxchg_u:
       return runAtomicCompareExchangeOp<uint32_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw8__cmpxchg_u:
       return runAtomicCompareExchangeOp<uint64_t, uint8_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw16__cmpxchg_u:
       return runAtomicCompareExchangeOp<uint64_t, uint16_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
     case OpCode::I64__atomic__rmw32__cmpxchg_u:
       return runAtomicCompareExchangeOp<uint64_t, uint32_t>(
-          StackMgr, *getMemInstByIdx(StackMgr, Instr.getTargetIndex()), Instr);
+          StackMgr,
+          *getMemInstByIdx(StackMgr.getModule(), Instr.getTargetIndex()),
+          Instr);
 
     default:
       return {};

--- a/lib/executor/engine/engine.cpp
+++ b/lib/executor/engine/engine.cpp
@@ -29,6 +29,10 @@ Executor::runFunction(Runtime::StackManager &StackMgr,
     Stat->startRecordWasm();
   }
 
+  // Clear any trace from a previous execution; its entries may reference
+  // modules that have since been freed.
+  StackTraceSize = 0;
+
   // Reset and push a dummy frame into stack.
   StackMgr.pushFrame(nullptr, AST::InstrView::iterator(), 0, 0);
 

--- a/lib/executor/engine/proxy.cpp
+++ b/lib/executor/engine/proxy.cpp
@@ -168,7 +168,7 @@ Expect<void> Executor::proxyCall(Runtime::StackManager &StackMgr,
 Expect<void> Executor::proxyCallIndirect(Runtime::StackManager &StackMgr,
                                          const uint32_t TableIdx,
                                          const uint32_t FuncTypeIdx,
-                                         const uint32_t FuncIdx,
+                                         const uint64_t FuncIdx,
                                          const ValVariant *Args,
                                          ValVariant *Rets) noexcept {
   const auto *TabInst = getTabInstByIdx(StackMgr, TableIdx);
@@ -597,7 +597,7 @@ Executor::proxyMemAtomicWait(Runtime::StackManager &StackMgr,
 
 Expect<void *> Executor::proxyTableGetFuncSymbol(
     Runtime::StackManager &StackMgr, const uint32_t TableIdx,
-    const uint32_t FuncTypeIdx, const uint32_t FuncIdx) noexcept {
+    const uint32_t FuncTypeIdx, const uint64_t FuncIdx) noexcept {
   const auto *TabInst = getTabInstByIdx(StackMgr, TableIdx);
   assuming(TabInst);
 

--- a/lib/executor/engine/proxy.cpp
+++ b/lib/executor/engine/proxy.cpp
@@ -160,10 +160,11 @@ Executor::proxyCall(Runtime::StackManager &StackMgr,
   }
 
   auto Instrs = FuncInst->getInstrs();
-  auto Res = enterFunction(StackMgr, *FuncInst, Instrs.end(), false, true)
-                 .and_then([&](AST::InstrView::iterator StartIt) {
-                   return execute(StackMgr, StartIt, Instrs.end());
-                 });
+  auto Res =
+      enterFunction(StackMgr, *FuncInst, Instrs.end(), false, true, ModInst)
+          .and_then([&](AST::InstrView::iterator StartIt) {
+            return execute(StackMgr, StartIt, Instrs.end());
+          });
   return callFromCompiled(StackMgr, *FuncInst, Rets, std::move(Res));
 }
 
@@ -218,18 +219,19 @@ Executor::proxyCallIndirect(Runtime::StackManager &StackMgr,
   }
 
   auto Instrs = FuncInst->getInstrs();
-  auto Res = enterFunction(StackMgr, *FuncInst, Instrs.end(), false, true)
-                 .and_then([&](AST::InstrView::iterator StartIt) {
-                   return execute(StackMgr, StartIt, Instrs.end());
-                 });
+  auto Res =
+      enterFunction(StackMgr, *FuncInst, Instrs.end(), false, true, ModInst)
+          .and_then([&](AST::InstrView::iterator StartIt) {
+            return execute(StackMgr, StartIt, Instrs.end());
+          });
   return callFromCompiled(StackMgr, *FuncInst, Rets, std::move(Res));
 }
 
-Expect<void> Executor::proxyCallRef(Runtime::StackManager &StackMgr,
-                                    const Runtime::Instance::ModuleInstance *,
-                                    const RefVariant Ref,
-                                    const ValVariant *Args,
-                                    ValVariant *Rets) noexcept {
+Expect<void>
+Executor::proxyCallRef(Runtime::StackManager &StackMgr,
+                       const Runtime::Instance::ModuleInstance *ModInst,
+                       const RefVariant Ref, const ValVariant *Args,
+                       ValVariant *Rets) noexcept {
   const auto *FuncInst = retrieveFuncRef(Ref);
   if (unlikely(!FuncInst)) {
     return Unexpect(ErrCode::Value::AccessNullFunc);
@@ -246,10 +248,11 @@ Expect<void> Executor::proxyCallRef(Runtime::StackManager &StackMgr,
   }
 
   auto Instrs = FuncInst->getInstrs();
-  auto Res = enterFunction(StackMgr, *FuncInst, Instrs.end(), false, true)
-                 .and_then([&](AST::InstrView::iterator StartIt) {
-                   return execute(StackMgr, StartIt, Instrs.end());
-                 });
+  auto Res =
+      enterFunction(StackMgr, *FuncInst, Instrs.end(), false, true, ModInst)
+          .and_then([&](AST::InstrView::iterator StartIt) {
+            return execute(StackMgr, StartIt, Instrs.end());
+          });
   return callFromCompiled(StackMgr, *FuncInst, Rets, std::move(Res));
 }
 

--- a/lib/executor/engine/proxy.cpp
+++ b/lib/executor/engine/proxy.cpp
@@ -11,7 +11,7 @@ namespace Executor {
 
 thread_local Executor *Executor::This = nullptr;
 thread_local Runtime::StackManager *Executor::CurrentStack = nullptr;
-thread_local Executor::ExecutionContextStruct Executor::ExecutionContext;
+thread_local Executor::ExecutorContext Executor::ExecutionContext;
 thread_local Executor::PendingExnStruct Executor::PendingExn;
 thread_local std::array<uint32_t, 256> Executor::StackTrace;
 thread_local size_t Executor::StackTraceSize = 0;

--- a/lib/executor/engine/proxy.cpp
+++ b/lib/executor/engine/proxy.cpp
@@ -600,9 +600,11 @@ Expect<uint64_t> Executor::proxyMemAtomicWait(
 }
 
 Expect<void *> Executor::proxyTableGetFuncSymbol(
-    Runtime::StackManager &StackMgr, const uint32_t TableIdx,
-    const uint32_t FuncTypeIdx, const uint64_t FuncIdx) noexcept {
-  const auto *TabInst = getTabInstByIdx(StackMgr.getModule(), TableIdx);
+    Runtime::StackManager &, const Runtime::Instance::ModuleInstance *ModInst,
+    const uint32_t TableIdx, const uint32_t FuncTypeIdx, const uint64_t FuncIdx,
+    Runtime::Instance::ModuleInstance::ModuleContext **CalleeCtxOut) noexcept {
+  *CalleeCtxOut = nullptr;
+  const auto *TabInst = getTabInstByIdx(ModInst, TableIdx);
   assuming(TabInst);
 
   if (unlikely(FuncIdx >= TabInst->getSize())) {
@@ -615,8 +617,6 @@ Expect<void *> Executor::proxyTableGetFuncSymbol(
     return Unexpect(ErrCode::Value::UninitializedElement);
   }
 
-  const auto *ModInst = StackMgr.getModule();
-  assuming(ModInst);
   const auto &ExpDefType = *ModInst->unsafeGetType(FuncTypeIdx);
   const auto *FuncInst = retrieveFuncRef(*Ref);
   assuming(FuncInst);
@@ -651,20 +651,38 @@ Expect<void *> Executor::proxyTableGetFuncSymbol(
   if (unlikely(!FuncInst->isCompiledFunction())) {
     return nullptr;
   }
+  if (FuncInst->getModule() != ModInst) {
+    *CalleeCtxOut =
+        &const_cast<Runtime::Instance::ModuleInstance *>(FuncInst->getModule())
+             ->ModCtx;
+  }
   return FuncInst->getSymbol().get();
 }
 
-Expect<void *> Executor::proxyRefGetFuncSymbol(Runtime::StackManager &,
-                                               const RefVariant Ref) noexcept {
+Expect<void *> Executor::proxyRefGetFuncSymbol(
+    Runtime::StackManager &, const Runtime::Instance::ModuleInstance *ModInst,
+    const RefVariant Ref,
+    Runtime::Instance::ModuleInstance::ModuleContext **CalleeCtxOut) noexcept {
+  *CalleeCtxOut = nullptr;
   const auto *FuncInst = retrieveFuncRef(Ref);
   assuming(FuncInst);
   if (likely(FuncInst->isCompiledFunction())) {
+    if (FuncInst->getModule() != ModInst) {
+      *CalleeCtxOut = &const_cast<Runtime::Instance::ModuleInstance *>(
+                           FuncInst->getModule())
+                           ->ModCtx;
+    }
     return FuncInst->getSymbol().get();
   }
   EXPECTED_TRY(checkLazyCompilation(FuncInst));
 
   if (unlikely(!FuncInst->isCompiledFunction())) {
     return nullptr;
+  }
+  if (FuncInst->getModule() != ModInst) {
+    *CalleeCtxOut =
+        &const_cast<Runtime::Instance::ModuleInstance *>(FuncInst->getModule())
+             ->ModCtx;
   }
   return FuncInst->getSymbol().get();
 }

--- a/lib/executor/engine/proxy.cpp
+++ b/lib/executor/engine/proxy.cpp
@@ -146,7 +146,7 @@ Expect<void> Executor::proxyTrap(Runtime::StackManager &,
 Expect<void> Executor::proxyCall(Runtime::StackManager &StackMgr,
                                  const uint32_t FuncIdx, const ValVariant *Args,
                                  ValVariant *Rets) noexcept {
-  const auto *FuncInst = getFuncInstByIdx(StackMgr, FuncIdx);
+  const auto *FuncInst = getFuncInstByIdx(StackMgr.getModule(), FuncIdx);
   assuming(FuncInst);
   EXPECTED_TRY(checkLazyCompilation(FuncInst));
   const auto &FuncType = FuncInst->getFuncType();
@@ -171,7 +171,7 @@ Expect<void> Executor::proxyCallIndirect(Runtime::StackManager &StackMgr,
                                          const uint64_t FuncIdx,
                                          const ValVariant *Args,
                                          ValVariant *Rets) noexcept {
-  const auto *TabInst = getTabInstByIdx(StackMgr, TableIdx);
+  const auto *TabInst = getTabInstByIdx(StackMgr.getModule(), TableIdx);
   assuming(TabInst);
 
   if (unlikely(FuncIdx >= TabInst->getSize())) {
@@ -253,7 +253,7 @@ Expect<void> Executor::proxyCallRef(Runtime::StackManager &StackMgr,
 
 Expect<RefVariant> Executor::proxyRefFunc(Runtime::StackManager &StackMgr,
                                           const uint32_t FuncIdx) noexcept {
-  auto *FuncInst = getFuncInstByIdx(StackMgr, FuncIdx);
+  auto *FuncInst = getFuncInstByIdx(StackMgr.getModule(), FuncIdx);
   assuming(FuncInst);
   return RefVariant(FuncInst->getDefType(), FuncInst);
 }
@@ -444,16 +444,16 @@ Expect<void> Executor::proxyTableInit(Runtime::StackManager &StackMgr,
                                       const uint64_t DstOff,
                                       const uint32_t SrcOff,
                                       const uint32_t Len) noexcept {
-  auto *TabInst = getTabInstByIdx(StackMgr, TableIdx);
+  auto *TabInst = getTabInstByIdx(StackMgr.getModule(), TableIdx);
   assuming(TabInst);
-  auto *ElemInst = getElemInstByIdx(StackMgr, ElemIdx);
+  auto *ElemInst = getElemInstByIdx(StackMgr.getModule(), ElemIdx);
   assuming(ElemInst);
   return TabInst->setRefs(ElemInst->getRefs(), DstOff, SrcOff, Len);
 }
 
 Expect<void> Executor::proxyElemDrop(Runtime::StackManager &StackMgr,
                                      const uint32_t ElemIdx) noexcept {
-  auto *ElemInst = getElemInstByIdx(StackMgr, ElemIdx);
+  auto *ElemInst = getElemInstByIdx(StackMgr.getModule(), ElemIdx);
   assuming(ElemInst);
   ElemInst->clear();
   return {};
@@ -465,9 +465,9 @@ Expect<void> Executor::proxyTableCopy(Runtime::StackManager &StackMgr,
                                       const uint64_t DstOff,
                                       const uint64_t SrcOff,
                                       const uint64_t Len) noexcept {
-  auto *TabInstDst = getTabInstByIdx(StackMgr, TableIdxDst);
+  auto *TabInstDst = getTabInstByIdx(StackMgr.getModule(), TableIdxDst);
   assuming(TabInstDst);
-  auto *TabInstSrc = getTabInstByIdx(StackMgr, TableIdxSrc);
+  auto *TabInstSrc = getTabInstByIdx(StackMgr.getModule(), TableIdxSrc);
   assuming(TabInstSrc);
 
   EXPECTED_TRY(auto Refs, TabInstSrc->getRefs(0, SrcOff + Len));
@@ -478,7 +478,7 @@ Expect<uint64_t> Executor::proxyTableGrow(Runtime::StackManager &StackMgr,
                                           const uint32_t TableIdx,
                                           const RefVariant Val,
                                           const uint64_t NewSize) noexcept {
-  auto *TabInst = getTabInstByIdx(StackMgr, TableIdx);
+  auto *TabInst = getTabInstByIdx(StackMgr.getModule(), TableIdx);
   assuming(TabInst);
   const auto AddrType = TabInst->getTableType().getLimit().getAddrType();
   const uint64_t CurrTableSize = TabInst->getSize();
@@ -500,7 +500,7 @@ Expect<void> Executor::proxyTableFill(Runtime::StackManager &StackMgr,
                                       const uint32_t TableIdx,
                                       const uint64_t Off, const RefVariant Ref,
                                       const uint64_t Len) noexcept {
-  auto *TabInst = getTabInstByIdx(StackMgr, TableIdx);
+  auto *TabInst = getTabInstByIdx(StackMgr.getModule(), TableIdx);
   assuming(TabInst);
   return TabInst->fillRefs(Ref, Off, Len);
 }
@@ -508,7 +508,7 @@ Expect<void> Executor::proxyTableFill(Runtime::StackManager &StackMgr,
 Expect<uint64_t> Executor::proxyMemGrow(Runtime::StackManager &StackMgr,
                                         const uint32_t MemIdx,
                                         const uint64_t NewSize) noexcept {
-  auto *MemInst = getMemInstByIdx(StackMgr, MemIdx);
+  auto *MemInst = getMemInstByIdx(StackMgr.getModule(), MemIdx);
   assuming(MemInst);
   const auto AddrType = MemInst->getMemoryType().getLimit().getAddrType();
   const uint64_t CurrPageSize = MemInst->getPageSize();
@@ -530,16 +530,16 @@ Expect<void>
 Executor::proxyMemInit(Runtime::StackManager &StackMgr, const uint32_t MemIdx,
                        const uint32_t DataIdx, const uint64_t DstOff,
                        const uint32_t SrcOff, const uint32_t Len) noexcept {
-  auto *MemInst = getMemInstByIdx(StackMgr, MemIdx);
+  auto *MemInst = getMemInstByIdx(StackMgr.getModule(), MemIdx);
   assuming(MemInst);
-  auto *DataInst = getDataInstByIdx(StackMgr, DataIdx);
+  auto *DataInst = getDataInstByIdx(StackMgr.getModule(), DataIdx);
   assuming(DataInst);
   return MemInst->setBytes(DataInst->getData(), DstOff, SrcOff, Len);
 }
 
 Expect<void> Executor::proxyDataDrop(Runtime::StackManager &StackMgr,
                                      const uint32_t DataIdx) noexcept {
-  auto *DataInst = getDataInstByIdx(StackMgr, DataIdx);
+  auto *DataInst = getDataInstByIdx(StackMgr.getModule(), DataIdx);
   assuming(DataInst);
   DataInst->clear();
   return {};
@@ -551,9 +551,9 @@ Expect<void> Executor::proxyMemCopy(Runtime::StackManager &StackMgr,
                                     const uint64_t DstOff,
                                     const uint64_t SrcOff,
                                     const uint64_t Len) noexcept {
-  auto *MemInstDst = getMemInstByIdx(StackMgr, DstMemIdx);
+  auto *MemInstDst = getMemInstByIdx(StackMgr.getModule(), DstMemIdx);
   assuming(MemInstDst);
-  auto *MemInstSrc = getMemInstByIdx(StackMgr, SrcMemIdx);
+  auto *MemInstSrc = getMemInstByIdx(StackMgr.getModule(), SrcMemIdx);
   assuming(MemInstSrc);
 
   EXPECTED_TRY(auto Data, MemInstSrc->getBytes(SrcOff, Len));
@@ -564,7 +564,7 @@ Expect<void> Executor::proxyMemFill(Runtime::StackManager &StackMgr,
                                     const uint32_t MemIdx, const uint64_t Off,
                                     const uint8_t Val,
                                     const uint64_t Len) noexcept {
-  auto *MemInst = getMemInstByIdx(StackMgr, MemIdx);
+  auto *MemInst = getMemInstByIdx(StackMgr.getModule(), MemIdx);
   assuming(MemInst);
   return MemInst->fillBytes(Val, Off, Len);
 }
@@ -573,7 +573,7 @@ Expect<uint64_t> Executor::proxyMemAtomicNotify(Runtime::StackManager &StackMgr,
                                                 const uint32_t MemIdx,
                                                 const uint64_t Offset,
                                                 const uint64_t Count) noexcept {
-  auto *MemInst = getMemInstByIdx(StackMgr, MemIdx);
+  auto *MemInst = getMemInstByIdx(StackMgr.getModule(), MemIdx);
   assuming(MemInst);
   return atomicNotify(*MemInst, Offset, Count);
 }
@@ -583,7 +583,7 @@ Executor::proxyMemAtomicWait(Runtime::StackManager &StackMgr,
                              const uint32_t MemIdx, const uint64_t Offset,
                              const uint64_t Expected, const int64_t Timeout,
                              const uint32_t BitWidth) noexcept {
-  auto *MemInst = getMemInstByIdx(StackMgr, MemIdx);
+  auto *MemInst = getMemInstByIdx(StackMgr.getModule(), MemIdx);
   assuming(MemInst);
 
   if (BitWidth == 64) {
@@ -598,7 +598,7 @@ Executor::proxyMemAtomicWait(Runtime::StackManager &StackMgr,
 Expect<void *> Executor::proxyTableGetFuncSymbol(
     Runtime::StackManager &StackMgr, const uint32_t TableIdx,
     const uint32_t FuncTypeIdx, const uint64_t FuncIdx) noexcept {
-  const auto *TabInst = getTabInstByIdx(StackMgr, TableIdx);
+  const auto *TabInst = getTabInstByIdx(StackMgr.getModule(), TableIdx);
   assuming(TabInst);
 
   if (unlikely(FuncIdx >= TabInst->getSize())) {
@@ -668,7 +668,7 @@ Expect<void *> Executor::proxyRefGetFuncSymbol(Runtime::StackManager &,
 Expect<void *>
 Executor::proxyFuncGetFuncSymbol(Runtime::StackManager &StackMgr,
                                  const uint32_t FuncIdx) noexcept {
-  const auto *FuncInst = getFuncInstByIdx(StackMgr, FuncIdx);
+  const auto *FuncInst = getFuncInstByIdx(StackMgr.getModule(), FuncIdx);
   assuming(FuncInst);
   if (likely(FuncInst->isCompiledFunction())) {
     return FuncInst->getSymbol().get();
@@ -684,7 +684,7 @@ Executor::proxyFuncGetFuncSymbol(Runtime::StackManager &StackMgr,
 Expect<void> Executor::proxyThrow(Runtime::StackManager &StackMgr,
                                   const uint32_t TagIdx, const ValVariant *Vals,
                                   const uint32_t Num) noexcept {
-  auto *TagInst = getTagInstByIdx(StackMgr, TagIdx);
+  auto *TagInst = getTagInstByIdx(StackMgr.getModule(), TagIdx);
   assuming(TagInst);
   assuming(TagInst->getTagType().getAssocValSize() == Num);
   PendingExn.TagInst = TagInst;

--- a/lib/executor/engine/proxy.cpp
+++ b/lib/executor/engine/proxy.cpp
@@ -263,9 +263,10 @@ Expect<RefVariant> Executor::proxyStructNew(Runtime::StackManager &StackMgr,
                                             const ValVariant *Args,
                                             const uint32_t ArgSize) noexcept {
   if (Args == nullptr) {
-    return structNew(StackMgr, TypeIdx);
+    return structNew(StackMgr.getModule(), TypeIdx);
   } else {
-    return structNew(StackMgr, TypeIdx, Span<const ValVariant>(Args, ArgSize));
+    return structNew(StackMgr.getModule(), TypeIdx,
+                     Span<const ValVariant>(Args, ArgSize));
   }
 }
 
@@ -274,7 +275,8 @@ Expect<void> Executor::proxyStructGet(Runtime::StackManager &StackMgr,
                                       const uint32_t TypeIdx,
                                       const uint32_t Off, const bool IsSigned,
                                       ValVariant *Ret) noexcept {
-  EXPECTED_TRY(auto Val, structGet(StackMgr, Ref, TypeIdx, Off, IsSigned));
+  EXPECTED_TRY(auto Val,
+               structGet(StackMgr.getModule(), Ref, TypeIdx, Off, IsSigned));
   *Ret = Val;
   return {};
 }
@@ -284,7 +286,7 @@ Expect<void> Executor::proxyStructSet(Runtime::StackManager &StackMgr,
                                       const uint32_t TypeIdx,
                                       const uint32_t Off,
                                       const ValVariant *Val) noexcept {
-  return structSet(StackMgr, Ref, *Val, TypeIdx, Off);
+  return structSet(StackMgr.getModule(), Ref, *Val, TypeIdx, Off);
 }
 
 Expect<RefVariant> Executor::proxyArrayNew(Runtime::StackManager &StackMgr,
@@ -294,11 +296,11 @@ Expect<RefVariant> Executor::proxyArrayNew(Runtime::StackManager &StackMgr,
                                            const uint32_t ArgSize) noexcept {
   assuming(ArgSize == 0 || ArgSize == 1 || ArgSize == Length);
   if (ArgSize == 0) {
-    return arrayNew(StackMgr, TypeIdx, Length);
+    return arrayNew(StackMgr.getModule(), TypeIdx, Length);
   } else if (ArgSize == 1) {
-    return arrayNew(StackMgr, TypeIdx, Length, {Args[0]});
+    return arrayNew(StackMgr.getModule(), TypeIdx, Length, {Args[0]});
   } else {
-    return arrayNew(StackMgr, TypeIdx, Length,
+    return arrayNew(StackMgr.getModule(), TypeIdx, Length,
                     Span<const ValVariant>(Args, ArgSize));
   }
 }
@@ -308,7 +310,7 @@ Expect<RefVariant> Executor::proxyArrayNewData(Runtime::StackManager &StackMgr,
                                                const uint32_t DataIdx,
                                                const uint32_t Start,
                                                const uint32_t Length) noexcept {
-  return arrayNewData(StackMgr, TypeIdx, DataIdx, Start, Length);
+  return arrayNewData(StackMgr.getModule(), TypeIdx, DataIdx, Start, Length);
 }
 
 Expect<RefVariant> Executor::proxyArrayNewElem(Runtime::StackManager &StackMgr,
@@ -316,7 +318,7 @@ Expect<RefVariant> Executor::proxyArrayNewElem(Runtime::StackManager &StackMgr,
                                                const uint32_t ElemIdx,
                                                const uint32_t Start,
                                                const uint32_t Length) noexcept {
-  return arrayNewElem(StackMgr, TypeIdx, ElemIdx, Start, Length);
+  return arrayNewElem(StackMgr.getModule(), TypeIdx, ElemIdx, Start, Length);
 }
 
 Expect<void> Executor::proxyArrayGet(Runtime::StackManager &StackMgr,
@@ -324,7 +326,8 @@ Expect<void> Executor::proxyArrayGet(Runtime::StackManager &StackMgr,
                                      const uint32_t TypeIdx, const uint32_t Idx,
                                      const bool IsSigned,
                                      ValVariant *Ret) noexcept {
-  EXPECTED_TRY(auto Val, arrayGet(StackMgr, Ref, TypeIdx, Idx, IsSigned));
+  EXPECTED_TRY(auto Val,
+               arrayGet(StackMgr.getModule(), Ref, TypeIdx, Idx, IsSigned));
   *Ret = Val;
   return {};
 }
@@ -333,7 +336,7 @@ Expect<void> Executor::proxyArraySet(Runtime::StackManager &StackMgr,
                                      const RefVariant Ref,
                                      const uint32_t TypeIdx, const uint32_t Idx,
                                      const ValVariant *Val) noexcept {
-  return arraySet(StackMgr, Ref, *Val, TypeIdx, Idx);
+  return arraySet(StackMgr.getModule(), Ref, *Val, TypeIdx, Idx);
 }
 
 Expect<uint32_t> Executor::proxyArrayLen(Runtime::StackManager &,
@@ -350,7 +353,7 @@ Expect<void> Executor::proxyArrayFill(Runtime::StackManager &StackMgr,
                                       const uint32_t TypeIdx,
                                       const uint32_t Idx, const uint32_t Cnt,
                                       const ValVariant *Val) noexcept {
-  return arrayFill(StackMgr, Ref, *Val, TypeIdx, Idx, Cnt);
+  return arrayFill(StackMgr.getModule(), Ref, *Val, TypeIdx, Idx, Cnt);
 }
 
 Expect<void>
@@ -359,22 +362,24 @@ Executor::proxyArrayCopy(Runtime::StackManager &StackMgr,
                          const uint32_t DstIdx, const RefVariant SrcRef,
                          const uint32_t SrcTypeIdx, const uint32_t SrcIdx,
                          const uint32_t Cnt) noexcept {
-  return arrayCopy(StackMgr, DstRef, DstTypeIdx, DstIdx, SrcRef, SrcTypeIdx,
-                   SrcIdx, Cnt);
+  return arrayCopy(StackMgr.getModule(), DstRef, DstTypeIdx, DstIdx, SrcRef,
+                   SrcTypeIdx, SrcIdx, Cnt);
 }
 
 Expect<void> Executor::proxyArrayInitData(
     Runtime::StackManager &StackMgr, const RefVariant Ref,
     const uint32_t TypeIdx, const uint32_t DataIdx, const uint32_t DstIdx,
     const uint32_t SrcIdx, const uint32_t Cnt) noexcept {
-  return arrayInitData(StackMgr, Ref, TypeIdx, DataIdx, DstIdx, SrcIdx, Cnt);
+  return arrayInitData(StackMgr.getModule(), Ref, TypeIdx, DataIdx, DstIdx,
+                       SrcIdx, Cnt);
 }
 
 Expect<void> Executor::proxyArrayInitElem(
     Runtime::StackManager &StackMgr, const RefVariant Ref,
     const uint32_t TypeIdx, const uint32_t ElemIdx, const uint32_t DstIdx,
     const uint32_t SrcIdx, const uint32_t Cnt) noexcept {
-  return arrayInitElem(StackMgr, Ref, TypeIdx, ElemIdx, DstIdx, SrcIdx, Cnt);
+  return arrayInitElem(StackMgr.getModule(), Ref, TypeIdx, ElemIdx, DstIdx,
+                       SrcIdx, Cnt);
 }
 
 Expect<uint32_t> Executor::proxyRefTest(Runtime::StackManager &StackMgr,

--- a/lib/executor/engine/proxy.cpp
+++ b/lib/executor/engine/proxy.cpp
@@ -143,10 +143,12 @@ Expect<void> Executor::proxyTrap(Runtime::StackManager &,
   return Unexpect(static_cast<ErrCategory>(Code >> 24), Code);
 }
 
-Expect<void> Executor::proxyCall(Runtime::StackManager &StackMgr,
-                                 const uint32_t FuncIdx, const ValVariant *Args,
-                                 ValVariant *Rets) noexcept {
-  const auto *FuncInst = getFuncInstByIdx(StackMgr.getModule(), FuncIdx);
+Expect<void>
+Executor::proxyCall(Runtime::StackManager &StackMgr,
+                    const Runtime::Instance::ModuleInstance *ModInst,
+                    const uint32_t FuncIdx, const ValVariant *Args,
+                    ValVariant *Rets) noexcept {
+  const auto *FuncInst = getFuncInstByIdx(ModInst, FuncIdx);
   assuming(FuncInst);
   EXPECTED_TRY(checkLazyCompilation(FuncInst));
   const auto &FuncType = FuncInst->getFuncType();
@@ -165,13 +167,13 @@ Expect<void> Executor::proxyCall(Runtime::StackManager &StackMgr,
   return callFromCompiled(StackMgr, *FuncInst, Rets, std::move(Res));
 }
 
-Expect<void> Executor::proxyCallIndirect(Runtime::StackManager &StackMgr,
-                                         const uint32_t TableIdx,
-                                         const uint32_t FuncTypeIdx,
-                                         const uint64_t FuncIdx,
-                                         const ValVariant *Args,
-                                         ValVariant *Rets) noexcept {
-  const auto *TabInst = getTabInstByIdx(StackMgr.getModule(), TableIdx);
+Expect<void>
+Executor::proxyCallIndirect(Runtime::StackManager &StackMgr,
+                            const Runtime::Instance::ModuleInstance *ModInst,
+                            const uint32_t TableIdx, const uint32_t FuncTypeIdx,
+                            const uint64_t FuncIdx, const ValVariant *Args,
+                            ValVariant *Rets) noexcept {
+  const auto *TabInst = getTabInstByIdx(ModInst, TableIdx);
   assuming(TabInst);
 
   if (unlikely(FuncIdx >= TabInst->getSize())) {
@@ -184,7 +186,6 @@ Expect<void> Executor::proxyCallIndirect(Runtime::StackManager &StackMgr,
     return Unexpect(ErrCode::Value::UninitializedElement);
   }
 
-  const auto *ModInst = StackMgr.getModule();
   assuming(ModInst);
   const auto &ExpDefType = *ModInst->unsafeGetType(FuncTypeIdx);
   const auto *FuncInst = retrieveFuncRef(*Ref);
@@ -225,6 +226,7 @@ Expect<void> Executor::proxyCallIndirect(Runtime::StackManager &StackMgr,
 }
 
 Expect<void> Executor::proxyCallRef(Runtime::StackManager &StackMgr,
+                                    const Runtime::Instance::ModuleInstance *,
                                     const RefVariant Ref,
                                     const ValVariant *Args,
                                     ValVariant *Rets) noexcept {
@@ -251,92 +253,88 @@ Expect<void> Executor::proxyCallRef(Runtime::StackManager &StackMgr,
   return callFromCompiled(StackMgr, *FuncInst, Rets, std::move(Res));
 }
 
-Expect<RefVariant> Executor::proxyRefFunc(Runtime::StackManager &StackMgr,
-                                          const uint32_t FuncIdx) noexcept {
-  auto *FuncInst = getFuncInstByIdx(StackMgr.getModule(), FuncIdx);
+Expect<RefVariant>
+Executor::proxyRefFunc(Runtime::StackManager &,
+                       const Runtime::Instance::ModuleInstance *ModInst,
+                       const uint32_t FuncIdx) noexcept {
+  auto *FuncInst = getFuncInstByIdx(ModInst, FuncIdx);
   assuming(FuncInst);
   return RefVariant(FuncInst->getDefType(), FuncInst);
 }
 
-Expect<RefVariant> Executor::proxyStructNew(Runtime::StackManager &StackMgr,
-                                            const uint32_t TypeIdx,
-                                            const ValVariant *Args,
-                                            const uint32_t ArgSize) noexcept {
+Expect<RefVariant>
+Executor::proxyStructNew(Runtime::StackManager &,
+                         const Runtime::Instance::ModuleInstance *ModInst,
+                         const uint32_t TypeIdx, const ValVariant *Args,
+                         const uint32_t ArgSize) noexcept {
   if (Args == nullptr) {
-    return structNew(StackMgr.getModule(), TypeIdx);
+    return structNew(ModInst, TypeIdx);
   } else {
-    return structNew(StackMgr.getModule(), TypeIdx,
-                     Span<const ValVariant>(Args, ArgSize));
+    return structNew(ModInst, TypeIdx, Span<const ValVariant>(Args, ArgSize));
   }
 }
 
-Expect<void> Executor::proxyStructGet(Runtime::StackManager &StackMgr,
-                                      const RefVariant Ref,
-                                      const uint32_t TypeIdx,
-                                      const uint32_t Off, const bool IsSigned,
-                                      ValVariant *Ret) noexcept {
-  EXPECTED_TRY(auto Val,
-               structGet(StackMgr.getModule(), Ref, TypeIdx, Off, IsSigned));
+Expect<void> Executor::proxyStructGet(
+    Runtime::StackManager &, const Runtime::Instance::ModuleInstance *ModInst,
+    const RefVariant Ref, const uint32_t TypeIdx, const uint32_t Off,
+    const bool IsSigned, ValVariant *Ret) noexcept {
+  EXPECTED_TRY(auto Val, structGet(ModInst, Ref, TypeIdx, Off, IsSigned));
   *Ret = Val;
   return {};
 }
 
-Expect<void> Executor::proxyStructSet(Runtime::StackManager &StackMgr,
-                                      const RefVariant Ref,
-                                      const uint32_t TypeIdx,
-                                      const uint32_t Off,
-                                      const ValVariant *Val) noexcept {
-  return structSet(StackMgr.getModule(), Ref, *Val, TypeIdx, Off);
+Expect<void>
+Executor::proxyStructSet(Runtime::StackManager &,
+                         const Runtime::Instance::ModuleInstance *ModInst,
+                         const RefVariant Ref, const uint32_t TypeIdx,
+                         const uint32_t Off, const ValVariant *Val) noexcept {
+  return structSet(ModInst, Ref, *Val, TypeIdx, Off);
 }
 
-Expect<RefVariant> Executor::proxyArrayNew(Runtime::StackManager &StackMgr,
-                                           const uint32_t TypeIdx,
-                                           const uint32_t Length,
-                                           const ValVariant *Args,
-                                           const uint32_t ArgSize) noexcept {
+Expect<RefVariant> Executor::proxyArrayNew(
+    Runtime::StackManager &, const Runtime::Instance::ModuleInstance *ModInst,
+    const uint32_t TypeIdx, const uint32_t Length, const ValVariant *Args,
+    const uint32_t ArgSize) noexcept {
   assuming(ArgSize == 0 || ArgSize == 1 || ArgSize == Length);
   if (ArgSize == 0) {
-    return arrayNew(StackMgr.getModule(), TypeIdx, Length);
+    return arrayNew(ModInst, TypeIdx, Length);
   } else if (ArgSize == 1) {
-    return arrayNew(StackMgr.getModule(), TypeIdx, Length, {Args[0]});
+    return arrayNew(ModInst, TypeIdx, Length, {Args[0]});
   } else {
-    return arrayNew(StackMgr.getModule(), TypeIdx, Length,
+    return arrayNew(ModInst, TypeIdx, Length,
                     Span<const ValVariant>(Args, ArgSize));
   }
 }
 
-Expect<RefVariant> Executor::proxyArrayNewData(Runtime::StackManager &StackMgr,
-                                               const uint32_t TypeIdx,
-                                               const uint32_t DataIdx,
-                                               const uint32_t Start,
-                                               const uint32_t Length) noexcept {
-  return arrayNewData(StackMgr.getModule(), TypeIdx, DataIdx, Start, Length);
+Expect<RefVariant> Executor::proxyArrayNewData(
+    Runtime::StackManager &, const Runtime::Instance::ModuleInstance *ModInst,
+    const uint32_t TypeIdx, const uint32_t DataIdx, const uint32_t Start,
+    const uint32_t Length) noexcept {
+  return arrayNewData(ModInst, TypeIdx, DataIdx, Start, Length);
 }
 
-Expect<RefVariant> Executor::proxyArrayNewElem(Runtime::StackManager &StackMgr,
-                                               const uint32_t TypeIdx,
-                                               const uint32_t ElemIdx,
-                                               const uint32_t Start,
-                                               const uint32_t Length) noexcept {
-  return arrayNewElem(StackMgr.getModule(), TypeIdx, ElemIdx, Start, Length);
+Expect<RefVariant> Executor::proxyArrayNewElem(
+    Runtime::StackManager &, const Runtime::Instance::ModuleInstance *ModInst,
+    const uint32_t TypeIdx, const uint32_t ElemIdx, const uint32_t Start,
+    const uint32_t Length) noexcept {
+  return arrayNewElem(ModInst, TypeIdx, ElemIdx, Start, Length);
 }
 
-Expect<void> Executor::proxyArrayGet(Runtime::StackManager &StackMgr,
-                                     const RefVariant Ref,
-                                     const uint32_t TypeIdx, const uint32_t Idx,
-                                     const bool IsSigned,
-                                     ValVariant *Ret) noexcept {
-  EXPECTED_TRY(auto Val,
-               arrayGet(StackMgr.getModule(), Ref, TypeIdx, Idx, IsSigned));
+Expect<void> Executor::proxyArrayGet(
+    Runtime::StackManager &, const Runtime::Instance::ModuleInstance *ModInst,
+    const RefVariant Ref, const uint32_t TypeIdx, const uint32_t Idx,
+    const bool IsSigned, ValVariant *Ret) noexcept {
+  EXPECTED_TRY(auto Val, arrayGet(ModInst, Ref, TypeIdx, Idx, IsSigned));
   *Ret = Val;
   return {};
 }
 
-Expect<void> Executor::proxyArraySet(Runtime::StackManager &StackMgr,
-                                     const RefVariant Ref,
-                                     const uint32_t TypeIdx, const uint32_t Idx,
-                                     const ValVariant *Val) noexcept {
-  return arraySet(StackMgr.getModule(), Ref, *Val, TypeIdx, Idx);
+Expect<void>
+Executor::proxyArraySet(Runtime::StackManager &,
+                        const Runtime::Instance::ModuleInstance *ModInst,
+                        const RefVariant Ref, const uint32_t TypeIdx,
+                        const uint32_t Idx, const ValVariant *Val) noexcept {
+  return arraySet(ModInst, Ref, *Val, TypeIdx, Idx);
 }
 
 Expect<uint32_t> Executor::proxyArrayLen(Runtime::StackManager &,
@@ -348,49 +346,45 @@ Expect<uint32_t> Executor::proxyArrayLen(Runtime::StackManager &,
   return Inst->getLength();
 }
 
-Expect<void> Executor::proxyArrayFill(Runtime::StackManager &StackMgr,
-                                      const RefVariant Ref,
-                                      const uint32_t TypeIdx,
-                                      const uint32_t Idx, const uint32_t Cnt,
-                                      const ValVariant *Val) noexcept {
-  return arrayFill(StackMgr.getModule(), Ref, *Val, TypeIdx, Idx, Cnt);
+Expect<void> Executor::proxyArrayFill(
+    Runtime::StackManager &, const Runtime::Instance::ModuleInstance *ModInst,
+    const RefVariant Ref, const uint32_t TypeIdx, const uint32_t Idx,
+    const uint32_t Cnt, const ValVariant *Val) noexcept {
+  return arrayFill(ModInst, Ref, *Val, TypeIdx, Idx, Cnt);
 }
 
-Expect<void>
-Executor::proxyArrayCopy(Runtime::StackManager &StackMgr,
-                         const RefVariant DstRef, const uint32_t DstTypeIdx,
-                         const uint32_t DstIdx, const RefVariant SrcRef,
-                         const uint32_t SrcTypeIdx, const uint32_t SrcIdx,
-                         const uint32_t Cnt) noexcept {
-  return arrayCopy(StackMgr.getModule(), DstRef, DstTypeIdx, DstIdx, SrcRef,
-                   SrcTypeIdx, SrcIdx, Cnt);
+Expect<void> Executor::proxyArrayCopy(
+    Runtime::StackManager &, const Runtime::Instance::ModuleInstance *ModInst,
+    const RefVariant DstRef, const uint32_t DstTypeIdx, const uint32_t DstIdx,
+    const RefVariant SrcRef, const uint32_t SrcTypeIdx, const uint32_t SrcIdx,
+    const uint32_t Cnt) noexcept {
+  return arrayCopy(ModInst, DstRef, DstTypeIdx, DstIdx, SrcRef, SrcTypeIdx,
+                   SrcIdx, Cnt);
 }
 
 Expect<void> Executor::proxyArrayInitData(
-    Runtime::StackManager &StackMgr, const RefVariant Ref,
-    const uint32_t TypeIdx, const uint32_t DataIdx, const uint32_t DstIdx,
-    const uint32_t SrcIdx, const uint32_t Cnt) noexcept {
-  return arrayInitData(StackMgr.getModule(), Ref, TypeIdx, DataIdx, DstIdx,
-                       SrcIdx, Cnt);
+    Runtime::StackManager &, const Runtime::Instance::ModuleInstance *ModInst,
+    const RefVariant Ref, const uint32_t TypeIdx, const uint32_t DataIdx,
+    const uint32_t DstIdx, const uint32_t SrcIdx, const uint32_t Cnt) noexcept {
+  return arrayInitData(ModInst, Ref, TypeIdx, DataIdx, DstIdx, SrcIdx, Cnt);
 }
 
 Expect<void> Executor::proxyArrayInitElem(
-    Runtime::StackManager &StackMgr, const RefVariant Ref,
-    const uint32_t TypeIdx, const uint32_t ElemIdx, const uint32_t DstIdx,
-    const uint32_t SrcIdx, const uint32_t Cnt) noexcept {
-  return arrayInitElem(StackMgr.getModule(), Ref, TypeIdx, ElemIdx, DstIdx,
-                       SrcIdx, Cnt);
+    Runtime::StackManager &, const Runtime::Instance::ModuleInstance *ModInst,
+    const RefVariant Ref, const uint32_t TypeIdx, const uint32_t ElemIdx,
+    const uint32_t DstIdx, const uint32_t SrcIdx, const uint32_t Cnt) noexcept {
+  return arrayInitElem(ModInst, Ref, TypeIdx, ElemIdx, DstIdx, SrcIdx, Cnt);
 }
 
-Expect<uint32_t> Executor::proxyRefTest(Runtime::StackManager &StackMgr,
-                                        const RefVariant Ref,
-                                        ValType VTTest) noexcept {
+Expect<uint32_t>
+Executor::proxyRefTest(Runtime::StackManager &,
+                       const Runtime::Instance::ModuleInstance *ModInst,
+                       const RefVariant Ref, ValType VTTest) noexcept {
   // Copy the value type here due to handling the externalized case.
   auto VT = Ref.getType();
   if (VT.isExternalized()) {
     VT = ValType(TypeCode::Ref, TypeCode::ExternRef);
   }
-  const auto *ModInst = StackMgr.getModule();
   assuming(ModInst);
   Span<const AST::SubType *const> GotTypeList = ModInst->getTypeList();
   if (!VT.isAbsHeapType()) {
@@ -410,15 +404,15 @@ Expect<uint32_t> Executor::proxyRefTest(Runtime::StackManager &StackMgr,
   }
 }
 
-Expect<RefVariant> Executor::proxyRefCast(Runtime::StackManager &StackMgr,
-                                          const RefVariant Ref,
-                                          ValType VTCast) noexcept {
+Expect<RefVariant>
+Executor::proxyRefCast(Runtime::StackManager &,
+                       const Runtime::Instance::ModuleInstance *ModInst,
+                       const RefVariant Ref, ValType VTCast) noexcept {
   // Copy the value type here due to handling the externalized case.
   auto VT = Ref.getType();
   if (VT.isExternalized()) {
     VT = ValType(TypeCode::Ref, TypeCode::ExternRef);
   }
-  const auto *ModInst = StackMgr.getModule();
   assuming(ModInst);
   Span<const AST::SubType *const> GotTypeList = ModInst->getTypeList();
   if (!VT.isAbsHeapType()) {
@@ -443,47 +437,46 @@ Expect<RefVariant> Executor::proxyRefCast(Runtime::StackManager &StackMgr,
 // conversion to a 32- or 64-bit value according to the address type in the LLVM
 // compiler.
 
-Expect<void> Executor::proxyTableInit(Runtime::StackManager &StackMgr,
-                                      const uint32_t TableIdx,
-                                      const uint32_t ElemIdx,
-                                      const uint64_t DstOff,
-                                      const uint32_t SrcOff,
-                                      const uint32_t Len) noexcept {
-  auto *TabInst = getTabInstByIdx(StackMgr.getModule(), TableIdx);
+Expect<void> Executor::proxyTableInit(
+    Runtime::StackManager &, const Runtime::Instance::ModuleInstance *ModInst,
+    const uint32_t TableIdx, const uint32_t ElemIdx, const uint64_t DstOff,
+    const uint32_t SrcOff, const uint32_t Len) noexcept {
+  auto *TabInst = getTabInstByIdx(ModInst, TableIdx);
   assuming(TabInst);
-  auto *ElemInst = getElemInstByIdx(StackMgr.getModule(), ElemIdx);
+  auto *ElemInst = getElemInstByIdx(ModInst, ElemIdx);
   assuming(ElemInst);
   return TabInst->setRefs(ElemInst->getRefs(), DstOff, SrcOff, Len);
 }
 
-Expect<void> Executor::proxyElemDrop(Runtime::StackManager &StackMgr,
-                                     const uint32_t ElemIdx) noexcept {
-  auto *ElemInst = getElemInstByIdx(StackMgr.getModule(), ElemIdx);
+Expect<void>
+Executor::proxyElemDrop(Runtime::StackManager &,
+                        const Runtime::Instance::ModuleInstance *ModInst,
+                        const uint32_t ElemIdx) noexcept {
+  auto *ElemInst = getElemInstByIdx(ModInst, ElemIdx);
   assuming(ElemInst);
   ElemInst->clear();
   return {};
 }
 
-Expect<void> Executor::proxyTableCopy(Runtime::StackManager &StackMgr,
-                                      const uint32_t TableIdxDst,
-                                      const uint32_t TableIdxSrc,
-                                      const uint64_t DstOff,
-                                      const uint64_t SrcOff,
-                                      const uint64_t Len) noexcept {
-  auto *TabInstDst = getTabInstByIdx(StackMgr.getModule(), TableIdxDst);
+Expect<void> Executor::proxyTableCopy(
+    Runtime::StackManager &, const Runtime::Instance::ModuleInstance *ModInst,
+    const uint32_t TableIdxDst, const uint32_t TableIdxSrc,
+    const uint64_t DstOff, const uint64_t SrcOff, const uint64_t Len) noexcept {
+  auto *TabInstDst = getTabInstByIdx(ModInst, TableIdxDst);
   assuming(TabInstDst);
-  auto *TabInstSrc = getTabInstByIdx(StackMgr.getModule(), TableIdxSrc);
+  auto *TabInstSrc = getTabInstByIdx(ModInst, TableIdxSrc);
   assuming(TabInstSrc);
 
   EXPECTED_TRY(auto Refs, TabInstSrc->getRefs(0, SrcOff + Len));
   return TabInstDst->setRefs(Refs, DstOff, SrcOff, Len);
 }
 
-Expect<uint64_t> Executor::proxyTableGrow(Runtime::StackManager &StackMgr,
-                                          const uint32_t TableIdx,
-                                          const RefVariant Val,
-                                          const uint64_t NewSize) noexcept {
-  auto *TabInst = getTabInstByIdx(StackMgr.getModule(), TableIdx);
+Expect<uint64_t>
+Executor::proxyTableGrow(Runtime::StackManager &,
+                         const Runtime::Instance::ModuleInstance *ModInst,
+                         const uint32_t TableIdx, const RefVariant Val,
+                         const uint64_t NewSize) noexcept {
+  auto *TabInst = getTabInstByIdx(ModInst, TableIdx);
   assuming(TabInst);
   const auto AddrType = TabInst->getTableType().getLimit().getAddrType();
   const uint64_t CurrTableSize = TabInst->getSize();
@@ -501,19 +494,21 @@ Expect<uint64_t> Executor::proxyTableGrow(Runtime::StackManager &StackMgr,
   }
 }
 
-Expect<void> Executor::proxyTableFill(Runtime::StackManager &StackMgr,
-                                      const uint32_t TableIdx,
-                                      const uint64_t Off, const RefVariant Ref,
-                                      const uint64_t Len) noexcept {
-  auto *TabInst = getTabInstByIdx(StackMgr.getModule(), TableIdx);
+Expect<void>
+Executor::proxyTableFill(Runtime::StackManager &,
+                         const Runtime::Instance::ModuleInstance *ModInst,
+                         const uint32_t TableIdx, const uint64_t Off,
+                         const RefVariant Ref, const uint64_t Len) noexcept {
+  auto *TabInst = getTabInstByIdx(ModInst, TableIdx);
   assuming(TabInst);
   return TabInst->fillRefs(Ref, Off, Len);
 }
 
-Expect<uint64_t> Executor::proxyMemGrow(Runtime::StackManager &StackMgr,
-                                        const uint32_t MemIdx,
-                                        const uint64_t NewSize) noexcept {
-  auto *MemInst = getMemInstByIdx(StackMgr.getModule(), MemIdx);
+Expect<uint64_t>
+Executor::proxyMemGrow(Runtime::StackManager &,
+                       const Runtime::Instance::ModuleInstance *ModInst,
+                       const uint32_t MemIdx, const uint64_t NewSize) noexcept {
+  auto *MemInst = getMemInstByIdx(ModInst, MemIdx);
   assuming(MemInst);
   const auto AddrType = MemInst->getMemoryType().getLimit().getAddrType();
   const uint64_t CurrPageSize = MemInst->getPageSize();
@@ -531,64 +526,65 @@ Expect<uint64_t> Executor::proxyMemGrow(Runtime::StackManager &StackMgr,
   }
 }
 
-Expect<void>
-Executor::proxyMemInit(Runtime::StackManager &StackMgr, const uint32_t MemIdx,
-                       const uint32_t DataIdx, const uint64_t DstOff,
-                       const uint32_t SrcOff, const uint32_t Len) noexcept {
-  auto *MemInst = getMemInstByIdx(StackMgr.getModule(), MemIdx);
+Expect<void> Executor::proxyMemInit(
+    Runtime::StackManager &, const Runtime::Instance::ModuleInstance *ModInst,
+    const uint32_t MemIdx, const uint32_t DataIdx, const uint64_t DstOff,
+    const uint32_t SrcOff, const uint32_t Len) noexcept {
+  auto *MemInst = getMemInstByIdx(ModInst, MemIdx);
   assuming(MemInst);
-  auto *DataInst = getDataInstByIdx(StackMgr.getModule(), DataIdx);
+  auto *DataInst = getDataInstByIdx(ModInst, DataIdx);
   assuming(DataInst);
   return MemInst->setBytes(DataInst->getData(), DstOff, SrcOff, Len);
 }
 
-Expect<void> Executor::proxyDataDrop(Runtime::StackManager &StackMgr,
-                                     const uint32_t DataIdx) noexcept {
-  auto *DataInst = getDataInstByIdx(StackMgr.getModule(), DataIdx);
+Expect<void>
+Executor::proxyDataDrop(Runtime::StackManager &,
+                        const Runtime::Instance::ModuleInstance *ModInst,
+                        const uint32_t DataIdx) noexcept {
+  auto *DataInst = getDataInstByIdx(ModInst, DataIdx);
   assuming(DataInst);
   DataInst->clear();
   return {};
 }
 
-Expect<void> Executor::proxyMemCopy(Runtime::StackManager &StackMgr,
-                                    const uint32_t DstMemIdx,
-                                    const uint32_t SrcMemIdx,
-                                    const uint64_t DstOff,
-                                    const uint64_t SrcOff,
-                                    const uint64_t Len) noexcept {
-  auto *MemInstDst = getMemInstByIdx(StackMgr.getModule(), DstMemIdx);
+Expect<void> Executor::proxyMemCopy(
+    Runtime::StackManager &, const Runtime::Instance::ModuleInstance *ModInst,
+    const uint32_t DstMemIdx, const uint32_t SrcMemIdx, const uint64_t DstOff,
+    const uint64_t SrcOff, const uint64_t Len) noexcept {
+  auto *MemInstDst = getMemInstByIdx(ModInst, DstMemIdx);
   assuming(MemInstDst);
-  auto *MemInstSrc = getMemInstByIdx(StackMgr.getModule(), SrcMemIdx);
+  auto *MemInstSrc = getMemInstByIdx(ModInst, SrcMemIdx);
   assuming(MemInstSrc);
 
   EXPECTED_TRY(auto Data, MemInstSrc->getBytes(SrcOff, Len));
   return MemInstDst->setBytes(Data, DstOff, 0, Len);
 }
 
-Expect<void> Executor::proxyMemFill(Runtime::StackManager &StackMgr,
-                                    const uint32_t MemIdx, const uint64_t Off,
-                                    const uint8_t Val,
-                                    const uint64_t Len) noexcept {
-  auto *MemInst = getMemInstByIdx(StackMgr.getModule(), MemIdx);
+Expect<void>
+Executor::proxyMemFill(Runtime::StackManager &,
+                       const Runtime::Instance::ModuleInstance *ModInst,
+                       const uint32_t MemIdx, const uint64_t Off,
+                       const uint8_t Val, const uint64_t Len) noexcept {
+  auto *MemInst = getMemInstByIdx(ModInst, MemIdx);
   assuming(MemInst);
   return MemInst->fillBytes(Val, Off, Len);
 }
 
-Expect<uint64_t> Executor::proxyMemAtomicNotify(Runtime::StackManager &StackMgr,
-                                                const uint32_t MemIdx,
-                                                const uint64_t Offset,
-                                                const uint64_t Count) noexcept {
-  auto *MemInst = getMemInstByIdx(StackMgr.getModule(), MemIdx);
+Expect<uint64_t>
+Executor::proxyMemAtomicNotify(Runtime::StackManager &,
+                               const Runtime::Instance::ModuleInstance *ModInst,
+                               const uint32_t MemIdx, const uint64_t Offset,
+                               const uint64_t Count) noexcept {
+  auto *MemInst = getMemInstByIdx(ModInst, MemIdx);
   assuming(MemInst);
   return atomicNotify(*MemInst, Offset, Count);
 }
 
-Expect<uint64_t>
-Executor::proxyMemAtomicWait(Runtime::StackManager &StackMgr,
-                             const uint32_t MemIdx, const uint64_t Offset,
-                             const uint64_t Expected, const int64_t Timeout,
-                             const uint32_t BitWidth) noexcept {
-  auto *MemInst = getMemInstByIdx(StackMgr.getModule(), MemIdx);
+Expect<uint64_t> Executor::proxyMemAtomicWait(
+    Runtime::StackManager &, const Runtime::Instance::ModuleInstance *ModInst,
+    const uint32_t MemIdx, const uint64_t Offset, const uint64_t Expected,
+    const int64_t Timeout, const uint32_t BitWidth) noexcept {
+  auto *MemInst = getMemInstByIdx(ModInst, MemIdx);
   assuming(MemInst);
 
   if (BitWidth == 64) {
@@ -670,10 +666,10 @@ Expect<void *> Executor::proxyRefGetFuncSymbol(Runtime::StackManager &,
   return FuncInst->getSymbol().get();
 }
 
-Expect<void *>
-Executor::proxyFuncGetFuncSymbol(Runtime::StackManager &StackMgr,
-                                 const uint32_t FuncIdx) noexcept {
-  const auto *FuncInst = getFuncInstByIdx(StackMgr.getModule(), FuncIdx);
+Expect<void *> Executor::proxyFuncGetFuncSymbol(
+    Runtime::StackManager &, const Runtime::Instance::ModuleInstance *ModInst,
+    const uint32_t FuncIdx) noexcept {
+  const auto *FuncInst = getFuncInstByIdx(ModInst, FuncIdx);
   assuming(FuncInst);
   if (likely(FuncInst->isCompiledFunction())) {
     return FuncInst->getSymbol().get();
@@ -686,10 +682,12 @@ Executor::proxyFuncGetFuncSymbol(Runtime::StackManager &StackMgr,
   return FuncInst->getSymbol().get();
 }
 
-Expect<void> Executor::proxyThrow(Runtime::StackManager &StackMgr,
-                                  const uint32_t TagIdx, const ValVariant *Vals,
-                                  const uint32_t Num) noexcept {
-  auto *TagInst = getTagInstByIdx(StackMgr.getModule(), TagIdx);
+Expect<void>
+Executor::proxyThrow(Runtime::StackManager &,
+                     const Runtime::Instance::ModuleInstance *ModInst,
+                     const uint32_t TagIdx, const ValVariant *Vals,
+                     const uint32_t Num) noexcept {
+  auto *TagInst = getTagInstByIdx(ModInst, TagIdx);
   assuming(TagInst);
   assuming(TagInst->getTagType().getAssocValSize() == Num);
   PendingExn.TagInst = TagInst;
@@ -710,9 +708,11 @@ Expect<void> Executor::proxyThrowRef(Runtime::StackManager &,
   return {};
 }
 
-Expect<void> Executor::proxyCatchPop(Runtime::StackManager &StackMgr,
-                                     ValVariant *Out, const uint32_t PopPayload,
-                                     const uint32_t NeedRef) noexcept {
+Expect<void>
+Executor::proxyCatchPop(Runtime::StackManager &,
+                        const Runtime::Instance::ModuleInstance *ModInst,
+                        ValVariant *Out, const uint32_t PopPayload,
+                        const uint32_t NeedRef) noexcept {
   auto *TagInst = PendingExn.TagInst;
   assuming(TagInst);
   uint32_t Idx = 0;
@@ -723,11 +723,10 @@ Expect<void> Executor::proxyCatchPop(Runtime::StackManager &StackMgr,
   if (NeedRef != 0) {
     const auto *Inst = PendingExn.Inst;
     if (Inst == nullptr) {
-      auto *ModInst =
-          const_cast<Runtime::Instance::ModuleInstance *>(StackMgr.getModule());
       assuming(ModInst);
-      Inst = ModInst->newException(
-          TagInst, std::vector<ValVariant>(PendingExn.getPayload()));
+      Inst = const_cast<Runtime::Instance::ModuleInstance *>(ModInst)
+                 ->newException(
+                     TagInst, std::vector<ValVariant>(PendingExn.getPayload()));
     }
     Out[Idx] = RefVariant(ValType(TypeCode::Ref, TypeCode::ExnRef), Inst);
   }

--- a/lib/executor/engine/proxy.cpp
+++ b/lib/executor/engine/proxy.cpp
@@ -13,7 +13,7 @@ thread_local Executor *Executor::This = nullptr;
 thread_local Runtime::StackManager *Executor::CurrentStack = nullptr;
 thread_local Executor::ExecutorContext Executor::ExecutionContext;
 thread_local Executor::PendingExnStruct Executor::PendingExn;
-thread_local std::array<uint32_t, 256> Executor::StackTrace;
+thread_local std::array<StackTraceEntry, 256> Executor::StackTrace;
 thread_local size_t Executor::StackTraceSize = 0;
 
 namespace {

--- a/lib/executor/engine/refInstr.cpp
+++ b/lib/executor/engine/refInstr.cpp
@@ -76,7 +76,7 @@ void logTableOOB(const ErrCode &Code,
 Expect<void> Executor::runRefNullOp(Runtime::StackManager &StackMgr,
                                     const ValType &Type) const noexcept {
   // A null reference is typed with the least type in its respective hierarchy.
-  StackMgr.push(RefVariant(toBottomType(StackMgr, Type)));
+  StackMgr.push(RefVariant(toBottomType(StackMgr.getModule(), Type)));
   return {};
 }
 
@@ -87,7 +87,7 @@ Expect<void> Executor::runRefIsNullOp(ValVariant &Val) const noexcept {
 
 Expect<void> Executor::runRefFuncOp(Runtime::StackManager &StackMgr,
                                     uint32_t Idx) const noexcept {
-  const auto *FuncInst = getFuncInstByIdx(StackMgr, Idx);
+  const auto *FuncInst = getFuncInstByIdx(StackMgr.getModule(), Idx);
   StackMgr.push(RefVariant(FuncInst->getDefType(), FuncInst));
   return {};
 }
@@ -117,7 +117,7 @@ Expect<void> Executor::runStructNewOp(Runtime::StackManager &StackMgr,
   if (IsDefault) {
     StackMgr.push(*structNew(StackMgr, TypeIdx));
   } else {
-    const auto &CompType = getCompositeTypeByIdx(StackMgr, TypeIdx);
+    const auto &CompType = getCompositeTypeByIdx(StackMgr.getModule(), TypeIdx);
     const uint32_t N = static_cast<uint32_t>(CompType.getFieldTypes().size());
     std::vector<ValVariant> Vals = StackMgr.pop(N);
     StackMgr.push(*structNew(StackMgr, TypeIdx, Vals));
@@ -174,17 +174,19 @@ Executor::runArrayNewDataOp(Runtime::StackManager &StackMgr,
                             const AST::Instruction &Instr) const noexcept {
   const uint32_t Length = StackMgr.pop().get<uint32_t>();
   const uint32_t Start = StackMgr.getTop().get<uint32_t>();
-  EXPECTED_TRY(
-      auto InstRef,
-      arrayNewData(StackMgr, TypeIdx, DataIdx, Start, Length)
-          .map_error([&](auto E) {
-            auto *DataInst = getDataInstByIdx(StackMgr, DataIdx);
-            const uint32_t BSize =
-                getArrayStorageTypeByIdx(StackMgr, TypeIdx).getBitWidth() / 8;
-            return logError(E, Instr, [&]() {
-              return logMemoryOOB(E, *DataInst, Start, BSize * Length);
-            });
-          }));
+  EXPECTED_TRY(auto InstRef,
+               arrayNewData(StackMgr, TypeIdx, DataIdx, Start, Length)
+                   .map_error([&](auto E) {
+                     auto *DataInst =
+                         getDataInstByIdx(StackMgr.getModule(), DataIdx);
+                     const uint32_t BSize =
+                         getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx)
+                             .getBitWidth() /
+                         8;
+                     return logError(E, Instr, [&]() {
+                       return logMemoryOOB(E, *DataInst, Start, BSize * Length);
+                     });
+                   }));
   StackMgr.getTop().emplace<RefVariant>(InstRef);
   return {};
 }
@@ -198,7 +200,8 @@ Executor::runArrayNewElemOp(Runtime::StackManager &StackMgr,
   EXPECTED_TRY(auto InstRef,
                arrayNewElem(StackMgr, TypeIdx, ElemIdx, Start, Length)
                    .map_error([&](auto E) {
-                     auto *ElemInst = getElemInstByIdx(StackMgr, ElemIdx);
+                     auto *ElemInst =
+                         getElemInstByIdx(StackMgr.getModule(), ElemIdx);
                      return logError(E, Instr, [&]() {
                        return logTableOOB(E, *ElemInst, Start, Length);
                      });
@@ -291,9 +294,11 @@ Expect<void> Executor::runArrayInitDataOp(
   EXPECTED_TRY(
       arrayInitData(StackMgr, Ref, TypeIdx, DataIdx, DstIdx, SrcIdx, Cnt)
           .map_error([&](auto E) {
-            auto *DataInst = getDataInstByIdx(StackMgr, DataIdx);
+            auto *DataInst = getDataInstByIdx(StackMgr.getModule(), DataIdx);
             const uint32_t BSize =
-                getArrayStorageTypeByIdx(StackMgr, TypeIdx).getBitWidth() / 8;
+                getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx)
+                    .getBitWidth() /
+                8;
             return logError(
                 E, Instr, [&]() { return logArrayOOB(E, DstIdx, Cnt, Ref); },
                 [&]() {
@@ -312,7 +317,7 @@ Expect<void> Executor::runArrayInitElemOp(
   EXPECTED_TRY(
       arrayInitElem(StackMgr, Ref, TypeIdx, ElemIdx, DstIdx, SrcIdx, Cnt)
           .map_error([&](auto E) {
-            auto *ElemInst = getElemInstByIdx(StackMgr, ElemIdx);
+            auto *ElemInst = getElemInstByIdx(StackMgr.getModule(), ElemIdx);
             return logError(
                 E, Instr, [&]() { return logArrayOOB(E, DstIdx, Cnt, Ref); },
                 [&]() { return logTableOOB(E, *ElemInst, SrcIdx, Cnt); });
@@ -415,7 +420,7 @@ Executor::structNew(Runtime::StackManager &StackMgr, const uint32_t TypeIdx,
   /// TODO: The array and struct instances are currently owned by the module
   /// instance because they refer to the defined types of the module instances.
   /// This may be changed after applying the garbage collection mechanism.
-  const auto &CompType = getCompositeTypeByIdx(StackMgr, TypeIdx);
+  const auto &CompType = getCompositeTypeByIdx(StackMgr.getModule(), TypeIdx);
   uint32_t N = static_cast<uint32_t>(CompType.getFieldTypes().size());
   Runtime::Instance::ModuleInstance *ModInst =
       const_cast<Runtime::Instance::ModuleInstance *>(StackMgr.getModule());
@@ -426,7 +431,8 @@ Executor::structNew(Runtime::StackManager &StackMgr, const uint32_t TypeIdx,
       Vals[I] = packVal(VType, Args[I]);
     } else {
       Vals[I] = VType.isRefType()
-                    ? ValVariant(RefVariant(toBottomType(StackMgr, VType)))
+                    ? ValVariant(
+                          RefVariant(toBottomType(StackMgr.getModule(), VType)))
                     : ValVariant(static_cast<uint128_t>(0U));
     }
   }
@@ -444,7 +450,8 @@ Expect<ValVariant> Executor::structGet(Runtime::StackManager &StackMgr,
   if (Inst == nullptr) {
     return Unexpect(ErrCode::Value::AccessNullStruct);
   }
-  const auto &VType = getStructStorageTypeByIdx(StackMgr, TypeIdx, Off);
+  const auto &VType =
+      getStructStorageTypeByIdx(StackMgr.getModule(), TypeIdx, Off);
   return unpackVal(VType, Inst->getField(Off), IsSigned);
 }
 
@@ -456,7 +463,8 @@ Expect<void> Executor::structSet(Runtime::StackManager &StackMgr,
   if (Inst == nullptr) {
     return Unexpect(ErrCode::Value::AccessNullStruct);
   }
-  const auto &VType = getStructStorageTypeByIdx(StackMgr, TypeIdx, Off);
+  const auto &VType =
+      getStructStorageTypeByIdx(StackMgr.getModule(), TypeIdx, Off);
   Inst->getField(Off) = packVal(VType, Val);
   return {};
 }
@@ -468,15 +476,16 @@ Executor::arrayNew(Runtime::StackManager &StackMgr, const uint32_t TypeIdx,
   /// TODO: The array and struct instances are currently owned by the module
   /// instance because they refer to the defined types of the module instances.
   /// This may be changed after applying the garbage collection mechanism.
-  const auto &VType = getArrayStorageTypeByIdx(StackMgr, TypeIdx);
+  const auto &VType = getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx);
   WasmEdge::Runtime::Instance::ArrayInstance *Inst = nullptr;
   Runtime::Instance::ModuleInstance *ModInst =
       const_cast<Runtime::Instance::ModuleInstance *>(StackMgr.getModule());
   if (Args.size() == 0) {
     // New and fill with default values.
-    auto InitVal = VType.isRefType()
-                       ? ValVariant(RefVariant(toBottomType(StackMgr, VType)))
-                       : ValVariant(static_cast<uint128_t>(0U));
+    auto InitVal =
+        VType.isRefType()
+            ? ValVariant(RefVariant(toBottomType(StackMgr.getModule(), VType)))
+            : ValVariant(static_cast<uint128_t>(0U));
     Inst = ModInst->newArray(TypeIdx, Length, InitVal);
   } else if (Args.size() == 1) {
     // Create and fill with the argument value.
@@ -494,9 +503,9 @@ Expect<RefVariant>
 Executor::arrayNewData(Runtime::StackManager &StackMgr, const uint32_t TypeIdx,
                        const uint32_t DataIdx, const uint32_t Start,
                        const uint32_t Length) const noexcept {
-  const auto &VType = getArrayStorageTypeByIdx(StackMgr, TypeIdx);
+  const auto &VType = getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx);
   const uint32_t BSize = VType.getBitWidth() / 8;
-  auto *DataInst = getDataInstByIdx(StackMgr, DataIdx);
+  auto *DataInst = getDataInstByIdx(StackMgr.getModule(), DataIdx);
   assuming(DataInst);
   if (static_cast<uint64_t>(Start) + static_cast<uint64_t>(Length) * BSize >
       DataInst->getData().size()) {
@@ -519,8 +528,8 @@ Expect<RefVariant>
 Executor::arrayNewElem(Runtime::StackManager &StackMgr, const uint32_t TypeIdx,
                        const uint32_t ElemIdx, const uint32_t Start,
                        const uint32_t Length) const noexcept {
-  const auto &VType = getArrayStorageTypeByIdx(StackMgr, TypeIdx);
-  auto *ElemInst = getElemInstByIdx(StackMgr, ElemIdx);
+  const auto &VType = getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx);
+  auto *ElemInst = getElemInstByIdx(StackMgr.getModule(), ElemIdx);
   assuming(ElemInst);
   auto ElemSrc = ElemInst->getRefs();
   if (static_cast<uint64_t>(Start) + static_cast<uint64_t>(Length) >
@@ -548,7 +557,7 @@ Expect<ValVariant> Executor::arrayGet(Runtime::StackManager &StackMgr,
   if (Idx >= Inst->getLength()) {
     return Unexpect(ErrCode::Value::ArrayOutOfBounds);
   }
-  const auto &VType = getArrayStorageTypeByIdx(StackMgr, TypeIdx);
+  const auto &VType = getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx);
   return unpackVal(VType, Inst->getData(Idx), IsSigned);
 }
 
@@ -563,7 +572,7 @@ Expect<void> Executor::arraySet(Runtime::StackManager &StackMgr,
   if (Idx >= Inst->getLength()) {
     return Unexpect(ErrCode::Value::ArrayOutOfBounds);
   }
-  const auto &VType = getArrayStorageTypeByIdx(StackMgr, TypeIdx);
+  const auto &VType = getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx);
   Inst->getData(Idx) = packVal(VType, Val);
   return {};
 }
@@ -580,7 +589,7 @@ Expect<void> Executor::arrayFill(Runtime::StackManager &StackMgr,
       Inst->getLength()) {
     return Unexpect(ErrCode::Value::ArrayOutOfBounds);
   }
-  const auto &VType = getArrayStorageTypeByIdx(StackMgr, TypeIdx);
+  const auto &VType = getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx);
   auto Arr = Inst->getArray();
   std::fill(Arr.begin() + Idx, Arr.begin() + Idx + Cnt, packVal(VType, Val));
   return {};
@@ -599,9 +608,9 @@ Executor::arrayInitData(Runtime::StackManager &StackMgr, const RefVariant &Ref,
       Inst->getLength()) {
     return Unexpect(ErrCode::Value::ArrayOutOfBounds);
   }
-  const auto &VType = getArrayStorageTypeByIdx(StackMgr, TypeIdx);
+  const auto &VType = getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx);
   const uint32_t BSize = VType.getBitWidth() / 8;
-  auto *DataInst = getDataInstByIdx(StackMgr, DataIdx);
+  auto *DataInst = getDataInstByIdx(StackMgr.getModule(), DataIdx);
   assuming(DataInst);
   if (static_cast<uint64_t>(SrcIdx) + static_cast<uint64_t>(Cnt) * BSize >
       DataInst->getData().size()) {
@@ -629,8 +638,8 @@ Executor::arrayInitElem(Runtime::StackManager &StackMgr, const RefVariant &Ref,
       Inst->getLength()) {
     return Unexpect(ErrCode::Value::ArrayOutOfBounds);
   }
-  const auto &VType = getArrayStorageTypeByIdx(StackMgr, TypeIdx);
-  auto *ElemInst = getElemInstByIdx(StackMgr, ElemIdx);
+  const auto &VType = getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx);
+  auto *ElemInst = getElemInstByIdx(StackMgr.getModule(), ElemIdx);
   assuming(ElemInst);
   auto ElemSrc = ElemInst->getRefs();
   if (static_cast<uint64_t>(SrcIdx) + static_cast<uint64_t>(Cnt) >
@@ -670,8 +679,10 @@ Executor::arrayCopy(Runtime::StackManager &StackMgr, const RefVariant &DstRef,
 
   auto SrcArr = SrcInst->getArray();
   auto DstArr = DstInst->getArray();
-  const auto &SrcVType = getArrayStorageTypeByIdx(StackMgr, SrcTypeIdx);
-  const auto &DstVType = getArrayStorageTypeByIdx(StackMgr, DstTypeIdx);
+  const auto &SrcVType =
+      getArrayStorageTypeByIdx(StackMgr.getModule(), SrcTypeIdx);
+  const auto &DstVType =
+      getArrayStorageTypeByIdx(StackMgr.getModule(), DstTypeIdx);
   if (DstIdx <= SrcIdx) {
     std::transform(SrcArr.begin() + SrcIdx, SrcArr.begin() + SrcIdx + Cnt,
                    DstArr.begin() + DstIdx, [&](const ValVariant &V) {

--- a/lib/executor/engine/refInstr.cpp
+++ b/lib/executor/engine/refInstr.cpp
@@ -115,12 +115,12 @@ Expect<void> Executor::runStructNewOp(Runtime::StackManager &StackMgr,
                                       const uint32_t TypeIdx,
                                       const bool IsDefault) const noexcept {
   if (IsDefault) {
-    StackMgr.push(*structNew(StackMgr, TypeIdx));
+    StackMgr.push(*structNew(StackMgr.getModule(), TypeIdx));
   } else {
     const auto &CompType = getCompositeTypeByIdx(StackMgr.getModule(), TypeIdx);
     const uint32_t N = static_cast<uint32_t>(CompType.getFieldTypes().size());
     std::vector<ValVariant> Vals = StackMgr.pop(N);
-    StackMgr.push(*structNew(StackMgr, TypeIdx, Vals));
+    StackMgr.push(*structNew(StackMgr.getModule(), TypeIdx, Vals));
   }
   return {};
 }
@@ -131,11 +131,9 @@ Expect<void> Executor::runStructGetOp(Runtime::StackManager &StackMgr,
                                       const AST::Instruction &Instr,
                                       const bool IsSigned) const noexcept {
   const RefVariant Ref = StackMgr.getTop().get<RefVariant>();
-  EXPECTED_TRY(
-      auto Val,
-      structGet(StackMgr, Ref, TypeIdx, Off, IsSigned).map_error([&](auto E) {
-        return logError(E, Instr);
-      }));
+  EXPECTED_TRY(auto Val,
+               structGet(StackMgr.getModule(), Ref, TypeIdx, Off, IsSigned)
+                   .map_error([&](auto E) { return logError(E, Instr); }));
   StackMgr.getTop() = Val;
   return {};
 }
@@ -145,10 +143,8 @@ Executor::runStructSetOp(Runtime::StackManager &StackMgr, const ValVariant &Val,
                          const uint32_t TypeIdx, const uint32_t Off,
                          const AST::Instruction &Instr) const noexcept {
   const RefVariant Ref = StackMgr.pop().get<RefVariant>();
-  EXPECTED_TRY(
-      structSet(StackMgr, Ref, Val, TypeIdx, Off).map_error([&](auto E) {
-        return logError(E, Instr);
-      }));
+  EXPECTED_TRY(structSet(StackMgr.getModule(), Ref, Val, TypeIdx, Off)
+                   .map_error([&](auto E) { return logError(E, Instr); }));
   return {};
 }
 
@@ -158,12 +154,13 @@ Expect<void> Executor::runArrayNewOp(Runtime::StackManager &StackMgr,
                                      uint32_t Length) const noexcept {
   assuming(InitCnt == 0 || InitCnt == 1 || InitCnt == Length);
   if (InitCnt == 0) {
-    StackMgr.push(*arrayNew(StackMgr, TypeIdx, Length));
+    StackMgr.push(*arrayNew(StackMgr.getModule(), TypeIdx, Length));
   } else if (InitCnt == 1) {
     StackMgr.getTop().emplace<RefVariant>(
-        *arrayNew(StackMgr, TypeIdx, Length, {StackMgr.getTop()}));
+        *arrayNew(StackMgr.getModule(), TypeIdx, Length, {StackMgr.getTop()}));
   } else {
-    StackMgr.push(*arrayNew(StackMgr, TypeIdx, Length, StackMgr.pop(Length)));
+    StackMgr.push(
+        *arrayNew(StackMgr.getModule(), TypeIdx, Length, StackMgr.pop(Length)));
   }
   return {};
 }
@@ -174,19 +171,19 @@ Executor::runArrayNewDataOp(Runtime::StackManager &StackMgr,
                             const AST::Instruction &Instr) const noexcept {
   const uint32_t Length = StackMgr.pop().get<uint32_t>();
   const uint32_t Start = StackMgr.getTop().get<uint32_t>();
-  EXPECTED_TRY(auto InstRef,
-               arrayNewData(StackMgr, TypeIdx, DataIdx, Start, Length)
-                   .map_error([&](auto E) {
-                     auto *DataInst =
-                         getDataInstByIdx(StackMgr.getModule(), DataIdx);
-                     const uint32_t BSize =
-                         getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx)
-                             .getBitWidth() /
-                         8;
-                     return logError(E, Instr, [&]() {
-                       return logMemoryOOB(E, *DataInst, Start, BSize * Length);
-                     });
-                   }));
+  EXPECTED_TRY(
+      auto InstRef,
+      arrayNewData(StackMgr.getModule(), TypeIdx, DataIdx, Start, Length)
+          .map_error([&](auto E) {
+            auto *DataInst = getDataInstByIdx(StackMgr.getModule(), DataIdx);
+            const uint32_t BSize =
+                getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx)
+                    .getBitWidth() /
+                8;
+            return logError(E, Instr, [&]() {
+              return logMemoryOOB(E, *DataInst, Start, BSize * Length);
+            });
+          }));
   StackMgr.getTop().emplace<RefVariant>(InstRef);
   return {};
 }
@@ -197,15 +194,15 @@ Executor::runArrayNewElemOp(Runtime::StackManager &StackMgr,
                             const AST::Instruction &Instr) const noexcept {
   const uint32_t Length = StackMgr.pop().get<uint32_t>();
   const uint32_t Start = StackMgr.getTop().get<uint32_t>();
-  EXPECTED_TRY(auto InstRef,
-               arrayNewElem(StackMgr, TypeIdx, ElemIdx, Start, Length)
-                   .map_error([&](auto E) {
-                     auto *ElemInst =
-                         getElemInstByIdx(StackMgr.getModule(), ElemIdx);
-                     return logError(E, Instr, [&]() {
-                       return logTableOOB(E, *ElemInst, Start, Length);
-                     });
-                   }));
+  EXPECTED_TRY(
+      auto InstRef,
+      arrayNewElem(StackMgr.getModule(), TypeIdx, ElemIdx, Start, Length)
+          .map_error([&](auto E) {
+            auto *ElemInst = getElemInstByIdx(StackMgr.getModule(), ElemIdx);
+            return logError(E, Instr, [&]() {
+              return logTableOOB(E, *ElemInst, Start, Length);
+            });
+          }));
   StackMgr.getTop().emplace<RefVariant>(InstRef);
   return {};
 }
@@ -216,12 +213,13 @@ Expect<void> Executor::runArrayGetOp(Runtime::StackManager &StackMgr,
                                      const bool IsSigned) const noexcept {
   const uint32_t Idx = StackMgr.pop().get<uint32_t>();
   const RefVariant Ref = StackMgr.getTop().get<RefVariant>();
-  EXPECTED_TRY(
-      auto Val,
-      arrayGet(StackMgr, Ref, TypeIdx, Idx, IsSigned).map_error([&](auto E) {
-        return logError(E, Instr,
-                        [&]() { return logArrayOOB(E, Idx, 1, Ref); });
-      }));
+  EXPECTED_TRY(auto Val,
+               arrayGet(StackMgr.getModule(), Ref, TypeIdx, Idx, IsSigned)
+                   .map_error([&](auto E) {
+                     return logError(E, Instr, [&]() {
+                       return logArrayOOB(E, Idx, 1, Ref);
+                     });
+                   }));
   StackMgr.getTop() = Val;
   return {};
 }
@@ -232,11 +230,12 @@ Executor::runArraySetOp(Runtime::StackManager &StackMgr, const ValVariant &Val,
                         const AST::Instruction &Instr) const noexcept {
   const uint32_t Idx = StackMgr.pop().get<uint32_t>();
   const RefVariant Ref = StackMgr.pop().get<RefVariant>();
-  EXPECTED_TRY(
-      arraySet(StackMgr, Ref, Val, TypeIdx, Idx).map_error([&](auto E) {
-        return logError(E, Instr,
-                        [&]() { return logArrayOOB(E, Idx, 1, Ref); });
-      }));
+  EXPECTED_TRY(arraySet(StackMgr.getModule(), Ref, Val, TypeIdx, Idx)
+                   .map_error([&](auto E) {
+                     return logError(E, Instr, [&]() {
+                       return logArrayOOB(E, Idx, 1, Ref);
+                     });
+                   }));
   return {};
 }
 
@@ -258,11 +257,12 @@ Executor::runArrayFillOp(Runtime::StackManager &StackMgr, const uint32_t Cnt,
                          const AST::Instruction &Instr) const noexcept {
   const uint32_t Idx = StackMgr.pop().get<uint32_t>();
   const RefVariant Ref = StackMgr.pop().get<RefVariant>();
-  EXPECTED_TRY(
-      arrayFill(StackMgr, Ref, Val, TypeIdx, Idx, Cnt).map_error([&](auto E) {
-        return logError(E, Instr,
-                        [&]() { return logArrayOOB(E, Idx, Cnt, Ref); });
-      }));
+  EXPECTED_TRY(arrayFill(StackMgr.getModule(), Ref, Val, TypeIdx, Idx, Cnt)
+                   .map_error([&](auto E) {
+                     return logError(E, Instr, [&]() {
+                       return logArrayOOB(E, Idx, Cnt, Ref);
+                     });
+                   }));
   return {};
 }
 
@@ -274,8 +274,8 @@ Executor::runArrayCopyOp(Runtime::StackManager &StackMgr, const uint32_t Cnt,
   const RefVariant SrcRef = StackMgr.pop().get<RefVariant>();
   const uint32_t DstIdx = StackMgr.pop().get<uint32_t>();
   const RefVariant DstRef = StackMgr.pop().get<RefVariant>();
-  EXPECTED_TRY(arrayCopy(StackMgr, DstRef, DstTypeIdx, DstIdx, SrcRef,
-                         SrcTypeIdx, SrcIdx, Cnt)
+  EXPECTED_TRY(arrayCopy(StackMgr.getModule(), DstRef, DstTypeIdx, DstIdx,
+                         SrcRef, SrcTypeIdx, SrcIdx, Cnt)
                    .map_error([&](auto E) {
                      return logError(E, Instr, [&]() {
                        return logDoubleArrayOOB(E, SrcIdx, Cnt, SrcRef, DstIdx,
@@ -292,7 +292,8 @@ Expect<void> Executor::runArrayInitDataOp(
   const uint32_t DstIdx = StackMgr.pop().get<uint32_t>();
   const RefVariant Ref = StackMgr.pop().get<RefVariant>();
   EXPECTED_TRY(
-      arrayInitData(StackMgr, Ref, TypeIdx, DataIdx, DstIdx, SrcIdx, Cnt)
+      arrayInitData(StackMgr.getModule(), Ref, TypeIdx, DataIdx, DstIdx, SrcIdx,
+                    Cnt)
           .map_error([&](auto E) {
             auto *DataInst = getDataInstByIdx(StackMgr.getModule(), DataIdx);
             const uint32_t BSize =
@@ -315,7 +316,8 @@ Expect<void> Executor::runArrayInitElemOp(
   const uint32_t DstIdx = StackMgr.pop().get<uint32_t>();
   const RefVariant Ref = StackMgr.pop().get<RefVariant>();
   EXPECTED_TRY(
-      arrayInitElem(StackMgr, Ref, TypeIdx, ElemIdx, DstIdx, SrcIdx, Cnt)
+      arrayInitElem(StackMgr.getModule(), Ref, TypeIdx, ElemIdx, DstIdx, SrcIdx,
+                    Cnt)
           .map_error([&](auto E) {
             auto *ElemInst = getElemInstByIdx(StackMgr.getModule(), ElemIdx);
             return logError(
@@ -415,15 +417,15 @@ Expect<void> Executor::runI31GetOp(ValVariant &Val,
 }
 
 Expect<RefVariant>
-Executor::structNew(Runtime::StackManager &StackMgr, const uint32_t TypeIdx,
+Executor::structNew(const Runtime::Instance::ModuleInstance *ModInstArg,
+                    const uint32_t TypeIdx,
                     Span<const ValVariant> Args) const noexcept {
   /// TODO: The array and struct instances are currently owned by the module
   /// instance because they refer to the defined types of the module instances.
   /// This may be changed after applying the garbage collection mechanism.
-  const auto &CompType = getCompositeTypeByIdx(StackMgr.getModule(), TypeIdx);
+  const auto &CompType = getCompositeTypeByIdx(ModInstArg, TypeIdx);
   uint32_t N = static_cast<uint32_t>(CompType.getFieldTypes().size());
-  Runtime::Instance::ModuleInstance *ModInst =
-      const_cast<Runtime::Instance::ModuleInstance *>(StackMgr.getModule());
+  auto *ModInst = const_cast<Runtime::Instance::ModuleInstance *>(ModInstArg);
   std::vector<ValVariant> Vals(N);
   for (uint32_t I = 0; I < N; I++) {
     const auto &VType = CompType.getFieldTypes()[I].getStorageType();
@@ -431,8 +433,7 @@ Executor::structNew(Runtime::StackManager &StackMgr, const uint32_t TypeIdx,
       Vals[I] = packVal(VType, Args[I]);
     } else {
       Vals[I] = VType.isRefType()
-                    ? ValVariant(
-                          RefVariant(toBottomType(StackMgr.getModule(), VType)))
+                    ? ValVariant(RefVariant(toBottomType(ModInstArg, VType)))
                     : ValVariant(static_cast<uint128_t>(0U));
     }
   }
@@ -441,51 +442,46 @@ Executor::structNew(Runtime::StackManager &StackMgr, const uint32_t TypeIdx,
   return RefVariant(Inst->getDefType(), Inst);
 }
 
-Expect<ValVariant> Executor::structGet(Runtime::StackManager &StackMgr,
-                                       const RefVariant Ref,
-                                       const uint32_t TypeIdx,
-                                       const uint32_t Off,
-                                       const bool IsSigned) const noexcept {
+Expect<ValVariant>
+Executor::structGet(const Runtime::Instance::ModuleInstance *ModInst,
+                    const RefVariant Ref, const uint32_t TypeIdx,
+                    const uint32_t Off, const bool IsSigned) const noexcept {
   const auto *Inst = Ref.getPtr<Runtime::Instance::StructInstance>();
   if (Inst == nullptr) {
     return Unexpect(ErrCode::Value::AccessNullStruct);
   }
-  const auto &VType =
-      getStructStorageTypeByIdx(StackMgr.getModule(), TypeIdx, Off);
+  const auto &VType = getStructStorageTypeByIdx(ModInst, TypeIdx, Off);
   return unpackVal(VType, Inst->getField(Off), IsSigned);
 }
 
-Expect<void> Executor::structSet(Runtime::StackManager &StackMgr,
-                                 const RefVariant Ref, const ValVariant Val,
-                                 const uint32_t TypeIdx,
-                                 const uint32_t Off) const noexcept {
+Expect<void>
+Executor::structSet(const Runtime::Instance::ModuleInstance *ModInst,
+                    const RefVariant Ref, const ValVariant Val,
+                    const uint32_t TypeIdx, const uint32_t Off) const noexcept {
   auto *Inst = Ref.getPtr<Runtime::Instance::StructInstance>();
   if (Inst == nullptr) {
     return Unexpect(ErrCode::Value::AccessNullStruct);
   }
-  const auto &VType =
-      getStructStorageTypeByIdx(StackMgr.getModule(), TypeIdx, Off);
+  const auto &VType = getStructStorageTypeByIdx(ModInst, TypeIdx, Off);
   Inst->getField(Off) = packVal(VType, Val);
   return {};
 }
 
 Expect<RefVariant>
-Executor::arrayNew(Runtime::StackManager &StackMgr, const uint32_t TypeIdx,
-                   const uint32_t Length,
+Executor::arrayNew(const Runtime::Instance::ModuleInstance *ModInstArg,
+                   const uint32_t TypeIdx, const uint32_t Length,
                    Span<const ValVariant> Args) const noexcept {
   /// TODO: The array and struct instances are currently owned by the module
   /// instance because they refer to the defined types of the module instances.
   /// This may be changed after applying the garbage collection mechanism.
-  const auto &VType = getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx);
+  const auto &VType = getArrayStorageTypeByIdx(ModInstArg, TypeIdx);
   WasmEdge::Runtime::Instance::ArrayInstance *Inst = nullptr;
-  Runtime::Instance::ModuleInstance *ModInst =
-      const_cast<Runtime::Instance::ModuleInstance *>(StackMgr.getModule());
+  auto *ModInst = const_cast<Runtime::Instance::ModuleInstance *>(ModInstArg);
   if (Args.size() == 0) {
     // New and fill with default values.
-    auto InitVal =
-        VType.isRefType()
-            ? ValVariant(RefVariant(toBottomType(StackMgr.getModule(), VType)))
-            : ValVariant(static_cast<uint128_t>(0U));
+    auto InitVal = VType.isRefType()
+                       ? ValVariant(RefVariant(toBottomType(ModInstArg, VType)))
+                       : ValVariant(static_cast<uint128_t>(0U));
     Inst = ModInst->newArray(TypeIdx, Length, InitVal);
   } else if (Args.size() == 1) {
     // Create and fill with the argument value.
@@ -500,19 +496,19 @@ Executor::arrayNew(Runtime::StackManager &StackMgr, const uint32_t TypeIdx,
 }
 
 Expect<RefVariant>
-Executor::arrayNewData(Runtime::StackManager &StackMgr, const uint32_t TypeIdx,
-                       const uint32_t DataIdx, const uint32_t Start,
+Executor::arrayNewData(const Runtime::Instance::ModuleInstance *ModInstArg,
+                       const uint32_t TypeIdx, const uint32_t DataIdx,
+                       const uint32_t Start,
                        const uint32_t Length) const noexcept {
-  const auto &VType = getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx);
+  const auto &VType = getArrayStorageTypeByIdx(ModInstArg, TypeIdx);
   const uint32_t BSize = VType.getBitWidth() / 8;
-  auto *DataInst = getDataInstByIdx(StackMgr.getModule(), DataIdx);
+  auto *DataInst = getDataInstByIdx(ModInstArg, DataIdx);
   assuming(DataInst);
   if (static_cast<uint64_t>(Start) + static_cast<uint64_t>(Length) * BSize >
       DataInst->getData().size()) {
     return Unexpect(ErrCode::Value::MemoryOutOfBounds);
   }
-  Runtime::Instance::ModuleInstance *ModInst =
-      const_cast<Runtime::Instance::ModuleInstance *>(StackMgr.getModule());
+  auto *ModInst = const_cast<Runtime::Instance::ModuleInstance *>(ModInstArg);
   std::vector<ValVariant> Args;
   Args.reserve(Length);
   for (uint32_t Idx = 0; Idx < Length; Idx++) {
@@ -525,11 +521,12 @@ Executor::arrayNewData(Runtime::StackManager &StackMgr, const uint32_t TypeIdx,
 }
 
 Expect<RefVariant>
-Executor::arrayNewElem(Runtime::StackManager &StackMgr, const uint32_t TypeIdx,
-                       const uint32_t ElemIdx, const uint32_t Start,
+Executor::arrayNewElem(const Runtime::Instance::ModuleInstance *ModInstArg,
+                       const uint32_t TypeIdx, const uint32_t ElemIdx,
+                       const uint32_t Start,
                        const uint32_t Length) const noexcept {
-  const auto &VType = getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx);
-  auto *ElemInst = getElemInstByIdx(StackMgr.getModule(), ElemIdx);
+  const auto &VType = getArrayStorageTypeByIdx(ModInstArg, TypeIdx);
+  auto *ElemInst = getElemInstByIdx(ModInstArg, ElemIdx);
   assuming(ElemInst);
   auto ElemSrc = ElemInst->getRefs();
   if (static_cast<uint64_t>(Start) + static_cast<uint64_t>(Length) >
@@ -538,18 +535,16 @@ Executor::arrayNewElem(Runtime::StackManager &StackMgr, const uint32_t TypeIdx,
   }
   std::vector<ValVariant> Refs(ElemSrc.begin() + Start,
                                ElemSrc.begin() + Start + Length);
-  Runtime::Instance::ModuleInstance *ModInst =
-      const_cast<Runtime::Instance::ModuleInstance *>(StackMgr.getModule());
+  auto *ModInst = const_cast<Runtime::Instance::ModuleInstance *>(ModInstArg);
   WasmEdge::Runtime::Instance::ArrayInstance *Inst =
       ModInst->newArray(TypeIdx, packVals(VType, std::move(Refs)));
   return RefVariant(Inst->getDefType(), Inst);
 }
 
-Expect<ValVariant> Executor::arrayGet(Runtime::StackManager &StackMgr,
-                                      const RefVariant &Ref,
-                                      const uint32_t TypeIdx,
-                                      const uint32_t Idx,
-                                      const bool IsSigned) const noexcept {
+Expect<ValVariant>
+Executor::arrayGet(const Runtime::Instance::ModuleInstance *ModInst,
+                   const RefVariant &Ref, const uint32_t TypeIdx,
+                   const uint32_t Idx, const bool IsSigned) const noexcept {
   const auto *Inst = Ref.getPtr<Runtime::Instance::ArrayInstance>();
   if (Inst == nullptr) {
     return Unexpect(ErrCode::Value::AccessNullArray);
@@ -557,14 +552,14 @@ Expect<ValVariant> Executor::arrayGet(Runtime::StackManager &StackMgr,
   if (Idx >= Inst->getLength()) {
     return Unexpect(ErrCode::Value::ArrayOutOfBounds);
   }
-  const auto &VType = getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx);
+  const auto &VType = getArrayStorageTypeByIdx(ModInst, TypeIdx);
   return unpackVal(VType, Inst->getData(Idx), IsSigned);
 }
 
-Expect<void> Executor::arraySet(Runtime::StackManager &StackMgr,
-                                const RefVariant &Ref, const ValVariant &Val,
-                                const uint32_t TypeIdx,
-                                const uint32_t Idx) const noexcept {
+Expect<void>
+Executor::arraySet(const Runtime::Instance::ModuleInstance *ModInst,
+                   const RefVariant &Ref, const ValVariant &Val,
+                   const uint32_t TypeIdx, const uint32_t Idx) const noexcept {
   auto *Inst = Ref.getPtr<Runtime::Instance::ArrayInstance>();
   if (Inst == nullptr) {
     return Unexpect(ErrCode::Value::AccessNullArray);
@@ -572,15 +567,16 @@ Expect<void> Executor::arraySet(Runtime::StackManager &StackMgr,
   if (Idx >= Inst->getLength()) {
     return Unexpect(ErrCode::Value::ArrayOutOfBounds);
   }
-  const auto &VType = getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx);
+  const auto &VType = getArrayStorageTypeByIdx(ModInst, TypeIdx);
   Inst->getData(Idx) = packVal(VType, Val);
   return {};
 }
 
-Expect<void> Executor::arrayFill(Runtime::StackManager &StackMgr,
-                                 const RefVariant &Ref, const ValVariant &Val,
-                                 const uint32_t TypeIdx, const uint32_t Idx,
-                                 const uint32_t Cnt) const noexcept {
+Expect<void>
+Executor::arrayFill(const Runtime::Instance::ModuleInstance *ModInst,
+                    const RefVariant &Ref, const ValVariant &Val,
+                    const uint32_t TypeIdx, const uint32_t Idx,
+                    const uint32_t Cnt) const noexcept {
   auto *Inst = Ref.getPtr<Runtime::Instance::ArrayInstance>();
   if (Inst == nullptr) {
     return Unexpect(ErrCode::Value::AccessNullArray);
@@ -589,17 +585,16 @@ Expect<void> Executor::arrayFill(Runtime::StackManager &StackMgr,
       Inst->getLength()) {
     return Unexpect(ErrCode::Value::ArrayOutOfBounds);
   }
-  const auto &VType = getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx);
+  const auto &VType = getArrayStorageTypeByIdx(ModInst, TypeIdx);
   auto Arr = Inst->getArray();
   std::fill(Arr.begin() + Idx, Arr.begin() + Idx + Cnt, packVal(VType, Val));
   return {};
 }
 
-Expect<void>
-Executor::arrayInitData(Runtime::StackManager &StackMgr, const RefVariant &Ref,
-                        const uint32_t TypeIdx, const uint32_t DataIdx,
-                        const uint32_t DstIdx, const uint32_t SrcIdx,
-                        const uint32_t Cnt) const noexcept {
+Expect<void> Executor::arrayInitData(
+    const Runtime::Instance::ModuleInstance *ModInst, const RefVariant &Ref,
+    const uint32_t TypeIdx, const uint32_t DataIdx, const uint32_t DstIdx,
+    const uint32_t SrcIdx, const uint32_t Cnt) const noexcept {
   auto *Inst = Ref.getPtr<Runtime::Instance::ArrayInstance>();
   if (Inst == nullptr) {
     return Unexpect(ErrCode::Value::AccessNullArray);
@@ -608,9 +603,9 @@ Executor::arrayInitData(Runtime::StackManager &StackMgr, const RefVariant &Ref,
       Inst->getLength()) {
     return Unexpect(ErrCode::Value::ArrayOutOfBounds);
   }
-  const auto &VType = getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx);
+  const auto &VType = getArrayStorageTypeByIdx(ModInst, TypeIdx);
   const uint32_t BSize = VType.getBitWidth() / 8;
-  auto *DataInst = getDataInstByIdx(StackMgr.getModule(), DataIdx);
+  auto *DataInst = getDataInstByIdx(ModInst, DataIdx);
   assuming(DataInst);
   if (static_cast<uint64_t>(SrcIdx) + static_cast<uint64_t>(Cnt) * BSize >
       DataInst->getData().size()) {
@@ -625,11 +620,10 @@ Executor::arrayInitData(Runtime::StackManager &StackMgr, const RefVariant &Ref,
   return {};
 }
 
-Expect<void>
-Executor::arrayInitElem(Runtime::StackManager &StackMgr, const RefVariant &Ref,
-                        const uint32_t TypeIdx, const uint32_t ElemIdx,
-                        const uint32_t DstIdx, const uint32_t SrcIdx,
-                        const uint32_t Cnt) const noexcept {
+Expect<void> Executor::arrayInitElem(
+    const Runtime::Instance::ModuleInstance *ModInst, const RefVariant &Ref,
+    const uint32_t TypeIdx, const uint32_t ElemIdx, const uint32_t DstIdx,
+    const uint32_t SrcIdx, const uint32_t Cnt) const noexcept {
   auto *Inst = Ref.getPtr<Runtime::Instance::ArrayInstance>();
   if (Inst == nullptr) {
     return Unexpect(ErrCode::Value::AccessNullArray);
@@ -638,8 +632,8 @@ Executor::arrayInitElem(Runtime::StackManager &StackMgr, const RefVariant &Ref,
       Inst->getLength()) {
     return Unexpect(ErrCode::Value::ArrayOutOfBounds);
   }
-  const auto &VType = getArrayStorageTypeByIdx(StackMgr.getModule(), TypeIdx);
-  auto *ElemInst = getElemInstByIdx(StackMgr.getModule(), ElemIdx);
+  const auto &VType = getArrayStorageTypeByIdx(ModInst, TypeIdx);
+  auto *ElemInst = getElemInstByIdx(ModInst, ElemIdx);
   assuming(ElemInst);
   auto ElemSrc = ElemInst->getRefs();
   if (static_cast<uint64_t>(SrcIdx) + static_cast<uint64_t>(Cnt) >
@@ -656,10 +650,11 @@ Executor::arrayInitElem(Runtime::StackManager &StackMgr, const RefVariant &Ref,
 }
 
 Expect<void>
-Executor::arrayCopy(Runtime::StackManager &StackMgr, const RefVariant &DstRef,
-                    const uint32_t DstTypeIdx, const uint32_t DstIdx,
-                    const RefVariant &SrcRef, const uint32_t SrcTypeIdx,
-                    const uint32_t SrcIdx, const uint32_t Cnt) const noexcept {
+Executor::arrayCopy(const Runtime::Instance::ModuleInstance *ModInst,
+                    const RefVariant &DstRef, const uint32_t DstTypeIdx,
+                    const uint32_t DstIdx, const RefVariant &SrcRef,
+                    const uint32_t SrcTypeIdx, const uint32_t SrcIdx,
+                    const uint32_t Cnt) const noexcept {
   auto *SrcInst = SrcRef.getPtr<Runtime::Instance::ArrayInstance>();
   auto *DstInst = DstRef.getPtr<Runtime::Instance::ArrayInstance>();
   if (SrcInst == nullptr) {
@@ -679,10 +674,8 @@ Executor::arrayCopy(Runtime::StackManager &StackMgr, const RefVariant &DstRef,
 
   auto SrcArr = SrcInst->getArray();
   auto DstArr = DstInst->getArray();
-  const auto &SrcVType =
-      getArrayStorageTypeByIdx(StackMgr.getModule(), SrcTypeIdx);
-  const auto &DstVType =
-      getArrayStorageTypeByIdx(StackMgr.getModule(), DstTypeIdx);
+  const auto &SrcVType = getArrayStorageTypeByIdx(ModInst, SrcTypeIdx);
+  const auto &DstVType = getArrayStorageTypeByIdx(ModInst, DstTypeIdx);
   if (DstIdx <= SrcIdx) {
     std::transform(SrcArr.begin() + SrcIdx, SrcArr.begin() + SrcIdx + Cnt,
                    DstArr.begin() + DstIdx, [&](const ValVariant &V) {

--- a/lib/executor/engine/variableInstr.cpp
+++ b/lib/executor/engine/variableInstr.cpp
@@ -29,7 +29,7 @@ Expect<void> Executor::runLocalTeeOp(Runtime::StackManager &StackMgr,
 
 Expect<void> Executor::runGlobalGetOp(Runtime::StackManager &StackMgr,
                                       uint32_t Idx) const noexcept {
-  auto *GlobInst = getGlobInstByIdx(StackMgr, Idx);
+  auto *GlobInst = getGlobInstByIdx(StackMgr.getModule(), Idx);
   assuming(GlobInst);
   StackMgr.push(GlobInst->getValue());
   return {};
@@ -37,7 +37,7 @@ Expect<void> Executor::runGlobalGetOp(Runtime::StackManager &StackMgr,
 
 Expect<void> Executor::runGlobalSetOp(Runtime::StackManager &StackMgr,
                                       uint32_t Idx) const noexcept {
-  auto *GlobInst = getGlobInstByIdx(StackMgr, Idx);
+  auto *GlobInst = getGlobInstByIdx(StackMgr.getModule(), Idx);
   assuming(GlobInst);
   GlobInst->setValue(StackMgr.pop());
   return {};

--- a/lib/executor/executor.cpp
+++ b/lib/executor/executor.cpp
@@ -5,12 +5,51 @@
 
 #include "common/errinfo.h"
 #include "common/spdlog.h"
+#include "runtime/instance/module.h"
 #include "system/stacktrace.h"
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <vector>
 
 using namespace std::literals;
 
 namespace WasmEdge {
 namespace Executor {
+
+namespace {
+
+/// Render a recorded stack trace as "module:index" frames. Modules without a
+/// registered name are numbered by their order of appearance in the trace.
+void dumpStackTrace(Span<const StackTraceEntry> Stack) noexcept {
+  std::vector<const Runtime::Instance::ModuleInstance *> Anonymous;
+  std::string Out;
+  for (size_t I = 0; I < Stack.size(); ++I) {
+    if (I != 0) {
+      Out += ", "sv;
+    }
+    const auto *Module = Stack[I].Module;
+    std::string_view Name =
+        Module ? Module->getModuleName() : std::string_view{};
+    if (!Name.empty()) {
+      Out += fmt::format("{}:{}"sv, Name, Stack[I].FuncIndex);
+    } else {
+      auto Iter = std::find(Anonymous.begin(), Anonymous.end(), Module);
+      size_t Ordinal;
+      if (Iter == Anonymous.end()) {
+        Ordinal = Anonymous.size();
+        Anonymous.push_back(Module);
+      } else {
+        Ordinal = static_cast<size_t>(Iter - Anonymous.begin());
+      }
+      Out += fmt::format("module[{}]:{}"sv, Ordinal, Stack[I].FuncIndex);
+    }
+  }
+  spdlog::error("calling stack:{}"sv, Out);
+}
+
+} // namespace
 
 /// Instantiate a WASM Module. See "include/executor/executor.h".
 Expect<std::unique_ptr<Runtime::Instance::ModuleInstance>>
@@ -153,7 +192,8 @@ Executor::invoke(const Runtime::Instance::FunctionInstance *FuncInst,
   // Call runFunction.
   EXPECTED_TRY(runFunction(StackMgr, *FuncInst, Params).map_error([](auto E) {
     if (E != ErrCode::Value::Terminated) {
-      dumpStackTrace(Span<const uint32_t>{StackTrace}.first(StackTraceSize));
+      dumpStackTrace(
+          Span<const StackTraceEntry>{StackTrace}.first(StackTraceSize));
     }
     return E;
   }));

--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -42,11 +42,11 @@ Executor::SavedThreadLocal::~SavedThreadLocal() noexcept {
   This = SavedThis;
 }
 
-Expect<AST::InstrView::iterator>
-Executor::enterFunction(Runtime::StackManager &StackMgr,
-                        const Runtime::Instance::FunctionInstance &Func,
-                        const AST::InstrView::iterator RetIt, bool IsTailCall,
-                        bool IsNativeEntry) {
+Expect<AST::InstrView::iterator> Executor::enterFunction(
+    Runtime::StackManager &StackMgr,
+    const Runtime::Instance::FunctionInstance &Func,
+    const AST::InstrView::iterator RetIt, bool IsTailCall, bool IsNativeEntry,
+    const Runtime::Instance::ModuleInstance *CallerModInst) {
   // RetIt: the return position when the entered function returns.
 
   // Check whether interruption occurred.
@@ -81,7 +81,10 @@ Executor::enterFunction(Runtime::StackManager &StackMgr,
     // Generate CallingFrame from current frame.
     // The module instance will be nullptr if current frame is a dummy frame.
     // For this case, use the module instance of this host function.
-    const auto *ModInst = StackMgr.getModule();
+    const auto *ModInst = CallerModInst;
+    if (ModInst == nullptr) {
+      ModInst = StackMgr.getModule();
+    }
     if (ModInst == nullptr) {
       ModInst = Func.getModule();
     }

--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -4,10 +4,13 @@
 #include "executor/executor.h"
 
 #include "common/spdlog.h"
+#include "runtime/storemgr.h"
 #include "system/fault.h"
 #include "system/stacktrace.h"
 
 #include <cstdint>
+#include <shared_mutex>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -187,8 +190,9 @@ Expect<AST::InstrView::iterator> Executor::enterFunction(
             OuterStackTrace = OuterStackTrace.first(OuterStackTrace.size() - 1);
           }
         }
+        auto LiveModules = collectLiveModules(StackMgr);
         StackTraceSize =
-            compiledStackTrace(StackMgr, InnerStackTrace, StackTrace).size();
+            compiledStackTrace(LiveModules, InnerStackTrace, StackTrace).size();
         Err = ErrCode(static_cast<ErrCategory>(Code >> 24), Code);
       } else {
         auto &Wrapper = FuncType.getSymbol();
@@ -284,6 +288,52 @@ Expect<AST::InstrView::iterator> Executor::enterFunction(
     // function body.
     return Instrs.begin();
   }
+}
+
+std::vector<const Runtime::Instance::ModuleInstance *>
+Executor::collectLiveModules(
+    const Runtime::StackManager &StackMgr) const noexcept {
+  std::vector<const Runtime::Instance::ModuleInstance *> Modules;
+  std::unordered_set<const Runtime::Instance::ModuleInstance *> Seen;
+  auto AddModule = [&](const Runtime::Instance::ModuleInstance *M) {
+    if (M != nullptr && Seen.insert(M).second) {
+      Modules.push_back(M);
+    }
+  };
+
+  for (const auto &Frame : StackMgr.getFramesSpan()) {
+    AddModule(Frame.Module);
+  }
+
+  std::unordered_set<Runtime::StoreManager *> Stores;
+  auto GatherStores = [&](const Runtime::Instance::ModuleInstance *M) {
+    if (M == nullptr) {
+      return;
+    }
+    std::shared_lock Lock(M->Mutex);
+    for (const auto &Entry : M->LinkedStore) {
+      Stores.insert(Entry.first.first);
+    }
+  };
+
+  const size_t SeedCount = Modules.size();
+  for (size_t I = 0; I < SeedCount; ++I) {
+    GatherStores(Modules[I]);
+    for (const auto *Func : Modules[I]->getFunctionInstances()) {
+      if (Func != nullptr) {
+        GatherStores(Func->getModule());
+      }
+    }
+  }
+
+  for (auto *Store : Stores) {
+    Store->getModuleList([&AddModule](const auto &NamedMod) {
+      for (const auto &Entry : NamedMod) {
+        AddModule(Entry.second);
+      }
+    });
+  }
+  return Modules;
 }
 
 Expect<void>

--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -16,21 +16,13 @@ namespace Executor {
 
 Executor::SavedThreadLocal::SavedThreadLocal(
     Executor &Ex, Runtime::StackManager &StackMgr,
-    const Runtime::Instance::FunctionInstance &Func) noexcept {
+    [[maybe_unused]] const Runtime::Instance::FunctionInstance &Func) noexcept {
   // Prepare the execution context.
-  auto *ModInst =
-      const_cast<Runtime::Instance::ModuleInstance *>(Func.getModule());
   SavedThis = This;
   This = &Ex;
 
   SavedExecutionContext = ExecutionContext;
-  ExecutionContext.Memories = ModInst->ModCtx.Memories;
-  ExecutionContext.MemorySizes = ModInst->ModCtx.MemorySizes;
-  ExecutionContext.TableRefs = ModInst->ModCtx.TableRefs;
-  ExecutionContext.TableSizes = ModInst->ModCtx.TableSizes;
-  ExecutionContext.Globals = ModInst->ModCtx.Globals;
-  ExecutionContext.Tags =
-      reinterpret_cast<void *const *>(ModInst->TagInsts.data());
+  ExecutionContext.StopToken = &Ex.StopToken;
   ExecutionContext.PendingExnTagAddr =
       reinterpret_cast<void *const *>(&PendingExn.TagInst);
   if (Ex.Stat) {
@@ -39,8 +31,6 @@ Executor::SavedThreadLocal::SavedThreadLocal(
     ExecutionContext.Gas = &Ex.Stat->getTotalCostRef();
     ExecutionContext.GasLimit = Ex.Stat->getCostLimit();
   }
-  ExecutionContext.StopToken = &Ex.StopToken;
-  ExecutionContext.ModuleInst = ModInst;
 
   SavedCurrentStack = CurrentStack;
   CurrentStack = &StackMgr;
@@ -199,8 +189,11 @@ Executor::enterFunction(Runtime::StackManager &StackMgr,
         Err = ErrCode(static_cast<ErrCategory>(Code >> 24), Code);
       } else {
         auto &Wrapper = FuncType.getSymbol();
-        Wrapper(&ExecutionContext, &ExecutionContext, Func.getSymbol().get(),
-                Args.data(), Rets.data());
+        Wrapper(
+            &const_cast<Runtime::Instance::ModuleInstance *>(Func.getModule())
+                 ->ModCtx,
+            &ExecutionContext, Func.getSymbol().get(), Args.data(),
+            Rets.data());
       }
     } catch (const ErrCode &E) {
       Err = E;

--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -207,7 +207,8 @@ Expect<AST::InstrView::iterator> Executor::enterFunction(
       }
       StackTraceSize +=
           interpreterStackTrace(
-              StackMgr, Span<uint32_t>{StackTrace}.subspan(StackTraceSize))
+              StackMgr,
+              Span<StackTraceEntry>{StackTrace}.subspan(StackTraceSize))
               .size();
       return Unexpect(Err);
     }

--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -24,11 +24,11 @@ Executor::SavedThreadLocal::SavedThreadLocal(
   This = &Ex;
 
   SavedExecutionContext = ExecutionContext;
-  ExecutionContext.Memories = ModInst->MemoryPtrs.data();
-  ExecutionContext.MemorySizes = ModInst->MemorySizePtrs.data();
-  ExecutionContext.TableRefs = ModInst->TableRefPtrs.data();
-  ExecutionContext.TableSizes = ModInst->TableSizePtrs.data();
-  ExecutionContext.Globals = ModInst->GlobalPtrs.data();
+  ExecutionContext.Memories = ModInst->ModCtx.Memories;
+  ExecutionContext.MemorySizes = ModInst->ModCtx.MemorySizes;
+  ExecutionContext.TableRefs = ModInst->ModCtx.TableRefs;
+  ExecutionContext.TableSizes = ModInst->ModCtx.TableSizes;
+  ExecutionContext.Globals = ModInst->ModCtx.Globals;
   ExecutionContext.Tags =
       reinterpret_cast<void *const *>(ModInst->TagInsts.data());
   ExecutionContext.PendingExnTagAddr =

--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -318,7 +318,8 @@ Expect<void> Executor::throwException(
     }
     // Checking through the catch clause.
     for (const auto &C : Handler->CatchClause) {
-      if (!C.IsAll && getTagInstByIdx(StackMgr, C.TagIndex) != &TagInst) {
+      if (!C.IsAll &&
+          getTagInstByIdx(StackMgr.getModule(), C.TagIndex) != &TagInst) {
         // Specific-tag clauses require tag-address equivalence; skip the
         // ones that do not match.
         continue;
@@ -392,9 +393,9 @@ Executor::checkOffsetOverflow(const Runtime::Instance::MemoryInstance &MemInst,
   return {};
 }
 
-const AST::SubType *Executor::getDefTypeByIdx(Runtime::StackManager &StackMgr,
-                                              const uint32_t Idx) const {
-  const auto *ModInst = StackMgr.getModule();
+const AST::SubType *
+Executor::getDefTypeByIdx(const Runtime::Instance::ModuleInstance *ModInst,
+                          const uint32_t Idx) const {
   // When the top frame is a dummy frame, the instance cannot be found.
   if (unlikely(ModInst == nullptr)) {
     return nullptr;
@@ -402,37 +403,35 @@ const AST::SubType *Executor::getDefTypeByIdx(Runtime::StackManager &StackMgr,
   return ModInst->unsafeGetType(Idx);
 }
 
-const WasmEdge::AST::CompositeType &
-Executor::getCompositeTypeByIdx(Runtime::StackManager &StackMgr,
-                                const uint32_t Idx) const noexcept {
-  auto *DefType = getDefTypeByIdx(StackMgr, Idx);
+const WasmEdge::AST::CompositeType &Executor::getCompositeTypeByIdx(
+    const Runtime::Instance::ModuleInstance *ModInst,
+    const uint32_t Idx) const noexcept {
+  auto *DefType = getDefTypeByIdx(ModInst, Idx);
   assuming(DefType);
   const auto &CompType = DefType->getCompositeType();
   assuming(!CompType.isFunc());
   return CompType;
 }
 
-const ValType &
-Executor::getStructStorageTypeByIdx(Runtime::StackManager &StackMgr,
-                                    const uint32_t Idx,
-                                    const uint32_t Off) const noexcept {
-  const auto &CompType = getCompositeTypeByIdx(StackMgr, Idx);
+const ValType &Executor::getStructStorageTypeByIdx(
+    const Runtime::Instance::ModuleInstance *ModInst, const uint32_t Idx,
+    const uint32_t Off) const noexcept {
+  const auto &CompType = getCompositeTypeByIdx(ModInst, Idx);
   assuming(static_cast<uint32_t>(CompType.getFieldTypes().size()) > Off);
   return CompType.getFieldTypes()[Off].getStorageType();
 }
 
-const ValType &
-Executor::getArrayStorageTypeByIdx(Runtime::StackManager &StackMgr,
-                                   const uint32_t Idx) const noexcept {
-  const auto &CompType = getCompositeTypeByIdx(StackMgr, Idx);
+const ValType &Executor::getArrayStorageTypeByIdx(
+    const Runtime::Instance::ModuleInstance *ModInst,
+    const uint32_t Idx) const noexcept {
+  const auto &CompType = getCompositeTypeByIdx(ModInst, Idx);
   assuming(static_cast<uint32_t>(CompType.getFieldTypes().size()) == 1);
   return CompType.getFieldTypes()[0].getStorageType();
 }
 
 Runtime::Instance::FunctionInstance *
-Executor::getFuncInstByIdx(Runtime::StackManager &StackMgr,
+Executor::getFuncInstByIdx(const Runtime::Instance::ModuleInstance *ModInst,
                            const uint32_t Idx) const {
-  const auto *ModInst = StackMgr.getModule();
   // When the top frame is a dummy frame, the instance cannot be found.
   if (unlikely(ModInst == nullptr)) {
     return nullptr;
@@ -441,9 +440,8 @@ Executor::getFuncInstByIdx(Runtime::StackManager &StackMgr,
 }
 
 Runtime::Instance::TableInstance *
-Executor::getTabInstByIdx(Runtime::StackManager &StackMgr,
+Executor::getTabInstByIdx(const Runtime::Instance::ModuleInstance *ModInst,
                           const uint32_t Idx) const {
-  const auto *ModInst = StackMgr.getModule();
   // When the top frame is a dummy frame, the instance cannot be found.
   if (unlikely(ModInst == nullptr)) {
     return nullptr;
@@ -452,9 +450,8 @@ Executor::getTabInstByIdx(Runtime::StackManager &StackMgr,
 }
 
 Runtime::Instance::MemoryInstance *
-Executor::getMemInstByIdx(Runtime::StackManager &StackMgr,
+Executor::getMemInstByIdx(const Runtime::Instance::ModuleInstance *ModInst,
                           const uint32_t Idx) const {
-  const auto *ModInst = StackMgr.getModule();
   // When the top frame is a dummy frame, the instance cannot be found.
   if (unlikely(ModInst == nullptr)) {
     return nullptr;
@@ -463,9 +460,8 @@ Executor::getMemInstByIdx(Runtime::StackManager &StackMgr,
 }
 
 Runtime::Instance::TagInstance *
-Executor::getTagInstByIdx(Runtime::StackManager &StackMgr,
+Executor::getTagInstByIdx(const Runtime::Instance::ModuleInstance *ModInst,
                           const uint32_t Idx) const {
-  const auto *ModInst = StackMgr.getModule();
   // When the top frame is a dummy frame, the instance cannot be found.
   if (unlikely(ModInst == nullptr)) {
     return nullptr;
@@ -474,9 +470,8 @@ Executor::getTagInstByIdx(Runtime::StackManager &StackMgr,
 }
 
 Runtime::Instance::GlobalInstance *
-Executor::getGlobInstByIdx(Runtime::StackManager &StackMgr,
+Executor::getGlobInstByIdx(const Runtime::Instance::ModuleInstance *ModInst,
                            const uint32_t Idx) const {
-  const auto *ModInst = StackMgr.getModule();
   // When the top frame is a dummy frame, the instance cannot be found.
   if (unlikely(ModInst == nullptr)) {
     return nullptr;
@@ -485,9 +480,8 @@ Executor::getGlobInstByIdx(Runtime::StackManager &StackMgr,
 }
 
 Runtime::Instance::ElementInstance *
-Executor::getElemInstByIdx(Runtime::StackManager &StackMgr,
+Executor::getElemInstByIdx(const Runtime::Instance::ModuleInstance *ModInst,
                            const uint32_t Idx) const {
-  const auto *ModInst = StackMgr.getModule();
   // When the top frame is a dummy frame, the instance cannot be found.
   if (unlikely(ModInst == nullptr)) {
     return nullptr;
@@ -496,9 +490,8 @@ Executor::getElemInstByIdx(Runtime::StackManager &StackMgr,
 }
 
 Runtime::Instance::DataInstance *
-Executor::getDataInstByIdx(Runtime::StackManager &StackMgr,
+Executor::getDataInstByIdx(const Runtime::Instance::ModuleInstance *ModInst,
                            const uint32_t Idx) const {
-  const auto *ModInst = StackMgr.getModule();
   // When the top frame is a dummy frame, the instance cannot be found.
   if (unlikely(ModInst == nullptr)) {
     return nullptr;
@@ -506,8 +499,9 @@ Executor::getDataInstByIdx(Runtime::StackManager &StackMgr,
   return ModInst->unsafeGetData(Idx);
 }
 
-TypeCode Executor::toBottomType(Runtime::StackManager &StackMgr,
-                                const ValType &Type) const {
+TypeCode
+Executor::toBottomType(const Runtime::Instance::ModuleInstance *ModInst,
+                       const ValType &Type) const {
   if (Type.isRefType()) {
     if (Type.isAbsHeapType()) {
       switch (Type.getHeapTypeCode()) {
@@ -531,9 +525,8 @@ TypeCode Executor::toBottomType(Runtime::StackManager &StackMgr,
         assumingUnreachable();
       }
     } else {
-      const auto &CompType = StackMgr.getModule()
-                                 ->unsafeGetType(Type.getTypeIndex())
-                                 ->getCompositeType();
+      const auto &CompType =
+          ModInst->unsafeGetType(Type.getTypeIndex())->getCompositeType();
       if (CompType.isFunc()) {
         return TypeCode::NullFuncRef;
       } else {

--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -199,8 +199,8 @@ Executor::enterFunction(Runtime::StackManager &StackMgr,
         Err = ErrCode(static_cast<ErrCategory>(Code >> 24), Code);
       } else {
         auto &Wrapper = FuncType.getSymbol();
-        Wrapper(&ExecutionContext, Func.getSymbol().get(), Args.data(),
-                Rets.data());
+        Wrapper(&ExecutionContext, &ExecutionContext, Func.getSymbol().get(),
+                Args.data(), Rets.data());
       }
     } catch (const ErrCode &E) {
       Err = E;

--- a/lib/executor/instantiate/component/component_module.cpp
+++ b/lib/executor/instantiate/component/component_module.cpp
@@ -108,6 +108,8 @@ Executor::instantiate(Runtime::Instance::ComponentImportManager &ImportMgr,
   EXPECTED_TRY(initMemory(StackMgr, DataSec)
                    .map_error(ReportError(ASTNodeAttr::Sec_Data)));
 
+  ModInst->buildContext();
+
   // Instantiate StartSection (StartSec)
   const AST::StartSection &StartSec = Mod.getStartSection();
   if (StartSec.getContent()) {

--- a/lib/executor/instantiate/data.cpp
+++ b/lib/executor/instantiate/data.cpp
@@ -32,7 +32,7 @@ Expect<void> Executor::instantiate(Runtime::StackManager &StackMgr,
                        }));
       // Get memory instance and address type.
       // Memory64 proposal is checked in validation phase.
-      auto *MemInst = getMemInstByIdx(StackMgr, DataSeg.getIdx());
+      auto *MemInst = getMemInstByIdx(StackMgr.getModule(), DataSeg.getIdx());
       assuming(MemInst);
       Offset = extractAddr(StackMgr.pop(),
                            MemInst->getMemoryType().getLimit().getAddrType());
@@ -65,9 +65,9 @@ Expect<void> Executor::initMemory(Runtime::StackManager &StackMgr,
     // Initialize memory if data mode is active.
     if (DataSeg.getMode() == AST::DataSegment::DataMode::Active) {
       // Memory and data indices are checked in the validation phase.
-      auto *MemInst = getMemInstByIdx(StackMgr, DataSeg.getIdx());
+      auto *MemInst = getMemInstByIdx(StackMgr.getModule(), DataSeg.getIdx());
       assuming(MemInst);
-      auto *DataInst = getDataInstByIdx(StackMgr, Idx);
+      auto *DataInst = getDataInstByIdx(StackMgr.getModule(), Idx);
       assuming(DataInst);
       const uint64_t Off = DataInst->getOffset();
 

--- a/lib/executor/instantiate/elem.cpp
+++ b/lib/executor/instantiate/elem.cpp
@@ -45,7 +45,7 @@ Expect<void> Executor::instantiate(Runtime::StackManager &StackMgr,
               }));
       // Get table instance and address type.
       // Memory64 proposal is checked in validation phase.
-      auto *TabInst = getTabInstByIdx(StackMgr, ElemSeg.getIdx());
+      auto *TabInst = getTabInstByIdx(StackMgr.getModule(), ElemSeg.getIdx());
       assuming(TabInst);
       Offset = extractAddr(StackMgr.pop(),
                            TabInst->getTableType().getLimit().getAddrType());
@@ -76,11 +76,11 @@ Expect<void> Executor::initTable(Runtime::StackManager &StackMgr,
   uint32_t Idx = 0;
   for (const auto &ElemSeg : ElemSec.getContent()) {
     // Element index is checked in validation phase.
-    auto *ElemInst = getElemInstByIdx(StackMgr, Idx);
+    auto *ElemInst = getElemInstByIdx(StackMgr.getModule(), Idx);
     assuming(ElemInst);
     if (ElemSeg.getMode() == AST::ElementSegment::ElemMode::Active) {
       // Table index is checked in validation phase.
-      auto *TabInst = getTabInstByIdx(StackMgr, ElemSeg.getIdx());
+      auto *TabInst = getTabInstByIdx(StackMgr.getModule(), ElemSeg.getIdx());
       assuming(TabInst);
       const uint64_t Off = ElemInst->getOffset();
 

--- a/lib/executor/instantiate/module.cpp
+++ b/lib/executor/instantiate/module.cpp
@@ -137,6 +137,8 @@ Executor::instantiate(Runtime::StoreManager &StoreMgr, const AST::Module &Mod,
   EXPECTED_TRY(initMemory(StackMgr, DataSec)
                    .map_error(ReportError(ASTNodeAttr::Sec_Data)));
 
+  ModInst->buildContext();
+
   // Instantiate StartSection (StartSec)
   const AST::StartSection &StartSec = Mod.getStartSection();
   if (StartSec.getContent()) {

--- a/lib/executor/instantiate/table.cpp
+++ b/lib/executor/instantiate/table.cpp
@@ -47,7 +47,8 @@ Expect<void> Executor::instantiate(Runtime::StackManager &StackMgr,
       // No init expression case. Use the null reference to initialize.
       // Normalize the type to the bottom abstract heap type so that null
       // references always carry abstract types, as ref.cast/ref.test assume.
-      auto BotType = toBottomType(StackMgr, TabSeg.getTableType().getRefType());
+      auto BotType = toBottomType(StackMgr.getModule(),
+                                  TabSeg.getTableType().getRefType());
       RefVariant InitTabValue(ValType(TypeCode::RefNull, BotType));
       ModInst.addTable(TabSeg.getTableType(), InitTabValue);
     }

--- a/lib/llvm/compiler.cpp
+++ b/lib/llvm/compiler.cpp
@@ -250,11 +250,11 @@ Expect<Data> Compiler::compile(const AST::Module &Module) noexcept {
 
 void Compiler::compile(const AST::TypeSection &TypeSec,
                        bool DeclarationsOnly) noexcept {
-  auto WrapperTy =
-      LLVM::Type::getFunctionType(Context->VoidTy,
-                                  {Context->ExecCtxPtrTy, Context->Int8PtrTy,
-                                   Context->Int8PtrTy, Context->Int8PtrTy},
-                                  false);
+  auto WrapperTy = LLVM::Type::getFunctionType(
+      Context->VoidTy,
+      {Context->ExecCtxPtrTy, Context->ExecCtxPtrTy, Context->Int8PtrTy,
+       Context->Int8PtrTy, Context->Int8PtrTy},
+      false);
   auto SubTypes = TypeSec.getContent();
   const auto Size = SubTypes.size();
   if (Size == 0) {
@@ -272,9 +272,11 @@ void Compiler::compile(const AST::TypeSection &TypeSec,
     FDecl.addFnAttr(Context->UWTable);
     FDecl.addParamAttr(0, Context->ReadOnly);
     FDecl.addParamAttr(0, Context->NoAlias);
+    FDecl.addParamAttr(1, Context->ReadOnly);
     FDecl.addParamAttr(1, Context->NoAlias);
     FDecl.addParamAttr(2, Context->NoAlias);
     FDecl.addParamAttr(3, Context->NoAlias);
+    FDecl.addParamAttr(4, Context->NoAlias);
   };
 
   // Iterate and compile types.
@@ -333,8 +335,9 @@ void Compiler::compile(const AST::TypeSection &TypeSec,
           std::vector<LLVM::Type> FPTy(FTy.getNumParams());
           FTy.getParamTypes(FPTy);
 
-          const size_t ArgCount = FPTy.size() - 1;
-          auto ExecCtxPtr = F.getFirstParam();
+          const size_t ArgCount = FPTy.size() - 2;
+          auto ModCtxPtr = F.getFirstParam();
+          auto ExecCtxPtr = ModCtxPtr.getNextParam();
           auto RawFunc = LLVM::FunctionCallee{
               FTy, Builder.createBitCast(ExecCtxPtr.getNextParam(),
                                          FTy.getPointerTo())};
@@ -343,10 +346,11 @@ void Compiler::compile(const AST::TypeSection &TypeSec,
 
           std::vector<LLVM::Value> Args;
           Args.reserve(FTy.getNumParams());
+          Args.push_back(ModCtxPtr);
           Args.push_back(ExecCtxPtr);
           for (size_t J = 0; J < ArgCount; ++J) {
             Args.push_back(Builder.createValuePtrLoad(
-                FPTy[J + 1], RawArgs, Context->Int8Ty, J * LLVM::kValSize));
+                FPTy[J + 2], RawArgs, Context->Int8Ty, J * LLVM::kValSize));
           }
 
           auto Ret = Builder.createCall(RawFunc, Args);
@@ -425,7 +429,7 @@ void Compiler::compile(const AST::ImportSection &ImportSec) noexcept {
       LLVM::Value Args = Builder.createArray(ArgSize, LLVM::kValSize);
       LLVM::Value Rets = Builder.createArray(RetSize, LLVM::kValSize);
 
-      auto Arg = F.Fn.getFirstParam();
+      auto Arg = F.Fn.getFirstParam().getNextParam();
       for (unsigned I = 0; I < ArgSize; ++I) {
         Arg = Arg.getNextParam();
         Builder.createValuePtrStore(Arg, Args, Context->Int8Ty,
@@ -575,6 +579,8 @@ void Compiler::compileFunctionDeclarations(
     F.Fn.addFnAttr(Context->UWTable);
     F.Fn.addParamAttr(0, Context->ReadOnly);
     F.Fn.addParamAttr(0, Context->NoAlias);
+    F.Fn.addParamAttr(1, Context->ReadOnly);
+    F.Fn.addParamAttr(1, Context->NoAlias);
 
     Context->Functions.emplace_back(TypeIdx, F, &Code);
   }

--- a/lib/llvm/compiler.cpp
+++ b/lib/llvm/compiler.cpp
@@ -229,10 +229,19 @@ Expect<Data> Compiler::compile(const AST::Module &Module) noexcept {
   // StartSection is not required for compilation.
 
   spdlog::info("verify start"sv);
-  LLModule.verify(LLVMPrintMessageAction);
+  if (LLVM::Message VerifyMsg; LLModule.hasVerificationError(VerifyMsg)) {
+    spdlog::error("LLVM module verification failed: {}"sv,
+                  VerifyMsg.string_view());
+    return Unexpect(ErrCode::Value::InvalidAOTConfigure);
+  }
 
   auto &TM = D.extract().TM;
   EXPECTED_TRY(optimize(LLModule, TM));
+  if (LLVM::Message VerifyMsg; LLModule.hasVerificationError(VerifyMsg)) {
+    spdlog::error("LLVM module verification failed after optimization: {}"sv,
+                  VerifyMsg.string_view());
+    return Unexpect(ErrCode::Value::InvalidAOTConfigure);
+  }
 
   // Set initializer for constant value
   Context->finalizeIntrinsicsTable();
@@ -642,7 +651,11 @@ LLVM::Compiler::compileInfrastructure(const AST::Module &Module) noexcept {
 
   // Set initializer for constant value
   Context->finalizeIntrinsicsTable();
-  LLModule.verify(LLVMPrintMessageAction);
+  if (LLVM::Message VerifyMsg; LLModule.hasVerificationError(VerifyMsg)) {
+    spdlog::error("LLVM module verification failed: {}"sv,
+                  VerifyMsg.string_view());
+    return Unexpect(ErrCode::Value::InvalidAOTConfigure);
+  }
 
   spdlog::info("[lazy-jit]: infrastructure compilation done"sv);
 
@@ -692,11 +705,20 @@ Compiler::compileFunctions(Data &&LLData, const AST::Module &Module,
   }
 
   spdlog::info("[lazy-jit]: verify batch ({} funcs) start"sv, Sorted.size());
-  LLModule.verify(LLVMPrintMessageAction);
+  if (LLVM::Message VerifyMsg; LLModule.hasVerificationError(VerifyMsg)) {
+    spdlog::error("[lazy-jit]: batch verification failed: {}"sv,
+                  VerifyMsg.string_view());
+    return Unexpect(ErrCode::Value::InvalidAOTConfigure);
+  }
   spdlog::info("[lazy-jit]: verify batch ({} funcs) done"sv, Sorted.size());
 
   auto &TM = LLData.extract().TM;
   EXPECTED_TRY(optimize(LLModule, TM));
+  if (LLVM::Message VerifyMsg; LLModule.hasVerificationError(VerifyMsg)) {
+    spdlog::error("LLVM module verification failed after optimization: {}"sv,
+                  VerifyMsg.string_view());
+    return Unexpect(ErrCode::Value::InvalidAOTConfigure);
+  }
 
   spdlog::debug("[lazy-jit]: compile functions batch ({}) done"sv,
                 Sorted.size());

--- a/lib/llvm/compiler.cpp
+++ b/lib/llvm/compiler.cpp
@@ -429,6 +429,7 @@ void Compiler::compile(const AST::ImportSection &ImportSec) noexcept {
       LLVM::Value Args = Builder.createArray(ArgSize, LLVM::kValSize);
       LLVM::Value Rets = Builder.createArray(RetSize, LLVM::kValSize);
 
+      auto ModCtx = Builder.createLoad(Context->ModCtxTy, F.Fn.getFirstParam());
       auto Arg = F.Fn.getFirstParam().getNextParam();
       for (unsigned I = 0; I < ArgSize; ++I) {
         Arg = Arg.getNextParam();
@@ -437,13 +438,14 @@ void Compiler::compile(const AST::ImportSection &ImportSec) noexcept {
       }
 
       Builder.createCall(
-          Context->getIntrinsic(
-              Builder, Executable::Intrinsics::kCall,
-              LLVM::Type::getFunctionType(
-                  Context->VoidTy,
-                  {Context->Int32Ty, Context->Int8PtrTy, Context->Int8PtrTy},
-                  false)),
-          {Context->LLContext.getInt32(FuncID), Args, Rets});
+          Context->getIntrinsic(Builder, Executable::Intrinsics::kCall,
+                                LLVM::Type::getFunctionType(
+                                    Context->VoidTy,
+                                    {Context->Int8PtrTy, Context->Int32Ty,
+                                     Context->Int8PtrTy, Context->Int8PtrTy},
+                                    false)),
+          {Context->getModuleInst(Builder, ModCtx),
+           Context->LLContext.getInt32(FuncID), Args, Rets});
 
       if (RetSize == 0) {
         Builder.createRetVoid();

--- a/lib/llvm/compiler.cpp
+++ b/lib/llvm/compiler.cpp
@@ -252,7 +252,7 @@ void Compiler::compile(const AST::TypeSection &TypeSec,
                        bool DeclarationsOnly) noexcept {
   auto WrapperTy = LLVM::Type::getFunctionType(
       Context->VoidTy,
-      {Context->ExecCtxPtrTy, Context->ExecCtxPtrTy, Context->Int8PtrTy,
+      {Context->ModCtxPtrTy, Context->ExecCtxPtrTy, Context->Int8PtrTy,
        Context->Int8PtrTy, Context->Int8PtrTy},
       false);
   auto SubTypes = TypeSec.getContent();
@@ -329,8 +329,8 @@ void Compiler::compile(const AST::TypeSection &TypeSec,
           Builder.positionAtEnd(
               LLVM::BasicBlock::create(Context->LLContext, F, "entry"));
 
-          auto FTy = toLLVMType(Context->LLContext, Context->ExecCtxPtrTy,
-                                CompType.getFuncType());
+          auto FTy = toLLVMType(Context->LLContext, Context->ModCtxPtrTy,
+                                Context->ExecCtxPtrTy, CompType.getFuncType());
           auto RTy = FTy.getReturnType();
           std::vector<LLVM::Type> FPTy(FTy.getNumParams());
           FTy.getParamTypes(FPTy);
@@ -404,8 +404,8 @@ void Compiler::compile(const AST::ImportSection &ImportSec) noexcept {
       assuming(TypeIdx < Context->CompositeTypes.size());
       assuming(Context->CompositeTypes[TypeIdx]->isFunc());
       const auto &FuncType = Context->CompositeTypes[TypeIdx]->getFuncType();
-      auto FTy =
-          toLLVMType(Context->LLContext, Context->ExecCtxPtrTy, FuncType);
+      auto FTy = toLLVMType(Context->LLContext, Context->ModCtxPtrTy,
+                            Context->ExecCtxPtrTy, FuncType);
       auto RTy = FTy.getReturnType();
       auto F =
           LLVM::FunctionCallee{FTy, Context->LLModule.get().addFunction(
@@ -567,7 +567,8 @@ void Compiler::compileFunctionDeclarations(
     assuming(Context->CompositeTypes[TypeIdx]->isFunc());
     const auto &FuncType = Context->CompositeTypes[TypeIdx]->getFuncType();
     const auto FuncID = Context->Functions.size();
-    auto FTy = toLLVMType(Context->LLContext, Context->ExecCtxPtrTy, FuncType);
+    auto FTy = toLLVMType(Context->LLContext, Context->ModCtxPtrTy,
+                          Context->ExecCtxPtrTy, FuncType);
     LLVM::FunctionCallee F = {FTy, Context->LLModule.get().addFunction(
                                        FTy, LLVMExternalLinkage,
                                        fmt::format("f{}"sv, FuncID).c_str())};

--- a/lib/llvm/compiler/context.cpp
+++ b/lib/llvm/compiler/context.cpp
@@ -42,23 +42,28 @@ Compiler::CompileContext::CompileContext(LLVM::Context C, LLVM::Module &M,
       Int8PtrTy(Int8Ty.getPointerTo()), Int32PtrTy(Int32Ty.getPointerTo()),
       Int64PtrTy(Int64Ty.getPointerTo()), Int128PtrTy(Int128Ty.getPointerTo()),
       Int8PtrPtrTy(Int8PtrTy.getPointerTo()),
+      ModCtxTy(
+          LLVM::Type::getStructType("ModCtx",
+                                    std::initializer_list<LLVM::Type>{
+                                        // MemoryPtrs
+                                        Int8PtrTy.getPointerTo(),
+                                        // MemorySizes
+                                        Int64PtrTy.getPointerTo(),
+                                        // TableRefs
+                                        Int64x2Ty.getPointerTo().getPointerTo(),
+                                        // TableSizes
+                                        Int64PtrTy.getPointerTo(),
+                                        // Globals
+                                        Int128PtrTy.getPointerTo(),
+                                        // ModuleInst
+                                        Int8PtrTy,
+                                        // Tags
+                                        Int8PtrPtrTy,
+                                    })),
+      ModCtxPtrTy(ModCtxTy.getPointerTo()),
       ExecCtxTy(LLVM::Type::getStructType(
           "ExecCtx",
           std::initializer_list<LLVM::Type>{
-              // MemoryPtrs
-              Int8PtrTy.getPointerTo(),
-              // MemorySizes
-              Int64PtrTy.getPointerTo(),
-              // TableRefs
-              Int64x2Ty.getPointerTo().getPointerTo(),
-              // TableSizes
-              Int64PtrTy.getPointerTo(),
-              // Globals
-              Int128PtrTy.getPointerTo(),
-              // Tags
-              Int8PtrPtrTy,
-              // PendingExnTagAddr
-              Int8PtrPtrTy,
               // InstrCount
               Int64PtrTy,
               // CostTable
@@ -69,8 +74,8 @@ Compiler::CompileContext::CompileContext(LLVM::Context C, LLVM::Module &M,
               Int64Ty,
               // StopToken
               Int32PtrTy,
-              // ModuleInst
-              Int8PtrTy,
+              // PendingExnTagAddr
+              Int8PtrPtrTy,
           })),
       ExecCtxPtrTy(ExecCtxTy.getPointerTo()),
       IntrinsicsTableTy(LLVM::Type::getArrayType(
@@ -178,11 +183,12 @@ toLLVMTypeVector(LLVM::Context LLContext,
 }
 
 std::vector<LLVM::Type> toLLVMArgsType(LLVM::Context LLContext,
+                                       LLVM::Type ModCtxPtrTy,
                                        LLVM::Type ExecCtxPtrTy,
                                        Span<const ValType> ValTypes) noexcept {
   auto Result = toLLVMTypeVector(LLContext, ValTypes);
   Result.insert(Result.begin(), ExecCtxPtrTy);
-  Result.insert(Result.begin(), ExecCtxPtrTy);
+  Result.insert(Result.begin(), ModCtxPtrTy);
   return Result;
 }
 
@@ -202,10 +208,11 @@ LLVM::Type toLLVMRetsType(LLVM::Context LLContext,
   return LLVM::Type::getStructType(Result);
 }
 
-LLVM::Type toLLVMType(LLVM::Context LLContext, LLVM::Type ExecCtxPtrTy,
+LLVM::Type toLLVMType(LLVM::Context LLContext, LLVM::Type ModCtxPtrTy,
+                      LLVM::Type ExecCtxPtrTy,
                       const AST::FunctionType &FuncType) noexcept {
-  auto ArgsTy =
-      toLLVMArgsType(LLContext, ExecCtxPtrTy, FuncType.getParamTypes());
+  auto ArgsTy = toLLVMArgsType(LLContext, ModCtxPtrTy, ExecCtxPtrTy,
+                               FuncType.getParamTypes());
   auto RetTy = toLLVMRetsType(LLContext, FuncType.getReturnTypes());
   return LLVM::Type::getFunctionType(RetTy, ArgsTy);
 }

--- a/lib/llvm/compiler/context.cpp
+++ b/lib/llvm/compiler/context.cpp
@@ -182,6 +182,7 @@ std::vector<LLVM::Type> toLLVMArgsType(LLVM::Context LLContext,
                                        Span<const ValType> ValTypes) noexcept {
   auto Result = toLLVMTypeVector(LLContext, ValTypes);
   Result.insert(Result.begin(), ExecCtxPtrTy);
+  Result.insert(Result.begin(), ExecCtxPtrTy);
   return Result;
 }
 

--- a/lib/llvm/compiler/context.h
+++ b/lib/llvm/compiler/context.h
@@ -59,6 +59,8 @@ struct Compiler::CompileContext {
   LLVM::Type Int64PtrTy;
   LLVM::Type Int128PtrTy;
   LLVM::Type Int8PtrPtrTy;
+  LLVM::Type ModCtxTy;
+  LLVM::Type ModCtxPtrTy;
   LLVM::Type ExecCtxTy;
   LLVM::Type ExecCtxPtrTy;
   LLVM::Type IntrinsicsTableTy;
@@ -114,9 +116,9 @@ struct Compiler::CompileContext {
   LLVM::FunctionCallee Trap;
   CompileContext(LLVM::Context C, LLVM::Module &M,
                  bool IsGenericBinary) noexcept;
-  LLVM::Value getMemory(LLVM::Builder &Builder, LLVM::Value ExecCtx,
+  LLVM::Value getMemory(LLVM::Builder &Builder, LLVM::Value ModCtx,
                         uint32_t Index) noexcept {
-    auto Array = Builder.createExtractValue(ExecCtx, 0);
+    auto Array = Builder.createExtractValue(ModCtx, 0);
 #if WASMEDGE_ALLOCATOR_IS_STABLE
     auto VPtr = Builder.createLoad(
         Int8PtrTy, Builder.createInBoundsGEP1(Int8PtrTy, Array,
@@ -135,9 +137,9 @@ struct Compiler::CompileContext {
 #endif
     return Builder.createBitCast(VPtr, Int8PtrTy);
   }
-  LLVM::Value getMemorySize(LLVM::Builder &Builder, LLVM::Value ExecCtx,
+  LLVM::Value getMemorySize(LLVM::Builder &Builder, LLVM::Value ModCtx,
                             uint32_t Index) noexcept {
-    auto Array = Builder.createExtractValue(ExecCtx, 1);
+    auto Array = Builder.createExtractValue(ModCtx, 1);
     auto VPtr = Builder.createLoad(
         Int64PtrTy, Builder.createInBoundsGEP1(Int64PtrTy, Array,
                                                LLContext.getInt64(Index)));
@@ -145,10 +147,10 @@ struct Compiler::CompileContext {
                      LLVM::Metadata(LLContext, {}));
     return Builder.createLoad(Int64Ty, VPtr);
   }
-  LLVM::Value getTable(LLVM::Builder &Builder, LLVM::Value ExecCtx,
+  LLVM::Value getTable(LLVM::Builder &Builder, LLVM::Value ModCtx,
                        uint32_t Index) noexcept {
     auto RefPtrTy = Int64x2Ty.getPointerTo();
-    auto Array = Builder.createExtractValue(ExecCtx, 2);
+    auto Array = Builder.createExtractValue(ModCtx, 2);
     auto VPtrPtr = Builder.createLoad(
         RefPtrTy.getPointerTo(),
         Builder.createInBoundsGEP1(RefPtrTy.getPointerTo(), Array,
@@ -159,9 +161,9 @@ struct Compiler::CompileContext {
         RefPtrTy,
         Builder.createInBoundsGEP1(RefPtrTy, VPtrPtr, LLContext.getInt64(0)));
   }
-  LLVM::Value getTableSize(LLVM::Builder &Builder, LLVM::Value ExecCtx,
+  LLVM::Value getTableSize(LLVM::Builder &Builder, LLVM::Value ModCtx,
                            uint32_t Index) noexcept {
-    auto Array = Builder.createExtractValue(ExecCtx, 3);
+    auto Array = Builder.createExtractValue(ModCtx, 3);
     auto VPtr = Builder.createLoad(
         Int64PtrTy, Builder.createInBoundsGEP1(Int64PtrTy, Array,
                                                LLContext.getInt64(Index)));
@@ -169,11 +171,15 @@ struct Compiler::CompileContext {
                      LLVM::Metadata(LLContext, {}));
     return Builder.createLoad(Int64Ty, VPtr);
   }
+  LLVM::Value getModuleInst(LLVM::Builder &Builder,
+                            LLVM::Value ModCtx) noexcept {
+    return Builder.createExtractValue(ModCtx, 5);
+  }
   std::pair<LLVM::Type, LLVM::Value> getGlobal(LLVM::Builder &Builder,
-                                               LLVM::Value ExecCtx,
+                                               LLVM::Value ModCtx,
                                                uint32_t Index) noexcept {
     auto Ty = Globals[Index];
-    auto Array = Builder.createExtractValue(ExecCtx, 4);
+    auto Array = Builder.createExtractValue(ModCtx, 4);
     auto VPtr = Builder.createLoad(
         Int128PtrTy, Builder.createInBoundsGEP1(Int8PtrTy, Array,
                                                 LLContext.getInt64(Index)));
@@ -182,9 +188,9 @@ struct Compiler::CompileContext {
     auto Ptr = Builder.createBitCast(VPtr, Ty.getPointerTo());
     return {Ty, Ptr};
   }
-  LLVM::Value getTag(LLVM::Builder &Builder, LLVM::Value ExecCtx,
+  LLVM::Value getTag(LLVM::Builder &Builder, LLVM::Value ModCtx,
                      uint32_t Index) noexcept {
-    auto Array = Builder.createExtractValue(ExecCtx, 5);
+    auto Array = Builder.createExtractValue(ModCtx, 6);
     auto VPtr = Builder.createLoad(
         Int8PtrTy, Builder.createInBoundsGEP1(Int8PtrTy, Array,
                                               LLContext.getInt64(Index)));
@@ -194,30 +200,26 @@ struct Compiler::CompileContext {
   }
   LLVM::Value getPendingExnTagAddr(LLVM::Builder &Builder,
                                    LLVM::Value ExecCtx) noexcept {
-    return Builder.createExtractValue(ExecCtx, 6);
+    return Builder.createExtractValue(ExecCtx, 5);
   }
   LLVM::Value getInstrCount(LLVM::Builder &Builder,
                             LLVM::Value ExecCtx) noexcept {
-    return Builder.createExtractValue(ExecCtx, 7);
+    return Builder.createExtractValue(ExecCtx, 0);
   }
   LLVM::Value getCostTable(LLVM::Builder &Builder,
                            LLVM::Value ExecCtx) noexcept {
-    return Builder.createExtractValue(ExecCtx, 8);
+    return Builder.createExtractValue(ExecCtx, 1);
   }
   LLVM::Value getGas(LLVM::Builder &Builder, LLVM::Value ExecCtx) noexcept {
-    return Builder.createExtractValue(ExecCtx, 9);
+    return Builder.createExtractValue(ExecCtx, 2);
   }
   LLVM::Value getGasLimit(LLVM::Builder &Builder,
                           LLVM::Value ExecCtx) noexcept {
-    return Builder.createExtractValue(ExecCtx, 10);
+    return Builder.createExtractValue(ExecCtx, 3);
   }
   LLVM::Value getStopToken(LLVM::Builder &Builder,
                            LLVM::Value ExecCtx) noexcept {
-    return Builder.createExtractValue(ExecCtx, 11);
-  }
-  LLVM::Value getModuleInst(LLVM::Builder &Builder,
-                            LLVM::Value ExecCtx) noexcept {
-    return Builder.createExtractValue(ExecCtx, 12);
+    return Builder.createExtractValue(ExecCtx, 4);
   }
   LLVM::FunctionCallee getIntrinsic(LLVM::Builder &Builder,
                                     Executable::Intrinsics Index,
@@ -284,12 +286,14 @@ bool isVoidReturn(WasmEdge::Span<const WasmEdge::ValType> ValTypes) noexcept;
 LLVM::Type toLLVMType(LLVM::Context LLContext,
                       const WasmEdge::ValType &ValType) noexcept;
 std::vector<LLVM::Type>
-toLLVMArgsType(LLVM::Context LLContext, LLVM::Type ExecCtxPtrTy,
+toLLVMArgsType(LLVM::Context LLContext, LLVM::Type ModCtxPtrTy,
+               LLVM::Type ExecCtxPtrTy,
                WasmEdge::Span<const WasmEdge::ValType> ValTypes) noexcept;
 LLVM::Type
 toLLVMRetsType(LLVM::Context LLContext,
                WasmEdge::Span<const WasmEdge::ValType> ValTypes) noexcept;
-LLVM::Type toLLVMType(LLVM::Context LLContext, LLVM::Type ExecCtxPtrTy,
+LLVM::Type toLLVMType(LLVM::Context LLContext, LLVM::Type ModCtxPtrTy,
+                      LLVM::Type ExecCtxPtrTy,
                       const WasmEdge::AST::FunctionType &FuncType) noexcept;
 LLVM::Value
 toLLVMConstantZero(LLVM::Context LLContext, const WasmEdge::ValType &ValType,

--- a/lib/llvm/compiler/function_compiler.cpp
+++ b/lib/llvm/compiler/function_compiler.cpp
@@ -1642,7 +1642,14 @@ void FunctionCompiler::compileReturnCallOp(
     Ret = Builder.createCall(Function, Args);
   }
 
-  Ret.setMustTailCall();
+  // Known limitation: musttail is only valid when the caller and callee
+  // prototypes match. A differing signature falls back to the tail hint, which
+  // LLVM may decline, so such a tail call is not guaranteed constant-space.
+  if (Ret.getInstructionCalledFunctionType().unwrap() == F.Ty.unwrap()) {
+    Ret.setMustTailCall();
+  } else {
+    Ret.setTailCall();
+  }
   auto Ty = Ret.getType();
   if (Ty.isVoidTy()) {
     Builder.createRetVoid();
@@ -1685,7 +1692,13 @@ void FunctionCompiler::compileReturnIndirectCallOp(
     Builder.positionAtEnd(NotNullBB);
 
     auto FPtrRet = Builder.createCall(LLVM::FunctionCallee(FTy, FPtr), ArgsVec);
-    FPtrRet.setMustTailCall();
+    // Known limitation: a mismatched prototype rules musttail out and the tail
+    // hint may be declined, so this tail call is not guaranteed constant-space.
+    if (FPtrRet.getInstructionCalledFunctionType().unwrap() == F.Ty.unwrap()) {
+      FPtrRet.setMustTailCall();
+    } else {
+      FPtrRet.setTailCall();
+    }
     if (RetSize == 0) {
       Builder.createRetVoid();
     } else {
@@ -1857,7 +1870,13 @@ void FunctionCompiler::compileReturnCallRefOp(
     Builder.positionAtEnd(NotNullBB);
 
     auto FPtrRet = Builder.createCall(LLVM::FunctionCallee(FTy, FPtr), ArgsVec);
-    FPtrRet.setMustTailCall();
+    // Known limitation: a mismatched prototype rules musttail out and the tail
+    // hint may be declined, so this tail call is not guaranteed constant-space.
+    if (FPtrRet.getInstructionCalledFunctionType().unwrap() == F.Ty.unwrap()) {
+      FPtrRet.setMustTailCall();
+    } else {
+      FPtrRet.setTailCall();
+    }
     if (RetSize == 0) {
       Builder.createRetVoid();
     } else {

--- a/lib/llvm/compiler/function_compiler.cpp
+++ b/lib/llvm/compiler/function_compiler.cpp
@@ -1517,9 +1517,9 @@ void FunctionCompiler::compileIndirectCallOp(
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kTableGetFuncSymbol,
             LLVM::Type::getFunctionType(
-                FPtrTy, {Context.Int32Ty, Context.Int32Ty, Context.Int32Ty},
+                FPtrTy, {Context.Int32Ty, Context.Int32Ty, Context.Int64Ty},
                 false)),
-        {TableIdx, TypeIdx, FuncIndex});
+        {TableIdx, TypeIdx, Idx64});
     Builder.createCondBr(
         Builder.createLikely(Builder.createNot(Builder.createIsNull(FPtr))),
         NotNullBB, IsNullBB);
@@ -1544,10 +1544,10 @@ void FunctionCompiler::compileIndirectCallOp(
             Builder, Executable::Intrinsics::kCallIndirect,
             LLVM::Type::getFunctionType(Context.VoidTy,
                                         {Context.Int32Ty, Context.Int32Ty,
-                                         Context.Int32Ty, Context.Int8PtrTy,
+                                         Context.Int64Ty, Context.Int8PtrTy,
                                          Context.Int8PtrTy},
                                         false)),
-        {TableIdx, TypeIdx, FuncIndex, Args, Rets});
+        {TableIdx, TypeIdx, Idx64, Args, Rets});
 
     if (RetSize == 0) {
       // nothing to do
@@ -1664,6 +1664,7 @@ void FunctionCompiler::compileReturnIndirectCallOp(
   auto IsNullBB = LLVM::BasicBlock::create(LLContext, F.Fn, "c_i.is_null");
 
   LLVM::Value FuncIndex = stackPop();
+  auto Idx64 = Builder.createZExt(FuncIndex, Context.Int64Ty);
   const auto &FuncType = Context.CompositeTypes[FuncTypeIndex]->getFuncType();
   auto FTy = toLLVMType(Context.LLContext, Context.ExecCtxPtrTy, FuncType);
   auto RTy = FTy.getReturnType();
@@ -1683,9 +1684,9 @@ void FunctionCompiler::compileReturnIndirectCallOp(
             Builder, Executable::Intrinsics::kTableGetFuncSymbol,
             LLVM::Type::getFunctionType(
                 FTy.getPointerTo(),
-                {Context.Int32Ty, Context.Int32Ty, Context.Int32Ty}, false)),
+                {Context.Int32Ty, Context.Int32Ty, Context.Int64Ty}, false)),
         {LLContext.getInt32(TableIndex), LLContext.getInt32(FuncTypeIndex),
-         FuncIndex});
+         Idx64});
     Builder.createCondBr(
         Builder.createLikely(Builder.createNot(Builder.createIsNull(FPtr))),
         NotNullBB, IsNullBB);
@@ -1719,11 +1720,11 @@ void FunctionCompiler::compileReturnIndirectCallOp(
             Builder, Executable::Intrinsics::kCallIndirect,
             LLVM::Type::getFunctionType(Context.VoidTy,
                                         {Context.Int32Ty, Context.Int32Ty,
-                                         Context.Int32Ty, Context.Int8PtrTy,
+                                         Context.Int64Ty, Context.Int8PtrTy,
                                          Context.Int8PtrTy},
                                         false)),
         {LLContext.getInt32(TableIndex), LLContext.getInt32(FuncTypeIndex),
-         FuncIndex, Args, Rets});
+         Idx64, Args, Rets});
 
     if (RetSize == 0) {
       Builder.createRetVoid();

--- a/lib/llvm/compiler/function_compiler.cpp
+++ b/lib/llvm/compiler/function_compiler.cpp
@@ -37,6 +37,8 @@ FunctionCompiler::FunctionCompiler(LLVM::Compiler::CompileContext &Context,
       Builder.createStore(LLContext.getInt64(0), LocalGas);
     }
 
+    CalleeCtxSlot = Builder.createAlloca(Context.ModCtxPtrTy);
+
     for (LLVM::Value Arg = F.Fn.getFirstParam().getNextParam().getNextParam();
          Arg; Arg = Arg.getNextParam()) {
       LLVM::Type Ty = Arg.getType();
@@ -1533,16 +1535,24 @@ void FunctionCompiler::compileIndirectCallOp(
     auto FPtr = Builder.createCall(
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kTableGetFuncSymbol,
-            LLVM::Type::getFunctionType(
-                FPtrTy, {Context.Int32Ty, Context.Int32Ty, Context.Int64Ty},
-                false)),
-        {TableIdx, TypeIdx, Idx64});
+            LLVM::Type::getFunctionType(FPtrTy,
+                                        {Context.Int8PtrTy, Context.Int32Ty,
+                                         Context.Int32Ty, Context.Int64Ty,
+                                         Context.ModCtxPtrTy.getPointerTo()},
+                                        false)),
+        {Context.getModuleInst(Builder, ModCtx), TableIdx, TypeIdx, Idx64,
+         CalleeCtxSlot});
     Builder.createCondBr(
         Builder.createLikely(Builder.createNot(Builder.createIsNull(FPtr))),
         NotNullBB, IsNullBB);
     Builder.positionAtEnd(NotNullBB);
 
-    auto FPtrRet = Builder.createCall(LLVM::FunctionCallee{FTy, FPtr}, ArgsVec);
+    auto Returned = Builder.createLoad(Context.ModCtxPtrTy, CalleeCtxSlot);
+    std::vector<LLVM::Value> SlowArgsVec = ArgsVec;
+    SlowArgsVec[0] = Builder.createSelect(Builder.createIsNull(Returned),
+                                          F.Fn.getFirstParam(), Returned);
+    auto FPtrRet =
+        Builder.createCall(LLVM::FunctionCallee{FTy, FPtr}, SlowArgsVec);
     FPtrRetsVec = UnpackRets(FPtrRet);
   }
 
@@ -1706,17 +1716,24 @@ void FunctionCompiler::compileReturnIndirectCallOp(
     auto FPtr = Builder.createCall(
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kTableGetFuncSymbol,
-            LLVM::Type::getFunctionType(
-                FTy.getPointerTo(),
-                {Context.Int32Ty, Context.Int32Ty, Context.Int64Ty}, false)),
-        {LLContext.getInt32(TableIndex), LLContext.getInt32(FuncTypeIndex),
-         Idx64});
+            LLVM::Type::getFunctionType(FTy.getPointerTo(),
+                                        {Context.Int8PtrTy, Context.Int32Ty,
+                                         Context.Int32Ty, Context.Int64Ty,
+                                         Context.ModCtxPtrTy.getPointerTo()},
+                                        false)),
+        {Context.getModuleInst(Builder, ModCtx), LLContext.getInt32(TableIndex),
+         LLContext.getInt32(FuncTypeIndex), Idx64, CalleeCtxSlot});
     Builder.createCondBr(
         Builder.createLikely(Builder.createNot(Builder.createIsNull(FPtr))),
         NotNullBB, IsNullBB);
     Builder.positionAtEnd(NotNullBB);
 
-    auto FPtrRet = Builder.createCall(LLVM::FunctionCallee(FTy, FPtr), ArgsVec);
+    auto Returned = Builder.createLoad(Context.ModCtxPtrTy, CalleeCtxSlot);
+    std::vector<LLVM::Value> SlowArgsVec = ArgsVec;
+    SlowArgsVec[0] = Builder.createSelect(Builder.createIsNull(Returned),
+                                          F.Fn.getFirstParam(), Returned);
+    auto FPtrRet =
+        Builder.createCall(LLVM::FunctionCallee(FTy, FPtr), SlowArgsVec);
     // Known limitation: a mismatched prototype rules musttail out and the tail
     // hint may be declined, so this tail call is not guaranteed constant-space.
     if (FPtrRet.getInstructionCalledFunctionType().unwrap() == F.Ty.unwrap()) {
@@ -1794,17 +1811,24 @@ void FunctionCompiler::compileCallRefOp(const unsigned int TypeIndex) noexcept {
   FPtrRetsVec.reserve(RetSize);
   {
     auto FPtr = Builder.createCall(
-        Context.getIntrinsic(Builder, Executable::Intrinsics::kRefGetFuncSymbol,
-                             LLVM::Type::getFunctionType(FTy.getPointerTo(),
-                                                         {Context.Int64x2Ty},
-                                                         false)),
-        {Ref});
+        Context.getIntrinsic(
+            Builder, Executable::Intrinsics::kRefGetFuncSymbol,
+            LLVM::Type::getFunctionType(FTy.getPointerTo(),
+                                        {Context.Int8PtrTy, Context.Int64x2Ty,
+                                         Context.ModCtxPtrTy.getPointerTo()},
+                                        false)),
+        {Context.getModuleInst(Builder, ModCtx), Ref, CalleeCtxSlot});
     Builder.createCondBr(
         Builder.createLikely(Builder.createNot(Builder.createIsNull(FPtr))),
         NotNullBB, IsNullBB);
     Builder.positionAtEnd(NotNullBB);
 
-    auto FPtrRet = Builder.createCall(LLVM::FunctionCallee{FTy, FPtr}, ArgsVec);
+    auto Returned = Builder.createLoad(Context.ModCtxPtrTy, CalleeCtxSlot);
+    std::vector<LLVM::Value> SlowArgsVec = ArgsVec;
+    SlowArgsVec[0] = Builder.createSelect(Builder.createIsNull(Returned),
+                                          F.Fn.getFirstParam(), Returned);
+    auto FPtrRet =
+        Builder.createCall(LLVM::FunctionCallee{FTy, FPtr}, SlowArgsVec);
     if (RetSize == 0) {
       // nothing to do
     } else if (RetSize == 1) {
@@ -1888,17 +1912,24 @@ void FunctionCompiler::compileReturnCallRefOp(
 
   {
     auto FPtr = Builder.createCall(
-        Context.getIntrinsic(Builder, Executable::Intrinsics::kRefGetFuncSymbol,
-                             LLVM::Type::getFunctionType(FTy.getPointerTo(),
-                                                         {Context.Int64x2Ty},
-                                                         false)),
-        {Ref});
+        Context.getIntrinsic(
+            Builder, Executable::Intrinsics::kRefGetFuncSymbol,
+            LLVM::Type::getFunctionType(FTy.getPointerTo(),
+                                        {Context.Int8PtrTy, Context.Int64x2Ty,
+                                         Context.ModCtxPtrTy.getPointerTo()},
+                                        false)),
+        {Context.getModuleInst(Builder, ModCtx), Ref, CalleeCtxSlot});
     Builder.createCondBr(
         Builder.createLikely(Builder.createNot(Builder.createIsNull(FPtr))),
         NotNullBB, IsNullBB);
     Builder.positionAtEnd(NotNullBB);
 
-    auto FPtrRet = Builder.createCall(LLVM::FunctionCallee(FTy, FPtr), ArgsVec);
+    auto Returned = Builder.createLoad(Context.ModCtxPtrTy, CalleeCtxSlot);
+    std::vector<LLVM::Value> SlowArgsVec = ArgsVec;
+    SlowArgsVec[0] = Builder.createSelect(Builder.createIsNull(Returned),
+                                          F.Fn.getFirstParam(), Returned);
+    auto FPtrRet =
+        Builder.createCall(LLVM::FunctionCallee(FTy, FPtr), SlowArgsVec);
     // Known limitation: a mismatched prototype rules musttail out and the tail
     // hint may be declined, so this tail call is not guaranteed constant-space.
     if (FPtrRet.getInstructionCalledFunctionType().unwrap() == F.Ty.unwrap()) {

--- a/lib/llvm/compiler/function_compiler.cpp
+++ b/lib/llvm/compiler/function_compiler.cpp
@@ -23,7 +23,9 @@ FunctionCompiler::FunctionCompiler(LLVM::Compiler::CompileContext &Context,
       Builder(LLContext) {
   if (F.Fn) {
     Builder.positionAtEnd(LLVM::BasicBlock::create(LLContext, F.Fn, "entry"));
-    ExecCtx = Builder.createLoad(Context.ExecCtxTy, F.Fn.getFirstParam());
+    ModCtx = Builder.createLoad(Context.ModCtxTy, F.Fn.getFirstParam());
+    ExecCtx = Builder.createLoad(Context.ExecCtxTy,
+                                 F.Fn.getFirstParam().getNextParam());
 
     if (InstructionCounting) {
       LocalInstrCount = Builder.createAlloca(Context.Int64Ty);
@@ -429,15 +431,14 @@ Expect<void> FunctionCompiler::compile(AST::InstrView Instrs) noexcept {
       Builder.createStore(Stack.back(), Local[Instr.getTargetIndex()].second);
       break;
     case OpCode::Global__get: {
-      const auto G =
-          Context.getGlobal(Builder, ExecCtx, Instr.getTargetIndex());
+      const auto G = Context.getGlobal(Builder, ModCtx, Instr.getTargetIndex());
       stackPush(Builder.createLoad(G.first, G.second));
       break;
     }
     case OpCode::Global__set:
       Builder.createStore(
           stackPop(),
-          Context.getGlobal(Builder, ExecCtx, Instr.getTargetIndex()).second);
+          Context.getGlobal(Builder, ModCtx, Instr.getTargetIndex()).second);
       break;
 
     // Table Instructions
@@ -447,13 +448,13 @@ Expect<void> FunctionCompiler::compile(AST::InstrView Instrs) noexcept {
       auto OkBB = LLVM::BasicBlock::create(LLContext, F.Fn, "t_get.ok");
       Builder.createCondBr(
           Builder.createLikely(Builder.createICmpULT(
-              Off, Context.getTableSize(Builder, ExecCtx, TableIndex))),
+              Off, Context.getTableSize(Builder, ModCtx, TableIndex))),
           OkBB, getTrapBB(ErrCode::Value::TableOutOfBounds));
       Builder.positionAtEnd(OkBB);
       stackPush(Builder.createLoad(
           Context.Int64x2Ty,
           Builder.createInBoundsGEP1(
-              Context.Int64x2Ty, Context.getTable(Builder, ExecCtx, TableIndex),
+              Context.Int64x2Ty, Context.getTable(Builder, ModCtx, TableIndex),
               Off)));
       break;
     }
@@ -464,13 +465,13 @@ Expect<void> FunctionCompiler::compile(AST::InstrView Instrs) noexcept {
       auto OkBB = LLVM::BasicBlock::create(LLContext, F.Fn, "t_set.ok");
       Builder.createCondBr(
           Builder.createLikely(Builder.createICmpULT(
-              Off, Context.getTableSize(Builder, ExecCtx, TableIndex))),
+              Off, Context.getTableSize(Builder, ModCtx, TableIndex))),
           OkBB, getTrapBB(ErrCode::Value::TableOutOfBounds));
       Builder.positionAtEnd(OkBB);
       Builder.createStore(
           Ref, Builder.createInBoundsGEP1(
                    Context.Int64x2Ty,
-                   Context.getTable(Builder, ExecCtx, TableIndex), Off));
+                   Context.getTable(Builder, ModCtx, TableIndex), Off));
       break;
     }
     case OpCode::Table__init: {
@@ -530,7 +531,7 @@ Expect<void> FunctionCompiler::compile(AST::InstrView Instrs) noexcept {
     }
     case OpCode::Table__size: {
       stackPush(Builder.createTrunc(
-          Context.getTableSize(Builder, ExecCtx, Instr.getTargetIndex()),
+          Context.getTableSize(Builder, ModCtx, Instr.getTargetIndex()),
           Context.TableAddrTypes[Instr.getTargetIndex()]));
       break;
     }
@@ -1226,7 +1227,7 @@ void FunctionCompiler::compileTryTableOp(
       auto NextBB =
           LLVM::BasicBlock::create(LLContext, F.Fn, "try.dispatch.next");
       auto IsMatch = Builder.createICmpEQ(
-          PendingTagInst, Context.getTag(Builder, ExecCtx, C.TagIndex));
+          PendingTagInst, Context.getTag(Builder, ModCtx, C.TagIndex));
       Builder.createCondBr(IsMatch, CaseBB, NextBB);
       Builder.positionAtEnd(NextBB);
     }
@@ -1355,7 +1356,8 @@ void FunctionCompiler::compileCallOp(const unsigned int FuncIndex) noexcept {
     if (IsImport) {
       Ret = Builder.createCall(Function, Args);
     } else {
-      auto FTy = toLLVMType(LLContext, Context.ExecCtxPtrTy, FuncType);
+      auto FTy = toLLVMType(LLContext, Context.ModCtxPtrTy,
+                            Context.ExecCtxPtrTy, FuncType);
 
       if (Context.LazyJITCacheVars.size() <= FuncIndex) {
         Context.LazyJITCacheVars.resize(Context.Functions.size());
@@ -1430,7 +1432,8 @@ void FunctionCompiler::compileIndirectCallOp(
 
   LLVM::Value FuncIndex = stackPop();
   const auto &FuncType = Context.CompositeTypes[FuncTypeIndex]->getFuncType();
-  auto FTy = toLLVMType(Context.LLContext, Context.ExecCtxPtrTy, FuncType);
+  auto FTy = toLLVMType(Context.LLContext, Context.ModCtxPtrTy,
+                        Context.ExecCtxPtrTy, FuncType);
   auto RTy = FTy.getReturnType();
   auto FPtrTy = FTy.getPointerTo();
   auto TableIdx = LLContext.getInt32(TableIndex);
@@ -1463,14 +1466,14 @@ void FunctionCompiler::compileIndirectCallOp(
   {
     Builder.createCondBr(
         Builder.createLikely(Builder.createICmpULT(
-            Idx64, Context.getTableSize(Builder, ExecCtx, TableIndex))),
+            Idx64, Context.getTableSize(Builder, ModCtx, TableIndex))),
         TryFastBB, SlowBB);
     Builder.positionAtEnd(TryFastBB);
 
     auto FuncRef = Builder.createLoad(
         Context.Int64x2Ty,
         Builder.createInBoundsGEP1(
-            Context.Int64x2Ty, Context.getTable(Builder, ExecCtx, TableIndex),
+            Context.Int64x2Ty, Context.getTable(Builder, ModCtx, TableIndex),
             Idx64));
     auto FuncInstInt =
         Builder.createExtractElement(FuncRef, LLContext.getInt64(1));
@@ -1495,10 +1498,9 @@ void FunctionCompiler::compileIndirectCallOp(
     auto Code =
         LoadField(FunctionInstance::getCompiledCodeOffset(), Context.Int8PtrTy);
     auto Hit = Builder.createAnd(
-        Builder.createAnd(
-            Builder.createICmpEQ(DefModule,
-                                 Context.getModuleInst(Builder, ExecCtx)),
-            Builder.createICmpEQ(CalleeTypeIdx, TypeIdx)),
+        Builder.createAnd(Builder.createICmpEQ(DefModule, Context.getModuleInst(
+                                                              Builder, ModCtx)),
+                          Builder.createICmpEQ(CalleeTypeIdx, TypeIdx)),
         Builder.createNot(Builder.createIsNull(Code)));
     Builder.createCondBr(Builder.createLikely(Hit), FastBB, SlowBB);
 
@@ -1596,7 +1598,8 @@ void FunctionCompiler::compileReturnCallOp(
     if (IsImport) {
       Ret = Builder.createCall(Function, Args);
     } else {
-      auto FTy = toLLVMType(LLContext, Context.ExecCtxPtrTy, FuncType);
+      auto FTy = toLLVMType(LLContext, Context.ModCtxPtrTy,
+                            Context.ExecCtxPtrTy, FuncType);
 
       if (Context.LazyJITCacheVars.size() <= FuncIndex) {
         Context.LazyJITCacheVars.resize(Context.Functions.size());
@@ -1669,7 +1672,8 @@ void FunctionCompiler::compileReturnIndirectCallOp(
   LLVM::Value FuncIndex = stackPop();
   auto Idx64 = Builder.createZExt(FuncIndex, Context.Int64Ty);
   const auto &FuncType = Context.CompositeTypes[FuncTypeIndex]->getFuncType();
-  auto FTy = toLLVMType(Context.LLContext, Context.ExecCtxPtrTy, FuncType);
+  auto FTy = toLLVMType(Context.LLContext, Context.ModCtxPtrTy,
+                        Context.ExecCtxPtrTy, FuncType);
   auto RTy = FTy.getReturnType();
 
   const size_t ArgSize = FuncType.getParamTypes().size();
@@ -1756,7 +1760,8 @@ void FunctionCompiler::compileCallRefOp(const unsigned int TypeIndex) noexcept {
   Builder.positionAtEnd(OkBB);
 
   const auto &FuncType = Context.CompositeTypes[TypeIndex]->getFuncType();
-  auto FTy = toLLVMType(Context.LLContext, Context.ExecCtxPtrTy, FuncType);
+  auto FTy = toLLVMType(Context.LLContext, Context.ModCtxPtrTy,
+                        Context.ExecCtxPtrTy, FuncType);
   auto RTy = FTy.getReturnType();
 
   const size_t ArgSize = FuncType.getParamTypes().size();
@@ -1851,7 +1856,8 @@ void FunctionCompiler::compileReturnCallRefOp(
   Builder.positionAtEnd(OkBB);
 
   const auto &FuncType = Context.CompositeTypes[TypeIndex]->getFuncType();
-  auto FTy = toLLVMType(Context.LLContext, Context.ExecCtxPtrTy, FuncType);
+  auto FTy = toLLVMType(Context.LLContext, Context.ModCtxPtrTy,
+                        Context.ExecCtxPtrTy, FuncType);
   auto RTy = FTy.getReturnType();
 
   const size_t ArgSize = FuncType.getParamTypes().size();

--- a/lib/llvm/compiler/function_compiler.cpp
+++ b/lib/llvm/compiler/function_compiler.cpp
@@ -35,8 +35,8 @@ FunctionCompiler::FunctionCompiler(LLVM::Compiler::CompileContext &Context,
       Builder.createStore(LLContext.getInt64(0), LocalGas);
     }
 
-    for (LLVM::Value Arg = F.Fn.getFirstParam().getNextParam(); Arg;
-         Arg = Arg.getNextParam()) {
+    for (LLVM::Value Arg = F.Fn.getFirstParam().getNextParam().getNextParam();
+         Arg; Arg = Arg.getNextParam()) {
       LLVM::Type Ty = Arg.getType();
       LLVM::Value ArgPtr = Builder.createAlloca(Ty);
       Builder.createStore(Arg, ArgPtr);
@@ -1341,11 +1341,12 @@ void FunctionCompiler::compileCallOp(const unsigned int FuncIndex) noexcept {
   const auto &Function = std::get<1>(Context.Functions[FuncIndex]);
   const auto &ParamTypes = FuncType.getParamTypes();
 
-  std::vector<LLVM::Value> Args(ParamTypes.size() + 1);
+  std::vector<LLVM::Value> Args(ParamTypes.size() + 2);
   Args[0] = F.Fn.getFirstParam();
+  Args[1] = F.Fn.getFirstParam().getNextParam();
   for (size_t I = 0; I < ParamTypes.size(); ++I) {
     const size_t J = ParamTypes.size() - 1 - I;
-    Args[J + 1] = stackPop();
+    Args[J + 2] = stackPop();
   }
 
   LLVM::Value Ret;
@@ -1437,10 +1438,11 @@ void FunctionCompiler::compileIndirectCallOp(
 
   const size_t ArgSize = FuncType.getParamTypes().size();
   const size_t RetSize = RTy.isVoidTy() ? 0 : FuncType.getReturnTypes().size();
-  std::vector<LLVM::Value> ArgsVec(ArgSize + 1, nullptr);
+  std::vector<LLVM::Value> ArgsVec(ArgSize + 2, nullptr);
   ArgsVec[0] = F.Fn.getFirstParam();
+  ArgsVec[1] = F.Fn.getFirstParam().getNextParam();
   for (size_t I = 0; I < ArgSize; ++I) {
-    const size_t J = ArgSize - I;
+    const size_t J = ArgSize - I + 1;
     ArgsVec[J] = stackPop();
   }
   auto UnpackRets = [&](LLVM::Value Ret) -> std::vector<LLVM::Value> {
@@ -1536,7 +1538,7 @@ void FunctionCompiler::compileIndirectCallOp(
   {
     LLVM::Value Args = Builder.createArray(ArgSize, LLVM::kValSize);
     LLVM::Value Rets = Builder.createArray(RetSize, LLVM::kValSize);
-    Builder.createArrayPtrStore(Span<LLVM::Value>(ArgsVec.begin() + 1, ArgSize),
+    Builder.createArrayPtrStore(Span<LLVM::Value>(ArgsVec.begin() + 2, ArgSize),
                                 Args, Context.Int8Ty, LLVM::kValSize);
 
     Builder.createCall(
@@ -1580,11 +1582,12 @@ void FunctionCompiler::compileReturnCallOp(
   const auto &Function = std::get<1>(Context.Functions[FuncIndex]);
   const auto &ParamTypes = FuncType.getParamTypes();
 
-  std::vector<LLVM::Value> Args(ParamTypes.size() + 1);
+  std::vector<LLVM::Value> Args(ParamTypes.size() + 2);
   Args[0] = F.Fn.getFirstParam();
+  Args[1] = F.Fn.getFirstParam().getNextParam();
   for (size_t I = 0; I < ParamTypes.size(); ++I) {
     const size_t J = ParamTypes.size() - 1 - I;
-    Args[J + 1] = stackPop();
+    Args[J + 2] = stackPop();
   }
 
   LLVM::Value Ret;
@@ -1671,10 +1674,11 @@ void FunctionCompiler::compileReturnIndirectCallOp(
 
   const size_t ArgSize = FuncType.getParamTypes().size();
   const size_t RetSize = RTy.isVoidTy() ? 0 : FuncType.getReturnTypes().size();
-  std::vector<LLVM::Value> ArgsVec(ArgSize + 1, nullptr);
+  std::vector<LLVM::Value> ArgsVec(ArgSize + 2, nullptr);
   ArgsVec[0] = F.Fn.getFirstParam();
+  ArgsVec[1] = F.Fn.getFirstParam().getNextParam();
   for (size_t I = 0; I < ArgSize; ++I) {
-    const size_t J = ArgSize - I;
+    const size_t J = ArgSize - I + 1;
     ArgsVec[J] = stackPop();
   }
 
@@ -1712,7 +1716,7 @@ void FunctionCompiler::compileReturnIndirectCallOp(
   {
     LLVM::Value Args = Builder.createArray(ArgSize, LLVM::kValSize);
     LLVM::Value Rets = Builder.createArray(RetSize, LLVM::kValSize);
-    Builder.createArrayPtrStore(Span<LLVM::Value>(ArgsVec.begin() + 1, ArgSize),
+    Builder.createArrayPtrStore(Span<LLVM::Value>(ArgsVec.begin() + 2, ArgSize),
                                 Args, Context.Int8Ty, LLVM::kValSize);
 
     Builder.createCall(
@@ -1757,10 +1761,11 @@ void FunctionCompiler::compileCallRefOp(const unsigned int TypeIndex) noexcept {
 
   const size_t ArgSize = FuncType.getParamTypes().size();
   const size_t RetSize = RTy.isVoidTy() ? 0 : FuncType.getReturnTypes().size();
-  std::vector<LLVM::Value> ArgsVec(ArgSize + 1, nullptr);
+  std::vector<LLVM::Value> ArgsVec(ArgSize + 2, nullptr);
   ArgsVec[0] = F.Fn.getFirstParam();
+  ArgsVec[1] = F.Fn.getFirstParam().getNextParam();
   for (size_t I = 0; I < ArgSize; ++I) {
-    const size_t J = ArgSize - I;
+    const size_t J = ArgSize - I + 1;
     ArgsVec[J] = stackPop();
   }
 
@@ -1797,7 +1802,7 @@ void FunctionCompiler::compileCallRefOp(const unsigned int TypeIndex) noexcept {
   {
     LLVM::Value Args = Builder.createArray(ArgSize, LLVM::kValSize);
     LLVM::Value Rets = Builder.createArray(RetSize, LLVM::kValSize);
-    Builder.createArrayPtrStore(Span<LLVM::Value>(ArgsVec.begin() + 1, ArgSize),
+    Builder.createArrayPtrStore(Span<LLVM::Value>(ArgsVec.begin() + 2, ArgSize),
                                 Args, Context.Int8Ty, LLVM::kValSize);
 
     Builder.createCall(
@@ -1851,10 +1856,11 @@ void FunctionCompiler::compileReturnCallRefOp(
 
   const size_t ArgSize = FuncType.getParamTypes().size();
   const size_t RetSize = RTy.isVoidTy() ? 0 : FuncType.getReturnTypes().size();
-  std::vector<LLVM::Value> ArgsVec(ArgSize + 1, nullptr);
+  std::vector<LLVM::Value> ArgsVec(ArgSize + 2, nullptr);
   ArgsVec[0] = F.Fn.getFirstParam();
+  ArgsVec[1] = F.Fn.getFirstParam().getNextParam();
   for (size_t I = 0; I < ArgSize; ++I) {
-    const size_t J = ArgSize - I;
+    const size_t J = ArgSize - I + 1;
     ArgsVec[J] = stackPop();
   }
 
@@ -1890,7 +1896,7 @@ void FunctionCompiler::compileReturnCallRefOp(
   {
     LLVM::Value Args = Builder.createArray(ArgSize, LLVM::kValSize);
     LLVM::Value Rets = Builder.createArray(RetSize, LLVM::kValSize);
-    Builder.createArrayPtrStore(Span<LLVM::Value>(ArgsVec.begin() + 1, ArgSize),
+    Builder.createArrayPtrStore(Span<LLVM::Value>(ArgsVec.begin() + 2, ArgSize),
                                 Args, Context.Int8Ty, LLVM::kValSize);
 
     Builder.createCall(

--- a/lib/llvm/compiler/function_compiler.cpp
+++ b/lib/llvm/compiler/function_compiler.cpp
@@ -320,10 +320,11 @@ Expect<void> FunctionCompiler::compile(AST::InstrView Instrs) noexcept {
       auto IsRefTest = Builder.createCall(
           Context.getIntrinsic(
               Builder, Executable::Intrinsics::kRefTest,
-              LLVM::Type::getFunctionType(Context.Int32Ty,
-                                          {Context.Int64x2Ty, Context.Int64Ty},
-                                          false)),
-          {Ref, VType});
+              LLVM::Type::getFunctionType(
+                  Context.Int32Ty,
+                  {Context.Int8PtrTy, Context.Int64x2Ty, Context.Int64Ty},
+                  false)),
+          {Context.getModuleInst(Builder, ModCtx), Ref, VType});
       auto Cond = (Instr.getOpCode() == OpCode::Br_on_cast)
                       ? Builder.createICmpNE(IsRefTest, LLContext.getInt32(0))
                       : Builder.createICmpEQ(IsRefTest, LLContext.getInt32(0));
@@ -482,20 +483,23 @@ Expect<void> FunctionCompiler::compile(AST::InstrView Instrs) noexcept {
           Context.getIntrinsic(
               Builder, Executable::Intrinsics::kTableInit,
               LLVM::Type::getFunctionType(Context.VoidTy,
-                                          {Context.Int32Ty, Context.Int32Ty,
-                                           Context.Int64Ty, Context.Int32Ty,
-                                           Context.Int32Ty},
+                                          {Context.Int8PtrTy, Context.Int32Ty,
+                                           Context.Int32Ty, Context.Int64Ty,
+                                           Context.Int32Ty, Context.Int32Ty},
                                           false)),
-          {LLContext.getInt32(Instr.getTargetIndex()),
+          {Context.getModuleInst(Builder, ModCtx),
+           LLContext.getInt32(Instr.getTargetIndex()),
            LLContext.getInt32(Instr.getSourceIndex()), Dst, Src, Len});
       break;
     }
     case OpCode::Elem__drop: {
       Builder.createCall(
-          Context.getIntrinsic(Builder, Executable::Intrinsics::kElemDrop,
-                               LLVM::Type::getFunctionType(
-                                   Context.VoidTy, {Context.Int32Ty}, false)),
-          {LLContext.getInt32(Instr.getTargetIndex())});
+          Context.getIntrinsic(
+              Builder, Executable::Intrinsics::kElemDrop,
+              LLVM::Type::getFunctionType(
+                  Context.VoidTy, {Context.Int8PtrTy, Context.Int32Ty}, false)),
+          {Context.getModuleInst(Builder, ModCtx),
+           LLContext.getInt32(Instr.getTargetIndex())});
       break;
     }
     case OpCode::Table__copy: {
@@ -506,11 +510,12 @@ Expect<void> FunctionCompiler::compile(AST::InstrView Instrs) noexcept {
           Context.getIntrinsic(
               Builder, Executable::Intrinsics::kTableCopy,
               LLVM::Type::getFunctionType(Context.VoidTy,
-                                          {Context.Int32Ty, Context.Int32Ty,
-                                           Context.Int64Ty, Context.Int64Ty,
-                                           Context.Int64Ty},
+                                          {Context.Int8PtrTy, Context.Int32Ty,
+                                           Context.Int32Ty, Context.Int64Ty,
+                                           Context.Int64Ty, Context.Int64Ty},
                                           false)),
-          {LLContext.getInt32(Instr.getTargetIndex()),
+          {Context.getModuleInst(Builder, ModCtx),
+           LLContext.getInt32(Instr.getTargetIndex()),
            LLContext.getInt32(Instr.getSourceIndex()), Dst, Src, Len});
       break;
     }
@@ -519,13 +524,14 @@ Expect<void> FunctionCompiler::compile(AST::InstrView Instrs) noexcept {
       auto Val = stackPop();
       stackPush(Builder.createTrunc(
           Builder.createCall(
-              Context.getIntrinsic(
-                  Builder, Executable::Intrinsics::kTableGrow,
-                  LLVM::Type::getFunctionType(
-                      Context.Int64Ty,
-                      {Context.Int32Ty, Context.Int64x2Ty, Context.Int64Ty},
-                      false)),
-              {LLContext.getInt32(Instr.getTargetIndex()), Val, NewSize}),
+              Context.getIntrinsic(Builder, Executable::Intrinsics::kTableGrow,
+                                   LLVM::Type::getFunctionType(
+                                       Context.Int64Ty,
+                                       {Context.Int8PtrTy, Context.Int32Ty,
+                                        Context.Int64x2Ty, Context.Int64Ty},
+                                       false)),
+              {Context.getModuleInst(Builder, ModCtx),
+               LLContext.getInt32(Instr.getTargetIndex()), Val, NewSize}),
           Context.TableAddrTypes[Instr.getTargetIndex()]));
       break;
     }
@@ -543,10 +549,12 @@ Expect<void> FunctionCompiler::compile(AST::InstrView Instrs) noexcept {
           Context.getIntrinsic(
               Builder, Executable::Intrinsics::kTableFill,
               LLVM::Type::getFunctionType(Context.Int32Ty,
-                                          {Context.Int32Ty, Context.Int64Ty,
-                                           Context.Int64x2Ty, Context.Int64Ty},
+                                          {Context.Int8PtrTy, Context.Int32Ty,
+                                           Context.Int64Ty, Context.Int64x2Ty,
+                                           Context.Int64Ty},
                                           false)),
-          {LLContext.getInt32(Instr.getTargetIndex()), Off, Val, Len});
+          {Context.getModuleInst(Builder, ModCtx),
+           LLContext.getInt32(Instr.getTargetIndex()), Off, Val, Len});
       break;
     }
 
@@ -1250,11 +1258,12 @@ void FunctionCompiler::compileTryTableOp(
       Builder.createCall(
           Context.getIntrinsic(
               Builder, Executable::Intrinsics::kCatchPop,
-              LLVM::Type::getFunctionType(
-                  Context.VoidTy,
-                  {Context.Int8PtrTy, Context.Int32Ty, Context.Int32Ty},
-                  false)),
-          {Out, LLContext.getInt32(C->IsAll ? 0 : 1),
+              LLVM::Type::getFunctionType(Context.VoidTy,
+                                          {Context.Int8PtrTy, Context.Int8PtrTy,
+                                           Context.Int32Ty, Context.Int32Ty},
+                                          false)),
+          {Context.getModuleInst(Builder, ModCtx), Out,
+           LLContext.getInt32(C->IsAll ? 0 : 1),
            LLContext.getInt32(C->IsRef ? 1 : 0)});
 
       uint32_t OutIdx = 0;
@@ -1303,10 +1312,12 @@ void FunctionCompiler::compileThrowOp(const uint32_t TagIndex) noexcept {
   Builder.createCall(
       Context.getIntrinsic(
           Builder, Executable::Intrinsics::kThrow,
-          LLVM::Type::getFunctionType(
-              Context.VoidTy,
-              {Context.Int32Ty, Context.Int8PtrTy, Context.Int32Ty}, false)),
-      {LLContext.getInt32(TagIndex), Vals, LLContext.getInt32(Arity)});
+          LLVM::Type::getFunctionType(Context.VoidTy,
+                                      {Context.Int8PtrTy, Context.Int32Ty,
+                                       Context.Int8PtrTy, Context.Int32Ty},
+                                      false)),
+      {Context.getModuleInst(Builder, ModCtx), LLContext.getInt32(TagIndex),
+       Vals, LLContext.getInt32(Arity)});
 
   Builder.createBr(getEHDispatchTarget());
   setUnreachable();
@@ -1387,9 +1398,11 @@ void FunctionCompiler::compileCallOp(const unsigned int FuncIndex) noexcept {
       auto FPtr = Builder.createCall(
           Context.getIntrinsic(
               Builder, Executable::Intrinsics::kFuncGetFuncSymbol,
-              LLVM::Type::getFunctionType(FTy.getPointerTo(), {Context.Int32Ty},
+              LLVM::Type::getFunctionType(FTy.getPointerTo(),
+                                          {Context.Int8PtrTy, Context.Int32Ty},
                                           false)),
-          {LLContext.getInt32(FuncIndex)});
+          {Context.getModuleInst(Builder, ModCtx),
+           LLContext.getInt32(FuncIndex)});
       auto Store = Builder.createStore(FPtr, CacheVar);
       Store.setAlignment(8);
       Store.setOrdering(LLVMAtomicOrderingRelease);
@@ -1547,11 +1560,12 @@ void FunctionCompiler::compileIndirectCallOp(
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kCallIndirect,
             LLVM::Type::getFunctionType(Context.VoidTy,
-                                        {Context.Int32Ty, Context.Int32Ty,
-                                         Context.Int64Ty, Context.Int8PtrTy,
-                                         Context.Int8PtrTy},
+                                        {Context.Int8PtrTy, Context.Int32Ty,
+                                         Context.Int32Ty, Context.Int64Ty,
+                                         Context.Int8PtrTy, Context.Int8PtrTy},
                                         false)),
-        {TableIdx, TypeIdx, Idx64, Args, Rets});
+        {Context.getModuleInst(Builder, ModCtx), TableIdx, TypeIdx, Idx64, Args,
+         Rets});
 
     if (RetSize == 0) {
       // nothing to do
@@ -1629,9 +1643,11 @@ void FunctionCompiler::compileReturnCallOp(
       auto FPtr = Builder.createCall(
           Context.getIntrinsic(
               Builder, Executable::Intrinsics::kFuncGetFuncSymbol,
-              LLVM::Type::getFunctionType(FTy.getPointerTo(), {Context.Int32Ty},
+              LLVM::Type::getFunctionType(FTy.getPointerTo(),
+                                          {Context.Int8PtrTy, Context.Int32Ty},
                                           false)),
-          {LLContext.getInt32(FuncIndex)});
+          {Context.getModuleInst(Builder, ModCtx),
+           LLContext.getInt32(FuncIndex)});
       auto Store = Builder.createStore(FPtr, CacheVar);
       Store.setAlignment(8);
       Store.setOrdering(LLVMAtomicOrderingRelease);
@@ -1727,12 +1743,12 @@ void FunctionCompiler::compileReturnIndirectCallOp(
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kCallIndirect,
             LLVM::Type::getFunctionType(Context.VoidTy,
-                                        {Context.Int32Ty, Context.Int32Ty,
-                                         Context.Int64Ty, Context.Int8PtrTy,
-                                         Context.Int8PtrTy},
+                                        {Context.Int8PtrTy, Context.Int32Ty,
+                                         Context.Int32Ty, Context.Int64Ty,
+                                         Context.Int8PtrTy, Context.Int8PtrTy},
                                         false)),
-        {LLContext.getInt32(TableIndex), LLContext.getInt32(FuncTypeIndex),
-         Idx64, Args, Rets});
+        {Context.getModuleInst(Builder, ModCtx), LLContext.getInt32(TableIndex),
+         LLContext.getInt32(FuncTypeIndex), Idx64, Args, Rets});
 
     if (RetSize == 0) {
       Builder.createRetVoid();
@@ -1813,11 +1829,11 @@ void FunctionCompiler::compileCallRefOp(const unsigned int TypeIndex) noexcept {
     Builder.createCall(
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kCallRef,
-            LLVM::Type::getFunctionType(
-                Context.VoidTy,
-                {Context.Int64x2Ty, Context.Int8PtrTy, Context.Int8PtrTy},
-                false)),
-        {Ref, Args, Rets});
+            LLVM::Type::getFunctionType(Context.VoidTy,
+                                        {Context.Int8PtrTy, Context.Int64x2Ty,
+                                         Context.Int8PtrTy, Context.Int8PtrTy},
+                                        false)),
+        {Context.getModuleInst(Builder, ModCtx), Ref, Args, Rets});
 
     if (RetSize == 0) {
       // nothing to do
@@ -1908,11 +1924,11 @@ void FunctionCompiler::compileReturnCallRefOp(
     Builder.createCall(
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kCallRef,
-            LLVM::Type::getFunctionType(
-                Context.VoidTy,
-                {Context.Int64x2Ty, Context.Int8PtrTy, Context.Int8PtrTy},
-                false)),
-        {Ref, Args, Rets});
+            LLVM::Type::getFunctionType(Context.VoidTy,
+                                        {Context.Int8PtrTy, Context.Int64x2Ty,
+                                         Context.Int8PtrTy, Context.Int8PtrTy},
+                                        false)),
+        {Context.getModuleInst(Builder, ModCtx), Ref, Args, Rets});
 
     if (RetSize == 0) {
       Builder.createRetVoid();

--- a/lib/llvm/compiler/function_compiler.h
+++ b/lib/llvm/compiler/function_compiler.h
@@ -249,6 +249,10 @@ private:
   std::vector<LLVM::Value> Stack;
   LLVM::Value LocalInstrCount = nullptr;
   LLVM::Value LocalGas = nullptr;
+  // Entry-block slot reused by every call that resolves its callee at runtime.
+  // Only entry-block allocas become static frame slots; one inside a loop body
+  // grows the native stack on every iteration.
+  LLVM::Value CalleeCtxSlot = nullptr;
   std::unordered_map<ErrCode::Value, LLVM::BasicBlock> TrapBB;
   bool IsUnreachable = false;
   bool Interruptible = false;

--- a/lib/llvm/compiler/function_compiler.h
+++ b/lib/llvm/compiler/function_compiler.h
@@ -279,6 +279,7 @@ private:
   bool IsLazyJIT;
   std::vector<Control> ControlStack;
   LLVM::FunctionCallee F;
+  LLVM::Value ModCtx;
   LLVM::Value ExecCtx;
   LLVM::BasicBlock UnwindBB;
   LLVM::Builder Builder;

--- a/lib/llvm/compiler/memoryInstr.cpp
+++ b/lib/llvm/compiler/memoryInstr.cpp
@@ -117,10 +117,12 @@ FunctionCompiler::compileMemoryOp(const AST::Instruction &Instr) noexcept {
         Builder.createCall(
             Context.getIntrinsic(
                 Builder, Executable::Intrinsics::kMemGrow,
-                LLVM::Type::getFunctionType(Context.Int64Ty,
-                                            {Context.Int32Ty, Context.Int64Ty},
-                                            false)),
-            {LLContext.getInt32(Instr.getTargetIndex()), NewPageSize}),
+                LLVM::Type::getFunctionType(
+                    Context.Int64Ty,
+                    {Context.Int8PtrTy, Context.Int32Ty, Context.Int64Ty},
+                    false)),
+            {Context.getModuleInst(Builder, ModCtx),
+             LLContext.getInt32(Instr.getTargetIndex()), NewPageSize}),
         Context.MemoryAddrTypes[Instr.getTargetIndex()]));
     break;
   }
@@ -132,20 +134,23 @@ FunctionCompiler::compileMemoryOp(const AST::Instruction &Instr) noexcept {
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kMemInit,
             LLVM::Type::getFunctionType(Context.VoidTy,
-                                        {Context.Int32Ty, Context.Int32Ty,
-                                         Context.Int64Ty, Context.Int32Ty,
-                                         Context.Int32Ty},
+                                        {Context.Int8PtrTy, Context.Int32Ty,
+                                         Context.Int32Ty, Context.Int64Ty,
+                                         Context.Int32Ty, Context.Int32Ty},
                                         false)),
-        {LLContext.getInt32(Instr.getTargetIndex()),
+        {Context.getModuleInst(Builder, ModCtx),
+         LLContext.getInt32(Instr.getTargetIndex()),
          LLContext.getInt32(Instr.getSourceIndex()), Dst, Src, Len});
     break;
   }
   case OpCode::Data__drop: {
     Builder.createCall(
-        Context.getIntrinsic(Builder, Executable::Intrinsics::kDataDrop,
-                             LLVM::Type::getFunctionType(
-                                 Context.VoidTy, {Context.Int32Ty}, false)),
-        {LLContext.getInt32(Instr.getTargetIndex())});
+        Context.getIntrinsic(
+            Builder, Executable::Intrinsics::kDataDrop,
+            LLVM::Type::getFunctionType(
+                Context.VoidTy, {Context.Int8PtrTy, Context.Int32Ty}, false)),
+        {Context.getModuleInst(Builder, ModCtx),
+         LLContext.getInt32(Instr.getTargetIndex())});
     break;
   }
   case OpCode::Memory__copy: {
@@ -156,11 +161,12 @@ FunctionCompiler::compileMemoryOp(const AST::Instruction &Instr) noexcept {
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kMemCopy,
             LLVM::Type::getFunctionType(Context.VoidTy,
-                                        {Context.Int32Ty, Context.Int32Ty,
-                                         Context.Int64Ty, Context.Int64Ty,
-                                         Context.Int64Ty},
+                                        {Context.Int8PtrTy, Context.Int32Ty,
+                                         Context.Int32Ty, Context.Int64Ty,
+                                         Context.Int64Ty, Context.Int64Ty},
                                         false)),
-        {LLContext.getInt32(Instr.getTargetIndex()),
+        {Context.getModuleInst(Builder, ModCtx),
+         LLContext.getInt32(Instr.getTargetIndex()),
          LLContext.getInt32(Instr.getSourceIndex()), Dst, Src, Len});
     break;
   }
@@ -172,10 +178,12 @@ FunctionCompiler::compileMemoryOp(const AST::Instruction &Instr) noexcept {
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kMemFill,
             LLVM::Type::getFunctionType(Context.VoidTy,
-                                        {Context.Int32Ty, Context.Int64Ty,
-                                         Context.Int8Ty, Context.Int64Ty},
+                                        {Context.Int8PtrTy, Context.Int32Ty,
+                                         Context.Int64Ty, Context.Int8Ty,
+                                         Context.Int64Ty},
                                         false)),
-        {LLContext.getInt32(Instr.getTargetIndex()), Off, Val, Len});
+        {Context.getModuleInst(Builder, ModCtx),
+         LLContext.getInt32(Instr.getTargetIndex()), Off, Val, Len});
     break;
   }
 

--- a/lib/llvm/compiler/memoryInstr.cpp
+++ b/lib/llvm/compiler/memoryInstr.cpp
@@ -108,7 +108,7 @@ FunctionCompiler::compileMemoryOp(const AST::Instruction &Instr) noexcept {
     break;
   case OpCode::Memory__size:
     stackPush(Builder.createTrunc(
-        Context.getMemorySize(Builder, ExecCtx, Instr.getTargetIndex()),
+        Context.getMemorySize(Builder, ModCtx, Instr.getTargetIndex()),
         Context.MemoryAddrTypes[Instr.getTargetIndex()]));
     break;
   case OpCode::Memory__grow: {
@@ -243,7 +243,7 @@ void FunctionCompiler::compileLoadOp(unsigned MemoryIndex, uint64_t Offset,
   }
 
   auto VPtr = Builder.createInBoundsGEP1(
-      Context.Int8Ty, Context.getMemory(Builder, ExecCtx, MemoryIndex), Off);
+      Context.Int8Ty, Context.getMemory(Builder, ModCtx, MemoryIndex), Off);
   auto Ptr = Builder.createBitCast(VPtr, LoadTy.getPointerTo());
   auto LoadInst = Builder.createLoad(LoadTy, Ptr, true);
   LoadInst.setAlignment(1 << Alignment);
@@ -284,7 +284,7 @@ void FunctionCompiler::compileStoreOp(uint32_t MemoryIndex, uint64_t Offset,
   }
   V = switchEndian(V);
   auto VPtr = Builder.createInBoundsGEP1(
-      Context.Int8Ty, Context.getMemory(Builder, ExecCtx, MemoryIndex), Off);
+      Context.Int8Ty, Context.getMemory(Builder, ModCtx, MemoryIndex), Off);
   auto Ptr = Builder.createBitCast(VPtr, LoadTy.getPointerTo());
   auto StoreInst = Builder.createStore(V, Ptr, true);
   StoreInst.setAlignment(1 << Alignment);

--- a/lib/llvm/compiler/refInstr.cpp
+++ b/lib/llvm/compiler/refInstr.cpp
@@ -70,8 +70,10 @@ FunctionCompiler::compileRefOp(const AST::Instruction &Instr) noexcept {
     stackPush(Builder.createCall(
         Context.getIntrinsic(Builder, Executable::Intrinsics::kRefFunc,
                              LLVM::Type::getFunctionType(
-                                 Context.Int64x2Ty, {Context.Int32Ty}, false)),
-        {LLContext.getInt32(Instr.getTargetIndex())}));
+                                 Context.Int64x2Ty,
+                                 {Context.Int8PtrTy, Context.Int32Ty}, false)),
+        {Context.getModuleInst(Builder, ModCtx),
+         LLContext.getInt32(Instr.getTargetIndex())}));
     break;
   case OpCode::Ref__eq: {
     LLVM::Value RHS = stackPop();
@@ -117,10 +119,12 @@ FunctionCompiler::compileRefOp(const AST::Instruction &Instr) noexcept {
     stackPush(Builder.createCall(
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kStructNew,
-            LLVM::Type::getFunctionType(
-                Context.Int64x2Ty,
-                {Context.Int32Ty, Context.Int8PtrTy, Context.Int32Ty}, false)),
-        {LLContext.getInt32(Instr.getTargetIndex()), Args,
+            LLVM::Type::getFunctionType(Context.Int64x2Ty,
+                                        {Context.Int8PtrTy, Context.Int32Ty,
+                                         Context.Int8PtrTy, Context.Int32Ty},
+                                        false)),
+        {Context.getModuleInst(Builder, ModCtx),
+         LLContext.getInt32(Instr.getTargetIndex()), Args,
          LLContext.getInt32(static_cast<uint32_t>(ArgSize))}));
     break;
   }
@@ -144,11 +148,12 @@ FunctionCompiler::compileRefOp(const AST::Instruction &Instr) noexcept {
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kStructGet,
             LLVM::Type::getFunctionType(Context.VoidTy,
-                                        {Context.Int64x2Ty, Context.Int32Ty,
-                                         Context.Int32Ty, Context.Int8Ty,
-                                         Context.Int8PtrTy},
+                                        {Context.Int8PtrTy, Context.Int64x2Ty,
+                                         Context.Int32Ty, Context.Int32Ty,
+                                         Context.Int8Ty, Context.Int8PtrTy},
                                         false)),
-        {Ref, LLContext.getInt32(Instr.getTargetIndex()),
+        {Context.getModuleInst(Builder, ModCtx), Ref,
+         LLContext.getInt32(Instr.getTargetIndex()),
          LLContext.getInt32(Instr.getSourceIndex()), IsSigned, Ret});
 
     switch (StorageType.getCode()) {
@@ -195,10 +200,12 @@ FunctionCompiler::compileRefOp(const AST::Instruction &Instr) noexcept {
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kStructSet,
             LLVM::Type::getFunctionType(Context.VoidTy,
-                                        {Context.Int64x2Ty, Context.Int32Ty,
-                                         Context.Int32Ty, Context.Int8PtrTy},
+                                        {Context.Int8PtrTy, Context.Int64x2Ty,
+                                         Context.Int32Ty, Context.Int32Ty,
+                                         Context.Int8PtrTy},
                                         false)),
-        {Ref, LLContext.getInt32(Instr.getTargetIndex()),
+        {Context.getModuleInst(Builder, ModCtx), Ref,
+         LLContext.getInt32(Instr.getTargetIndex()),
          LLContext.getInt32(Instr.getSourceIndex()), Arg});
     break;
   }
@@ -211,10 +218,12 @@ FunctionCompiler::compileRefOp(const AST::Instruction &Instr) noexcept {
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kArrayNew,
             LLVM::Type::getFunctionType(Context.Int64x2Ty,
-                                        {Context.Int32Ty, Context.Int32Ty,
-                                         Context.Int8PtrTy, Context.Int32Ty},
+                                        {Context.Int8PtrTy, Context.Int32Ty,
+                                         Context.Int32Ty, Context.Int8PtrTy,
+                                         Context.Int32Ty},
                                         false)),
-        {LLContext.getInt32(Instr.getTargetIndex()), Length, Arg,
+        {Context.getModuleInst(Builder, ModCtx),
+         LLContext.getInt32(Instr.getTargetIndex()), Length, Arg,
          LLContext.getInt32(1)}));
     break;
   }
@@ -225,10 +234,12 @@ FunctionCompiler::compileRefOp(const AST::Instruction &Instr) noexcept {
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kArrayNew,
             LLVM::Type::getFunctionType(Context.Int64x2Ty,
-                                        {Context.Int32Ty, Context.Int32Ty,
-                                         Context.Int8PtrTy, Context.Int32Ty},
+                                        {Context.Int8PtrTy, Context.Int32Ty,
+                                         Context.Int32Ty, Context.Int8PtrTy,
+                                         Context.Int32Ty},
                                         false)),
-        {LLContext.getInt32(Instr.getTargetIndex()), Length, Arg,
+        {Context.getModuleInst(Builder, ModCtx),
+         LLContext.getInt32(Instr.getTargetIndex()), Length, Arg,
          LLContext.getInt32(0)}));
     break;
   }
@@ -244,10 +255,12 @@ FunctionCompiler::compileRefOp(const AST::Instruction &Instr) noexcept {
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kArrayNew,
             LLVM::Type::getFunctionType(Context.Int64x2Ty,
-                                        {Context.Int32Ty, Context.Int32Ty,
-                                         Context.Int8PtrTy, Context.Int32Ty},
+                                        {Context.Int8PtrTy, Context.Int32Ty,
+                                         Context.Int32Ty, Context.Int8PtrTy,
+                                         Context.Int32Ty},
                                         false)),
-        {LLContext.getInt32(Instr.getTargetIndex()),
+        {Context.getModuleInst(Builder, ModCtx),
+         LLContext.getInt32(Instr.getTargetIndex()),
          LLContext.getInt32(ArgSize), Args, LLContext.getInt32(ArgSize)}));
     break;
   }
@@ -262,10 +275,12 @@ FunctionCompiler::compileRefOp(const AST::Instruction &Instr) noexcept {
                  ? Executable::Intrinsics::kArrayNewData
                  : Executable::Intrinsics::kArrayNewElem),
             LLVM::Type::getFunctionType(Context.Int64x2Ty,
-                                        {Context.Int32Ty, Context.Int32Ty,
-                                         Context.Int32Ty, Context.Int32Ty},
+                                        {Context.Int8PtrTy, Context.Int32Ty,
+                                         Context.Int32Ty, Context.Int32Ty,
+                                         Context.Int32Ty},
                                         false)),
-        {LLContext.getInt32(Instr.getTargetIndex()),
+        {Context.getModuleInst(Builder, ModCtx),
+         LLContext.getInt32(Instr.getTargetIndex()),
          LLContext.getInt32(Instr.getSourceIndex()), Start, Length}));
     break;
   }
@@ -288,11 +303,12 @@ FunctionCompiler::compileRefOp(const AST::Instruction &Instr) noexcept {
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kArrayGet,
             LLVM::Type::getFunctionType(Context.VoidTy,
-                                        {Context.Int64x2Ty, Context.Int32Ty,
-                                         Context.Int32Ty, Context.Int8Ty,
-                                         Context.Int8PtrTy},
+                                        {Context.Int8PtrTy, Context.Int64x2Ty,
+                                         Context.Int32Ty, Context.Int32Ty,
+                                         Context.Int8Ty, Context.Int8PtrTy},
                                         false)),
-        {Ref, LLContext.getInt32(Instr.getTargetIndex()), Idx, IsSigned, Ret});
+        {Context.getModuleInst(Builder, ModCtx), Ref,
+         LLContext.getInt32(Instr.getTargetIndex()), Idx, IsSigned, Ret});
 
     switch (StorageType.getCode()) {
     case TypeCode::I8:
@@ -339,10 +355,12 @@ FunctionCompiler::compileRefOp(const AST::Instruction &Instr) noexcept {
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kArraySet,
             LLVM::Type::getFunctionType(Context.VoidTy,
-                                        {Context.Int64x2Ty, Context.Int32Ty,
-                                         Context.Int32Ty, Context.Int8PtrTy},
+                                        {Context.Int8PtrTy, Context.Int64x2Ty,
+                                         Context.Int32Ty, Context.Int32Ty,
+                                         Context.Int8PtrTy},
                                         false)),
-        {Ref, LLContext.getInt32(Instr.getTargetIndex()), Idx, Arg});
+        {Context.getModuleInst(Builder, ModCtx), Ref,
+         LLContext.getInt32(Instr.getTargetIndex()), Idx, Arg});
     break;
   }
   case OpCode::Array__len: {
@@ -365,11 +383,12 @@ FunctionCompiler::compileRefOp(const AST::Instruction &Instr) noexcept {
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kArrayFill,
             LLVM::Type::getFunctionType(Context.VoidTy,
-                                        {Context.Int64x2Ty, Context.Int32Ty,
+                                        {Context.Int8PtrTy, Context.Int64x2Ty,
                                          Context.Int32Ty, Context.Int32Ty,
-                                         Context.Int8PtrTy},
+                                         Context.Int32Ty, Context.Int8PtrTy},
                                         false)),
-        {Ref, LLContext.getInt32(Instr.getTargetIndex()), Off, Cnt, Arg});
+        {Context.getModuleInst(Builder, ModCtx), Ref,
+         LLContext.getInt32(Instr.getTargetIndex()), Off, Cnt, Arg});
     break;
   }
   case OpCode::Array__copy: {
@@ -382,12 +401,13 @@ FunctionCompiler::compileRefOp(const AST::Instruction &Instr) noexcept {
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kArrayCopy,
             LLVM::Type::getFunctionType(Context.VoidTy,
-                                        {Context.Int64x2Ty, Context.Int32Ty,
-                                         Context.Int32Ty, Context.Int64x2Ty,
+                                        {Context.Int8PtrTy, Context.Int64x2Ty,
                                          Context.Int32Ty, Context.Int32Ty,
-                                         Context.Int32Ty},
+                                         Context.Int64x2Ty, Context.Int32Ty,
+                                         Context.Int32Ty, Context.Int32Ty},
                                         false)),
-        {DstRef, LLContext.getInt32(Instr.getTargetIndex()), DstOff, SrcRef,
+        {Context.getModuleInst(Builder, ModCtx), DstRef,
+         LLContext.getInt32(Instr.getTargetIndex()), DstOff, SrcRef,
          LLContext.getInt32(Instr.getSourceIndex()), SrcOff, Cnt});
     break;
   }
@@ -404,11 +424,13 @@ FunctionCompiler::compileRefOp(const AST::Instruction &Instr) noexcept {
                  ? Executable::Intrinsics::kArrayInitData
                  : Executable::Intrinsics::kArrayInitElem),
             LLVM::Type::getFunctionType(Context.VoidTy,
-                                        {Context.Int64x2Ty, Context.Int32Ty,
+                                        {Context.Int8PtrTy, Context.Int64x2Ty,
                                          Context.Int32Ty, Context.Int32Ty,
-                                         Context.Int32Ty, Context.Int32Ty},
+                                         Context.Int32Ty, Context.Int32Ty,
+                                         Context.Int32Ty},
                                         false)),
-        {Ref, LLContext.getInt32(Instr.getTargetIndex()),
+        {Context.getModuleInst(Builder, ModCtx), Ref,
+         LLContext.getInt32(Instr.getTargetIndex()),
          LLContext.getInt32(Instr.getSourceIndex()), DstOff, SrcOff, Cnt});
     break;
   }
@@ -425,8 +447,10 @@ FunctionCompiler::compileRefOp(const AST::Instruction &Instr) noexcept {
         Context.getIntrinsic(
             Builder, Executable::Intrinsics::kRefTest,
             LLVM::Type::getFunctionType(
-                Context.Int32Ty, {Context.Int64x2Ty, Context.Int64Ty}, false)),
-        {Ref, VType}));
+                Context.Int32Ty,
+                {Context.Int8PtrTy, Context.Int64x2Ty, Context.Int64Ty},
+                false)),
+        {Context.getModuleInst(Builder, ModCtx), Ref, VType}));
     break;
   }
   case OpCode::Ref__cast:
@@ -439,11 +463,13 @@ FunctionCompiler::compileRefOp(const AST::Instruction &Instr) noexcept {
                               Context.Int64x2Ty),
         LLContext.getInt64(0));
     stackPush(Builder.createCall(
-        Context.getIntrinsic(Builder, Executable::Intrinsics::kRefCast,
-                             LLVM::Type::getFunctionType(
-                                 Context.Int64x2Ty,
-                                 {Context.Int64x2Ty, Context.Int64Ty}, false)),
-        {Ref, VType}));
+        Context.getIntrinsic(
+            Builder, Executable::Intrinsics::kRefCast,
+            LLVM::Type::getFunctionType(
+                Context.Int64x2Ty,
+                {Context.Int8PtrTy, Context.Int64x2Ty, Context.Int64Ty},
+                false)),
+        {Context.getModuleInst(Builder, ModCtx), Ref, VType}));
     break;
   }
   case OpCode::Any__convert_extern: {

--- a/lib/llvm/compiler/threadInstr.cpp
+++ b/lib/llvm/compiler/threadInstr.cpp
@@ -416,7 +416,7 @@ void FunctionCompiler::compileAtomicLoad(unsigned MemoryIndex,
   }
   compileAtomicCheckOffsetAlignment(Offset, TargetType);
   auto VPtr = Builder.createInBoundsGEP1(
-      Context.Int8Ty, Context.getMemory(Builder, ExecCtx, MemoryIndex), Offset);
+      Context.Int8Ty, Context.getMemory(Builder, ModCtx, MemoryIndex), Offset);
 
   auto Ptr = Builder.createBitCast(VPtr, TargetType.getPointerTo());
   auto Load = switchEndian(Builder.createLoad(TargetType, Ptr, true));
@@ -452,7 +452,7 @@ void FunctionCompiler::compileAtomicStore(unsigned MemoryIndex,
   }
   compileAtomicCheckOffsetAlignment(Offset, TargetType);
   auto VPtr = Builder.createInBoundsGEP1(
-      Context.Int8Ty, Context.getMemory(Builder, ExecCtx, MemoryIndex), Offset);
+      Context.Int8Ty, Context.getMemory(Builder, ModCtx, MemoryIndex), Offset);
   auto Ptr = Builder.createBitCast(VPtr, TargetType.getPointerTo());
   auto Store = Builder.createStore(V, Ptr, true);
   Store.setAlignment(1 << Alignment);
@@ -473,7 +473,7 @@ void FunctionCompiler::compileAtomicRMWOp(
   }
   compileAtomicCheckOffsetAlignment(Offset, TargetType);
   auto VPtr = Builder.createInBoundsGEP1(
-      Context.Int8Ty, Context.getMemory(Builder, ExecCtx, MemoryIndex), Offset);
+      Context.Int8Ty, Context.getMemory(Builder, ModCtx, MemoryIndex), Offset);
   auto Ptr = Builder.createBitCast(VPtr, TargetType.getPointerTo());
 
   LLVM::Value Ret;
@@ -542,7 +542,7 @@ void FunctionCompiler::compileAtomicCompareExchange(
   }
   compileAtomicCheckOffsetAlignment(Offset, TargetType);
   auto VPtr = Builder.createInBoundsGEP1(
-      Context.Int8Ty, Context.getMemory(Builder, ExecCtx, MemoryIndex), Offset);
+      Context.Int8Ty, Context.getMemory(Builder, ModCtx, MemoryIndex), Offset);
   auto Ptr = Builder.createBitCast(VPtr, TargetType.getPointerTo());
 
   auto Ret = Builder.createAtomicCmpXchg(

--- a/lib/llvm/compiler/threadInstr.cpp
+++ b/lib/llvm/compiler/threadInstr.cpp
@@ -369,10 +369,12 @@ void FunctionCompiler::compileAtomicNotify(unsigned MemoryIndex,
       Builder.createCall(
           Context.getIntrinsic(
               Builder, Executable::Intrinsics::kMemAtomicNotify,
-              LLVM::Type::getFunctionType(
-                  Context.Int64Ty,
-                  {Context.Int32Ty, Context.Int64Ty, Context.Int64Ty}, false)),
-          {LLContext.getInt32(MemoryIndex), Offset, Count}),
+              LLVM::Type::getFunctionType(Context.Int64Ty,
+                                          {Context.Int8PtrTy, Context.Int32Ty,
+                                           Context.Int64Ty, Context.Int64Ty},
+                                          false)),
+          {Context.getModuleInst(Builder, ModCtx),
+           LLContext.getInt32(MemoryIndex), Offset, Count}),
       Context.MemoryAddrTypes[MemoryIndex]));
 }
 
@@ -392,11 +394,12 @@ void FunctionCompiler::compileAtomicWait(unsigned MemoryIndex,
           Context.getIntrinsic(
               Builder, Executable::Intrinsics::kMemAtomicWait,
               LLVM::Type::getFunctionType(Context.Int64Ty,
-                                          {Context.Int32Ty, Context.Int64Ty,
+                                          {Context.Int8PtrTy, Context.Int32Ty,
                                            Context.Int64Ty, Context.Int64Ty,
-                                           Context.Int32Ty},
+                                           Context.Int64Ty, Context.Int32Ty},
                                           false)),
-          {LLContext.getInt32(MemoryIndex), Offset, ExpectedValue, Timeout,
+          {Context.getModuleInst(Builder, ModCtx),
+           LLContext.getInt32(MemoryIndex), Offset, ExpectedValue, Timeout,
            LLContext.getInt32(BitWidth)}),
       Context.MemoryAddrTypes[MemoryIndex]));
 }

--- a/lib/llvm/compiler/vectorInstr.cpp
+++ b/lib/llvm/compiler/vectorInstr.cpp
@@ -1764,8 +1764,8 @@ void FunctionCompiler::compileVectorVectorQ15MulSat() noexcept {
 #if defined(__aarch64__)
         if (Context.SupportNEON) {
           assuming(LLVM::Core::AArch64NeonSQRDMulH != LLVM::Core::NotIntrinsic);
-          return Builder.createBinaryIntrinsic(LLVM::Core::AArch64NeonSQRDMulH,
-                                               LHS, RHS);
+          return Builder.createIntrinsic(LLVM::Core::AArch64NeonSQRDMulH,
+                                         {Context.Int16x8Ty}, {LHS, RHS});
         }
 #endif
 
@@ -1848,8 +1848,8 @@ void FunctionCompiler::compileVectorVectorUAvgr(LLVM::Type VectorTy) noexcept {
 #if defined(__aarch64__)
         if (Context.SupportNEON) {
           assuming(LLVM::Core::AArch64NeonURHAdd != LLVM::Core::NotIntrinsic);
-          return Builder.createBinaryIntrinsic(LLVM::Core::AArch64NeonURHAdd,
-                                               LHS, RHS);
+          return Builder.createIntrinsic(LLVM::Core::AArch64NeonURHAdd,
+                                         {VectorTy}, {LHS, RHS});
         }
 #endif
 

--- a/lib/llvm/llvm.h
+++ b/lib/llvm/llvm.h
@@ -809,6 +809,10 @@ public:
   inline void setMetadata(Context &C, unsigned int KindID,
                           Metadata Node) noexcept;
   inline void setMustTailCall() noexcept;
+  inline void setTailCall() noexcept;
+  Type getInstructionCalledFunctionType() const noexcept {
+    return LLVMGetCalledFunctionType(Ref);
+  }
 
   Value getFirstParam() noexcept { return LLVMGetFirstParam(Ref); }
   Value getNextParam() noexcept { return LLVMGetNextParam(Ref); }
@@ -1062,6 +1066,9 @@ void Value::setMetadata(Context &C, unsigned int KindID,
 
 void Value::setMustTailCall() noexcept {
   LLVMSetTailCallKind(Ref, LLVMTailCallKindMustTail);
+}
+void Value::setTailCall() noexcept {
+  LLVMSetTailCallKind(Ref, LLVMTailCallKindTail);
 }
 
 static inline Message getDefaultTargetTriple() noexcept {

--- a/lib/llvm/llvm.h
+++ b/lib/llvm/llvm.h
@@ -363,7 +363,7 @@ public:
   inline Value getFirstFunction() noexcept;
   inline Value getNamedFunction(const char *Name) noexcept;
   inline Message printModuleToFile(const char *File) noexcept;
-  inline Message verify(LLVMVerifierFailureAction Action) noexcept;
+  inline bool hasVerificationError(Message &OutMsg) noexcept;
 
   constexpr operator bool() const noexcept { return Ref != nullptr; }
   constexpr auto &unwrap() const noexcept { return Ref; }
@@ -1006,10 +1006,8 @@ Message Module::printModuleToFile(const char *Filename) noexcept {
   return M;
 }
 
-Message Module::verify(LLVMVerifierFailureAction Action) noexcept {
-  Message M;
-  LLVMVerifyModule(Ref, Action, &M.unwrap());
-  return M;
+bool Module::hasVerificationError(Message &OutMsg) noexcept {
+  return LLVMVerifyModule(Ref, LLVMReturnStatusAction, &OutMsg.unwrap()) != 0;
 }
 
 Type Context::getVoidTy() noexcept { return LLVMVoidTypeInContext(Ref); }

--- a/lib/llvm/llvm.h
+++ b/lib/llvm/llvm.h
@@ -1605,18 +1605,6 @@ public:
     }
     return createCall(C, {V}, Name);
   }
-  Value createBinaryIntrinsic(unsigned int ID, Value LHS, Value RHS,
-                              const char *Name = "") noexcept {
-    FunctionCallee C;
-    {
-      LLVMTypeRef ParamTypes[2] = {LHS.getType().unwrap(),
-                                   RHS.getType().unwrap()};
-      C.Fn = LLVMGetIntrinsicDeclaration(getMod(), ID, ParamTypes, 2);
-      C.Ty = LLVMIntrinsicGetType(getCtx(), ID, ParamTypes, 2);
-    }
-    return createCall(C, {LHS, RHS}, Name);
-  }
-
   Value createVectorSplat(unsigned int ElementCount, Value V,
                           const char *Name = "") noexcept {
     Value Zero = Value::getConstInt(LLVMInt32TypeInContext(getCtx()), 0);

--- a/lib/system/stacktrace.cpp
+++ b/lib/system/stacktrace.cpp
@@ -3,7 +3,10 @@
 
 #include "system/stacktrace.h"
 #include "common/spdlog.h"
-#include <fmt/ranges.h>
+
+#include "runtime/instance/module.h"
+#include <cstdint>
+#include <map>
 
 #if WASMEDGE_OS_WINDOWS
 #include "system/winapi.h"
@@ -14,8 +17,6 @@
 #endif
 
 namespace WasmEdge {
-
-using namespace std::literals;
 
 Span<void *const> stackTrace(Span<void *> Buffer) noexcept {
 #if WASMEDGE_OS_WINDOWS
@@ -74,9 +75,9 @@ Span<void *const> stackTrace(Span<void *> Buffer) noexcept {
 #endif
 }
 
-Span<const uint32_t>
+Span<const StackTraceEntry>
 interpreterStackTrace(const Runtime::StackManager &StackMgr,
-                      Span<uint32_t> Buffer) noexcept {
+                      Span<StackTraceEntry> Buffer) noexcept {
   size_t Index = 0;
   if (auto Module = StackMgr.getModule()) {
     const auto FuncInsts = Module->getFunctionInstances();
@@ -86,7 +87,7 @@ interpreterStackTrace(const Runtime::StackManager &StackMgr,
       if (Func && Func->isWasmFunction()) {
         const auto &Instrs = Func->getInstrs();
         Funcs.emplace(Instrs.end(), INT64_C(-1));
-        Funcs.emplace(Instrs.begin(), I);
+        Funcs.emplace(Instrs.begin(), static_cast<int64_t>(I));
       }
     }
     for (const auto &Frame : StackMgr.getFramesSpan()) {
@@ -98,22 +99,25 @@ interpreterStackTrace(const Runtime::StackManager &StackMgr,
       }
       if (Iter != Funcs.end() && Iter->first < Entry &&
           Iter->second >= INT64_C(0) && Index < Buffer.size()) {
-        Buffer[Index++] = static_cast<uint32_t>(Iter->second);
+        Buffer[Index++] =
+            StackTraceEntry{Module, static_cast<uint32_t>(Iter->second)};
       }
     }
   }
   return Buffer.first(Index);
 }
 
-Span<const uint32_t> compiledStackTrace(const Runtime::StackManager &StackMgr,
-                                        Span<uint32_t> Buffer) noexcept {
+Span<const StackTraceEntry>
+compiledStackTrace(const Runtime::StackManager &StackMgr,
+                   Span<StackTraceEntry> Buffer) noexcept {
   std::array<void *, 256> StackTraceBuffer;
   return compiledStackTrace(StackMgr, stackTrace(StackTraceBuffer), Buffer);
 }
 
-Span<const uint32_t> compiledStackTrace(const Runtime::StackManager &StackMgr,
-                                        Span<void *const> Stack,
-                                        Span<uint32_t> Buffer) noexcept {
+Span<const StackTraceEntry>
+compiledStackTrace(const Runtime::StackManager &StackMgr,
+                   Span<void *const> Stack,
+                   Span<StackTraceEntry> Buffer) noexcept {
   std::map<void *, int64_t> Funcs;
   size_t Index = 0;
   if (auto Module = StackMgr.getModule()) {
@@ -124,7 +128,7 @@ Span<const uint32_t> compiledStackTrace(const Runtime::StackManager &StackMgr,
         Funcs.emplace(
             reinterpret_cast<void *>(Func->getFuncType().getSymbol().get()),
             INT64_C(-1));
-        Funcs.emplace(Func->getSymbol().get(), I);
+        Funcs.emplace(Func->getSymbol().get(), static_cast<int64_t>(I));
       }
     }
     for (auto Entry : Stack) {
@@ -135,15 +139,12 @@ Span<const uint32_t> compiledStackTrace(const Runtime::StackManager &StackMgr,
       }
       if (Iter != Funcs.end() && Iter->first < Entry &&
           Iter->second >= INT64_C(0) && Index < Buffer.size()) {
-        Buffer[Index++] = static_cast<uint32_t>(Iter->second);
+        Buffer[Index++] =
+            StackTraceEntry{Module, static_cast<uint32_t>(Iter->second)};
       }
     }
   }
   return Buffer.first(Index);
-}
-
-void dumpStackTrace(Span<const uint32_t> Stack) noexcept {
-  spdlog::error("calling stack:{}"sv, fmt::join(Stack, ", "sv));
 }
 
 } // namespace WasmEdge

--- a/lib/system/stacktrace.cpp
+++ b/lib/system/stacktrace.cpp
@@ -122,40 +122,46 @@ interpreterStackTrace(const Runtime::StackManager &StackMgr,
 }
 
 Span<const StackTraceEntry>
-compiledStackTrace(const Runtime::StackManager &StackMgr,
-                   Span<StackTraceEntry> Buffer) noexcept {
-  std::array<void *, 256> StackTraceBuffer;
-  return compiledStackTrace(StackMgr, stackTrace(StackTraceBuffer), Buffer);
-}
-
-Span<const StackTraceEntry>
-compiledStackTrace(const Runtime::StackManager &StackMgr,
+compiledStackTrace(Span<const Runtime::Instance::ModuleInstance *const> Modules,
                    Span<void *const> Stack,
                    Span<StackTraceEntry> Buffer) noexcept {
-  std::map<void *, int64_t> Funcs;
-  size_t Index = 0;
-  if (auto Module = StackMgr.getModule()) {
+  struct FuncEntry {
+    const Runtime::Instance::ModuleInstance *Module;
+    int64_t Index;
+  };
+  // Known limitation: two instances of the same compiled module share their
+  // code addresses, so emplace keeps whichever instance is enumerated first and
+  // a trap in the other one is reported against it. A native frame carries no
+  // instance identity to tell them apart.
+  std::map<void *, FuncEntry> Funcs;
+  for (const auto *Module : Modules) {
+    if (Module == nullptr) {
+      continue;
+    }
     const auto FuncInsts = Module->getFunctionInstances();
     for (size_t I = 0; I < FuncInsts.size(); ++I) {
       const auto &Func = FuncInsts[I];
-      if (Func && Func->isCompiledFunction()) {
+      if (Func && Func->isCompiledFunction() && Func->getModule() == Module) {
         Funcs.emplace(
             reinterpret_cast<void *>(Func->getFuncType().getSymbol().get()),
-            INT64_C(-1));
-        Funcs.emplace(Func->getSymbol().get(), static_cast<int64_t>(I));
+            FuncEntry{Module, INT64_C(-1)});
+        Funcs.emplace(Func->getSymbol().get(),
+                      FuncEntry{Module, static_cast<int64_t>(I)});
       }
     }
-    for (auto Entry : Stack) {
-      auto Iter = Funcs.lower_bound(Entry);
-      if ((Iter == Funcs.end() || Iter->first > Entry) &&
-          Iter != Funcs.begin()) {
-        --Iter;
-      }
-      if (Iter != Funcs.end() && Iter->first < Entry &&
-          Iter->second >= INT64_C(0) && Index < Buffer.size()) {
-        Buffer[Index++] =
-            StackTraceEntry{Module, static_cast<uint32_t>(Iter->second)};
-      }
+  }
+  size_t Index = 0;
+  for (auto Address : Stack) {
+    auto Probe =
+        reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(Address) - 1);
+    auto Iter = Funcs.lower_bound(Probe);
+    if ((Iter == Funcs.end() || Iter->first > Probe) && Iter != Funcs.begin()) {
+      --Iter;
+    }
+    if (Iter != Funcs.end() && Iter->first < Probe &&
+        Iter->second.Index >= INT64_C(0) && Index < Buffer.size()) {
+      Buffer[Index++] = StackTraceEntry{
+          Iter->second.Module, static_cast<uint32_t>(Iter->second.Index)};
     }
   }
   return Buffer.first(Index);

--- a/lib/system/stacktrace.cpp
+++ b/lib/system/stacktrace.cpp
@@ -7,6 +7,7 @@
 #include "runtime/instance/module.h"
 #include <cstdint>
 #include <map>
+#include <unordered_map>
 
 #if WASMEDGE_OS_WINDOWS
 #include "system/winapi.h"
@@ -79,29 +80,42 @@ Span<const StackTraceEntry>
 interpreterStackTrace(const Runtime::StackManager &StackMgr,
                       Span<StackTraceEntry> Buffer) noexcept {
   size_t Index = 0;
-  if (auto Module = StackMgr.getModule()) {
-    const auto FuncInsts = Module->getFunctionInstances();
-    std::map<AST::InstrView::iterator, int64_t> Funcs;
-    for (size_t I = 0; I < FuncInsts.size(); ++I) {
-      const auto &Func = FuncInsts[I];
-      if (Func && Func->isWasmFunction()) {
-        const auto &Instrs = Func->getInstrs();
-        Funcs.emplace(Instrs.end(), INT64_C(-1));
-        Funcs.emplace(Instrs.begin(), static_cast<int64_t>(I));
+  std::unordered_map<const Runtime::Instance::ModuleInstance *,
+                     std::map<AST::InstrView::iterator, int64_t>>
+      Cache;
+  const auto Frames = StackMgr.getFramesSpan();
+  for (size_t I = 1; I < Frames.size(); ++I) {
+    // A native-entry frame carries the callee's own end iterator instead of a
+    // return address in the caller, so it resolves against no module.
+    if (Frames[I].NativeEntry) {
+      continue;
+    }
+    const auto *Module = Frames[I - 1].Module;
+    if (Module == nullptr) {
+      continue;
+    }
+    auto [CacheIter, Inserted] = Cache.try_emplace(Module);
+    auto &Funcs = CacheIter->second;
+    if (Inserted) {
+      const auto FuncInsts = Module->getFunctionInstances();
+      for (size_t J = 0; J < FuncInsts.size(); ++J) {
+        const auto &Func = FuncInsts[J];
+        if (Func && Func->isWasmFunction()) {
+          const auto &Instrs = Func->getInstrs();
+          Funcs.emplace(Instrs.end(), INT64_C(-1));
+          Funcs.emplace(Instrs.begin(), static_cast<int64_t>(J));
+        }
       }
     }
-    for (const auto &Frame : StackMgr.getFramesSpan()) {
-      auto Entry = Frame.From;
-      auto Iter = Funcs.lower_bound(Entry);
-      if ((Iter == Funcs.end() || Iter->first > Entry) &&
-          Iter != Funcs.begin()) {
-        --Iter;
-      }
-      if (Iter != Funcs.end() && Iter->first < Entry &&
-          Iter->second >= INT64_C(0) && Index < Buffer.size()) {
-        Buffer[Index++] =
-            StackTraceEntry{Module, static_cast<uint32_t>(Iter->second)};
-      }
+    auto Entry = Frames[I].From;
+    auto Iter = Funcs.lower_bound(Entry);
+    if ((Iter == Funcs.end() || Iter->first > Entry) && Iter != Funcs.begin()) {
+      --Iter;
+    }
+    if (Iter != Funcs.end() && Iter->first <= Entry &&
+        Iter->second >= INT64_C(0) && Index < Buffer.size()) {
+      Buffer[Index++] =
+          StackTraceEntry{Module, static_cast<uint32_t>(Iter->second)};
     }
   }
   return Buffer.first(Index);

--- a/test/llvm/LLVMcoreTest.cpp
+++ b/test/llvm/LLVMcoreTest.cpp
@@ -16,9 +16,13 @@
 
 #include "common/defines.h"
 #include "common/spdlog.h"
+#include "executor/executor.h"
+#include "loader/loader.h"
+#include "validator/validator.h"
 #include "vm/vm.h"
 #include "llvm/codegen.h"
 #include "llvm/compiler.h"
+#include "llvm/jit.h"
 
 #include "../spec/hostfunc.h"
 #include "../spec/spectest.h"
@@ -48,6 +52,300 @@ class NativeCoreTest : public testing::TestWithParam<std::string> {};
 class CustomWasmCoreTest : public testing::TestWithParam<std::string> {};
 class JITCoreTest : public testing::TestWithParam<std::string> {};
 class LazyJITCoreTest : public testing::TestWithParam<std::string> {};
+
+// A compiled cross-module call must run the callee with its own context and
+// restore the caller's on return. run_ref computes
+// call_ref(read) * 10 + memory.grow(0) = 187*10 + 1 = 1871 with contexts kept
+// separate (callee global 187, caller's 1-page memory); a leaked callee context
+// reads its 5-page memory and gives 1875. memory.grow is the probe because it
+// resolves memory live, unlike inline accesses snapshotted on function entry.
+//   callee: (memory 5) (global $g (mut i32) 187)
+//           (func (export "read") (result i32) (global.get $g))
+//   caller: (import "callee" "read" (func $read (result i32)))
+//           (memory 1) (global $g (mut i32) 170)
+//           (table 1 funcref) (elem (i32.const 0) func $read)
+//           (func (export "run_ref") (result i32)
+//             (i32.add (i32.mul (call_ref $t (ref.func $read)) (i32.const 10))
+//                      (memory.grow (i32.const 0))))
+//           run_direct and run_indirect are the same with (call $read) and
+//           (call_indirect (type $t) (i32.const 0)).
+const std::array<WasmEdge::Byte, 70> CrossModuleCalleeWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x05, 0x03, 0x01, 0x00, 0x05,
+    0x06, 0x07, 0x01, 0x7f, 0x01, 0x41, 0xbb, 0x01, 0x0b, 0x07, 0x08, 0x01,
+    0x04, 0x72, 0x65, 0x61, 0x64, 0x00, 0x00, 0x0a, 0x06, 0x01, 0x04, 0x00,
+    0x23, 0x00, 0x0b, 0x00, 0x11, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x04, 0x04,
+    0x01, 0x00, 0x01, 0x74, 0x07, 0x04, 0x01, 0x00, 0x01, 0x67};
+
+const std::array<WasmEdge::Byte, 183> CrossModuleCallerWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x02, 0x0f, 0x01, 0x06, 0x63, 0x61, 0x6c, 0x6c, 0x65,
+    0x65, 0x04, 0x72, 0x65, 0x61, 0x64, 0x00, 0x00, 0x03, 0x04, 0x03, 0x00,
+    0x00, 0x00, 0x04, 0x04, 0x01, 0x70, 0x00, 0x01, 0x05, 0x03, 0x01, 0x00,
+    0x01, 0x06, 0x07, 0x01, 0x7f, 0x01, 0x41, 0xaa, 0x01, 0x0b, 0x07, 0x27,
+    0x03, 0x07, 0x72, 0x75, 0x6e, 0x5f, 0x72, 0x65, 0x66, 0x00, 0x01, 0x0a,
+    0x72, 0x75, 0x6e, 0x5f, 0x64, 0x69, 0x72, 0x65, 0x63, 0x74, 0x00, 0x02,
+    0x0c, 0x72, 0x75, 0x6e, 0x5f, 0x69, 0x6e, 0x64, 0x69, 0x72, 0x65, 0x63,
+    0x74, 0x00, 0x03, 0x09, 0x07, 0x01, 0x00, 0x41, 0x00, 0x0b, 0x01, 0x00,
+    0x0a, 0x2d, 0x03, 0x0e, 0x00, 0xd2, 0x00, 0x14, 0x00, 0x41, 0x0a, 0x6c,
+    0x41, 0x00, 0x40, 0x00, 0x6a, 0x0b, 0x0c, 0x00, 0x10, 0x00, 0x41, 0x0a,
+    0x6c, 0x41, 0x00, 0x40, 0x00, 0x6a, 0x0b, 0x0f, 0x00, 0x41, 0x00, 0x11,
+    0x00, 0x00, 0x41, 0x0a, 0x6c, 0x41, 0x00, 0x40, 0x00, 0x6a, 0x0b, 0x00,
+    0x1a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x01, 0x07, 0x01, 0x00, 0x04, 0x72,
+    0x65, 0x61, 0x64, 0x04, 0x04, 0x01, 0x00, 0x01, 0x74, 0x07, 0x04, 0x01,
+    0x00, 0x01, 0x67};
+
+// Parse, validate, compile, and attach compiled symbols. The Loader gets the
+// executor's intrinsics table so loadExecutable can patch the code's intrinsics
+// global; without it, intrinsic calls jump through a null table.
+std::shared_ptr<AST::Module> compileToJIT(const Configure &Conf,
+                                          Span<const Byte> Bytes) {
+  Loader::Loader LoaderEngine(Conf, &Executor::Executor::Intrinsics);
+  Validator::Validator ValidatorEngine(Conf);
+  auto ModOrErr = LoaderEngine.parseModule(Bytes);
+  if (!ModOrErr) {
+    return nullptr;
+  }
+  std::shared_ptr<AST::Module> Mod{std::move(*ModOrErr)};
+  if (!ValidatorEngine.validate(*Mod)) {
+    return nullptr;
+  }
+  LLVM::Compiler Compiler(Conf);
+  if (!Compiler.checkConfigure()) {
+    return nullptr;
+  }
+  auto Data = Compiler.compile(*Mod);
+  if (!Data) {
+    return nullptr;
+  }
+  LLVM::JIT JIT(Conf);
+  auto Exec = JIT.load(std::move(*Data));
+  if (!Exec) {
+    return nullptr;
+  }
+  if (!LoaderEngine.loadExecutable(*Mod, std::move(*Exec))) {
+    return nullptr;
+  }
+  return Mod;
+}
+
+// Both modules are compiled, then registered and instantiated in one store
+// under one executor, so the result is not an artifact of cross-VM sharing.
+TEST(AOTCrossModule, CompiledCallUsesCalleeContext) {
+  Configure Conf;
+  Conf.addProposal(Proposal::ReferenceTypes);
+  Conf.addProposal(Proposal::FunctionReferences);
+
+  // Declared before the instances that reference their compiled code.
+  auto CalleeMod = compileToJIT(Conf, CrossModuleCalleeWasm);
+  ASSERT_NE(CalleeMod, nullptr);
+  auto CallerMod = compileToJIT(Conf, CrossModuleCallerWasm);
+  ASSERT_NE(CallerMod, nullptr);
+
+  Executor::Executor ExecEngine(Conf);
+  Runtime::StoreManager Store;
+
+  // CalleeInst is declared first so the dependent caller tears down before it.
+  auto CalleeInstOrErr = ExecEngine.registerModule(Store, *CalleeMod, "callee");
+  ASSERT_TRUE(CalleeInstOrErr);
+  auto CalleeInst = std::move(*CalleeInstOrErr);
+  const auto *ReadFn = CalleeInst->findFuncExports("read");
+  ASSERT_NE(ReadFn, nullptr);
+  ASSERT_TRUE(ReadFn->isCompiledFunction());
+
+  auto CallerInstOrErr = ExecEngine.instantiateModule(Store, *CallerMod);
+  ASSERT_TRUE(CallerInstOrErr);
+  auto CallerInst = std::move(*CallerInstOrErr);
+
+  // call_ref of a cross-module funcref must read the callee's global.
+  const auto *RunRef = CallerInst->findFuncExports("run_ref");
+  ASSERT_NE(RunRef, nullptr);
+  ASSERT_TRUE(RunRef->isCompiledFunction());
+  auto RRef = ExecEngine.invoke(RunRef, {}, {});
+  ASSERT_TRUE(RRef);
+  ASSERT_EQ(RRef->size(), 1u);
+  EXPECT_EQ((*RRef)[0].first.get<uint32_t>(), 1871u)
+      << "call_ref did not keep the two modules' contexts apart";
+
+  const auto *RunDirect = CallerInst->findFuncExports("run_direct");
+  ASSERT_NE(RunDirect, nullptr);
+  ASSERT_TRUE(RunDirect->isCompiledFunction());
+  auto RDir = ExecEngine.invoke(RunDirect, {}, {});
+  ASSERT_TRUE(RDir);
+  ASSERT_EQ(RDir->size(), 1u);
+  EXPECT_EQ((*RDir)[0].first.get<uint32_t>(), 1871u)
+      << "direct call did not keep the two modules' contexts apart";
+
+  // call_indirect resolves through proxyTableGetFuncSymbol, which must mediate
+  // as well.
+  const auto *RunInd = CallerInst->findFuncExports("run_indirect");
+  ASSERT_NE(RunInd, nullptr);
+  ASSERT_TRUE(RunInd->isCompiledFunction());
+  auto RInd = ExecEngine.invoke(RunInd, {}, {});
+  ASSERT_TRUE(RInd);
+  ASSERT_EQ(RInd->size(), 1u);
+  EXPECT_EQ((*RInd)[0].first.get<uint32_t>(), 1871u)
+      << "call_indirect did not keep the two modules' contexts apart";
+}
+
+// A cross-module return_call_ref must run each side with its own state. The
+// kCallRef proxy nests a proxy and an enterFunction frame (~1 KiB) per hop, so
+// the recursion stays well within a 1 MiB thread stack. This covers context
+// handling only; constant-space cross-module tail calls are not implemented.
+//   callee: (global $g (mut i32) 187) (global $peer (export "peer")
+//           (mut (ref null $t)) (ref.null $t))
+//           (func $f (export "f") (param i32) (result i32)
+//             if (global.get $g) != 187 -> 1
+//             if param == 0 -> 0
+//             return_call_ref $t (param - 1) (global.get $peer))
+//   caller: (import "callee" "f") (import "callee" "peer")
+//           (global $g (mut i32) 170)
+//           (func $a (param i32) (result i32)
+//             if (global.get $g) != 170 -> 2
+//             if param == 0 -> 0
+//             return_call_ref $t (param - 1) (ref.func $f))
+//           (func (export "run") (param i32) (result i32)
+//             global.set $peer (ref.func $a)
+//             return_call_ref $t (param) (ref.func $f))
+const std::array<WasmEdge::Byte, 116> CrossModuleTailCalleeWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x06, 0x01, 0x60,
+    0x01, 0x7f, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x06, 0x0d, 0x02, 0x7f,
+    0x01, 0x41, 0xbb, 0x01, 0x0b, 0x63, 0x00, 0x01, 0xd0, 0x00, 0x0b, 0x07,
+    0x0c, 0x02, 0x04, 0x70, 0x65, 0x65, 0x72, 0x03, 0x01, 0x01, 0x66, 0x00,
+    0x00, 0x0a, 0x22, 0x01, 0x20, 0x00, 0x23, 0x00, 0x41, 0xbb, 0x01, 0x47,
+    0x04, 0x40, 0x41, 0x01, 0x0f, 0x0b, 0x20, 0x00, 0x45, 0x04, 0x40, 0x41,
+    0x00, 0x0f, 0x0b, 0x20, 0x00, 0x41, 0x01, 0x6b, 0x23, 0x01, 0x15, 0x00,
+    0x0b, 0x00, 0x1d, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x01, 0x04, 0x01, 0x00,
+    0x01, 0x66, 0x04, 0x04, 0x01, 0x00, 0x01, 0x74, 0x07, 0x0a, 0x02, 0x00,
+    0x01, 0x67, 0x01, 0x04, 0x70, 0x65, 0x65, 0x72};
+
+const std::array<WasmEdge::Byte, 160> CrossModuleTailCallerWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x06, 0x01, 0x60,
+    0x01, 0x7f, 0x01, 0x7f, 0x02, 0x1c, 0x02, 0x06, 0x63, 0x61, 0x6c, 0x6c,
+    0x65, 0x65, 0x01, 0x66, 0x00, 0x00, 0x06, 0x63, 0x61, 0x6c, 0x6c, 0x65,
+    0x65, 0x04, 0x70, 0x65, 0x65, 0x72, 0x03, 0x63, 0x00, 0x01, 0x03, 0x03,
+    0x02, 0x00, 0x00, 0x06, 0x07, 0x01, 0x7f, 0x01, 0x41, 0xaa, 0x01, 0x0b,
+    0x07, 0x07, 0x01, 0x03, 0x72, 0x75, 0x6e, 0x00, 0x02, 0x09, 0x06, 0x01,
+    0x03, 0x00, 0x02, 0x01, 0x00, 0x0a, 0x2f, 0x02, 0x20, 0x00, 0x23, 0x01,
+    0x41, 0xaa, 0x01, 0x47, 0x04, 0x40, 0x41, 0x02, 0x0f, 0x0b, 0x20, 0x00,
+    0x45, 0x04, 0x40, 0x41, 0x00, 0x0f, 0x0b, 0x20, 0x00, 0x41, 0x01, 0x6b,
+    0xd2, 0x00, 0x15, 0x00, 0x0b, 0x0c, 0x00, 0xd2, 0x01, 0x24, 0x00, 0x20,
+    0x00, 0xd2, 0x00, 0x15, 0x00, 0x0b, 0x00, 0x20, 0x04, 0x6e, 0x61, 0x6d,
+    0x65, 0x01, 0x07, 0x02, 0x00, 0x01, 0x66, 0x01, 0x01, 0x61, 0x04, 0x04,
+    0x01, 0x00, 0x01, 0x74, 0x07, 0x0a, 0x02, 0x00, 0x04, 0x70, 0x65, 0x65,
+    0x72, 0x01, 0x01, 0x67};
+
+TEST(AOTCrossModule, CompiledTailCallUsesCalleeContext) {
+  Configure Conf;
+  Conf.addProposal(Proposal::ReferenceTypes);
+  Conf.addProposal(Proposal::FunctionReferences);
+  Conf.addProposal(Proposal::TailCall);
+
+  auto CalleeMod = compileToJIT(Conf, CrossModuleTailCalleeWasm);
+  ASSERT_NE(CalleeMod, nullptr);
+  auto CallerMod = compileToJIT(Conf, CrossModuleTailCallerWasm);
+  ASSERT_NE(CallerMod, nullptr);
+
+  Executor::Executor ExecEngine(Conf);
+  Runtime::StoreManager Store;
+
+  auto CalleeInstOrErr = ExecEngine.registerModule(Store, *CalleeMod, "callee");
+  ASSERT_TRUE(CalleeInstOrErr);
+  auto CalleeInst = std::move(*CalleeInstOrErr);
+
+  auto CallerInstOrErr = ExecEngine.instantiateModule(Store, *CallerMod);
+  ASSERT_TRUE(CallerInstOrErr);
+  auto CallerInst = std::move(*CallerInstOrErr);
+
+  const auto *Run = CallerInst->findFuncExports("run");
+  ASSERT_NE(Run, nullptr);
+  ASSERT_TRUE(Run->isCompiledFunction());
+
+  const std::array<ValVariant, 1> Args{ValVariant(uint32_t(8U))};
+  const std::array<ValType, 1> ArgTypes{ValType(TypeCode::I32)};
+  auto R = ExecEngine.invoke(Run, Args, ArgTypes);
+  ASSERT_TRUE(R);
+  ASSERT_EQ(R->size(), 1u);
+  EXPECT_EQ((*R)[0].first.get<uint32_t>(), 0u)
+      << "a cross-module tail call ran with the wrong module's globals";
+}
+
+// Lazy JIT resolves calls through its own per-function symbol cache, so cover
+// the same reads under RunMode::LazyJIT.
+TEST(AOTCrossModule, LazyJITCallUsesCalleeContext) {
+  Configure Conf;
+  Conf.getRuntimeConfigure().setRunMode(RunMode::LazyJIT);
+  Conf.addProposal(Proposal::ReferenceTypes);
+  Conf.addProposal(Proposal::FunctionReferences);
+  VM::VM VM(Conf);
+
+  ASSERT_TRUE(VM.registerModule("callee"sv, CrossModuleCalleeWasm));
+  ASSERT_TRUE(VM.loadWasm(CrossModuleCallerWasm));
+  ASSERT_TRUE(VM.validate());
+  ASSERT_TRUE(VM.instantiate());
+
+  for (const auto &Name : {"run_direct"sv, "run_ref"sv, "run_indirect"sv}) {
+    auto R = VM.execute(Name);
+    ASSERT_TRUE(R) << Name;
+    ASSERT_EQ(R->size(), 1u) << Name;
+    EXPECT_EQ((*R)[0].first.get<uint32_t>(), 1871u)
+        << Name << " did not keep the two modules' contexts apart";
+  }
+}
+
+const std::array<WasmEdge::Byte, 67> CrossModuleNestCalleeWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x05, 0x03, 0x01, 0x00, 0x05,
+    0x06, 0x07, 0x01, 0x7f, 0x01, 0x41, 0xbb, 0x01, 0x0b, 0x07, 0x05, 0x01,
+    0x01, 0x63, 0x00, 0x00, 0x0a, 0x06, 0x01, 0x04, 0x00, 0x23, 0x00, 0x0b,
+    0x00, 0x11, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x04, 0x04, 0x01, 0x00, 0x01,
+    0x74, 0x07, 0x04, 0x01, 0x00, 0x01, 0x67};
+
+const std::array<WasmEdge::Byte, 115> CrossModuleNestCallerWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x02, 0x0c, 0x01, 0x06, 0x63, 0x61, 0x6c, 0x6c, 0x65,
+    0x65, 0x01, 0x63, 0x00, 0x00, 0x03, 0x03, 0x02, 0x00, 0x00, 0x05, 0x03,
+    0x01, 0x00, 0x01, 0x06, 0x07, 0x01, 0x7f, 0x01, 0x41, 0xaa, 0x01, 0x0b,
+    0x07, 0x07, 0x01, 0x03, 0x72, 0x75, 0x6e, 0x00, 0x02, 0x09, 0x05, 0x01,
+    0x03, 0x00, 0x01, 0x00, 0x0a, 0x15, 0x02, 0x06, 0x00, 0xd2, 0x00, 0x15,
+    0x00, 0x0b, 0x0c, 0x00, 0x10, 0x01, 0x41, 0x0a, 0x6c, 0x41, 0x00, 0x40,
+    0x00, 0x6a, 0x0b, 0x00, 0x1a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x01, 0x07,
+    0x02, 0x00, 0x01, 0x63, 0x01, 0x01, 0x62, 0x04, 0x04, 0x01, 0x00, 0x01,
+    0x74, 0x07, 0x04, 0x01, 0x00, 0x01, 0x67};
+
+// A tail call must not leave the caller's caller running with the target's
+// module. Here A.a calls A.b through the same-module fast path, which pushes no
+// frame, and A.b tail-calls into B; when B returns, control lands back in A.a,
+// which must still resolve its own memory.
+TEST(AOTCrossModule, TailCallLeavesCallerContextIntact) {
+  Configure Conf;
+  Conf.addProposal(Proposal::ReferenceTypes);
+  Conf.addProposal(Proposal::FunctionReferences);
+  Conf.addProposal(Proposal::TailCall);
+
+  auto CalleeMod = compileToJIT(Conf, CrossModuleNestCalleeWasm);
+  ASSERT_NE(CalleeMod, nullptr);
+  auto CallerMod = compileToJIT(Conf, CrossModuleNestCallerWasm);
+  ASSERT_NE(CallerMod, nullptr);
+
+  Executor::Executor ExecEngine(Conf);
+  Runtime::StoreManager Store;
+  auto CalleeInstOrErr = ExecEngine.registerModule(Store, *CalleeMod, "callee");
+  ASSERT_TRUE(CalleeInstOrErr);
+  auto CalleeInst = std::move(*CalleeInstOrErr);
+  auto CallerInstOrErr = ExecEngine.instantiateModule(Store, *CallerMod);
+  ASSERT_TRUE(CallerInstOrErr);
+  auto CallerInst = std::move(*CallerInstOrErr);
+
+  const auto *Run = CallerInst->findFuncExports("run");
+  ASSERT_NE(Run, nullptr);
+  ASSERT_TRUE(Run->isCompiledFunction());
+  auto R = ExecEngine.invoke(Run, {}, {});
+  ASSERT_TRUE(R);
+  ASSERT_EQ(R->size(), 1u);
+  EXPECT_EQ((*R)[0].first.get<uint32_t>(), 1871u)
+      << "the caller resumed with the tail-call target's module";
+}
 
 TEST_P(NativeCoreTest, TestSuites) {
   auto [Proposal, Conf, UnitName] = T.resolve(GetParam());

--- a/test/llvm/LLVMcoreTest.cpp
+++ b/test/llvm/LLVMcoreTest.cpp
@@ -129,6 +129,23 @@ std::shared_ptr<AST::Module> compileToJIT(const Configure &Conf,
   return Mod;
 }
 
+// Parse and validate a module without compiling it, so its functions run under
+// the interpreter. Exercises interpreterStackTrace directly.
+std::shared_ptr<AST::Module> loadModule(const Configure &Conf,
+                                        Span<const Byte> Bytes) {
+  Loader::Loader LoaderEngine(Conf);
+  Validator::Validator ValidatorEngine(Conf);
+  auto ModOrErr = LoaderEngine.parseModule(Bytes);
+  if (!ModOrErr) {
+    return nullptr;
+  }
+  std::shared_ptr<AST::Module> Mod{std::move(*ModOrErr)};
+  if (!ValidatorEngine.validate(*Mod)) {
+    return nullptr;
+  }
+  return Mod;
+}
+
 // Both modules are compiled, then registered and instantiated in one store
 // under one executor, so the result is not an artifact of cross-VM sharing.
 TEST(AOTCrossModule, CompiledCallUsesCalleeContext) {
@@ -809,6 +826,70 @@ TEST(AOTCrossModule, CompiledThrowUsesCalleeTagSpace) {
   ASSERT_EQ(R->size(), 1u);
   EXPECT_EQ((*R)[0].first.get<uint32_t>(), 1u)
       << "the callee's throw did not resolve its tag in the callee's module";
+}
+
+//   callee (trapper2): (func $g (result i32) unreachable)
+//                       (func $f (export "f") (result i32) (call $g))
+const std::array<WasmEdge::Byte, 55> InterpTrapCalleeWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01,
+    0x60, 0x00, 0x01, 0x7f, 0x03, 0x03, 0x02, 0x00, 0x00, 0x07, 0x05,
+    0x01, 0x01, 0x66, 0x00, 0x01, 0x0a, 0x0a, 0x02, 0x03, 0x00, 0x00,
+    0x0b, 0x04, 0x00, 0x10, 0x00, 0x0b, 0x00, 0x0e, 0x04, 0x6e, 0x61,
+    0x6d, 0x65, 0x01, 0x07, 0x02, 0x00, 0x01, 0x67, 0x01, 0x01, 0x66};
+
+//   caller: (import "trapper2" "f" (func $f (result i32)))
+//           (func (export "run") (result i32) (call $f))
+const std::array<WasmEdge::Byte, 65> InterpTrapCallerWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01,
+    0x60, 0x00, 0x01, 0x7f, 0x02, 0x0e, 0x01, 0x08, 0x74, 0x72, 0x61,
+    0x70, 0x70, 0x65, 0x72, 0x32, 0x01, 0x66, 0x00, 0x00, 0x03, 0x02,
+    0x01, 0x00, 0x07, 0x07, 0x01, 0x03, 0x72, 0x75, 0x6e, 0x00, 0x01,
+    0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00, 0x0b, 0x00, 0x0b, 0x04,
+    0x6e, 0x61, 0x6d, 0x65, 0x01, 0x04, 0x01, 0x00, 0x01, 0x66};
+
+// A cross-module interpreter stack must attribute each frame to its own module.
+// run() (caller) calls f() (callee) calls g(), which traps; the caller's frame
+// must resolve against the caller module, not the top (callee) module.
+TEST(AOTCrossModule, InterpreterTrapAttributesCallerModule) {
+  Configure Conf;
+
+  auto CalleeMod = loadModule(Conf, InterpTrapCalleeWasm);
+  ASSERT_NE(CalleeMod, nullptr);
+  auto CallerMod = loadModule(Conf, InterpTrapCallerWasm);
+  ASSERT_NE(CallerMod, nullptr);
+
+  Executor::Executor ExecEngine(Conf);
+  Runtime::StoreManager Store;
+
+  auto CalleeInstOrErr =
+      ExecEngine.registerModule(Store, *CalleeMod, "trapper2");
+  ASSERT_TRUE(CalleeInstOrErr);
+  auto CalleeInst = std::move(*CalleeInstOrErr);
+
+  auto CallerInstOrErr = ExecEngine.instantiateModule(Store, *CallerMod);
+  ASSERT_TRUE(CallerInstOrErr);
+  auto CallerInst = std::move(*CallerInstOrErr);
+
+  const auto *Run = CallerInst->findFuncExports("run");
+  ASSERT_NE(Run, nullptr);
+
+  auto R = ExecEngine.invoke(Run, {}, {});
+  ASSERT_FALSE(R);
+
+  auto Trace = Executor::Executor::getRecordedStackTrace();
+  bool SawCaller = false;
+  bool SawCallee = false;
+  for (const auto &E : Trace) {
+    if (E.Module == CallerInst.get()) {
+      SawCaller = true;
+    }
+    if (E.Module == CalleeInst.get()) {
+      SawCallee = true;
+    }
+  }
+  EXPECT_TRUE(SawCaller) << "cross-module interpreter frame was not attributed "
+                            "to the caller module";
+  EXPECT_TRUE(SawCallee);
 }
 
 TEST_P(NativeCoreTest, TestSuites) {

--- a/test/llvm/LLVMcoreTest.cpp
+++ b/test/llvm/LLVMcoreTest.cpp
@@ -347,6 +347,470 @@ TEST(AOTCrossModule, TailCallLeavesCallerContextIntact) {
       << "the caller resumed with the tail-call target's module";
 }
 
+// A cross-module return_call_indirect must hand the callee its own module. This
+// covers compileReturnIndirectCallOp, the last cross-module tail site (call_ref
+// and call_indirect are covered above). The probe combines the callee's global
+// and memory.grow(0), both in the callee's body: the callee context gives
+// 187*10 + 5 = 1875; a leaked caller context reads 170 and a 1-page memory for
+// 1701.
+//   callee: (memory 5) (global $g (mut i32) 187)
+//           (func (export "probe") (result i32)
+//             (i32.add (i32.mul (global.get $g) (i32.const 10))
+//                      (memory.grow (i32.const 0))))
+//   caller: (import "callee" "probe" (func $probe (result i32)))
+//           (table 1 funcref) (elem (i32.const 0) func $probe)
+//           (memory 1) (global $g (mut i32) 170)
+//           (func (export "run") (result i32)
+//             (return_call_indirect (type $t) (i32.const 0)))
+const std::array<WasmEdge::Byte, 89> CrossModuleRetIndirectCalleeWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x05, 0x03, 0x01, 0x00, 0x05,
+    0x06, 0x07, 0x01, 0x7f, 0x01, 0x41, 0xbb, 0x01, 0x0b, 0x07, 0x09, 0x01,
+    0x05, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x00, 0x00, 0x0a, 0x0e, 0x01, 0x0c,
+    0x00, 0x23, 0x00, 0x41, 0x0a, 0x6c, 0x41, 0x00, 0x40, 0x00, 0x6a, 0x0b,
+    0x00, 0x1b, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x01, 0x08, 0x01, 0x00, 0x05,
+    0x70, 0x72, 0x6f, 0x62, 0x65, 0x04, 0x04, 0x01, 0x00, 0x01, 0x74, 0x07,
+    0x04, 0x01, 0x00, 0x01, 0x67};
+
+const std::array<WasmEdge::Byte, 120> CrossModuleRetIndirectCallerWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x02, 0x10, 0x01, 0x06, 0x63, 0x61, 0x6c, 0x6c, 0x65,
+    0x65, 0x05, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x00, 0x00, 0x03, 0x02, 0x01,
+    0x00, 0x04, 0x04, 0x01, 0x70, 0x00, 0x01, 0x05, 0x03, 0x01, 0x00, 0x01,
+    0x06, 0x07, 0x01, 0x7f, 0x01, 0x41, 0xaa, 0x01, 0x0b, 0x07, 0x07, 0x01,
+    0x03, 0x72, 0x75, 0x6e, 0x00, 0x01, 0x09, 0x07, 0x01, 0x00, 0x41, 0x00,
+    0x0b, 0x01, 0x00, 0x0a, 0x09, 0x01, 0x07, 0x00, 0x41, 0x00, 0x13, 0x00,
+    0x00, 0x0b, 0x00, 0x20, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x01, 0x0d, 0x02,
+    0x00, 0x05, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x01, 0x03, 0x72, 0x75, 0x6e,
+    0x04, 0x04, 0x01, 0x00, 0x01, 0x74, 0x07, 0x04, 0x01, 0x00, 0x01, 0x67};
+
+TEST(AOTCrossModule, CompiledReturnCallIndirectUsesCalleeContext) {
+  Configure Conf;
+  Conf.addProposal(Proposal::ReferenceTypes);
+  Conf.addProposal(Proposal::TailCall);
+
+  auto CalleeMod = compileToJIT(Conf, CrossModuleRetIndirectCalleeWasm);
+  ASSERT_NE(CalleeMod, nullptr);
+  auto CallerMod = compileToJIT(Conf, CrossModuleRetIndirectCallerWasm);
+  ASSERT_NE(CallerMod, nullptr);
+
+  Executor::Executor ExecEngine(Conf);
+  Runtime::StoreManager Store;
+
+  auto CalleeInstOrErr = ExecEngine.registerModule(Store, *CalleeMod, "callee");
+  ASSERT_TRUE(CalleeInstOrErr);
+  auto CalleeInst = std::move(*CalleeInstOrErr);
+
+  auto CallerInstOrErr = ExecEngine.instantiateModule(Store, *CallerMod);
+  ASSERT_TRUE(CallerInstOrErr);
+  auto CallerInst = std::move(*CallerInstOrErr);
+
+  const auto *Run = CallerInst->findFuncExports("run");
+  ASSERT_NE(Run, nullptr);
+  ASSERT_TRUE(Run->isCompiledFunction());
+  auto R = ExecEngine.invoke(Run, {}, {});
+  ASSERT_TRUE(R);
+  ASSERT_EQ(R->size(), 1u);
+  EXPECT_EQ((*R)[0].first.get<uint32_t>(), 1875u)
+      << "a cross-module return_call_indirect did not run with the callee's "
+         "module";
+}
+
+// Gas metering is one thread-local counter shared by the whole call chain, so
+// it must keep charging once a compiled call crosses into another module. Run 1
+// measures the total cost of one cross-module run_direct invocation; run 2 sets
+// the limit one unit below that and must fail with CostLimitExceeded, proving
+// the callee's instructions charge against the same budget as the caller's.
+TEST(AOTCrossModule, GasMeteringSpansCrossModuleCall) {
+  Configure Conf;
+  Conf.addProposal(Proposal::ReferenceTypes);
+  Conf.addProposal(Proposal::FunctionReferences);
+  Conf.getStatisticsConfigure().setCostMeasuring(true);
+
+  auto CalleeMod = compileToJIT(Conf, CrossModuleCalleeWasm);
+  ASSERT_NE(CalleeMod, nullptr);
+  auto CallerMod = compileToJIT(Conf, CrossModuleCallerWasm);
+  ASSERT_NE(CallerMod, nullptr);
+
+  uint64_t FullCost = 0;
+  {
+    Statistics::Statistics Stat;
+    Executor::Executor ExecEngine(Conf, &Stat);
+    Runtime::StoreManager Store;
+
+    auto CalleeInstOrErr =
+        ExecEngine.registerModule(Store, *CalleeMod, "callee");
+    ASSERT_TRUE(CalleeInstOrErr);
+    auto CalleeInst = std::move(*CalleeInstOrErr);
+    auto CallerInstOrErr = ExecEngine.instantiateModule(Store, *CallerMod);
+    ASSERT_TRUE(CallerInstOrErr);
+    auto CallerInst = std::move(*CallerInstOrErr);
+
+    const auto *RunDirect = CallerInst->findFuncExports("run_direct");
+    ASSERT_NE(RunDirect, nullptr);
+    auto R = ExecEngine.invoke(RunDirect, {}, {});
+    ASSERT_TRUE(R);
+    ASSERT_EQ(R->size(), 1u);
+    EXPECT_EQ((*R)[0].first.get<uint32_t>(), 1871u);
+
+    FullCost = Stat.getTotalCost();
+    EXPECT_GT(FullCost, 0u)
+        << "gas metering did not run across the cross-module call";
+  }
+
+  // Executor::Executor() re-seeds the cost limit from its Configure, so set the
+  // second run's limit here rather than on the Statistics constructor.
+  Conf.getStatisticsConfigure().setCostLimit(FullCost - 1);
+  {
+    Statistics::Statistics Stat;
+    Executor::Executor ExecEngine(Conf, &Stat);
+    Runtime::StoreManager Store;
+
+    auto CalleeInstOrErr =
+        ExecEngine.registerModule(Store, *CalleeMod, "callee");
+    ASSERT_TRUE(CalleeInstOrErr);
+    auto CalleeInst = std::move(*CalleeInstOrErr);
+    auto CallerInstOrErr = ExecEngine.instantiateModule(Store, *CallerMod);
+    ASSERT_TRUE(CallerInstOrErr);
+    auto CallerInst = std::move(*CallerInstOrErr);
+
+    const auto *RunDirect = CallerInst->findFuncExports("run_direct");
+    ASSERT_NE(RunDirect, nullptr);
+    auto R = ExecEngine.invoke(RunDirect, {}, {});
+    ASSERT_FALSE(R) << "a cost limit one below the measured cross-module "
+                       "total should have been enforced";
+    EXPECT_EQ(R.error(), ErrCode::Value::CostLimitExceeded);
+  }
+}
+
+// One compiled image can back many instances. The shared module is registered
+// twice under different names, each with its own mutated global; a third module
+// call_refs "read" on both. If context selection ever keyed on the (identical)
+// compiled function pointer instead of the calling FunctionInstance, it fails.
+//   shared: (global $g (export "g") (mut i32) 0)
+//           (func (export "read") (result i32) (global.get $g))
+//   caller: (import "inst_a" "read") (import "inst_b" "read")
+//           (func (export "run") (result i32)
+//             (i32.add (i32.mul (call_ref $t (ref.func $ra)) (i32.const 1000))
+//                      (call_ref $t (ref.func $rb))))
+const std::array<WasmEdge::Byte, 71> CrossModuleSharedInstWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x06, 0x06, 0x01, 0x7f, 0x01,
+    0x41, 0x00, 0x0b, 0x07, 0x0c, 0x02, 0x01, 0x67, 0x03, 0x00, 0x04, 0x72,
+    0x65, 0x61, 0x64, 0x00, 0x00, 0x0a, 0x06, 0x01, 0x04, 0x00, 0x23, 0x00,
+    0x0b, 0x00, 0x14, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x01, 0x07, 0x01, 0x00,
+    0x04, 0x72, 0x65, 0x61, 0x64, 0x07, 0x04, 0x01, 0x00, 0x01, 0x67};
+
+const std::array<WasmEdge::Byte, 115> CrossModuleSharedInstCallerWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x02, 0x1d, 0x02, 0x06, 0x69, 0x6e, 0x73, 0x74, 0x5f,
+    0x61, 0x04, 0x72, 0x65, 0x61, 0x64, 0x00, 0x00, 0x06, 0x69, 0x6e, 0x73,
+    0x74, 0x5f, 0x62, 0x04, 0x72, 0x65, 0x61, 0x64, 0x00, 0x00, 0x03, 0x02,
+    0x01, 0x00, 0x07, 0x07, 0x01, 0x03, 0x72, 0x75, 0x6e, 0x00, 0x02, 0x09,
+    0x06, 0x01, 0x03, 0x00, 0x02, 0x00, 0x01, 0x0a, 0x11, 0x01, 0x0f, 0x00,
+    0xd2, 0x00, 0x14, 0x00, 0x41, 0xe8, 0x07, 0x6c, 0xd2, 0x01, 0x14, 0x00,
+    0x6a, 0x0b, 0x00, 0x1b, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x01, 0x0e, 0x03,
+    0x00, 0x02, 0x72, 0x61, 0x01, 0x02, 0x72, 0x62, 0x02, 0x03, 0x72, 0x75,
+    0x6e, 0x04, 0x04, 0x01, 0x00, 0x01, 0x74};
+
+TEST(AOTCrossModule, SameCompiledModuleTwoInstancesKeepOwnState) {
+  Configure Conf;
+  Conf.addProposal(Proposal::ReferenceTypes);
+  Conf.addProposal(Proposal::FunctionReferences);
+
+  auto SharedMod = compileToJIT(Conf, CrossModuleSharedInstWasm);
+  ASSERT_NE(SharedMod, nullptr);
+  auto CallerMod = compileToJIT(Conf, CrossModuleSharedInstCallerWasm);
+  ASSERT_NE(CallerMod, nullptr);
+
+  Executor::Executor ExecEngine(Conf);
+  Runtime::StoreManager Store;
+
+  auto InstAOrErr = ExecEngine.registerModule(Store, *SharedMod, "inst_a");
+  ASSERT_TRUE(InstAOrErr);
+  auto InstA = std::move(*InstAOrErr);
+  auto InstBOrErr = ExecEngine.registerModule(Store, *SharedMod, "inst_b");
+  ASSERT_TRUE(InstBOrErr);
+  auto InstB = std::move(*InstBOrErr);
+  ASSERT_NE(InstA.get(), InstB.get())
+      << "registering the same compiled module twice must produce two "
+         "distinct instances";
+
+  auto *GlobalA = InstA->findGlobalExports("g");
+  ASSERT_NE(GlobalA, nullptr);
+  GlobalA->setValue(ValVariant(uint32_t(111U)));
+  auto *GlobalB = InstB->findGlobalExports("g");
+  ASSERT_NE(GlobalB, nullptr);
+  GlobalB->setValue(ValVariant(uint32_t(222U)));
+
+  auto CallerInstOrErr = ExecEngine.instantiateModule(Store, *CallerMod);
+  ASSERT_TRUE(CallerInstOrErr);
+  auto CallerInst = std::move(*CallerInstOrErr);
+
+  const auto *Run = CallerInst->findFuncExports("run");
+  ASSERT_NE(Run, nullptr);
+  ASSERT_TRUE(Run->isCompiledFunction());
+  auto R = ExecEngine.invoke(Run, {}, {});
+  ASSERT_TRUE(R);
+  ASSERT_EQ(R->size(), 1u);
+  EXPECT_EQ((*R)[0].first.get<uint32_t>(), 111222u)
+      << "the two instances of the identical compiled module did not keep "
+         "their own global state apart";
+}
+
+// A host function reached from a compiled cross-module callee must see the
+// callee's own CallingFrame so CallingFrame::getMemoryByIndex() resolves the
+// callee's memory. The callee is entered via call_ref (a native call that never
+// touches StackManager), then calls its host import; the explicit CallerModInst
+// threaded through Executor::enterFunction keeps that host call's module right.
+class CrossModuleReadMem0 : public Runtime::HostFunction<CrossModuleReadMem0> {
+public:
+  Expect<uint32_t> body(const Runtime::CallingFrame &Frame) {
+    auto *MemInst = Frame.getMemoryByIndex(0);
+    if (MemInst == nullptr) {
+      return Unexpect(ErrCode::Value::HostFuncError);
+    }
+    const auto *Ptr = MemInst->getPointer<const uint32_t *>(0);
+    if (Ptr == nullptr) {
+      return Unexpect(ErrCode::Value::HostFuncError);
+    }
+    return *Ptr;
+  }
+};
+
+class CrossModuleHostModule : public Runtime::Instance::ModuleInstance {
+public:
+  CrossModuleHostModule() : ModuleInstance("host") {
+    addHostFunc("read0", std::make_unique<CrossModuleReadMem0>());
+  }
+};
+
+//   callee: (import "host" "read0" (func $read0 (result i32)))
+//           (memory 1) (data (i32.const 0) "\22\22\22\00")
+//           (func (export "probe") (result i32) (call $read0))
+//   caller: (import "callee" "probe" (func $probe (result i32)))
+//           (memory 1) (data (i32.const 0) "\11\11\11\00")
+//           (func (export "run") (result i32)
+//             (call_ref $t (ref.func $probe)))
+const std::array<WasmEdge::Byte, 101> CrossModuleHostCalleeWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x02, 0x0e, 0x01, 0x04, 0x68, 0x6f, 0x73, 0x74, 0x05,
+    0x72, 0x65, 0x61, 0x64, 0x30, 0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0x05,
+    0x03, 0x01, 0x00, 0x01, 0x07, 0x09, 0x01, 0x05, 0x70, 0x72, 0x6f, 0x62,
+    0x65, 0x00, 0x01, 0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00, 0x0b, 0x0b,
+    0x0a, 0x01, 0x00, 0x41, 0x00, 0x0b, 0x04, 0x22, 0x22, 0x22, 0x00, 0x00,
+    0x1c, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x01, 0x0f, 0x02, 0x00, 0x05, 0x72,
+    0x65, 0x61, 0x64, 0x30, 0x01, 0x05, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x04,
+    0x04, 0x01, 0x00, 0x01, 0x74};
+
+const std::array<WasmEdge::Byte, 108> CrossModuleHostCallerWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x02, 0x10, 0x01, 0x06, 0x63, 0x61, 0x6c, 0x6c, 0x65,
+    0x65, 0x05, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x00, 0x00, 0x03, 0x02, 0x01,
+    0x00, 0x05, 0x03, 0x01, 0x00, 0x01, 0x07, 0x07, 0x01, 0x03, 0x72, 0x75,
+    0x6e, 0x00, 0x01, 0x09, 0x05, 0x01, 0x03, 0x00, 0x01, 0x00, 0x0a, 0x08,
+    0x01, 0x06, 0x00, 0xd2, 0x00, 0x14, 0x00, 0x0b, 0x0b, 0x0a, 0x01, 0x00,
+    0x41, 0x00, 0x0b, 0x04, 0x11, 0x11, 0x11, 0x00, 0x00, 0x1a, 0x04, 0x6e,
+    0x61, 0x6d, 0x65, 0x01, 0x0d, 0x02, 0x00, 0x05, 0x70, 0x72, 0x6f, 0x62,
+    0x65, 0x01, 0x03, 0x72, 0x75, 0x6e, 0x04, 0x04, 0x01, 0x00, 0x01, 0x74};
+
+TEST(AOTCrossModule, HostFunctionSeesCalleeMemory) {
+  Configure Conf;
+  Conf.addProposal(Proposal::ReferenceTypes);
+  Conf.addProposal(Proposal::FunctionReferences);
+
+  auto CalleeMod = compileToJIT(Conf, CrossModuleHostCalleeWasm);
+  ASSERT_NE(CalleeMod, nullptr);
+  auto CallerMod = compileToJIT(Conf, CrossModuleHostCallerWasm);
+  ASSERT_NE(CallerMod, nullptr);
+
+  Executor::Executor ExecEngine(Conf);
+  Runtime::StoreManager Store;
+
+  CrossModuleHostModule HostMod;
+  ASSERT_TRUE(ExecEngine.registerModule(Store, HostMod));
+
+  auto CalleeInstOrErr = ExecEngine.registerModule(Store, *CalleeMod, "callee");
+  ASSERT_TRUE(CalleeInstOrErr);
+  auto CalleeInst = std::move(*CalleeInstOrErr);
+
+  auto CallerInstOrErr = ExecEngine.instantiateModule(Store, *CallerMod);
+  ASSERT_TRUE(CallerInstOrErr);
+  auto CallerInst = std::move(*CallerInstOrErr);
+
+  const auto *Run = CallerInst->findFuncExports("run");
+  ASSERT_NE(Run, nullptr);
+  ASSERT_TRUE(Run->isCompiledFunction());
+  auto R = ExecEngine.invoke(Run, {}, {});
+  ASSERT_TRUE(R);
+  ASSERT_EQ(R->size(), 1u);
+  EXPECT_EQ((*R)[0].first.get<uint32_t>(), 0x00222222U)
+      << "the host function saw the caller's memory instead of the callee's";
+}
+
+// A cross-module struct.new_default must resolve its type index against the
+// callee's own type section and own the result under the callee's module. The
+// modules number types differently: callee $S is at index 1, while caller index
+// 1 is a differently-shaped struct ($Collide), so a wrongly-bound context reads
+// a valid but wrong type instead of crashing. $S's second field is a concrete
+// (ref null $T), the only default-init field kind that reaches toBottomType.
+//   callee: (type $T (struct (field i32)))
+//           (type $S (struct (field $tag (mut i32)) (field $next (ref null
+//           $T)))) (func (export "make") (result (ref $S)) (struct.new_default
+//           $S))
+//   caller: (type $Collide (struct (field (mut i32)) (field (mut i32))))
+//           (type $S_caller (struct (field (mut i32)) (field (ref null
+//           $T_caller)))) (import "callee" "make" (func $make (result (ref
+//           $S_caller)))) (table 1 funcref) (elem (i32.const 0) func $make)
+//           (func (export "run") (result (ref $S_caller))
+//             (call_indirect (type $MkTy) (i32.const 0)))
+const std::array<WasmEdge::Byte, 97> CrossModuleGCCalleeWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x11, 0x03,
+    0x5f, 0x01, 0x7f, 0x00, 0x5f, 0x02, 0x7f, 0x01, 0x63, 0x00, 0x00,
+    0x60, 0x00, 0x01, 0x64, 0x01, 0x03, 0x02, 0x01, 0x02, 0x07, 0x08,
+    0x01, 0x04, 0x6d, 0x61, 0x6b, 0x65, 0x00, 0x00, 0x0a, 0x07, 0x01,
+    0x05, 0x00, 0xfb, 0x01, 0x01, 0x0b, 0x00, 0x2d, 0x04, 0x6e, 0x61,
+    0x6d, 0x65, 0x01, 0x07, 0x01, 0x00, 0x04, 0x6d, 0x61, 0x6b, 0x65,
+    0x04, 0x0d, 0x03, 0x00, 0x01, 0x54, 0x01, 0x01, 0x53, 0x02, 0x04,
+    0x4d, 0x6b, 0x54, 0x79, 0x0a, 0x0e, 0x01, 0x01, 0x02, 0x00, 0x03,
+    0x74, 0x61, 0x67, 0x01, 0x04, 0x6e, 0x65, 0x78, 0x74};
+
+const std::array<WasmEdge::Byte, 160> CrossModuleGCCallerWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x1a, 0x05, 0x60,
+    0x00, 0x00, 0x5f, 0x02, 0x7f, 0x01, 0x7f, 0x01, 0x5f, 0x01, 0x7f, 0x00,
+    0x5f, 0x02, 0x7f, 0x01, 0x63, 0x02, 0x00, 0x60, 0x00, 0x01, 0x64, 0x03,
+    0x02, 0x0f, 0x01, 0x06, 0x63, 0x61, 0x6c, 0x6c, 0x65, 0x65, 0x04, 0x6d,
+    0x61, 0x6b, 0x65, 0x00, 0x04, 0x03, 0x02, 0x01, 0x04, 0x04, 0x04, 0x01,
+    0x70, 0x00, 0x01, 0x07, 0x07, 0x01, 0x03, 0x72, 0x75, 0x6e, 0x00, 0x01,
+    0x09, 0x07, 0x01, 0x00, 0x41, 0x00, 0x0b, 0x01, 0x00, 0x0a, 0x09, 0x01,
+    0x07, 0x00, 0x41, 0x00, 0x11, 0x04, 0x00, 0x0b, 0x00, 0x42, 0x04, 0x6e,
+    0x61, 0x6d, 0x65, 0x01, 0x0c, 0x02, 0x00, 0x04, 0x6d, 0x61, 0x6b, 0x65,
+    0x01, 0x03, 0x72, 0x75, 0x6e, 0x04, 0x2d, 0x05, 0x00, 0x07, 0x41, 0x46,
+    0x69, 0x6c, 0x6c, 0x65, 0x72, 0x01, 0x07, 0x43, 0x6f, 0x6c, 0x6c, 0x69,
+    0x64, 0x65, 0x02, 0x08, 0x54, 0x5f, 0x63, 0x61, 0x6c, 0x6c, 0x65, 0x72,
+    0x03, 0x08, 0x53, 0x5f, 0x63, 0x61, 0x6c, 0x6c, 0x65, 0x72, 0x04, 0x04,
+    0x4d, 0x6b, 0x54, 0x79};
+
+TEST(AOTCrossModule, CrossModuleStructNewOwnedByCallee) {
+  Configure Conf;
+  Conf.addProposal(Proposal::ReferenceTypes);
+  Conf.addProposal(Proposal::FunctionReferences);
+  Conf.addProposal(Proposal::GC);
+
+  auto CalleeMod = compileToJIT(Conf, CrossModuleGCCalleeWasm);
+  ASSERT_NE(CalleeMod, nullptr);
+  auto CallerMod = compileToJIT(Conf, CrossModuleGCCallerWasm);
+  ASSERT_NE(CallerMod, nullptr);
+
+  Executor::Executor ExecEngine(Conf);
+  Runtime::StoreManager Store;
+
+  auto CalleeInstOrErr = ExecEngine.registerModule(Store, *CalleeMod, "callee");
+  ASSERT_TRUE(CalleeInstOrErr);
+  auto CalleeInst = std::move(*CalleeInstOrErr);
+
+  auto CallerInstOrErr = ExecEngine.instantiateModule(Store, *CallerMod);
+  ASSERT_TRUE(CallerInstOrErr);
+  auto CallerInst = std::move(*CallerInstOrErr);
+
+  const auto *Run = CallerInst->findFuncExports("run");
+  ASSERT_NE(Run, nullptr);
+  ASSERT_TRUE(Run->isCompiledFunction());
+  auto R = ExecEngine.invoke(Run, {}, {});
+  ASSERT_TRUE(R);
+  ASSERT_EQ(R->size(), 1u);
+
+  const auto *Inst = (*R)[0]
+                         .first.get<RefVariant>()
+                         .getPtr<Runtime::Instance::StructInstance>();
+  ASSERT_NE(Inst, nullptr);
+  EXPECT_EQ(Inst->getModule(), CalleeInst.get())
+      << "the struct created by the callee's struct.new_default is not "
+         "owned by the callee module";
+  EXPECT_NE(Inst->getModule(), CallerInst.get())
+      << "the struct is owned by the caller instead of the callee";
+  EXPECT_EQ(Inst->getField(0).get<uint32_t>(), 0u);
+  EXPECT_TRUE(Inst->getField(1).get<RefVariant>().isNull())
+      << "the default-initialized concrete reference field did not resolve "
+         "to a null bottom type through the callee's own type section";
+}
+
+// A compiled throw must resolve its tag in the throwing module's tag space. The
+// two modules disagree on what tag index 1 means: it is $b1 in the callee but
+// the caller's own $a1, so a throw resolved against the caller is caught by
+// catch_all (2) instead of the imported $b1 (1). call_ref is the probe because
+// it reaches the callee natively, without an interpreter frame to carry the
+// module.
+//   callee: (tag $b0) (tag $b1) (export "b1" (tag $b1))
+//           (func (export "throw1") (throw $b1))
+//   caller: (import "callee" "b1" (tag $ib1))
+//           (import "callee" "throw1" (func $throw1))
+//           (tag $a1)
+//           (func (export "run") (result i32)
+//             (block $on_b1 (block $on_any
+//               (try_table (catch $ib1 $on_b1) (catch_all $on_any)
+//                 (call_ref $v (ref.func $throw1)))
+//               (return (i32.const 0)))
+//               (return (i32.const 2)))
+//             (i32.const 1))
+const std::array<WasmEdge::Byte, 85> CrossModuleThrowCalleeWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x04, 0x01,
+    0x60, 0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0x0d, 0x05, 0x02, 0x00,
+    0x00, 0x00, 0x00, 0x07, 0x0f, 0x02, 0x06, 0x74, 0x68, 0x72, 0x6f,
+    0x77, 0x31, 0x00, 0x00, 0x02, 0x62, 0x31, 0x04, 0x01, 0x0a, 0x06,
+    0x01, 0x04, 0x00, 0x08, 0x01, 0x0b, 0x00, 0x21, 0x04, 0x6e, 0x61,
+    0x6d, 0x65, 0x01, 0x09, 0x01, 0x00, 0x06, 0x74, 0x68, 0x72, 0x6f,
+    0x77, 0x31, 0x04, 0x04, 0x01, 0x00, 0x01, 0x76, 0x0b, 0x09, 0x02,
+    0x00, 0x02, 0x62, 0x30, 0x01, 0x02, 0x62, 0x31};
+
+const std::array<WasmEdge::Byte, 164> CrossModuleThrowCallerWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x60,
+    0x00, 0x00, 0x60, 0x00, 0x01, 0x7f, 0x02, 0x1e, 0x02, 0x06, 0x63, 0x61,
+    0x6c, 0x6c, 0x65, 0x65, 0x02, 0x62, 0x31, 0x04, 0x00, 0x00, 0x06, 0x63,
+    0x61, 0x6c, 0x6c, 0x65, 0x65, 0x06, 0x74, 0x68, 0x72, 0x6f, 0x77, 0x31,
+    0x00, 0x00, 0x03, 0x02, 0x01, 0x01, 0x0d, 0x03, 0x01, 0x00, 0x00, 0x07,
+    0x07, 0x01, 0x03, 0x72, 0x75, 0x6e, 0x00, 0x01, 0x09, 0x05, 0x01, 0x03,
+    0x00, 0x01, 0x00, 0x0a, 0x1f, 0x01, 0x1d, 0x00, 0x02, 0x40, 0x02, 0x40,
+    0x1f, 0x40, 0x02, 0x00, 0x00, 0x01, 0x02, 0x00, 0xd2, 0x00, 0x14, 0x00,
+    0x0b, 0x41, 0x00, 0x0f, 0x0b, 0x41, 0x02, 0x0f, 0x0b, 0x41, 0x01, 0x0b,
+    0x00, 0x36, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x01, 0x09, 0x01, 0x00, 0x06,
+    0x74, 0x68, 0x72, 0x6f, 0x77, 0x31, 0x03, 0x12, 0x01, 0x01, 0x02, 0x00,
+    0x05, 0x6f, 0x6e, 0x5f, 0x62, 0x31, 0x01, 0x06, 0x6f, 0x6e, 0x5f, 0x61,
+    0x6e, 0x79, 0x04, 0x04, 0x01, 0x00, 0x01, 0x76, 0x0b, 0x0a, 0x02, 0x00,
+    0x03, 0x69, 0x62, 0x31, 0x01, 0x02, 0x61, 0x31};
+
+TEST(AOTCrossModule, CompiledThrowUsesCalleeTagSpace) {
+  Configure Conf;
+  Conf.addProposal(Proposal::ReferenceTypes);
+  Conf.addProposal(Proposal::FunctionReferences);
+  Conf.addProposal(Proposal::ExceptionHandling);
+
+  auto CalleeMod = compileToJIT(Conf, CrossModuleThrowCalleeWasm);
+  ASSERT_NE(CalleeMod, nullptr);
+  auto CallerMod = compileToJIT(Conf, CrossModuleThrowCallerWasm);
+  ASSERT_NE(CallerMod, nullptr);
+
+  Executor::Executor ExecEngine(Conf);
+  Runtime::StoreManager Store;
+
+  auto CalleeInstOrErr = ExecEngine.registerModule(Store, *CalleeMod, "callee");
+  ASSERT_TRUE(CalleeInstOrErr);
+  auto CalleeInst = std::move(*CalleeInstOrErr);
+
+  auto CallerInstOrErr = ExecEngine.instantiateModule(Store, *CallerMod);
+  ASSERT_TRUE(CallerInstOrErr);
+  auto CallerInst = std::move(*CallerInstOrErr);
+
+  const auto *Run = CallerInst->findFuncExports("run");
+  ASSERT_NE(Run, nullptr);
+  ASSERT_TRUE(Run->isCompiledFunction());
+  auto R = ExecEngine.invoke(Run, {}, {});
+  ASSERT_TRUE(R);
+  ASSERT_EQ(R->size(), 1u);
+  EXPECT_EQ((*R)[0].first.get<uint32_t>(), 1u)
+      << "the callee's throw did not resolve its tag in the callee's module";
+}
+
 TEST_P(NativeCoreTest, TestSuites) {
   auto [Proposal, Conf, UnitName] = T.resolve(GetParam());
   // Native AOT spec test: explicitly opt into RunMode::AOT so the runtime

--- a/test/llvm/LLVMcoreTest.cpp
+++ b/test/llvm/LLVMcoreTest.cpp
@@ -892,6 +892,79 @@ TEST(AOTCrossModule, InterpreterTrapAttributesCallerModule) {
   EXPECT_TRUE(SawCallee);
 }
 
+//   callee (trapper): (func (export "boom") (result i32) unreachable)
+const std::array<WasmEdge::Byte, 36> TrapCalleeWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x07, 0x08, 0x01, 0x04, 0x62,
+    0x6f, 0x6f, 0x6d, 0x00, 0x00, 0x0a, 0x05, 0x01, 0x03, 0x00, 0x00, 0x0b};
+
+//   caller: (import "trapper" "boom" (func $boom (result i32)))
+//           (table 1 funcref) (elem (i32.const 0) $boom)
+//           (func (export "run") (result i32)
+//             (call_indirect (type $t) (i32.const 0)))
+const std::array<WasmEdge::Byte, 94> TrapCallerWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x02, 0x10, 0x01, 0x07, 0x74, 0x72, 0x61, 0x70, 0x70,
+    0x65, 0x72, 0x04, 0x62, 0x6f, 0x6f, 0x6d, 0x00, 0x00, 0x03, 0x02, 0x01,
+    0x00, 0x04, 0x04, 0x01, 0x70, 0x00, 0x01, 0x07, 0x07, 0x01, 0x03, 0x72,
+    0x75, 0x6e, 0x00, 0x01, 0x09, 0x07, 0x01, 0x00, 0x41, 0x00, 0x0b, 0x01,
+    0x00, 0x0a, 0x09, 0x01, 0x07, 0x00, 0x41, 0x00, 0x11, 0x00, 0x00, 0x0b,
+    0x00, 0x14, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x01, 0x07, 0x01, 0x00, 0x04,
+    0x62, 0x6f, 0x6f, 0x6d, 0x04, 0x04, 0x01, 0x00, 0x01, 0x74};
+
+// A trap inside a frameless cross-module compiled callee must be attributed to
+// the callee's module. The caller's run() call_indirects into the callee's
+// boom(), which traps. The only top-frame module is the caller, so resolving
+// the callee's frame needs the whole live store enumerated.
+TEST(AOTCrossModule, CompiledFramelessTrapAttributedToCallee) {
+  Configure Conf;
+  Conf.addProposal(Proposal::ReferenceTypes);
+  Conf.addProposal(Proposal::FunctionReferences);
+
+  auto CalleeMod = compileToJIT(Conf, TrapCalleeWasm);
+  ASSERT_NE(CalleeMod, nullptr);
+  auto CallerMod = compileToJIT(Conf, TrapCallerWasm);
+  ASSERT_NE(CallerMod, nullptr);
+
+  Executor::Executor ExecEngine(Conf);
+  Runtime::StoreManager Store;
+
+  auto CalleeInstOrErr =
+      ExecEngine.registerModule(Store, *CalleeMod, "trapper");
+  ASSERT_TRUE(CalleeInstOrErr);
+  auto CalleeInst = std::move(*CalleeInstOrErr);
+  const auto *Boom = CalleeInst->findFuncExports("boom");
+  ASSERT_NE(Boom, nullptr);
+  ASSERT_TRUE(Boom->isCompiledFunction());
+
+  auto CallerInstOrErr = ExecEngine.instantiateModule(Store, *CallerMod);
+  ASSERT_TRUE(CallerInstOrErr);
+  auto CallerInst = std::move(*CallerInstOrErr);
+
+  const auto *Run = CallerInst->findFuncExports("run");
+  ASSERT_NE(Run, nullptr);
+  ASSERT_TRUE(Run->isCompiledFunction());
+
+  auto R = ExecEngine.invoke(Run, {}, {});
+  ASSERT_FALSE(R);
+
+  auto Trace = Executor::Executor::getRecordedStackTrace();
+  if (Trace.empty()) {
+    // Walking a compiled frame needs unwind information that the generated
+    // code registers only on some platforms; without it there is nothing to
+    // attribute.
+    GTEST_SKIP() << "no compiled frame was walkable on this platform";
+  }
+  bool SawCallee = false;
+  for (const auto &E : Trace) {
+    if (E.Module == CalleeInst.get()) {
+      SawCallee = true;
+    }
+  }
+  EXPECT_TRUE(SawCallee)
+      << "frameless cross-module trap was not attributed to the callee module";
+}
+
 TEST_P(NativeCoreTest, TestSuites) {
   auto [Proposal, Conf, UnitName] = T.resolve(GetParam());
   // Native AOT spec test: explicitly opt into RunMode::AOT so the runtime


### PR DESCRIPTION
## Description

Replaces the single-commit version of this PR. That version fixed the bug by *disabling* the compiled fast path whenever a call crossed a module instance, which cost cross-module tail calls their constant-space guarantee. This version instead makes the compiled ABI able to express a module switch, so the fast path survives and the tail-call regression is gone.

### The bug

A compiled `call`, `call_indirect`, or `call_ref` into a **different module instance** ran the callee against the **caller's** execution context. Since that context holds the running module's memories, tables, and globals, the callee read the wrong instance's state — `global.get 0` or `memory.grow` inside the callee resolved in the caller's module.

The root cause is that the compiled ABI had a single `ExecutionContext` per thread mixing two different lifetimes: per-module state (memories, tables, globals, module identity) and per-thread state (instruction count, gas, stop token). A cross-module call needs to swap the first and keep the second, and one struct cannot do that.

### The fix

Split the compiled context in two and thread both through the ABI:

| Context | Lifetime | Fields |
| --- | --- | --- |
| `ModuleContext` (param 0) | per module instance | `Memories`, `MemorySizes`, `TableRefs`, `TableSizes`, `Globals`, `ModuleInst`, `Tags` |
| `ExecutorContext` (param 1) | per thread | `InstrCount`, `CostTable`, `Gas`, `GasLimit`, `StopToken`, `PendingExnTagAddr` |

`Executable::Wrapper` becomes 5-arg (`ModCtx`, `ExecCtx`, `Function`, `Args`, `Rets`). Module accessors in codegen read `ModCtx`, thread accessors read `ExecCtx`. The `call` / `call_indirect` / `call_ref` proxies now resolve the callee's `ModuleContext`, enter the callee with it, and rebind on return; gas and instruction counting keep running across the boundary because they live in the other context.

Because compiled code can now execute under a module that is not the top frame's, every module-sensitive intrinsic (memory, table, ref, thread, GC, host-call `CallingFrame`, exception tags) had to stop resolving its module via `StackManager::getModule()`. Those all gained explicit-module overloads and are passed the module derived from the incoming `ModuleContext`.

Both `ModuleContext` and `ExecutorContext` are mirrored by hand in `lib/llvm/compiler/context.cpp` as LLVM struct types indexed by field number; `static_assert`s on the C++ side now pin the layout each side agrees on.

### Second fix: cross-module fault attribution

The same frameless fast path breaks stack traces. When a compiled callee is reached without pushing a `StackManager` frame, a trap inside it was attributed to the *caller's* module, so `calling stack:` named a function that never ran.

Three commits address it: stack-trace entries become `(module, function index)` pairs instead of bare indices and are cleared at top-level invocation (so a fault never renders a freed module); the interpreter resolves each frame against that frame's own module rather than the top one; and the compiled path builds its address→`(module, index)` map across every live module — frame-stack seeds plus each instance in a reachable store — so a frameless callee's trap resolves to the callee.

### Drive-by AOT fixes

Four independent bugs found while building the above, kept as their own commits at the base of the stack:

- **`musttail` on mismatched prototypes** — cross-module and indirect tail calls whose signatures differ from the caller's tripped the LLVM verifier. Those lower through an ordinary `tail` call now; `musttail` is reserved for the matching-prototype fast path.
- **`table64` index truncation** — compiled `call_indirect` truncated an i64 element index to i32 before the bounds check, dropping the high bits.
- **Over-mangled AArch64 NEON intrinsics** — `createBinaryIntrinsic` always passed two overload types, so the single-overload `llvm.aarch64.neon.sqrdmulh` and `llvm.aarch64.neon.urhadd` were declared as `…sqrdmulh.v8i16.v8i16`, which the LLVM verifier rejects (*"Intrinsic name not mangled correctly for type arguments"*). Latent on `master` because nothing verified the module; fatal once the verifier runs, so it lands **before** the verifier commit to keep every commit bisectable on arm64. The helper had no correct use left and is removed.
- **Silent bad IR** — codegen never ran the LLVM module verifier, so malformed generated IR could reach the object emitter. A verification failure is now a hard compilation error. (This is what surfaced both the `musttail` and the NEON bug.)

### Known limitations

Recorded as comments at the relevant sites rather than fixed here:

- A tail call whose callee prototype differs from the caller's falls back to the `tail` *hint*, which LLVM may decline. Such a call is not guaranteed constant-space. There is no general fix without a prototype-normalizing trampoline.
- Two instances of the same compiled module share code addresses, so the compiled trace map keeps whichever instance is enumerated first; a trap in the second one is reported against the first. A native frame carries no instance identity to tell them apart.
- `ModuleInstance::buildContext()` snapshots the instance vectors' buffers, so adding an instance after finalization would leave the context dangling. The `unsafeImportInstance` / `unsafeAddInstance` helpers now `assuming(!isInstantiateFinalized())`.

### Commits

16 commits, ordered so each builds and tests standalone:

| # | |
| --- | --- |
| 1 | `fix(aot)`: lower mismatched-prototype tail calls with `tail`, not `musttail` |
| 2 | `fix(aot)`: widen `call_indirect` table index to 64-bit for table64 |
| 3 | `fix(aot)`: mangle single-overload AArch64 NEON intrinsics correctly |
| 4 | `fix(aot)`: fail compilation on LLVM verification error |
| 5 | `refactor(executor)`: add per-instance `ModuleContext` as module-field authority |
| 6 | `refactor(aot)`: thread a second context pointer through the compiled ABI |
| 7 | `refactor(aot)`: split compiled context into `ModuleContext` and `ExecutorContext` |
| 8 | `refactor(executor)`: add explicit-module overloads for instance/type lookups |
| 9 | `refactor(executor)`: add explicit-module overloads for GC operation delegates |
| 10 | `refactor(aot)`: pass the executing module explicitly to module-sensitive intrinsics |
| 11 | `refactor(executor)`: construct host `CallingFrame` from the explicit caller module |
| 12 | `fix(aot)`: run compiled cross-module calls with the callee's module context |
| 13 | `test(aot)`: cross-module coverage for tail-indirect, gas, multi-instance, host, and GC |
| 14 | `refactor(executor)`: make recorded stack traces module-qualified |
| 15 | `fix(executor)`: attribute interpreter stack frames to their own module |
| 16 | `fix(executor)`: attribute compiled cross-module traps across live modules |

23 files changed, 2330 insertions, 768 deletions.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

This contribution was developed with assistance from Claude (Anthropic).

## Test Evidence

Built with clang++ 21, `-DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_USE_LLVM=ON`, Release.

Twelve `AOTCrossModule` cases in `test/llvm/LLVMcoreTest.cpp`. Each compiles both modules up front and instantiates them into a **single store owned by a single executor**, so nothing here is an artifact of sharing modules across VMs.

| Test | What it pins down |
| --- | --- |
| `CompiledCallUsesCalleeContext` | `call_ref`, direct `call`, and `call_indirect` read the callee's state and give the caller's back |
| `CompiledTailCallUsesCalleeContext` | cross-module `return_call_ref` keeps each side on its own globals |
| `LazyJITCallUsesCalleeContext` | the same reads under `RunMode::LazyJIT` |
| `TailCallLeavesCallerContextIntact` | `A.a → A.b → tail → B.c`; `A.a` resumes on its own memory |
| `CompiledReturnCallIndirectUsesCalleeContext` | `return_call_indirect` context handoff |
| `GasMeteringSpansCrossModuleCall` | gas keeps accumulating across the boundary (the per-thread context is *not* swapped) |
| `SameCompiledModuleTwoInstancesKeepOwnState` | one compiled image, two instances, separate state |
| `HostFunctionSeesCalleeMemory` | a host function reached through a compiled callee gets the callee's `CallingFrame` |
| `CrossModuleStructNewOwnedByCallee` | GC `struct.new_default` resolves its type in the callee's module |
| `CompiledThrowUsesCalleeTagSpace` | `throw` / `catch_pop` resolve the tag index in the callee's tag space |
| `InterpreterTrapAttributesCallerModule` | interpreter trace names each frame's own module |
| `CompiledFramelessTrapAttributedToCallee` | a trap in a frameless compiled callee is attributed to the callee, not the caller |

The context tests make the caller return `callee_global * 10 + memory.grow(0)` — **1871** correct, **1875** leaked. The second term deliberately goes through `memory.grow`: that intrinsic resolves the memory live, whereas an inline `memory.size` or `global.get` reads the context snapshotted on function entry and cannot observe a stale rebind at all. An earlier version of these tests used an inline read and passed against known-broken code.

Each of the behavioural fixes was red-verified — reverted against its own test before landing.

`CompiledFramelessTrapAttributedToCallee` needs the platform's native backtrace to walk into generated code. That works on Linux (x86_64 and aarch64), where the assertion runs; on macOS and Windows the generated code registers no unwind information and the recorded trace comes back empty, so the case skips itself rather than asserting on something the platform cannot provide.

```
$ ./build/test/llvm/wasmedgeLLVMCoreTests --gtest_filter='AOTCrossModule.*'
[==========] Running 12 tests from 1 test suite.
[ RUN      ] AOTCrossModule.CompiledCallUsesCalleeContext
[       OK ] AOTCrossModule.CompiledCallUsesCalleeContext (15 ms)
[ RUN      ] AOTCrossModule.CompiledTailCallUsesCalleeContext
[       OK ] AOTCrossModule.CompiledTailCallUsesCalleeContext (12 ms)
[ RUN      ] AOTCrossModule.LazyJITCallUsesCalleeContext
[       OK ] AOTCrossModule.LazyJITCallUsesCalleeContext (12 ms)
[ RUN      ] AOTCrossModule.TailCallLeavesCallerContextIntact
[       OK ] AOTCrossModule.TailCallLeavesCallerContextIntact (9 ms)
[ RUN      ] AOTCrossModule.CompiledReturnCallIndirectUsesCalleeContext
[       OK ] AOTCrossModule.CompiledReturnCallIndirectUsesCalleeContext (7 ms)
[ RUN      ] AOTCrossModule.GasMeteringSpansCrossModuleCall
[error] wasmedge runtime failed: cost limit exceeded, Code: 0x003
[error] calling stack:module[0]:3, module[0]:2
[       OK ] AOTCrossModule.GasMeteringSpansCrossModuleCall (23 ms)
[ RUN      ] AOTCrossModule.SameCompiledModuleTwoInstancesKeepOwnState
[       OK ] AOTCrossModule.SameCompiledModuleTwoInstancesKeepOwnState (9 ms)
[ RUN      ] AOTCrossModule.HostFunctionSeesCalleeMemory
[       OK ] AOTCrossModule.HostFunctionSeesCalleeMemory (8 ms)
[ RUN      ] AOTCrossModule.CrossModuleStructNewOwnedByCallee
[       OK ] AOTCrossModule.CrossModuleStructNewOwnedByCallee (10 ms)
[ RUN      ] AOTCrossModule.CompiledThrowUsesCalleeTagSpace
[       OK ] AOTCrossModule.CompiledThrowUsesCalleeTagSpace (8 ms)
[ RUN      ] AOTCrossModule.InterpreterTrapAttributesCallerModule
[error] execution failed: unreachable, Code: 0x40a
[error]     In instruction: unreachable (0x00) , Bytecode offset: 0x00000020
[error] calling stack:module[0]:1, trapper2:1
[       OK ] AOTCrossModule.InterpreterTrapAttributesCallerModule (0 ms)
[ RUN      ] AOTCrossModule.CompiledFramelessTrapAttributedToCallee
[error] execution failed: unreachable, Code: 0x40a
[error] calling stack:trapper:0, module[0]:1
[       OK ] AOTCrossModule.CompiledFramelessTrapAttributedToCallee (9 ms)
[==========] 12 tests from 1 test suite ran. (127 ms total)
[  PASSED  ] 12 tests.
```

Note the two trace tests: `calling stack:module[0]:1, trapper2:1` and `calling stack:trapper:0, module[0]:1` are module-qualified and name the correct module on each side. Before these commits both sides were labelled with a single module.

Full suite, including the WASM spec tests:

```
$ ctest
100% tests passed, 0 tests failed out of 30

Total Test time (real) = 119.34 sec
```

Also built and run clean under g++ 14 Release in a separate build tree. `clang-format` 22 clean over `include lib tools plugins examples`; `lineguard` clean on all 23 changed files.
