### PR TITLE
fix: correct Ubuntu 20.04 fallback to read /etc/lsb-release in instal…

### DIFF
--- a/utils/install.py
+++ b/utils/install.py
@@ -1253,7 +1253,7 @@ class Compat:
                     if VersionString(__lsb_rel).compare(
                         "20.04"
                     ) >= 0 or "Ubuntu 20.04" in run_shell_command(
-                        "cat /etc/lsb_release 2>/dev/null | grep DESCRIPTION"
+                        "cat /etc/lsb-release 2>/dev/null | grep DESCRIPTION"
                     ):
                         # ARM-based Ubuntu 20.04 is supported after 0.13.5
                         if self.arch == "x86_64" or (


### PR DESCRIPTION
…l.py

The Python 3 distro detection has a fallback that reads /etc/lsb_release with an underscore. On Ubuntu the file is /etc/lsb-release with a hyphen, so the underscore path never exists. The 2>/dev/null hides the missing-file error, so run_shell_command returns an empty string and "Ubuntu 20.04" in "" is always false, leaving the fallback unable to detect anything.

The other two reads in the same block already use the hyphenated path, so this was a typo. Point the fallback at /etc/lsb-release so it can actually match an Ubuntu 20.04 host when the primary RELEASE-line check misses.

## Description
<!-- Describe your changes here -->

## Checklist

Before submitting this PR, please ensure the following:

- [ ] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [ ] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [ ] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [ ] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
