### PR TITLE
feat(api): add cAPI support for coredump configuration options

### DIFF
--- a/include/api/wasmedge/wasmedge_configure.h
+++ b/include/api/wasmedge/wasmedge_configure.h
@@ -208,6 +208,49 @@ WASMEDGE_CAPI_EXPORT extern void WasmEdge_ConfigureSetAllowAFUNIX(
 WASMEDGE_CAPI_EXPORT extern bool WasmEdge_ConfigureIsAllowAFUNIX(
     const WasmEdge_ConfigureContext *Cxt) WASMEDGE_CAPI_NOEXCEPT;
 
+/// Set the option of enabling/disabling coredump generation.
+///
+/// This function is thread-safe.
+///
+/// \param Cxt the WasmEdge_ConfigureContext to set the boolean value.
+/// \param EnableCoredump the boolean value to determine to enable coredump
+/// generation or not.
+WASMEDGE_CAPI_EXPORT extern void WasmEdge_ConfigureSetEnableCoredump(
+    WasmEdge_ConfigureContext *Cxt,
+    const bool EnableCoredump) WASMEDGE_CAPI_NOEXCEPT;
+
+/// Get the EnableCoredump option.
+///
+/// This function is thread-safe.
+///
+/// \param Cxt the WasmEdge_ConfigureContext to get the boolean value.
+///
+/// \returns the boolean value to determine to enable coredump generation or not.
+WASMEDGE_CAPI_EXPORT extern bool WasmEdge_ConfigureIsEnableCoredump(
+    const WasmEdge_ConfigureContext *Cxt) WASMEDGE_CAPI_NOEXCEPT;
+
+/// Set the option of enabling/disabling wasmgdb format for coredump.
+///
+/// This function is thread-safe.
+///
+/// \param Cxt the WasmEdge_ConfigureContext to set the boolean value.
+/// \param CoredumpWasmgdb the boolean value to determine to enable wasmgdb format
+/// for coredump or not.
+WASMEDGE_CAPI_EXPORT extern void WasmEdge_ConfigureSetCoredumpWasmgdb(
+    WasmEdge_ConfigureContext *Cxt,
+    const bool CoredumpWasmgdb) WASMEDGE_CAPI_NOEXCEPT;
+
+/// Get the CoredumpWasmgdb option.
+///
+/// This function is thread-safe.
+///
+/// \param Cxt the WasmEdge_ConfigureContext to get the boolean value.
+///
+/// \returns the boolean value to determine to enable wasmgdb format for
+/// coredump or not.
+WASMEDGE_CAPI_EXPORT extern bool WasmEdge_ConfigureIsCoredumpWasmgdb(
+    const WasmEdge_ConfigureContext *Cxt) WASMEDGE_CAPI_NOEXCEPT;
+
 /// Set the optimization level of the AOT compiler.
 ///
 /// This function is thread-safe.

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -1032,6 +1032,39 @@ WasmEdge_ConfigureIsAllowAFUNIX(const WasmEdge_ConfigureContext *Cxt) noexcept {
   return false;
 }
 
+WASMEDGE_CAPI_EXPORT void
+WasmEdge_ConfigureSetEnableCoredump(WasmEdge_ConfigureContext *Cxt,
+                                    const bool EnableCoredump) noexcept {
+  if (Cxt) {
+    Cxt->Conf.getRuntimeConfigure().setEnableCoredump(EnableCoredump);
+  }
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_ConfigureIsEnableCoredump(const WasmEdge_ConfigureContext *Cxt) noexcept {
+  if (Cxt) {
+    return Cxt->Conf.getRuntimeConfigure().isEnableCoredump();
+  }
+  return false;
+}
+
+WASMEDGE_CAPI_EXPORT void
+WasmEdge_ConfigureSetCoredumpWasmgdb(WasmEdge_ConfigureContext *Cxt,
+                                     const bool CoredumpWasmgdb) noexcept {
+  if (Cxt) {
+    Cxt->Conf.getRuntimeConfigure().setCoredumpWasmgdb(CoredumpWasmgdb);
+  }
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_ConfigureIsCoredumpWasmgdb(
+    const WasmEdge_ConfigureContext *Cxt) noexcept {
+  if (Cxt) {
+    return Cxt->Conf.getRuntimeConfigure().isCoredumpWasmgdb();
+  }
+  return false;
+}
+
 WASMEDGE_CAPI_EXPORT bool WasmEdge_ConfigureIsForceInterpreter(
     const WasmEdge_ConfigureContext *Cxt) noexcept {
   if (Cxt) {

--- a/test/api/APIUnitTest.cpp
+++ b/test/api/APIUnitTest.cpp
@@ -769,6 +769,15 @@ TEST(APICoreTest, Configure) {
   EXPECT_EQ(WasmEdge_ConfigureGetRunMode(Conf), WasmEdge_RunMode_Interpreter);
   // Reset to a deterministic mode for the rest of the test.
   WasmEdge_ConfigureSetRunMode(Conf, WasmEdge_RunMode_Interpreter);
+  // Tests for coredump configurations.
+  WasmEdge_ConfigureSetEnableCoredump(ConfNull, true);
+  WasmEdge_ConfigureSetEnableCoredump(Conf, true);
+  EXPECT_NE(WasmEdge_ConfigureIsEnableCoredump(ConfNull), true);
+  EXPECT_EQ(WasmEdge_ConfigureIsEnableCoredump(Conf), true);
+  WasmEdge_ConfigureSetCoredumpWasmgdb(ConfNull, true);
+  WasmEdge_ConfigureSetCoredumpWasmgdb(Conf, true);
+  EXPECT_NE(WasmEdge_ConfigureIsCoredumpWasmgdb(ConfNull), true);
+  EXPECT_EQ(WasmEdge_ConfigureIsCoredumpWasmgdb(Conf), true);
   // Tests for AOT compiler configurations.
   WasmEdge_ConfigureCompilerSetOptimizationLevel(
       ConfNull, WasmEdge_CompilerOptimizationLevel_Os);


### PR DESCRIPTION
Fixes #5207.

### Description

This PR exposes the `EnableCoredump` and `CoredumpWasmgdb` options in the WasmEdge C API (`wasmedge_configure.h` and `lib/api/wasmedge.cpp`).

Previously, these settings were only configurable via the C++ `RuntimeConfigure` class and the CLI flags (`--enable-coredump` and `--coredump-wasmgdb`). Exposing them in the C API enables embedding applications and language SDKs (such as Go and Rust bindings) to programmatically configure WebAssembly coredump generation when execution traps occur.

### Changes Made

- **`include/api/wasmedge/wasmedge_configure.h`**: Added C API declarations for:
  - `WasmEdge_ConfigureSetEnableCoredump`
  - `WasmEdge_ConfigureIsEnableCoredump`
  - `WasmEdge_ConfigureSetCoredumpWasmgdb`
  - `WasmEdge_ConfigureIsCoredumpWasmgdb`
- **`lib/api/wasmedge.cpp`**: Implemented the four wrapper functions in the C API layer.
- **`test/api/APIUnitTest.cpp`**: Added unit tests in `APICoreTest.Configure` to verify getters, setters, and null context safety.
