### PR TITLE
feat(api): expose forbidden-plugin configuration through the C API

### DIFF
--- a/include/api/wasmedge/wasmedge_configure.h
+++ b/include/api/wasmedge/wasmedge_configure.h
@@ -208,6 +208,31 @@ WASMEDGE_CAPI_EXPORT extern void WasmEdge_ConfigureSetAllowAFUNIX(
 WASMEDGE_CAPI_EXPORT extern bool WasmEdge_ConfigureIsAllowAFUNIX(
     const WasmEdge_ConfigureContext *Cxt) WASMEDGE_CAPI_NOEXCEPT;
 
+/// Add a plugin name to the forbidden list in the WasmEdge_ConfigureContext.
+///
+/// Plugins whose name matches any entry in this list will be skipped during
+/// plugin loading in the VM.
+///
+/// This function is thread-safe.
+///
+/// \param Cxt the WasmEdge_ConfigureContext to add the forbidden plugin name.
+/// \param PluginName the plugin name string to deny-list.
+WASMEDGE_CAPI_EXPORT extern void
+WasmEdge_ConfigureAddForbiddenPlugin(WasmEdge_ConfigureContext *Cxt,
+                                     const char *PluginName) WASMEDGE_CAPI_NOEXCEPT;
+
+/// Check if a plugin name is in the forbidden list.
+///
+/// This function is thread-safe.
+///
+/// \param Cxt the WasmEdge_ConfigureContext to check.
+/// \param PluginName the plugin name string to check.
+///
+/// \returns true if the plugin name is in the forbidden list, false if not.
+WASMEDGE_CAPI_EXPORT extern bool
+WasmEdge_ConfigureIsForbiddenPlugin(const WasmEdge_ConfigureContext *Cxt,
+                                    const char *PluginName) WASMEDGE_CAPI_NOEXCEPT;
+
 /// Set the optimization level of the AOT compiler.
 ///
 /// This function is thread-safe.

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -1032,6 +1032,23 @@ WasmEdge_ConfigureIsAllowAFUNIX(const WasmEdge_ConfigureContext *Cxt) noexcept {
   return false;
 }
 
+WASMEDGE_CAPI_EXPORT void
+WasmEdge_ConfigureAddForbiddenPlugin(WasmEdge_ConfigureContext *Cxt,
+                                     const char *PluginName) noexcept {
+  if (Cxt && PluginName) {
+    Cxt->Conf.addForbiddenPlugins(PluginName);
+  }
+}
+
+WASMEDGE_CAPI_EXPORT bool
+WasmEdge_ConfigureIsForbiddenPlugin(const WasmEdge_ConfigureContext *Cxt,
+                                    const char *PluginName) noexcept {
+  if (Cxt && PluginName) {
+    return Cxt->Conf.isForbiddenPlugins(PluginName);
+  }
+  return false;
+}
+
 WASMEDGE_CAPI_EXPORT bool WasmEdge_ConfigureIsForceInterpreter(
     const WasmEdge_ConfigureContext *Cxt) noexcept {
   if (Cxt) {

--- a/test/api/APIUnitTest.cpp
+++ b/test/api/APIUnitTest.cpp
@@ -732,6 +732,13 @@ TEST(APICoreTest, Configure) {
       ConfNull, WasmEdge_HostRegistration_Wasi));
   EXPECT_FALSE(WasmEdge_ConfigureHasHostRegistration(
       Conf, WasmEdge_HostRegistration_Wasi));
+  // Tests for forbidden plugins.
+  WasmEdge_ConfigureAddForbiddenPlugin(ConfNull, "wasi_logging");
+  WasmEdge_ConfigureAddForbiddenPlugin(Conf, "wasi_logging");
+  EXPECT_FALSE(WasmEdge_ConfigureIsForbiddenPlugin(ConfNull, "wasi_logging"));
+  EXPECT_FALSE(WasmEdge_ConfigureIsForbiddenPlugin(Conf, nullptr));
+  EXPECT_TRUE(WasmEdge_ConfigureIsForbiddenPlugin(Conf, "wasi_logging"));
+  EXPECT_FALSE(WasmEdge_ConfigureIsForbiddenPlugin(Conf, "wasmedge_image"));
   // Tests for memory limits.
   WasmEdge_ConfigureSetMaxMemoryPage(ConfNull, 1234U);
   WasmEdge_ConfigureSetMaxMemoryPage(Conf, 1234U);


### PR DESCRIPTION
## Description

This PR exposes `WasmEdge_ConfigureAddForbiddenPlugin` and `WasmEdge_ConfigureIsForbiddenPlugin` in the WasmEdge C API (`wasmedge_configure.h` and `lib/api/wasmedge.cpp`), completing feature parity with the C++ `Configure` class and CLI `--forbidden-plugin` option.

Fixes #5209.

### Proposed Changes

- `include/api/wasmedge/wasmedge_configure.h`: Declare `WasmEdge_ConfigureAddForbiddenPlugin` and `WasmEdge_ConfigureIsForbiddenPlugin`.
- `lib/api/wasmedge.cpp`: Implement both C API functions.
- `test/api/APIUnitTest.cpp`: Add unit tests covering valid usage, null pointer handling, and forbidden plugin lookup in `APICoreTest.Configure`.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

```text
[  PASSED  ] APICoreTest.Configure
[  PASSED  ] 1 test from APICoreTest.
```
