### PR TITLE
docs: fix broken Contributor Ladder link in GOVERNANCE.md

### DIFF
--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -44,7 +44,7 @@ The WasmEdge project and its leadership embrace the following values:
 There are three levels of maintainers for WasmEdge. The WasmEdge maintainers oversee the overall
 project and its health. Committers focus on a single codebase, a group of related
 codebases, a service (e.g., a website), or project to support the other projects (e.g., marketing or
-community management). Reviewers help review the GitHub issues and PRs. See the [Contributor Ladder](./CONTRIBUTION_LADDER.md) for more detailed information on responsibilities.
+community management). Reviewers help review the GitHub issues and PRs. See the [Contributor Ladder](./CONTRIBUTOR_LADDER.md) for more detailed information on responsibilities.
 
 ## Adding new projects
 


### PR DESCRIPTION
The link pointed to CONTRIBUTION_LADDER.md, but the file is named
CONTRIBUTOR_LADDER.md, so it 404s on GitHub. README.md, README-ja.md,
README-zh.md, and docs/technical-review.md all reference the correct name.

## Description

The Contributor Ladder link in `docs/GOVERNANCE.md` 404s — it points at
`CONTRIBUTION_LADDER.md`, but the file is named `CONTRIBUTOR_LADDER.md`.

`docs/GOVERNANCE.md:47` is the only place in the repo using the wrong name.
Four other files already reference it correctly:

- `README.md:69`
- `README-ja.md:69`
- `README-zh.md:69`
- `docs/technical-review.md:17`

Docs-only change: one word on one line, no code touched.

This message was written with assistance from Claude (Anthropic).

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

No code is affected, so the build and test suites are unchanged. Verified the
link resolution directly:
