### PR TITLE
fix(system): keep the embedder's signal handlers and alternate stack usable

### DIFF
--- a/include/system/fault.h
+++ b/include/system/fault.h
@@ -14,9 +14,14 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
+#include "common/defines.h"
 #include "common/errcode.h"
 #include <array>
 #include <csetjmp>
+
+#if !WASMEDGE_OS_WINDOWS
+#include <setjmp.h>
+#endif
 
 namespace WasmEdge {
 
@@ -38,9 +43,13 @@ private:
   Fault *Prev = nullptr;
   std::jmp_buf Buffer;
   std::array<void *, 256> StackTraceBuffer;
-  size_t StackTraceSize;
+  size_t StackTraceSize = 0;
 };
 
 } // namespace WasmEdge
 
+#if WASMEDGE_OS_WINDOWS
 #define PREPARE_FAULT(f) (static_cast<uint32_t>(setjmp((f).buffer())))
+#else
+#define PREPARE_FAULT(f) (static_cast<uint32_t>(_setjmp((f).buffer())))
+#endif

--- a/include/system/winapi.h
+++ b/include/system/winapi.h
@@ -1369,6 +1369,7 @@ static inline constexpr const DWORD_ EXCEPTION_INT_DIVIDE_BY_ZERO_ =
 static inline constexpr const DWORD_ EXCEPTION_INT_OVERFLOW_ = 0xC0000095L;
 static inline constexpr const LONG_ EXCEPTION_CONTINUE_EXECUTION_ =
     static_cast<LONG_>(0xffffffff);
+static inline constexpr const LONG_ EXCEPTION_CONTINUE_SEARCH_ = 0L;
 
 using EXCEPTION_RECORD_ = struct _EXCEPTION_RECORD {
   DWORD_ ExceptionCode;

--- a/lib/system/fault.cpp
+++ b/lib/system/fault.cpp
@@ -18,6 +18,7 @@
 
 #if defined(SA_SIGINFO)
 #include <pthread.h>
+#include <sys/ucontext.h>
 #endif
 
 #if WASMEDGE_OS_WINDOWS
@@ -79,25 +80,80 @@ void forwardSignal(int Signal, siginfo_t *Siginfo, void *Context) noexcept {
   }
 }
 
+thread_local ErrCode PendingFault;
+thread_local bool FaultRedirected = false;
+
+[[noreturn]] void faultTrampoline() { Fault::emitFault(PendingFault); }
+
+bool redirectFault(void *Context, ErrCode Error) noexcept {
+  if (Context == nullptr || FaultRedirected) {
+    return false;
+  }
+
+  [[maybe_unused]] auto *Ucontext = static_cast<ucontext_t *>(Context);
+  [[maybe_unused]] const auto Target =
+      reinterpret_cast<uintptr_t>(&faultTrampoline);
+
+#if WASMEDGE_OS_MACOS && (defined(__aarch64__) || defined(__arm64__))
+  Ucontext->uc_mcontext->__ss.__sp &= ~static_cast<uintptr_t>(15);
+  Ucontext->uc_mcontext->__ss.__lr = 0;
+  Ucontext->uc_mcontext->__ss.__pc = Target;
+#elif WASMEDGE_OS_MACOS && defined(__x86_64__)
+  Ucontext->uc_mcontext->__ss.__rsp =
+      (Ucontext->uc_mcontext->__ss.__rsp & ~static_cast<uintptr_t>(15)) - 8;
+  Ucontext->uc_mcontext->__ss.__rip = Target;
+#elif WASMEDGE_OS_LINUX && defined(__aarch64__)
+  Ucontext->uc_mcontext.sp &= ~static_cast<uintptr_t>(15);
+  Ucontext->uc_mcontext.regs[30] = 0;
+  Ucontext->uc_mcontext.pc = Target;
+#elif WASMEDGE_OS_LINUX && defined(__x86_64__)
+  Ucontext->uc_mcontext.gregs[REG_RSP] = static_cast<greg_t>(
+      (static_cast<uintptr_t>(Ucontext->uc_mcontext.gregs[REG_RSP]) &
+       ~static_cast<uintptr_t>(15)) -
+      8);
+  Ucontext->uc_mcontext.gregs[REG_RIP] = static_cast<greg_t>(Target);
+#else
+  return false;
+#endif
+
+  PendingFault = Error;
+  FaultRedirected = true;
+  return true;
+}
+
+void restoreSignalMask(int Signal, void *Context) noexcept {
+  if (Context != nullptr) {
+    pthread_sigmask(SIG_SETMASK,
+                    &static_cast<ucontext_t *>(Context)->uc_sigmask, nullptr);
+    return;
+  }
+
+  sigset_t Set;
+  sigemptyset(&Set);
+  sigaddset(&Set, Signal);
+  pthread_sigmask(SIG_UNBLOCK, &Set, nullptr);
+}
+
 void signalHandler(int Signal, siginfo_t *Siginfo, void *Context) {
   if (localHandler == nullptr) {
     forwardSignal(Signal, Siginfo, Context);
     return;
   }
 
-  {
-    // Unblock current signal
-    sigset_t Set;
-    sigemptyset(&Set);
-    sigaddset(&Set, Signal);
-    pthread_sigmask(SIG_UNBLOCK, &Set, nullptr);
-  }
   switch (Signal) {
   case SIGBUS:
   case SIGSEGV:
+    if (redirectFault(Context, ErrCode::Value::MemoryOutOfBounds)) {
+      return;
+    }
+    restoreSignalMask(Signal, Context);
     Fault::emitFault(ErrCode::Value::MemoryOutOfBounds);
   case SIGFPE:
     if (Siginfo != nullptr && Siginfo->si_code == FPE_INTDIV) {
+      if (redirectFault(Context, ErrCode::Value::DivideByZero)) {
+        return;
+      }
+      restoreSignalMask(Signal, Context);
       Fault::emitFault(ErrCode::Value::DivideByZero);
     }
     forwardSignal(Signal, Siginfo, Context);
@@ -183,9 +239,16 @@ Fault::~Fault() noexcept {
 
 [[noreturn]] void Fault::emitFault(ErrCode Error) {
   assuming(localHandler != nullptr);
+#if defined(SA_SIGINFO)
+  FaultRedirected = false;
+#endif
   auto Buffer = stackTrace(localHandler->StackTraceBuffer);
   localHandler->StackTraceSize = Buffer.size();
+#if WASMEDGE_OS_WINDOWS
   longjmp(localHandler->Buffer, static_cast<int>(Error.operator uint32_t()));
+#else
+  _longjmp(localHandler->Buffer, static_cast<int>(Error.operator uint32_t()));
+#endif
 }
 
 } // namespace WasmEdge

--- a/lib/system/fault.cpp
+++ b/lib/system/fault.cpp
@@ -8,11 +8,17 @@
 #include "common/spdlog.h"
 #include "system/stacktrace.h"
 
-#include <atomic>
+#include <array>
 #include <csetjmp>
 #include <csignal>
 #include <cstdint>
+#include <cstdlib>
+#include <mutex>
 #include <utility>
+
+#if defined(SA_SIGINFO)
+#include <pthread.h>
+#endif
 
 #if WASMEDGE_OS_WINDOWS
 #include "system/winapi.h"
@@ -22,11 +28,63 @@ namespace WasmEdge {
 
 namespace {
 
-std::atomic_uint handlerCount = 0;
+std::mutex HandlerMutex;
+uint32_t HandlerCount = 0;
 thread_local Fault *localHandler = nullptr;
 
 #if defined(SA_SIGINFO)
-void signalHandler(int Signal, siginfo_t *Siginfo, void *) {
+
+constexpr std::array FaultSignals{SIGFPE, SIGBUS, SIGSEGV};
+std::array<struct sigaction, FaultSignals.size()> PreviousActions{};
+
+size_t signalIndex(int Signal) noexcept {
+  for (size_t I = 0; I < FaultSignals.size(); ++I) {
+    if (FaultSignals[I] == Signal) {
+      return I;
+    }
+  }
+  assumingUnreachable();
+}
+
+[[noreturn]] void raiseDefaultSignal(int Signal,
+                                     const struct sigaction &Action) noexcept {
+  sigaction(Signal, &Action, nullptr);
+  sigset_t Set;
+  sigemptyset(&Set);
+  sigaddset(&Set, Signal);
+  pthread_sigmask(SIG_UNBLOCK, &Set, nullptr);
+  raise(Signal);
+  std::_Exit(128 + Signal);
+}
+
+void forwardSignal(int Signal, siginfo_t *Siginfo, void *Context) noexcept {
+  const auto &Action = PreviousActions[signalIndex(Signal)];
+  if (Action.sa_handler == SIG_IGN) {
+    return;
+  }
+  if (Action.sa_handler == SIG_DFL) {
+    raiseDefaultSignal(Signal, Action);
+  }
+
+  sigset_t Set = Action.sa_mask;
+  if ((Action.sa_flags & SA_NODEFER) == 0) {
+    sigaddset(&Set, Signal);
+  }
+  pthread_sigmask(SIG_BLOCK, &Set, nullptr);
+
+  if ((Action.sa_flags & SA_SIGINFO) != 0) {
+    Action.sa_sigaction(Signal, Siginfo, Context);
+  } else {
+    Action.sa_handler(Signal);
+  }
+}
+
+void signalHandler(int Signal, siginfo_t *Siginfo, void *Context) {
+  if (localHandler == nullptr) {
+    forwardSignal(Signal, Siginfo, Context);
+    return;
+  }
+
   {
     // Unblock current signal
     sigset_t Set;
@@ -39,8 +97,11 @@ void signalHandler(int Signal, siginfo_t *Siginfo, void *) {
   case SIGSEGV:
     Fault::emitFault(ErrCode::Value::MemoryOutOfBounds);
   case SIGFPE:
-    assuming(Siginfo->si_code == FPE_INTDIV);
-    Fault::emitFault(ErrCode::Value::DivideByZero);
+    if (Siginfo != nullptr && Siginfo->si_code == FPE_INTDIV) {
+      Fault::emitFault(ErrCode::Value::DivideByZero);
+    }
+    forwardSignal(Signal, Siginfo, Context);
+    return;
   default:
     assumingUnreachable();
   }
@@ -48,23 +109,27 @@ void signalHandler(int Signal, siginfo_t *Siginfo, void *) {
 
 void enableHandler() noexcept {
   struct sigaction Action{};
+  sigemptyset(&Action.sa_mask);
   Action.sa_sigaction = &signalHandler;
   Action.sa_flags = SA_SIGINFO | SA_ONSTACK;
-  sigaction(SIGFPE, &Action, nullptr);
-  sigaction(SIGBUS, &Action, nullptr);
-  sigaction(SIGSEGV, &Action, nullptr);
+  for (size_t I = 0; I < FaultSignals.size(); ++I) {
+    sigaction(FaultSignals[I], &Action, &PreviousActions[I]);
+  }
 }
 
 void disableHandler() noexcept {
-  std::signal(SIGFPE, SIG_DFL);
-  std::signal(SIGBUS, SIG_DFL);
-  std::signal(SIGSEGV, SIG_DFL);
+  for (size_t I = 0; I < FaultSignals.size(); ++I) {
+    sigaction(FaultSignals[I], &PreviousActions[I], nullptr);
+  }
 }
 
 #elif WASMEDGE_OS_WINDOWS
 
 winapi::LONG_ WASMEDGE_WINAPI_WINAPI_CC
 vectoredExceptionHandler(winapi::PEXCEPTION_POINTERS_ ExceptionInfo) {
+  if (localHandler == nullptr) {
+    return winapi::EXCEPTION_CONTINUE_SEARCH_;
+  }
   const winapi::DWORD_ Code = ExceptionInfo->ExceptionRecord->ExceptionCode;
   switch (Code) {
   case winapi::EXCEPTION_INT_DIVIDE_BY_ZERO_:
@@ -74,7 +139,7 @@ vectoredExceptionHandler(winapi::PEXCEPTION_POINTERS_ ExceptionInfo) {
   case winapi::EXCEPTION_ACCESS_VIOLATION_:
     Fault::emitFault(ErrCode::Value::MemoryOutOfBounds);
   }
-  return winapi::EXCEPTION_CONTINUE_EXECUTION_;
+  return winapi::EXCEPTION_CONTINUE_SEARCH_;
 }
 
 void *HandlerHandle = nullptr;
@@ -91,13 +156,15 @@ void disableHandler() noexcept {
 #endif
 
 void increaseHandler() noexcept {
-  if (handlerCount++ == 0) {
+  std::lock_guard Lock(HandlerMutex);
+  if (HandlerCount++ == 0) {
     enableHandler();
   }
 }
 
 void decreaseHandler() noexcept {
-  if (--handlerCount == 0) {
+  std::lock_guard Lock(HandlerMutex);
+  if (--HandlerCount == 0) {
     disableHandler();
   }
 }

--- a/lib/system/fault.cpp
+++ b/lib/system/fault.cpp
@@ -49,7 +49,7 @@ void signalHandler(int Signal, siginfo_t *Siginfo, void *) {
 void enableHandler() noexcept {
   struct sigaction Action{};
   Action.sa_sigaction = &signalHandler;
-  Action.sa_flags = SA_SIGINFO;
+  Action.sa_flags = SA_SIGINFO | SA_ONSTACK;
   sigaction(SIGFPE, &Action, nullptr);
   sigaction(SIGBUS, &Action, nullptr);
   sigaction(SIGSEGV, &Action, nullptr);

--- a/test/llvm/LazyJITTest.cpp
+++ b/test/llvm/LazyJITTest.cpp
@@ -24,8 +24,14 @@
 #include "vm/vm.h"
 #include "llvm/compiler.h"
 #include "llvm/jit.h"
+#include <csignal>
+#include <cstring>
 #include <gtest/gtest.h>
 #include <thread>
+
+#if defined(SA_SIGINFO)
+#include <pthread.h>
+#endif
 
 namespace {
 
@@ -107,6 +113,44 @@ std::vector<uint8_t> IntrinsicsWasm = {
     0x04, 0x74, 0x72, 0x61, 0x70, 0x00, 0x00, 0x04, 0x67, 0x72, 0x6f,
     0x77, 0x00, 0x01, 0x0a, 0x0c, 0x02, 0x03, 0x00, 0x00, 0x0b, 0x06,
     0x00, 0x20, 0x00, 0x40, 0x00, 0x0b};
+
+std::vector<uint8_t> OutOfBoundsLoadWasm = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x05, 0x03, 0x01, 0x00, 0x01,
+    0x07, 0x08, 0x01, 0x04, 0x6c, 0x6f, 0x61, 0x64, 0x00, 0x00, 0x0a, 0x0b,
+    0x01, 0x09, 0x00, 0x41, 0x80, 0x80, 0x04, 0x28, 0x02, 0x00, 0x0b};
+
+#if defined(SA_SIGINFO) && defined(SA_ONSTACK)
+
+class AlternateSignalStackGuard {
+public:
+  AlternateSignalStackGuard() : Buffer(64 * 1024) {
+    if (sigaltstack(nullptr, &Original) != 0) {
+      return;
+    }
+
+    stack_t Stack{};
+    Stack.ss_sp = Buffer.data();
+    Stack.ss_size = Buffer.size();
+    Stack.ss_flags = 0;
+    Valid = sigaltstack(&Stack, nullptr) == 0;
+  }
+
+  ~AlternateSignalStackGuard() {
+    if (Valid) {
+      sigaltstack(&Original, nullptr);
+    }
+  }
+
+  bool valid() const noexcept { return Valid; }
+
+private:
+  std::vector<uint8_t> Buffer;
+  stack_t Original{};
+  bool Valid = false;
+};
+
+#endif
 
 class HostAdd : public Runtime::HostFunction<HostAdd> {
 public:
@@ -680,6 +724,41 @@ TEST_F(LazyJITTest, LazyJITIntrinsicsReachableFromCompiledCode) {
 
   EXPECT_EQ(VM->getLazyCompiledFuncCount(), 2U);
 }
+
+#if defined(SA_SIGINFO) && defined(SA_ONSTACK)
+
+TEST_F(LazyJITTest, RepeatedFaultsPreserveAlternateSignalState) {
+  AlternateSignalStackGuard AlternateStack;
+  ASSERT_TRUE(AlternateStack.valid());
+
+  stack_t ExpectedStack{};
+  ASSERT_EQ(sigaltstack(nullptr, &ExpectedStack), 0);
+  sigset_t ExpectedMask;
+  ASSERT_EQ(pthread_sigmask(SIG_SETMASK, nullptr, &ExpectedMask), 0);
+
+  auto VM = createEagerJITVM();
+  ASSERT_TRUE(VM->loadWasm(OutOfBoundsLoadWasm));
+  ASSERT_TRUE(VM->validate());
+  ASSERT_TRUE(VM->instantiate());
+
+  for (uint32_t I = 0; I < 2; ++I) {
+    auto Result = VM->execute("load");
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), ErrCode::Value::MemoryOutOfBounds);
+
+    stack_t CurrentStack{};
+    ASSERT_EQ(sigaltstack(nullptr, &CurrentStack), 0);
+    EXPECT_EQ(CurrentStack.ss_sp, ExpectedStack.ss_sp);
+    EXPECT_EQ(CurrentStack.ss_size, ExpectedStack.ss_size);
+    EXPECT_EQ(CurrentStack.ss_flags, ExpectedStack.ss_flags);
+
+    sigset_t CurrentMask;
+    ASSERT_EQ(pthread_sigmask(SIG_SETMASK, nullptr, &CurrentMask), 0);
+    EXPECT_EQ(std::memcmp(&CurrentMask, &ExpectedMask, sizeof(sigset_t)), 0);
+  }
+}
+
+#endif
 
 TEST_F(LazyJITTest, LazyJITConcurrentSameFunction) {
   auto VM = createLazyJITVM();

--- a/test/thread/ThreadTest.cpp
+++ b/test/thread/ThreadTest.cpp
@@ -25,12 +25,66 @@
 
 #include <array>
 #include <csignal>
+#include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace {
+
+#if defined(SA_SIGINFO) && defined(SA_ONSTACK)
+
+constexpr std::array FaultSignals{SIGFPE, SIGBUS, SIGSEGV};
+
+void emptySignalHandler(int) {}
+
+void exitSignalHandler(int) { std::_Exit(EXIT_SUCCESS); }
+
+class SignalActionGuard {
+public:
+  SignalActionGuard() {
+    struct sigaction Action{};
+    sigemptyset(&Action.sa_mask);
+    sigaddset(&Action.sa_mask, SIGUSR1);
+    Action.sa_handler = emptySignalHandler;
+    Action.sa_flags = SA_RESTART;
+
+    for (size_t I = 0; I < FaultSignals.size(); ++I) {
+      if (sigaction(FaultSignals[I], &Action, &Original[I]) != 0) {
+        Valid = false;
+        return;
+      }
+      InstalledCount = I + 1;
+      if (sigaction(FaultSignals[I], nullptr, &Installed[I]) != 0) {
+        Valid = false;
+        return;
+      }
+    }
+  }
+
+  ~SignalActionGuard() {
+    for (size_t I = 0; I < InstalledCount; ++I) {
+      sigaction(FaultSignals[I], &Original[I], nullptr);
+    }
+  }
+
+  bool valid() const noexcept { return Valid; }
+
+  const struct sigaction &installed(size_t I) const noexcept {
+    return Installed[I];
+  }
+
+private:
+  std::array<struct sigaction, FaultSignals.size()> Original{};
+  std::array<struct sigaction, FaultSignals.size()> Installed{};
+  size_t InstalledCount = 0;
+  bool Valid = true;
+};
+
+#endif
 
 // See mt19937.c for source of this webassembly data.
 std::array<WasmEdge::Byte, 1481> MersenneTwister19937{
@@ -233,15 +287,54 @@ TEST(AsyncExecute, GasThreadTest) {
 
 #if defined(SA_SIGINFO) && defined(SA_ONSTACK)
 
-TEST(FaultHandler, UsesAlternateSignalStack) {
-  WasmEdge::Fault FaultHandler;
-  constexpr std::array Signals{SIGFPE, SIGBUS, SIGSEGV};
+TEST(FaultHandler, PreservesPreviousSignalActions) {
+  SignalActionGuard Guard;
+  ASSERT_TRUE(Guard.valid());
 
-  for (const int Signal : Signals) {
-    struct sigaction Action{};
-    ASSERT_EQ(sigaction(Signal, nullptr, &Action), 0);
-    EXPECT_NE(Action.sa_flags & SA_ONSTACK, 0);
+  {
+    WasmEdge::Fault FaultHandler;
+    const uint32_t Code = PREPARE_FAULT(FaultHandler);
+    ASSERT_EQ(Code, 0U);
+
+    for (const int Signal : FaultSignals) {
+      struct sigaction Action{};
+      ASSERT_EQ(sigaction(Signal, nullptr, &Action), 0);
+      EXPECT_NE(Action.sa_flags & SA_ONSTACK, 0);
+    }
   }
+
+  for (size_t I = 0; I < FaultSignals.size(); ++I) {
+    struct sigaction Action{};
+    ASSERT_EQ(sigaction(FaultSignals[I], nullptr, &Action), 0);
+    EXPECT_EQ(Action.sa_handler, Guard.installed(I).sa_handler);
+    EXPECT_EQ(Action.sa_flags, Guard.installed(I).sa_flags);
+    EXPECT_EQ(std::memcmp(&Action.sa_mask, &Guard.installed(I).sa_mask,
+                          sizeof(sigset_t)),
+              0);
+  }
+}
+
+TEST(FaultHandler, ChainsSignalFromThreadWithoutFaultContext) {
+  EXPECT_EXIT(
+      {
+        struct sigaction Action{};
+        sigemptyset(&Action.sa_mask);
+        Action.sa_handler = exitSignalHandler;
+        if (sigaction(SIGFPE, &Action, nullptr) != 0) {
+          std::_Exit(EXIT_FAILURE);
+        }
+
+        WasmEdge::Fault FaultHandler;
+        const uint32_t Code = PREPARE_FAULT(FaultHandler);
+        if (Code != 0) {
+          std::_Exit(EXIT_FAILURE);
+        }
+
+        std::thread Worker([] { raise(SIGFPE); });
+        Worker.join();
+        std::_Exit(EXIT_FAILURE);
+      },
+      ::testing::ExitedWithCode(EXIT_SUCCESS), "");
 }
 
 #endif

--- a/test/thread/ThreadTest.cpp
+++ b/test/thread/ThreadTest.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "common/spdlog.h"
+#include "system/fault.h"
 #include "vm/vm.h"
 
 #ifdef WASMEDGE_USE_LLVM
@@ -22,6 +23,8 @@
 
 #include "gtest/gtest.h"
 
+#include <array>
+#include <csignal>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -227,6 +230,21 @@ TEST(AsyncExecute, GasThreadTest) {
     }
   }
 }
+
+#if defined(SA_SIGINFO) && defined(SA_ONSTACK)
+
+TEST(FaultHandler, UsesAlternateSignalStack) {
+  WasmEdge::Fault FaultHandler;
+  constexpr std::array Signals{SIGFPE, SIGBUS, SIGSEGV};
+
+  for (const int Signal : Signals) {
+    struct sigaction Action{};
+    ASSERT_EQ(sigaction(Signal, nullptr, &Action), 0);
+    EXPECT_NE(Action.sa_flags & SA_ONSTACK, 0);
+  }
+}
+
+#endif
 
 #ifdef WASMEDGE_USE_LLVM
 


### PR DESCRIPTION
## Description

Fixes #2400.

WasmEdge installs POSIX fault handlers while running WebAssembly. The old path had a few problems that show up under embedders like Go/cgo:

1. Handlers were registered without SA_ONSTACK, so Go can abort with "non-Go code set up signal handler without SA_ONSTACK flag".
2. Even with SA_ONSTACK, we left the handler via longjmp and never hit sigreturn. On Darwin that can leave SS_ONSTACK latched, so later signals (including ones we never register, like SIGURG) land off the alternate stack.
3. enableHandler overwrote the embedder's handlers, and disableHandler reset them to SIG_DFL instead of restoring them.
4. A fault on a thread with no Fault context hit assuming(localHandler != nullptr), which is UB under NDEBUG.

This PR:

- sets SA_ONSTACK on the fault handlers
- resumes faults through a ucontext rewrite + normal return so the kernel sigreturn clears SS_ONSTACK and restores the pre signal mask, then longjmps from a trampoline on the original stack
- saves and restores the previous sigactions
- chains to the previous handler when there is no local Fault (Windows VEH returns EXCEPTION_CONTINUE_SEARCH_ in the matching cases)
- uses _setjmp for PREPARE_FAULT on POSIX so the fast path does not pay for a mask save

## Tests

- FaultHandler.PreservesPreviousSignalActions
- FaultHandler.ChainsSignalFromThreadWithoutFaultContext
- LazyJITTest.RepeatedFaultsPreserveAlternateSignalState (real sigaltstack, two JIT traps, mask and alt stack state unchanged)

## Checklist

* [x] DCO Signed-off: All commits are signed-off (`git commit -s`).
* [x] Commit Messages: Conventional Commits.
* [x] Coding Style: clang-format clean on the touched sources.
* [x] Local Tests Passed: logs below.
* [x] AI Disclosure: Assisted-by trailer in commits; noted here.
* [x] Human-in-the-loop: reviewed and verified locally before submit.

This contribution was developed with assistance from Claude Code (Anthropic) and earlier from OpenAI GPT-5.6.

## Test Evidence

macOS arm64, WASMEDGE_USE_LLVM=ON (RelWithDebInfo) and OFF (Debug):

```text
wasmedgeThreadTests: 4/4 passed
wasmedgeLazyJITTests: 22/22 passed
```

Also checked:

```text
clang-format: clean on the changed sources
git diff --check: clean
codespell: clean
```

## Notes

I have not yet confirmed the original Go/cgo reproducer end to end. The new tests cover the mechanism Go trips over, but Fixes #2400 should not be treated as fully demonstrated until a real WasmEdge-go path is run. Linux ucontext paths are in the code and need CI; local exercise was on macOS arm64.