### PR TITLE
feat(api): expose cost limit configuration for statistics in the C API

### DIFF
--- a/include/api/wasmedge/wasmedge_configure.h
+++ b/include/api/wasmedge/wasmedge_configure.h
@@ -383,6 +383,27 @@ WASMEDGE_CAPI_EXPORT extern void WasmEdge_ConfigureStatisticsSetTimeMeasuring(
 WASMEDGE_CAPI_EXPORT extern bool WasmEdge_ConfigureStatisticsIsTimeMeasuring(
     const WasmEdge_ConfigureContext *Cxt) WASMEDGE_CAPI_NOEXCEPT;
 
+/// Set the cost limit option for the statistics in the WasmEdge_ConfigureContext.
+///
+/// This function is thread-safe.
+///
+/// \param Cxt the WasmEdge_ConfigureContext to set the cost limit value.
+/// \param Limit the cost limit value.
+WASMEDGE_CAPI_EXPORT extern void
+WasmEdge_ConfigureStatisticsSetCostLimit(WasmEdge_ConfigureContext *Cxt,
+                                         const uint64_t Limit) WASMEDGE_CAPI_NOEXCEPT;
+
+/// Get the cost limit option for the statistics in the WasmEdge_ConfigureContext.
+///
+/// This function is thread-safe.
+///
+/// \param Cxt the WasmEdge_ConfigureContext to get the cost limit value.
+///
+/// \returns the cost limit value.
+WASMEDGE_CAPI_EXPORT extern uint64_t
+WasmEdge_ConfigureStatisticsGetCostLimit(
+    const WasmEdge_ConfigureContext *Cxt) WASMEDGE_CAPI_NOEXCEPT;
+
 /// Deletion of the WasmEdge_ConfigureContext.
 ///
 /// After calling this function, the context will be destroyed and should

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -1174,6 +1174,22 @@ WASMEDGE_CAPI_EXPORT bool WasmEdge_ConfigureStatisticsIsTimeMeasuring(
 }
 
 WASMEDGE_CAPI_EXPORT void
+WasmEdge_ConfigureStatisticsSetCostLimit(WasmEdge_ConfigureContext *Cxt,
+                                         const uint64_t Limit) noexcept {
+  if (Cxt) {
+    Cxt->Conf.getStatisticsConfigure().setCostLimit(Limit);
+  }
+}
+
+WASMEDGE_CAPI_EXPORT uint64_t WasmEdge_ConfigureStatisticsGetCostLimit(
+    const WasmEdge_ConfigureContext *Cxt) noexcept {
+  if (Cxt) {
+    return Cxt->Conf.getStatisticsConfigure().getCostLimit();
+  }
+  return 0;
+}
+
+WASMEDGE_CAPI_EXPORT void
 WasmEdge_ConfigureDelete(WasmEdge_ConfigureContext *Cxt) noexcept {
   delete Cxt;
 }

--- a/test/api/APIUnitTest.cpp
+++ b/test/api/APIUnitTest.cpp
@@ -811,6 +811,10 @@ TEST(APICoreTest, Configure) {
   WasmEdge_ConfigureStatisticsSetTimeMeasuring(Conf, true);
   EXPECT_NE(WasmEdge_ConfigureStatisticsIsTimeMeasuring(ConfNull), true);
   EXPECT_EQ(WasmEdge_ConfigureStatisticsIsTimeMeasuring(Conf), true);
+  WasmEdge_ConfigureStatisticsSetCostLimit(ConfNull, 1000U);
+  WasmEdge_ConfigureStatisticsSetCostLimit(Conf, 1000U);
+  EXPECT_NE(WasmEdge_ConfigureStatisticsGetCostLimit(ConfNull), 1000U);
+  EXPECT_EQ(WasmEdge_ConfigureStatisticsGetCostLimit(Conf), 1000U);
   // Test to delete nullptr.
   WasmEdge_ConfigureDelete(ConfNull);
   EXPECT_TRUE(true);


### PR DESCRIPTION
## Description

This PR exposes `WasmEdge_ConfigureStatisticsSetCostLimit` and `WasmEdge_ConfigureStatisticsGetCostLimit` in the WasmEdge C API (`wasmedge_configure.h` and `lib/api/wasmedge.cpp`), completing feature parity with the C++ `StatisticsConfigure` class and CLI `--cost-limit` option.

Fixes #5215.

### Proposed Changes

- `include/api/wasmedge/wasmedge_configure.h`: Declare `WasmEdge_ConfigureStatisticsSetCostLimit` and `WasmEdge_ConfigureStatisticsGetCostLimit`.
- `lib/api/wasmedge.cpp`: Implement both wrapper functions in the C API layer.
- `test/api/APIUnitTest.cpp`: Add unit tests in `APICoreTest.Configure` verifying getters, setters, and null context safety.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

```text
[  PASSED  ] APICoreTest.Configure
[  PASSED  ] 1 test from APICoreTest.
```
