### PR TITLE
feat(wasi-crypto): support Ed25519 keypair construction

### DIFF
--- a/plugins/wasi_crypto/signatures/eddsa.cpp
+++ b/plugins/wasi_crypto/signatures/eddsa.cpp
@@ -3,6 +3,7 @@
 
 #include "signatures/eddsa.h"
 
+#include <openssl/crypto.h>
 #include <openssl/evp.h>
 #include <openssl/x509.h>
 
@@ -93,8 +94,20 @@ Eddsa::SecretKey::publicKey() const noexcept {
 }
 
 WasiCryptoExpect<Eddsa::KeyPair>
-Eddsa::SecretKey::toKeyPair(const PublicKey &) const noexcept {
-  return WasiCryptoUnexpect(__WASI_CRYPTO_ERRNO_NOT_IMPLEMENTED);
+Eddsa::SecretKey::toKeyPair(const PublicKey &Pk) const noexcept {
+  size_t Size = PkSize;
+  std::vector<uint8_t> DerivedPk(PkSize);
+  opensslCheck(EVP_PKEY_get_raw_public_key(Ctx.get(), DerivedPk.data(), &Size));
+  ensureOrReturn(Size == PkSize, __WASI_CRYPTO_ERRNO_ALGORITHM_FAILURE);
+
+  auto SuppliedPk = Pk.exportData(__WASI_PUBLICKEY_ENCODING_RAW);
+  if (!SuppliedPk) {
+    return WasiCryptoUnexpect(SuppliedPk);
+  }
+  ensureOrReturn(!CRYPTO_memcmp(DerivedPk.data(), SuppliedPk->data(), PkSize),
+                 __WASI_CRYPTO_ERRNO_INVALID_KEY);
+
+  return Ctx;
 }
 
 WasiCryptoExpect<SecretVec> Eddsa::SecretKey::exportData(

--- a/test/plugins/wasi_crypto/asymmetric.cpp
+++ b/test/plugins/wasi_crypto/asymmetric.cpp
@@ -637,6 +637,65 @@ TEST_F(WasiCryptoTest, Asymmetric) {
                        __WASI_CRYPTO_ERRNO_INVALID_HANDLE);
 }
 
+TEST_F(WasiCryptoTest, Ed25519KeypairFromPkAndSk) {
+  const auto PublicKey =
+      "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"_u8v;
+  const auto SecretKey =
+      "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60"_u8v;
+  const auto KeyPair =
+      "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60"
+      "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"_u8v;
+  const auto MismatchedPublicKey =
+      "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c"_u8v;
+
+  WASI_CRYPTO_EXPECT_SUCCESS(
+      PkHandle, publickeyImport(__WASI_ALGORITHM_TYPE_SIGNATURES, "Ed25519"sv,
+                                PublicKey, __WASI_PUBLICKEY_ENCODING_RAW));
+  WASI_CRYPTO_EXPECT_SUCCESS(
+      SkHandle, secretkeyImport(__WASI_ALGORITHM_TYPE_SIGNATURES, "Ed25519"sv,
+                                SecretKey, __WASI_SECRETKEY_ENCODING_RAW));
+  WASI_CRYPTO_EXPECT_SUCCESS(KpHandle, keypairFromPkAndSk(PkHandle, SkHandle));
+  WASI_CRYPTO_EXPECT_TRUE(publickeyClose(PkHandle));
+  WASI_CRYPTO_EXPECT_TRUE(secretkeyClose(SkHandle));
+
+  WASI_CRYPTO_EXPECT_SUCCESS(
+      KpOutputHandle, keypairExport(KpHandle, __WASI_KEYPAIR_ENCODING_RAW));
+  std::vector<uint8_t> ExportedKeyPair(KeyPair.size());
+  WASI_CRYPTO_EXPECT_TRUE(arrayOutputPull(KpOutputHandle, ExportedKeyPair));
+  EXPECT_EQ(ExportedKeyPair, KeyPair);
+
+  WASI_CRYPTO_EXPECT_SUCCESS(StateHandle, signatureStateOpen(KpHandle));
+  WASI_CRYPTO_EXPECT_TRUE(signatureStateUpdate(StateHandle, "test"_u8));
+  WASI_CRYPTO_EXPECT_SUCCESS(SigHandle, signatureStateSign(StateHandle));
+  WASI_CRYPTO_EXPECT_TRUE(signatureStateClose(StateHandle));
+  WASI_CRYPTO_EXPECT_SUCCESS(DerivedPkHandle, keypairPublickey(KpHandle));
+  WASI_CRYPTO_EXPECT_SUCCESS(VerificationStateHandle,
+                             signatureVerificationStateOpen(DerivedPkHandle));
+  WASI_CRYPTO_EXPECT_TRUE(
+      signatureVerificationStateUpdate(VerificationStateHandle, "test"_u8));
+  WASI_CRYPTO_EXPECT_TRUE(
+      signatureVerificationStateVerify(VerificationStateHandle, SigHandle));
+  WASI_CRYPTO_EXPECT_TRUE(
+      signatureVerificationStateClose(VerificationStateHandle));
+  WASI_CRYPTO_EXPECT_TRUE(signatureClose(SigHandle));
+  WASI_CRYPTO_EXPECT_TRUE(publickeyClose(DerivedPkHandle));
+  WASI_CRYPTO_EXPECT_TRUE(keypairClose(KpHandle));
+
+  WASI_CRYPTO_EXPECT_SUCCESS(MismatchedPkHandle,
+                             publickeyImport(__WASI_ALGORITHM_TYPE_SIGNATURES,
+                                             "Ed25519"sv, MismatchedPublicKey,
+                                             __WASI_PUBLICKEY_ENCODING_RAW));
+  WASI_CRYPTO_EXPECT_SUCCESS(MismatchedSkHandle,
+                             secretkeyImport(__WASI_ALGORITHM_TYPE_SIGNATURES,
+                                             "Ed25519"sv, SecretKey,
+                                             __WASI_SECRETKEY_ENCODING_RAW));
+  WASI_CRYPTO_EXPECT_FAILURE(
+      keypairFromPkAndSk(MismatchedPkHandle, MismatchedSkHandle),
+      __WASI_CRYPTO_ERRNO_INVALID_KEY);
+  WASI_CRYPTO_EXPECT_TRUE(publickeyClose(MismatchedPkHandle));
+  WASI_CRYPTO_EXPECT_TRUE(secretkeyClose(MismatchedSkHandle));
+}
+
 } // namespace WasiCrypto
 } // namespace Host
 } // namespace WasmEdge


### PR DESCRIPTION
Construct Ed25519 keypairs from matching public and secret keys. Validate the supplied public key against the public key derived by OpenSSL and add coverage for export, signing, handle lifetime, and mismatched keys.



Assisted-by: Codex (OpenAI)

## Description
<!-- Describe your changes here -->

## Checklist

Before submitting this PR, please ensure the following:

- [ ] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [ ] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [ ] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [ ] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->
<img width="584" height="97" alt="image" src="https://github.com/user-attachments/assets/d46f54fd-c21d-48c6-90ae-ba193c80202c" />
The project built successfully, and the complete `wasiCryptoTests` test
executable passed locally with 100% tests passing.

Additional checks:

- The focused `WasiCryptoTest.Ed25519KeypairFromPkAndSk` test passed.
- The changed regions pass `clang-format`.
- `git diff --check` passes.
---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
