### PR TITLE
fix(wasi): resolve memory by exported name instead of index 0

### DIFF
--- a/include/runtime/callingframe.h
+++ b/include/runtime/callingframe.h
@@ -53,6 +53,16 @@ public:
     return nullptr;
   }
 
+  /// Helper function for getting the memory instance exported with the given
+  /// name from the module.
+  Instance::MemoryInstance *
+  getMemoryByExportName(std::string_view Name) const noexcept {
+    if (Module) {
+      return Module->findMemoryExports(Name);
+    }
+    return nullptr;
+  }
+
 private:
   Executor::Executor *Exec;
   const Instance::ModuleInstance *Module;

--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -385,7 +385,7 @@ Expect<uint32_t> WasiArgsGet::body(const Runtime::CallingFrame &Frame,
   // ArgvBufPtr should be aligned to at least 1 byte (which is always true)
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -428,7 +428,7 @@ Expect<uint32_t> WasiArgsSizesGet::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -459,7 +459,7 @@ Expect<uint32_t> WasiEnvironGet::body(const Runtime::CallingFrame &Frame,
   // EnvBufPtr should be aligned to at least 1 byte (which is always true)
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -502,7 +502,7 @@ Expect<uint32_t> WasiEnvironSizesGet::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -534,7 +534,7 @@ Expect<uint32_t> WasiClockResGet::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -567,7 +567,7 @@ Expect<uint32_t> WasiClockTimeGet::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -654,7 +654,7 @@ Expect<uint32_t> WasiFdFdstatGet::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -725,7 +725,7 @@ Expect<uint32_t> WasiFdFilestatGet::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -791,7 +791,7 @@ Expect<uint32_t> WasiFdPread::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -850,7 +850,7 @@ Expect<uint32_t> WasiFdPrestatDirName::body(const Runtime::CallingFrame &Frame,
   // PathBufPtr should be aligned to at least 1 byte (which is always true)
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -877,7 +877,7 @@ Expect<uint32_t> WasiFdPrestatGet::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -910,7 +910,7 @@ Expect<uint32_t> WasiFdPwrite::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -979,7 +979,7 @@ Expect<uint32_t> WasiFdRead::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1040,7 +1040,7 @@ Expect<uint32_t> WasiFdReadDir::body(const Runtime::CallingFrame &Frame,
   // BufPtr should be aligned to at least 1 byte (which is always true)
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1088,7 +1088,7 @@ Expect<int32_t> WasiFdSeek::body(const Runtime::CallingFrame &Frame, int32_t Fd,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1133,7 +1133,7 @@ Expect<uint32_t> WasiFdTell::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1167,7 +1167,7 @@ Expect<uint32_t> WasiFdWrite::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1224,7 +1224,7 @@ WasiPathCreateDirectory::body(const Runtime::CallingFrame &Frame, int32_t Fd,
                               uint32_t PathPtr, uint32_t PathLen) {
   // PathPtr should be aligned to at least 1 byte (which is always true)
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1254,7 +1254,7 @@ Expect<uint32_t> WasiPathFilestatGet::body(const Runtime::CallingFrame &Frame,
   // PathPtr should be aligned to at least 1 byte (which is always true)
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1294,7 +1294,7 @@ WasiPathFilestatSetTimes::body(const Runtime::CallingFrame &Frame, int32_t Fd,
   // PathPtr should be aligned to at least 1 byte (which is always true)
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1340,7 +1340,7 @@ Expect<uint32_t> WasiPathLink::body(const Runtime::CallingFrame &Frame,
   // always true)
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1386,7 +1386,7 @@ Expect<uint32_t> WasiPathOpen::body(
   // PathPtr should be aligned to at least 1 byte (which is always true)
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1470,7 +1470,7 @@ Expect<uint32_t> WasiPathReadLink::body(const Runtime::CallingFrame &Frame,
   // true)
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1508,7 +1508,7 @@ WasiPathRemoveDirectory::body(const Runtime::CallingFrame &Frame, int32_t Fd,
   // PathPtr should be aligned to at least 1 byte (which is always true)
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1537,7 +1537,7 @@ Expect<uint32_t> WasiPathRename::body(const Runtime::CallingFrame &Frame,
   // always true).
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1573,7 +1573,7 @@ Expect<uint32_t> WasiPathSymlink::body(const Runtime::CallingFrame &Frame,
   // always true)
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1609,7 +1609,7 @@ Expect<uint32_t> WasiPathUnlinkFile::body(const Runtime::CallingFrame &Frame,
   // PathPtr should be aligned to at least 1 byte (which is always true)
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1642,7 +1642,7 @@ Expect<uint32_t> WasiPollOneoff<Trigger>::body(
     return __WASI_ERRNO_ADDRNOTAVAIL;
   }
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1779,7 +1779,7 @@ Expect<uint32_t> WasiRandomGet::body(const Runtime::CallingFrame &Frame,
   // BufPtr should be aligned to at least 1 byte (which is always true)
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1806,7 +1806,7 @@ Expect<uint32_t> WasiSockOpenV1::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1853,7 +1853,7 @@ Expect<uint32_t> WasiSockBindV1::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1909,7 +1909,7 @@ Expect<uint32_t> WasiSockAcceptV1::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1937,7 +1937,7 @@ Expect<uint32_t> WasiSockAcceptV2::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -1971,7 +1971,7 @@ Expect<uint32_t> WasiSockConnectV1::body(const Runtime::CallingFrame &Frame,
     return __WASI_ERRNO_ADDRNOTAVAIL;
   }
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -2029,7 +2029,7 @@ Expect<uint32_t> WasiSockRecvV1::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -2119,7 +2119,7 @@ Expect<uint32_t> WasiSockRecvFromV1::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -2209,7 +2209,7 @@ Expect<uint32_t> WasiSockSendV1::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -2287,7 +2287,7 @@ Expect<uint32_t> WasiSockSendToV1::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -2397,7 +2397,7 @@ Expect<uint32_t> WasiSockSetOpt::body(const Runtime::CallingFrame &Frame,
   // Alignment checks
   // FlagPtr should be aligned to at least 1 byte (which is always true)
 
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -2451,7 +2451,7 @@ Expect<uint32_t> WasiSockGetAddrinfo::body(
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -2629,7 +2629,7 @@ WasiSockGetLocalAddrV1::body(const Runtime::CallingFrame &Frame, int32_t Fd,
     return __WASI_ERRNO_ADDRNOTAVAIL;
   }
 
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -2709,7 +2709,7 @@ Expect<uint32_t> WasiSockGetPeerAddrV1::body(const Runtime::CallingFrame &Frame,
     return __WASI_ERRNO_ADDRNOTAVAIL;
   }
 
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -2782,7 +2782,7 @@ Expect<uint32_t> WasiSockOpenV2::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -2829,7 +2829,7 @@ Expect<uint32_t> WasiSockBindV2::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -2892,7 +2892,7 @@ Expect<uint32_t> WasiSockConnectV2::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -2957,7 +2957,7 @@ Expect<uint32_t> WasiSockRecvV2::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -3050,7 +3050,7 @@ Expect<uint32_t> WasiSockRecvFromV2::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -3164,7 +3164,7 @@ Expect<uint32_t> WasiSockSendV2::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -3242,7 +3242,7 @@ Expect<uint32_t> WasiSockSendToV2::body(const Runtime::CallingFrame &Frame,
   }
 
   // Check memory instance from module.
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -3346,7 +3346,7 @@ Expect<uint32_t> WasiSockGetOpt::body(const Runtime::CallingFrame &Frame,
     return __WASI_ERRNO_ADDRNOTAVAIL;
   }
 
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -3399,7 +3399,7 @@ WasiSockGetLocalAddrV2::body(const Runtime::CallingFrame &Frame, int32_t Fd,
     return __WASI_ERRNO_ADDRNOTAVAIL;
   }
 
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }
@@ -3455,7 +3455,7 @@ Expect<uint32_t> WasiSockGetPeerAddrV2::body(const Runtime::CallingFrame &Frame,
     return __WASI_ERRNO_ADDRNOTAVAIL;
   }
 
-  auto *MemInst = Frame.getMemoryByIndex(0);
+  auto *MemInst = Frame.getMemoryByExportName("memory");
   if (MemInst == nullptr) {
     return __WASI_ERRNO_FAULT;
   }

--- a/test/host/wasi/wasi.cpp
+++ b/test/host/wasi/wasi.cpp
@@ -441,6 +441,37 @@ TEST(WasiTest, Args) {
   Env.fini();
 }
 
+TEST(WasiTest, MemoryNotExported) {
+  WasmEdge::Host::WASI::Environ Env;
+  WasmEdge::Runtime::Instance::ModuleInstance Mod("");
+  Mod.addHostMemory(
+      "not_memory",
+      std::make_unique<WasmEdge::Runtime::Instance::MemoryInstance>(
+          WasmEdge::AST::MemoryType(1)));
+  ASSERT_TRUE(Mod.findMemoryExports("memory") == nullptr);
+  WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
+
+  WasmEdge::Host::WasiArgsSizesGet WasiArgsSizesGet(Env);
+  WasmEdge::Host::WasiRandomGet WasiRandomGet(Env);
+  std::array<WasmEdge::ValVariant, 1> Errno;
+
+  Env.init({}, "test"s, {}, {});
+  EXPECT_TRUE(WasiArgsSizesGet.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0), UINT32_C(4)},
+      Errno));
+  EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_FAULT);
+  Env.fini();
+
+  Env.init({}, "test"s, {}, {});
+  EXPECT_TRUE(WasiRandomGet.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{UINT32_C(0), UINT32_C(1)},
+      Errno));
+  EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_FAULT);
+  Env.fini();
+}
+
 TEST(WasiTest, Envs) {
   WasmEdge::Host::WASI::Environ Env;
   WasmEdge::Runtime::Instance::ModuleInstance Mod("");


### PR DESCRIPTION
WASI host functions looked up the guest module's linear memory with Frame.getMemoryByIndex(0), so any module exposing a memory at index 0 was accepted even when that memory was not exported as "memory". This let a malformed module run against uninitialized or unintended memory instead of failing with a fault.

Add CallingFrame::getMemoryByExportName() and use it across the WASI host functions to look up the memory by its exported name, matching the WASI ABI convention.

Fixes #2932

## Description
<!-- Describe your changes here -->

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [ ] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
