### PR TITLE
fix(common): avoid span underflow in rapidHash tail read

### DIFF
--- a/lib/common/hash.cpp
+++ b/lib/common/hash.cpp
@@ -57,6 +57,7 @@ WASMEDGE_EXPORT uint64_t Hash::rapidHash(Span<const std::byte> Data) noexcept {
       A = B = 0;
     }
   } else {
+    const Span<const std::byte> Orig = Data;
     if (Data.size() > 48) {
       uint64_t See1 = Seed, See2 = Seed;
       do {
@@ -79,8 +80,8 @@ WASMEDGE_EXPORT uint64_t Hash::rapidHash(Span<const std::byte> Data) noexcept {
                         read(Data.subspan<24>().first<8>()) ^ Seed);
       }
     }
-    A = read(Data.last<16>().first<8>()) ^ Data.size();
-    B = read(Data.last<8>());
+    A = read(Orig.last<16>().first<8>()) ^ Data.size();
+    B = read(Orig.last<8>());
   }
   A ^= Secret[1];
   B ^= Seed;

--- a/test/common/hashTest.cpp
+++ b/test/common/hashTest.cpp
@@ -107,4 +107,23 @@ TEST(HashTest, IntegralHash) {
   EXPECT_EQ(Seen.size(), 1000u);
 }
 
+// Tail read must stay in bounds when the >48-byte loop leaves a short
+// remainder; run under -fsanitize=undefined to detect the underflow.
+TEST(HashTest, TailReadAfterLoopIsInBounds) {
+  // Lengths where size % 48 falls in [1, 15], plus in-bounds controls.
+  const std::vector<size_t> Affected = {49, 50, 63, 97, 100, 145};
+  const std::vector<size_t> Controls = {17, 32, 48, 64, 96, 128};
+
+  std::unordered_set<uint64_t> Seen;
+  for (auto Size : Affected) {
+    std::string Input(Size, 'x');
+    Seen.insert(hashBytes(Input.data(), Input.size()));
+  }
+  for (auto Size : Controls) {
+    std::string Input(Size, 'x');
+    Seen.insert(hashBytes(Input.data(), Input.size()));
+  }
+  EXPECT_EQ(Seen.size(), Affected.size() + Controls.size());
+}
+
 } // namespace


### PR DESCRIPTION
Fixes #5212

## Description

`rapidHash` advances `Data` by 48 bytes per loop iteration in the `> 48` path, then took the tail read from the *remaining* span:

```cpp
A = read(Data.last<16>().first<8>()) ^ Data.size();
B = read(Data.last<8>());
```

When the remainder is shorter than 16 bytes, `span::last<16>()` computes `data() + (size() - 16)` with unsigned arithmetic, so the offset wraps. Affected lengths are those where `size % 48` falls in `[1, 15]` — e.g. any input of 49–63 bytes.

Reachable from ordinary module validation: `Validator::validate(const AST::ExportSection &)` hashes every export name of every module loaded, so a module with a 49-byte export name triggers it.

**Scope:** the wrapped pointer lands on the same bytes, so hash values are unchanged and there is no wrong-result bug. This removes the undefined behaviour only. `span::last<Count>()`'s `static_assert(Count <= Extent)` is vacuous for a `dynamic_extent` span, so nothing catches the runtime case today.

The fix keeps a reference to the original span and takes the tail from that. In this branch `Orig.size() > 16` always holds, so both reads are in bounds by construction. `^ Data.size()` is deliberately unchanged — upstream mixes the *remaining* length there, not the total.

If you'd prefer broader coverage, a runtime bounds guard on `span::last<Count>()` / `first<Count>()` would catch any other caller with the same pattern. Happy to open that separately.

This contribution was developed with assistance from Claude (Anthropic).

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

Built with UBSan:

```console
$ cmake -S . -Bbuild-asan -GNinja -DCMAKE_BUILD_TYPE=Debug \
    -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_USE_LLVM=OFF -DWASMEDGE_BUILD_PLUGINS=OFF \
    -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g1" \
    -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
$ cmake --build build-asan
```

**With this change** — the new case and the whole common suite are clean:

```console
$ cd build-asan/test/common && ./wasmedgeCommonTests
[==========] 84 tests from 9 test suites ran.
[  PASSED  ] 84 tests.

$ ./wasmedgeCommonTests 2>&1 | grep -c "span.hpp:207"
0
```

**Negative control** — reverting only `lib/common/hash.cpp` and keeping the new test reproduces the UB, so the case is not passing vacuously:

```console
$ ./wasmedgeCommonTests --gtest_filter=HashTest.TailReadAfterLoopIsInBounds 2>&1 | grep -c "span.hpp:207"
4
```

Sample report from that run:

```console
include/experimental/span.hpp:207:34: runtime error: addition of unsigned offset to 0x606000000d70 overflowed to 0x606000000d61
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior include/experimental/span.hpp:207:34 in
```

`-15` from `last<16>()` and `-7` from `last<8>()`, for each of the two triggering lengths the case exercises. The test still reports `OK` because UBSan runs in non-halting mode — the defect is sanitizer-detectable rather than value-detectable, since the wrapped pointer reads the same bytes.

**Full spec suite** with the change, under ASan + UBSan:

```console
$ cd build-asan/test/executor && ./wasmedgeExecutorCoreTests
[==========] 530 tests from 6 test suites ran. (64762 ms total)
[  PASSED  ] 530 tests.
```
0 sanitizer reports.

**Release build** (no sanitizers), to confirm nothing regresses:

```console
$ cd build/test/common && ./wasmedgeCommonTests
[==========] 84 tests from 9 test suites ran.
[  PASSED  ] 84 tests.
```

Tested on macOS 15 (Darwin 24.6.0), arm64, against master @ `c30edc5ef`.
