### PR TITLE
fix(executor): handle NaN in f64x2 trunc_sat interpreter path

### DIFF
--- a/include/executor/engine/unary_numeric_vector.ipp
+++ b/include/executor/engine/unary_numeric_vector.ipp
@@ -159,6 +159,7 @@ Expect<void> Executor::runVectorTruncSatOp(ValVariant &Val) const {
     const VTOut2 IMax = VTOut2{} + std::numeric_limits<TOut>::max();
     VTIn X = {std::trunc(V[0]), std::trunc(V[1])};
     VTOut2 Y = __builtin_convertvector(X, VTOut2);
+    Y = detail::vectorSelect(X == X, Y, VTOut2{});
     Y = detail::vectorSelect(X <= FMin, IMin, Y);
     Y = detail::vectorSelect(X >= FMax, IMax, Y);
     using VTOut22 [[gnu::vector_size(32)]] = TOut2;


### PR DESCRIPTION
## Description
i found this while going through the SIMD trunc_sat instructions in `include/executor/engine/unary_numeric_vector.ipp`. The `runVectorTruncSatOp<TIn, TOut>` template has two paths depending on whether TIn and TOut are the same size:

The f32x4->i32x4 path (same size) has a NaN guard before the conversion result gets used:

```cpp
VTOut Y = __builtin_convertvector(X, VTOut);
Y = detail::vectorSelect(X == X, Y, VTOut{});  // zero out NaN lanes
```

The f64x2->i32x4 path (different sizes, goes through an intermediate 64 bit type) doesn't have this guard at all:

```cpp
VTIn X = {std::trunc(V[0]), std::trunc(V[1])};
VTOut2 Y = __builtin_convertvector(X, VTOut2);
Y = detail::vectorSelect(X <= FMin, IMin, Y);
Y = detail::vectorSelect(X >= FMax, IMax, Y);
```

Converting a NaN through `__builtin_convertvector` to an integer type is undefined behavior in C++, since NaN doesn't fit `X <= FMin` or `X >= FMax` (both are false for NaN), nothing catches it, whatever the UB conversion produces just flows through as the result. Per the WebAssembly spec, `trunc_sat` on NaN should always give 0, this isn't a spec-conformant guarantee right now on this path, it's just whatever the compiler's NaN-to-int conversion happens to produce.

I checked the MSVC interpreter variant (`unary_numeric_vector_msvc.ipp:149`) and it does `std::isnan(V[I])` explicitly in a loop covering both cases, so that one's fine. Checked the AOT compiler too (`vectorInstr.cpp:1585`, uses `createFCmpORD(V, V)`), also fine. So this is specifically a gap in the GCC/Clang interpreter path for `i32x4.trunc_sat_f64x2_s_zero`, `i32x4.trunc_sat_f64x2_u_zero`, and their relaxed variants.

Fix is one line, add the same guard the f32x4 path already has:

```cpp
VTOut2 Y = __builtin_convertvector(X, VTOut2);
Y = detail::vectorSelect(X == X, Y, VTOut2{});
Y = detail::vectorSelect(X <= FMin, IMin, Y);
Y = detail::vectorSelect(X >= FMax, IMax, Y);
```

One caveat I want to be upfront about since I actually tested this both ways: on this x86_64 machine, the bug doesn't currently change the observable output. I wrote a small standalone probe converting a NaN vector through `__builtin_convertvector` directly and it already comes out as 0 on this GCC/x86_64 combo, so my regression test passes whether the fix is present or not here, I confirmed this by literally removing the fix and rerunning, same result. I also tried building with `-fsanitize=undefined,float-cast-overflow` to catch the UB directly and it didn't flag anything either, `__builtin_convertvector` seems to not get instrumented by UBSan the same way a normal cast would. So I don't have a locally reproducible failing case, I'm relying on the fact that this is genuinely undefined behavior per the language standard (relying on unspecified NaN-to-int conversion results is not something the code should do regardless of what today's compiler happens to produce) and that it brings this path in line with the other two implementations that already guard against it. Happy to have a maintainer double check this reasoning if it seems off.

Added a regression test anyway (`TruncSatF64x2NaNProducesZero`) since it documents the expected spec behavior even though it can't currently prove the difference between buggy/fixed on x86.

Assisted-by: Claude (Anthropic)

## Checklist

Before submitting this PR, please ensure the following:
- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:
- [ ] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [ ] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
$ ninja wasmedgeExecutorRegressionTests
[18/18] Linking CXX executable test/executor/wasmedgeExecutorRegressionTests

$ ./test/executor/wasmedgeExecutorRegressionTests
[==========] Running 8 tests from 1 test suite.
[ RUN ] ExecutorRegression.RefTestNullAbility
[ OK ] ExecutorRegression.RefTestNullAbility (6 ms)
[ RUN ] ExecutorRegression.RefCastNullAbility
[ OK ] ExecutorRegression.RefCastNullAbility (0 ms)
[ RUN ] ExecutorRegression.BrOnCastNullAbility
[ OK ] ExecutorRegression.BrOnCastNullAbility (0 ms)
[ RUN ] ExecutorRegression.NullLocalConcreteType
[ OK ] ExecutorRegression.NullLocalConcreteType (0 ms)
[ RUN ] ExecutorRegression.ThrowRefPreservesPayload
[ OK ] ExecutorRegression.ThrowRefPreservesPayload (0 ms)
[ RUN ] ExecutorRegression.CatchAllDiscardsPayload
[ OK ] ExecutorRegression.CatchAllDiscardsPayload (0 ms)
[ RUN ] ExecutorRegression.TruncSatF64x2NaNProducesZero
[ OK ] ExecutorRegression.TruncSatF64x2NaNProducesZero (0 ms)
[ RUN ] ExecutorRegression.CallIndirectNonFuncTable
[ OK ] ExecutorRegression.CallIndirectNonFuncTable (0 ms)
[==========] 8 tests from 1 test suite ran. (7 ms total)
[ PASSED ] 8 tests.
---
> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.