### PR TITLE
feat: prototype implementation of wide arithmetic opcodes

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -409,6 +409,12 @@ OFC(Table__grow, "table.grow", 0xFC, 15)
 OFC(Table__size, "table.size", 0xFC, 16)
 OFC(Table__fill, "table.fill", 0xFC, 17)
 
+// 0xFC prefix - Wide Arithmetic Instructions
+OFC(I64__add128, "i64.add128", 0xFC, 19)
+OFC(I64__sub128, "i64.sub128", 0xFC, 20)
+OFC(I64__mul_wide_s, "i64.mul_wide_s", 0xFC, 21)
+OFC(I64__mul_wide_u, "i64.mul_wide_u", 0xFC, 22)
+
 // 0xFD prefix - Vector Memory Instructions (part 1)
 OFD(V128__load, "v128.load", 0xFD, 0)
 OFD(V128__load8x8_s, "v128.load8x8_s", 0xFD, 1)

--- a/lib/executor/engine/engine.cpp
+++ b/lib/executor/engine/engine.cpp
@@ -767,6 +767,46 @@ Expect<void> Executor::execute(Runtime::StackManager &StackMgr,
       ValVariant Rhs = StackMgr.pop();
       return runRotrOp<uint64_t>(StackMgr.getTop(), Rhs);
     }
+    case OpCode::I64__add128: {
+      uint64_t BHigh = StackMgr.pop().get<uint64_t>();
+      uint64_t BLow = StackMgr.pop().get<uint64_t>();
+      uint64_t AHigh = StackMgr.pop().get<uint64_t>();
+      uint64_t ALow = StackMgr.getTop().get<uint64_t>();
+      WasmEdge::uint128_t A = (static_cast<WasmEdge::uint128_t>(AHigh) << 64) | ALow;
+      WasmEdge::uint128_t B = (static_cast<WasmEdge::uint128_t>(BHigh) << 64) | BLow;
+      WasmEdge::uint128_t Res = A + B;
+      StackMgr.getTop() = static_cast<uint64_t>(Res); // ResLow
+      StackMgr.push(static_cast<uint64_t>(Res >> 64)); // ResHigh
+      return {};
+    }
+    case OpCode::I64__sub128: {
+      uint64_t BHigh = StackMgr.pop().get<uint64_t>();
+      uint64_t BLow = StackMgr.pop().get<uint64_t>();
+      uint64_t AHigh = StackMgr.pop().get<uint64_t>();
+      uint64_t ALow = StackMgr.getTop().get<uint64_t>();
+      WasmEdge::uint128_t A = (static_cast<WasmEdge::uint128_t>(AHigh) << 64) | ALow;
+      WasmEdge::uint128_t B = (static_cast<WasmEdge::uint128_t>(BHigh) << 64) | BLow;
+      WasmEdge::uint128_t Res = A - B;
+      StackMgr.getTop() = static_cast<uint64_t>(Res); // ResLow
+      StackMgr.push(static_cast<uint64_t>(Res >> 64)); // ResHigh
+      return {};
+    }
+    case OpCode::I64__mul_wide_s: {
+      int64_t B = StackMgr.pop().get<int64_t>();
+      int64_t A = StackMgr.getTop().get<int64_t>();
+      __int128 Res = static_cast<__int128>(A) * static_cast<__int128>(B);
+      StackMgr.getTop() = static_cast<uint64_t>(Res); // ResLow
+      StackMgr.push(static_cast<uint64_t>(Res >> 64)); // ResHigh
+      return {};
+    }
+    case OpCode::I64__mul_wide_u: {
+      uint64_t B = StackMgr.pop().get<uint64_t>();
+      uint64_t A = StackMgr.getTop().get<uint64_t>();
+      WasmEdge::uint128_t Res = static_cast<WasmEdge::uint128_t>(A) * static_cast<WasmEdge::uint128_t>(B);
+      StackMgr.getTop() = static_cast<uint64_t>(Res); // ResLow
+      StackMgr.push(static_cast<uint64_t>(Res >> 64)); // ResHigh
+      return {};
+    }
     case OpCode::F32__add: {
       ValVariant Rhs = StackMgr.pop();
       return runAddOp<float>(StackMgr.getTop(), Rhs);

--- a/lib/loader/ast/instruction.cpp
+++ b/lib/loader/ast/instruction.cpp
@@ -738,6 +738,10 @@ Expect<void> Loader::loadInstruction(AST::Instruction &Instr) {
   case OpCode::F64__min:
   case OpCode::F64__max:
   case OpCode::F64__copysign:
+  case OpCode::I64__add128:
+  case OpCode::I64__sub128:
+  case OpCode::I64__mul_wide_s:
+  case OpCode::I64__mul_wide_u:
     return {};
 
   // SIMD Memory Instruction.

--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -1454,6 +1454,15 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::I64__rotr:
     return StackTrans({ValType(TypeCode::I64), ValType(TypeCode::I64)},
                       {ValType(TypeCode::I64)});
+  case OpCode::I64__add128:
+  case OpCode::I64__sub128:
+    return StackTrans({ValType(TypeCode::I64), ValType(TypeCode::I64),
+                       ValType(TypeCode::I64), ValType(TypeCode::I64)},
+                      {ValType(TypeCode::I64), ValType(TypeCode::I64)});
+  case OpCode::I64__mul_wide_s:
+  case OpCode::I64__mul_wide_u:
+    return StackTrans({ValType(TypeCode::I64), ValType(TypeCode::I64)},
+                      {ValType(TypeCode::I64), ValType(TypeCode::I64)});
   case OpCode::F32__add:
   case OpCode::F32__sub:
   case OpCode::F32__mul:


### PR DESCRIPTION
Adds local prototype evaluation for i64.add128, i64.sub128, i64.mul_wide_s, and i64.mul_wide_u to demonstrate end-to-end WasmEdge opcode parsing, validation, and native 128-bit execution logic.

Assisted-by: Copilot

## Description
This draft PR contains the initial logic for 128-bit wide arithmetic operations.
