### PR TITLE
fix: trap on misaligned wasi args env and clock pointers

### DIFF
--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -421,10 +421,10 @@ Expect<uint32_t> WasiArgsSizesGet::body(const Runtime::CallingFrame &Frame,
                                         uint32_t /* Out */ ArgvBufSizePtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_size_t>(ArgcPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
   if (unlikely(isMisaligned<__wasi_size_t>(ArgvBufSizePtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   // Check memory instance from module.
@@ -454,7 +454,7 @@ Expect<uint32_t> WasiEnvironGet::body(const Runtime::CallingFrame &Frame,
                                       uint32_t EnvPtr, uint32_t EnvBufPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<uint8_t_ptr>(EnvPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
   // EnvBufPtr should be aligned to at least 1 byte (which is always true)
 
@@ -495,10 +495,10 @@ Expect<uint32_t> WasiEnvironSizesGet::body(const Runtime::CallingFrame &Frame,
                                            uint32_t /* Out */ EnvBufSizePtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_size_t>(EnvCntPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
   if (unlikely(isMisaligned<__wasi_size_t>(EnvBufSizePtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   // Check memory instance from module.
@@ -530,7 +530,7 @@ Expect<uint32_t> WasiClockResGet::body(const Runtime::CallingFrame &Frame,
                                        uint32_t /* Out */ ResolutionPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_timestamp_t>(ResolutionPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   // Check memory instance from module.
@@ -563,7 +563,7 @@ Expect<uint32_t> WasiClockTimeGet::body(const Runtime::CallingFrame &Frame,
                                         uint32_t /* Out */ TimePtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_timestamp_t>(TimePtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   // Check memory instance from module.

--- a/test/host/wasi/wasi.cpp
+++ b/test/host/wasi/wasi.cpp
@@ -6133,21 +6133,23 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_size_t) * 3);
 
     // Test misaligned ArgcPtr
-    EXPECT_TRUE(
-        WasiArgsSizesGet.run(CallFrame,
-                             std::initializer_list<WasmEdge::ValVariant>{
-                                 MisalignedArgcPtr, // misaligned
-                                 AlignedArgvBufSizePtr},
-                             Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    Res = WasiArgsSizesGet.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            MisalignedArgcPtr, // misaligned
+            AlignedArgvBufSizePtr},
+        Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     // Test misaligned ArgvBufSizePtr
-    EXPECT_TRUE(WasiArgsSizesGet.run(
+    Res = WasiArgsSizesGet.run(
         CallFrame,
         std::initializer_list<WasmEdge::ValVariant>{
             AlignedArgcPtr, MisalignedArgvBufSizePtr}, // misaligned
-        Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+        Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     writeDummyMemoryContent(MemInst);
     // Test properly aligned parameters (should succeed)
@@ -6172,12 +6174,14 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(uint8_t_ptr) * 3);
 
     // Test misaligned EnvPtr
-    EXPECT_TRUE(WasiEnvironGet.run(CallFrame,
-                                   std::initializer_list<WasmEdge::ValVariant>{
-                                       MisalignedEnvPtr, // misaligned
-                                       static_cast<uint32_t>(0)},
-                                   Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    auto Res =
+        WasiEnvironGet.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               MisalignedEnvPtr, // misaligned
+                               static_cast<uint32_t>(0)},
+                           Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned pointers (should succeed)
@@ -6201,21 +6205,23 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_size_t) * 5);
 
     // Test misaligned EnvCntPtr
-    EXPECT_TRUE(
-        WasiEnvironSizesGet.run(CallFrame,
-                                std::initializer_list<WasmEdge::ValVariant>{
-                                    MisalignedEnvCntPtr, // misaligned
-                                    AlignedEnvBufSizePtr},
-                                Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    Res = WasiEnvironSizesGet.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            MisalignedEnvCntPtr, // misaligned
+            AlignedEnvBufSizePtr},
+        Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     // Test misaligned EnvBufSizePtr
-    EXPECT_TRUE(WasiEnvironSizesGet.run(
+    Res = WasiEnvironSizesGet.run(
         CallFrame,
         std::initializer_list<WasmEdge::ValVariant>{
             AlignedEnvCntPtr, MisalignedEnvBufSizePtr}, // misaligned
-        Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+        Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned pointers (should succeed)
@@ -6240,13 +6246,14 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(uint64_t) * 2);
 
       // Test misaligned ResolutionPtr
-      EXPECT_TRUE(WasiClockResGet.run(
+      auto Res = WasiClockResGet.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<uint32_t>(__WASI_CLOCKID_REALTIME),
               MisalignedResolutionPtr}, // misaligned
-          Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+          Errno);
+      ASSERT_FALSE(Res);
+      EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
       writeDummyMemoryContent(MemInst);
       // Test correctly aligned pointer (should succeed)
@@ -6274,13 +6281,14 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(uint64_t) * 3);
 
       // Test misaligned timestamp pointer
-      EXPECT_TRUE(WasiClockTimeGet.run(
+      auto Res = WasiClockTimeGet.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               static_cast<uint32_t>(__WASI_CLOCKID_REALTIME), UINT64_C(0),
               MisalignedTimePtr}, // misaligned
-          Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+          Errno);
+      ASSERT_FALSE(Res);
+      EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
       writeDummyMemoryContent(MemInst);
       // Test correctly aligned timestamp pointer (should succeed)


### PR DESCRIPTION
## Description

This is a follow-up to #5089.

This PR extends the same WASI typed pointer misalignment trap behavior to args/env and clock host functions. Misaligned typed pointers now trap with `ErrCode::Value::UnalignedAtomicAccess` instead of returning `__WASI_ERRNO_ADDRNOTAVAIL`.

Updated checks:
- `args_sizes_get`: `ArgcPtr`, `ArgvBufSizePtr`
- `environ_get`: `EnvPtr`
- `environ_sizes_get`: `EnvCntPtr`, `EnvBufSizePtr`
- `clock_res_get`: `ResolutionPtr`
- `clock_time_get`: `TimePtr`

Related to #4960.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by: GPT 5.6` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

Local unit test:

```console
cmake --build build-lfx-repro --target wasiTests -j$(sysctl -n hw.logicalcpu)

./build-lfx-repro/test/host/wasi/wasiTests --gtest_filter=WasiTest.PointerAlignment
```

Result:

```console
[  PASSED  ] 1 test.
```

Local lint checks:

```console
lineguard --config .lineguardrc -r lib/host/wasi/wasifunc.cpp test/host/wasi/wasi.cpp

git diff --check
```

Result:

```console
All files passed lint checks.
```

CLI smoke tests:

```console
cmake --build build-lfx-repro --target wasmedge wasmedgec -j$(sysctl -n hw.logicalcpu)
```

| Case | Interpreter | JIT | AOT compile | AOT run |
|---|---:|---:|---:|---:|
| `args_sizes_get` misaligned `argc_ptr` | 134 | 134 | 0 | 134 |
| `clock_time_get` misaligned `time_ptr` | 134 | 134 | 0 | 134 |

Both smoke tests trap before `proc_exit`. JIT/AOT diagnostics include `execution failed: unaligned atomic, Code: 0x410`.

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
