### PR TITLE
test(ffmpeg): add missing host function tests

### DIFF
--- a/plugins/wasmedge_ffmpeg/avcodec/module.cpp
+++ b/plugins/wasmedge_ffmpeg/avcodec/module.cpp
@@ -59,9 +59,8 @@ WasmEdgeFFmpegAVCodecModule::WasmEdgeFFmpegAVCodecModule(
               std::make_unique<AVPacketRescaleTs>(Env));
   addHostFunc("wasmedge_ffmpeg_avcodec_av_packet_make_writable",
               std::make_unique<AVPacketMakeWritable>(Env));
-  addHostFunc(
-      "wasmedge_ffmpeg_avcodec_avcodec_parameters_copy",
-      std::make_unique<AVCodecParametersCopy>(Env));
+  addHostFunc("wasmedge_ffmpeg_avcodec_avcodec_parameters_copy",
+              std::make_unique<AVCodecParametersCopy>(Env));
   addHostFunc("wasmedge_ffmpeg_avcodec_avcodec_version",
               std::make_unique<AVCodecVersion>(Env));
   addHostFunc("wasmedge_ffmpeg_avcodec_avcodec_flush_buffers",

--- a/plugins/wasmedge_ffmpeg/avcodec/module.cpp
+++ b/plugins/wasmedge_ffmpeg/avcodec/module.cpp
@@ -61,7 +61,7 @@ WasmEdgeFFmpegAVCodecModule::WasmEdgeFFmpegAVCodecModule(
               std::make_unique<AVPacketMakeWritable>(Env));
   addHostFunc(
       "wasmedge_ffmpeg_avcodec_avcodec_parameters_copy",
-      std::make_unique<AVCodecParametersCopy>(Env)); // TODO: Write Test.
+      std::make_unique<AVCodecParametersCopy>(Env));
   addHostFunc("wasmedge_ffmpeg_avcodec_avcodec_version",
               std::make_unique<AVCodecVersion>(Env));
   addHostFunc("wasmedge_ffmpeg_avcodec_avcodec_flush_buffers",

--- a/plugins/wasmedge_ffmpeg/avformat/module.cpp
+++ b/plugins/wasmedge_ffmpeg/avformat/module.cpp
@@ -66,9 +66,8 @@ WasmEdgeFFmpegAVFormatModule::WasmEdgeFFmpegAVFormatModule(
               std::make_unique<AVWriteFrame>(Env));
   addHostFunc("wasmedge_ffmpeg_avformat_av_interleaved_write_frame",
               std::make_unique<AVInterleavedWriteFrame>(Env));
-  addHostFunc(
-      "wasmedge_ffmpeg_avformat_avformat_new_stream",
-      std::make_unique<AVFormatNewStream>(Env));
+  addHostFunc("wasmedge_ffmpeg_avformat_avformat_new_stream",
+              std::make_unique<AVFormatNewStream>(Env));
   addHostFunc("wasmedge_ffmpeg_avformat_av_guess_codec", // TODO: Write Test
               std::make_unique<AVGuessCodec>(Env));
   addHostFunc("wasmedge_ffmpeg_avformat_avformat_configuration_length",

--- a/plugins/wasmedge_ffmpeg/avformat/module.cpp
+++ b/plugins/wasmedge_ffmpeg/avformat/module.cpp
@@ -35,7 +35,7 @@ WasmEdgeFFmpegAVFormatModule::WasmEdgeFFmpegAVFormatModule(
               std::make_unique<AVFormatFreeContext>(Env));
   addHostFunc("wasmedge_ffmpeg_avformat_av_find_best_stream",
               std::make_unique<AVFindBestStream>(Env));
-  addHostFunc("wasmedge_ffmpeg_avformat_av_read_frame", // TODO: Write Test
+  addHostFunc("wasmedge_ffmpeg_avformat_av_read_frame",
               std::make_unique<AVReadFrame>(Env));
   addHostFunc("wasmedge_ffmpeg_avformat_avio_close",
               std::make_unique<AVIOClose>(Env));
@@ -67,7 +67,7 @@ WasmEdgeFFmpegAVFormatModule::WasmEdgeFFmpegAVFormatModule(
   addHostFunc("wasmedge_ffmpeg_avformat_av_interleaved_write_frame",
               std::make_unique<AVInterleavedWriteFrame>(Env));
   addHostFunc(
-      "wasmedge_ffmpeg_avformat_avformat_new_stream", // TODO: Write Test
+      "wasmedge_ffmpeg_avformat_avformat_new_stream",
       std::make_unique<AVFormatNewStream>(Env));
   addHostFunc("wasmedge_ffmpeg_avformat_av_guess_codec", // TODO: Write Test
               std::make_unique<AVGuessCodec>(Env));

--- a/plugins/wasmedge_ffmpeg/avutil/module.cpp
+++ b/plugins/wasmedge_ffmpeg/avutil/module.cpp
@@ -223,13 +223,13 @@ WasmEdgeFFmpegAVUtilModule::WasmEdgeFFmpegAVUtilModule(
   addHostFunc("wasmedge_ffmpeg_avutil_av_get_channel_layout_nb_channels",
               std::make_unique<AVGetChannelLayoutNbChannels>(Env));
   addHostFunc(
-      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name_len", // TODO: Write
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name_len",
       std::make_unique<AVGetChannelLayoutNameLen>(Env));
   addHostFunc(
-      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name", // TODO: Write Test
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name",
       std::make_unique<AVGetChannelLayoutName>(Env));
   addHostFunc(
-      "wasmedge_ffmpeg_avutil_av_get_channel_layout_mask", // TODO: Write Test
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_mask",
       std::make_unique<AVGetChannelLayoutMask>(Env));
   addHostFunc("wasmedge_ffmpeg_avutil_av_get_default_channel_layout",
               std::make_unique<AVGetDefaultChannelLayout>(Env));

--- a/plugins/wasmedge_ffmpeg/avutil/module.cpp
+++ b/plugins/wasmedge_ffmpeg/avutil/module.cpp
@@ -222,15 +222,12 @@ WasmEdgeFFmpegAVUtilModule::WasmEdgeFFmpegAVUtilModule(
               std::make_unique<AVRescaleQRnd>(Env));
   addHostFunc("wasmedge_ffmpeg_avutil_av_get_channel_layout_nb_channels",
               std::make_unique<AVGetChannelLayoutNbChannels>(Env));
-  addHostFunc(
-      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name_len",
-      std::make_unique<AVGetChannelLayoutNameLen>(Env));
-  addHostFunc(
-      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name",
-      std::make_unique<AVGetChannelLayoutName>(Env));
-  addHostFunc(
-      "wasmedge_ffmpeg_avutil_av_get_channel_layout_mask",
-      std::make_unique<AVGetChannelLayoutMask>(Env));
+  addHostFunc("wasmedge_ffmpeg_avutil_av_get_channel_layout_name_len",
+              std::make_unique<AVGetChannelLayoutNameLen>(Env));
+  addHostFunc("wasmedge_ffmpeg_avutil_av_get_channel_layout_name",
+              std::make_unique<AVGetChannelLayoutName>(Env));
+  addHostFunc("wasmedge_ffmpeg_avutil_av_get_channel_layout_mask",
+              std::make_unique<AVGetChannelLayoutMask>(Env));
   addHostFunc("wasmedge_ffmpeg_avutil_av_get_default_channel_layout",
               std::make_unique<AVGetDefaultChannelLayout>(Env));
   addHostFunc("wasmedge_ffmpeg_avutil_avutil_version",

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avCodecParameters.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avCodecParameters.cpp
@@ -68,6 +68,174 @@ TEST_F(FFmpegTest, AVCodecParameters) {
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
   }
 }
+
+TEST_F(FFmpegTest, AVCodecParametersCopy) {
+  ASSERT_TRUE(AVCodecMod != nullptr);
+  ASSERT_TRUE(AVFormatMod != nullptr);
+
+  uint32_t FormatCtxPtr = UINT32_C(4);
+  uint32_t CodecParamPtr = UINT32_C(8);
+  uint32_t EmptyParamPtr = UINT32_C(12);
+  uint32_t FilePtr = UINT32_C(100);
+
+  std::string FileName = "ffmpeg-assets/sample_video.mp4";
+  initFormatCtx(FormatCtxPtr, FilePtr, FileName);
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  auto *FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformat_find_stream_info");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncAVFormatFindStreamInfo = FuncInst->getHostFunc();
+  EXPECT_TRUE(HostFuncAVFormatFindStreamInfo.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, UINT32_C(0)},
+      Result));
+  EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
+
+  FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_av_find_best_stream");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncAVFindBestStream = FuncInst->getHostFunc();
+
+  EXPECT_TRUE(HostFuncAVFindBestStream.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          FormatCtxId, UINT32_C(0), INT32_C(-1), INT32_C(-1), UINT32_C(0),
+          UINT32_C(0)},
+      Result));
+  const uint32_t StreamIdx = static_cast<uint32_t>(Result[0].get<int32_t>());
+  ASSERT_TRUE(static_cast<int32_t>(StreamIdx) >= 0);
+
+  FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avStream_codecpar");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncAVStreamCodecpar = FuncInst->getHostFunc();
+
+  EXPECT_TRUE(HostFuncAVStreamCodecpar.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, StreamIdx,
+                                                  CodecParamPtr},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t StreamParamId = readUInt32(MemInst, CodecParamPtr);
+  ASSERT_TRUE(StreamParamId > 0);
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodecparam_codec_id");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncAVCodecParamCodecId = FuncInst->getHostFunc();
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodecparam_codec_type");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncAVCodecParamCodecType = FuncInst->getHostFunc();
+
+  // Before: sample video stream carries H264 / video.
+  EXPECT_TRUE(HostFuncAVCodecParamCodecId.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{StreamParamId},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), 27);
+  EXPECT_TRUE(HostFuncAVCodecParamCodecType.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{StreamParamId},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), 0);
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_parameters_alloc");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncAVCodecParametersAlloc = FuncInst->getHostFunc();
+
+  EXPECT_TRUE(HostFuncAVCodecParametersAlloc.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{EmptyParamPtr},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t EmptyParamId = readUInt32(MemInst, EmptyParamPtr);
+  ASSERT_TRUE(EmptyParamId > 0);
+
+  // Fresh parameters default to NONE / UNKNOWN.
+  EXPECT_TRUE(HostFuncAVCodecParamCodecId.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{EmptyParamId},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), 0);
+  EXPECT_TRUE(HostFuncAVCodecParamCodecType.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{EmptyParamId},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), -1); // AVMEDIA_TYPE_UNKNOWN
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_parameters_copy");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncAVCodecParametersCopy = FuncInst->getHostFunc();
+
+  spdlog::info("Testing AVCodecParametersCopy"sv);
+  // Copies source AVCodecParameters into stream->codecpar.
+  EXPECT_TRUE(HostFuncAVCodecParametersCopy.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, EmptyParamId,
+                                                  StreamIdx},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), 0);
+
+  // After: stream codecpar should now match the empty source.
+  EXPECT_TRUE(HostFuncAVCodecParamCodecId.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{StreamParamId},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), 0);
+  EXPECT_TRUE(HostFuncAVCodecParamCodecType.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{StreamParamId},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), -1); // AVMEDIA_TYPE_UNKNOWN
+
+  // If an audio stream exists, also exercise a non-zero StreamIdx path.
+  EXPECT_TRUE(HostFuncAVFindBestStream.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          FormatCtxId, UINT32_C(1), INT32_C(-1), INT32_C(-1), UINT32_C(0),
+          UINT32_C(0)},
+      Result));
+  const int32_t AudioStreamIdx = Result[0].get<int32_t>();
+  if (AudioStreamIdx >= 0 &&
+      static_cast<uint32_t>(AudioStreamIdx) != StreamIdx) {
+    uint32_t AudioParamPtr = UINT32_C(16);
+    EXPECT_TRUE(HostFuncAVStreamCodecpar.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            FormatCtxId, static_cast<uint32_t>(AudioStreamIdx), AudioParamPtr},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    uint32_t AudioParamId = readUInt32(MemInst, AudioParamPtr);
+    ASSERT_TRUE(AudioParamId > 0);
+
+    EXPECT_TRUE(HostFuncAVCodecParamCodecType.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{AudioParamId},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), 1); // audio
+
+    EXPECT_TRUE(HostFuncAVCodecParametersCopy.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            FormatCtxId, EmptyParamId, static_cast<uint32_t>(AudioStreamIdx)},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), 0);
+
+    EXPECT_TRUE(HostFuncAVCodecParamCodecId.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{AudioParamId},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), 0);
+    EXPECT_TRUE(HostFuncAVCodecParamCodecType.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{AudioParamId},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), -1);
+  }
+}
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avCodecParameters.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avCodecParameters.cpp
@@ -106,8 +106,9 @@ TEST_F(FFmpegTest, AVCodecParametersCopy) {
                                                   INT32_C(-1), INT32_C(-1),
                                                   UINT32_C(0), UINT32_C(0)},
       Result));
-  const uint32_t StreamIdx = static_cast<uint32_t>(Result[0].get<int32_t>());
-  ASSERT_TRUE(static_cast<int32_t>(StreamIdx) >= 0);
+  const int32_t StreamIdxI32 = Result[0].get<int32_t>();
+  ASSERT_GE(StreamIdxI32, 0);
+  const uint32_t StreamIdx = static_cast<uint32_t>(StreamIdxI32);
 
   FuncInst = AVFormatMod->findFuncExports(
       "wasmedge_ffmpeg_avformat_avStream_codecpar");

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avCodecParameters.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avCodecParameters.cpp
@@ -102,9 +102,9 @@ TEST_F(FFmpegTest, AVCodecParametersCopy) {
 
   EXPECT_TRUE(HostFuncAVFindBestStream.run(
       CallFrame,
-      std::initializer_list<WasmEdge::ValVariant>{
-          FormatCtxId, UINT32_C(0), INT32_C(-1), INT32_C(-1), UINT32_C(0),
-          UINT32_C(0)},
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, UINT32_C(0),
+                                                  INT32_C(-1), INT32_C(-1),
+                                                  UINT32_C(0), UINT32_C(0)},
       Result));
   const uint32_t StreamIdx = static_cast<uint32_t>(Result[0].get<int32_t>());
   ASSERT_TRUE(static_cast<int32_t>(StreamIdx) >= 0);
@@ -115,11 +115,11 @@ TEST_F(FFmpegTest, AVCodecParametersCopy) {
   ASSERT_TRUE(FuncInst->isHostFunction());
   auto &HostFuncAVStreamCodecpar = FuncInst->getHostFunc();
 
-  EXPECT_TRUE(HostFuncAVStreamCodecpar.run(
-      CallFrame,
-      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, StreamIdx,
-                                                  CodecParamPtr},
-      Result));
+  EXPECT_TRUE(
+      HostFuncAVStreamCodecpar.run(CallFrame,
+                                   std::initializer_list<WasmEdge::ValVariant>{
+                                       FormatCtxId, StreamIdx, CodecParamPtr},
+                                   Result));
   EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
   uint32_t StreamParamId = readUInt32(MemInst, CodecParamPtr);
   ASSERT_TRUE(StreamParamId > 0);
@@ -197,9 +197,9 @@ TEST_F(FFmpegTest, AVCodecParametersCopy) {
   // If an audio stream exists, also exercise a non-zero StreamIdx path.
   EXPECT_TRUE(HostFuncAVFindBestStream.run(
       CallFrame,
-      std::initializer_list<WasmEdge::ValVariant>{
-          FormatCtxId, UINT32_C(1), INT32_C(-1), INT32_C(-1), UINT32_C(0),
-          UINT32_C(0)},
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, UINT32_C(1),
+                                                  INT32_C(-1), INT32_C(-1),
+                                                  UINT32_C(0), UINT32_C(0)},
       Result));
   const int32_t AudioStreamIdx = Result[0].get<int32_t>();
   if (AudioStreamIdx >= 0 &&

--- a/test/plugins/wasmedge_ffmpeg/avcodec/avcodec_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avcodec/avcodec_func.cpp
@@ -258,22 +258,6 @@ TEST_F(FFmpegTest, AVCodecFunc) {
     EXPECT_EQ(Result[0].get<int32_t>(), 0);
   }
 
-  // TODO: Need FormatCtxId to test this function.
-  //  FuncInst = AVCodecMod->findFuncExports(
-  //      "wasmedge_ffmpeg_avcodec_avcodec_parameters_copy");
-  //  EXPECT_NE(FuncInst, nullptr);
-  //  EXPECT_TRUE(FuncInst->isHostFunction());
-  //
-  //  auto &HostFuncAVCodecParametersCopy = dynamic_cast<
-  //      WasmEdge::Host::WasmEdgeFFmpeg::AVcodec::AVCodecParametersCopy &>(
-  //      FuncInst->getHostFunc());
-  //
-  //   {
-  //     EXPECT_TRUE(HostFuncAVCodecParametersCopy.run(
-  //         CallFrame, std::initializer_list<WasmEdge::ValVariant>{}, Result));
-  //     EXPECT_EQ(Result[0].get<int32_t>(),
-  //     static_cast<int32_t>(ErrNo::Success));
-  //   }
   FuncInst =
       AVCodecMod->findFuncExports("wasmedge_ffmpeg_avcodec_avcodec_version");
   ASSERT_NE(FuncInst, nullptr);

--- a/test/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
@@ -162,6 +162,114 @@ TEST_F(FFmpegTest, AVFormatContextStruct) {
   }
 }
 
+TEST_F(FFmpegTest, AVFormatNewStream) {
+  ASSERT_TRUE(AVFormatMod != nullptr);
+  ASSERT_TRUE(AVCodecMod != nullptr);
+
+  uint32_t FormatCtxPtr = UINT32_C(4);
+  uint32_t CodecEncoderPtr = UINT32_C(8);
+  uint32_t FilePtr = UINT32_C(100);
+  uint32_t CodecNamePtr = UINT32_C(150);
+
+  std::string FileName = "ffmpeg-assets/sample_video.mp4";
+  initFormatCtx(FormatCtxPtr, FilePtr, FileName);
+  uint32_t FormatCtxId = readUInt32(MemInst, FormatCtxPtr);
+  ASSERT_TRUE(FormatCtxId > 0);
+
+  auto *FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformat_find_stream_info");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  EXPECT_TRUE(FuncInst->getHostFunc().run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, UINT32_C(0)},
+      Result));
+  EXPECT_TRUE(Result[0].get<int32_t>() >= 0);
+
+  FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformatContext_nb_streams");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncAVFormatCtxNbStreams = FuncInst->getHostFunc();
+
+  EXPECT_TRUE(HostFuncAVFormatCtxNbStreams.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+      Result));
+  const int32_t NbStreamsBefore = Result[0].get<int32_t>();
+  ASSERT_GT(NbStreamsBefore, 0);
+
+  std::string CodecName = "mpeg1video";
+  fillMemContent(MemInst, CodecNamePtr, CodecName);
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodec_find_encoder_by_name");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  EXPECT_TRUE(FuncInst->getHostFunc().run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          CodecEncoderPtr, CodecNamePtr,
+          static_cast<uint32_t>(CodecName.length())},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t AVCodecEncoderId = readUInt32(MemInst, CodecEncoderPtr);
+  ASSERT_TRUE(AVCodecEncoderId > 0);
+
+  FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avformat_new_stream");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncAVFormatNewStream = FuncInst->getHostFunc();
+
+  spdlog::info("Testing AVFormatNewStream"sv);
+  EXPECT_TRUE(HostFuncAVFormatNewStream.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId,
+                                                  AVCodecEncoderId},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), 1);
+
+  EXPECT_TRUE(HostFuncAVFormatCtxNbStreams.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), NbStreamsBefore + 1);
+
+  // Encoder argument should initialize the new stream codecpar (MPEG1VIDEO=1).
+  FuncInst = AVFormatMod->findFuncExports(
+      "wasmedge_ffmpeg_avformat_avStream_codecpar");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  uint32_t NewStreamParamPtr = UINT32_C(20);
+  EXPECT_TRUE(FuncInst->getHostFunc().run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{
+          FormatCtxId, static_cast<uint32_t>(NbStreamsBefore),
+          NewStreamParamPtr},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+  uint32_t NewStreamParamId = readUInt32(MemInst, NewStreamParamPtr);
+  ASSERT_TRUE(NewStreamParamId > 0);
+
+  FuncInst = AVCodecMod->findFuncExports(
+      "wasmedge_ffmpeg_avcodec_avcodecparam_codec_id");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  EXPECT_TRUE(FuncInst->getHostFunc().run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{NewStreamParamId}, Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), 1); // MPEG1VIDEO
+
+  // Passing a null codec is valid and FFmpeg still creates a stream.
+  EXPECT_TRUE(HostFuncAVFormatNewStream.run(
+      CallFrame,
+      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId, UINT32_C(0)},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), 1);
+  EXPECT_TRUE(HostFuncAVFormatCtxNbStreams.run(
+      CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
+      Result));
+  EXPECT_EQ(Result[0].get<int32_t>(), NbStreamsBefore + 2);
+}
+
 } // namespace WasmEdgeFFmpeg
 } // namespace Host
 } // namespace WasmEdge

--- a/test/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avformat/avformatContext.cpp
@@ -221,42 +221,17 @@ TEST_F(FFmpegTest, AVFormatNewStream) {
   auto &HostFuncAVFormatNewStream = FuncInst->getHostFunc();
 
   spdlog::info("Testing AVFormatNewStream"sv);
-  EXPECT_TRUE(HostFuncAVFormatNewStream.run(
-      CallFrame,
-      std::initializer_list<WasmEdge::ValVariant>{FormatCtxId,
-                                                  AVCodecEncoderId},
-      Result));
+  EXPECT_TRUE(
+      HostFuncAVFormatNewStream.run(CallFrame,
+                                    std::initializer_list<WasmEdge::ValVariant>{
+                                        FormatCtxId, AVCodecEncoderId},
+                                    Result));
   EXPECT_EQ(Result[0].get<int32_t>(), 1);
 
   EXPECT_TRUE(HostFuncAVFormatCtxNbStreams.run(
       CallFrame, std::initializer_list<WasmEdge::ValVariant>{FormatCtxId},
       Result));
   EXPECT_EQ(Result[0].get<int32_t>(), NbStreamsBefore + 1);
-
-  // Encoder argument should initialize the new stream codecpar (MPEG1VIDEO=1).
-  FuncInst = AVFormatMod->findFuncExports(
-      "wasmedge_ffmpeg_avformat_avStream_codecpar");
-  ASSERT_NE(FuncInst, nullptr);
-  ASSERT_TRUE(FuncInst->isHostFunction());
-  uint32_t NewStreamParamPtr = UINT32_C(20);
-  EXPECT_TRUE(FuncInst->getHostFunc().run(
-      CallFrame,
-      std::initializer_list<WasmEdge::ValVariant>{
-          FormatCtxId, static_cast<uint32_t>(NbStreamsBefore),
-          NewStreamParamPtr},
-      Result));
-  EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
-  uint32_t NewStreamParamId = readUInt32(MemInst, NewStreamParamPtr);
-  ASSERT_TRUE(NewStreamParamId > 0);
-
-  FuncInst = AVCodecMod->findFuncExports(
-      "wasmedge_ffmpeg_avcodec_avcodecparam_codec_id");
-  ASSERT_NE(FuncInst, nullptr);
-  ASSERT_TRUE(FuncInst->isHostFunction());
-  EXPECT_TRUE(FuncInst->getHostFunc().run(
-      CallFrame,
-      std::initializer_list<WasmEdge::ValVariant>{NewStreamParamId}, Result));
-  EXPECT_EQ(Result[0].get<int32_t>(), 1); // MPEG1VIDEO
 
   // Passing a null codec is valid and FFmpeg still creates a stream.
   EXPECT_TRUE(HostFuncAVFormatNewStream.run(

--- a/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
@@ -214,8 +214,8 @@ TEST_F(FFmpegTest, AVUtilFunc) {
             ChannelId, ChannelNamePtr, static_cast<uint32_t>(FrontLeftNameLen)},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
-    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(ChannelNamePtr),
-                               static_cast<size_t>(FrontLeftNameLen)),
+    EXPECT_EQ(MemInst->getStringView(ChannelNamePtr,
+                                     static_cast<uint64_t>(FrontLeftNameLen)),
               "FL"sv);
 
     // FRONT_RIGHT → "FR".
@@ -234,8 +234,8 @@ TEST_F(FFmpegTest, AVUtilFunc) {
             static_cast<uint32_t>(FrontRightNameLen)},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
-    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(ChannelNamePtr),
-                               static_cast<size_t>(FrontRightNameLen)),
+    EXPECT_EQ(MemInst->getStringView(ChannelNamePtr,
+                                     static_cast<uint64_t>(FrontRightNameLen)),
               "FR"sv);
 
     // NameLen == 0: success, but destination bytes must stay untouched.

--- a/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
@@ -165,8 +165,7 @@ TEST_F(FFmpegTest, AVUtilFunc) {
     // Guest FRONT_RIGHT (bit 1) maps to native AV_CH_FRONT_RIGHT (0x2).
     EXPECT_TRUE(HostFuncAVGetChannelLayoutMask.run(
         CallFrame,
-        std::initializer_list<WasmEdge::ValVariant>{UINT64_C(1) << 1},
-        Result));
+        std::initializer_list<WasmEdge::ValVariant>{UINT64_C(1) << 1}, Result));
     EXPECT_EQ(Result[0].get<uint64_t>(), UINT64_C(2));
 
     // Multi-bit: FRONT_LEFT | FRONT_RIGHT must OR both native bits (0x3).
@@ -212,8 +211,7 @@ TEST_F(FFmpegTest, AVUtilFunc) {
     EXPECT_TRUE(HostFuncAVGetChannelLayoutName.run(
         CallFrame,
         std::initializer_list<WasmEdge::ValVariant>{
-            ChannelId, ChannelNamePtr,
-            static_cast<uint32_t>(FrontLeftNameLen)},
+            ChannelId, ChannelNamePtr, static_cast<uint32_t>(FrontLeftNameLen)},
         Result));
     EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
     EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(ChannelNamePtr),
@@ -223,8 +221,7 @@ TEST_F(FFmpegTest, AVUtilFunc) {
     // FRONT_RIGHT → "FR".
     EXPECT_TRUE(HostFuncAVGetChannelLayoutNameLen.run(
         CallFrame,
-        std::initializer_list<WasmEdge::ValVariant>{UINT64_C(1) << 1},
-        Result));
+        std::initializer_list<WasmEdge::ValVariant>{UINT64_C(1) << 1}, Result));
     const int32_t FrontRightNameLen = Result[0].get<int32_t>();
     EXPECT_EQ(FrontRightNameLen, 2);
     fillMemContent(MemInst, ChannelNamePtr,

--- a/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
+++ b/test/plugins/wasmedge_ffmpeg/avutil/avutil_func.cpp
@@ -9,9 +9,13 @@
 
 #include <gtest/gtest.h>
 
+#include <string_view>
+
 namespace WasmEdge {
 namespace Host {
 namespace WasmEdgeFFmpeg {
+
+using namespace std::literals;
 
 TEST_F(FFmpegTest, AVUtilFunc) {
   ASSERT_TRUE(AVUtilMod != nullptr);
@@ -142,6 +146,113 @@ TEST_F(FFmpegTest, AVUtilFunc) {
         Result));
     EXPECT_EQ(Result[0].get<uint64_t>(),
               UINT64_C(67108868)); // guest-encoded AV_CH_LAYOUT_MONO
+  }
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_mask");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncAVGetChannelLayoutMask = FuncInst->getHostFunc();
+
+  spdlog::info("Testing AVGetChannelLayoutMask"sv);
+  {
+    // Guest FRONT_LEFT (bit 0) maps to native AV_CH_FRONT_LEFT (0x1).
+    EXPECT_TRUE(HostFuncAVGetChannelLayoutMask.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{ChannelId},
+        Result));
+    EXPECT_EQ(Result[0].get<uint64_t>(), UINT64_C(1));
+
+    // Guest FRONT_RIGHT (bit 1) maps to native AV_CH_FRONT_RIGHT (0x2).
+    EXPECT_TRUE(HostFuncAVGetChannelLayoutMask.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{UINT64_C(1) << 1},
+        Result));
+    EXPECT_EQ(Result[0].get<uint64_t>(), UINT64_C(2));
+
+    // Multi-bit: FRONT_LEFT | FRONT_RIGHT must OR both native bits (0x3).
+    // This covers fromChannelLayoutID converting each guest bit and combining.
+    const uint64_t StereoGuestId = (UINT64_C(1) << 0) | (UINT64_C(1) << 1);
+    EXPECT_TRUE(HostFuncAVGetChannelLayoutMask.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{StereoGuestId},
+        Result));
+    EXPECT_EQ(Result[0].get<uint64_t>(), UINT64_C(3));
+
+    // No guest channel bits set → empty native mask.
+    EXPECT_TRUE(HostFuncAVGetChannelLayoutMask.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{UINT64_C(0)},
+        Result));
+    EXPECT_EQ(Result[0].get<uint64_t>(), UINT64_C(0));
+  }
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name_len");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncAVGetChannelLayoutNameLen = FuncInst->getHostFunc();
+
+  FuncInst = AVUtilMod->findFuncExports(
+      "wasmedge_ffmpeg_avutil_av_get_channel_layout_name");
+  ASSERT_NE(FuncInst, nullptr);
+  ASSERT_TRUE(FuncInst->isHostFunction());
+  auto &HostFuncAVGetChannelLayoutName = FuncInst->getHostFunc();
+
+  spdlog::info("Testing AVGetChannelLayoutNameLen / Name"sv);
+  {
+    // FRONT_LEFT → FFmpeg av_channel_name returns "FL".
+    EXPECT_TRUE(HostFuncAVGetChannelLayoutNameLen.run(
+        CallFrame, std::initializer_list<WasmEdge::ValVariant>{ChannelId},
+        Result));
+    const int32_t FrontLeftNameLen = Result[0].get<int32_t>();
+    EXPECT_EQ(FrontLeftNameLen, 2);
+
+    uint32_t ChannelNamePtr = UINT32_C(200);
+    fillMemContent(MemInst, ChannelNamePtr,
+                   static_cast<uint32_t>(FrontLeftNameLen),
+                   static_cast<uint8_t>(0xAA));
+    EXPECT_TRUE(HostFuncAVGetChannelLayoutName.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            ChannelId, ChannelNamePtr,
+            static_cast<uint32_t>(FrontLeftNameLen)},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(ChannelNamePtr),
+                               static_cast<size_t>(FrontLeftNameLen)),
+              "FL"sv);
+
+    // FRONT_RIGHT → "FR".
+    EXPECT_TRUE(HostFuncAVGetChannelLayoutNameLen.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{UINT64_C(1) << 1},
+        Result));
+    const int32_t FrontRightNameLen = Result[0].get<int32_t>();
+    EXPECT_EQ(FrontRightNameLen, 2);
+    fillMemContent(MemInst, ChannelNamePtr,
+                   static_cast<uint32_t>(FrontRightNameLen),
+                   static_cast<uint8_t>(0xAA));
+    EXPECT_TRUE(HostFuncAVGetChannelLayoutName.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{
+            UINT64_C(1) << 1, ChannelNamePtr,
+            static_cast<uint32_t>(FrontRightNameLen)},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(std::string_view(MemInst->getPointer<char *>(ChannelNamePtr),
+                               static_cast<size_t>(FrontRightNameLen)),
+              "FR"sv);
+
+    // NameLen == 0: success, but destination bytes must stay untouched.
+    fillMemContent(MemInst, ChannelNamePtr, 2, static_cast<uint8_t>(0x5A));
+    EXPECT_TRUE(HostFuncAVGetChannelLayoutName.run(
+        CallFrame,
+        std::initializer_list<WasmEdge::ValVariant>{ChannelId, ChannelNamePtr,
+                                                    UINT32_C(0)},
+        Result));
+    EXPECT_EQ(Result[0].get<int32_t>(), static_cast<int32_t>(ErrNo::Success));
+    EXPECT_EQ(MemInst->getPointer<uint8_t *>(ChannelNamePtr)[0],
+              static_cast<uint8_t>(0x5A));
+    EXPECT_EQ(MemInst->getPointer<uint8_t *>(ChannelNamePtr)[1],
+              static_cast<uint8_t>(0x5A));
   }
 
   uint32_t Length = 0;


### PR DESCRIPTION
## Description
This PR adds tests for FFmpeg host functions that were previously marked with
`// TODO: Write Test`.

I added test coverage for the following functions:
| Area | Host function(s) | Verification |
| --- | --- | --- |
| avutil | channel layout helpers | returned layout values, names, and name length |
| avcodec | avcodec_parameters_copy | codec parameters are copied correctly |
| avformat | avformat_new_stream | stream creation success and stream count changes |

Initially, this test checked `codecpar.codec_id` after creating a new stream.
After verification with the CI-matching FFmpeg environment, I found that this
value is not guaranteed in the current FFmpeg version.

The test now focuses on the expected behavior: successful stream creation and
`nb_streams` update.

Other TODO items such as `av_guess_codec` and `avchapter_dynarray_add` are not
covered in this PR.

I used Cursor and ChatGPT (OpenAI GPT-5.5) as development assistance.
All changes were reviewed and verified manually before submission.

## Checklist

Before submitting this PR, please ensure the following:

- [X] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [X] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [X] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [X] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [X] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [X] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
The tests were executed in the same Docker-based build environment used for
verification:

- Docker image:
  `wasmedge/wasmedge:ubuntu-24.04-build-clang-plugins-deps`

Commands:

```bash
cmake --build build --target wasmedgeFFmpegTests
ctest --test-dir build -R wasmedgeFFmpegTests --output-on-failure
```

Result:

```text
[2/2] Linking CXX executable test/plugins/wasmedge_ffmpeg/wasmedgeFFmpegTests

1/1 Test #23: wasmedgeFFmpegTests .............. Passed    0.77 sec

100% tests passed, 0 tests failed out of 1
Total Test time (real) = 0.78 sec
```

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
