### PR TITLE
fix(common): prevent uint64_t overflow bypass in addCost (#5228)

### DIFF
--- a/include/common/statistics.h
+++ b/include/common/statistics.h
@@ -88,11 +88,11 @@ public:
     uint64_t OldCostSum = CostSum.load(std::memory_order_relaxed);
     uint64_t NewCostSum;
     do {
-      NewCostSum = OldCostSum + Cost;
-      if (unlikely(NewCostSum > Limit)) {
+      if (unlikely(OldCostSum > Limit || Cost > Limit - OldCostSum)) {
         spdlog::error("Cost exceeded limit. Force terminate the execution."sv);
         return false;
       }
+      NewCostSum = OldCostSum + Cost;
     } while (!CostSum.compare_exchange_weak(OldCostSum, NewCostSum,
                                             std::memory_order_relaxed));
     return true;


### PR DESCRIPTION
## fix(common): prevent uint64_t overflow bypass in `addCost`

Fixes #5228

### Problem

`addCost` in `include/common/statistics.h` computes `NewCostSum = OldCostSum + Cost` using unchecked `uint64_t` addition. When the true mathematical sum exceeds `UINT64_MAX`, C++ unsigned integer wraparound produces a small value that passes the `NewCostSum > Limit` guard. This silently bypasses the cost limit and resets `CostSum` to the wrapped near-zero value.

**Example:**
| Variable | Value |
|---|---|
| `CostLimit` | `18446744073709551615` (`UINT64_MAX`) |
| `OldCostSum` | `18446744073709551610` (`UINT64_MAX - 5`) |
| `Cost` | `100` |
| **Expected** `NewCostSum` | `18446744073709551710` (exceeds limit → reject) |
| **Actual** `NewCostSum` | `94` (wrapped → passes guard → accepted ❌) |

A Wasm module that has consumed nearly all of its gas budget can trigger the overflow and continue executing with near-zero reported gas usage, effectively multiplying the gas budget by a large factor.

### Fix

Replace the post-addition comparison with a pre-addition overflow-safe check:

```diff
     do {
-      NewCostSum = OldCostSum + Cost;
-      if (unlikely(NewCostSum > Limit)) {
+      if (unlikely(OldCostSum > Limit || Cost > Limit - OldCostSum)) {
         spdlog::error("Cost exceeded limit. Force terminate the execution."sv);
         return false;
       }
+      NewCostSum = OldCostSum + Cost;
```

**How it works:**
- `OldCostSum > Limit` — catches the case where the accumulated cost already exceeds the limit
- `Cost > Limit - OldCostSum` — mathematically equivalent to `OldCostSum + Cost > Limit`, but uses subtraction which cannot underflow (guarded by the first condition). This avoids the `uint64_t` wraparound entirely.

The addition on the next line is now guaranteed to be safe since we've verified `OldCostSum + Cost <= Limit`.

### Testing

The fix was verified against the reproduction scenario from the issue:
- `setCostLimit(UINT64_MAX)`, `CostSum = UINT64_MAX - 5`, `addCost(100)` → now correctly returns `false`