### PR TITLE
fix(loader): reject reserved br_on_cast/br_on_cast_fail flag bits using dedicated MalformedCastFlags error

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -945,6 +945,8 @@ E(MalformedMemoryOpFlags, 0x011C, "malformed memop flags")
 E(MalformedLimitFlags, 0x011D, "malformed limits flags")
 // Malformed catch flag (Exception-handling proposal).
 E(MalformedCatchFlags, 0x011E, "malformed catch flags")
+// Malformed cast flag (GC proposal).
+E(MalformedCastFlags, 0x011F, "malformed cast flags")
 // @}
 
 // Component model load phase

--- a/lib/loader/ast/instruction.cpp
+++ b/lib/loader/ast/instruction.cpp
@@ -456,6 +456,10 @@ Expect<void> Loader::loadInstruction(AST::Instruction &Instr) {
     // Read the flag.
     uint8_t Flag = 0U;
     EXPECTED_TRY(readU8(Flag).map_error(ReportError));
+    if (unlikely(Flag > 0x03U)) {
+      return logLoadError(ErrCode::Value::MalformedCastFlags,
+                          FMgr.getLastOffset(), ASTNodeAttr::Instruction);
+    }
     // Read the label index.
     uint32_t LabelIdx = 0U;
     EXPECTED_TRY(readU32(LabelIdx).map_error(ReportError));

--- a/test/loader/instructionTest.cpp
+++ b/test/loader/instructionTest.cpp
@@ -1307,4 +1307,111 @@ TEST(InstructionTest, LoadTryTable) {
   EXPECT_FALSE(Ldr.parseModule(Vec));
 }
 
+TEST(InstructionTest, LoadBrOnCastFlags) {
+  std::vector<uint8_t> Vec;
+
+  // 15. Test br_on_cast and br_on_cast_fail flag validation.
+  //
+  //   1.  Load br_on_cast with all valid flag values (0x00-0x03).
+  //   2.  Load br_on_cast_fail with all valid flag values (0x00-0x03).
+  //   3.  Reject br_on_cast with reserved flag 0x04 (issue #5232 regression).
+  //   4.  Reject br_on_cast with reserved flag 0xFF.
+  //   5.  Reject br_on_cast_fail with reserved flag 0x04.
+  //   6.  Reject br_on_cast_fail with reserved flag 0xFF.
+
+  for (uint8_t Flag = 0x00U; Flag <= 0x03U; ++Flag) {
+    Vec = {
+        0x0AU,        // Code section
+        0x0AU,        // Content size = 10
+        0x01U,        // Vector length = 1
+        0x08U,        // Code segment size = 8
+        0x00U,        // Local vec(0)
+        0xFBU, 0x18U, // OpCode Br_on_cast.
+        Flag,         // Flag byte (valid: 0x00-0x03).
+        0x00U,        // Label index = 0.
+        0x6DU,        // HeapType1: eq.
+        0x6DU,        // HeapType2: eq.
+        0x0BU         // Expression End.
+    };
+    EXPECT_TRUE(Ldr.parseModule(prefixedVec(Vec)));
+  }
+
+  for (uint8_t Flag = 0x00U; Flag <= 0x03U; ++Flag) {
+    Vec = {
+        0x0AU,        // Code section
+        0x0AU,        // Content size = 10
+        0x01U,        // Vector length = 1
+        0x08U,        // Code segment size = 8
+        0x00U,        // Local vec(0)
+        0xFBU, 0x19U, // OpCode Br_on_cast_fail.
+        Flag,         // Flag byte (valid: 0x00-0x03).
+        0x00U,        // Label index = 0.
+        0x6DU,        // HeapType1: eq.
+        0x6DU,        // HeapType2: eq.
+        0x0BU         // Expression End.
+    };
+    EXPECT_TRUE(Ldr.parseModule(prefixedVec(Vec)));
+  }
+
+  Vec = {
+      0x0AU,        // Code section
+      0x0AU,        // Content size = 10
+      0x01U,        // Vector length = 1
+      0x08U,        // Code segment size = 8
+      0x00U,        // Local vec(0)
+      0xFBU, 0x18U, // OpCode Br_on_cast.
+      0x04U,        // INVALID flag (reserved bit 2 set).
+      0x00U,        // Label index = 0.
+      0x6DU,        // HeapType1: eq.
+      0x6DU,        // HeapType2: eq.
+      0x0BU         // Expression End.
+  };
+  EXPECT_FALSE(Ldr.parseModule(prefixedVec(Vec)));
+
+  Vec = {
+      0x0AU,        // Code section
+      0x0AU,        // Content size = 10
+      0x01U,        // Vector length = 1
+      0x08U,        // Code segment size = 8
+      0x00U,        // Local vec(0)
+      0xFBU, 0x18U, // OpCode Br_on_cast.
+      0xFFU,        // INVALID flag (all reserved bits set).
+      0x00U,        // Label index = 0.
+      0x6DU,        // HeapType1: eq.
+      0x6DU,        // HeapType2: eq.
+      0x0BU         // Expression End.
+  };
+  EXPECT_FALSE(Ldr.parseModule(prefixedVec(Vec)));
+
+  Vec = {
+      0x0AU,        // Code section
+      0x0AU,        // Content size = 10
+      0x01U,        // Vector length = 1
+      0x08U,        // Code segment size = 8
+      0x00U,        // Local vec(0)
+      0xFBU, 0x19U, // OpCode Br_on_cast_fail.
+      0x04U,        // INVALID flag (reserved bit 2 set).
+      0x00U,        // Label index = 0.
+      0x6DU,        // HeapType1: eq.
+      0x6DU,        // HeapType2: eq.
+      0x0BU         // Expression End.
+  };
+  EXPECT_FALSE(Ldr.parseModule(prefixedVec(Vec)));
+
+  Vec = {
+      0x0AU,        // Code section
+      0x0AU,        // Content size = 10
+      0x01U,        // Vector length = 1
+      0x08U,        // Code segment size = 8
+      0x00U,        // Local vec(0)
+      0xFBU, 0x19U, // OpCode Br_on_cast_fail.
+      0xFFU,        // INVALID flag (all reserved bits set).
+      0x00U,        // Label index = 0.
+      0x6DU,        // HeapType1: eq.
+      0x6DU,        // HeapType2: eq.
+      0x0BU         // Expression End.
+  };
+  EXPECT_FALSE(Ldr.parseModule(prefixedVec(Vec)));
+}
+
 } // namespace


### PR DESCRIPTION
## Summary

Fixes #5232.

The loader for `br_on_cast` / `br_on_cast_fail` reads a single flag
byte but only checks bits `0x01` and `0x02` (source/destination
nullability). It never validates that the remaining bits are zero, so
reserved values such as `0x04` or `0xFF` are silently accepted instead
of being rejected, even though the WebAssembly binary grammar only
defines four legal castop flag values: `0x00`–`0x03`.

This PR adds a check in `Loader::loadInstruction` that rejects any
flag bits outside `0x03` for both `br_on_cast` and `br_on_cast_fail`,
and adds regression tests covering both the accepted range and
reserved values.

## Changes

- `lib/loader/ast/instruction.cpp`: reject `Flag & ~0x03U` before
  decoding the heap types, for both `Br_on_cast` and `Br_on_cast_fail`.
- Added a new `ErrCode::Value::MalformedCastFlags` error code and its
  associated message mapping.
- `test/loader/instructionTest.cpp`:
  - Positive tests confirming flag values `0x00`–`0x03` still decode
    correctly for both opcodes.
  - Regression test for `br_on_cast` with reserved flag `0x04` (from
    the issue's repro case).
  - Equivalent regression test for `br_on_cast_fail` with a reserved
    flag.

## Error code — updated

**Previous approach:** this PR originally used the existing
`ErrCode::Value::IllegalGrammar` to report the rejection, as the
closest available "binary doesn't match spec grammar" code, since no
merged precedent existed at the time — a similar issue (#4631,
reserved bits in memarg) was closed as *not planned* without a fix
landing.

**Current approach:** per @uda18's pointer on #5232, PR #4676 already
established a precedent for this exact class of bug — it introduced
`MalformedCatchFlags` when `try_table` accepted catch flag values
outside `0x00`–`0x03`. This PR now follows that same convention and
introduces a matching `MalformedCastFlags` error code instead, so the
two reserved-flag-bits fixes (`try_table` catch flags and
`br_on_cast`/`br_on_cast_fail` cast flags) stay consistent.

## Testing

- `wasmedgeLoaderASTTests` passes locally, including the new tests.
- No other test regressions observed.