### PR TITLE
fix(cmake): fall back to bundled simdjson when its include prefix shadows bundled fmt

### DIFF
--- a/cmake/Helper.cmake
+++ b/cmake/Helper.cmake
@@ -442,8 +442,27 @@ function(wasmedge_setup_simdjson)
   endif()
   # setup simdjson
   if(NOT WASMEDGE_FORCE_DOWNLOAD_SIMDJSON)
-    message(STATUS "Checking SIMDJSON from system")
-    find_package(simdjson QUIET)
+    # Package managers such as Homebrew export their entire install prefix as
+    # INTERFACE_INCLUDE_DIRECTORIES; a co-installed fmt 12.2.0 would then
+    # shadow the bundled 12.1.0 at compile time. CMake does not provide a
+    # supported way to remove or replace an imported target once created, so
+    # the check must happen before find_package.
+    set(_wasmedge_use_system_simdjson TRUE)
+    foreach(_pm_prefix /opt/homebrew /opt/local /usr/local)
+      if(IS_DIRECTORY "${_pm_prefix}/lib/cmake/simdjson" AND
+         EXISTS "${_pm_prefix}/include/fmt/format.h")
+        message(STATUS "SIMDJSON at ${_pm_prefix} co-installs with fmt headers; "
+          "downloading simdjson to avoid bundled fmt version conflict")
+        set(_wasmedge_use_system_simdjson FALSE)
+        break()
+      endif()
+    endforeach()
+    unset(_pm_prefix)
+    if(_wasmedge_use_system_simdjson)
+      message(STATUS "Checking SIMDJSON from system")
+      find_package(simdjson QUIET)
+    endif()
+    unset(_wasmedge_use_system_simdjson)
   endif()
   if(simdjson_FOUND)
     message(STATUS "SIMDJSON found")


### PR DESCRIPTION
## Description

## Issue

On macOS with Homebrew, building WasmEdge with tests fails with a linker error when the user has fmt installed (even as a transitive Homebrew dependency):

```text
Undefined symbols for architecture arm64:
  "fmt::v12::detail::allocate(unsigned long)", referenced from:
      fmt::v12::basic_memory_buffer<char, 250ul, ...>::grow(...) in
      libwasmedgeTestSpec.a[2](spectest.cpp.o)
```

The build proceeds past cmake configure and compiles the core library and tools (wasmedge, wasmedgec) successfully, but fails when linking test binaries.

## Root Cause

A three-way interaction:

1. WasmEdge pins fmt to 12.1.0 (cmake/Helper.cmake, `wasmedge_setup_spdlog`) for CMake 3.18 compatibility. The bundled `libfmt.a` is compiled from this version.
2. Homebrew's simdjson CMake package exports its entire install prefix (`/opt/homebrew/include`) as `INTERFACE_INCLUDE_DIRECTORIES` rather than a simdjson-specific path. Any target that links `simdjson::simdjson` inherits `-isystem /opt/homebrew/include`.
3. fmt 12.2.0 changed the ABI of `detail::allocator<char>::allocate`: it was refactored from a fully inline member into a call to a new non-inline free function `FMT_API auto detail::allocate(size_t) -> void*`. If the user has `fmt@12.2.0` installed under Homebrew (e.g. as a transitive dep), `/opt/homebrew/include/fmt/format.h` resolves to 12.2.0 headers — ahead of the bundled 12.1.0 headers in the include search order.

Result: `spectest.cpp` (and other targets depending on both `simdjson` and `fmt`) are compiled against 12.2.0 headers, generating a reference to `fmt::v12::detail::allocate`, which is absent from the bundled 12.1.0 `libfmt.a`. Linker fails.

Ubuntu 24.04 is unaffected (inferred: system simdjson is typically absent, causing `FetchContent` to be used automatically so no broad package-manager prefix is injected; or the system fmt predates 12.2.0). Linux/Windows systems where simdjson is installed under a package-specific prefix without co-located fmt headers are also unaffected.

## Fix

In `wasmedge_setup_simdjson()`(cmake/Helper.cmake), before calling `find_package`(simdjson), check the known package manager prefixes (/opt/homebrew, /opt/local, /usr/local). If a prefix contains both `lib/cmake/simdjson/`and `include/fmt/format.h`, `skip find_package(simdjson)` entirely and fall back to FetchContent.

The detection must happen before `find_package`: CMake does not provide a supported way to remove or replace an imported target once it has been created. Performing the check afterward would leave `simdjson::simdjson` already carrying the conflicting include path. Preflight detection is the cleanest approach.

## Testing

Verified on macOS 26.5.2 (Tahoe), arm64, Apple clang 21, with `brew install fmt` and `brew install simdjson` (system packages present)::

- Before fix: `cmake --build build` fails at step `250/268` with undefined symbol.
- After fix (this PR): configure detects the conflict, downloads `simdjson` via `FetchContent`, build completes `268/268`, `wasmedge --version` prints `0.17.0-272-g329591e8c`.


## Checklist

Before submitting this PR, please ensure the following:

- [X] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [X] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [X] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [X] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [X] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [X] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
<img width="1546" height="1350" alt="image" src="https://github.com/user-attachments/assets/4f7eb4d1-34ae-432c-a9db-2f805c7dd834" />
