### PR TITLE
fix(common): avoid undefined behavior in clz() for zero inputs

### DIFF
--- a/include/common/int128.h
+++ b/include/common/int128.h
@@ -29,29 +29,29 @@
 namespace WasmEdge {
 
 inline constexpr int clz(uint32_t V) noexcept {
-#if defined(_MSC_VER) && !defined(__clang__)
   if (V) {
+#if defined(_MSC_VER) && !defined(__clang__)
     unsigned long LeadingZero = 0;
     _BitScanReverse(&LeadingZero, V);
     return 31 ^ static_cast<int>(LeadingZero);
+#else
+    return __builtin_clz(V);
+#endif
   }
   return 32;
-#else
-  return __builtin_clz(V);
-#endif
 }
 
 inline constexpr int clz(uint64_t V) noexcept {
-#if defined(_MSC_VER) && !defined(__clang__)
   if (V) {
+#if defined(_MSC_VER) && !defined(__clang__)
     unsigned long LeadingZero = 0;
     _BitScanReverse64(&LeadingZero, V);
     return 63 ^ static_cast<int>(LeadingZero);
+#else
+    return __builtin_clzll(V);
+#endif
   }
   return 64;
-#else
-  return __builtin_clzll(V);
-#endif
 }
 
 inline auto udiv128by64to64(uint64_t U1, uint64_t U0, uint64_t V,

--- a/test/common/int128Test.cpp
+++ b/test/common/int128Test.cpp
@@ -105,4 +105,14 @@ TEST(Int128Test, Int128OutputTest) {
     }
   }
 }
+
+TEST(Int128Test, Int128ClzTest) {
+  EXPECT_EQ(WasmEdge::clz(static_cast<uint32_t>(0)), 32);
+  EXPECT_EQ(WasmEdge::clz(static_cast<uint32_t>(1)), 31);
+  EXPECT_EQ(WasmEdge::clz(static_cast<uint32_t>(0x80000000U)), 0);
+  EXPECT_EQ(WasmEdge::clz(static_cast<uint64_t>(0)), 64);
+  EXPECT_EQ(WasmEdge::clz(static_cast<uint64_t>(1)), 63);
+  EXPECT_EQ(WasmEdge::clz(static_cast<uint64_t>(0x8000000000000000ULL)), 0);
+}
+
 } // namespace


### PR DESCRIPTION
While reading `include/common/int128.h`, I noticed that the free `clz()` helpers handled zero inputs differently across compilers. The MSVC implementation explicitly handles zero, while the GCC/Clang implementation directly calls `__builtin_clz()`/`__builtin_clzll()`, which have undefined behavior for zero inputs.

This PR makes the behavior consistent across supported compilers by guarding the builtin calls and adds regression tests covering zero, `1`, and the highest-bit cases for both 32-bit and 64-bit unsigned integers.

## Checklist

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

```text
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from Int128Test
[ RUN      ] Int128Test.Int128OutputTest
[       OK ] Int128Test.Int128OutputTest (0 ms)
[ RUN      ] Int128Test.Int128ClzTest
[       OK ] Int128Test.Int128ClzTest (0 ms)
[----------] 2 tests from Int128Test (0 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 2 tests.
```