### PR TITLE
fix(common): correct display strings and comments in enum.inc

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -658,6 +658,7 @@ OFD(F32x4__pmin, "f32x4.pmin", 0xFD, 234)
 OFD(F32x4__pmax, "f32x4.pmax", 0xFD, 235)
 OFD(F64x2__abs, "f64x2.abs", 0xFD, 236)
 OFD(F64x2__neg, "f64x2.neg", 0xFD, 237)
+// 0xFD 238: Reserved
 OFD(F64x2__sqrt, "f64x2.sqrt", 0xFD, 239)
 OFD(F64x2__add, "f64x2.add", 0xFD, 240)
 OFD(F64x2__sub, "f64x2.sub", 0xFD, 241)
@@ -676,7 +677,7 @@ OFD(I32x4__trunc_sat_f64x2_u_zero, "i32x4.trunc_sat_f64x2_u_zero", 0xFD, 253)
 OFD(F64x2__convert_low_i32x4_s, "f64x2.convert_low_i32x4_s", 0xFD, 254)
 OFD(F64x2__convert_low_i32x4_u, "f64x2.convert_low_i32x4_u", 0xFD, 255)
 
-// 0xFE prefix - Relaxed SIMD Instructions (part 4)
+// 0xFD prefix - Relaxed SIMD Instructions (part 4)
 OFD(I8x16__relaxed_swizzle, "i8x16.relaxed_swizzle", 0xFD, 256)
 OFD(I32x4__relaxed_trunc_f32x4_s, "i32x4.relaxed_trunc_f32x4_s", 0xFD, 257)
 OFD(I32x4__relaxed_trunc_f32x4_u, "i32x4.relaxed_trunc_f32x4_u", 0xFD, 258)
@@ -686,8 +687,8 @@ OFD(I32x4__relaxed_trunc_f64x2_u_zero, "i32x4.relaxed_trunc_f64x2_u_zero", 0xFD,
     260)
 OFD(F32x4__relaxed_madd, "f32x4.relaxed_madd", 0xFD, 261)
 OFD(F32x4__relaxed_nmadd, "f32x4.relaxed_nmadd", 0xFD, 262)
-OFD(F64x2__relaxed_madd, "f32x4.relaxed_madd", 0xFD, 263)
-OFD(F64x2__relaxed_nmadd, "f32x4.relaxed_nmadd", 0xFD, 264)
+OFD(F64x2__relaxed_madd, "f64x2.relaxed_madd", 0xFD, 263)
+OFD(F64x2__relaxed_nmadd, "f64x2.relaxed_nmadd", 0xFD, 264)
 OFD(I8x16__relaxed_laneselect, "i8x16.relaxed_laneselect", 0xFD, 265)
 OFD(I16x8__relaxed_laneselect, "i16x8.relaxed_laneselect", 0xFD, 266)
 OFD(I32x4__relaxed_laneselect, "i32x4.relaxed_laneselect", 0xFD, 267)
@@ -872,9 +873,9 @@ E(SetValueToConst, 0x000A, "set value into const")
 E(SetValueErrorType, 0x000B, "set value type mismatch")
 // User defined error
 E(UserDefError, 0x000C, "user defined error code")
-// Invalid AOT Configure
+// Invalid AOT/JIT configure
 E(InvalidAOTConfigure, 0x000D, "invalid AOT/JIT configure")
-// Invalid Configure
+// Instruction not implemented in AOT/JIT
 E(AOTNotImpl, 0x000E, "Not implemented instructions in AOT/JIT")
 // Lazy JIT Compilation Error
 E(LazyCompilationError, 0x000F, "Lazy JIT compilation failure")
@@ -1361,10 +1362,10 @@ T(List, 0x70, "list")                // list type
 T(Tuple, 0x6F, "tuple")              // tuple type
 T(Flags, 0x6E, "flags")              // flags type
 T(Enum, 0x6D, "enum")                // enum type
-T(Option, 0x6B, "enum")              // option type
+T(Option, 0x6B, "option")            // option type
 T(Result, 0x6A, "result")            // result type
 T(Own, 0x69, "own")                  // own type
-T(Borrow, 0x68, "own")               // borrow type
+T(Borrow, 0x68, "borrow")            // borrow type
 T(ListLen, 0x67, "list_len")         // list type with length
 T(Stream, 0x66, "stream")            // stream type
 T(Future, 0x65, "future")            // future type


### PR DESCRIPTION
Assisted-by: Cursor
Assisted-by: ChatGPT (OpenAI GPT-5.5)

## Description
This PR fixes several incorrect display strings and comments in `include/common/enum.inc`.

### Changes

1. Fixed incorrect display strings for the following Relaxed SIMD opcodes:
   - `F64x2__relaxed_madd`: `"f32x4.relaxed_madd"` → `"f64x2.relaxed_madd"`
   - `F64x2__relaxed_nmadd`: `"f32x4.relaxed_nmadd"` → `"f64x2.relaxed_nmadd"`

   The enum names and opcodes are correct, but the display strings were inconsistent. I compared them with the WebAssembly specification and corrected the string mappings.

2. Fixed incorrect component type display strings:
   - `Option`: `"enum"` → `"option"`
   - `Borrow`: `"own"` → `"borrow"`

3. Corrected several comments for consistency:
   - Fixed the incorrect Relaxed SIMD prefix comment (`0xFE` → `0xFD`)
   - Added the missing `0xFD 238: Reserved` comment
   - Updated ErrCode comments to match the corresponding entries

These changes only affect display strings and comments, and do not change runtime behavior.

## Checklist
Local tests were not run because this PR only updates display strings and comments and does not change runtime behavior.

Before submitting this PR, please ensure the following:

- [X] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [X] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [X] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [X] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [X] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
Not run.

This change only updates display strings and comments in `include/common/enum.inc` and does not affect runtime behavior.

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
