### PR TITLE
fix(common): allow subCost to reduce total cost to zero

### DIFF
--- a/include/common/statistics.h
+++ b/include/common/statistics.h
@@ -103,7 +103,7 @@ public:
     uint64_t OldCostSum = CostSum.load(std::memory_order_relaxed);
     uint64_t NewCostSum;
     do {
-      if (unlikely(OldCostSum <= Cost)) {
+      if (unlikely(OldCostSum < Cost)) {
         return false;
       }
       NewCostSum = OldCostSum - Cost;

--- a/test/common/statisticsTest.cpp
+++ b/test/common/statisticsTest.cpp
@@ -22,15 +22,17 @@ TEST(StatisticsTest, AddCostRespectsLimit) {
   EXPECT_EQ(S.getTotalCost(), UINT64_C(100));
 }
 
-TEST(StatisticsTest, SubCostRejectsCostAtOrAboveTotal) {
+TEST(StatisticsTest, SubCostRejectsCostExceedingTotal) {
   Statistics S;
   EXPECT_TRUE(S.addCost(10));
   EXPECT_TRUE(S.subCost(5));
   EXPECT_EQ(S.getTotalCost(), UINT64_C(5));
-  EXPECT_FALSE(S.subCost(5));
-  EXPECT_EQ(S.getTotalCost(), UINT64_C(5));
+  EXPECT_TRUE(S.subCost(5));
+  EXPECT_EQ(S.getTotalCost(), UINT64_C(0));
   EXPECT_FALSE(S.subCost(10));
-  EXPECT_EQ(S.getTotalCost(), UINT64_C(5));
+  EXPECT_EQ(S.getTotalCost(), UINT64_C(0));
+  EXPECT_FALSE(S.subCost(1));
+  EXPECT_EQ(S.getTotalCost(), UINT64_C(0));
 }
 
 TEST(StatisticsTest, SetCostLimit) {
@@ -66,8 +68,8 @@ TEST(StatisticsTest, CustomCostTableAndSubInstrCost) {
   EXPECT_EQ(S.getTotalCost(), UINT64_C(14));
   EXPECT_TRUE(S.subInstrCost(OpCode::Block));
   EXPECT_EQ(S.getTotalCost(), UINT64_C(7));
-  EXPECT_FALSE(S.subInstrCost(OpCode::Block));
-  EXPECT_EQ(S.getTotalCost(), UINT64_C(7));
+  EXPECT_TRUE(S.subInstrCost(OpCode::Block));
+  EXPECT_EQ(S.getTotalCost(), UINT64_C(0));
 }
 
 TEST(StatisticsTest, ClearResetsCountersNotLimit) {


### PR DESCRIPTION
## Description

`Statistics::subCost()` in `include/common/statistics.h` guarded against unsigned integer underflow with `OldCostSum <= Cost`. This incorrectly rejected the valid case where `OldCostSum == Cost`: the subtraction would yield exactly `0` (a valid `uint64_t`), not an underflow. The guard only needs to fire when `OldCostSum < Cost`.

Changed the condition from `<=` to `<` so a full refund (total cost reduced to zero) is accepted. `subInstrCost()` delegates to `subCost()`, so it is corrected by the same change.

Before:
```
addCost(10); subCost(5) -> total=5; subCost(5) -> returns false, total stays 5
```
After:
```
addCost(10); subCost(5) -> total=5; subCost(5) -> returns true, total=0
```

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: I wrote this code entirely myself. No AI-assisted tools were used to generate or modify the changes in this PR.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

Built and ran `test/common/wasmedgeCommonTests` with `--gtest_filter='*Statistics*'`:

```
[ RUN      ] StatisticsTest.AddCostRespectsLimit
[       OK ] StatisticsTest.AddCostRespectsLimit (0 ms)
[ RUN      ] StatisticsTest.SubCostRejectsCostExceedingTotal
[       OK ] StatisticsTest.SubCostRejectsCostExceedingTotal (0 ms)
[ RUN      ] StatisticsTest.SetCostLimit
[       OK ] StatisticsTest.SetCostLimit (0 ms)
[ RUN      ] StatisticsTest.InstructionCounter
[       OK ] StatisticsTest.InstructionCounter (0 ms)
[ RUN      ] StatisticsTest.DefaultCostTableChargesOnePerInstr
[       OK ] StatisticsTest.DefaultCostTableChargesOnePerInstr (0 ms)
[ RUN      ] StatisticsTest.CustomCostTableAndSubInstrCost
[       OK ] StatisticsTest.CustomCostTableAndSubInstrCost (0 ms)
[ RUN      ] StatisticsTest.ClearResetsCountersNotLimit
[       OK ] StatisticsTest.ClearResetsCountersNotLimit (0 ms)
[  PASSED  ] 7 tests.
```

Existing `SubCostRejectsCostAtOrAboveTotal` was renamed to `SubCostRejectsCostExceedingTotal` and `CustomCostTableAndSubInstrCost` was updated to expect the corrected behavior (reducing to zero succeeds).

Fixes: #5242
