### PR TITLE
feat(ci): add issue assignment command

### DIFF
--- a/.github/scripts/test_assign_issue.mjs
+++ b/.github/scripts/test_assign_issue.mjs
@@ -1,0 +1,550 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The WasmEdge Authors
+
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const workflowUrl = new URL('../workflows/assign-issue.yml', import.meta.url);
+const workflow = await readFile(workflowUrl, 'utf8');
+const workflowLines = workflow.split('\n');
+const stepMarkerIndex = workflowLines.findIndex(
+  (line) => line.trim() === '- name: Assign contributor',
+);
+assert.notEqual(
+  stepMarkerIndex,
+  -1,
+  'expected assign-issue.yml to contain a step named "Assign contributor"; this suite extracts the workflow script by that literal step name',
+);
+const scriptMarkerIndex = workflowLines.findIndex(
+  (line, index) => index > stepMarkerIndex && line.trim() === 'script: |',
+);
+assert.notEqual(
+  scriptMarkerIndex,
+  -1,
+  'expected a "script: |" block scalar after the "Assign contributor" step; this suite extracts the workflow script from that block',
+);
+
+const blockLines = workflowLines.slice(scriptMarkerIndex + 1);
+const firstContentLine = blockLines.find((line) => line.trim() !== '');
+assert.notEqual(
+  firstContentLine,
+  undefined,
+  'expected the "script: |" block of the "Assign contributor" step to be non-empty',
+);
+const blockIndent = firstContentLine.match(/^ */)[0];
+assert.notEqual(
+  blockIndent,
+  '',
+  'expected the "script: |" block content to be indented so the end of the block can be detected',
+);
+
+const scriptLines = [];
+for (const line of blockLines) {
+  if (line.trim() === '') {
+    scriptLines.push('');
+    continue;
+  }
+  if (!line.startsWith(blockIndent)) {
+    break;
+  }
+  scriptLines.push(line.slice(blockIndent.length));
+}
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+const runWorkflow = new AsyncFunction(
+  'github',
+  'context',
+  'core',
+  scriptLines.join('\n'),
+);
+
+const sliceBlock = (lines, startIndex, indent) => {
+  const block = [];
+  for (const line of lines.slice(startIndex)) {
+    if (line.trim() !== '' && !line.startsWith(indent)) {
+      break;
+    }
+    block.push(line);
+  }
+  return block;
+};
+
+const jobsIndex = workflowLines.findIndex((line) => line === 'jobs:');
+assert.notEqual(
+  jobsIndex,
+  -1,
+  'expected assign-issue.yml to declare a top-level "jobs:" mapping',
+);
+const jobsLines = sliceBlock(workflowLines, jobsIndex + 1, '  ');
+const jobNames = jobsLines
+  .map((line) => line.match(/^ {2}(\S+):$/))
+  .filter((match) => match !== null)
+  .map((match) => match[1]);
+
+const assignJobIndex = jobsLines.findIndex(
+  (line) => line === '  assign-issue:',
+);
+assert.notEqual(
+  assignJobIndex,
+  -1,
+  'expected assign-issue.yml to declare an "assign-issue" job',
+);
+const assignJobLines = sliceBlock(jobsLines, assignJobIndex + 1, '    ');
+const assignJob = assignJobLines.join('\n');
+
+const conditionIndex = assignJobLines.findIndex(
+  (line) => line.trim() === 'if: >-',
+);
+assert.notEqual(
+  conditionIndex,
+  -1,
+  'expected the "assign-issue" job to be gated by an "if: >-" condition',
+);
+const assignJobCondition = sliceBlock(assignJobLines, conditionIndex + 1, '      ')
+  .map((line) => line.trim())
+  .join(' ')
+  .replace(/\s+/g, ' ')
+  .trim();
+
+const makeIssue = (assignees = [], state = 'open', number = 1) => ({
+  number,
+  state,
+  assignees: assignees.map((login) => ({ login })),
+  html_url: `https://github.com/WasmEdge/WasmEdge/issues/${number}`,
+});
+
+async function runScenario({
+  body = '/assign @alice',
+  payloadIssue = makeIssue(),
+  issue = makeIssue(),
+  issueError,
+  commentError,
+  conflictingIssues = [],
+  assignable = true,
+  eligibilityStatus = 404,
+  assignmentResult = makeIssue(['Alice']),
+}) {
+  const comments = [];
+  const commentCalls = [];
+  const addAssigneeCalls = [];
+  const conflictScanParams = [];
+  const failures = [];
+  const warnings = [];
+  let issueFetches = 0;
+  let eligibilityChecks = 0;
+  const listForRepo = async () => {};
+  const github = {
+    rest: {
+      issues: {
+        createComment: async (params) => {
+          commentCalls.push(structuredClone(params));
+          if (commentError) {
+            throw commentError;
+          }
+          comments.push(params.body);
+          return { data: { id: 900 + comments.length } };
+        },
+        get: async () => {
+          issueFetches += 1;
+          if (issueError) {
+            throw issueError;
+          }
+          return { data: structuredClone(issue) };
+        },
+        listForRepo,
+        checkUserCanBeAssignedToIssue: async () => {
+          eligibilityChecks += 1;
+          if (!assignable) {
+            const error = new Error('Not assignable');
+            error.status = eligibilityStatus;
+            throw error;
+          }
+        },
+        addAssignees: async (params) => {
+          addAssigneeCalls.push(structuredClone(params));
+          return { data: structuredClone(assignmentResult) };
+        },
+      },
+    },
+    paginate: async (endpoint, params) => {
+      if (endpoint === listForRepo) {
+        conflictScanParams.push(structuredClone(params));
+        return structuredClone(conflictingIssues);
+      }
+      throw new Error('Unexpected paginated endpoint');
+    },
+  };
+  const context = {
+    repo: { owner: 'WasmEdge', repo: 'WasmEdge' },
+    payload: {
+      comment: {
+        id: 12345,
+        body,
+        created_at: '2026-07-31T00:00:00Z',
+        user: { login: 'hydai' },
+      },
+      issue: structuredClone(payloadIssue),
+    },
+  };
+  const core = {
+    setFailed: (message) => failures.push(message),
+    warning: (message) => warnings.push(message),
+  };
+  let workflowError;
+  try {
+    await runWorkflow(github, context, core);
+  } catch (error) {
+    workflowError = error;
+  }
+  return {
+    added: addAssigneeCalls.length,
+    addAssigneeCalls,
+    commentCalls,
+    comments,
+    conflictScanParams,
+    eligibilityChecks,
+    failures,
+    issueFetches,
+    warnings,
+    workflowError,
+  };
+}
+
+test('declares the assign job as the only job in the workflow', () => {
+  assert.deepEqual(jobNames, ['assign-issue']);
+});
+
+test('bounds runtime and blocks unauthorized egress', () => {
+  assert.match(assignJob, /^ {4}timeout-minutes: 10$/m);
+  assert.match(assignJob, /^ {10}egress-policy: block$/m);
+  assert.match(
+    assignJob,
+    /^ {10}allowed-endpoints: >\n {12}api\.github\.com:443$/m,
+  );
+});
+
+test('retries transient GitHub API failures', () => {
+  assert.match(assignJob, /^ {10}retries: 3$/m);
+});
+
+test('gates the job on the maintainer allowlist and the /assign command', () => {
+  assert.equal(
+    assignJobCondition,
+    'github.event.issue.pull_request == null && ' +
+      "contains( fromJSON('[10806,251849,274041,2776756,3313947,4726889," +
+      '7088579,14789875,16274282,22004511,23314210,24819143,30090427,' +
+      "34829253,36074633,40065278,45785633,53310459,56215747,61797109,94267867]')," +
+      ' github.event.comment.user.id ) && ' +
+      "contains(github.event.comment.body, '/assign')",
+    'this condition is the authorization boundary of the workflow; change it here only together with a deliberate review of the job gate',
+  );
+});
+
+test('ignores a comment that only mentions /assign mid-text', async () => {
+  const result = await runScenario({ body: 'use /assign @alice to claim' });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.issueFetches, 0);
+  assert.equal(result.added, 0);
+  assert.deepEqual(result.comments, []);
+});
+
+test('ignores a comment starting with a word that extends /assign', async () => {
+  const result = await runScenario({ body: '/assigned to me yesterday' });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.issueFetches, 0);
+  assert.equal(result.added, 0);
+  assert.deepEqual(result.comments, []);
+});
+
+test('ignores a comment starting with /assignee', async () => {
+  const result = await runScenario({ body: '/assignee is bob' });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.issueFetches, 0);
+  assert.equal(result.added, 0);
+  assert.deepEqual(result.comments, []);
+});
+
+test('ignores a comment starting with a hyphenated extension of /assign', async () => {
+  const result = await runScenario({ body: '/assign-issue.yml has a bug' });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.issueFetches, 0);
+  assert.equal(result.added, 0);
+  assert.deepEqual(result.comments, []);
+});
+
+test('ignores an assign command that is not on the first line', async () => {
+  const result = await runScenario({
+    body: 'Thanks for volunteering!\n\n/assign @alice',
+  });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.issueFetches, 0);
+  assert.equal(result.added, 0);
+  assert.deepEqual(result.comments, []);
+});
+
+test('replies with usage guidance when the target is not separated', async () => {
+  const result = await runScenario({ body: '/assign@alice' });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.issueFetches, 0);
+  assert.equal(result.added, 0);
+  assert.deepEqual(result.comments, [
+    '@hydai, use `/assign @username` with exactly one GitHub username.',
+  ]);
+});
+
+test('replies with usage guidance for a multiline assign command', async () => {
+  const result = await runScenario({ body: '/assign\n@alice' });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.issueFetches, 0);
+  assert.equal(result.added, 0);
+  assert.deepEqual(result.comments, [
+    '@hydai, use `/assign @username` with exactly one GitHub username.',
+  ]);
+});
+
+test('replies with usage guidance for a malformed assign command', async () => {
+  const result = await runScenario({ body: '/assign alice' });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.issueFetches, 0);
+  assert.equal(result.added, 0);
+  assert.deepEqual(result.comments, [
+    '@hydai, use `/assign @username` with exactly one GitHub username.',
+  ]);
+});
+
+test('accepts an assign command with surrounding whitespace', async () => {
+  const result = await runScenario({ body: '  /assign @alice \n' });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.added, 1);
+  assert.deepEqual(result.comments, ['Assigned this issue to @alice.']);
+});
+
+test('accepts an assign command followed by further comment text', async () => {
+  const result = await runScenario({
+    body: '/assign @alice\r\n\r\nThanks for picking this up!',
+  });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.added, 1);
+  assert.deepEqual(result.comments, ['Assigned this issue to @alice.']);
+});
+
+test('accepts an assign command separated by a non-breaking space', async () => {
+  const result = await runScenario({ body: '/assign\u00a0@alice' });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.added, 1);
+  assert.deepEqual(result.comments, ['Assigned this issue to @alice.']);
+});
+
+test('accepts a mixed-case assign command', async () => {
+  const result = await runScenario({ body: '/Assign @alice' });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.added, 1);
+  assert.deepEqual(result.comments, ['Assigned this issue to @alice.']);
+});
+
+test('accepts an assign command containing zero-width characters', async () => {
+  const result = await runScenario({ body: '\uFEFF/assign @alice\u200B' });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.added, 1);
+  assert.deepEqual(result.comments, ['Assigned this issue to @alice.']);
+});
+
+test('rejects assignment on a closed issue', async () => {
+  const result = await runScenario({ issue: makeIssue([], 'closed') });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.issueFetches, 1);
+  assert.deepEqual(result.conflictScanParams, []);
+  assert.equal(result.eligibilityChecks, 0);
+  assert.equal(result.added, 0);
+  assert.deepEqual(result.comments, [
+    '@hydai, only open issues can be assigned.',
+  ]);
+});
+
+test('reports when the target is already the sole assignee', async () => {
+  const result = await runScenario({ issue: makeIssue(['Alice']) });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.eligibilityChecks, 0);
+  assert.equal(result.added, 0);
+  assert.deepEqual(result.comments, [
+    '@hydai, `@alice` is already assigned to this issue.',
+  ]);
+});
+
+test('rejects an issue that is already assigned to someone else', async () => {
+  const result = await runScenario({ issue: makeIssue(['Bob']) });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.eligibilityChecks, 0);
+  assert.equal(result.added, 0);
+  assert.deepEqual(result.comments, [
+    '@hydai, this issue is already assigned to `@Bob`. Each issue can be assigned to only one contributor.',
+  ]);
+});
+
+test('omits the requested target from the blocking assignee list', async () => {
+  const result = await runScenario({ issue: makeIssue(['Alice', 'Bob']) });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.added, 0);
+  assert.deepEqual(result.comments, [
+    '@hydai, this issue is already assigned to `@Bob`. Each issue can be assigned to only one contributor.',
+  ]);
+});
+
+test('assigns when a stale payload assignee has been removed', async () => {
+  const result = await runScenario({ payloadIssue: makeIssue(['Bob']) });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.issueFetches, 1);
+  assert.equal(result.added, 1);
+  assert.deepEqual(result.comments, ['Assigned this issue to @alice.']);
+});
+
+test('rejects a target who already holds another open issue', async () => {
+  const result = await runScenario({
+    conflictingIssues: [makeIssue(['Alice'], 'open', 2)],
+  });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.eligibilityChecks, 1);
+  assert.equal(result.added, 0);
+  assert.deepEqual(result.comments, [
+    '@hydai, `@alice` is already assigned to [#2](https://github.com/WasmEdge/WasmEdge/issues/2). Contributors can be assigned to only one open issue at a time and cannot receive another until the current issue is resolved.',
+  ]);
+});
+
+test('reports a target that cannot be assigned before scanning for conflicts', async () => {
+  const result = await runScenario({ assignable: false });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.eligibilityChecks, 1);
+  assert.deepEqual(result.conflictScanParams, []);
+  assert.equal(result.added, 0);
+  assert.deepEqual(result.comments, [
+    '@hydai, GitHub does not allow `@alice` to be assigned to this issue.',
+  ]);
+});
+
+test('reports an unexpected eligibility-check failure', async () => {
+  const result = await runScenario({
+    assignable: false,
+    eligibilityStatus: 403,
+  });
+
+  assert.equal(result.workflowError, undefined);
+  assert.deepEqual(result.conflictScanParams, []);
+  assert.equal(result.added, 0);
+  assert.deepEqual(result.comments, [
+    '@hydai, the `/assign` command failed unexpectedly. Please try again later.',
+  ]);
+  assert.deepEqual(result.failures, [
+    'The /assign command failed: Not assignable',
+  ]);
+});
+
+test('reports an unexpected issue-lookup failure', async () => {
+  const issueError = new Error('Server Error');
+  issueError.status = 500;
+  const result = await runScenario({ issueError });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.eligibilityChecks, 0);
+  assert.equal(result.added, 0);
+  assert.deepEqual(result.comments, [
+    '@hydai, the `/assign` command failed unexpectedly. Please try again later.',
+  ]);
+  assert.deepEqual(result.failures, [
+    'The /assign command failed: Server Error',
+  ]);
+});
+
+test('reports when GitHub silently ignores the assignee', async () => {
+  const result = await runScenario({ assignmentResult: makeIssue() });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.added, 1);
+  assert.deepEqual(result.comments, [
+    '@hydai, GitHub did not allow `@alice` to be assigned to this issue.',
+  ]);
+});
+
+test('reports when a concurrent assignment left another assignee in place', async () => {
+  const result = await runScenario({
+    assignmentResult: makeIssue(['Bob', 'Alice']),
+  });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.added, 1);
+  assert.deepEqual(result.comments, [
+    '@hydai, `@alice` was assigned alongside `@Bob`. Each issue can be assigned to only one contributor; please remove the extra assignees.',
+  ]);
+});
+
+test('records a warning instead of failing when the reply cannot be posted', async () => {
+  const commentError = new Error('You have exceeded a secondary rate limit');
+  commentError.status = 403;
+  const result = await runScenario({ commentError });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.added, 1);
+  assert.deepEqual(result.failures, []);
+  assert.deepEqual(result.warnings, [
+    'Failed to post the /assign reply: You have exceeded a secondary rate limit',
+  ]);
+});
+
+test('assigns an eligible target and excludes pull requests and this issue from the conflict scan', async () => {
+  const result = await runScenario({
+    conflictingIssues: [
+      { ...makeIssue(['Alice'], 'open', 7), pull_request: {} },
+      makeIssue(['Alice'], 'open', 1),
+    ],
+  });
+
+  assert.equal(result.workflowError, undefined);
+  assert.equal(result.issueFetches, 1);
+  assert.equal(result.eligibilityChecks, 1);
+  assert.deepEqual(result.conflictScanParams, [
+    {
+      owner: 'WasmEdge',
+      repo: 'WasmEdge',
+      assignee: 'alice',
+      state: 'open',
+      per_page: 100,
+    },
+  ]);
+  assert.deepEqual(result.addAssigneeCalls, [
+    {
+      owner: 'WasmEdge',
+      repo: 'WasmEdge',
+      issue_number: 1,
+      assignees: ['alice'],
+    },
+  ]);
+  assert.deepEqual(result.commentCalls, [
+    {
+      owner: 'WasmEdge',
+      repo: 'WasmEdge',
+      issue_number: 1,
+      body: 'Assigned this issue to @alice.',
+    },
+  ]);
+  assert.deepEqual(result.comments, ['Assigned this issue to @alice.']);
+});

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -205,6 +205,8 @@ workflows are called by the entries below and are not listed here; see
 | Build WasmEdge on Nix | `build_for_nix.yml` | `push` (`master`), `pull_request` (`master`, `proposal/**`); paths: workflow, `flake.nix`, `flake.lock`, `include/`, `lib/`, `thirdparty/`, `tools/`, `cmake/`, `CMakeLists.txt` | `nix build` + `nix flake check` |
 | Pull Request Labeler | `labeler.yml` | `pull_request_target` (opened/synchronize/reopened/closed); no path filter | auto-labels by path; runs in base-repo context |
 | Cleanup PR caches | `cleanup-pr-caches.yml` | `pull_request_target` (closed); no path filter | deletes the closed PR's Actions caches to free the repository cache quota; runs in base-repo context |
+| Assign issue contributors | `assign-issue.yml` | `issue_comment` (created comments starting with `/assign` on issues) | lets maintainers, committers, and reviewers listed in `docs/OWNER.md` use `/assign @username`; allows one assignee per issue and one assigned open issue per contributor; comments from users outside the allowlist are ignored without a reply |
+| Assign issue checks | `assign-issue-checks.yml` | `push` (`master`), `pull_request` (both with paths: the assign-issue workflows and test script), `workflow_dispatch` | runs the `assign-issue.yml` script tests with `node --test` |
 | release | `release.yml` | `workflow_dispatch`, `push` tags `X.Y.Z*` | creates release, tarball, release builds |
 | Submit WasmEdge MSI package to the Windows Package Manager Community Repository | `winget-submit.yml` | `workflow_dispatch`, `release` (released) | submits the MSI to the Windows Package Manager |
 

--- a/.github/workflows/assign-issue-checks.yml
+++ b/.github/workflows/assign-issue-checks.yml
@@ -1,0 +1,52 @@
+name: Assign issue checks
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/test_assign_issue.mjs'
+      - '.github/workflows/assign-issue-checks.yml'
+      - '.github/workflows/assign-issue.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  assign-issue-checks:
+    name: assign issue checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Harden the runner (Block unauthorized outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Test issue assignment workflow
+        run: |
+          node --test .github/scripts/test_assign_issue.mjs
+      - name: Lint issue assignment workflows
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -sSfL -o "${archive}" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}"
+          echo "${ACTIONLINT_SHA256}  ${archive}" | sha256sum -c -
+          tar -xzf "${archive}" actionlint
+          # actionlint does not know the concurrency "queue" key that GitHub
+          # added on 2026-05-07; drop this once rhysd/actionlint#657 ships.
+          ./actionlint \
+            -ignore 'unexpected key "queue" for "concurrency" section' \
+            .github/workflows/assign-issue.yml \
+            .github/workflows/assign-issue-checks.yml

--- a/.github/workflows/assign-issue-checks.yml
+++ b/.github/workflows/assign-issue-checks.yml
@@ -1,11 +1,19 @@
 name: Assign issue checks
 
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/scripts/test_assign_issue.mjs'
+      - '.github/workflows/assign-issue-checks.yml'
+      - '.github/workflows/assign-issue.yml'
   pull_request:
     paths:
       - '.github/scripts/test_assign_issue.mjs'
       - '.github/workflows/assign-issue-checks.yml'
       - '.github/workflows/assign-issue.yml'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -1,0 +1,210 @@
+name: Assign issue contributors
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  assign-issue:
+    name: Process /assign command
+    # User IDs of the maintainers, committers, and reviewers in docs/OWNER.md;
+    # update this list manually when that list changes.
+    #   10806 = juntao
+    #   251849 = ibmibmibm
+    #   274041 = dm4
+    #   2776756 = hydai
+    #   3313947 = q82419
+    #   4726889 = apepkuss
+    #   7088579 = LFsWang
+    #   14789875 = L-jasmine
+    #   16274282 = grorge123
+    #   22004511 = dannypsnl
+    #   23314210 = am009
+    #   24819143 = MediosZ
+    #   30090427 = 0yi0
+    #   34829253 = gusye1234
+    #   36074633 = yanghaku
+    #   40065278 = michael1017
+    #   45785633 = alabulei1
+    #   53310459 = PeterD1524
+    #   56215747 = sonder-joker
+    #   61797109 = SAtacker
+    #   94267867 = hangedfish
+    if: >-
+      github.event.issue.pull_request == null &&
+      contains(
+        fromJSON('[10806,251849,274041,2776756,3313947,4726889,7088579,14789875,16274282,22004511,23314210,24819143,30090427,34829253,36074633,40065278,45785633,53310459,56215747,61797109,94267867]'),
+        github.event.comment.user.id
+      ) &&
+      contains(github.event.comment.body, '/assign')
+    concurrency:
+      group: wasmedge-assign-issue
+      cancel-in-progress: false
+      queue: max
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Harden the runner (Block unauthorized outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+
+      # .github/scripts/test_assign_issue.mjs extracts the script below by the
+      # literal step name and the "script: |" line; update that test when
+      # renaming either.
+      - name: Assign contributor
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          retries: 3
+          script: |
+            const command = context.payload.comment.body
+              .replace(/[\u200B\u200C\u200D\u2060\uFEFF]/g, '')
+              .trim()
+              .split('\n', 1)[0]
+              .trim();
+            if (!/^\/assign(?![\w-])/i.test(command)) {
+              return;
+            }
+
+            const issueParams = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+            };
+            const actor = context.payload.comment.user.login;
+            const reply = async (body) => {
+              try {
+                await github.rest.issues.createComment({ ...issueParams, body });
+              } catch (error) {
+                core.warning(
+                  `Failed to post the /assign reply: ${error?.message ?? String(error)}`,
+                );
+              }
+            };
+
+            const loginPattern = '[a-z\\d](?:[a-z\\d-]{0,37}[a-z\\d])?';
+            const commandMatch = command.match(
+              new RegExp(`^/assign[^\\S\\r\\n]+@(${loginPattern})$`, 'i'),
+            );
+            if (!commandMatch) {
+              await reply(
+                `@${actor}, use \`/assign @username\` with exactly one GitHub username.`,
+              );
+              return;
+            }
+            const target = commandMatch[1];
+            const hasAssignee = (issueData) =>
+              (issueData.assignees ?? []).some(
+                (assignee) => assignee.login.toLowerCase() === target.toLowerCase(),
+              );
+
+            try {
+              const { data: issue } = await github.rest.issues.get(issueParams);
+              if (issue.state !== 'open') {
+                await reply(`@${actor}, only open issues can be assigned.`);
+                return;
+              }
+              const currentAssignees = issue.assignees ?? [];
+              if (currentAssignees.length === 1 && hasAssignee(issue)) {
+                await reply(
+                  `@${actor}, \`@${target}\` is already assigned to this issue.`,
+                );
+                return;
+              }
+              if (currentAssignees.length > 0) {
+                const assignees = currentAssignees
+                  .filter(
+                    (assignee) =>
+                      assignee.login.toLowerCase() !== target.toLowerCase(),
+                  )
+                  .map((assignee) => `\`@${assignee.login}\``)
+                  .join(', ');
+                await reply(
+                  `@${actor}, this issue is already assigned to ${assignees}. Each issue can be assigned to only one contributor.`,
+                );
+                return;
+              }
+
+              try {
+                await github.rest.issues.checkUserCanBeAssignedToIssue({
+                  ...issueParams,
+                  assignee: target,
+                });
+              } catch (error) {
+                if (error?.status !== 404) {
+                  throw error;
+                }
+                await reply(
+                  `@${actor}, GitHub does not allow \`@${target}\` to be assigned to this issue.`,
+                );
+                return;
+              }
+
+              const assignedIssues = await github.paginate(
+                github.rest.issues.listForRepo,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  assignee: target,
+                  state: 'open',
+                  per_page: 100,
+                },
+              );
+              const conflictingIssues = assignedIssues
+                .filter(
+                  (assignedIssue) =>
+                    !assignedIssue.pull_request &&
+                    assignedIssue.number !== issueParams.issue_number,
+                )
+                .sort((left, right) => left.number - right.number);
+              if (conflictingIssues.length > 0) {
+                const references = conflictingIssues
+                  .map(
+                    (conflict) => `[#${conflict.number}](${conflict.html_url})`,
+                  )
+                  .join(', ');
+                await reply(
+                  `@${actor}, \`@${target}\` is already assigned to ${references}. Contributors can be assigned to only one open issue at a time and cannot receive another until the current issue is resolved.`,
+                );
+                return;
+              }
+
+              const { data: assignedIssue } =
+                await github.rest.issues.addAssignees({
+                  ...issueParams,
+                  assignees: [target],
+                });
+              if (!hasAssignee(assignedIssue)) {
+                await reply(
+                  `@${actor}, GitHub did not allow \`@${target}\` to be assigned to this issue.`,
+                );
+                return;
+              }
+              const otherAssignees = (assignedIssue.assignees ?? []).filter(
+                (assignee) =>
+                  assignee.login.toLowerCase() !== target.toLowerCase(),
+              );
+              if (otherAssignees.length > 0) {
+                const others = otherAssignees
+                  .map((assignee) => `\`@${assignee.login}\``)
+                  .join(', ');
+                await reply(
+                  `@${actor}, \`@${target}\` was assigned alongside ${others}. Each issue can be assigned to only one contributor; please remove the extra assignees.`,
+                );
+                return;
+              }
+              await reply(`Assigned this issue to @${target}.`);
+            } catch (error) {
+              core.setFailed(
+                `The /assign command failed: ${error?.message ?? String(error)}`,
+              );
+              await reply(
+                `@${actor}, the \`/assign\` command failed unexpectedly. Please try again later.`,
+              );
+            }


### PR DESCRIPTION
## Description

Allow maintainers, committers, and reviewers to assign a single contributor from issue comments. Reject duplicate or conflicting open assignments, test the workflow script in CI, and document the workflow.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
