### PR TITLE
fix(executor): gate if-else statistics by configuration

### DIFF
--- a/lib/executor/engine/controlInstr.cpp
+++ b/lib/executor/engine/controlInstr.cpp
@@ -21,9 +21,17 @@ Expect<void> Executor::runIfElseOp(Runtime::StackManager &StackMgr,
       PC += (Instr.getJumpEnd() - 1);
     } else {
       if (Stat) {
-        Stat->incInstrCount();
-        if (unlikely(!Stat->addInstrCost(OpCode::Else))) {
-          return Unexpect(ErrCode::Value::CostLimitExceeded);
+        if (Conf.getStatisticsConfigure().isInstructionCounting()) {
+          Stat->incInstrCount();
+        }
+        if (Conf.getStatisticsConfigure().isCostMeasuring()) {
+          if (unlikely(!Stat->addInstrCost(OpCode::Else))) {
+            const AST::Instruction &ElseInstr = *(PC + Instr.getJumpElse());
+            spdlog::error(ErrCode::Value::CostLimitExceeded);
+            spdlog::error(ErrInfo::InfoInstruction(ElseInstr.getOpCode(),
+                                                   ElseInstr.getOffset()));
+            return Unexpect(ErrCode::Value::CostLimitExceeded);
+          }
         }
       }
       // Else-statement case. Jump to the Else instruction to continue.

--- a/lib/executor/engine/engine.cpp
+++ b/lib/executor/engine/engine.cpp
@@ -2356,6 +2356,7 @@ Expect<void> Executor::execute(Runtime::StackManager &StackMgr,
       if (Conf.getStatisticsConfigure().isCostMeasuring()) {
         if (unlikely(!Stat->addInstrCost(Code))) {
           const AST::Instruction &Instr = *PC;
+          spdlog::error(ErrCode::Value::CostLimitExceeded);
           spdlog::error(
               ErrInfo::InfoInstruction(Instr.getOpCode(), Instr.getOffset()));
           return Unexpect(ErrCode::Value::CostLimitExceeded);

--- a/lib/executor/engine/engine.cpp
+++ b/lib/executor/engine/engine.cpp
@@ -2110,6 +2110,7 @@ Expect<void> Executor::execute(Runtime::StackManager &StackMgr,
       if (Conf.getStatisticsConfigure().isCostMeasuring()) {
         if (unlikely(!Stat->addInstrCost(Code))) {
           const AST::Instruction &Instr = *PC;
+          spdlog::error(ErrCode::Value::CostLimitExceeded);
           spdlog::error(
               ErrInfo::InfoInstruction(Instr.getOpCode(), Instr.getOffset()));
           return Unexpect(ErrCode::Value::CostLimitExceeded);

--- a/test/executor/ExecutorRegressionTest.cpp
+++ b/test/executor/ExecutorRegressionTest.cpp
@@ -19,6 +19,7 @@
 #include <array>
 #include <cstdint>
 #include <gtest/gtest.h>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -553,6 +554,25 @@ std::array<WasmEdge::Byte, 61> CatchAllRefPayloadNotLeakedWasm{
     0x00, 0x00, 0x0a, 0x15, 0x01, 0x13, 0x00, 0x41, 0x01, 0x02, 0x69, 0x1f,
     0x40, 0x01, 0x03, 0x00, 0x41, 0x2a, 0x08, 0x00, 0x0b, 0x00, 0x0b, 0x1a,
     0x0b};
+
+/// Binary Wasm module: if/else false branch (takes Else).
+///
+/// Executed opcodes on the false path (default cost = 1 each):
+///   i32.const 0, if, else, i32.const 2, end, end  => 6
+///
+/// (module
+///   (func (export "test") (result i32)
+///     i32.const 0
+///     if (result i32)
+///       i32.const 1
+///     else
+///       i32.const 2
+///     end))
+std::array<WasmEdge::Byte, 45> IfElseFalseBranchWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x07, 0x08, 0x01, 0x04, 0x74,
+    0x65, 0x73, 0x74, 0x00, 0x00, 0x0a, 0x0e, 0x01, 0x0c, 0x00, 0x41, 0x00,
+    0x04, 0x7f, 0x41, 0x01, 0x05, 0x41, 0x02, 0x0b, 0x0b};
 // clang-format on
 
 /// Regression test for ref.test on externalized nullable references.
@@ -1071,6 +1091,64 @@ TEST(ExecutorRegression, CallIndirectNonFuncTable) {
   auto Result = VM.validate();
   ASSERT_FALSE(Result);
   EXPECT_EQ(Result.error(), ErrCode::Value::TypeCheckFailed);
+}
+
+/// Regression test for if→else statistics gating in runIfElseOp.
+///
+/// When the if condition is 0 and an else arm exists, the interpreter jumps to
+/// Else and used to always call incInstrCount() + addInstrCost(Else) whenever
+/// Stat was non-null. Because the executor keeps Stat as soon as *either*
+/// instruction counting or cost measuring is enabled, that leaked cost into
+/// counting-only runs and leaked instruction counts into cost-only runs.
+///
+/// False-branch opcodes (default cost 1): const, if, else, const, end, end.
+TEST(ExecutorRegression, IfElseFalseBranchStatisticsGate) {
+  constexpr uint64_t ExpectedInstrs = 6;
+
+  auto RunFalseBranch = [](bool Counting, bool CostMeasuring) {
+    Configure Conf;
+    Conf.getStatisticsConfigure().setInstructionCounting(Counting);
+    Conf.getStatisticsConfigure().setCostMeasuring(CostMeasuring);
+    VM::VM VM(Conf);
+    EXPECT_TRUE(VM.loadWasm(IfElseFalseBranchWasm));
+    EXPECT_TRUE(VM.validate());
+    EXPECT_TRUE(VM.instantiate());
+    VM.getStatistics().clear();
+    auto Result = VM.execute("test");
+    EXPECT_TRUE(Result);
+    EXPECT_EQ((*Result).size(), 1U);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), 2U);
+    return std::make_pair(VM.getStatistics().getInstrCount(),
+                          VM.getStatistics().getTotalCost());
+  };
+
+  // --- Part 1: instruction counting only ---
+  // Else jump must not charge cost when cost measuring is off.
+  {
+    auto [Count, Cost] = RunFalseBranch(/*Counting=*/true,
+                                        /*CostMeasuring=*/false);
+    EXPECT_EQ(Count, ExpectedInstrs);
+    EXPECT_EQ(Cost, 0U)
+        << "counting-only must not charge Else cost on if→else jump";
+  }
+
+  // --- Part 2: cost measuring only ---
+  // Else jump must not bump instruction count when counting is off.
+  {
+    auto [Count, Cost] = RunFalseBranch(/*Counting=*/false,
+                                        /*CostMeasuring=*/true);
+    EXPECT_EQ(Count, 0U)
+        << "cost-only must not increment instruction count on if→else jump";
+    EXPECT_EQ(Cost, ExpectedInstrs);
+  }
+
+  // --- Part 3: both statistics options off ---
+  {
+    auto [Count, Cost] = RunFalseBranch(/*Counting=*/false,
+                                        /*CostMeasuring=*/false);
+    EXPECT_EQ(Count, 0U);
+    EXPECT_EQ(Cost, 0U);
+  }
 }
 
 } // namespace

--- a/test/executor/ExecutorRegressionTest.cpp
+++ b/test/executor/ExecutorRegressionTest.cpp
@@ -19,6 +19,7 @@
 #include <array>
 #include <cstdint>
 #include <gtest/gtest.h>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -671,6 +672,25 @@ std::array<WasmEdge::Byte, 129> TailCallHostImportWasm{
     0xe3, 0x00, 0x10, 0x01, 0x0b, 0x06, 0x00, 0x41, 0x07, 0x10, 0x02, 0x0b,
     0x00, 0x13, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x01, 0x0c, 0x03, 0x00, 0x01,
     0x68, 0x01, 0x02, 0x66, 0x32, 0x02, 0x02, 0x66, 0x31};
+
+/// Binary Wasm module: if/else false branch (takes Else).
+///
+/// Executed opcodes on the false path (default cost = 1 each):
+///   i32.const 0, if, else, i32.const 2, end, end  => 6
+///
+/// (module
+///   (func (export "test") (result i32)
+///     i32.const 0
+///     if (result i32)
+///       i32.const 1
+///     else
+///       i32.const 2
+///     end))
+std::array<WasmEdge::Byte, 45> IfElseFalseBranchWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x07, 0x08, 0x01, 0x04, 0x74,
+    0x65, 0x73, 0x74, 0x00, 0x00, 0x0a, 0x0e, 0x01, 0x0c, 0x00, 0x41, 0x00,
+    0x04, 0x7f, 0x41, 0x01, 0x05, 0x41, 0x02, 0x0b, 0x0b};
 // clang-format on
 
 /// Regression test for ref.test on externalized nullable references.
@@ -1282,6 +1302,64 @@ TEST(ExecutorRegression, TailCallToHostImport) {
     auto Args = HostMod.getArgs();
     ASSERT_EQ(Args.size(), 1);
     EXPECT_EQ(Args[0], 7);
+  }
+}
+
+/// Regression test for if→else statistics gating in runIfElseOp.
+///
+/// When the if condition is 0 and an else arm exists, the interpreter jumps to
+/// Else and used to always call incInstrCount() + addInstrCost(Else) whenever
+/// Stat was non-null. Because the executor keeps Stat as soon as *either*
+/// instruction counting or cost measuring is enabled, that leaked cost into
+/// counting-only runs and leaked instruction counts into cost-only runs.
+///
+/// False-branch opcodes (default cost 1): const, if, else, const, end, end.
+TEST(ExecutorRegression, IfElseFalseBranchStatisticsGate) {
+  constexpr uint64_t ExpectedInstrs = 6;
+
+  auto RunFalseBranch = [](bool Counting, bool CostMeasuring) {
+    Configure Conf;
+    Conf.getStatisticsConfigure().setInstructionCounting(Counting);
+    Conf.getStatisticsConfigure().setCostMeasuring(CostMeasuring);
+    VM::VM VM(Conf);
+    EXPECT_TRUE(VM.loadWasm(IfElseFalseBranchWasm));
+    EXPECT_TRUE(VM.validate());
+    EXPECT_TRUE(VM.instantiate());
+    VM.getStatistics().clear();
+    auto Result = VM.execute("test");
+    EXPECT_TRUE(Result);
+    EXPECT_EQ((*Result).size(), 1U);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), 2U);
+    return std::make_pair(VM.getStatistics().getInstrCount(),
+                          VM.getStatistics().getTotalCost());
+  };
+
+  // --- Part 1: instruction counting only ---
+  // Else jump must not charge cost when cost measuring is off.
+  {
+    auto [Count, Cost] = RunFalseBranch(/*Counting=*/true,
+                                        /*CostMeasuring=*/false);
+    EXPECT_EQ(Count, ExpectedInstrs);
+    EXPECT_EQ(Cost, 0U)
+        << "counting-only must not charge Else cost on if→else jump";
+  }
+
+  // --- Part 2: cost measuring only ---
+  // Else jump must not bump instruction count when counting is off.
+  {
+    auto [Count, Cost] = RunFalseBranch(/*Counting=*/false,
+                                        /*CostMeasuring=*/true);
+    EXPECT_EQ(Count, 0U)
+        << "cost-only must not increment instruction count on if→else jump";
+    EXPECT_EQ(Cost, ExpectedInstrs);
+  }
+
+  // --- Part 3: both statistics options off ---
+  {
+    auto [Count, Cost] = RunFalseBranch(/*Counting=*/false,
+                                        /*CostMeasuring=*/false);
+    EXPECT_EQ(Count, 0U);
+    EXPECT_EQ(Cost, 0U);
   }
 }
 


### PR DESCRIPTION
Assisted-by: Cursor

Assisted-by: ChatGPT (OpenAI GPT-5.5)

## Description
This PR fixes inconsistent statistics handling for the `if -> else` execution path.

In the normal execution path, instruction counting and cost measuring are gated independently by their corresponding configuration options. However, the `if -> else` path updated both statistics whenever `Stat` was available, causing instruction counts and costs to leak into configurations where they were disabled.

This change applies the same configuration checks to the `if -> else` path, making its behavior consistent with the normal instruction execution path.

Additionally, the `CostLimitExceeded` path now reports the error code before the instruction information, matching the logging behavior used in other execution paths.

A regression test has been added to verify the `if -> else` false branch under instruction-counting-only, cost-measuring-only, and both-disabled configurations.

## Checklist

Before submitting this PR, please ensure the following:

- [X] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [X] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [X] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [X] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [X] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [X] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
Build succeeded.

Regression test:

```text
./build/test/executor/wasmedgeExecutorRegressionTests \
  --gtest_filter=ExecutorRegression.IfElseFalseBranchStatisticsGate

[==========] Running 1 test from 1 test suite.
[  PASSED  ] 1 test.
```
---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
