### PR TITLE
fix(executor): drop stale try_table handlers at branch time to stop OOB write

### DIFF
--- a/include/runtime/stackmgr.h
+++ b/include/runtime/stackmgr.h
@@ -184,8 +184,10 @@ public:
   /// Unsafe remove inactive handler.
   void removeInactiveHandler(AST::InstrView::iterator PC) noexcept {
     assuming(!FrameStack.empty());
-    // First pop the inactive handlers. Br instructions may cause the handlers
-    // in current frame becomes inactive.
+    // Pop the handlers the branch left behind. Callers must run this while the
+    // inactive handlers are still on top: a handler buried under a later
+    // try_table is indistinguishable from an active one here, so branchToLabel
+    // cleans up before any new handler can be pushed over the stale ones.
     auto &HandlerStack = FrameStack.back().HandlerStack;
     while (!HandlerStack.empty()) {
       auto &Handler = HandlerStack.back();

--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -300,6 +300,12 @@ Executor::branchToLabel(Runtime::StackManager &StackMgr,
   StackMgr.eraseValueStack(JumpDesc.StackEraseBegin, JumpDesc.StackEraseEnd);
   // PC needs -1 here because the PC will increase in the next iteration.
   PC += (JumpDesc.PCOffset - 1);
+  // A branch leaves the innermost blocks without running their `end`, so the
+  // handlers it strands are the top of the handler stack right now. Drop them
+  // here: once a later try_table is pushed on top they are indistinguishable
+  // from active handlers, and their stale VPos would invert the erase range in
+  // popTopHandler. PC + 1 is the instruction being branched to.
+  StackMgr.removeInactiveHandler(PC + 1);
   return {};
 }
 

--- a/test/executor/ExecutorRegressionTest.cpp
+++ b/test/executor/ExecutorRegressionTest.cpp
@@ -553,6 +553,64 @@ std::array<WasmEdge::Byte, 61> CatchAllRefPayloadNotLeakedWasm{
     0x00, 0x00, 0x0a, 0x15, 0x01, 0x13, 0x00, 0x41, 0x01, 0x02, 0x69, 0x1f,
     0x40, 0x01, 0x03, 0x00, 0x41, 0x2a, 0x08, 0x00, 0x0b, 0x00, 0x0b, 0x1a,
     0x0b};
+
+/// Binary Wasm module: a try_table handler left inactive by a br and then
+/// buried under a newer try_table.
+///
+/// (module
+///   (tag $tx)
+///   (tag $ty (param i32 i32))
+///   (func (export "go")
+///     (block $outer
+///       ;; raise the stack so try_table $A records a high VPos
+///       (i32.const 1) (i32.const 1) (i32.const 1) (i32.const 1)
+///       (try_table $A (catch $tx $outer)
+///         (br $outer))              ;; leave $A without running its end: stale
+///       unreachable)
+///     ;; the stack is low again; try_table $B buries the stale handler $A
+///     (try_table $B (catch $tx 0)
+///       (i32.const 7) (i32.const 8)
+///       (throw $ty))))              ;; uncaught: search reaches stale $A
+std::array<WasmEdge::Byte, 78> BuriedStaleHandlerWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x09, 0x02, 0x60,
+    0x00, 0x00, 0x60, 0x02, 0x7f, 0x7f, 0x00, 0x03, 0x02, 0x01, 0x00, 0x0d,
+    0x05, 0x02, 0x00, 0x00, 0x00, 0x01, 0x07, 0x06, 0x01, 0x02, 0x67, 0x6f,
+    0x00, 0x00, 0x0a, 0x26, 0x01, 0x24, 0x00, 0x02, 0x40, 0x41, 0x01, 0x41,
+    0x01, 0x41, 0x01, 0x41, 0x01, 0x1f, 0x40, 0x01, 0x00, 0x00, 0x00, 0x0c,
+    0x01, 0x0b, 0x00, 0x0b, 0x1f, 0x40, 0x01, 0x00, 0x00, 0x00, 0x41, 0x07,
+    0x41, 0x08, 0x08, 0x01, 0x0b, 0x0b};
+
+/// Binary Wasm module: a loop that leaves a stale handler behind on every
+/// iteration, so the stale handlers pile up under one another before a newer
+/// try_table buries them.
+///
+/// (module
+///   (tag $tx)
+///   (tag $ty (param i32 i32))
+///   (func (export "go") (local $i i32)
+///     (loop $L
+///       (block $out
+///         ;; raise the stack so try_table $A records a high VPos
+///         (i32.const 1) (i32.const 1) (i32.const 1) (i32.const 1)
+///         (try_table $A (catch $tx $out)
+///           (br $out))            ;; leave $A without running its end: stale
+///         unreachable)
+///       ;; every iteration strands another handler, all sharing one Try
+///       (local.set $i (i32.add (local.get $i) (i32.const 1)))
+///       (br_if $L (i32.lt_u (local.get $i) (i32.const 3))))
+///     (try_table $B (catch $tx 0)
+///       (i32.const 7) (i32.const 8)
+///       (throw $ty))))            ;; uncaught: search reaches the stale pile
+std::array<WasmEdge::Byte, 97> StaleHandlerPileWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x09, 0x02, 0x60,
+    0x00, 0x00, 0x60, 0x02, 0x7f, 0x7f, 0x00, 0x03, 0x02, 0x01, 0x00, 0x0d,
+    0x05, 0x02, 0x00, 0x00, 0x00, 0x01, 0x07, 0x06, 0x01, 0x02, 0x67, 0x6f,
+    0x00, 0x00, 0x0a, 0x39, 0x01, 0x37, 0x01, 0x01, 0x7f, 0x03, 0x40, 0x02,
+    0x40, 0x41, 0x01, 0x41, 0x01, 0x41, 0x01, 0x41, 0x01, 0x1f, 0x40, 0x01,
+    0x00, 0x00, 0x00, 0x0c, 0x01, 0x0b, 0x00, 0x0b, 0x20, 0x00, 0x41, 0x01,
+    0x6a, 0x21, 0x00, 0x20, 0x00, 0x41, 0x03, 0x49, 0x0d, 0x00, 0x0b, 0x1f,
+    0x40, 0x01, 0x00, 0x00, 0x00, 0x41, 0x07, 0x41, 0x08, 0x08, 0x01, 0x0b,
+    0x0b};
 // clang-format on
 
 /// Regression test for ref.test on externalized nullable references.
@@ -1050,6 +1108,51 @@ TEST(ExecutorRegression, CatchAllPayloadNotLeaked) {
     EXPECT_EQ((*Result)[0].first.get<uint32_t>(), 1U)
         << "catch_all_ref must not leak the throw payload alongside the exnref";
   }
+}
+
+/// Regression test for a try_table handler buried by a later try_table.
+///
+/// A br out of a try_table leaves its handler inactive without popping it, and
+/// a second try_table buries it. An uncaught throw then reached the buried
+/// handler, whose VPos was recorded above the current stack height, and
+/// popTopHandler erased the value stack with first > last, moving values past
+/// the end of the buffer -- a guest-controlled out-of-bounds write. Execution
+/// must instead report an orderly uncaught exception.
+///
+/// The write is only visible in a release build under one heap layout, so this
+/// case must be run with assertions enabled or under ASan, where it aborts in
+/// popTopHandler before returning.
+TEST(ExecutorRegression, BuriedStaleTryTableHandler) {
+  Configure Conf;
+  VM::VM VM(Conf);
+  ASSERT_TRUE(VM.loadWasm(BuriedStaleHandlerWasm));
+  ASSERT_TRUE(VM.validate());
+  ASSERT_TRUE(VM.instantiate());
+  auto Result = VM.execute("go");
+  ASSERT_FALSE(Result);
+  EXPECT_EQ(Result.error(), ErrCode::Value::UncaughtException)
+      << "the buried stale handler must not corrupt the value stack";
+}
+
+/// Regression test for stale try_table handlers piling up across loop
+/// iterations.
+///
+/// A loop that branches out of a try_table strands one handler per iteration,
+/// all sharing the same Try pointer, so a scan looking for inactive handlers
+/// cannot tell them apart from an active one. The pile both grew without bound
+/// and left the oldest entries reachable with a stale VPos. Reaping at branch
+/// time keeps the stack bounded, so execution must report an orderly uncaught
+/// exception.
+TEST(ExecutorRegression, StaleTryTableHandlerPile) {
+  Configure Conf;
+  VM::VM VM(Conf);
+  ASSERT_TRUE(VM.loadWasm(StaleHandlerPileWasm));
+  ASSERT_TRUE(VM.validate());
+  ASSERT_TRUE(VM.instantiate());
+  auto Result = VM.execute("go");
+  ASSERT_FALSE(Result);
+  EXPECT_EQ(Result.error(), ErrCode::Value::UncaughtException)
+      << "handlers stranded by a loop must not survive to corrupt the stack";
 }
 
 /// Regression test for call_indirect on a non-funcref table (type confusion).


### PR DESCRIPTION
## Description

A `br` out of a `try_table` leaves its handler inactive without popping it, and the
handlers were only reaped later — at `enterFunction` and `throwException` — by a scan
that stops at the first still-active handler. Entering a second `try_table` in the
meantime buried the stale handler below an active one, where that scan could never
reach it.

An uncaught `throw` then reached the buried handler, whose absolute `VPos` had been
recorded above the current stack height, so `popTopHandler` called
`ValueStack.erase(first, last)` with `first > last` and moved 16-byte `ValVariant`s
past the end of the buffer. Offset, width and contents are all guest-chosen; with the
stack raised to the reserved capacity the write lands on the adjacent `FrameStack`,
letting a module plant a pointer the runtime dereferences. The module needs no
imports and exception handling is enabled by default (CWE-787).

**Fix.** Reap the handlers in `Executor::branchToLabel`, where the blocks the branch
leaves are still the *top* of the handler stack — so nothing can be buried, and the
existing back-to-front scan in `removeInactiveHandler` stays correct and O(1) in the
common case.

This also bounds handler-stack growth: a loop branching out of a `try_table` every
iteration previously accumulated one handler per iteration (317 MB RSS over 3M
iterations, vs 59 MB once reaped) — a memory-exhaustion DoS in its own right.

Reaping the whole stack instead (e.g. `std::remove_if` over all handlers) was
measured and rejected: it costs **2.2x** on a frame with 400 active handlers
(2.01s → 4.51s) and turns the accumulation case **quadratic** (0.31s → 6.21s at 20k
handlers; 40k = 23.75s), because it loses the early break. It also cannot fix the
accumulation at all, since handlers stacked by a loop share one `Try` pointer and all
test as active.

`br`, `br_if`, `br_table`, `br_on_null`, `br_on_non_null`, `br_on_cast` and
`br_on_cast_fail` all route through `branchToLabel`, as does the catch path in
`throwException`, so the single site covers every branch form, plus a `throw`
crossing a call into the frame that holds the stale handler.

### Files

| File | Change |
|---|---|
| `lib/executor/helper.cpp` | Reap stale handlers in `branchToLabel` (root-cause fix) |
| `include/runtime/stackmgr.h` | Document the ordering contract `removeInactiveHandler` now relies on |
| `test/executor/ExecutorRegressionTest.cpp` | `ExecutorRegression.BuriedStaleTryTableHandler` and `ExecutorRegression.StaleTryTableHandlerPile` |

### AOT/JIT

Compiled code is unaffected by construction: `compileTryTableOp` resolves the
dispatch target lexically at compile time (`getEHDispatchTarget()` walks the
compiler's `ControlStack`), and runtime EH state is a single `PendingExn` plus a tag
pointer — there is no runtime handler stack, no `VPos`, and no erase range. Verified
with gdb breakpoints (see evidence below).

The **mixed** path was affected, however: an AOT callee's `proxyThrow` escapes into an
interpreted caller via `enterFunction`'s `PendingExn` block → `throwException`. That
case reproduces before the fix and is covered by it.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

> This contribution was developed with assistance from Claude (Anthropic). The commit
> carries the `Assisted-by: Claude (Anthropic)` trailer.

## Test Evidence

### Regression test — fails before, passes after

```
$ ctest -R wasmedgeExecutorRegressionTests          # before the fix
ExecutorRegressionTest: include/runtime/stackmgr.h:171:
  std::optional<...> WasmEdge::Runtime::StackManager::popTopHandler(uint32_t):
  Assertion `TopHandler.VPos <= ValueStack.size() - AssocValSize' failed.
Aborted (core dumped)                                                    # exit 134

$ ctest -R wasmedgeExecutorRegressionTests          # after the fix
[ RUN      ] ExecutorRegression.BuriedStaleTryTableHandler
[       OK ] ExecutorRegression.BuriedStaleTryTableHandler
[ RUN      ] ExecutorRegression.StaleTryTableHandlerPile
[       OK ] ExecutorRegression.StaleTryTableHandlerPile
```

`StaleTryTableHandlerPile` covers the loop shape: one handler stranded per
iteration, all sharing a single `Try` pointer, which is the case a scan for
inactive handlers cannot resolve and which drove the unbounded growth. It asserts
identically before the fix.

### Full suites — Debug + ASan (`WASMEDGE_USE_LLVM=OFF`)

```
    Start 5: wasmedgeExecutorCoreTests
1/2 Test #5: wasmedgeExecutorCoreTests .........   Passed  125.02 sec
    Start 6: wasmedgeExecutorRegressionTests
2/2 Test #6: wasmedgeExecutorRegressionTests ...   Passed    0.07 sec

100% tests passed, 0 tests failed out of 2
```

### Full suites — Debug, `WASMEDGE_USE_LLVM=ON` (LLVM 21), covering AOT / JIT / LazyJIT

```
    Start  3: wasmedgeLLVMCoreTests
1/5 Test  #3: wasmedgeLLVMCoreTests .............   Passed   97.75 sec
    Start  4: wasmedgeLazyJITTests
2/5 Test  #4: wasmedgeLazyJITTests ..............   Passed    0.11 sec
    Start 18: wasmedgeAPIAOTCoreTests
5/5 Test #18: wasmedgeAPIAOTCoreTests ...........   Passed   67.87 sec

100% tests passed, 0 tests failed out of 5

    Start 10: wasmedgeExecutorCoreTests
3/5 Test #10: wasmedgeExecutorCoreTests .........   Passed   54.50 sec
    Start 11: wasmedgeExecutorRegressionTests
4/5 Test #11: wasmedgeExecutorRegressionTests ...   Passed    0.03 sec

100% tests passed, 0 tests failed out of 2
```

`wasm-3.0-exceptions` (including `try_table.wast`) carries no mode restriction, so it
runs in AOT and JIT within `wasmedgeLLVMCoreTests` / `wasmedgeAPIAOTCoreTests`.

### Reproducers across run modes

Six hand-built modules: the two branch forms (`br`, `br_table`) of the buried-handler
case, a cross-frame variant (throw in a callee, stale handler in the caller), the
minimised module used by the regression test, a negative control (same shape without
the burial), and a module exercising legitimate `try_table` catch/rethrow.

| module | pre-fix interpreter | post-fix interpreter | pre/post AOT | pre/post JIT |
|---|---|---|---|---|
| `pov` (`br`) | **assert / abort** | orderly `0x419` | orderly | orderly |
| `pov_brtable` | **assert / abort** | orderly `0x419` | orderly | orderly |
| `crossframe` | **assert / abort** | orderly `0x419` | orderly | orderly |
| `regr_min` | **assert / abort** | orderly `0x419` | orderly | orderly |
| `control` (no burial) | orderly `0x419` | orderly `0x419` | orderly | orderly |
| `legit` (catch works) | exit 0 | exit 0 | exit 0 | exit 0 |

### Adversarial battery

Sixteen further modules aimed at every way a handler can be left behind or the value
stack can shrink while one is recorded: `br` to the `try_table`'s own `end`; a
`br_table` exiting three `try_table`s at once; three nested `try_table`s exited by one
`br`; a backward `br_if` to an enclosing `loop`; `try_table`/`loop`/`try_table`; a
tail call out of a frame holding a stale handler; `catch_ref` capture followed by
`throw_ref`; a catch label landing inside another `try_table`; `br_on_null`; a throw
caught across a call; `try_table` with block parameters; a 16-value tag payload; a
throw raised while unwinding; `br` out of an `if`/`else` arm; 20-deep recursion with a
stale handler per frame; and `br` out of a `try_table` that is then re-entered by a
loop.

**12 of the 16 reach the defect before the fix** (`Assertion 'TopHandler.VPos <=
ValueStack.size() - AssocValSize' failed`), covering shapes the original reproducer
does not — the loop, `throw_ref`, `br_on_null`, block-parameter, large-payload,
recursion and re-entry cases. **All 16 are clean after it**, in both interpreter and
JIT (32 runs, zero assertions). The four that never trigger do so for structural
reasons: `br` to the block's own `end` still reaches that `end`, and a tail call
clears the handler stack.

### Mixed AOT-callee / interpreted-caller

Two modules: an AOT-compiled helper that throws, registered alongside a plain-wasm
main that holds the stale handler (`RunMode::AOT`; the main module logs the expected
"falling back to interpreter"). gdb confirms the mixing — `proxyThrow` from compiled
code, `pushHandler` from the interpreter:

```
proxyThrow ................ hit 1 time     (compiled helper)
pushHandler ............... hit 2 times    (interpreted caller)
popTopHandler ............. hit 2 times
removeInactiveHandler ..... hit 4 times

before: Assertion `TopHandler.VPos <= ValueStack.size() - AssocValSize' failed
after:  RESULT: ok=0 code=0x419 msg=uncaught exception
```

Same result under `RunMode::LazyJIT`.

### AOT/JIT do not use the handler stack

gdb breakpoint hit counts on the same reproducer:

| mode | `pushHandler` | `popTopHandler` | `removeInactiveHandler` |
|---|---|---|---|
| interpreter | 2 | 2 | 3 |
| JIT | 0 | 0 | 0 |
| LazyJIT | 0 | 0 | 0 |
| AOT | 0 | 0 | 0 |

### Performance and memory

```
400 nested active handlers, 200k calls   pre-fix 2.01s   this PR 2.11s   (remove_if 4.51s)
20k accumulating handlers                pre-fix 0.31s   this PR 0.31s   (remove_if 6.21s)
handler growth, 3M iterations            pre-fix 317 MB  this PR 59.6 MB (control 59 MB)
```

### Style

```
$ clang-format --style=file <each file> | diff - <file>      # no differences
$ lineguard --config .lineguardrc <3 files>
✓ All files passed lint checks!
  Files checked: 3
```

Commit header 77/100 chars, no body line over 100, Conventional Commits format,
`Signed-off-by` matches the author.
