### PR TITLE
fix(loader): bound-check AOT custom section symbol offsets

### DIFF
--- a/include/ast/section.h
+++ b/include/ast/section.h
@@ -286,11 +286,11 @@ public:
 private:
   /// \name Data of AOTSection.
   /// @{
-  uint32_t Version;
-  uint8_t OSType;
-  uint8_t ArchType;
-  uint64_t VersionAddress;
-  uint64_t IntrinsicsAddress;
+  uint32_t Version = 0;
+  uint8_t OSType = 0;
+  uint8_t ArchType = 0;
+  uint64_t VersionAddress = 0;
+  uint64_t IntrinsicsAddress = 0;
   std::vector<uintptr_t> TypesAddress;
   std::vector<uintptr_t> CodesAddress;
   std::vector<std::tuple<uint8_t, uint64_t, uint64_t, std::vector<Byte>>>

--- a/include/loader/aot_section.h
+++ b/include/loader/aot_section.h
@@ -36,8 +36,10 @@ public:
 
   Symbol<const IntrinsicsTable *> getIntrinsics() noexcept override {
     if (Binary) {
-      return createSymbol<const IntrinsicsTable *>(
-          getPointer<const IntrinsicsTable *>(IntrinsicsAddress));
+      if (auto *const Pointer = getPointer<const IntrinsicsTable *>(
+              IntrinsicsAddress, sizeof(const IntrinsicsTable *))) {
+        return createSymbol<const IntrinsicsTable *>(Pointer);
+      }
     }
     return {};
   }
@@ -47,7 +49,11 @@ public:
     if (Binary) {
       Result.reserve(TypesAddress.size());
       for (const auto Address : TypesAddress) {
-        Result.push_back(createSymbol<Wrapper>(getPointer<Wrapper>(Address)));
+        auto *const Pointer = getPointer<Wrapper>(Address, 1);
+        if (!Pointer) {
+          return {};
+        }
+        Result.push_back(createSymbol<Wrapper>(Pointer));
       }
     }
     return Result;
@@ -58,7 +64,11 @@ public:
     if (Binary) {
       Result.reserve(CodesAddress.size());
       for (const auto Address : CodesAddress) {
-        Result.push_back(createSymbol<void>(getPointer<void>(Address)));
+        auto *const Pointer = getPointer<void>(Address, 1);
+        if (!Pointer) {
+          return {};
+        }
+        Result.push_back(createSymbol<void>(Pointer));
       }
     }
     return Result;
@@ -69,7 +79,16 @@ private:
     return reinterpret_cast<uintptr_t>(Binary);
   }
 
-  template <typename T> T *getPointer(uint64_t Address) const noexcept {
+  /// Check that [Offset, Offset + Length) stays inside the mapped binary.
+  bool checkAccessBound(uint64_t Offset, uint64_t Length) const noexcept {
+    return Offset <= BinarySize && Length <= BinarySize - Offset;
+  }
+
+  template <typename T>
+  T *getPointer(uint64_t Address, uint64_t Size) const noexcept {
+    if (!checkAccessBound(Address, Size)) {
+      return nullptr;
+    }
     return reinterpret_cast<T *>(getOffset() + Address);
   }
 

--- a/lib/loader/aot_section.cpp
+++ b/lib/loader/aot_section.cpp
@@ -44,6 +44,30 @@ Expect<void> AOTSection::load(const AST::AOTSection &AOTSec) noexcept {
   }
   BinarySize = roundUpPageBoundary(BinarySize);
 
+  // The symbol addresses are offsets into the binary about to be mapped, and
+  // are dereferenced without any further check, so reject the out-of-range
+  // ones here.
+  if (!checkAccessBound(AOTSec.getIntrinsicsAddress(),
+                        sizeof(const IntrinsicsTable *))) {
+    spdlog::error(ErrCode::Value::IntegerTooLarge);
+    spdlog::error("    AOT intrinsics address out of range."sv);
+    return Unexpect(ErrCode::Value::IntegerTooLarge);
+  }
+  for (const auto Address : AOTSec.getTypesAddress()) {
+    if (!checkAccessBound(Address, 1)) {
+      spdlog::error(ErrCode::Value::IntegerTooLarge);
+      spdlog::error("    AOT type address out of range."sv);
+      return Unexpect(ErrCode::Value::IntegerTooLarge);
+    }
+  }
+  for (const auto Address : AOTSec.getCodesAddress()) {
+    if (!checkAccessBound(Address, 1)) {
+      spdlog::error(ErrCode::Value::IntegerTooLarge);
+      spdlog::error("    AOT code address out of range."sv);
+      return Unexpect(ErrCode::Value::IntegerTooLarge);
+    }
+  }
+
   Binary = Allocator::allocate_chunk(BinarySize);
   if (unlikely(!Binary)) {
     spdlog::error(ErrCode::Value::MemoryOutOfBounds);

--- a/test/loader/sectionTest.cpp
+++ b/test/loader/sectionTest.cpp
@@ -12,6 +12,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "loader/aot_section.h"
 #include "loader/loader.h"
 
 #include <cstdint>
@@ -595,5 +596,60 @@ TEST(SectionTest, LoadDataCountSection) {
       0x00U, // Content size = 0
   };
   EXPECT_FALSE(LdrWASM1.parseModule(prefixedVec(Vec)));
+}
+
+TEST(SectionTest, LoadAOTSectionSymbolAddress) {
+  // The AOT symbol addresses are offsets into the code chunk about to be
+  // mapped, and are turned into pointers without any bound check. Loading an
+  // out-of-range one gives an arbitrary write at load time, so they must be
+  // rejected.
+  auto CraftAOTSection = []() {
+    WasmEdge::AST::AOTSection Sec;
+    Sec.setIntrinsicsAddress(0);
+    Sec.getSections().emplace_back(UINT8_C(2), UINT64_C(0), UINT64_C(16),
+                                   std::vector<WasmEdge::Byte>(16, 0x00U));
+    return Sec;
+  };
+
+  // In-range addresses are accepted.
+  {
+    WasmEdge::AST::AOTSection Sec = CraftAOTSection();
+    Sec.getTypesAddress() = {0};
+    Sec.getCodesAddress() = {0};
+    WasmEdge::Loader::AOTSection Exec;
+    EXPECT_TRUE(Exec.load(Sec));
+  }
+
+  // Out-of-range intrinsics address.
+  {
+    WasmEdge::AST::AOTSection Sec = CraftAOTSection();
+    Sec.setIntrinsicsAddress(UINT64_C(0xFFFFFFFF00000000));
+    WasmEdge::Loader::AOTSection Exec;
+    EXPECT_FALSE(Exec.load(Sec));
+  }
+
+  // Intrinsics address whose end wraps around back into range.
+  {
+    WasmEdge::AST::AOTSection Sec = CraftAOTSection();
+    Sec.setIntrinsicsAddress(UINT64_MAX - 3);
+    WasmEdge::Loader::AOTSection Exec;
+    EXPECT_FALSE(Exec.load(Sec));
+  }
+
+  // Out-of-range type address.
+  {
+    WasmEdge::AST::AOTSection Sec = CraftAOTSection();
+    Sec.getTypesAddress() = {0, static_cast<uintptr_t>(UINT64_MAX)};
+    WasmEdge::Loader::AOTSection Exec;
+    EXPECT_FALSE(Exec.load(Sec));
+  }
+
+  // Out-of-range code address.
+  {
+    WasmEdge::AST::AOTSection Sec = CraftAOTSection();
+    Sec.getCodesAddress() = {0, static_cast<uintptr_t>(UINT64_MAX)};
+    WasmEdge::Loader::AOTSection Exec;
+    EXPECT_FALSE(Exec.load(Sec));
+  }
 }
 } // namespace


### PR DESCRIPTION

## Description

The wasmedge AOT custom section stores IntrinsicsAddress, TypesAddress[] and CodesAddress[] as raw u64 offsets into the mapped code chunk. The loader read them without any range check and AOTSection::getPointer added them to the chunk base unconditionally, so loading a crafted universal-WASM file in AOT mode produced an attacker-controlled 8-byte write (the intrinsics-table pointer stored at Binary + IntrinsicsAddress in loadExecutable) and a set of attacker-controlled function-entry pointers, before any AOT code ran. The offset addition wraps, so the target could name any address in the process. This mirrors the check AOTSection::load already applies to section offsets and sizes, which the symbol addresses bypassed.

Reject out-of-range IntrinsicsAddress / TypesAddress[] / CodesAddress[] at load time against BinarySize, and make getPointer take the access size and return nullptr when the range escapes the binary so the symbol getters fail closed. Also default-initialize the AOTSection scalar members so a partially populated node cannot carry an indeterminate address.

Add SectionTest.LoadAOTSectionSymbolAddress covering in-range acceptance, each out-of-range address kind, and the wrap-around case.

Assisted-by: Claude (Anthropic)

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
