### PR TITLE
chore(install): remove dead Ubuntu 20.04 DESCRIPTION fallback

### DIFF
--- a/utils/install.py
+++ b/utils/install.py
@@ -1250,11 +1250,7 @@ class Compat:
                     __lsb_rel = run_shell_command(
                         "cat /etc/lsb-release 2>/dev/null | grep RELEASE"
                     )[-5:]
-                    if VersionString(__lsb_rel).compare(
-                        "20.04"
-                    ) >= 0 or "Ubuntu 20.04" in run_shell_command(
-                        "cat /etc/lsb_release 2>/dev/null | grep DESCRIPTION"
-                    ):
+                    if VersionString(__lsb_rel).compare("20.04") >= 0:
                         # ARM-based Ubuntu 20.04 is supported after 0.13.5
                         if self.arch == "x86_64" or (
                             self.arch == "aarch64"


### PR DESCRIPTION
While reading `utils/install.py` I noticed the Python 3 branch of the Ubuntu 20.04 detection (#5187) had a dead `or` clause. The primary check reads `/etc/lsb-release` (hyphen) and parses `DISTRIB_RELEASE`; the second `or` operand read `/etc/lsb_release` (underscore), which never exists, so it always evaluated `False` and was unreachable.

Per @hydai's suggestion, rather than fix the typo, this removes the dead operand and keeps the working `RELEASE`-based check. Detection of Ubuntu 20.04 is unchanged.

## Test plan

- `python3 -m py_compile utils/install.py` passes.
- No behavior change: on Ubuntu 20.04 the `RELEASE` check still resolves `self.dist = "ubuntu20.04"`; on non-20.04 the `else` branch is unchanged.

Fixes #5187