### PR TITLE
feat(coredump): reconstruct data instances in generateCoredump

### DIFF
--- a/lib/executor/coredump.cpp
+++ b/lib/executor/coredump.cpp
@@ -35,9 +35,8 @@ void generateCoredump(const Runtime::StackManager &StackMgr,
   Module.getCustomSections().emplace_back(createCore());
   Module.getCustomSections().emplace_back(createCorestack(
       Ser, StackMgr.getFramesSpan(), StackMgr.getValueSpan(), ForWasmgdb));
-  // TODO: reconstruct data instances
-  // Module.getDataSection() =
-  //     createData(CurrentInstance->getOwnedDataInstances());
+  Module.getDataSection() =
+      createData(CurrentInstance->getOwnedDataInstances());
   // TODO: pass all module instances
   Module.getCustomSections().emplace_back(
       createCoremodules(Ser, {CurrentInstance}));
@@ -148,19 +147,24 @@ AST::CustomSection createCorestack(
   return CoreStack;
 }
 
-// AST::DataSection
-// createData(Span<const Runtime::Instance::DataInstance *const> DataInstances)
-// {
-//   AST::DataSection DataSec;
-//   AST::DataSegment Seg;
-//   auto &Content = Seg.getData();
-//   for (auto &Data : DataInstances) {
-//     Content.insert(Content.end(), Data->getData().begin(),
-//                    Data->getData().end());
-//   }
-//   DataSec.getContent().push_back(Seg);
-//   return DataSec;
-// }
+AST::DataSection
+createData(Span<const Runtime::Instance::DataInstance *const> DataInstances) {
+  AST::DataSection DataSec;
+  for (const auto *Data : DataInstances) {
+    if (Data == nullptr) {
+      continue;
+    }
+    const auto Bytes = Data->getData();
+    if (Bytes.empty()) {
+      continue;
+    }
+    AST::DataSegment Seg;
+    Seg.setMode(AST::DataSegment::DataMode::Passive);
+    Seg.getData().assign(Bytes.begin(), Bytes.end());
+    DataSec.getContent().push_back(std::move(Seg));
+  }
+  return DataSec;
+}
 AST::GlobalSection createGlobals(
     Span<const Runtime::Instance::GlobalInstance *const> GlobalInstances) {
   AST::GlobalSection Globals;

--- a/test/executor/ExecutorTest.cpp
+++ b/test/executor/ExecutorTest.cpp
@@ -331,6 +331,60 @@ TEST(Coredump, generateCoredump) {
   }
   EXPECT_TRUE(FindCoredump);
 }
+TEST(Coredump, dataSectionRoundTrip) {
+  WasmEdge::Configure Conf;
+  Conf.getRuntimeConfigure().setEnableCoredump(true);
+  Conf.getRuntimeConfigure().setCoredumpWasmgdb(false);
+  WasmEdge::VM::VM VM(Conf);
+
+  // Same 70-byte module as generateCoredump, PLUS a real active data
+  // segment appended (id 0x0b = Data section):
+  //   flags=0x00 (active, memory 0)
+  //   offset expr: i32.const 0, end   -> 0x41 0x00 0x0b
+  //   vector length = 4               -> 0x04
+  //   payload bytes                   -> 0xDE 0xAD 0xBE 0xEF
+  std::array<WasmEdge::Byte, 82> Wasm{
+      0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x04, 0x01, 0x60,
+      0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0x05, 0x03, 0x01, 0x00, 0x01, 0x07,
+      0x1e, 0x02, 0x03, 0x6d, 0x65, 0x6d, 0x02, 0x00, 0x14, 0x61, 0x63, 0x63,
+      0x65, 0x73, 0x73, 0x5f, 0x6f, 0x75, 0x74, 0x5f, 0x6f, 0x66, 0x5f, 0x62,
+      0x6f, 0x75, 0x6e, 0x64, 0x73, 0x00, 0x00, 0x0a, 0x0d, 0x01, 0x0b, 0x00,
+      0x41, 0xf0, 0xa2, 0x04, 0x41, 0x00, 0x36, 0x02, 0x00, 0x0b,
+      // --- appended data section ---
+      0x0b, 0x0a, 0x01, 0x00, 0x41, 0x00, 0x0b, 0x04, 0xde, 0xad, 0xbe, 0xef};
+
+  ASSERT_TRUE(VM.loadWasm(Wasm));
+  ASSERT_TRUE(VM.validate());
+  ASSERT_TRUE(VM.instantiate());
+  VM.execute("access_out_of_bounds");
+
+  // Find the coredump file the trap just generated.
+  std::filesystem::path CoredumpPath;
+  bool FindCoredump = false;
+  for (const auto &Entry : std::filesystem::directory_iterator("./")) {
+    if (Entry.path().string().find("coredump.") != std::string::npos) {
+      CoredumpPath = Entry.path();
+      FindCoredump = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(FindCoredump);
+
+  // Parse the coredump binary back as a wasm module and check the
+  // data section round-tripped correctly.
+  WasmEdge::Loader::Loader Ldr(Conf);
+  auto CoredumpAST = Ldr.parseModule(CoredumpPath);
+  ASSERT_TRUE(CoredumpAST);
+
+  const auto &DataSecs = (*CoredumpAST)->getDataSection().getContent();
+  ASSERT_EQ(DataSecs.size(), 1u);
+
+  std::vector<WasmEdge::Byte> Expected = {0xde, 0xad, 0xbe, 0xef};
+  EXPECT_EQ(DataSecs[0].getData(), Expected);
+
+  // Clean up the generated coredump file.
+  std::filesystem::remove(CoredumpPath);
+}
 
 } // namespace
 


### PR DESCRIPTION
## Description
This re-enables `createData()`, which was fully implemented but commented
out since the original coredump feature landed in #3860. `generateCoredump()`
now calls it via `CurrentInstance->getOwnedDataInstances()`, same pattern
already used for `createGlobals()` right below it.

Checked git history first, this function hasn't been touched since #3860,
and there's no open issue or PR against it currently.

Opening as draft since the existing tests only check that coredump
generation doesn't crash, not that the data section content is correct.
Planning to add a regression test that generates a coredump from a module
with a real `(data ...)` segment and checks the bytes round-trip, will
flip to ready to review, once im done

## Checklist

- [x] **DCO Signed-off**
- [x] **Commit Messages**
- [x] **Coding Style**
- [x] **Local Tests Passed**
- [x] AI Disclosure
- [x] Human-in-the-loop

## Test Evidence

macOS arm64, WASMEDGE_USE_LLVM=OFF:

<img width="651" height="370" alt="Screenshot 2026-08-06 at 11 15 56 PM" src="https://github.com/user-attachments/assets/456be47d-627b-48ac-8a2b-c6d717f6629c" />
<img width="640" height="406" alt="Screenshot 2026-08-06 at 11 16 49 PM" src="https://github.com/user-attachments/assets/10fe4c0c-6927-4123-89cb-3f6f45a6fb3e" />

Both `wasmedgeExecutorCoreTests` and `wasmedgeDriverToolTests` passed,
including `RunSubcommand.RunSpecificFlags` covering the `--enable-coredump`
CLI path.