### PR TITLE
refactor: remove legacy proposal enable flags

### DIFF
--- a/include/driver/options.h
+++ b/include/driver/options.h
@@ -47,29 +47,6 @@ struct DriverProposalOptions {
         PropRelaxedSIMD(PO::Description("Disable Relaxed SIMD proposal"sv)),
         PropExceptionHandling(
             PO::Description("Disable Exception handling proposal"sv)),
-        PropTailCallDeprecated(PO::Description(
-            "(DEPRECATED) Enable Tail-call proposal. WASM 3.0 includes this "
-            "proposal, and this option will be removed in the future."sv)),
-        PropExtendConstDeprecated(PO::Description(
-            "(DEPRECATED) Enable Extended-const proposal. WASM 3.0 includes "
-            "this proposal, and this option will be removed in the future."sv)),
-        PropFunctionReferenceDeprecated(PO::Description(
-            "(DEPRECATED) Enable Function Reference proposal. WASM 3.0 "
-            "includes this proposal, and this option will be removed in the "
-            "future."sv)),
-        PropGCDeprecated(PO::Description(
-            "(DEPRECATED) Enable GC proposal. WASM 3.0 includes this proposal, "
-            "and this option will be removed in the future."sv)),
-        PropMultiMemDeprecated(PO::Description(
-            "(DEPRECATED) Enable Multiple memories proposal. WASM 3.0 includes "
-            "this proposal, and this option will be removed in the future."sv)),
-        PropRelaxedSIMDDeprecated(PO::Description(
-            "(DEPRECATED) Enable Relaxed SIMD proposal. WASM 3.0 includes this "
-            "proposal, and this option will be removed in the future."sv)),
-        PropExceptionHandlingDeprecated(PO::Description(
-            "(DEPRECATED) Enable Exception handling proposal. WASM 3.0 "
-            "includes this proposal, and this option will be removed in the "
-            "future."sv)),
         PropMemory64(PO::Description("Disable Memory64 proposal"sv)),
         PropThreads(PO::Description("Enable Threads proposal"sv)),
         PropAll(PO::Description("Enable all features"sv)) {}
@@ -91,13 +68,6 @@ struct DriverProposalOptions {
   PO::Option<PO::Toggle> PropMultiMem;
   PO::Option<PO::Toggle> PropRelaxedSIMD;
   PO::Option<PO::Toggle> PropExceptionHandling;
-  PO::Option<PO::Toggle> PropTailCallDeprecated;
-  PO::Option<PO::Toggle> PropExtendConstDeprecated;
-  PO::Option<PO::Toggle> PropFunctionReferenceDeprecated;
-  PO::Option<PO::Toggle> PropGCDeprecated;
-  PO::Option<PO::Toggle> PropMultiMemDeprecated;
-  PO::Option<PO::Toggle> PropRelaxedSIMDDeprecated;
-  PO::Option<PO::Toggle> PropExceptionHandlingDeprecated;
   PO::Option<PO::Toggle> PropMemory64;
   PO::Option<PO::Toggle> PropThreads;
   PO::Option<PO::Toggle> PropAll;
@@ -120,15 +90,6 @@ struct DriverProposalOptions {
         .add_option("disable-multi-memory"sv, PropMultiMem)
         .add_option("disable-relaxed-simd"sv, PropRelaxedSIMD)
         .add_option("disable-exception-handling"sv, PropExceptionHandling)
-        .add_option("enable-tail-call"sv, PropTailCallDeprecated)
-        .add_option("enable-extended-const"sv, PropExtendConstDeprecated)
-        .add_option("enable-function-reference"sv,
-                    PropFunctionReferenceDeprecated)
-        .add_option("enable-gc"sv, PropGCDeprecated)
-        .add_option("enable-multi-memory"sv, PropMultiMemDeprecated)
-        .add_option("enable-relaxed-simd"sv, PropRelaxedSIMDDeprecated)
-        .add_option("enable-exception-handling"sv,
-                    PropExceptionHandlingDeprecated)
         .add_option("disable-memory64"sv, PropMemory64)
         .add_option("enable-threads"sv, PropThreads)
         .add_option("enable-all"sv, PropAll);

--- a/lib/driver/toolConfig.cpp
+++ b/lib/driver/toolConfig.cpp
@@ -64,21 +64,6 @@ createProposalConfigure(const struct DriverProposalOptions &Opt) noexcept {
   if (Opt.PropMemory64.value()) {
     Conf.removeProposal(Proposal::Memory64);
   }
-  if (Opt.PropTailCallDeprecated.value()) {
-    Conf.addProposal(Proposal::TailCall);
-  }
-  if (Opt.PropExtendConstDeprecated.value()) {
-    Conf.addProposal(Proposal::ExtendedConst);
-  }
-  if (Opt.PropMultiMemDeprecated.value()) {
-    Conf.addProposal(Proposal::MultiMemories);
-  }
-  if (Opt.PropRelaxedSIMDDeprecated.value()) {
-    Conf.addProposal(Proposal::RelaxSIMD);
-  }
-  if (Opt.PropExceptionHandlingDeprecated.value()) {
-    Conf.addProposal(Proposal::ExceptionHandling);
-  }
 
   // Handle the proposal removal which has dependency.
   // The GC proposal depends on the func-ref proposal, and the func-ref proposal
@@ -94,12 +79,6 @@ createProposalConfigure(const struct DriverProposalOptions &Opt) noexcept {
     // This will automatically not work if the GC or func-ref proposal not
     // disabled.
     Conf.removeProposal(Proposal::ReferenceTypes);
-  }
-  if (Opt.PropFunctionReferenceDeprecated.value()) {
-    Conf.addProposal(Proposal::FunctionReferences);
-  }
-  if (Opt.PropGCDeprecated.value()) {
-    Conf.addProposal(Proposal::GC);
   }
 
   if (Opt.PropThreads.value()) {

--- a/test/driver/driverToolTest.cpp
+++ b/test/driver/driverToolTest.cpp
@@ -412,13 +412,6 @@ TEST(ParseSubcommand, EnableProposalFlags) {
   EXPECT_EQ(callParse({"--enable-all", Path}), EXIT_SUCCESS);
   EXPECT_EQ(callParse({"--enable-threads", Path}), EXIT_SUCCESS);
   EXPECT_EQ(callParse({"--enable-component", Path}), EXIT_SUCCESS);
-  EXPECT_EQ(callParse({"--enable-tail-call", Path}), EXIT_SUCCESS);
-  EXPECT_EQ(callParse({"--enable-extended-const", Path}), EXIT_SUCCESS);
-  EXPECT_EQ(callParse({"--enable-function-reference", Path}), EXIT_SUCCESS);
-  EXPECT_EQ(callParse({"--enable-gc", Path}), EXIT_SUCCESS);
-  EXPECT_EQ(callParse({"--enable-multi-memory", Path}), EXIT_SUCCESS);
-  EXPECT_EQ(callParse({"--enable-relaxed-simd", Path}), EXIT_SUCCESS);
-  EXPECT_EQ(callParse({"--enable-exception-handling", Path}), EXIT_SUCCESS);
 }
 
 TEST(ParseSubcommand, WasmStandardFlags) {
@@ -615,13 +608,6 @@ TEST(ValidateSubcommand, EnableProposalFlags) {
   EXPECT_EQ(callValidate({"--enable-all", Path}), EXIT_SUCCESS);
   EXPECT_EQ(callValidate({"--enable-threads", Path}), EXIT_SUCCESS);
   EXPECT_EQ(callValidate({"--enable-component", Path}), EXIT_SUCCESS);
-  EXPECT_EQ(callValidate({"--enable-tail-call", Path}), EXIT_SUCCESS);
-  EXPECT_EQ(callValidate({"--enable-extended-const", Path}), EXIT_SUCCESS);
-  EXPECT_EQ(callValidate({"--enable-function-reference", Path}), EXIT_SUCCESS);
-  EXPECT_EQ(callValidate({"--enable-gc", Path}), EXIT_SUCCESS);
-  EXPECT_EQ(callValidate({"--enable-multi-memory", Path}), EXIT_SUCCESS);
-  EXPECT_EQ(callValidate({"--enable-relaxed-simd", Path}), EXIT_SUCCESS);
-  EXPECT_EQ(callValidate({"--enable-exception-handling", Path}), EXIT_SUCCESS);
 }
 
 TEST(ValidateSubcommand, WasmStandardFlags) {


### PR DESCRIPTION
# Description

This PR removes the legacy WebAssembly proposal enable flags that were marked for removal in WasmEdge 0.18.0 (tracking issue #4996).

The following CLI options have been removed from the parser:

* `--enable-tail-call`
* `--enable-extended-const`
* `--enable-function-reference`
* `--enable-gc`
* `--enable-multi-memory`
* `--enable-relaxed-simd`
* `--enable-exception-handling`

These proposals are already enabled by the default `WASM_3` configuration, so the explicit `--enable-*` flags are no longer required. After this change, passing any of the removed flags results in the standard CLI "unknown option" error.

This PR also removes the associated parser configuration and updates the driver tests accordingly. The removal of other deprecated options (such as `--enable-jit`, `--force-interpreter`, and deprecated CMake options) is intentionally out of scope and will be handled in separate changes.

**Related Issue:** #4996

## Checklist

* [x] **DCO Signed-off**: All commits are signed off (`git commit -s`).
* [x] **Commit Messages**: Commit messages follow the Conventional Commit specification.
* [x] **Coding Style**: Code has been formatted according to the project's coding style.
* [x] **Local Tests Passed**: Local build and driver tests completed successfully.
* [ ] **AI Disclosure**: Not applicable.
* [x] **Human-in-the-loop**: All changes have been reviewed and verified before submission.

## Test Evidence

### Build

* Successfully built WasmEdge after the changes.

### Automated Tests

* Updated `wasmedgeDriverToolTests` to remove expectations for the deleted flags.
* Verified the driver test suite passes locally.

### Manual Verification

* Confirmed `wasmedge --help` no longer lists the removed `--enable-*` options.
* Verified each removed option is rejected by the CLI parser with an "unknown option" error.
