### PR TITLE
[WIP] feat: Implement Wide Arithmetic Proposal (Interpreter)

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -409,6 +409,12 @@ OFC(Table__grow, "table.grow", 0xFC, 15)
 OFC(Table__size, "table.size", 0xFC, 16)
 OFC(Table__fill, "table.fill", 0xFC, 17)
 
+// 0xFC prefix - Wide Arithmetic Instructions
+OFC(I64__add128, "i64.add128", 0xFC, 19)
+OFC(I64__sub128, "i64.sub128", 0xFC, 20)
+OFC(I64__mul_wide_s, "i64.mul_wide_s", 0xFC, 21)
+OFC(I64__mul_wide_u, "i64.mul_wide_u", 0xFC, 22)
+
 // 0xFD prefix - Vector Memory Instructions (part 1)
 OFD(V128__load, "v128.load", 0xFD, 0)
 OFD(V128__load8x8_s, "v128.load8x8_s", 0xFD, 1)

--- a/lib/executor/engine/engine.cpp
+++ b/lib/executor/engine/engine.cpp
@@ -851,6 +851,55 @@ Expect<void> Executor::execute(Runtime::StackManager &StackMgr,
     case OpCode::I64__trunc_sat_f64_u:
       return runTruncateSatOp<double, uint64_t>(StackMgr.getTop());
 
+    // Wide Arithmetic Instructions
+    case OpCode::I64__add128: {
+      using uint128 = unsigned __int128;
+      uint64_t Hi2 = StackMgr.pop().get<uint64_t>();
+      uint64_t Lo2 = StackMgr.pop().get<uint64_t>();
+      uint64_t Hi1 = StackMgr.pop().get<uint64_t>();
+      uint128 V1 = (static_cast<uint128>(Hi1) << 64) |
+                   StackMgr.getTop().get<uint64_t>();
+      uint128 V2 = (static_cast<uint128>(Hi2) << 64) | Lo2;
+      uint128 Result = V1 + V2;
+      StackMgr.getTop().emplace<uint64_t>(static_cast<uint64_t>(Result));
+      StackMgr.push(ValVariant(static_cast<uint64_t>(Result >> 64)));
+      return {};
+    }
+    case OpCode::I64__sub128: {
+      using uint128 = unsigned __int128;
+      uint64_t Hi2 = StackMgr.pop().get<uint64_t>();
+      uint64_t Lo2 = StackMgr.pop().get<uint64_t>();
+      uint64_t Hi1 = StackMgr.pop().get<uint64_t>();
+      uint128 V1 = (static_cast<uint128>(Hi1) << 64) |
+                   StackMgr.getTop().get<uint64_t>();
+      uint128 V2 = (static_cast<uint128>(Hi2) << 64) | Lo2;
+      uint128 Result = V1 - V2;
+      StackMgr.getTop().emplace<uint64_t>(static_cast<uint64_t>(Result));
+      StackMgr.push(ValVariant(static_cast<uint64_t>(Result >> 64)));
+      return {};
+    }
+    case OpCode::I64__mul_wide_s: {
+      using int128 = __int128;
+      int64_t V2 = StackMgr.pop().get<int64_t>();
+      int128 Result =
+          static_cast<int128>(StackMgr.getTop().get<int64_t>()) *
+          static_cast<int128>(V2);
+      auto UResult = static_cast<unsigned __int128>(Result);
+      StackMgr.getTop().emplace<uint64_t>(static_cast<uint64_t>(UResult));
+      StackMgr.push(ValVariant(static_cast<uint64_t>(UResult >> 64)));
+      return {};
+    }
+    case OpCode::I64__mul_wide_u: {
+      using uint128 = unsigned __int128;
+      uint64_t V2 = StackMgr.pop().get<uint64_t>();
+      uint128 Result =
+          static_cast<uint128>(StackMgr.getTop().get<uint64_t>()) *
+          static_cast<uint128>(V2);
+      StackMgr.getTop().emplace<uint64_t>(static_cast<uint64_t>(Result));
+      StackMgr.push(ValVariant(static_cast<uint64_t>(Result >> 64)));
+      return {};
+    }
+
     // SIMD Memory Instructions
     case OpCode::V128__load:
       return runLoadOp<uint128_t>(

--- a/lib/loader/ast/instruction.cpp
+++ b/lib/loader/ast/instruction.cpp
@@ -659,6 +659,10 @@ Expect<void> Loader::loadInstruction(AST::Instruction &Instr) {
   case OpCode::I64__trunc_sat_f32_u:
   case OpCode::I64__trunc_sat_f64_s:
   case OpCode::I64__trunc_sat_f64_u:
+  case OpCode::I64__add128:
+  case OpCode::I64__sub128:
+  case OpCode::I64__mul_wide_s:
+  case OpCode::I64__mul_wide_u:
 
   // Binary Numeric Instructions.
   case OpCode::I32__eq:

--- a/lib/loader/serialize/serial_instruction.cpp
+++ b/lib/loader/serialize/serial_instruction.cpp
@@ -410,6 +410,10 @@ Serializer::serializeInstruction(const AST::Instruction &Instr,
   case OpCode::I64__trunc_sat_f32_u:
   case OpCode::I64__trunc_sat_f64_s:
   case OpCode::I64__trunc_sat_f64_u:
+  case OpCode::I64__add128:
+  case OpCode::I64__sub128:
+  case OpCode::I64__mul_wide_s:
+  case OpCode::I64__mul_wide_u:
 
   // Binary Numeric Instructions.
   case OpCode::I32__eq:

--- a/lib/validator/formchecker.cpp
+++ b/lib/validator/formchecker.cpp
@@ -1379,6 +1379,17 @@ Expect<void> FormChecker::checkInstr(const AST::Instruction &Instr) {
   case OpCode::I64__trunc_sat_f64_u:
     return StackTrans({ValType(TypeCode::F64)}, {ValType(TypeCode::I64)});
 
+  // Wide Arithmetic Instructions.
+  case OpCode::I64__add128:
+  case OpCode::I64__sub128:
+    return StackTrans({ValType(TypeCode::I64), ValType(TypeCode::I64),
+                       ValType(TypeCode::I64), ValType(TypeCode::I64)},
+                      {ValType(TypeCode::I64), ValType(TypeCode::I64)});
+  case OpCode::I64__mul_wide_s:
+  case OpCode::I64__mul_wide_u:
+    return StackTrans({ValType(TypeCode::I64), ValType(TypeCode::I64)},
+                      {ValType(TypeCode::I64), ValType(TypeCode::I64)});
+
   // Binary Numeric Instructions.
   case OpCode::I32__eq:
   case OpCode::I32__ne:

--- a/test/executor/ExecutorRegressionTest.cpp
+++ b/test/executor/ExecutorRegressionTest.cpp
@@ -1176,6 +1176,100 @@ TEST(ExecutorRegression, CallIndirectNonFuncTable) {
   EXPECT_EQ(Result.error(), ErrCode::Value::TypeCheckFailed);
 }
 
+/// Test Wide Arithmetic proposal interpreter execution (i64.add128, i64.sub128, i64.mul_wide_s, i64.mul_wide_u).
+TEST(ExecutorRegression, WideArithmeticInstructions) {
+  const std::vector<uint8_t> Wasm = {
+      // Preamble
+      0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+      // Type section: 1 type (func () -> (i64, i64)) - 6 bytes
+      0x01, 0x06, 0x01, 0x60, 0x00, 0x02, 0x7e, 0x7e,
+      // Function section: 4 functions using type 0 - 5 bytes
+      0x03, 0x05, 0x04, 0x00, 0x00, 0x00, 0x00,
+      // Export section: 4 exports - 45 bytes (0x2d)
+      0x07, 0x2d, 0x04,
+      0x06, 'a', 'd', 'd', '1', '2', '8', 0x00, 0x00,
+      0x06, 's', 'u', 'b', '1', '2', '8', 0x00, 0x01,
+      0x0a, 'm', 'u', 'l', '_', 'w', 'i', 'd', 'e', '_', 's', 0x00, 0x02,
+      0x0a, 'm', 'u', 'l', '_', 'w', 'i', 'd', 'e', '_', 'u', 0x00, 0x03,
+      // Code section: 53 bytes (0x35)
+      0x0a, 0x35, 0x04,
+      // Function 0: add128 (12 bytes = 0x0c)
+      0x0c, 0x00,
+      0x42, 0x7f,                                                       // i64.const -1 (0xFFFFFFFFFFFFFFFF)
+      0x42, 0x00,                                                       // i64.const 0
+      0x42, 0x01,                                                       // i64.const 1
+      0x42, 0x00,                                                       // i64.const 0
+      0xfc, 0x13,                                                       // i64.add128
+      0x0b,
+      // Function 1: sub128 (12 bytes = 0x0c)
+      0x0c, 0x00,
+      0x42, 0x00,                                                       // i64.const 0
+      0x42, 0x01,                                                       // i64.const 1
+      0x42, 0x01,                                                       // i64.const 1
+      0x42, 0x00,                                                       // i64.const 0
+      0xfc, 0x14,                                                       // i64.sub128
+      0x0b,
+      // Function 2: mul_wide_s (8 bytes = 0x08)
+      0x08, 0x00,
+      0x42, 0x7f,                                                       // i64.const -1
+      0x42, 0x01,                                                       // i64.const 1
+      0xfc, 0x15,                                                       // i64.mul_wide_s
+      0x0b,
+      // Function 3: mul_wide_u (16 bytes = 0x10)
+      0x10, 0x00,
+      0x42, 0x80, 0x80, 0x80, 0x80, 0x10,                               // i64.const 0x100000000
+      0x42, 0x80, 0x80, 0x80, 0x80, 0x10,                               // i64.const 0x100000000
+      0xfc, 0x16,                                                       // i64.mul_wide_u
+      0x0b
+  };
+
+  Configure Conf;
+  VM::VM VM(Conf);
+  ASSERT_TRUE(VM.loadWasm(Wasm));
+  ASSERT_TRUE(VM.validate());
+  ASSERT_TRUE(VM.instantiate());
+
+  // Test add128: 0xFFFFFFFFFFFFFFFF + 1 = 0 (lo), 1 (hi)
+  {
+    auto Res = VM.execute("add128");
+    ASSERT_TRUE(Res);
+    auto Returns = Res.value();
+    ASSERT_EQ(Returns.size(), 2U);
+    EXPECT_EQ(Returns[0].first.get<uint64_t>(), 0ULL);
+    EXPECT_EQ(Returns[1].first.get<uint64_t>(), 1ULL);
+  }
+
+  // Test sub128: (0, 1) - (1, 0) = 0xFFFFFFFFFFFFFFFF (lo), 0 (hi)
+  {
+    auto Res = VM.execute("sub128");
+    ASSERT_TRUE(Res);
+    auto Returns = Res.value();
+    ASSERT_EQ(Returns.size(), 2U);
+    EXPECT_EQ(Returns[0].first.get<uint64_t>(), 0xFFFFFFFFFFFFFFFFULL);
+    EXPECT_EQ(Returns[1].first.get<uint64_t>(), 0ULL);
+  }
+
+  // Test mul_wide_s: -1 * 1 = -1 (lo), -1 (hi)
+  {
+    auto Res = VM.execute("mul_wide_s");
+    ASSERT_TRUE(Res);
+    auto Returns = Res.value();
+    ASSERT_EQ(Returns.size(), 2U);
+    EXPECT_EQ(Returns[0].first.get<uint64_t>(), 0xFFFFFFFFFFFFFFFFULL);
+    EXPECT_EQ(Returns[1].first.get<uint64_t>(), 0xFFFFFFFFFFFFFFFFULL);
+  }
+
+  // Test mul_wide_u: 2^32 * 2^32 = 0 (lo), 1 (hi)
+  {
+    auto Res = VM.execute("mul_wide_u");
+    ASSERT_TRUE(Res);
+    auto Returns = Res.value();
+    ASSERT_EQ(Returns.size(), 2U);
+    EXPECT_EQ(Returns[0].first.get<uint64_t>(), 0ULL);
+    EXPECT_EQ(Returns[1].first.get<uint64_t>(), 1ULL);
+  }
+}
+
 } // namespace
 
 GTEST_API_ int main(int argc, char **argv) {


### PR DESCRIPTION
### Description
This draft PR implements the Interpreter path for the WebAssembly Wide Arithmetic Proposal (Issue #5153). 

This is being submitted as part of my LFX Term 3 Mentorship application process to prove out the core logic before moving to the LLVM AOT/JIT implementation.

**Completed in this PR:**
* Registered `i64.add128`, `i64.sub128`, `i64.mul_wide_s`, and `i64.mul_wide_u` in the `0xFC` opcode space.
* Added Loader and Serializer support for bytecode decoding/encoding.
* Added Validator stack shape enforcement (4->2 and 2->2 transitions).
* Implemented 128-bit execution logic natively in `engine.cpp`.
* Added comprehensive unit tests in `ExecutorRegressionTest.cpp`.

**Known Remaining Work:**
* **Windows Build CI:** The current `engine.cpp` implementation leverages the fast path `unsigned __int128` extension for GCC/Clang. I am aware this will fail the MSVC Windows CI checks, and I will be adding the `#ifdef _MSC_VER` compiler intrinsic fallbacks (e.g., `_addcarry_u64`) shortly.
* **AOT/JIT Lowering:** Wiring up the LLVM IR generation in `lib/llvm/compiler/numericInstr.cpp`.

Would appreciate any early feedback on the interpreter dispatch or validator logic while I spin up the LLVM build!