### PR TITLE
fix(wasi): trap on misaligned wasi fd path and poll pointers

### DIFF
--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -650,7 +650,7 @@ Expect<uint32_t> WasiFdFdstatGet::body(const Runtime::CallingFrame &Frame,
                                        uint32_t /* Out */ FdStatPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_fdstat_t>(FdStatPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   // Check memory instance from module.
@@ -721,7 +721,7 @@ Expect<uint32_t> WasiFdFilestatGet::body(const Runtime::CallingFrame &Frame,
                                          uint32_t /* Out */ FilestatPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_filestat_t>(FilestatPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   // Check memory instance from module.
@@ -783,11 +783,11 @@ Expect<uint32_t> WasiFdPread::body(const Runtime::CallingFrame &Frame,
                                    uint32_t /* Out */ NReadPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_iovec_t>(IOVsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(NReadPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   // Check memory instance from module.
@@ -873,7 +873,7 @@ Expect<uint32_t> WasiFdPrestatGet::body(const Runtime::CallingFrame &Frame,
                                         uint32_t /* Out */ PreStatPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_prestat_t>(PreStatPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   // Check memory instance from module.
@@ -902,11 +902,11 @@ Expect<uint32_t> WasiFdPwrite::body(const Runtime::CallingFrame &Frame,
                                     uint32_t /* Out */ NWrittenPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_ciovec_t>(IOVsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(NWrittenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   // Check memory instance from module.
@@ -971,11 +971,11 @@ Expect<uint32_t> WasiFdRead::body(const Runtime::CallingFrame &Frame,
                                   uint32_t /* Out */ NReadPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_iovec_t>(IOVsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(NReadPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   // Check memory instance from module.
@@ -1035,7 +1035,7 @@ Expect<uint32_t> WasiFdReadDir::body(const Runtime::CallingFrame &Frame,
                                      uint32_t /* Out */ NReadPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_size_t>(NReadPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
   // BufPtr should be aligned to at least 1 byte (which is always true)
 
@@ -1084,7 +1084,7 @@ Expect<int32_t> WasiFdSeek::body(const Runtime::CallingFrame &Frame, int32_t Fd,
                                  uint32_t /* Out */ NewOffsetPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_filesize_t>(NewOffsetPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   // Check memory instance from module.
@@ -1129,7 +1129,7 @@ Expect<uint32_t> WasiFdTell::body(const Runtime::CallingFrame &Frame,
                                   int32_t Fd, uint32_t /* Out */ OffsetPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_filesize_t>(OffsetPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   // Check memory instance from module.
@@ -1249,7 +1249,7 @@ Expect<uint32_t> WasiPathFilestatGet::body(const Runtime::CallingFrame &Frame,
                                            uint32_t /* Out */ FilestatPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_filestat_t>(FilestatPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
   // PathPtr should be aligned to at least 1 byte (which is always true)
 
@@ -1381,7 +1381,7 @@ Expect<uint32_t> WasiPathOpen::body(
     uint64_t FsRightsInheriting, uint32_t FsFlags, uint32_t /* Out */ FdPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_fd_t>(FdPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
   // PathPtr should be aligned to at least 1 byte (which is always true)
 
@@ -1464,7 +1464,7 @@ Expect<uint32_t> WasiPathReadLink::body(const Runtime::CallingFrame &Frame,
                                         uint32_t /* Out */ NReadPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_size_t>(NReadPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
   // BufPtr and PathPtr should be aligned to at least 1 byte (which is always
   // true)
@@ -1633,13 +1633,13 @@ Expect<uint32_t> WasiPollOneoff<Trigger>::body(
     uint32_t NSubscriptions, uint32_t /* Out */ NEventsPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_subscription_t>(InPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
   if (unlikely(isMisaligned<__wasi_event_t>(OutPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
   if (unlikely(isMisaligned<__wasi_size_t>(NEventsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
   // Check memory instance from module.
   auto *MemInst = Frame.getMemoryByIndex(0);

--- a/test/host/wasi/wasi.cpp
+++ b/test/host/wasi/wasi.cpp
@@ -4531,12 +4531,13 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_fdstat_t) * 3);
 
     // Test misaligned FdStatPtr
-    EXPECT_TRUE(WasiFdFdstatGet.run(CallFrame,
-                                    std::initializer_list<WasmEdge::ValVariant>{
-                                        static_cast<int32_t>(0), // stdin fd
-                                        MisalignedFdStatPtr},    // misaligned
-                                    Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    auto Res = WasiFdFdstatGet.run(CallFrame,
+                                   std::initializer_list<WasmEdge::ValVariant>{
+                                       static_cast<int32_t>(0), // stdin fd
+                                       MisalignedFdStatPtr},    // misaligned
+                                   Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned FdStatPtr (should succeed)
@@ -4558,13 +4559,14 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_filestat_t) * 3);
 
     // Test misaligned FilestatPtr
-    EXPECT_TRUE(
+    auto Res =
         WasiFdFilestatGet.run(CallFrame,
                               std::initializer_list<WasmEdge::ValVariant>{
                                   static_cast<int32_t>(0), // stdin fd
                                   MisalignedFilestatPtr},  // misaligned
-                              Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+                              Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned FilestatPtr (should succeed)
@@ -4590,26 +4592,28 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_size_t) * 4);
 
     // Test misaligned IOVsPtr
-    EXPECT_TRUE(WasiFdPread.run(CallFrame,
-                                std::initializer_list<WasmEdge::ValVariant>{
-                                    static_cast<int32_t>(0), // stdin fd
-                                    MisalignedIOVsPtr, // misaligned IOVsPtr
-                                    static_cast<uint32_t>(1), // IOVsLen
-                                    static_cast<uint64_t>(0), // Offset
-                                    AlignedNReadPtr}, // aligned NReadPtr
-                                Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    auto Res = WasiFdPread.run(CallFrame,
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   static_cast<int32_t>(0), // stdin fd
+                                   MisalignedIOVsPtr, // misaligned IOVsPtr
+                                   static_cast<uint32_t>(1), // IOVsLen
+                                   static_cast<uint64_t>(0), // Offset
+                                   AlignedNReadPtr},         // aligned NReadPtr
+                               Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     // Test misaligned NReadPtr
-    EXPECT_TRUE(WasiFdPread.run(CallFrame,
-                                std::initializer_list<WasmEdge::ValVariant>{
-                                    static_cast<int32_t>(0),  // stdin fd
-                                    AlignedIOVsPtr,           // aligned IOVsPtr
-                                    static_cast<uint32_t>(1), // IOVsLen
-                                    static_cast<uint64_t>(0), // Offset
-                                    MisalignedNReadPtr}, // misaligned NReadPtr
-                                Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    Res = WasiFdPread.run(CallFrame,
+                          std::initializer_list<WasmEdge::ValVariant>{
+                              static_cast<int32_t>(0),  // stdin fd
+                              AlignedIOVsPtr,           // aligned IOVsPtr
+                              static_cast<uint32_t>(1), // IOVsLen
+                              static_cast<uint64_t>(0), // Offset
+                              MisalignedNReadPtr},      // misaligned NReadPtr
+                          Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned pointers (should pass alignment but may fail on
@@ -4635,13 +4639,13 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_prestat_t) * 2);
 
     // Test misaligned PreStatPtr
-    EXPECT_TRUE(
-        WasiFdPrestatGet.run(CallFrame,
-                             std::initializer_list<WasmEdge::ValVariant>{
-                                 static_cast<int32_t>(3), // preopen fd
-                                 MisalignedPreStatPtr},   // misaligned
-                             Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    auto Res = WasiFdPrestatGet.run(CallFrame,
+                                    std::initializer_list<WasmEdge::ValVariant>{
+                                        static_cast<int32_t>(3), // preopen fd
+                                        MisalignedPreStatPtr},   // misaligned
+                                    Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned PreStatPtr (should succeed)
@@ -4667,27 +4671,28 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_ciovec_t) * 2);
 
     // Test misaligned IOVsPtr
-    EXPECT_TRUE(WasiFdPwrite.run(CallFrame,
-                                 std::initializer_list<WasmEdge::ValVariant>{
-                                     static_cast<int32_t>(1), // stdout fd
-                                     MisalignedIOVsPtr, // misaligned IOVsPtr
-                                     static_cast<uint32_t>(1), // IOVsLen
-                                     static_cast<uint64_t>(0), // Offset
-                                     AlignedNWrittenPtr}, // aligned NWrittenPtr
-                                 Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    auto Res = WasiFdPwrite.run(CallFrame,
+                                std::initializer_list<WasmEdge::ValVariant>{
+                                    static_cast<int32_t>(1), // stdout fd
+                                    MisalignedIOVsPtr, // misaligned IOVsPtr
+                                    static_cast<uint32_t>(1), // IOVsLen
+                                    static_cast<uint64_t>(0), // Offset
+                                    AlignedNWrittenPtr}, // aligned NWrittenPtr
+                                Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     // Test misaligned NWrittenPtr
-    EXPECT_TRUE(
-        WasiFdPwrite.run(CallFrame,
-                         std::initializer_list<WasmEdge::ValVariant>{
-                             static_cast<int32_t>(1),  // stdout fd
-                             AlignedIOVsPtr,           // aligned IOVsPtr
-                             static_cast<uint32_t>(1), // IOVsLen
-                             static_cast<uint64_t>(0), // Offset
-                             MisalignedNWrittenPtr},   // misaligned NWrittenPtr
-                         Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    Res = WasiFdPwrite.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               static_cast<int32_t>(1),  // stdout fd
+                               AlignedIOVsPtr,           // aligned IOVsPtr
+                               static_cast<uint32_t>(1), // IOVsLen
+                               static_cast<uint64_t>(0), // Offset
+                               MisalignedNWrittenPtr},   // misaligned NWrittenPtr
+                           Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned pointers (should pass alignment but may fail on
@@ -4716,24 +4721,26 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_size_t) * 2);
 
     // Test misaligned IOVsPtr
-    EXPECT_TRUE(WasiFdRead.run(CallFrame,
-                               std::initializer_list<WasmEdge::ValVariant>{
-                                   static_cast<int32_t>(0), // stdin fd
-                                   MisalignedIOVsPtr, // misaligned IOVsPtr
-                                   static_cast<uint32_t>(1), // IOVsLen
-                                   AlignedNReadPtr},         // aligned NReadPtr
-                               Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    auto Res = WasiFdRead.run(CallFrame,
+                              std::initializer_list<WasmEdge::ValVariant>{
+                                  static_cast<int32_t>(0), // stdin fd
+                                  MisalignedIOVsPtr, // misaligned IOVsPtr
+                                  static_cast<uint32_t>(1), // IOVsLen
+                                  AlignedNReadPtr},         // aligned NReadPtr
+                              Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     // Test misaligned NReadPtr
-    EXPECT_TRUE(WasiFdRead.run(CallFrame,
-                               std::initializer_list<WasmEdge::ValVariant>{
-                                   static_cast<int32_t>(0),  // stdin fd
-                                   AlignedIOVsPtr,           // aligned IOVsPtr
-                                   static_cast<uint32_t>(1), // IOVsLen
-                                   MisalignedNReadPtr}, // misaligned NReadPtr
-                               Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    Res = WasiFdRead.run(CallFrame,
+                         std::initializer_list<WasmEdge::ValVariant>{
+                             static_cast<int32_t>(0),  // stdin fd
+                             AlignedIOVsPtr,           // aligned IOVsPtr
+                             static_cast<uint32_t>(1), // IOVsLen
+                             MisalignedNReadPtr},      // misaligned NReadPtr
+                         Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned pointers (should pass alignment but may fail on
@@ -4758,7 +4765,7 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_size_t) * 2);
 
     // Test misaligned NReadPtr
-    EXPECT_TRUE(WasiFdReadDir.run(
+    auto Res = WasiFdReadDir.run(
         CallFrame,
         std::initializer_list<WasmEdge::ValVariant>{
             static_cast<int32_t>(3),    // preopen directory fd
@@ -4766,8 +4773,9 @@ TEST(WasiTest, PointerAlignment) {
             static_cast<uint32_t>(256), // BufLen
             static_cast<uint64_t>(0),   // Cookie
             MisalignedNReadPtr},        // misaligned NReadPtr
-        Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+        Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned NReadPtr (should succeed)
@@ -4793,15 +4801,16 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_filesize_t) * 4);
 
     // Test misaligned NewOffsetPtr
-    EXPECT_TRUE(
+    auto Res =
         WasiFdSeek.run(CallFrame,
                        std::initializer_list<WasmEdge::ValVariant>{
                            static_cast<int32_t>(0),                  // stdin fd
                            static_cast<int64_t>(0),                  // Offset
                            static_cast<uint32_t>(__WASI_WHENCE_SET), // Whence
                            MisalignedNewOffsetPtr}, // misaligned NewOffsetPtr
-                       Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+                       Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned NewOffsetPtr (should pass alignment but may fail
@@ -4827,12 +4836,13 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_filesize_t) * 2);
 
     // Test misaligned OffsetPtr
-    EXPECT_TRUE(WasiFdTell.run(CallFrame,
-                               std::initializer_list<WasmEdge::ValVariant>{
-                                   static_cast<int32_t>(0), // stdin fd
-                                   MisalignedOffsetPtr}, // misaligned OffsetPtr
-                               Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    auto Res = WasiFdTell.run(CallFrame,
+                              std::initializer_list<WasmEdge::ValVariant>{
+                                  static_cast<int32_t>(0), // stdin fd
+                                  MisalignedOffsetPtr}, // misaligned OffsetPtr
+                              Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned OffsetPtr (should pass alignment but may fail on
@@ -4906,7 +4916,7 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_filestat_t) * 2);
 
     // Test misaligned FilestatPtr
-    EXPECT_TRUE(WasiPathFilestatGet.run(
+    auto Res = WasiPathFilestatGet.run(
         CallFrame,
         std::initializer_list<WasmEdge::ValVariant>{
             static_cast<int32_t>(0),                                  // fd
@@ -4914,8 +4924,9 @@ TEST(WasiTest, PointerAlignment) {
             static_cast<uint32_t>(0), // path ptr
             static_cast<uint32_t>(4), // path len
             MisalignedFilestatPtr},   // misaligned FilestatPtr
-        Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+        Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned FilestatPtr (should not fail due to alignment)
@@ -4942,7 +4953,7 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_fd_t) * 4);
 
     // Test misaligned FdPtr
-    EXPECT_TRUE(
+    auto Res =
         WasiPathOpen.run(CallFrame,
                          std::initializer_list<WasmEdge::ValVariant>{
                              static_cast<int32_t>(0),  // DirFd
@@ -4954,8 +4965,9 @@ TEST(WasiTest, PointerAlignment) {
                              static_cast<uint64_t>(0), // FsRightsInheriting
                              static_cast<uint32_t>(0), // FsFlags
                              MisalignedFdPtr},         // misaligned FdPtr
-                         Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+                         Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned FdPtr (should not fail due to alignment)
@@ -4986,7 +4998,7 @@ TEST(WasiTest, PointerAlignment) {
         static_cast<uint32_t>(alignof(__wasi_size_t) * 2);
 
     // Test misaligned NReadPtr
-    EXPECT_TRUE(
+    auto Res =
         WasiPathReadLink.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  static_cast<int32_t>(0),  // Fd
@@ -4995,8 +5007,9 @@ TEST(WasiTest, PointerAlignment) {
                                  static_cast<uint32_t>(0), // BufPtr
                                  static_cast<uint32_t>(4), // BufLen
                                  MisalignedNReadPtr}, // misaligned NReadPtr
-                             Errno));
-    EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+                             Errno);
+    ASSERT_FALSE(Res);
+    EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
     writeDummyMemoryContent(MemInst);
     // Test correctly aligned NReadPtr (should not fail due to alignment)
@@ -6057,28 +6070,31 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_size_t) * 3);
 
       // Test misaligned InPtr
-      EXPECT_TRUE(WasiPollOneoff.run(
+      auto Res = WasiPollOneoff.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               MisalignedInPtr, AlignedOutPtr, Count, AlignedNEventsPtr},
-          Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+          Errno);
+      ASSERT_FALSE(Res);
+      EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
       // Test misaligned OutPtr
-      EXPECT_TRUE(WasiPollOneoff.run(
+      Res = WasiPollOneoff.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               AlignedInPtr, MisalignedOutPtr, Count, AlignedNEventsPtr},
-          Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+          Errno);
+      ASSERT_FALSE(Res);
+      EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
       // Test misaligned for NEventsPtr
-      EXPECT_TRUE(WasiPollOneoff.run(
+      Res = WasiPollOneoff.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               AlignedInPtr, AlignedOutPtr, Count, MisalignedNEventsPtr},
-          Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+          Errno);
+      ASSERT_FALSE(Res);
+      EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
       // Test properly aligned parameters (should pass alignment but may fail
       // on subscription validation)
@@ -6323,13 +6339,14 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_filestat_t));
 
       // Test misaligned filestat pointer
-      EXPECT_TRUE(WasiPathFilestatGet.run(
+      auto Res = WasiPathFilestatGet.run(
           CallFrame,
           std::initializer_list<WasmEdge::ValVariant>{
               Fd, static_cast<uint32_t>(__WASI_LOOKUPFLAGS_SYMLINK_FOLLOW),
               PathPtr, PathSize, MisalignedFilestatPtr}, // misaligned
-          Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+          Errno);
+      ASSERT_FALSE(Res);
+      EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
 
       // Correctly aligned filestat pointer (should succeed)
       EXPECT_TRUE(WasiPathFilestatGet.run(


### PR DESCRIPTION
## Description

This PR is a follow-up to #5089 and #5229. It changes the remaining selected WASI host functions to trap on misaligned typed guest pointers with `ErrCode::Value::UnalignedAtomicAccess` instead of returning `__WASI_ERRNO_ADDRNOTAVAIL`.

Updated pointer checks:

- FD simple output pointers: `fd_fdstat_get`, `fd_filestat_get`, `fd_prestat_get`, `fd_readdir`, `fd_seek`, and `fd_tell`.
- FD iovec paths: `fd_read`, `fd_pread`, and `fd_pwrite`.
- Path functions: `path_filestat_get`, `path_open`, and `path_readlink`.
- Poll: `poll_oneoff` input and output pointers.

The existing `WasiTest.PointerAlignment` coverage now verifies the trap and the returned `ErrCode` for the affected checks.

Related: #4960

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by: GPT-5.6` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

Unit test:

```console
cmake --build build-lfx-repro --target wasiTests -j$(sysctl -n hw.logicalcpu) 

./build-lfx-repro/test/host/wasi/wasiTests --gtest_filter=WasiTest.PointerAlignment
```

Result:

<img width="923" height="182" alt="image" src="https://github.com/user-attachments/assets/0d41767c-786b-4bb1-8800-946cfb6d2f94" />

Local checks:

```console
lineguard --config .lineguardrc -r lib/host/wasi/wasifunc.cpp test/host/wasi/wasi.cpp
```

Result:

```console
Checking 2 files...
✓ All files passed lint checks!
  Files checked: 2
```

CLI smoke tests covered 18 misaligned pointer cases across Interpreter, JIT, and AOT:

| Path | Cases | Interpreter | JIT | AOT compile | AOT run |
|---|---:|---:|---:|---:|---:|
| FD simple output pointers | 6 | 134 | 134 | 0 | 134 |
| FD iovec, path, and poll pointers | 12 | 134 | 134 | 0 | 134 |

All cases trapped before guest `proc_exit`. AOT compilation succeeded, and the trap occurred when each AOT module was executed.

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
