### PR TITLE
fix(loader): reject malformed cast flags

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -945,6 +945,8 @@ E(MalformedMemoryOpFlags, 0x011C, "malformed memop flags")
 E(MalformedLimitFlags, 0x011D, "malformed limits flags")
 // Malformed catch flag (Exception-handling proposal).
 E(MalformedCatchFlags, 0x011E, "malformed catch flags")
+// Malformed cast flag (GC proposal).
+E(MalformedCastFlags, 0x011F, "malformed cast flags")
 // @}
 
 // Component model load phase

--- a/lib/loader/ast/instruction.cpp
+++ b/lib/loader/ast/instruction.cpp
@@ -456,6 +456,10 @@ Expect<void> Loader::loadInstruction(AST::Instruction &Instr) {
     // Read the flag.
     uint8_t Flag = 0U;
     EXPECTED_TRY(readU8(Flag).map_error(ReportError));
+    if (unlikely(Flag > 0x03U)) {
+      return logLoadError(ErrCode::Value::MalformedCastFlags,
+                          FMgr.getLastOffset(), ASTNodeAttr::Instruction);
+    }
     // Read the label index.
     uint32_t LabelIdx = 0U;
     EXPECTED_TRY(readU32(LabelIdx).map_error(ReportError));

--- a/test/loader/instructionTest.cpp
+++ b/test/loader/instructionTest.cpp
@@ -1307,4 +1307,22 @@ TEST(InstructionTest, LoadTryTable) {
   EXPECT_FALSE(Ldr.parseModule(Vec));
 }
 
+TEST(InstructionTest, LoadBrOnCastFlags) {
+  const auto MakeModule = [](uint8_t Opcode, uint8_t Flag) {
+    return prefixedVec({0x0AU, 0x0AU, 0x01U, 0x08U, 0x00U, 0xFBU, Opcode, Flag,
+                        0x00U, 0x6DU, 0x6DU, 0x0BU});
+  };
+  const uint8_t Opcodes[] = {0x18U, 0x19U};
+  const uint8_t InvalidFlags[] = {0x04U, 0xFFU};
+
+  for (const uint8_t Opcode : Opcodes) {
+    for (uint8_t Flag = 0x00U; Flag <= 0x03U; ++Flag) {
+      EXPECT_TRUE(Ldr.parseModule(MakeModule(Opcode, Flag)));
+    }
+    for (const uint8_t Flag : InvalidFlags) {
+      EXPECT_FALSE(Ldr.parseModule(MakeModule(Opcode, Flag)));
+    }
+  }
+}
+
 } // namespace

--- a/test/loader/instructionTest.cpp
+++ b/test/loader/instructionTest.cpp
@@ -1308,21 +1308,114 @@ TEST(InstructionTest, LoadTryTable) {
 }
 
 TEST(InstructionTest, LoadBrOnCastFlags) {
-  const auto MakeModule = [](uint8_t Opcode, uint8_t Flag) {
-    return prefixedVec({0x0AU, 0x0AU, 0x01U, 0x08U, 0x00U, 0xFBU, Opcode, Flag,
-                        0x00U, 0x6DU, 0x6DU, 0x0BU});
-  };
-  const uint8_t Opcodes[] = {0x18U, 0x19U};
-  const uint8_t InvalidFlags[] = {0x04U, 0xFFU};
+  std::vector<uint8_t> Vec;
 
-  for (const uint8_t Opcode : Opcodes) {
-    for (uint8_t Flag = 0x00U; Flag <= 0x03U; ++Flag) {
-      EXPECT_TRUE(Ldr.parseModule(MakeModule(Opcode, Flag)));
-    }
-    for (const uint8_t Flag : InvalidFlags) {
-      EXPECT_FALSE(Ldr.parseModule(MakeModule(Opcode, Flag)));
-    }
-  }
+  // 15. Test br_on_cast and br_on_cast_fail flags.
+  //
+  //   1.  Load both instructions with all valid flags (0x00-0x03).
+  //   2.  Load br_on_cast with invalid flag 0x04.
+  //   3.  Load br_on_cast with invalid flag 0xFF.
+  //   4.  Load br_on_cast_fail with invalid flag 0x04.
+  //   5.  Load br_on_cast_fail with invalid flag 0xFF.
+
+  Vec = {
+      0x0AU, // Code section
+      0x34U, // Content size = 52
+      0x01U, // Vector length = 1
+      0x32U, // Code segment size = 50
+      0x00U, // Local vec(0)
+
+      0xFBU, 0x18U, // OpCode Br_on_cast.
+      0x00U,        // Cast flags.
+      0x00U,        // Label index.
+      0x6DU, 0x6DU, // Source and destination heap types.
+      0xFBU, 0x18U, // OpCode Br_on_cast.
+      0x01U,        // Cast flags.
+      0x00U,        // Label index.
+      0x6DU, 0x6DU, // Source and destination heap types.
+      0xFBU, 0x18U, // OpCode Br_on_cast.
+      0x02U,        // Cast flags.
+      0x00U,        // Label index.
+      0x6DU, 0x6DU, // Source and destination heap types.
+      0xFBU, 0x18U, // OpCode Br_on_cast.
+      0x03U,        // Cast flags.
+      0x00U,        // Label index.
+      0x6DU, 0x6DU, // Source and destination heap types.
+      0xFBU, 0x19U, // OpCode Br_on_cast_fail.
+      0x00U,        // Cast flags.
+      0x00U,        // Label index.
+      0x6DU, 0x6DU, // Source and destination heap types.
+      0xFBU, 0x19U, // OpCode Br_on_cast_fail.
+      0x01U,        // Cast flags.
+      0x00U,        // Label index.
+      0x6DU, 0x6DU, // Source and destination heap types.
+      0xFBU, 0x19U, // OpCode Br_on_cast_fail.
+      0x02U,        // Cast flags.
+      0x00U,        // Label index.
+      0x6DU, 0x6DU, // Source and destination heap types.
+      0xFBU, 0x19U, // OpCode Br_on_cast_fail.
+      0x03U,        // Cast flags.
+      0x00U,        // Label index.
+      0x6DU, 0x6DU, // Source and destination heap types.
+      0x0BU         // Expression End.
+  };
+  EXPECT_TRUE(Ldr.parseModule(prefixedVec(Vec)));
+
+  Vec = {
+      0x0AU,        // Code section
+      0x0AU,        // Content size = 10
+      0x01U,        // Vector length = 1
+      0x08U,        // Code segment size = 8
+      0x00U,        // Local vec(0)
+      0xFBU, 0x18U, // OpCode Br_on_cast.
+      0x04U,        // Invalid cast flags.
+      0x00U,        // Label index.
+      0x6DU, 0x6DU, // Source and destination heap types.
+      0x0BU         // Expression End.
+  };
+  EXPECT_FALSE(Ldr.parseModule(prefixedVec(Vec)));
+
+  Vec = {
+      0x0AU,        // Code section
+      0x0AU,        // Content size = 10
+      0x01U,        // Vector length = 1
+      0x08U,        // Code segment size = 8
+      0x00U,        // Local vec(0)
+      0xFBU, 0x18U, // OpCode Br_on_cast.
+      0xFFU,        // Invalid cast flags.
+      0x00U,        // Label index.
+      0x6DU, 0x6DU, // Source and destination heap types.
+      0x0BU         // Expression End.
+  };
+  EXPECT_FALSE(Ldr.parseModule(prefixedVec(Vec)));
+
+  Vec = {
+      0x0AU,        // Code section
+      0x0AU,        // Content size = 10
+      0x01U,        // Vector length = 1
+      0x08U,        // Code segment size = 8
+      0x00U,        // Local vec(0)
+      0xFBU, 0x19U, // OpCode Br_on_cast_fail.
+      0x04U,        // Invalid cast flags.
+      0x00U,        // Label index.
+      0x6DU, 0x6DU, // Source and destination heap types.
+      0x0BU         // Expression End.
+  };
+  EXPECT_FALSE(Ldr.parseModule(prefixedVec(Vec)));
+
+  Vec = {
+      0x0AU,        // Code section
+      0x0AU,        // Content size = 10
+      0x01U,        // Vector length = 1
+      0x08U,        // Code segment size = 8
+      0x00U,        // Local vec(0)
+      0xFBU, 0x19U, // OpCode Br_on_cast_fail.
+      0xFFU,        // Invalid cast flags.
+      0x00U,        // Label index.
+      0x6DU, 0x6DU, // Source and destination heap types.
+      0x0BU         // Expression End.
+  };
+  EXPECT_FALSE(Ldr.parseModule(prefixedVec(Vec)));
 }
 
 } // namespace


### PR DESCRIPTION
 ## Description

  Fixes #5232.

  Reject reserved flag values greater than `0x03` when loading the
  `br_on_cast` and `br_on_cast_fail` instructions.

  This change introduces the dedicated `MalformedCastFlags` loader error and
  adds regression coverage for both instructions. The tests verify that flag
  values `0x00` through `0x03` remain valid while reserved values such as
  `0x04` and `0xFF` are rejected.

  This contribution was developed with assistance from OpenAI Codex. I reviewed
  and verified the changes.

  ## Checklist

  - [x] DCO Signed-off: All commits are signed off using `git commit -s`.
  - [x] Commit Messages: The commit follows the Conventional Commit format.
  - [x] Coding Style: The modified C++ files were formatted with `clang-format`.
  - [x] Local Tests Passed: The relevant loader test suite passes locally.
  - [x] AI Disclosure: AI assistance is disclosed in the commit and PR description.
  - [x] Human-in-the-loop: I reviewed and verified the implementation and tests.


  ## Human Verification

  I reviewed the loader validation, error-code addition, and regression tests. I
  also built and ran the loader AST test suite locally and verified that it
  passes.
 


  ## Test Evidence

  ```text
  cmake --build build --target wasmedgeLoaderASTTests -j2
  [2/2] Linking CXX executable test/loader/wasmedgeLoaderASTTests

  ctest --test-dir build -R wasmedgeLoaderASTTests --output-on-failure
  1/1 Test #3: wasmedgeLoaderASTTests ........... Passed
  100% tests passed, 0 tests failed out of 1
```



<img width="557" height="103" alt="image" src="https://github.com/user-attachments/assets/ec109cc4-ba03-425a-b74f-70d64dce25db" />

  
