### PR TITLE
fix(plugin/stablediffusion): validate image sizes and fix buffer handling

### DIFF
--- a/plugins/wasmedge_stablediffusion/sd_func.cpp
+++ b/plugins/wasmedge_stablediffusion/sd_func.cpp
@@ -18,6 +18,7 @@
 #define STB_IMAGE_RESIZE_IMPLEMENTATION
 #define STB_IMAGE_RESIZE_STATIC
 #include "stb_image_resize.h"
+#include <limits>
 
 namespace WasmEdge {
 namespace Host {
@@ -58,10 +59,33 @@ namespace StableDiffusion {
     return static_cast<uint32_t>(ErrNo::MissingMemory);                        \
   }
 
+// The stb loader, writer, and resizer take buffer sizes, dimensions, and
+// strides as int, and the plugin sizes allocations from Width * Height * 3.
+// Reject values outside the int range before converting or multiplying.
+constexpr uint64_t MaxInt =
+    static_cast<uint64_t>(std::numeric_limits<int>::max());
+constexpr uint64_t BytesPerPixel = 3;
+
 bool parameterCheck(SDEnviornment &Env, uint32_t Width, uint32_t Height,
                     uint32_t SessionId) {
   if (SessionId >= Env.getContextSize()) {
     spdlog::error("[WasmEdge-StableDiffusion] Session ID is invalid."sv);
+    return false;
+  }
+  if (unlikely(Width == 0 || Height == 0)) {
+    spdlog::error("[WasmEdge-StableDiffusion] Image size {}x{} is invalid."sv,
+                  Width, Height);
+    return false;
+  }
+  // Each dimension is handed to stb as an int, and the pixel buffer is sized
+  // from Width * Height * 3, so both the dimensions and that product have to
+  // stay inside the int range.
+  if (unlikely(static_cast<uint64_t>(Width) > MaxInt ||
+               static_cast<uint64_t>(Height) > MaxInt ||
+               static_cast<uint64_t>(Width) * Height >
+                   MaxInt / BytesPerPixel)) {
+    spdlog::error("[WasmEdge-StableDiffusion] Image size {}x{} is too large."sv,
+                  Width, Height);
     return false;
   }
   if (Width % 64 != 0) {
@@ -88,8 +112,15 @@ sd_image_t *readControlImage(Span<uint8_t> ControlImage, int Width, int Height,
     ControlImageBuffer = stbi_load(ControlImagePath.substr(5).data(), &Width,
                                    &Height, &Channel, 3);
   } else {
+    if (unlikely(ControlImage.size() > MaxInt)) {
+      spdlog::error(
+          "[WasmEdge-StableDiffusion] Control image buffer size {} is too large."sv,
+          ControlImage.size());
+      return nullptr;
+    }
     ControlImageBuffer = stbi_load_from_memory(
-        ControlImage.data(), ControlImage.size(), &Width, &Height, &Channel, 3);
+        ControlImage.data(), static_cast<int>(ControlImage.size()), &Width,
+        &Height, &Channel, 3);
   }
 
   if (ControlImageBuffer == nullptr) {
@@ -117,7 +148,14 @@ sd_image_t readMaskImage(Span<uint8_t> MaskImage, int Width, int Height) {
     MaskImageBuffer =
         stbi_load(MaskImagePath.substr(5).data(), &Width, &Height, &Channel, 3);
   } else if (MaskImage.size() != 0) {
-    MaskImageBuffer = stbi_load_from_memory(MaskImage.data(), MaskImage.size(),
+    if (unlikely(MaskImage.size() > MaxInt)) {
+      spdlog::error(
+          "[WasmEdge-StableDiffusion] Mask image buffer size {} is too large."sv,
+          MaskImage.size());
+      return {0, 0, 1, nullptr};
+    }
+    MaskImageBuffer = stbi_load_from_memory(MaskImage.data(),
+                                            static_cast<int>(MaskImage.size()),
                                             &Width, &Height, &Channel, 3);
   } else {
     std::vector<uint8_t> Arr(Width * Height, 255);
@@ -161,10 +199,27 @@ bool saveResults(sd_image_t *Results, uint32_t BatchCount,
                  std::string OutputPath, uint32_t OutputPathLen,
                  uint32_t *BytesWritten, uint32_t OutBufferMaxSize,
                  uint8_t *OutputBufferSpanPtr) {
-  int Len;
+  int Len = 0;
+  if (unlikely(Results[0].data == nullptr)) {
+    spdlog::error("[WasmEdge-StableDiffusion] The result image is empty."sv);
+    for (uint32_t I = 0; I < BatchCount; I++) {
+      free(Results[I].data);
+    }
+    free(Results);
+    return false;
+  }
   unsigned char *Png = stbi_write_png_to_mem(
-      reinterpret_cast<const unsigned char *>(Results), 0, Results->width,
-      Results->height, Results->channel, &Len, nullptr);
+      reinterpret_cast<const unsigned char *>(Results[0].data), 0,
+      Results[0].width, Results[0].height, Results[0].channel, &Len, nullptr);
+  if (unlikely(Png == nullptr)) {
+    spdlog::error(
+        "[WasmEdge-StableDiffusion] Failed to encode the result image."sv);
+    for (uint32_t I = 0; I < BatchCount; I++) {
+      free(Results[I].data);
+    }
+    free(Results);
+    return false;
+  }
   if (OutputPathLen != 0) {
     size_t Last = OutputPath.find_last_of(".");
     std::string DummyName = OutputPath;
@@ -194,16 +249,21 @@ bool saveResults(sd_image_t *Results, uint32_t BatchCount,
     }
   }
   *BytesWritten = Len;
-  if (OutBufferMaxSize < *BytesWritten) {
+  const bool Fits = OutBufferMaxSize >= *BytesWritten;
+  if (Fits) {
+    std::copy_n(Png, *BytesWritten, OutputBufferSpanPtr);
+  } else {
     spdlog::error("[WasmEdge-StableDiffusion] Output buffer is not enough."sv);
-    free(Png);
-    free(Results);
-    return false;
   }
-  std::copy_n(Png, *BytesWritten, OutputBufferSpanPtr);
+  // The image buffers are only released above when writing to a path, so free
+  // them here for the buffer-output case. They are set to nullptr after being
+  // freed, and free(nullptr) is a no-op.
+  for (uint32_t I = 0; I < BatchCount; I++) {
+    free(Results[I].data);
+  }
   free(Png);
   free(Results);
-  return true;
+  return Fits;
 }
 
 Expect<uint32_t> SDConvert::body(const Runtime::CallingFrame &Frame,
@@ -495,49 +555,65 @@ Expect<uint32_t> SDImageToImage::body(
           "[WasmEdge-StableDiffusion] Load image from input image failed."sv);
       return static_cast<uint32_t>(ErrNo::InvalidArgument);
     }
-    if (Channel < 3) {
-      spdlog::error(
-          "[WasmEdge-StableDiffusion] The number of channels for the input image must be >= 3."sv);
-      free(InputImageBuffer);
-      return static_cast<uint32_t>(ErrNo::InvalidArgument);
-    }
-    if (ImageWidth <= 0) {
-      spdlog::error(
-          "[WasmEdge-StableDiffusion] The width of image must be greater than 0."sv);
-      free(InputImageBuffer);
-      return static_cast<uint32_t>(ErrNo::InvalidArgument);
-    }
-    if (ImageHeight <= 0) {
-      spdlog::error(
-          "[WasmEdge-StableDiffusion] The height of image must be greater than 0."sv);
-      free(InputImageBuffer);
-      return static_cast<uint32_t>(ErrNo::InvalidArgument);
-    }
-    // Resize image when its size does not match the width and height.
-    if (Height != static_cast<uint32_t>(ImageHeight) ||
-        Width != static_cast<uint32_t>(ImageWidth)) {
-      int ResizedHeight = Height;
-      int ResizedWidth = Width;
-      uint8_t *ResizedImageBuffer =
-          (uint8_t *)malloc(ResizedHeight * ResizedWidth * 3);
-      if (ResizedImageBuffer == nullptr) {
-        spdlog::error(
-            "[WasmEdge-StableDiffusion] Failed to allocate memory for resize input image."sv);
-        free(InputImageBuffer);
-        return static_cast<uint32_t>(ErrNo::InvalidArgument);
-      }
-      stbir_resize(InputImageBuffer, ImageWidth, ImageHeight, 0,
-                   ResizedImageBuffer, ResizedWidth, ResizedHeight, 0,
-                   STBIR_TYPE_UINT8, 3, STBIR_ALPHA_CHANNEL_NONE, 0,
-                   STBIR_EDGE_CLAMP, STBIR_EDGE_CLAMP, STBIR_FILTER_BOX,
-                   STBIR_FILTER_BOX, STBIR_COLORSPACE_SRGB, nullptr);
-      free(InputImageBuffer);
-      InputImageBuffer = ResizedImageBuffer;
-    }
   } else {
-    InputImageBuffer =
-        stbi_load_from_memory(ImageSpan.data(), ImageSpan.size(), &ImageWidth,
-                              &ImageHeight, &Channel, 3);
+    if (unlikely(ImageSpan.size() > MaxInt)) {
+      spdlog::error(
+          "[WasmEdge-StableDiffusion] Input image buffer size {} is too large."sv,
+          ImageSpan.size());
+      return static_cast<uint32_t>(ErrNo::InvalidArgument);
+    }
+    InputImageBuffer = stbi_load_from_memory(
+        ImageSpan.data(), static_cast<int>(ImageSpan.size()), &ImageWidth,
+        &ImageHeight, &Channel, 3);
+    if (unlikely(InputImageBuffer == nullptr)) {
+      spdlog::error(
+          "[WasmEdge-StableDiffusion] Load image from input image failed."sv);
+      return static_cast<uint32_t>(ErrNo::InvalidArgument);
+    }
+  }
+  if (Channel < 3) {
+    spdlog::error(
+        "[WasmEdge-StableDiffusion] The number of channels for the input image must be >= 3."sv);
+    free(InputImageBuffer);
+    return static_cast<uint32_t>(ErrNo::InvalidArgument);
+  }
+  if (ImageWidth <= 0) {
+    spdlog::error(
+        "[WasmEdge-StableDiffusion] The width of image must be greater than 0."sv);
+    free(InputImageBuffer);
+    return static_cast<uint32_t>(ErrNo::InvalidArgument);
+  }
+  if (ImageHeight <= 0) {
+    spdlog::error(
+        "[WasmEdge-StableDiffusion] The height of image must be greater than 0."sv);
+    free(InputImageBuffer);
+    return static_cast<uint32_t>(ErrNo::InvalidArgument);
+  }
+  // Resize image when its size does not match the width and height.
+  if (Height != static_cast<uint32_t>(ImageHeight) ||
+      Width != static_cast<uint32_t>(ImageWidth)) {
+    int ResizedHeight = Height;
+    int ResizedWidth = Width;
+    // Width and Height are bounded by parameterCheck, so this product
+    // cannot overflow, but compute it in 64-bit so the size the allocator
+    // sees is the size that was validated.
+    const uint64_t ResizedSize =
+        static_cast<uint64_t>(Width) * Height * BytesPerPixel;
+    uint8_t *ResizedImageBuffer =
+        (uint8_t *)malloc(static_cast<size_t>(ResizedSize));
+    if (ResizedImageBuffer == nullptr) {
+      spdlog::error(
+          "[WasmEdge-StableDiffusion] Failed to allocate memory for resize input image."sv);
+      free(InputImageBuffer);
+      return static_cast<uint32_t>(ErrNo::InvalidArgument);
+    }
+    stbir_resize(InputImageBuffer, ImageWidth, ImageHeight, 0,
+                 ResizedImageBuffer, ResizedWidth, ResizedHeight, 0,
+                 STBIR_TYPE_UINT8, 3, STBIR_ALPHA_CHANNEL_NONE, 0,
+                 STBIR_EDGE_CLAMP, STBIR_EDGE_CLAMP, STBIR_FILTER_BOX,
+                 STBIR_FILTER_BOX, STBIR_COLORSPACE_SRGB, nullptr);
+    free(InputImageBuffer);
+    InputImageBuffer = ResizedImageBuffer;
   }
   sd_image_t InputImage = {Width, Height, 3, InputImageBuffer};
   // Read control image

--- a/test/plugins/wasmedge_stablediffusion/wasmedge_stablediffusion.cpp
+++ b/test/plugins/wasmedge_stablediffusion/wasmedge_stablediffusion.cpp
@@ -575,6 +575,69 @@ TEST(WasmEdgeStableDiffusionTest, ModuleFunctions) {
     EXPECT_EQ(Errno[0].get<int32_t>(),
               static_cast<uint32_t>(ErrNo::InvalidArgument));
   }
+
+  // Test: image_to_image -- out of range image size.
+  // A real input image is supplied so the loader succeeds and execution
+  // reaches the resize path; SessionId is valid too. The rejection can
+  // therefore only come from the image-size validation.
+  {
+    uint32_t InputPathPtr = UINT32_C(0);
+    writeBinaries<char>(MemInst, InputPath, InputPathPtr);
+    const std::array<std::pair<uint32_t, uint32_t>, 3> BadSizes = {
+        std::make_pair(UINT32_C(0x40000000), UINT32_C(64)),
+        std::make_pair(UINT32_C(65536), UINT32_C(65536)),
+        std::make_pair(UINT32_C(0x20000000), UINT32_C(128))};
+    for (const auto &BadSize : BadSizes) {
+      EXPECT_TRUE(HostFuncImageToImage.run(
+          CallFrame,
+          std::initializer_list<WasmEdge::ValVariant>{
+              InputPathPtr,                            // ImagePtr
+              static_cast<uint32_t>(InputPath.size()), // ImageLen
+              UINT32_C(0),                             // MaskImagePtr
+              UINT32_C(0),                             // MaskImageLen
+              SessionId,                               // SessionId
+              3.5f,                                    // Guidance
+              BadSize.first,                           // Width
+              BadSize.second,                          // Height
+              UINT32_C(0),                             // ControlImagePtr
+              UINT32_C(0),                             // ControlImageLen
+              UINT32_C(0),                             // PromptPtr
+              UINT32_C(0),                             // PromptLen
+              UINT32_C(0),                             // NegativePromptPtr
+              UINT32_C(0),                             // NegativePromptLen
+              INT32_C(-1),                             // ClipSkip
+              7.0f,                                    // CfgScale
+              UINT32_C(0),                             // SampleMethod
+              UINT32_C(1),                             // SampleSteps
+              0.75f,                                   // Strength
+              UINT32_C(42),                            // Seed
+              UINT32_C(1),                             // BatchCount
+              0.9f,                                    // ControlStrength
+              20.0f,                                   // StyleRatio
+              UINT32_C(0),                             // NormalizeInput
+              UINT32_C(0),                             // InputIdImagesDirPtr
+              UINT32_C(0),                             // InputIdImagesDirLen
+              UINT32_C(0),                             // CannyPreprocess
+              UINT32_C(0),                             // UpscaleModelPathPtr
+              UINT32_C(0),                             // UpscaleModelPathLen
+              UINT32_C(1),                             // UpscaleRepeats
+              UINT32_C(0),                             // SkipLayersPtr
+              UINT32_C(0),                             // SkipLayersLen
+              0.0f,                                    // SlgScale
+              0.01f,                                   // SkipLayerStart
+              0.2f,                                    // SkipLayerEnd
+              UINT32_C(0),                             // OutputPathPtr
+              UINT32_C(0),                             // OutputPathLen
+              UINT32_C(0),                             // OutBufferPtr
+              UINT32_C(0),                             // OutBufferMaxSize
+              UINT32_C(0)},                            // BytesWrittenPtr
+          Errno));
+      EXPECT_EQ(Errno[0].get<int32_t>(),
+                static_cast<uint32_t>(ErrNo::InvalidArgument))
+          << "image_to_image accepted " << BadSize.first << "x"
+          << BadSize.second;
+    }
+  }
 }
 
 GTEST_API_ int main(int argc, char **argv) {


### PR DESCRIPTION
Fixes #5238

## Description

`Width` and `Height` come straight from the guest as `uint32_t`, and the only check on them was that each is a multiple of 64. Nothing set an upper bound, so `Width * Height * 3` wraps in int arithmetic. `malloc(0)` hands back a valid pointer, the null check passes, and `stbir_resize` then writes past the end of it.

@hydai asked me to review the rest of the plugin and unify everything to the style already used in `wasmedge_image`, so this covers more than the one line from the issue.

### Size validation

Three more call sites had the same shape. `stbi_load_from_memory` takes its length as an `int`, and `readControlImage`, `readMaskImage` and `SDImageToImage` all pass a guest-controlled span size straight in, so anything over 2 GB gets truncated.

The fix uses the same four checks `decodeImgToSize` already does: reject zero dimensions, reject dimensions and byte counts outside the int range, bound buffer sizes before narrowing them, and compute the allocation size in 64-bit so what reaches `malloc` is what was validated.

### Error paths

- `saveResults` never checked the pointer from `stbi_write_png_to_mem`. That function returns NULL on allocation failure without touching `out_len`, and `Len` was uninitialised, so a failed encode meant `*BytesWritten = <garbage>` followed by `std::copy_n(nullptr, garbage, dst)`.
- `SDImageToImage` checked the `stbi_load` result on the `path:` branch but not on the memory branch, so a malformed image passed a null pointer through.

### Memory leak in saveResults

`saveResults` owns `Results` and its per-image buffers, but `Results[I].data` was only freed inside the branch that writes to a file. A guest that asks for the PNG in a buffer instead of a path leaks the raw image data on every successful call, roughly 786 KB at 512x512. The buffer-too-small path leaked the same way.

I collapsed the two exit paths into one that frees the buffers either way. The file-writing branch already sets them to `nullptr` after freeing and `free(nullptr)` is a no-op, so nothing gets freed twice.

I also audited `SDConvert` and `SDCreateContext`. They only handle string paths through `MEM_SPAN_CHECK`, no narrowing or size arithmetic, so there was nothing to change there.

### Note on #4935

`readMaskImage` is missing the same null checks after its two `stbi_load` calls. I left that function alone because #4935 is already rewriting its tail to fix a dangling buffer, and I did not want to collide with that work. Happy to fold the null checks in here if #4935 lands first, or leave them for that PR.

This contribution was developed with assistance from Claude (Anthropic).

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

Built with the plugin enabled and ran the full stable-diffusion suite against the real model that CMake downloads.

**With the fix**, all three oversized pairs are rejected and the suite passes:

```console
$ ./build/test/plugins/wasmedge_stablediffusion/wasmedgeStableDiffusionTests
[ RUN      ] WasmEdgeStableDiffusionTest.ModuleFunctions
...
[error] [WasmEdge-StableDiffusion] Image size 1073741824x64 is too large.
[error] [WasmEdge-StableDiffusion] Image size 65536x65536 is too large.
[error] [WasmEdge-StableDiffusion] Image size 536870912x128 is too large.
[       OK ] WasmEdgeStableDiffusionTest.ModuleFunctions (79380 ms)
[  PASSED  ] 1 test.
exit 0
```

I also checked the test actually catches the bug rather than passing either way. With only `sd_func.cpp` reverted to master and the new case kept, the suite segfaults instead of failing an assertion:

```console
$ ./build/test/plugins/wasmedge_stablediffusion/wasmedgeStableDiffusionTests
[ RUN      ] WasmEdgeStableDiffusionTest.ModuleFunctions
...
[error] [WasmEdge-StableDiffusion] Session ID is invalid.
exit 139
```

The crash lands inside the new block before it logs anything, which is the `0x40000000 x 64` case from the issue.

The new case supplies a real input image and a valid session so execution reaches the resize path. That matters, because the size validation is then the only thing left that can reject the call. Passing zeros there would make the test pass for the wrong reason.

On the cleanup change: the suite makes 12 calls with a real output path and writes 4 PNGs, so the free-then-null branch runs and the new loop then frees those same pointers. No double free, no allocator warnings, exit 0. Worth being clear though that this only shows I did not break anything. Leaks do not crash, so proving the leak itself is gone would need an ASan or LSan build of the plugin, which I have not done.

Also confirmed: plugin and tests build with no warnings, `clang-format` clean, and the rest of the test suite is unaffected.

Tested on macOS 15 (Darwin 24.6.0), arm64, against master @ `b85cedd14`.
