### PR TITLE
fix: correct ElementSegment serialization modes

### DIFF
--- a/lib/loader/serialize/serial_segment.cpp
+++ b/lib/loader/serialize/serial_segment.cpp
@@ -51,7 +51,7 @@ Serializer::serializeSegment(const AST::ElementSegment &Seg,
   // vec(u32) + vec(expr)
   if (!Conf.hasProposal(Proposal::BulkMemoryOperations) &&
       !Conf.hasProposal(Proposal::ReferenceTypes) &&
-      (Seg.getMode() != AST::ElementSegment::ElemMode::Passive ||
+      (Seg.getMode() != AST::ElementSegment::ElemMode::Active ||
        Seg.getIdx() != 0)) {
     return logNeedProposal(ErrCode::Value::ExpectedZeroByte,
                            Proposal::BulkMemoryOperations,
@@ -77,8 +77,26 @@ Serializer::serializeSegment(const AST::ElementSegment &Seg,
     return E;
   };
 
+  // Distinguish between FuncIdx and Expr.
+  auto IsInitExpr = false;
+  if (Seg.getInitExprs().size() != 0) {
+    for (auto &Expr : Seg.getInitExprs()) {
+      if (Expr.getInstrs().size() != 2 ||
+          Expr.getInstrs()[0].getOpCode() != OpCode::Ref__func ||
+          Expr.getInstrs()[1].getOpCode() != OpCode::End) {
+        IsInitExpr = true;
+        break;
+      }
+    }
+  }
+  if (Seg.getRefType() != TypeCode::FuncRef) {
+    IsInitExpr = true;
+  }
+
   // Serialize idx.
-  if (Seg.getIdx() != 0) {
+  if (Seg.getIdx() != 0 ||
+      (Seg.getMode() == AST::ElementSegment::ElemMode::Active &&
+       Seg.getRefType() != TypeCode::FuncRef)) {
     Mode |= 0x02;
     serializeU32(Seg.getIdx(), OutVec);
   }
@@ -89,20 +107,8 @@ Serializer::serializeSegment(const AST::ElementSegment &Seg,
         serializeExpression(Seg.getExpr(), OutVec).map_error(ReportError));
   }
 
-  // Distinguish between FuncIdx and Expr.
-  if (Seg.getInitExprs().size() != 0) {
-    auto IsInitExpr = false;
-    for (auto &Expr : Seg.getInitExprs()) {
-      if (Expr.getInstrs().size() != 2 ||
-          Expr.getInstrs()[0].getOpCode() != OpCode::Ref__func ||
-          Expr.getInstrs()[1].getOpCode() != OpCode::End) {
-        IsInitExpr = true;
-        break;
-      }
-    }
-    if (IsInitExpr) {
-      Mode |= 0x04;
-    }
+  if (IsInitExpr) {
+    Mode |= 0x04;
   }
 
   // Serialize ElemKind or RefType.

--- a/test/loader/serializeSegmentTest.cpp
+++ b/test/loader/serializeSegmentTest.cpp
@@ -254,6 +254,11 @@ TEST(SerializeSegmentTest, SerializeElementSegment) {
   };
   EXPECT_EQ(Output, Expected);
 
+  // MVP active element segment
+  Output = {};
+  EXPECT_TRUE(SerWASM1.serializeSection(ElementSec, Output));
+  EXPECT_EQ(Output, Expected);
+
   ElementSeg.setMode(WasmEdge::AST::ElementSegment::ElemMode::Active);
   ElementSeg.getExpr().getInstrs() = {I32Eqz, I32Eq, I32Ne, End};
   RefFunc.getTargetIndex() = 0xFFFFFFFFU;
@@ -443,6 +448,31 @@ TEST(SerializeSegmentTest, SerializeElementSegment) {
   EXPECT_EQ(Output, Expected);
 
   EXPECT_FALSE(SerWASM1.serializeSection(ElementSec, Output));
+
+  // Active segment, idx = 0, RefType = ExternRef. Should be mode 6.
+  ElementSeg.setMode(WasmEdge::AST::ElementSegment::ElemMode::Active);
+  ElementSeg.setIdx(0x00U);
+  ElementSeg.setRefType(WasmEdge::TypeCode::ExternRef);
+  ElementSeg.getExpr().getInstrs() = {I32Eqz, I32Eq, I32Ne, End};
+  ElementSeg.getInitExprs().clear();
+  ElementSeg.getInitExprs().emplace_back();
+  ElementSeg.getInitExprs().back().getInstrs() = {I32Eqz, I32Eq, I32Ne, End};
+  ElementSec.getContent() = {ElementSeg};
+
+  Output = {};
+  EXPECT_TRUE(Ser.serializeSection(ElementSec, Output));
+  Expected = {
+      0x09U,                      // Element section
+      0x0DU,                      // Content size = 13
+      0x01U,                      // Vector length = 1
+      0x06U,                      // Prefix checking byte
+      0x00U,                      // TableIdx
+      0x45U, 0x46U, 0x47U, 0x0BU, // Offset Expression
+      0x6FU,                      // RefType (ExternRef)
+      0x01U,                      // Vector length = 1
+      0x45U, 0x46U, 0x47U, 0x0BU, // Vec[0]
+  };
+  EXPECT_EQ(Output, Expected);
 }
 
 TEST(SerializeSegmentTest, SerializeCodeSegment) {


### PR DESCRIPTION
## Description

Fix ElementSegment serialization issues identified in **#4992**.

This PR addresses two serializer bugs in `Serializer::serializeSegment()`:

1. **Incorrect MVP proposal gate**
   - The serializer incorrectly required `Passive` ElementSegments when both Bulk Memory and Reference Types proposals were disabled.
   - MVP WebAssembly requires active ElementSegments targeting table 0.
   - The proposal gate is corrected to accept `Active` segments with table index `0`.

2. **Active table-0 non-FuncRef segments incorrectly downgraded**
   - Active ElementSegments targeting table 0 with a non-`funcref` reference type could previously be serialized using Mode `0x04`.
   - Mode `0x04` implicitly represents `funcref`, causing the explicit reference type to be lost during serialization/deserialization.
   - Active non-`FuncRef` segments are now promoted to Mode `0x06`, explicitly encoding table index `0` and the `RefType`.

This preserves the correct ElementSegment semantics and prevents silent `externref` → `funcref` downgrades.

## Related Issue

Addresses the unresolved ElementSegment serialization bugs tracked in **#4992**.

## Changes

- Corrected the MVP ElementSegment proposal gate from `Passive` to `Active`.
- Ensured active non-`FuncRef` segments explicitly encode the table index and reference type.
- Added regression coverage for:
  - MVP active table-0 ElementSegments.
  - Active table-0 `externref` ElementSegments.
  - Correct Mode `0x06` byte-level serialization.
  - Explicit table index `0x00`.
  - Explicit `externref` type byte `0x6F`.

## Test Coverage

### Targeted Serializer Tests

```text
SerializeSegmentTest.*
5/5 tests passed
```

Full CTest Suite
100% tests passed, 0 tests failed out of 33
Total Test time (real) = 273.86 sec
Full Test Suite Screenshot

<img width="1436" height="587" alt="image" src="https://github.com/user-attachments/assets/ecc0e00a-fe2c-47c5-873e-0da73cefc266" />


The complete CTest suite passed successfully with 33/33 tests and zero failures.