### PR TITLE
fix(cmake): keep pinned fmt and system fmt from mixing across platforms

### DIFF
--- a/cmake/Helper.cmake
+++ b/cmake/Helper.cmake
@@ -504,51 +504,116 @@ function(wasmedge_setup_spdlog)
   if(TARGET spdlog::spdlog)
     return()
   endif()
-  # setup spdlog
-  find_package(spdlog QUIET)
-  if(spdlog_FOUND)
-    message(STATUS "spdlog found")
-    wasmedge_mark_system_includes(spdlog::spdlog)
+  # Static archive assembly extracts objects from fmt and spdlog with ar -x,
+  # which needs the pinned static builds rather than system packages.
+  if(NOT WASMEDGE_BUILD_STATIC_LIB)
+    find_package(spdlog QUIET)
+    if(NOT spdlog_FOUND AND APPLE AND NOT TARGET fmt::fmt)
+      # A package manager fmt without spdlog is common on macOS, where an
+      # injected -I/opt/homebrew/include otherwise shadows the fetched fmt
+      # headers with a different version than the one linked. Adopting the
+      # package keeps one fmt in play; elsewhere no such injection vector
+      # exists and the pinned pair is used as before.
+      find_package(fmt QUIET)
+    endif()
+  endif()
+  # Validate whichever fmt::fmt is in play now: one pulled in by the spdlog
+  # package, one found above, or one populated by an enclosing project. The
+  # loaded target itself is inspected, so every find_package entry point
+  # (fmt_DIR, fmt_ROOT, prefix paths, registries) is covered by construction.
+  if(TARGET fmt::fmt)
+    get_target_property(WASMEDGE_FMT_CONCRETE fmt::fmt ALIASED_TARGET)
+    if(NOT WASMEDGE_FMT_CONCRETE)
+      set(WASMEDGE_FMT_CONCRETE fmt::fmt)
+    endif()
+    get_target_property(WASMEDGE_FMT_TYPE ${WASMEDGE_FMT_CONCRETE} TYPE)
+    get_target_property(WASMEDGE_FMT_IMPORTED ${WASMEDGE_FMT_CONCRETE} IMPORTED)
+    if(WASMEDGE_BUILD_STATIC_LIB AND WASMEDGE_FMT_TYPE STREQUAL "SHARED_LIBRARY")
+      # The static archive assembly extracts fmt objects with ar -x, which a
+      # shared library cannot satisfy; master failed the same setup at build
+      # time inside the archive assembly step.
+      message(FATAL_ERROR "WASMEDGE_BUILD_STATIC_LIB needs a static fmt archive, but the fmt::fmt target is a shared library. Provide a static fmt or let WasmEdge fetch its pinned copy.")
+    endif()
+    if(NOT WASMEDGE_FMT_IMPORTED)
+      # A source fmt populated by an enclosing project must be position
+      # independent to link into the shared library outputs, matching the
+      # treatment the fetched copy receives from wasmedge_setup_target().
+      set_property(TARGET ${WASMEDGE_FMT_CONCRETE} PROPERTY
+        POSITION_INDEPENDENT_CODE ON)
+    else()
+      # A static archive is accepted as master did: package managers build
+      # them with PIC as a rule, and a non-PIC one fails at link with the
+      # linker naming the object and asking for -fPIC, which an imported
+      # target cannot predict at configure time.
+      include(CheckCXXSourceCompiles)
+      check_cxx_source_compiles(
+        "int main() { return static_cast<int>(sizeof(__int128)); }"
+        WASMEDGE_HAS_NATIVE_INT128)
+      if(NOT WASMEDGE_HAS_NATIVE_INT128 AND
+          (NOT fmt_VERSION OR NOT fmt_VERSION VERSION_LESS 12.2.0))
+        # fmt 12.2.0 cannot compile its 128-bit fallback without a native
+        # __int128 (see the pin below).
+        message(FATAL_ERROR "The fmt package (version '${fmt_VERSION}') needs a native __int128 which this toolchain lacks. Install fmt older than 12.2.0 or set -DCMAKE_DISABLE_FIND_PACKAGE_spdlog=ON -DCMAKE_DISABLE_FIND_PACKAGE_fmt=ON to use the pinned copies.")
+      endif()
+    endif()
+    message(STATUS "fmt found")
     wasmedge_mark_system_includes(fmt::fmt)
     wasmedge_mark_system_includes(fmt::fmt-header-only)
+  endif()
+  if(spdlog_FOUND)
+    # The sources include fmt headers directly, so a spdlog built against its
+    # bundled fmt neither provides the headers nor links the same fmt, and
+    # one binary would mix two fmt copies. An external-fmt package records
+    # SPDLOG_FMT_EXTERNAL in its interface and pulls fmt::fmt in through its
+    # own find_dependency call.
+    get_target_property(WASMEDGE_SPDLOG_DEFS spdlog::spdlog
+      INTERFACE_COMPILE_DEFINITIONS)
+    if(NOT TARGET fmt::fmt OR
+        NOT WASMEDGE_SPDLOG_DEFS MATCHES "SPDLOG_FMT_EXTERNAL")
+      message(FATAL_ERROR "The spdlog package was built against its bundled fmt, which cannot satisfy the direct fmt usage in the sources. Install a spdlog built with SPDLOG_FMT_EXTERNAL or set -DCMAKE_DISABLE_FIND_PACKAGE_spdlog=ON to use the pinned copies.")
+    endif()
+    message(STATUS "spdlog found")
+    wasmedge_mark_system_includes(spdlog::spdlog)
   else()
     include(FetchContent)
-    message(STATUS "Downloading fmt source")
-    # Held at 12.1.0. fmt 12.2.0 needs CMake 3.19 or later, which this project
-    # does not require: it sets VERSION, SOVERSION and DEBUG_POSTFIX on the
-    # fmt-header-only INTERFACE target, and CMake rejects non-whitelisted
-    # properties on INTERFACE libraries before 3.19. Debian bullseye, which
-    # builds the static release, carries CMake 3.18. fmt 12.2.0 also fails to
-    # compile its own 128-bit fallback in do_format_decimal, which every target
-    # without a native __int128 -- MSVC among them -- instantiates.
-    FetchContent_Declare(
-      fmt
-      GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-      GIT_TAG        407c905e45ad75fc29bf0f9bb7c5c2fd3475976f  # 12.1.0
-      GIT_SHALLOW    TRUE
-    )
-    set(FMT_INSTALL OFF CACHE BOOL "Generate the install target." FORCE)
-    set(FMT_SYSTEM_HEADERS ON CACHE BOOL "Expose headers with marking them as system." FORCE)
-    FetchContent_MakeAvailable(fmt)
-    message(STATUS "Downloading fmt source -- done")
-    wasmedge_setup_target(fmt)
-    wasmedge_mark_system_includes(fmt)
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-      target_compile_options(fmt
-        PRIVATE
-        -Wno-missing-noreturn
-        -Wno-sign-conversion
+    if(NOT TARGET fmt::fmt)
+      message(STATUS "Downloading fmt source")
+      # Held at 12.1.0. fmt 12.2.0 needs CMake 3.19 or later, which this project
+      # does not require: it sets VERSION, SOVERSION and DEBUG_POSTFIX on the
+      # fmt-header-only INTERFACE target, and CMake rejects non-whitelisted
+      # properties on INTERFACE libraries before 3.19. Debian bullseye, which
+      # builds the static release, carries CMake 3.18. fmt 12.2.0 also fails to
+      # compile its own 128-bit fallback in do_format_decimal, which every target
+      # without a native __int128 -- MSVC among them -- instantiates.
+      FetchContent_Declare(
+        fmt
+        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+        GIT_TAG        407c905e45ad75fc29bf0f9bb7c5c2fd3475976f  # 12.1.0
+        GIT_SHALLOW    TRUE
       )
-    endif()
-    wasmedge_suppress_shadow_warnings(fmt)
-    if (WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-      target_compile_options(fmt
-        PRIVATE
-        -Wno-duplicate-enum
-        -Wno-padded
-        -Wno-error=unique-object-duplication
-        -Wno-error=nrvo
-      )
+      set(FMT_INSTALL OFF CACHE BOOL "Generate the install target." FORCE)
+      set(FMT_SYSTEM_HEADERS ON CACHE BOOL "Expose headers with marking them as system." FORCE)
+      FetchContent_MakeAvailable(fmt)
+      message(STATUS "Downloading fmt source -- done")
+      wasmedge_setup_target(fmt)
+      wasmedge_mark_system_includes(fmt)
+      if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        target_compile_options(fmt
+          PRIVATE
+          -Wno-missing-noreturn
+          -Wno-sign-conversion
+        )
+      endif()
+      wasmedge_suppress_shadow_warnings(fmt)
+      if (WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        target_compile_options(fmt
+          PRIVATE
+          -Wno-duplicate-enum
+          -Wno-padded
+          -Wno-error=unique-object-duplication
+          -Wno-error=nrvo
+        )
+      endif()
     endif()
 
     message(STATUS "Downloading spdlog source")


### PR DESCRIPTION
## Description

The fmt/spdlog setup in `cmake/Helper.cmake` had two ways to end up with an incoherent fmt pairing:

1. **`find_package(spdlog)` accepted any system spdlog**, but a spdlog built against its *bundled* fmt (upstream default for source installs) provides neither fmt headers nor the `fmt::fmt` target. Since the WasmEdge sources include `<fmt/...>` directly, the build dies with `fmt/format.h: No such file or directory`. Reproduced on Ubuntu 24.04 with a source-installed vanilla spdlog v1.17.0 — on current master as well, so this is a pre-existing bug. With a standalone fmt additionally installed, one binary would silently mix two fmt copies instead.
2. **When no system spdlog exists, the pinned fmt 12.1.0 is fetched**, but since 073727f5a (#5152) its headers are exposed through `-isystem`, which Clang searches after every `-I` path. On macOS, any dependency that injects `-I/opt/homebrew/include` (Homebrew simdjson exports its whole prefix; the WASI-NN MLX dependencies do the same) makes a Homebrew fmt 12.2.0 shadow the pinned 12.1.0 headers, and objects silently compile against a different fmt than the one linked, failing at link time with undefined references such as `fmt::v12::detail::allocate`.

Both are the same root problem — mixing the pinned copy with a foreign system package. **Design: instead of predicting what `find_package` would load (which amounts to reimplementing its documented search algorithm), run it and validate the targets it actually created.** Every entry point (`spdlog_DIR`, `_ROOT` variables, prefix paths, environment variables, package registries) is covered by construction, because the check inspects the real loaded package.

- **macOS keeps one fmt in play**: when no spdlog package exists, a packaged fmt is adopted outright — headers and library then come from the same package, so nothing is left to shadow. Other platforms have no package-prefix injection vector and keep fetching the pinned pair as before.
- **An accepted spdlog package must record `SPDLOG_FMT_EXTERNAL`** in its interface compile definitions. A bundled-fmt spdlog stops configuration with an actionable message (`-DCMAKE_DISABLE_FIND_PACKAGE_spdlog=ON` to use the pinned copies) instead of failing later inside a fmt header.
- **A loaded `fmt::fmt` is checked against the outputs that consume it**: a shared fmt cannot feed the `ar -x` static archive assembly (`WASMEDGE_BUILD_STATIC_LIB`), an imported static archive cannot be assumed position independent for the ELF shared library, and toolchains without a native `__int128` reject fmt >= 12.2.0, whose 128-bit fallback does not compile there (the reason for the pin). Each mismatch stops configuration with the matching `CMAKE_DISABLE_FIND_PACKAGE_*` escape hatch, where master failed later with an opaque build error.
- **A source fmt populated by an enclosing project** (superbuild `add_subdirectory`/`FetchContent`) is accepted and made position independent, matching the treatment the fetched copy receives from `wasmedge_setup_target()`.
- **Static library builds skip the probing entirely** — the `ar -x` archive assembly needs the pinned static builds.
- The fetched copies keep their system-header treatment on every platform, so the MSVC `/W4 /WX` path is byte-identical to master.

This contribution was developed with assistance from Codex (OpenAI) and GitHub Copilot CLI (Claude Fable 5).

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines. (CMake-only change; `lineguard` passes.)
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

**Common configure flags**: `-GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_USE_LLVM=OFF -DWASMEDGE_BUILD_TOOLS=OFF -DWASMEDGE_BUILD_PLUGINS=OFF`

### macOS (26.5.2 arm64, Apple clang 21, Homebrew fmt 12.2.0 + spdlog 1.17.0 installed)

| # | Environment | Result |
|---|---|---|
| M1 | brew pair | `fmt found` + `spdlog found`, system pair accepted |
| M2 | `WASMEDGE_BUILD_STATIC_LIB=ON` | probing skipped, pinned pair fetched, `libwasmedge.a` assembly intact |
| M3 | brew fmt only (`-DCMAKE_DISABLE_FIND_PACKAGE_spdlog=TRUE`) | system fmt + fetched spdlog; `grep -c 'fmt-src/include' build.ninja` = **0** — a single fmt in play, no shadowing possible |

### Linux (Docker `ubuntu:24.04`, GCC 13, `-Wall -Wextra -Werror`)

| # | Environment | Result |
|---|---|---|
| L1 | source-installed vanilla spdlog, no fmt | configure stops with `The spdlog package was built against its bundled fmt...` and names the escape hatch — master instead dies mid-build with `fmt/format.h: No such file or directory` |
| L2 | same + `-DCMAKE_DISABLE_FIND_PACKAGE_spdlog=ON` | pinned pair fetched, full build passes |
| L3 | static source-installed fmt only | fmt not probed on Linux, pinned pair fetched, full parity with master |
| L4 | apt `libspdlog-dev` + `libfmt-dev` pair | `fmt found` + `spdlog found` (validated via `SPDLOG_FMT_EXTERNAL` interface definition), full build passes |
| L5 | superbuild: `FetchContent_MakeAvailable(fmt)` (static, non-PIC by default) before `add_subdirectory(WasmEdge)` | source fmt made PIC, full shared build links `libwasmedge.so` with no relocation errors |

### Windows

The FetchContent path is byte-identical to master (`FMT_SYSTEM_HEADERS ON` + `wasmedge_mark_system_includes(fmt)` unchanged), relying on CI for confirmation.

### Lint

`lineguard --config .lineguardrc cmake/Helper.cmake` passes.
