### PR TITLE
fix(wasi_nn): mark MLX headers as system includes for the test target

### DIFF
--- a/cmake/WASINNDeps.cmake
+++ b/cmake/WASINNDeps.cmake
@@ -578,18 +578,31 @@ function(wasmedge_setup_mlx_target target)
 
   find_program(FFMPEG_EXECUTABLE ffmpeg)
 
+  # Reach the MLX wrapper and third-party headers through -isystem so they
+  # are never compiled under the project warning flags. The tests see these
+  # directories as plain -I through the plugin's INCLUDE_DIRECTORIES
+  # property and do not link mlx, so mlx's PUBLIC warning suppressions do
+  # not apply to them.
+  FetchContent_GetProperties(gguflib)
+  target_include_directories(${target}
+    SYSTEM PRIVATE
+    ${CMAKE_SOURCE_DIR}/plugins/wasi_nn/MLX
+    ${MLX_INCLUDE_DIRS}
+    $<BUILD_INTERFACE:${gguflib_SOURCE_DIR}>
+  )
+  if(TARGET mlx)
+    target_include_directories(${target}
+      SYSTEM PRIVATE
+      $<TARGET_PROPERTY:mlx,INTERFACE_INCLUDE_DIRECTORIES>
+    )
+  endif()
+
   # Only the plugin library needs to fully link the dependency.
   if(WASMEDGE_WASINNDEPS_${target}_PLUGINLIB)
     wasmedge_setup_simdjson()
     target_include_directories(${target}
       PRIVATE
       ${tokenizers_SOURCE_DIR}/include
-    )
-    target_include_directories(${target}
-      SYSTEM PRIVATE
-      ${CMAKE_SOURCE_DIR}/plugins/wasi_nn/MLX
-      ${MLX_INCLUDE_DIRS}
-      $<BUILD_INTERFACE:${gguflib_SOURCE_DIR}>
     )
     target_link_libraries(${target}
       PRIVATE


### PR DESCRIPTION
## Description

Fixes the `Plugins / darwin_23-arm64 / wasi_nn-mlx` CI job, which fails to compile `test/plugins/wasi_nn/wasi_nn.cpp` with:

```text
build/_deps/mlx-src/mlx/types/bf16.h:28:3: error: definition of implicit copy
assignment operator for '_MLX_BFloat16' is deprecated because it has a
user-declared copy constructor [-Werror,-Wdeprecated-copy]
```

Example failing run: https://github.com/WasmEdge/WasmEdge/actions/runs/31456212535/job/93670666365

### Root cause

- `wasiNNTests` includes `wasinn_mlx.h`, which pulls in `mlx/mlx.h`, but it reaches those headers through `$<TARGET_PROPERTY:wasmedgePluginWasiNN,INCLUDE_DIRECTORIES>`. That property propagation drops the `SYSTEM` marking (plain `-I`), and the test never links the `mlx` target, so mlx's `PUBLIC -Wno-deprecated-copy` never applies to the test sources.
- The build previously survived only because the gtest suppression block in `test/CMakeLists.txt` leaked `-Wno-deprecated` across the whole test directory. The googletest v1.17.0 upgrade (db546df4e) removed that block, so `-Werror` started failing on the deprecated implicit copy assignment in mlx's `bf16.h`. The MLX job is path-filtered, so the failure only surfaced on later runs that touched matching paths.

### Fix

In `wasmedge_setup_mlx_target` (`cmake/WASINNDeps.cmake`):

- Provide the MLX wrapper (`plugins/wasi_nn/MLX`), `${MLX_INCLUDE_DIRS}`, and gguflib include directories to every WASI-NN consumer through `SYSTEM PRIVATE` (`-isystem` overrides the inherited plain `-I`), instead of only the plugin library.
- Add `$<TARGET_PROPERTY:mlx,INTERFACE_INCLUDE_DIRECTORIES>` as `SYSTEM PRIVATE` when the `mlx` target exists, so consumers that do not link `mlx` (the tests) still see `mlx-src` and `metal_cpp-src` as system headers.
- Add `FetchContent_GetProperties(gguflib)` so `gguflib_SOURCE_DIR` is populated in non-PLUGINLIB invocations of the function.

This is the same treatment simdjson, llama.cpp, and googletest already receive (see 0a2f939b9, db546df4e). The change is scoped entirely to the `BACKEND STREQUAL "mlx"` path; other backends and platforms are untouched.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines. (CMake-only change; `lineguard` passes.)
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

This contribution was developed with assistance from GitHub Copilot CLI (Claude Fable 5).

## Test Evidence

Reproduced the CI failure locally on macOS arm64 with the CI configuration (`-DCMAKE_BUILD_TYPE=Release -DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_TOOLS=OFF -DWASMEDGE_USE_LLVM=OFF -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=MLX -DCMAKE_POLICY_VERSION_MINIMUM=3.5`) — `wasi_nn.cpp.o` fails with the same `-Wdeprecated-copy` error before the fix.

After the fix (rebased on current master):

```text
$ git log --oneline -1
876f1b104 fix(wasi_nn): mark MLX headers as system includes for the test target

[OK] compile test/plugins/wasi_nn/CMakeFiles/wasiNNTests.dir/wasi_nn.cpp.o
[OK] compile test/plugins/wasi_nn/CMakeFiles/wasiNNTests.dir/resource_table_test.cpp.o
[OK] compile plugins/wasi_nn/CMakeFiles/wasmedgePluginWasiNN.dir/wasinn_mlx.cpp.o
```

The previously failing translation units now compile cleanly. Verification is compile-level: this machine lacks the Metal toolchain required to build the mlx Metal kernels, so the full `wasiNNTests` binary link and test run are left to the `darwin_23-arm64` CI job, which this change targets. The change only alters include flags; link inputs are untouched.

```text
$ lineguard --config .lineguardrc cmake/WASINNDeps.cmake
✓ All files passed lint checks!
  Files checked: 1
```
