### PR TITLE
feat: implement WasmEdge code signing and verification tools (#2090)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ option(WASMEDGE_BUILD_FUZZING "Generate fuzzing test tools. Couldn't build with 
 option(WASMEDGE_BUILD_PLUGINS "Generate plugins." ON)
 option(WASMEDGE_BUILD_EXAMPLE "Generate examples." OFF)
 option(WASMEDGE_BUILD_WASI_NN_RPC "Generate WASI-NN RPC." OFF)
+option(WASMEDGE_BUILD_SIGNATURE_TOOLS "Generate WasmEdge signature tools. Depends on OpenSSL." OFF)
 option(WASMEDGE_USE_LLVM "Enable WasmEdge LLVM-based compilation runtime." ON)
 if(WASMEDGE_BUILD_AOT_RUNTIME)
   message(WARNING "WASMEDGE_BUILD_AOT_RUNTIME option was renamed to WASMEDGE_USE_LLVM.")
@@ -176,6 +177,10 @@ if(WASMEDGE_BUILD_WASI_NN_RPC)
   if(WASMEDGE_BUILD_WASI_NN_RPC AND NOT WASMEDGE_BUILD_SHARED_LIB)
     message(FATAL_ERROR "WASMEDGE_BUILD_WASI_NN_RPC depends on WASMEDGE_BUILD_SHARED_LIB.")
   endif()
+endif()
+
+if(WASMEDGE_BUILD_SIGNATURE_TOOLS)
+  find_package(OpenSSL REQUIRED)
 endif()
 
 set(WASMEDGE_BUILD_PACKAGE "DEB;RPM" CACHE STRING "Package generate types")

--- a/include/driver/signTool.h
+++ b/include/driver/signTool.h
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The WasmEdge Authors
+
+//===-- wasmedge/driver/signTool.h - Wasm module signing tool -------------===//
+//
+// Part of the WasmEdge Project.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Entry point for `wasmedge sign`.  Only available when
+/// WASMEDGE_BUILD_SIGNATURE_TOOLS is ON.
+///
+//===----------------------------------------------------------------------===//
+#pragma once
+
+namespace WasmEdge {
+namespace Driver {
+
+struct DriverToolOptions;
+
+/// Run the `wasmedge sign` subcommand.
+/// Reads the Wasm file specified in Opt.SoName, loads the private keypair from
+/// Opt.KeyFile, computes the rolling-hash digest over every non-signature
+/// section, produces a `signature` custom section prepended to the output, and
+/// writes the signed module to Opt.OutputFile (or <input>.signed.wasm by
+/// default).
+///
+/// Returns EXIT_SUCCESS or EXIT_FAILURE.
+int SignTool(struct DriverToolOptions &Opt) noexcept;
+
+} // namespace Driver
+} // namespace WasmEdge

--- a/include/driver/tool.h
+++ b/include/driver/tool.h
@@ -120,6 +120,13 @@ struct DriverToolOptions : public DriverProposalOptions {
   PO::List<std::string> LinkedModules;
   PO::List<std::string> ForbiddenPlugins;
   PO::Option<std::string> LogLevel;
+  PO::Option<std::string> KeyFile = PO::Option<std::string>(
+      PO::Description("Path to the key file"sv), PO::MetaVar("KEY_FILE"sv),
+      PO::DefaultValue<std::string>(std::string()));
+  PO::Option<std::string> OutputFile = PO::Option<std::string>(
+      PO::Description("Output path for the signed WASM file"sv),
+      PO::MetaVar("OUTPUT_FILE"sv),
+      PO::DefaultValue<std::string>(std::string()));
 
 private:
   void addGlobalOptions(PO::ArgumentParser &Parser) noexcept {
@@ -165,6 +172,18 @@ public:
         .add_option("gas-limit"sv, GasLim)
         .add_option("reactor"sv, Reactor);
   }
+
+#ifdef WASMEDGE_BUILD_SIGNATURE_TOOLS
+  void addSignatureSignOptions(PO::ArgumentParser &Parser) noexcept {
+    Parser.add_option(SoName)
+        .add_option("key"sv, KeyFile)
+        .add_option("output"sv, OutputFile);
+  }
+
+  void addSignatureVerifyOptions(PO::ArgumentParser &Parser) noexcept {
+    Parser.add_option(SoName).add_option("key"sv, KeyFile);
+  }
+#endif
 };
 Configure createConfigure(const struct DriverToolOptions &Opt) noexcept;
 std::optional<RunMode> parseRunModeArg(std::string_view S) noexcept;

--- a/include/driver/verifyTool.h
+++ b/include/driver/verifyTool.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The WasmEdge Authors
+
+//===-- wasmedge/driver/verifyTool.h - Wasm module verification tool ------===//
+//
+// Part of the WasmEdge Project.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Entry point for `wasmedge verify`.  Only available when
+/// WASMEDGE_BUILD_SIGNATURE_TOOLS is ON.
+///
+//===----------------------------------------------------------------------===//
+#pragma once
+
+namespace WasmEdge {
+namespace Driver {
+
+struct DriverToolOptions;
+
+/// Run the `wasmedge verify` subcommand.
+/// Reads the Wasm file specified in Opt.SoName, locates the leading `signature`
+/// custom section, and verifies every recorded hash against the rolling SHA-256
+/// computed over the remaining module bytes.
+///
+/// When Opt.KeyFile is non-empty, only signatures whose embedded public key
+/// matches the supplied key are considered.  An empty KeyFile accepts any key.
+///
+/// Returns EXIT_SUCCESS or EXIT_FAILURE.
+int VerifyTool(struct DriverToolOptions &Opt) noexcept;
+
+} // namespace Driver
+} // namespace WasmEdge

--- a/lib/driver/CMakeLists.txt
+++ b/lib/driver/CMakeLists.txt
@@ -17,6 +17,10 @@ if(WASMEDGE_BUILD_WASI_NN_RPC)
   list(APPEND SOURCES wasiNNRPCServerTool.cpp)
 endif()
 
+if(WASMEDGE_BUILD_SIGNATURE_TOOLS)
+  list(APPEND SOURCES signTool.cpp verifyTool.cpp signature_crypto.cpp)
+endif()
+
 wasmedge_add_library(wasmedgeDriver
   ${SOURCES}
 )
@@ -32,6 +36,17 @@ target_link_libraries(wasmedgeDriver
   PUBLIC
   wasmedgeVM
 )
+
+if(WASMEDGE_BUILD_SIGNATURE_TOOLS)
+  target_link_libraries(wasmedgeDriver
+    PRIVATE
+    OpenSSL::Crypto
+  )
+  target_compile_definitions(wasmedgeDriver
+    PRIVATE
+    -DWASMEDGE_BUILD_SIGNATURE_TOOLS
+  )
+endif()
 
 if(WASMEDGE_USE_LLVM)
   target_compile_definitions(wasmedgeDriver

--- a/lib/driver/signTool.cpp
+++ b/lib/driver/signTool.cpp
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The WasmEdge Authors
+
+#include "driver/signTool.h"
+#include "common/spdlog.h"
+#include "driver/tool.h"
+#include "signature_crypto.h"
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using namespace std::literals;
+
+namespace WasmEdge {
+namespace Driver {
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Read the entire contents of a binary file.
+std::vector<uint8_t> readFile(const std::string &Path) noexcept {
+  std::FILE *F = std::fopen(Path.c_str(), "rb");
+  if (!F) {
+    spdlog::error("sign: cannot open file: {}"sv, Path);
+    return {};
+  }
+  if (std::fseek(F, 0, SEEK_END) != 0) {
+    spdlog::error("sign: fseek failed on: {}"sv, Path);
+    std::fclose(F);
+    return {};
+  }
+  const long Size = std::ftell(F);
+  if (Size < 0) {
+    spdlog::error("sign: ftell failed on: {}"sv, Path);
+    std::fclose(F);
+    return {};
+  }
+  std::rewind(F);
+  std::vector<uint8_t> Buf(static_cast<std::size_t>(Size));
+  if (Size > 0 && std::fread(Buf.data(), 1, static_cast<std::size_t>(Size),
+                             F) != static_cast<std::size_t>(Size)) {
+    spdlog::error("sign: read error on: {}"sv, Path);
+    std::fclose(F);
+    return {};
+  }
+  std::fclose(F);
+  return Buf;
+}
+
+/// Write a buffer to a file (atomic-ish via rename if possible, otherwise
+/// direct).
+bool writeFile(const std::string &Path,
+               const std::vector<uint8_t> &Data) noexcept {
+  std::FILE *F = std::fopen(Path.c_str(), "wb");
+  if (!F) {
+    spdlog::error("sign: cannot open output file: {}"sv, Path);
+    return false;
+  }
+  bool Ok = std::fwrite(Data.data(), 1, Data.size(), F) == Data.size();
+  std::fclose(F);
+  if (!Ok) {
+    spdlog::error("sign: write error on: {}"sv, Path);
+  }
+  return Ok;
+}
+
+/// Decode a LEB128 unsigned 32-bit integer from Buf starting at Pos.
+/// Advances Pos past the encoded bytes.  Returns false on overflow/truncation.
+bool decodeUleb128(const std::vector<uint8_t> &Buf, std::size_t &Pos,
+                   uint32_t &Out) noexcept {
+  uint32_t Result = 0;
+  unsigned Shift = 0;
+  while (Pos < Buf.size()) {
+    const uint8_t Byte = Buf[Pos++];
+    if (Shift >= 32) {
+      return false; // overflow
+    }
+    Result |= static_cast<uint32_t>(Byte & 0x7Fu) << Shift;
+    Shift += 7;
+    if ((Byte & 0x80u) == 0) {
+      Out = Result;
+      return true;
+    }
+  }
+  return false; // truncated
+}
+
+/// Encode a string-vector name as a name-section name (LEB128 len + bytes).
+std::vector<uint8_t> buildNameBytes(std::string_view Name) noexcept {
+  std::vector<uint8_t> Out;
+  auto Leb = encodeUleb128(static_cast<uint32_t>(Name.size()));
+  Out.insert(Out.end(), Leb.begin(), Leb.end());
+  Out.insert(Out.end(), reinterpret_cast<const uint8_t *>(Name.data()),
+             reinterpret_cast<const uint8_t *>(Name.data()) + Name.size());
+  return Out;
+}
+
+/// Build a Wasm custom section byte sequence:
+///   section_id(0x00) | section_size(uleb128) | name_len(uleb128) | name |
+///   payload
+std::vector<uint8_t>
+buildCustomSection(std::string_view Name,
+                   const std::vector<uint8_t> &Payload) noexcept {
+  auto NameBytes = buildNameBytes(Name);
+  // Content = name_bytes + payload
+  std::vector<uint8_t> Content;
+  Content.insert(Content.end(), NameBytes.begin(), NameBytes.end());
+  Content.insert(Content.end(), Payload.begin(), Payload.end());
+
+  auto ContentSizeBytes = encodeUleb128(static_cast<uint32_t>(Content.size()));
+
+  std::vector<uint8_t> Section;
+  Section.push_back(0x00u); // custom section id
+  Section.insert(Section.end(), ContentSizeBytes.begin(),
+                 ContentSizeBytes.end());
+  Section.insert(Section.end(), Content.begin(), Content.end());
+  return Section;
+}
+
+/// Parse the first section of `Wasm` (starting at offset 8, just after the
+/// 4-byte magic + 4-byte version), and return true if it is a custom section
+/// named "signature".  `SigSectionEnd` is set to the byte offset immediately
+/// past that section.
+bool hasLeadingSignatureSection(const std::vector<uint8_t> &Wasm,
+                                std::size_t &SigSectionEnd) noexcept {
+  if (Wasm.size() < 8) {
+    return false;
+  }
+  std::size_t Pos = 8;
+  if (Pos >= Wasm.size()) {
+    return false;
+  }
+  if (Wasm[Pos] != 0x00u) {
+    return false; // not a custom section
+  }
+  Pos++;
+  uint32_t ContentSize = 0;
+  if (!decodeUleb128(Wasm, Pos, ContentSize)) {
+    return false;
+  }
+  const std::size_t ContentStart = Pos;
+  if (ContentStart + ContentSize > Wasm.size()) {
+    return false;
+  }
+  // Read name length
+  uint32_t NameLen = 0;
+  if (!decodeUleb128(Wasm, Pos, NameLen)) {
+    return false;
+  }
+  if (Pos + NameLen > ContentStart + ContentSize) {
+    return false;
+  }
+  std::string_view SectionName(
+      reinterpret_cast<const char *>(Wasm.data() + Pos), NameLen);
+  if (SectionName != "signature"sv) {
+    return false;
+  }
+  SigSectionEnd = ContentStart + ContentSize;
+  return true;
+}
+
+/// Build the `signature` custom section payload (the raw signed data).
+/// Phase 1: one part, one hash, one signature, no key_id.
+///
+/// Payload layout (per Signatures.md):
+///   0x01           spec_version
+///   0x01           content_type (Wasm module)
+///   0x01           hash_fn (SHA-256)
+///   varuint32      signed_hashes_count = 1
+///   --- signed_hashes block ---
+///   varuint32      hashes_count = 1
+///   32 bytes       h1 = SHA-256(all non-sig content)
+///   varuint32      signatures_count = 1
+///   --- signature record ---
+///   varuint32      key_id_len = 0   (no key id for Phase 1)
+///   0x01           signature_id (Ed25519)
+///   varuint32      signature_len = 64
+///   64 bytes       Ed25519 signature over sig_msg
+///
+/// sig_msg = "wasmsig" | 0x01 | 0x01 | 0x01 | hashes
+std::vector<uint8_t>
+buildSignaturePayload(const std::array<uint8_t, kSha256DigestLen> &Hash,
+                      const std::vector<uint8_t> &Sig) noexcept {
+  // Build the hashes blob (single hash for Phase 1)
+  std::vector<uint8_t> Hashes(Hash.begin(), Hash.end());
+
+  std::vector<uint8_t> Payload;
+  // Header bytes
+  Payload.push_back(0x01u); // spec_version
+  Payload.push_back(0x01u); // content_type
+  Payload.push_back(0x01u); // hash_fn (SHA-256)
+  // signed_hashes_count = 1
+  for (auto B : encodeUleb128(1u)) {
+    Payload.push_back(B);
+  }
+  // --- signed_hashes ---
+  // hashes_count = 1
+  for (auto B : encodeUleb128(1u)) {
+    Payload.push_back(B);
+  }
+  // hashes (32 bytes)
+  Payload.insert(Payload.end(), Hashes.begin(), Hashes.end());
+  // signatures_count = 1
+  for (auto B : encodeUleb128(1u)) {
+    Payload.push_back(B);
+  }
+  // --- signature record ---
+  // key_id_len = 0
+  for (auto B : encodeUleb128(0u)) {
+    Payload.push_back(B);
+  }
+  // signature_id = 0x01 (Ed25519)
+  Payload.push_back(0x01u);
+  // signature_len
+  for (auto B : encodeUleb128(static_cast<uint32_t>(Sig.size()))) {
+    Payload.push_back(B);
+  }
+  // signature bytes
+  Payload.insert(Payload.end(), Sig.begin(), Sig.end());
+  return Payload;
+}
+
+/// Build the message that is actually signed:
+///   "wasmsig" || spec_version(0x01) || content_type(0x01) || hash_fn(0x01)
+///   || hashes
+std::vector<uint8_t>
+buildSigMessage(const std::array<uint8_t, kSha256DigestLen> &Hash) noexcept {
+  std::vector<uint8_t> Msg;
+  static constexpr std::string_view kPrefix = "wasmsig"sv;
+  Msg.insert(Msg.end(), reinterpret_cast<const uint8_t *>(kPrefix.data()),
+             reinterpret_cast<const uint8_t *>(kPrefix.data()) +
+                 kPrefix.size());
+  Msg.push_back(0x01u); // spec_version
+  Msg.push_back(0x01u); // content_type
+  Msg.push_back(0x01u); // hash_fn
+  // Append hashes
+  Msg.insert(Msg.end(), Hash.begin(), Hash.end());
+  return Msg;
+}
+
+} // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// SignTool — public entry point
+// ---------------------------------------------------------------------------
+
+int SignTool(struct DriverToolOptions &Opt) noexcept {
+  // --- Validate options ---
+  const std::string &WasmPath = Opt.SoName.value();
+  if (WasmPath.empty()) {
+    spdlog::error("sign: no input file specified. Usage: wasmedge sign "
+                  "<wasm> --key <keyfile> [--output <out.wasm>]"sv);
+    return EXIT_FAILURE;
+  }
+
+  const std::string &KeyPath = Opt.KeyFile.value();
+  if (KeyPath.empty()) {
+    spdlog::error(
+        "sign: --key is required. Provide an Ed25519 keypair file."sv);
+    return EXIT_FAILURE;
+  }
+
+  // Derive output path
+  std::string OutPath = Opt.OutputFile.value();
+  if (OutPath.empty()) {
+    // Default: <input>.signed.wasm
+    OutPath = WasmPath + ".signed.wasm"s;
+  }
+
+  // --- Load input Wasm ---
+  const auto Wasm = readFile(WasmPath);
+  if (Wasm.empty()) {
+    return EXIT_FAILURE;
+  }
+
+  // Validate Wasm magic + version
+  static constexpr std::array<uint8_t, 8> kWasmHeader = {
+      0x00, 0x61, 0x73, 0x6D, // \0asm
+      0x01, 0x00, 0x00, 0x00  // version 1
+  };
+  if (Wasm.size() < 8 ||
+      !std::equal(kWasmHeader.begin(), kWasmHeader.end(), Wasm.begin())) {
+    spdlog::error("sign: not a valid WebAssembly binary: {}"sv, WasmPath);
+    return EXIT_FAILURE;
+  }
+
+  // Reject already-signed modules to keep Phase 1 simple (idempotency guard).
+  std::size_t ExistingSigEnd = 0;
+  if (hasLeadingSignatureSection(Wasm, ExistingSigEnd)) {
+    spdlog::error("sign: module already contains a signature section. "
+                  "Re-signing is not supported in Phase 1."sv);
+    return EXIT_FAILURE;
+  }
+
+  // --- Load keypair ---
+  const auto KeyBlob = readFile(KeyPath);
+  if (KeyBlob.empty()) {
+    return EXIT_FAILURE;
+  }
+  WasmSigKey Key;
+  if (!Key.loadFromBytes(KeyBlob)) {
+    spdlog::error(
+        "sign: failed to load key from: {}. "
+        "Expected format: 0x81 | secret(32) | public(32) = 65 bytes."sv,
+        KeyPath);
+    return EXIT_FAILURE;
+  }
+  if (!Key.canSign()) {
+    spdlog::error("sign: key file contains a public key only. Signing requires "
+                  "a keypair (65-byte file, first byte 0x81)."sv);
+    return EXIT_FAILURE;
+  }
+
+  // --- Compute rolling hash over the payload bytes ---
+  // Per Signatures.md Phase 1 (no delimiters):
+  //   h1 = SHA-256(p1 || d1) where p1 is all sections and d1 is the
+  //   trailing delimiter.
+  //
+  // For Phase 1 with a single part and no delimiter, we compute:
+  //   h1 = SHA-256(all bytes after the 8-byte Wasm header)
+  //
+  // This matches the spec example: "SHA-256(sections 1..end)".
+  RollingHasher Hasher;
+  // Feed everything after the magic+version header.
+  if (!Hasher.update(Wasm.data() + 8, Wasm.size() - 8)) {
+    spdlog::error("sign: hash computation failed."sv);
+    return EXIT_FAILURE;
+  }
+  const auto Hash = Hasher.digest();
+
+  // --- Build and sign the message ---
+  const auto Msg = buildSigMessage(Hash);
+  const auto Sig = Key.sign(Msg.data(), Msg.size());
+  if (Sig.size() != kEd25519SigLen) {
+    spdlog::error("sign: signing failed."sv);
+    return EXIT_FAILURE;
+  }
+
+  // --- Build the signature custom section ---
+  const auto Payload = buildSignaturePayload(Hash, Sig);
+  const auto SigSection = buildCustomSection("signature"sv, Payload);
+
+  // --- Assemble signed module: header | sigSection | rest ---
+  std::vector<uint8_t> SignedWasm;
+  SignedWasm.reserve(Wasm.size() + SigSection.size());
+  // 8-byte Wasm header
+  SignedWasm.insert(SignedWasm.end(), Wasm.begin(), Wasm.begin() + 8);
+  // Prepend signature section (first custom section after header)
+  SignedWasm.insert(SignedWasm.end(), SigSection.begin(), SigSection.end());
+  // Remaining sections unchanged
+  SignedWasm.insert(SignedWasm.end(), Wasm.begin() + 8, Wasm.end());
+
+  // --- Write output ---
+  if (!writeFile(OutPath, SignedWasm)) {
+    return EXIT_FAILURE;
+  }
+
+  spdlog::info("sign: signed module written to: {}"sv, OutPath);
+  return EXIT_SUCCESS;
+}
+
+} // namespace Driver
+} // namespace WasmEdge

--- a/lib/driver/signature_crypto.cpp
+++ b/lib/driver/signature_crypto.cpp
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The WasmEdge Authors
+
+#include "signature_crypto.h"
+
+#include <openssl/evp.h>
+#include <openssl/sha.h>
+
+#include <cstring>
+
+namespace WasmEdge {
+namespace Driver {
+
+// ---------------------------------------------------------------------------
+// EvpPkeyDeleter / EvpMdCtxDeleter
+// ---------------------------------------------------------------------------
+
+void EvpPkeyDeleter::operator()(evp_pkey_st *Ptr) const noexcept {
+  EVP_PKEY_free(Ptr);
+}
+
+void EvpMdCtxDeleter::operator()(evp_md_ctx_st *Ptr) const noexcept {
+  EVP_MD_CTX_free(Ptr);
+}
+
+// ---------------------------------------------------------------------------
+// RollingHasher
+// ---------------------------------------------------------------------------
+
+RollingHasher::RollingHasher() noexcept : Ctx(EVP_MD_CTX_new()) {
+  if (Ctx) {
+    if (EVP_DigestInit_ex(Ctx.get(), EVP_sha256(), nullptr) != 1) {
+      Ctx.reset();
+    }
+  }
+}
+
+bool RollingHasher::update(const uint8_t *Data, std::size_t Len) noexcept {
+  if (!Ctx) {
+    return false;
+  }
+  return EVP_DigestUpdate(Ctx.get(), Data, Len) == 1;
+}
+
+std::array<uint8_t, kSha256DigestLen> RollingHasher::digest() const noexcept {
+  std::array<uint8_t, kSha256DigestLen> Out{};
+  if (!Ctx) {
+    return Out;
+  }
+  // Clone so we can finalize without disturbing the rolling state.
+  EvpMdCtxPtr Copy(EVP_MD_CTX_new());
+  if (!Copy) {
+    return Out;
+  }
+  if (EVP_MD_CTX_copy_ex(Copy.get(), Ctx.get()) != 1) {
+    return Out;
+  }
+  unsigned int Len = 0;
+  EVP_DigestFinal_ex(Copy.get(), Out.data(), &Len);
+  return Out;
+}
+
+// ---------------------------------------------------------------------------
+// WasmSigKey
+// ---------------------------------------------------------------------------
+
+bool WasmSigKey::loadFromBytes(const std::vector<uint8_t> &Blob) noexcept {
+  if (Blob.empty()) {
+    return false;
+  }
+  const uint8_t Tag = Blob[0];
+  if (Tag == 0x81) {
+    // Keypair: 0x81 | secret(32) | public(32)
+    if (Blob.size() != 65) {
+      return false;
+    }
+    const uint8_t *Secret = Blob.data() + 1;
+    // OpenSSL Ed25519 raw private key is the 32-byte seed.
+    EVP_PKEY *Pk =
+        EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519, nullptr, Secret, 32);
+    if (!Pk) {
+      return false;
+    }
+    Key.reset(Pk);
+    CanSign = true;
+    return true;
+  }
+  if (Tag == 0x01) {
+    // Public only: 0x01 | public(32)
+    if (Blob.size() != 33) {
+      return false;
+    }
+    const uint8_t *Pub = Blob.data() + 1;
+    EVP_PKEY *Pk =
+        EVP_PKEY_new_raw_public_key(EVP_PKEY_ED25519, nullptr, Pub, 32);
+    if (!Pk) {
+      return false;
+    }
+    Key.reset(Pk);
+    CanSign = false;
+    return true;
+  }
+  return false;
+}
+
+std::vector<uint8_t> WasmSigKey::sign(const uint8_t *Msg,
+                                      std::size_t MsgLen) const noexcept {
+  if (!Key || !CanSign) {
+    return {};
+  }
+  EvpMdCtxPtr Ctx(EVP_MD_CTX_new());
+  if (!Ctx) {
+    return {};
+  }
+  if (EVP_DigestSignInit(Ctx.get(), nullptr, nullptr, nullptr, Key.get()) !=
+      1) {
+    return {};
+  }
+  std::size_t SigLen = 0;
+  if (EVP_DigestSign(Ctx.get(), nullptr, &SigLen, Msg, MsgLen) != 1) {
+    return {};
+  }
+  std::vector<uint8_t> Sig(SigLen);
+  if (EVP_DigestSign(Ctx.get(), Sig.data(), &SigLen, Msg, MsgLen) != 1) {
+    return {};
+  }
+  Sig.resize(SigLen);
+  return Sig;
+}
+
+bool WasmSigKey::verify(const uint8_t *Msg, std::size_t MsgLen,
+                        const uint8_t *Sig, std::size_t SigLen) const noexcept {
+  if (!Key) {
+    return false;
+  }
+  EvpMdCtxPtr Ctx(EVP_MD_CTX_new());
+  if (!Ctx) {
+    return false;
+  }
+  if (EVP_DigestVerifyInit(Ctx.get(), nullptr, nullptr, nullptr, Key.get()) !=
+      1) {
+    return false;
+  }
+  return EVP_DigestVerify(Ctx.get(), Sig, SigLen, Msg, MsgLen) == 1;
+}
+
+// ---------------------------------------------------------------------------
+// encodeUleb128
+// ---------------------------------------------------------------------------
+
+std::vector<uint8_t> encodeUleb128(uint32_t Value) noexcept {
+  std::vector<uint8_t> Out;
+  do {
+    uint8_t Byte = static_cast<uint8_t>(Value & 0x7Fu);
+    Value >>= 7u;
+    if (Value != 0) {
+      Byte |= 0x80u;
+    }
+    Out.push_back(Byte);
+  } while (Value != 0);
+  return Out;
+}
+
+} // namespace Driver
+} // namespace WasmEdge

--- a/lib/driver/signature_crypto.h
+++ b/lib/driver/signature_crypto.h
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The WasmEdge Authors
+
+//===-- wasmedge/driver/signature_crypto.h - OpenSSL RAII wrappers --------===//
+//
+// Part of the WasmEdge Project.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// RAII wrappers for OpenSSL EVP objects used by the Wasm signature tool.
+/// Only compiled when WASMEDGE_BUILD_SIGNATURE_TOOLS is ON.
+///
+//===----------------------------------------------------------------------===//
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+// Forward declarations to avoid pulling full OpenSSL headers into every TU
+// that includes this header.  The actual definitions only appear in .cpp files.
+struct evp_pkey_st;
+struct evp_md_ctx_st;
+
+namespace WasmEdge {
+namespace Driver {
+
+/// Ed25519 signature length in bytes.
+static constexpr std::size_t kEd25519SigLen = 64;
+/// SHA-256 digest length in bytes.
+static constexpr std::size_t kSha256DigestLen = 32;
+
+/// RAII deleter for EVP_PKEY.
+struct EvpPkeyDeleter {
+  void operator()(evp_pkey_st *Ptr) const noexcept;
+};
+using EvpPkeyPtr = std::unique_ptr<evp_pkey_st, EvpPkeyDeleter>;
+
+/// RAII deleter for EVP_MD_CTX.
+struct EvpMdCtxDeleter {
+  void operator()(evp_md_ctx_st *Ptr) const noexcept;
+};
+using EvpMdCtxPtr = std::unique_ptr<evp_md_ctx_st, EvpMdCtxDeleter>;
+
+/// Rolling SHA-256 state that accumulates bytes fed into it.
+/// Call digest() to obtain the intermediate hash without resetting state.
+class RollingHasher {
+public:
+  RollingHasher() noexcept;
+
+  /// Feed raw bytes into the hash state.
+  /// Returns false on OpenSSL error.
+  bool update(const uint8_t *Data, std::size_t Len) noexcept;
+
+  /// Snapshot the current hash without finalising (copy-finalize trick).
+  /// Returns an empty vector on OpenSSL error.
+  std::array<uint8_t, kSha256DigestLen> digest() const noexcept;
+
+private:
+  EvpMdCtxPtr Ctx;
+};
+
+/// Ed25519 key loaded from the raw serialized format defined in Signatures.md.
+///
+/// Accepted key file formats (raw binary):
+///   - Keypair  (Phase 1 signing):  0x81 | secret(32) | public(32)  => 65 B
+///   - Public   (verification):     0x01 | public(32)               => 33 B
+class WasmSigKey {
+public:
+  WasmSigKey() noexcept = default;
+
+  /// Load from a binary blob whose first byte is the key-type identifier.
+  /// Returns false when the blob is malformed or the key type is unsupported.
+  bool loadFromBytes(const std::vector<uint8_t> &Blob) noexcept;
+
+  /// True after a successful loadFromBytes() call.
+  bool isLoaded() const noexcept { return Key != nullptr; }
+
+  /// True if this key can sign (i.e. it carries the private scalar).
+  bool canSign() const noexcept { return CanSign; }
+
+  /// Sign `Msg` with this key.  Returns 64-byte signature or empty on error.
+  std::vector<uint8_t> sign(const uint8_t *Msg,
+                            std::size_t MsgLen) const noexcept;
+
+  /// Verify `Sig` over `Msg` with this key.
+  /// Returns true iff verification succeeds.
+  bool verify(const uint8_t *Msg, std::size_t MsgLen, const uint8_t *Sig,
+              std::size_t SigLen) const noexcept;
+
+private:
+  EvpPkeyPtr Key;
+  bool CanSign = false;
+};
+
+/// LEB128 varuint32 encoding helpers used when building the custom section.
+std::vector<uint8_t> encodeUleb128(uint32_t Value) noexcept;
+
+} // namespace Driver
+} // namespace WasmEdge

--- a/lib/driver/uniTool.cpp
+++ b/lib/driver/uniTool.cpp
@@ -5,6 +5,10 @@
 #include "common/spdlog.h"
 #include "driver/compiler.h"
 #include "driver/tool.h"
+#ifdef WASMEDGE_BUILD_SIGNATURE_TOOLS
+#include "driver/signTool.h"
+#include "driver/verifyTool.h"
+#endif
 #include "po/argument_parser.h"
 
 #include <string_view>
@@ -29,11 +33,21 @@ int UniTool(int Argc, const char *Argv[], const ToolType ToolSelect) noexcept {
       PO::Description("Wasmedge instantiate tool subcommand"sv));
   PO::SubCommand ValidateSubCommand(
       PO::Description("Wasmedge validate tool subcommand"sv));
+#ifdef WASMEDGE_BUILD_SIGNATURE_TOOLS
+  PO::SubCommand SignSubCommand(
+      PO::Description("Wasmedge signature sign tool subcommand"sv));
+  PO::SubCommand VerifySubCommand(
+      PO::Description("Wasmedge signature verify tool subcommand"sv));
+#endif
   struct DriverToolOptions ToolOptions;
   struct DriverCompilerOptions CompilerOptions;
   struct DriverToolOptions ParseOptions;
   struct DriverToolOptions InstantiateOptions;
   struct DriverToolOptions ValidateOptions;
+#ifdef WASMEDGE_BUILD_SIGNATURE_TOOLS
+  struct DriverToolOptions SignOptions;
+  struct DriverToolOptions VerifyOptions;
+#endif
 
   // Construct Parser Subcommands and Options
   if (ToolSelect == ToolType::All) {
@@ -54,6 +68,14 @@ int UniTool(int Argc, const char *Argv[], const ToolType ToolSelect) noexcept {
     Parser.begin_subcommand(ValidateSubCommand, "validate"sv);
     ValidateOptions.addParserOptions(Parser);
     Parser.end_subcommand();
+#ifdef WASMEDGE_BUILD_SIGNATURE_TOOLS
+    Parser.begin_subcommand(SignSubCommand, "sign"sv);
+    SignOptions.addSignatureSignOptions(Parser);
+    Parser.end_subcommand();
+    Parser.begin_subcommand(VerifySubCommand, "verify"sv);
+    VerifyOptions.addSignatureVerifyOptions(Parser);
+    Parser.end_subcommand();
+#endif
   } else if (ToolSelect == ToolType::Tool) {
     ToolOptions.addOptions(Parser);
   } else if (ToolSelect == ToolType::Compiler) {
@@ -98,6 +120,9 @@ int UniTool(int Argc, const char *Argv[], const ToolType ToolSelect) noexcept {
 
   if (ToolSelect == ToolType::All) {
     if (!ParseSubCommand.is_selected() && !ValidateSubCommand.is_selected() &&
+#ifdef WASMEDGE_BUILD_SIGNATURE_TOOLS
+        !SignSubCommand.is_selected() && !VerifySubCommand.is_selected() &&
+#endif
         !InstantiateSubCommand.is_selected()) {
       ApplyLogLevel(ToolOptions.LogLevel.value());
     }
@@ -121,6 +146,12 @@ int UniTool(int Argc, const char *Argv[], const ToolType ToolSelect) noexcept {
   } else if (InstantiateSubCommand.is_selected() ||
              ToolSelect == ToolType::Instantiate) {
     return InstantiateTool(InstantiateOptions);
+#ifdef WASMEDGE_BUILD_SIGNATURE_TOOLS
+  } else if (SignSubCommand.is_selected()) {
+    return SignTool(SignOptions);
+  } else if (VerifySubCommand.is_selected()) {
+    return VerifyTool(VerifyOptions);
+#endif
   } else {
     return Tool(ToolOptions);
   }

--- a/lib/driver/verifyTool.cpp
+++ b/lib/driver/verifyTool.cpp
@@ -1,0 +1,415 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The WasmEdge Authors
+
+#include "driver/verifyTool.h"
+#include "common/spdlog.h"
+#include "driver/tool.h"
+#include "signature_crypto.h"
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using namespace std::literals;
+
+namespace WasmEdge {
+namespace Driver {
+
+namespace {
+
+/// Read entire file into a byte vector.
+std::vector<uint8_t> readFileV(const std::string &Path) noexcept {
+  std::FILE *F = std::fopen(Path.c_str(), "rb");
+  if (!F) {
+    spdlog::error("verify: cannot open file: {}"sv, Path);
+    return {};
+  }
+  if (std::fseek(F, 0, SEEK_END) != 0) {
+    std::fclose(F);
+    return {};
+  }
+  const long Size = std::ftell(F);
+  if (Size < 0) {
+    std::fclose(F);
+    return {};
+  }
+  std::rewind(F);
+  std::vector<uint8_t> Buf(static_cast<std::size_t>(Size));
+  if (Size > 0 && std::fread(Buf.data(), 1, static_cast<std::size_t>(Size),
+                             F) != static_cast<std::size_t>(Size)) {
+    spdlog::error("verify: read error on: {}"sv, Path);
+    std::fclose(F);
+    return {};
+  }
+  std::fclose(F);
+  return Buf;
+}
+
+/// Decode a LEB128 unsigned 32-bit integer from Buf at Pos.
+bool decodeUleb128V(const std::vector<uint8_t> &Buf, std::size_t &Pos,
+                    uint32_t &Out) noexcept {
+  uint32_t Result = 0;
+  unsigned Shift = 0;
+  while (Pos < Buf.size()) {
+    const uint8_t Byte = Buf[Pos++];
+    if (Shift >= 32) {
+      return false;
+    }
+    Result |= static_cast<uint32_t>(Byte & 0x7Fu) << Shift;
+    Shift += 7;
+    if ((Byte & 0x80u) == 0) {
+      Out = Result;
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Parsed representation of a single signature record.
+struct SigRecord {
+  std::vector<uint8_t> KeyId;    // may be empty
+  uint8_t SigAlgorithm = 0;      // 0x01 = Ed25519
+  std::vector<uint8_t> SigBytes; // raw signature
+};
+
+/// Parsed representation of a signed_hashes block.
+struct SignedHashBlock {
+  std::vector<std::array<uint8_t, kSha256DigestLen>> Hashes;
+  std::vector<SigRecord> Signatures;
+};
+
+/// Parsed signature section structure.
+struct SignatureSection {
+  uint8_t SpecVersion = 0;
+  uint8_t ContentType = 0;
+  uint8_t HashFn = 0;
+  std::vector<SignedHashBlock> Blocks;
+  /// Byte offset in the outer Wasm buffer where module content begins
+  /// (i.e., immediately after the signature custom section ends).
+  std::size_t ContentStart = 0;
+};
+
+/// Attempt to parse a `signature` custom section from `Wasm`.
+/// On success returns true and fills `Out`; ContentStart is set to the first
+/// byte of non-signature module content.
+bool parseSignatureSection(const std::vector<uint8_t> &Wasm,
+                           SignatureSection &Out) noexcept {
+  if (Wasm.size() < 8) {
+    return false;
+  }
+  std::size_t Pos = 8; // after magic+version
+  if (Pos >= Wasm.size()) {
+    return false;
+  }
+  // Must be a custom section (id=0)
+  if (Wasm[Pos] != 0x00u) {
+    spdlog::error("verify: first section is not a custom section."sv);
+    return false;
+  }
+  Pos++;
+  uint32_t ContentSize = 0;
+  if (!decodeUleb128V(Wasm, Pos, ContentSize)) {
+    return false;
+  }
+  const std::size_t ContentStart = Pos;
+  const std::size_t ContentEnd = ContentStart + ContentSize;
+  if (ContentEnd > Wasm.size()) {
+    return false;
+  }
+
+  // Parse name
+  uint32_t NameLen = 0;
+  if (!decodeUleb128V(Wasm, Pos, NameLen)) {
+    return false;
+  }
+  if (Pos + NameLen > ContentEnd) {
+    return false;
+  }
+  std::string_view Name(reinterpret_cast<const char *>(Wasm.data() + Pos),
+                        NameLen);
+  if (Name != "signature"sv) {
+    spdlog::error(
+        "verify: leading custom section is named '{}', not 'signature'."sv,
+        std::string(Name));
+    return false;
+  }
+  Pos += NameLen;
+
+  // Parse signature payload
+  if (Pos >= ContentEnd) {
+    return false;
+  }
+  Out.SpecVersion = Wasm[Pos++];
+  if (Pos >= ContentEnd) {
+    return false;
+  }
+  Out.ContentType = Wasm[Pos++];
+  if (Pos >= ContentEnd) {
+    return false;
+  }
+  Out.HashFn = Wasm[Pos++];
+
+  if (Out.SpecVersion != 0x01u) {
+    spdlog::error("verify: unsupported spec_version: 0x{:02x}."sv,
+                  Out.SpecVersion);
+    return false;
+  }
+  if (Out.ContentType != 0x01u) {
+    spdlog::error("verify: unsupported content_type: 0x{:02x}."sv,
+                  Out.ContentType);
+    return false;
+  }
+  if (Out.HashFn != 0x01u) {
+    spdlog::error("verify: unsupported hash_fn: 0x{:02x}. Only SHA-256 (0x01) "
+                  "is supported."sv,
+                  Out.HashFn);
+    return false;
+  }
+
+  uint32_t BlockCount = 0;
+  if (!decodeUleb128V(Wasm, Pos, BlockCount)) {
+    return false;
+  }
+
+  for (uint32_t Bi = 0; Bi < BlockCount; ++Bi) {
+    SignedHashBlock Block;
+
+    uint32_t HashCount = 0;
+    if (!decodeUleb128V(Wasm, Pos, HashCount)) {
+      return false;
+    }
+    for (uint32_t Hi = 0; Hi < HashCount; ++Hi) {
+      if (Pos + kSha256DigestLen > ContentEnd) {
+        return false;
+      }
+      std::array<uint8_t, kSha256DigestLen> H;
+      std::copy_n(Wasm.data() + Pos, kSha256DigestLen, H.data());
+      Pos += kSha256DigestLen;
+      Block.Hashes.push_back(H);
+    }
+
+    uint32_t SigCount = 0;
+    if (!decodeUleb128V(Wasm, Pos, SigCount)) {
+      return false;
+    }
+    for (uint32_t Si = 0; Si < SigCount; ++Si) {
+      SigRecord Rec;
+      uint32_t KeyIdLen = 0;
+      if (!decodeUleb128V(Wasm, Pos, KeyIdLen)) {
+        return false;
+      }
+      if (Pos + KeyIdLen > ContentEnd) {
+        return false;
+      }
+      Rec.KeyId.assign(Wasm.data() + Pos, Wasm.data() + Pos + KeyIdLen);
+      Pos += KeyIdLen;
+
+      if (Pos >= ContentEnd) {
+        return false;
+      }
+      Rec.SigAlgorithm = Wasm[Pos++];
+
+      uint32_t SigLen = 0;
+      if (!decodeUleb128V(Wasm, Pos, SigLen)) {
+        return false;
+      }
+      if (Pos + SigLen > ContentEnd) {
+        return false;
+      }
+      Rec.SigBytes.assign(Wasm.data() + Pos, Wasm.data() + Pos + SigLen);
+      Pos += SigLen;
+
+      Block.Signatures.push_back(std::move(Rec));
+    }
+
+    Out.Blocks.push_back(std::move(Block));
+  }
+
+  Out.ContentStart = ContentEnd;
+  return true;
+}
+
+/// Build the canonical message that was signed:
+///   "wasmsig" || spec_version || content_type || hash_fn || hashes
+std::vector<uint8_t> buildVerifyMessage(
+    uint8_t SpecVer, uint8_t ContentType, uint8_t HashFn,
+    const std::vector<std::array<uint8_t, kSha256DigestLen>> &Hashes) noexcept {
+  std::vector<uint8_t> Msg;
+  static constexpr std::string_view kPrefix = "wasmsig"sv;
+  Msg.insert(Msg.end(), reinterpret_cast<const uint8_t *>(kPrefix.data()),
+             reinterpret_cast<const uint8_t *>(kPrefix.data()) +
+                 kPrefix.size());
+  Msg.push_back(SpecVer);
+  Msg.push_back(ContentType);
+  Msg.push_back(HashFn);
+  for (const auto &H : Hashes) {
+    Msg.insert(Msg.end(), H.begin(), H.end());
+  }
+  return Msg;
+}
+
+} // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// VerifyTool — public entry point
+// ---------------------------------------------------------------------------
+
+int VerifyTool(struct DriverToolOptions &Opt) noexcept {
+  // --- Validate options ---
+  const std::string &WasmPath = Opt.SoName.value();
+  if (WasmPath.empty()) {
+    spdlog::error("verify: no input file specified. Usage: wasmedge verify "
+                  "<wasm> [--key <pubkey>]"sv);
+    return EXIT_FAILURE;
+  }
+
+  // --- Load Wasm ---
+  const auto Wasm = readFileV(WasmPath);
+  if (Wasm.empty()) {
+    return EXIT_FAILURE;
+  }
+
+  static constexpr std::array<uint8_t, 8> kWasmHeader = {
+      0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00};
+  if (Wasm.size() < 8 ||
+      !std::equal(kWasmHeader.begin(), kWasmHeader.end(), Wasm.begin())) {
+    spdlog::error("verify: not a valid WebAssembly binary: {}"sv, WasmPath);
+    return EXIT_FAILURE;
+  }
+
+  // --- Parse signature section ---
+  SignatureSection SigSec;
+  if (!parseSignatureSection(Wasm, SigSec)) {
+    spdlog::error("verify: no valid signature section found in: {}"sv,
+                  WasmPath);
+    return EXIT_FAILURE;
+  }
+
+  if (SigSec.Blocks.empty()) {
+    spdlog::error(
+        "verify: signature section contains no signed_hashes blocks."sv);
+    return EXIT_FAILURE;
+  }
+
+  // --- Optionally load public key for filtering ---
+  std::unique_ptr<WasmSigKey> PubKey;
+  const std::string &KeyPath = Opt.KeyFile.value();
+  if (!KeyPath.empty()) {
+    const auto KeyBlob = readFileV(KeyPath);
+    if (KeyBlob.empty()) {
+      return EXIT_FAILURE;
+    }
+    PubKey = std::make_unique<WasmSigKey>();
+    if (!PubKey->loadFromBytes(KeyBlob)) {
+      spdlog::error("verify: failed to load public key from: {}. "
+                    "Expected format: 0x01 | public(32) = 33 bytes, or "
+                    "0x81 | secret(32) | public(32) = 65 bytes."sv,
+                    KeyPath);
+      return EXIT_FAILURE;
+    }
+  }
+
+  // --- Recompute rolling hash over content after the signature section ---
+  // Phase 1: one part, the hash covers everything after the sig section.
+  // This matches what signTool.cpp committed: h1 = SHA-256(bytes after header).
+  //
+  // However, the signed module's "bytes after header" now includes the
+  // signature section itself prepended.  When verifying, we must hash
+  // everything from ContentStart to end of file (i.e. the original payload).
+  const std::size_t ContentOff = SigSec.ContentStart;
+  if (ContentOff > Wasm.size()) {
+    spdlog::error("verify: malformed signature section offsets."sv);
+    return EXIT_FAILURE;
+  }
+
+  RollingHasher Hasher;
+  if (Wasm.size() > ContentOff) {
+    if (!Hasher.update(Wasm.data() + ContentOff, Wasm.size() - ContentOff)) {
+      spdlog::error("verify: hash computation failed."sv);
+      return EXIT_FAILURE;
+    }
+  }
+  const auto ComputedHash = Hasher.digest();
+
+  // --- Verify each block ---
+  // For Phase 1, expect exactly one block with exactly one hash.
+  bool AnyBlockVerified = false;
+  for (const auto &Block : SigSec.Blocks) {
+    if (Block.Hashes.size() != 1) {
+      spdlog::warn(
+          "verify: block has {} hashes; Phase 1 expects 1. Skipping."sv,
+          Block.Hashes.size());
+      continue;
+    }
+
+    // Check that the embedded hash matches the recomputed hash.
+    if (Block.Hashes[0] != ComputedHash) {
+      spdlog::error(
+          "verify: content hash mismatch — module has been modified."sv);
+      return EXIT_FAILURE;
+    }
+
+    // Build the message that was originally signed.
+    const auto Msg = buildVerifyMessage(SigSec.SpecVersion, SigSec.ContentType,
+                                        SigSec.HashFn, Block.Hashes);
+
+    // Try to verify at least one signature in the block.
+    bool BlockVerified = false;
+    for (const auto &Rec : Block.Signatures) {
+      if (Rec.SigAlgorithm != 0x01u) {
+        spdlog::warn(
+            "verify: unknown signature algorithm 0x{:02x}, skipping."sv,
+            Rec.SigAlgorithm);
+        continue;
+      }
+
+      if (PubKey) {
+        // Verify against the user-supplied key.
+        if (PubKey->verify(Msg.data(), Msg.size(), Rec.SigBytes.data(),
+                           Rec.SigBytes.size())) {
+          BlockVerified = true;
+          break;
+        }
+      } else {
+        // No user-supplied key: we need to recover the public key from the
+        // key_id embedded in the signature record.  When key_id_len=0 (Phase
+        // 1), there is no embedded public key, so verification without a
+        // supplied key file is not possible.
+        if (Rec.KeyId.empty()) {
+          spdlog::error("verify: signature record carries no key identifier. "
+                        "Provide --key <pubkey> to verify."sv);
+          return EXIT_FAILURE;
+        }
+        // Future: parse key_id as a serialised public key.
+        spdlog::warn(
+            "verify: key_id present but key loading from key_id is not "
+            "yet implemented. Provide --key <pubkey> to verify."sv);
+        continue;
+      }
+    }
+
+    if (!BlockVerified) {
+      spdlog::error("verify: no valid signature found in block."sv);
+      return EXIT_FAILURE;
+    }
+    AnyBlockVerified = true;
+  }
+
+  if (!AnyBlockVerified) {
+    spdlog::error(
+        "verify: signature verification failed — no block verified."sv);
+    return EXIT_FAILURE;
+  }
+
+  spdlog::info("verify: signature verified OK: {}"sv, WasmPath);
+  return EXIT_SUCCESS;
+}
+
+} // namespace Driver
+} // namespace WasmEdge

--- a/test/driver/CMakeLists.txt
+++ b/test/driver/CMakeLists.txt
@@ -15,3 +15,10 @@ target_link_libraries(wasmedgeDriverToolTests
   ${GTEST_BOTH_LIBRARIES}
   wasmedgeDriver
 )
+
+if(WASMEDGE_BUILD_SIGNATURE_TOOLS)
+  target_compile_definitions(wasmedgeDriverToolTests
+    PRIVATE
+    -DWASMEDGE_BUILD_SIGNATURE_TOOLS
+  )
+endif()

--- a/test/driver/driverToolTest.cpp
+++ b/test/driver/driverToolTest.cpp
@@ -74,6 +74,22 @@ int callUniToolAll(std::initializer_list<const char *> Args) {
                                    WasmEdge::Driver::ToolType::All);
 }
 
+#if WASMEDGE_BUILD_SIGNATURE_TOOLS
+int callSign(std::initializer_list<const char *> Args) {
+  std::vector<const char *> Argv = {"wasmedge", "sign"};
+  Argv.insert(Argv.end(), Args.begin(), Args.end());
+  return WasmEdge::Driver::UniTool(static_cast<int>(Argv.size()), Argv.data(),
+                                   WasmEdge::Driver::ToolType::All);
+}
+
+int callVerify(std::initializer_list<const char *> Args) {
+  std::vector<const char *> Argv = {"wasmedge", "verify"};
+  Argv.insert(Argv.end(), Args.begin(), Args.end());
+  return WasmEdge::Driver::UniTool(static_cast<int>(Argv.size()), Argv.data(),
+                                   WasmEdge::Driver::ToolType::All);
+}
+#endif
+
 #if !WASMEDGE_OS_WINDOWS
 struct ToolResult {
   int ExitCode;
@@ -1017,6 +1033,118 @@ TEST(NoSubcommand, FallbackToRun) {
                             simplePath().c_str(), "add", "1", "2"}),
             EXIT_SUCCESS);
 }
+
+#if WASMEDGE_BUILD_SIGNATURE_TOOLS
+static const std::array<uint8_t, 65> ValidEd25519Key = {
+    0x81, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
+    0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
+    0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
+    0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+    0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+    0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
+
+static const std::array<uint8_t, 65> AnotherValidEd25519Key = {
+    0x81, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+    0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+    0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+    0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB,
+    0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB,
+    0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB};
+
+TEST(SignSubcommand, SignValidModule) {
+  std::string WasmPath = simplePath();
+  std::string KeyPath = writeWasmToFile(ValidEd25519Key.data(),
+                                        ValidEd25519Key.size(), "key1.pem");
+  std::string OutPath = TestDataPath + "/signed.wasm";
+
+  EXPECT_EQ(callSign({"--key", KeyPath.c_str(), "--output", OutPath.c_str(),
+                      WasmPath.c_str()}),
+            EXIT_SUCCESS);
+
+  // Check if out path exists and has valid signature section
+  std::ifstream Ifs(OutPath, std::ios::binary);
+  EXPECT_TRUE(Ifs.is_open());
+  Ifs.seekg(0, std::ios::end);
+  EXPECT_GT(Ifs.tellg(), static_cast<std::streampos>(SimpleWasm.size()));
+}
+
+TEST(SignSubcommand, SignMissingKey) {
+  std::string WasmPath = simplePath();
+  std::string OutPath = TestDataPath + "/signed.wasm";
+  EXPECT_NE(callSign({"--key", "nonexistent.pem", "--output", OutPath.c_str(),
+                      WasmPath.c_str()}),
+            EXIT_SUCCESS);
+  EXPECT_NE(callSign({"--output", OutPath.c_str(), WasmPath.c_str()}),
+            EXIT_SUCCESS);
+}
+
+TEST(VerifySubcommand, VerifyValidSignature) {
+  std::string WasmPath = simplePath();
+  std::string KeyPath = writeWasmToFile(ValidEd25519Key.data(),
+                                        ValidEd25519Key.size(), "key1.pem");
+  std::string OutPath = TestDataPath + "/signed.wasm";
+
+  EXPECT_EQ(callSign({"--key", KeyPath.c_str(), "--output", OutPath.c_str(),
+                      WasmPath.c_str()}),
+            EXIT_SUCCESS);
+
+  EXPECT_EQ(callVerify({"--key", KeyPath.c_str(), OutPath.c_str()}),
+            EXIT_SUCCESS);
+}
+
+TEST(VerifySubcommand, VerifyUnsignedModule) {
+  std::string WasmPath = simplePath();
+  std::string KeyPath = writeWasmToFile(ValidEd25519Key.data(),
+                                        ValidEd25519Key.size(), "key1.pem");
+  EXPECT_NE(callVerify({"--key", KeyPath.c_str(), WasmPath.c_str()}),
+            EXIT_SUCCESS);
+}
+
+TEST(VerifySubcommand, VerifyWrongKey) {
+  std::string WasmPath = simplePath();
+  std::string KeyPath1 = writeWasmToFile(ValidEd25519Key.data(),
+                                         ValidEd25519Key.size(), "key1.pem");
+  std::string KeyPath2 = writeWasmToFile(
+      AnotherValidEd25519Key.data(), AnotherValidEd25519Key.size(), "key2.pem");
+  std::string OutPath = TestDataPath + "/signed.wasm";
+
+  EXPECT_EQ(callSign({"--key", KeyPath1.c_str(), "--output", OutPath.c_str(),
+                      WasmPath.c_str()}),
+            EXIT_SUCCESS);
+
+  EXPECT_NE(callVerify({"--key", KeyPath2.c_str(), OutPath.c_str()}),
+            EXIT_SUCCESS);
+}
+
+TEST(VerifySubcommand, VerifyTamperedModule) {
+  std::string WasmPath = simplePath();
+  std::string KeyPath = writeWasmToFile(ValidEd25519Key.data(),
+                                        ValidEd25519Key.size(), "key1.pem");
+  std::string OutPath = TestDataPath + "/signed.wasm";
+
+  EXPECT_EQ(callSign({"--key", KeyPath.c_str(), "--output", OutPath.c_str(),
+                      WasmPath.c_str()}),
+            EXIT_SUCCESS);
+
+  // Tamper the module (e.g. modify byte 8 which is part of the Wasm format)
+  std::fstream Fs(OutPath, std::ios::in | std::ios::out | std::ios::binary);
+  ASSERT_TRUE(Fs.is_open());
+  Fs.seekp(8);
+  char C = 0xFF;
+  Fs.write(&C, 1);
+  Fs.close();
+
+  EXPECT_NE(callVerify({"--key", KeyPath.c_str(), OutPath.c_str()}),
+            EXIT_SUCCESS);
+}
+
+TEST(VerifySubcommand, VerifyMissingKey) {
+  std::string WasmPath = simplePath();
+  EXPECT_NE(callVerify({"--key", "nonexistent.pem", WasmPath.c_str()}),
+            EXIT_SUCCESS);
+  EXPECT_NE(callVerify({WasmPath.c_str()}), EXIT_SUCCESS);
+}
+#endif
 
 } // namespace
 


### PR DESCRIPTION
# feat: implement WasmEdge code signing and verification tools (#2090)

## Summary

Resolves #2090.

This PR implements `wasmedge sign` and `wasmedge verify` CLI subcommands, enabling developers to digitally sign WebAssembly modules and verify their integrity using Ed25519 signatures backed by OpenSSL EVP APIs.

The signature is stored inside a standard WebAssembly custom section, allowing the signed `.wasm` file to remain a valid WebAssembly module.

## What's implemented

- ✅ Integrated `sign` and `verify` subcommands into the unified `wasmedge` CLI via `UniTool`.
- ✅ Implemented Ed25519 signing and verification using OpenSSL EVP APIs.
- ✅ Added dedicated cryptographic helper functions for signing and verification.
- ✅ Embedded signatures inside a WebAssembly custom section.
- ✅ Added comprehensive GTest coverage for signing and verification workflows.
- ✅ Added failure-path coverage for missing keys, unsigned modules, incorrect keys, and tampered modules.
- ✅ Added optional build configuration for the signature tooling.
- ✅ Preserved existing driver behavior when signature tooling is disabled.
- ✅ Updated CMake configuration and driver test integration.

## CLI Usage

### Sign a WebAssembly module

```bash
wasmedge sign --key key.pem --output signed.wasm module.wasm
```

### Verify a signed WebAssembly module

```bash
wasmedge verify --key key.pem signed.wasm
```

A successful verification confirms that the module's signature is valid and matches the supplied public key.

## Implementation Details

### CLI integration

The new commands are integrated into the existing WasmEdge command infrastructure through `UniTool`.

This allows `sign` and `verify` to behave consistently with the existing WasmEdge CLI subcommands and argument parsing.

### Ed25519 cryptography

The signing and verification implementation uses OpenSSL's EVP APIs with Ed25519.

The cryptographic functionality is isolated into:

- `lib/driver/signature_crypto.cpp`
- `lib/driver/signature_crypto.h`

This keeps the cryptographic operations separated from the CLI command implementation.

### WebAssembly custom section

The generated signature is stored inside a standard WebAssembly custom section.

This ensures that a signed WebAssembly module remains structurally valid while carrying the information required for verification.

### Verification behavior

Verification correctly handles:

- Valid signatures
- Unsigned modules
- Incorrect public/private keys
- Tampered modules
- Missing key files
- Invalid or missing signature sections

## Build

The signature tooling can be enabled during configuration:

```bash
cmake -S . -B build \
  -DWASMEDGE_BUILD_TESTS=ON \
  -DWASMEDGE_BUILD_SIGNATURE_TOOLS=ON

cmake --build build -j$(nproc)
```

## Test Results

The implementation was tested at multiple levels, including the new signature-specific tests, the complete driver test suite, the full CTest suite, and LLVM/AOT tests.

---

## 1. Signature-specific tests

The new tests cover both `SignSubcommand` and `VerifySubcommand`.

### Command

```bash
./build/test/driver/wasmedgeDriverToolTests \
  --gtest_filter='SignSubcommand.*:VerifySubcommand.*'
```

### Result

```text
[----------] 2 tests from SignSubcommand

[ RUN      ] SignSubcommand.SignValidModule
[       OK ] SignSubcommand.SignValidModule

[ RUN      ] SignSubcommand.SignMissingKey
[       OK ] SignSubcommand.SignMissingKey

[----------] 2 tests from SignSubcommand

[----------] 5 tests from VerifySubcommand

[ RUN      ] VerifySubcommand.VerifyValidSignature
[       OK ] VerifySubcommand.VerifyValidSignature

[ RUN      ] VerifySubcommand.VerifyUnsignedModule
[       OK ] VerifySubcommand.VerifyUnsignedModule

[ RUN      ] VerifySubcommand.VerifyWrongKey
[       OK ] VerifySubcommand.VerifyWrongKey

[ RUN      ] VerifySubcommand.VerifyTamperedModule
[       OK ] VerifySubcommand.VerifyTamperedModule

[ RUN      ] VerifySubcommand.VerifyMissingKey
[       OK ] VerifySubcommand.VerifyMissingKey

[----------] 5 tests from VerifySubcommand

[==========] 7 tests from 2 test suites ran.
[  PASSED  ] 7 tests.
```

### Screenshot

**Signature-specific test results — 7/7 passed**

<img width="1313" height="685" alt="1" src="https://github.com/user-attachments/assets/0ea60156-33bd-4282-a4d3-3ab7980b0350" />


---

## 2. Complete DriverTool test suite

The complete driver test binary was executed to ensure the new implementation does not break the existing driver functionality.

### Command

```bash
./build/test/driver/wasmedgeDriverToolTests
```

### Result

```text
[----------] 5 tests from VerifySubcommand

[----------] Global test environment tear-down
[==========] 50 tests from 8 test suites ran. (783 ms total)
[  PASSED  ] 50 tests.
```

### Screenshot

**Complete DriverTool test suite — 50/50 passed**

<img width="1300" height="681" alt="2" src="https://github.com/user-attachments/assets/4eb542bc-9901-48b9-ac38-44795f227069" />


---

## 3. Full CTest suite

The complete configured CTest suite was executed.

### Command

```bash
ctest --test-dir build --output-on-failure
```

### Result

```text
100% tests passed, 0 tests failed out of 23

Total Test time (real) = 151.75 sec
```

### Screenshot

**Full CTest suite — 23/23 passed**

<img width="1005" height="672" alt="4" src="https://github.com/user-attachments/assets/5dcfd98b-44a1-4d13-9279-3e2654627bc2" />

---

## 4. LLVM AOT Core tests

The LLVM-enabled AOT core test suite was also executed directly.

### Command

```bash
cd ~/WasmEdge/build/test/api
./wasmedgeAPIAOTCoreTests
```

### Result

```text
[----------] 495 tests from TestUnit/CoreCompileTest

[==========] 495 tests from 1 test suite ran. (124787 ms total)
[  PASSED  ] 495 tests.
```

The test suite completed successfully with all 495 AOT compilation tests passing.

### Screenshot

**LLVM AOT Core — 495/495 passed**

<img width="1362" height="672" alt="5" src="https://github.com/user-attachments/assets/a3a3c0e0-452c-4f27-a28c-bb5991ac1925" />

---

## 5. LLVM AOT Nested VM test

The nested VM AOT test was also executed directly.

### Command

```bash
cd ~/WasmEdge/build/test/api
./wasmedgeAPIAOTNestedVMTests
```

### Result

```text
[----------] 1 test from APIAOTNestedVMTest

[ RUN      ] APIAOTNestedVMTest.NestedVM
[       OK ] APIAOTNestedVMTest.NestedVM

[==========] 1 test from 1 test suite ran. (247 ms total)
[  PASSED  ] 1 test.
```

### Screenshot

**LLVM AOT Nested VM — 1/1 passed**

<img width="1077" height="462" alt="3" src="https://github.com/user-attachments/assets/fc650571-a4ca-4cd4-aa6e-66096100fee4" />

---

## Test Summary

| Test Suite | Result |
|---|---:|
| `SignSubcommand` | 2/2 ✅ |
| `VerifySubcommand` | 5/5 ✅ |
| DriverTool tests | 50/50 ✅ |
| Full CTest suite | 23/23 ✅ |
| LLVM AOT Core | 495/495 ✅ |
| LLVM AOT Nested VM | 1/1 ✅ |

All executed test suites passed successfully.

## Security

- Uses Ed25519 through OpenSSL EVP APIs for signing and verification.
- Verification rejects invalid signatures.
- Unsigned modules are rejected by the verification command.
- Verification with an incorrect key fails.
- Tampered modules fail verification.
- Missing key files are handled as errors.

## Compatibility

The signature tooling is optional and integrated through the existing driver build system.

When the signature feature is disabled, the existing WasmEdge driver behavior remains unchanged.

## Files Changed

The implementation is contained in the following 12 files:

- `include/driver/signTool.h`
- `include/driver/verifyTool.h`
- `include/driver/tool.h`
- `lib/driver/signTool.cpp`
- `lib/driver/verifyTool.cpp`
- `lib/driver/signature_crypto.cpp`
- `lib/driver/signature_crypto.h`
- `lib/driver/uniTool.cpp`
- `lib/driver/CMakeLists.txt`
- `test/driver/driverToolTest.cpp`
- `test/driver/CMakeLists.txt`
- `CMakeLists.txt`

## Checklist

- [x] Implemented `sign` subcommand
- [x] Implemented `verify` subcommand
- [x] Added Ed25519 signing and verification
- [x] Added OpenSSL EVP-based cryptographic implementation
- [x] Added WebAssembly custom-section signature storage
- [x] Added comprehensive GTest coverage
- [x] Added success and failure-path tests
- [x] Added optional build configuration
- [x] Verified driver test suite
- [x] Verified full CTest suite
- [x] Verified LLVM AOT Core tests
- [x] Verified LLVM AOT Nested VM tests
- [x] Verified code formatting and project style

## Related Issue

Closes #2090

---
