### PR TITLE
fix(aot): bound-check memory64 loads and stores

### DIFF
--- a/lib/llvm/compiler/function_compiler.h
+++ b/lib/llvm/compiler/function_compiler.h
@@ -91,6 +91,8 @@ private:
 
   void compileReturnCallRefOp(const unsigned int TypeIndex) noexcept;
 
+  void boundsCheckMemory64(unsigned MemoryIndex, LLVM::Value Addr,
+                           uint64_t Offset, uint64_t AccessSize) noexcept;
   void compileLoadOp(unsigned MemoryIndex, uint64_t Offset, unsigned Alignment,
                      LLVM::Type LoadTy) noexcept;
   void compileLoadOp(unsigned MemoryIndex, uint64_t Offset, unsigned Alignment,

--- a/lib/llvm/compiler/memoryInstr.cpp
+++ b/lib/llvm/compiler/memoryInstr.cpp
@@ -3,6 +3,8 @@
 
 #include "compiler/function_compiler.h"
 
+#include <limits>
+
 namespace WasmEdge {
 
 Expect<void>
@@ -197,6 +199,36 @@ FunctionCompiler::compileMemoryOp(const AST::Instruction &Instr) noexcept {
   return {};
 }
 
+// Memory32 cannot escape the reservation's guard region, so it keeps the
+// guard-page fast path. Memory64 addresses are guest-controlled 64-bit values.
+void FunctionCompiler::boundsCheckMemory64(unsigned MemoryIndex,
+                                           LLVM::Value Addr, uint64_t Offset,
+                                           uint64_t AccessSize) noexcept {
+  if (Context.MemoryAddrTypes[MemoryIndex].getIntegerBitWidth() != 64) {
+    return;
+  }
+  if (Offset > std::numeric_limits<uint64_t>::max() - AccessSize) {
+    // No address can satisfy the access.
+    Builder.createBr(getTrapBB(ErrCode::Value::MemoryOutOfBounds));
+    Builder.positionAtEnd(
+        LLVM::BasicBlock::create(LLContext, F.Fn, "mem64.ok"));
+    return;
+  }
+  // Addr < usub_sat(SizeBytes, Offset + AccessSize - 1) is exactly
+  // Addr + Offset + AccessSize <= SizeBytes with every term kept in 64 bits.
+  const uint64_t OffsetAndSize = Offset + AccessSize;
+  auto SizeBytes =
+      Builder.createShl(Context.getMemorySize(Builder, ExecCtx, MemoryIndex),
+                        LLContext.getInt64(16));
+  auto Limit = Builder.createIntrinsic(
+      LLVM::Core::USubSat, {Context.Int64Ty},
+      {SizeBytes, LLContext.getInt64(OffsetAndSize - 1)});
+  auto OkBB = LLVM::BasicBlock::create(LLContext, F.Fn, "mem64.ok");
+  Builder.createCondBr(Builder.createLikely(Builder.createICmpULT(Addr, Limit)),
+                       OkBB, getTrapBB(ErrCode::Value::MemoryOutOfBounds));
+  Builder.positionAtEnd(OkBB);
+}
+
 void FunctionCompiler::compileLoadOp(unsigned MemoryIndex, uint64_t Offset,
                                      unsigned Alignment,
                                      LLVM::Type LoadTy) noexcept {
@@ -204,6 +236,8 @@ void FunctionCompiler::compileLoadOp(unsigned MemoryIndex, uint64_t Offset,
     Alignment = 0;
   }
   auto Off = Builder.createZExt(stackPop(), Context.Int64Ty);
+  boundsCheckMemory64(MemoryIndex, Off, Offset,
+                      LoadTy.getPrimitiveSizeInBits() / 8);
   if (Offset != 0) {
     Off = Builder.createAdd(Off, LLContext.getInt64(Offset));
   }
@@ -236,6 +270,8 @@ void FunctionCompiler::compileStoreOp(uint32_t MemoryIndex, uint64_t Offset,
   }
   auto V = stackPop();
   auto Off = Builder.createZExt(stackPop(), Context.Int64Ty);
+  boundsCheckMemory64(MemoryIndex, Off, Offset,
+                      LoadTy.getPrimitiveSizeInBits() / 8);
   if (Offset != 0) {
     Off = Builder.createAdd(Off, LLContext.getInt64(Offset));
   }

--- a/lib/llvm/compiler/threadInstr.cpp
+++ b/lib/llvm/compiler/threadInstr.cpp
@@ -407,9 +407,12 @@ void FunctionCompiler::compileAtomicLoad(unsigned MemoryIndex,
                                          LLVM::Type TargetType,
                                          bool Signed) noexcept {
 
-  auto Offset = Builder.createZExt(Stack.back(), Context.Int64Ty);
+  auto Addr = Builder.createZExt(Stack.back(), Context.Int64Ty);
+  boundsCheckMemory64(MemoryIndex, Addr, MemoryOffset,
+                      TargetType.getPrimitiveSizeInBits() / 8);
+  auto Offset = Addr;
   if (MemoryOffset != 0) {
-    Offset = Builder.createAdd(Offset, LLContext.getInt64(MemoryOffset));
+    Offset = Builder.createAdd(Addr, LLContext.getInt64(MemoryOffset));
   }
   compileAtomicCheckOffsetAlignment(Offset, TargetType);
   auto VPtr = Builder.createInBoundsGEP1(
@@ -440,9 +443,12 @@ void FunctionCompiler::compileAtomicStore(unsigned MemoryIndex,
     V = Builder.createZExtOrTrunc(V, TargetType);
   }
   V = switchEndian(V);
-  auto Offset = Builder.createZExt(Stack.back(), Context.Int64Ty);
+  auto Addr = Builder.createZExt(Stack.back(), Context.Int64Ty);
+  boundsCheckMemory64(MemoryIndex, Addr, MemoryOffset,
+                      TargetType.getPrimitiveSizeInBits() / 8);
+  auto Offset = Addr;
   if (MemoryOffset != 0) {
-    Offset = Builder.createAdd(Offset, LLContext.getInt64(MemoryOffset));
+    Offset = Builder.createAdd(Addr, LLContext.getInt64(MemoryOffset));
   }
   compileAtomicCheckOffsetAlignment(Offset, TargetType);
   auto VPtr = Builder.createInBoundsGEP1(
@@ -458,9 +464,12 @@ void FunctionCompiler::compileAtomicRMWOp(
     [[maybe_unused]] unsigned Alignment, LLVMAtomicRMWBinOp BinOp,
     LLVM::Type IntType, LLVM::Type TargetType, bool Signed) noexcept {
   auto Value = Builder.createSExtOrTrunc(stackPop(), TargetType);
-  auto Offset = Builder.createZExt(Stack.back(), Context.Int64Ty);
+  auto Addr = Builder.createZExt(Stack.back(), Context.Int64Ty);
+  boundsCheckMemory64(MemoryIndex, Addr, MemoryOffset,
+                      TargetType.getPrimitiveSizeInBits() / 8);
+  auto Offset = Addr;
   if (MemoryOffset != 0) {
-    Offset = Builder.createAdd(Offset, LLContext.getInt64(MemoryOffset));
+    Offset = Builder.createAdd(Addr, LLContext.getInt64(MemoryOffset));
   }
   compileAtomicCheckOffsetAlignment(Offset, TargetType);
   auto VPtr = Builder.createInBoundsGEP1(
@@ -524,9 +533,12 @@ void FunctionCompiler::compileAtomicCompareExchange(
 
   auto Replacement = Builder.createSExtOrTrunc(stackPop(), TargetType);
   auto Expected = Builder.createSExtOrTrunc(stackPop(), TargetType);
-  auto Offset = Builder.createZExt(Stack.back(), Context.Int64Ty);
+  auto Addr = Builder.createZExt(Stack.back(), Context.Int64Ty);
+  boundsCheckMemory64(MemoryIndex, Addr, MemoryOffset,
+                      TargetType.getPrimitiveSizeInBits() / 8);
+  auto Offset = Addr;
   if (MemoryOffset != 0) {
-    Offset = Builder.createAdd(Offset, LLContext.getInt64(MemoryOffset));
+    Offset = Builder.createAdd(Addr, LLContext.getInt64(MemoryOffset));
   }
   compileAtomicCheckOffsetAlignment(Offset, TargetType);
   auto VPtr = Builder.createInBoundsGEP1(

--- a/test/llvm/LLVMcoreTest.cpp
+++ b/test/llvm/LLVMcoreTest.cpp
@@ -942,6 +942,93 @@ TEST(SIMDNaN, F32x4MaxNaNHandling) {
   EXPECT_NO_THROW(std::filesystem::remove(Path));
 }
 
+TEST(AOTMemory64, BoundsCheck) {
+  // A full 64-bit index escapes the guard page that memory32 relies on, so
+  // check that a far out-of-bounds memory64 access traps rather than reaching
+  // host memory.
+  //
+  // (module
+  //   (memory $m1 (export "mem1") i64 1)
+  //   (func (export "peek") (param i64) (result i64)
+  //     (i64.load $m1 (local.get 0)))
+  //   (func (export "poke") (param i64 i64)
+  //     (i64.store $m1 (local.get 0) (local.get 1))))
+  std::array<WasmEdge::Byte, 90> Memory64Wasm{
+      0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0b, 0x02, 0x60,
+      0x01, 0x7e, 0x01, 0x7e, 0x60, 0x02, 0x7e, 0x7e, 0x00, 0x03, 0x03, 0x02,
+      0x00, 0x01, 0x05, 0x03, 0x01, 0x04, 0x01, 0x07, 0x16, 0x03, 0x04, 0x6d,
+      0x65, 0x6d, 0x31, 0x02, 0x00, 0x04, 0x70, 0x65, 0x65, 0x6b, 0x00, 0x00,
+      0x04, 0x70, 0x6f, 0x6b, 0x65, 0x00, 0x01, 0x0a, 0x13, 0x02, 0x07, 0x00,
+      0x20, 0x00, 0x29, 0x03, 0x00, 0x0b, 0x09, 0x00, 0x20, 0x00, 0x20, 0x01,
+      0x37, 0x03, 0x00, 0x0b, 0x00, 0x0c, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x06,
+      0x05, 0x01, 0x00, 0x02, 0x6d, 0x31};
+
+  WasmEdge::Configure Conf;
+  Conf.getCompilerConfigure().setOutputFormat(
+      CompilerConfigure::OutputFormat::Native);
+  Conf.getRuntimeConfigure().setRunMode(WasmEdge::RunMode::AOT);
+
+  WasmEdge::VM::VM VM(Conf);
+  WasmEdge::Loader::Loader Loader(Conf);
+  WasmEdge::Validator::Validator ValidatorEngine(Conf);
+  WasmEdge::LLVM::Compiler Compiler(Conf);
+  WasmEdge::LLVM::CodeGen CodeGen(Conf);
+
+  auto Path = std::filesystem::temp_directory_path() /
+              std::filesystem::u8path("AOTMemory64Test" WASMEDGE_LIB_EXTENSION);
+
+  auto Module = *Loader.parseModule(Memory64Wasm);
+  ASSERT_TRUE(ValidatorEngine.validate(*Module));
+  auto Data = Compiler.compile(*Module);
+  ASSERT_TRUE(Data);
+  ASSERT_TRUE(CodeGen.codegen(Memory64Wasm, std::move(*Data), Path));
+
+  ASSERT_TRUE(VM.loadWasm(Path));
+  ASSERT_TRUE(VM.validate());
+  ASSERT_TRUE(VM.instantiate());
+
+  const std::vector<WasmEdge::ValType> I64{
+      WasmEdge::ValType(WasmEdge::TypeCode::I64)};
+  const std::vector<WasmEdge::ValType> I64x2{
+      WasmEdge::ValType(WasmEdge::TypeCode::I64),
+      WasmEdge::ValType(WasmEdge::TypeCode::I64)};
+
+  // In-bounds store then load round-trips.
+  ASSERT_TRUE(VM.execute("poke",
+                         {WasmEdge::ValVariant(UINT64_C(8)),
+                          WasmEdge::ValVariant(UINT64_C(0x1234))},
+                         I64x2));
+  auto InBounds = VM.execute("peek", {WasmEdge::ValVariant(UINT64_C(8))}, I64);
+  ASSERT_TRUE(InBounds);
+  EXPECT_EQ((*InBounds)[0].first.get<uint64_t>(), UINT64_C(0x1234));
+
+  // Aim the index at an in-process heap buffer: a fixed huge constant would
+  // only fault into unmapped space, which proves nothing.
+  const auto *ModInst = VM.getActiveModule();
+  ASSERT_NE(ModInst, nullptr);
+  auto *MemInst = ModInst->findMemoryExports("mem1");
+  ASSERT_NE(MemInst, nullptr);
+  const uint8_t *Base = MemInst->getDataPtr();
+  auto Secret = std::make_unique<uint64_t>(UINT64_C(0xDEADBEEFCAFEBABE));
+  const uint64_t Off =
+      static_cast<uint64_t>(reinterpret_cast<uintptr_t>(Secret.get()) -
+                            reinterpret_cast<uintptr_t>(Base));
+  auto OobLoad = VM.execute("peek", {WasmEdge::ValVariant(Off)}, I64);
+  ASSERT_FALSE(OobLoad);
+  EXPECT_EQ(OobLoad.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  EXPECT_EQ(*Secret, UINT64_C(0xDEADBEEFCAFEBABE));
+
+  auto OobStore = VM.execute(
+      "poke", {WasmEdge::ValVariant(Off), WasmEdge::ValVariant(UINT64_C(0))},
+      I64x2);
+  ASSERT_FALSE(OobStore);
+  EXPECT_EQ(OobStore.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  EXPECT_EQ(*Secret, UINT64_C(0xDEADBEEFCAFEBABE));
+
+  VM.cleanup();
+  EXPECT_NO_THROW(std::filesystem::remove(Path));
+}
+
 } // namespace
 
 GTEST_API_ int main(int argc, char **argv) {


### PR DESCRIPTION
## Description

The AOT/JIT backend enforces linear-memory bounds with a guard-page reservation rather than a comparison: each memory is placed at a 4 GiB offset inside a 12 GiB PROT_NONE mapping, so any access that escapes the reservation faults. That holds for memory32, where the address is a zero-extended i32 and the validator caps the static offset, so the effective address can never leave the guard region. For memory64 the address is a full, guest-controlled 64-bit value fed straight into the GEP with no check, so an index more than 8 GiB from the base reaches arbitrary host memory -- a guest-to-host out-of-bounds read and write in the default configuration (memory64 is on by default), while the interpreter correctly traps via `checkAccessBound`.

Emit an explicit bound check for memory64 accesses. `compileLoadOp` and `compileStoreOp` (which also back every vector load/store) and the inline atomic load/store/rmw/cmpxchg paths now compare the address against the current memory size and branch to a `MemoryOutOfBounds` trap.

`Offset` and `AccessSize` are compile-time constants, so they are folded into the limit rather than added to the address. The emitted check is

```
Addr < usub_sat(SizeBytes, Offset + AccessSize - 1)
```

which is exactly `Addr + Offset + AccessSize <= SizeBytes` while keeping every term in 64 bits:

- when `SizeBytes >= Offset + AccessSize`, the saturating subtraction yields `SizeBytes - (Offset + AccessSize) + 1`, so the strict comparison accepts precisely the in-bounds addresses;
- when the memory is smaller than the access, the subtraction saturates to `0` and the comparison is unconditionally false, so every address traps;
- `AccessSize >= 1` always, so the `- 1` bias cannot underflow.

Neither side can wrap, so no widening is needed. An `Offset` that already overflows 64 bits folds to an unconditional trap at compile time. Because the limit depends only on the memory size, LICM can hoist the whole right-hand side out of loops that do not grow memory.

Memory32 keeps the guard-page fast path untouched -- its generated code is byte-for-byte identical to before this change -- and the bulk-memory and atomic wait/notify paths already route through range-checked runtime intrinsics.

Add `AOTMemory64.BoundsCheck`: it compiles a memory64 module, points the guest index at an in-process heap buffer, and asserts that both an out-of-bounds **load** and an out-of-bounds **store** trap and leave the host value untouched. Both reach host memory without the fix.

### Performance

Measured on the AOT backend with tight memory64 loops (600M iterations, median of 7, base = `master`). memory32 is included as a noise floor, since its generated code is unchanged:

| working set | kernel | master | this PR |
|---|---|---|---|
| 8 KiB | load only | 0.544 s | 0.548 s (+0.7%) |
| 8 KiB | store only | 0.540 s | 0.541 s (+0.2%) |
| 8 KiB | load + store | 0.598 s | 0.599 s (+0.2%) |
| 64 MiB | load only | 0.551 s | 0.559 s (+1.3%) |
| 64 MiB | store only | 0.549 s | 0.548 s (-0.1%) |
| 64 MiB | load + store | 0.582 s | 0.631 s (+7.6%) |

memory32 noise floor over the same runs: ±0.7%. The 64 MiB load+store row is the worst case (two checks per iteration over a large working set) and was re-measured over 15 reps to confirm it is stable.

Assisted-by: Claude (Anthropic)

This contribution was developed with assistance from Claude (Anthropic).


## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

`wasmedgeLLVMCoreTests` (covers the native AOT, custom-wasm AOT, JIT and LazyJIT spec suites plus the new regression test):

```
[==========] Running 1991 tests from 9 test suites.
...
[ RUN      ] AOTMemory64.BoundsCheck
[error] execution failed: out of bounds memory access, Code: 0x408
[error] calling stack:
[error]     When executing function name: "peek"
[error] execution failed: out of bounds memory access, Code: 0x408
[error] calling stack:
[error]     When executing function name: "poke"
[       OK ] AOTMemory64.BoundsCheck (98 ms)
...
[==========] 1991 tests from 9 test suites ran. (318287 ms total)
[  PASSED  ] 1991 tests.
```
