### PR TITLE
fix(coredump): fix coredump generation

### DIFF
--- a/include/driver/tool.h
+++ b/include/driver/tool.h
@@ -58,9 +58,12 @@ struct DriverToolOptions : public DriverProposalOptions {
         ConfEnableJIT(
             PO::Description("Enable Just-In-Time compiler for running WASM"sv)),
         ConfEnableCoredump(PO::Description(
-            "Enable coredump when WebAssembly enters a trap"sv)),
+            "Enable coredump when WebAssembly enters a trap. Requires the "
+            "interpreter run mode, otherwise it is disabled"sv)),
         ConfCoredumpWasmgdb(
-            PO::Description("Enable coredump for wasm-gdb to debug"sv)),
+            PO::Description("Enable coredump in the format expected by the "
+                            "wasmgdb debugger, which differs from the one of "
+                            "the WebAssembly tool conventions"sv)),
         ConfForceInterpreter(
             PO::Description("Forcibly run WASM in interpreter mode."sv)),
         ConfRunMode(PO::Description("Set execution mode. Valid values: "

--- a/include/executor/coredump.h
+++ b/include/executor/coredump.h
@@ -1,32 +1,29 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
-#include "ast/section.h"
-#include "ast/type.h"
+#pragma once
+
+#include "ast/instruction.h"
 #include "common/errcode.h"
-#include "common/span.h"
-#include "loader/serialize.h"
-#include "runtime/instance/memory.h"
 #include "runtime/stackmgr.h"
+
+#include <string>
 
 namespace WasmEdge {
 namespace Coredump {
 
-void generateCoredump(const Runtime::StackManager &StackMgr,
-                      bool ForWasmgdb) noexcept;
-AST::CustomSection createCore();
-AST::CustomSection createCoremodules(
-    Loader::Serializer &Ser,
-    Span<const Runtime::Instance::ModuleInstance *const> ModuleInstances);
-AST::CustomSection createCorestack(
-    Loader::Serializer &Ser, Span<const Runtime::StackManager::Frame> Frames,
-    Span<const Runtime::StackManager::Value> ValueStack, bool ForWasmgdb);
-AST::CustomSection createCoreinstances(
-    Span<const Runtime::Instance::ModuleInstance *const> ModuleInstances);
-AST::MemorySection createMemory(
-    Span<const Runtime::Instance::MemoryInstance *const> MemoryInstances);
-AST::GlobalSection createGlobals(
-    Span<const Runtime::Instance::GlobalInstance *const> GlobalInstances);
-AST::DataSection
-createData(Span<const Runtime::Instance::DataInstance *const> DataInstances);
+/// Dump the current execution state into a coredump file.
+///
+/// \param StackMgr the stack manager of the trapping execution.
+/// \param PC the instruction which caused the trap. May be an empty iterator
+/// when the trapping instruction is unknown.
+/// \param ForWasmgdb generate a coredump consumable by the `wasmgdb` debugger.
+/// Its parser reads the size of the operand stack vector but not its content,
+/// therefore the operand stack is omitted in this mode.
+///
+/// \returns the path of the generated coredump file, or an error code.
+Expect<std::string> generateCoredump(const Runtime::StackManager &StackMgr,
+                                     AST::InstrView::iterator PC,
+                                     bool ForWasmgdb) noexcept;
+
 } // namespace Coredump
 } // namespace WasmEdge

--- a/include/loader/serialize.h
+++ b/include/loader/serialize.h
@@ -68,6 +68,18 @@ public:
   void serializeU32(uint32_t Num, std::vector<uint8_t> &OutVec) const noexcept {
     serializeUN<uint32_t, 32>(Num, OutVec, OutVec.end());
   }
+  void serializeS32(int32_t Num, std::vector<uint8_t> &OutVec) const noexcept {
+    serializeSN<int32_t, 32>(Num, OutVec);
+  }
+  void serializeS64(int64_t Num, std::vector<uint8_t> &OutVec) const noexcept {
+    serializeSN<int64_t, 64>(Num, OutVec);
+  }
+  void serializeF32(float Num, std::vector<uint8_t> &OutVec) const noexcept {
+    serializeFN<float, uint32_t>(Num, OutVec);
+  }
+  void serializeF64(double Num, std::vector<uint8_t> &OutVec) const noexcept {
+    serializeFN<double, uint64_t>(Num, OutVec);
+  }
 
 private:
   /// \name Serialize functions for the other nodes of AST.
@@ -164,14 +176,8 @@ private:
     OutVec.insert(OutVec.end(), Buf, Buf + Len);
   }
 
-  void serializeS32(int32_t Num, std::vector<uint8_t> &OutVec) const noexcept {
-    serializeSN<int32_t, 32>(Num, OutVec);
-  }
   void serializeS33(int64_t Num, std::vector<uint8_t> &OutVec) const noexcept {
     serializeSN<int64_t, 33>(Num, OutVec);
-  }
-  void serializeS64(int64_t Num, std::vector<uint8_t> &OutVec) const noexcept {
-    serializeSN<int64_t, 64>(Num, OutVec);
   }
 
   template <typename NumType, typename IntType>
@@ -187,12 +193,6 @@ private:
     }
   }
 
-  void serializeF32(float Num, std::vector<uint8_t> &OutVec) const noexcept {
-    serializeFN<float, uint32_t>(Num, OutVec);
-  }
-  void serializeF64(double Num, std::vector<uint8_t> &OutVec) const noexcept {
-    serializeFN<double, uint64_t>(Num, OutVec);
-  }
   template <typename T, typename L>
   void serializeSectionContent(const T &Sec, uint8_t Code,
                                std::vector<uint8_t> &OutVec,

--- a/lib/driver/runtimeTool.cpp
+++ b/lib/driver/runtimeTool.cpp
@@ -424,11 +424,19 @@ int Tool(struct DriverToolOptions &Opt) noexcept {
     Conf.getCompilerConfigure().setOptimizationLevel(
         WasmEdge::CompilerConfigure::OptimizationLevel::O1);
   }
-  if (Opt.ConfEnableCoredump.value()) {
-    Conf.getRuntimeConfigure().setEnableCoredump(true);
+  bool IsCoredumpEnabled =
+      Opt.ConfEnableCoredump.value() || Opt.ConfCoredumpWasmgdb.value();
+  if (IsCoredumpEnabled && RunModeFromFlag != RunMode::Interpreter) {
+    spdlog::warn("The coredump generation is supported by the interpreter "
+                 "only; the coredump is disabled. Use --run-mode=interpreter "
+                 "to generate a coredump."sv);
+    IsCoredumpEnabled = false;
   }
-  if (Opt.ConfCoredumpWasmgdb.value()) {
-    Conf.getRuntimeConfigure().setCoredumpWasmgdb(true);
+  if (IsCoredumpEnabled) {
+    Conf.getRuntimeConfigure().setEnableCoredump(true);
+    if (Opt.ConfCoredumpWasmgdb.value()) {
+      Conf.getRuntimeConfigure().setCoredumpWasmgdb(true);
+    }
   }
   if (Opt.ConfAFUNIX.value()) {
     Conf.getRuntimeConfigure().setAllowAFUNIX(true);

--- a/lib/executor/coredump.cpp
+++ b/lib/executor/coredump.cpp
@@ -1,211 +1,566 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
+
 #include "executor/coredump.h"
+
 #include "ast/section.h"
+#include "ast/segment.h"
+#include "ast/type.h"
 #include "common/errcode.h"
+#include "common/spdlog.h"
 #include "common/types.h"
-#include "runtime/stackmgr.h"
-#include "spdlog/spdlog.h"
+#include "loader/serialize.h"
+#include "runtime/instance/memory.h"
+#include "runtime/instance/module.h"
+
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <ctime>
+#include <fstream>
+#include <map>
+#include <string>
+#include <string_view>
+#include <unordered_map>
 #include <vector>
 
 using namespace std::literals;
 
 namespace WasmEdge {
 namespace Coredump {
-void generateCoredump(const Runtime::StackManager &StackMgr,
-                      bool ForWasmgdb) noexcept {
-  spdlog::info("Generating coredump..."sv);
-  if (ForWasmgdb) {
-    spdlog::info("For wasmgdb"sv);
-  }
-  // Generate coredump.
-  const auto *CurrentInstance = StackMgr.getModule();
-  Loader::Serializer Ser;
-  AST::Module Module{};
-  std::vector<Byte> &Magic = Module.getMagic();
-  std::string MagicStr("\0asm", 4);
-  Magic.insert(Magic.begin(), MagicStr.begin(), MagicStr.end());
-  std::vector<Byte> &Version = Module.getVersion();
-  // Version must be 1 to support Wasmgdb.
-  Version.insert(Version.begin(), {0x01, 0x00, 0x00, 0x00});
 
-  Module.getCustomSections().emplace_back(createCore());
-  Module.getCustomSections().emplace_back(createCorestack(
-      Ser, StackMgr.getFramesSpan(), StackMgr.getValueSpan(), ForWasmgdb));
-  // TODO: reconstruct data instances
-  // Module.getDataSection() =
-  //     createData(CurrentInstance->getOwnedDataInstances());
-  // TODO: pass all module instances
-  Module.getCustomSections().emplace_back(
-      createCoremodules(Ser, {CurrentInstance}));
-  Module.getCustomSections().emplace_back(createCoreinstances({}));
-  Module.getMemorySection() =
-      createMemory(CurrentInstance->getMemoryInstances());
-  Module.getGlobalSection() =
-      createGlobals(CurrentInstance->getGlobalInstances());
-  auto Res = Ser.serializeModule(Module);
-  if (Res.has_value()) {
-    spdlog::info("Coredump generated."sv);
-    std::time_t Time = std::time(nullptr);
-    std::string CoredumpPath = "coredump." + std::to_string(Time);
-    std::ofstream File(CoredumpPath, std::ios::out | std::ios::binary);
-    if (File.is_open()) {
-      File.write(reinterpret_cast<const char *>(Res->data()),
-                 static_cast<uint32_t>(Res->size()));
-      File.close();
-    } else {
-      spdlog::error("Failed to generate coredump."sv);
-      assumingUnreachable();
-    }
-  } else {
-    spdlog::error("Failed to serialize coredump."sv);
-    assumingUnreachable();
-  }
+namespace {
 
-  return;
+using Runtime::StackManager;
+using Runtime::Instance::FunctionInstance;
+using Runtime::Instance::GlobalInstance;
+using Runtime::Instance::MemoryInstance;
+using Runtime::Instance::ModuleInstance;
+
+/// Type tags of the `value` production of the coredump format.
+static inline constexpr const Byte ValueMissing = 0x01;
+static inline constexpr const Byte ValueI32 = 0x7F;
+static inline constexpr const Byte ValueI64 = 0x7E;
+static inline constexpr const Byte ValueF32 = 0x7D;
+static inline constexpr const Byte ValueF64 = 0x7C;
+
+/// Serialize a wasm `name`, which is a length prefixed byte vector.
+void serializeName(const Loader::Serializer &Ser, std::string_view Name,
+                   std::vector<Byte> &OutVec) noexcept {
+  Ser.serializeU32(static_cast<uint32_t>(Name.size()), OutVec);
+  OutVec.insert(OutVec.end(), Name.begin(), Name.end());
 }
-AST::CustomSection createCore() {
+
+/// Serialize a `value`. The canonical encoder of the coredump format encodes
+/// the integers as LEB128, but the parser of wasmgdb reads them as fixed width
+/// little-endian values.
+void serializeValue(const Loader::Serializer &Ser, const ValVariant &Val,
+                    const ValType &Type, bool ForWasmgdb,
+                    std::vector<Byte> &OutVec) noexcept {
+  auto PushRaw = [&OutVec](const auto &Num) {
+    Byte Bytes[sizeof(Num)];
+    std::memcpy(Bytes, &Num, sizeof(Num));
+    OutVec.insert(OutVec.end(), std::begin(Bytes), std::end(Bytes));
+  };
+  switch (Type.getCode()) {
+  case TypeCode::I32:
+    OutVec.push_back(ValueI32);
+    if (ForWasmgdb) {
+      PushRaw(Val.get<int32_t>());
+    } else {
+      Ser.serializeS32(Val.get<int32_t>(), OutVec);
+    }
+    return;
+  case TypeCode::I64:
+    OutVec.push_back(ValueI64);
+    if (ForWasmgdb) {
+      PushRaw(Val.get<int64_t>());
+    } else {
+      Ser.serializeS64(Val.get<int64_t>(), OutVec);
+    }
+    return;
+  case TypeCode::F32:
+    OutVec.push_back(ValueF32);
+    Ser.serializeF32(Val.get<float>(), OutVec);
+    return;
+  case TypeCode::F64:
+    OutVec.push_back(ValueF64);
+    Ser.serializeF64(Val.get<double>(), OutVec);
+    return;
+  default:
+    // The coredump format has no encoding for V128 and reference values.
+    OutVec.push_back(ValueMissing);
+    return;
+  }
+}
+
+/// The index spaces of a coredump file. The runtime shares the entities between
+/// the importing and the exporting module instances, therefore the entities are
+/// deduplicated by their addresses and referred by the `coreinstances` section.
+class IndexSpaces {
+public:
+  void addModule(const ModuleInstance *Mod) noexcept {
+    if (Mod == nullptr || ModuleIdx.find(Mod) != ModuleIdx.end()) {
+      return;
+    }
+    ModuleIdx.emplace(Mod, static_cast<uint32_t>(Modules.size()));
+    Modules.push_back(Mod);
+    auto &MemIdxVec = InstanceMemories.emplace_back();
+    for (const auto *Mem : Mod->getMemoryInstances()) {
+      MemIdxVec.push_back(add(Mem, Memories, MemoryIdx));
+    }
+    auto &GlobIdxVec = InstanceGlobals.emplace_back();
+    for (const auto *Glob : Mod->getGlobalInstances()) {
+      GlobIdxVec.push_back(add(Glob, Globals, GlobalIdx));
+    }
+  }
+
+  uint32_t getModuleIdx(const ModuleInstance *Mod) const noexcept {
+    const auto Iter = ModuleIdx.find(Mod);
+    return Iter == ModuleIdx.end() ? 0U : Iter->second;
+  }
+
+  Span<const ModuleInstance *const> getModules() const noexcept {
+    return Modules;
+  }
+  Span<const MemoryInstance *const> getMemories() const noexcept {
+    return Memories;
+  }
+  Span<const GlobalInstance *const> getGlobals() const noexcept {
+    return Globals;
+  }
+  const std::vector<std::vector<uint32_t>> &
+  getInstanceMemories() const noexcept {
+    return InstanceMemories;
+  }
+  const std::vector<std::vector<uint32_t>> &
+  getInstanceGlobals() const noexcept {
+    return InstanceGlobals;
+  }
+
+private:
+  template <typename T>
+  static uint32_t add(const T *Entity, std::vector<const T *> &Vec,
+                      std::unordered_map<const T *, uint32_t> &Idx) noexcept {
+    const auto Iter = Idx.find(Entity);
+    if (Iter != Idx.end()) {
+      return Iter->second;
+    }
+    const auto NewIdx = static_cast<uint32_t>(Vec.size());
+    Idx.emplace(Entity, NewIdx);
+    Vec.push_back(Entity);
+    return NewIdx;
+  }
+
+  std::vector<const ModuleInstance *> Modules;
+  std::vector<const MemoryInstance *> Memories;
+  std::vector<const GlobalInstance *> Globals;
+  std::unordered_map<const ModuleInstance *, uint32_t> ModuleIdx;
+  std::unordered_map<const MemoryInstance *, uint32_t> MemoryIdx;
+  std::unordered_map<const GlobalInstance *, uint32_t> GlobalIdx;
+  std::vector<std::vector<uint32_t>> InstanceMemories;
+  std::vector<std::vector<uint32_t>> InstanceGlobals;
+};
+
+/// Resolve an instruction pointer back to the function which contains it.
+class FunctionResolver {
+public:
+  void addModule(const ModuleInstance *Mod) noexcept {
+    if (Mod == nullptr || Ranges.find(Mod) != Ranges.end()) {
+      return;
+    }
+    auto &Map = Ranges[Mod];
+    const auto FuncInsts = Mod->getFunctionInstances();
+    for (uint32_t I = 0; I < FuncInsts.size(); ++I) {
+      const auto *Func = FuncInsts[I];
+      if (Func == nullptr || !Func->isWasmFunction()) {
+        continue;
+      }
+      const auto Instrs = Func->getInstrs();
+      if (Instrs.begin() == Instrs.end()) {
+        continue;
+      }
+      Map.emplace(Instrs.begin(), std::make_pair(I, Func));
+      Map.emplace(Instrs.end(), std::make_pair(UINT32_MAX, nullptr));
+    }
+  }
+
+  /// Return the index and the instance of the function containing `It`.
+  std::pair<uint32_t, const FunctionInstance *>
+  resolve(const ModuleInstance *Mod,
+          AST::InstrView::iterator It) const noexcept {
+    const auto ModIter = Ranges.find(Mod);
+    if (ModIter == Ranges.end() || It == nullptr) {
+      return {0U, nullptr};
+    }
+    const auto &Map = ModIter->second;
+    auto Iter = Map.upper_bound(It);
+    if (Iter == Map.begin()) {
+      return {0U, nullptr};
+    }
+    --Iter;
+    if (Iter->second.second == nullptr) {
+      return {0U, nullptr};
+    }
+    return Iter->second;
+  }
+
+private:
+  std::unordered_map<const ModuleInstance *,
+                     std::map<AST::InstrView::iterator,
+                              std::pair<uint32_t, const FunctionInstance *>>>
+      Ranges;
+};
+
+/// The description of one wasm stack frame in the coredump.
+struct FrameInfo {
+  uint32_t InstanceIdx = 0;
+  uint32_t FuncIdx = 0;
+  uint32_t CodeOffset = 0;
+  const FunctionInstance *Func = nullptr;
+  Span<const StackManager::Value> Locals;
+  Span<const StackManager::Value> Stack;
+};
+
+/// Collect the wasm frames from the youngest one to the oldest one.
+std::vector<FrameInfo>
+collectFrames(const StackManager &StackMgr, AST::InstrView::iterator PC,
+              const IndexSpaces &Spaces,
+              const FunctionResolver &Resolver) noexcept {
+  const auto Frames = StackMgr.getFramesSpan();
+  const auto ValueStack = StackMgr.getValueSpan();
+  const auto FrameNum = Frames.size();
+  std::vector<FrameInfo> Result;
+  if (FrameNum == 0) {
+    return Result;
+  }
+  Result.reserve(FrameNum);
+  for (size_t Idx = FrameNum; Idx > 0; Idx--) {
+    const auto &Frame = Frames[Idx - 1];
+    // The bottom frame is a dummy frame pushed before entering a function.
+    if (Frame.Module == nullptr) {
+      continue;
+    }
+    FrameInfo Info;
+    Info.InstanceIdx = Spaces.getModuleIdx(Frame.Module);
+    // The `From` of the callee frame points to the call instruction in this
+    // frame, and the innermost frame is executing the trapping instruction.
+    const auto *const It = (Idx < FrameNum) ? Frames[Idx].From : PC;
+    std::tie(Info.FuncIdx, Info.Func) = Resolver.resolve(Frame.Module, It);
+    if (Info.Func != nullptr) {
+      // The code offset is relative to the start of the function body.
+      Info.CodeOffset = It->getOffset() - Info.Func->getInstrs()[0].getOffset();
+    }
+
+    // The locals of this frame are the values below its stack base, and its
+    // operand stack ends where the locals of the callee frame begin.
+    const auto ValueNum = static_cast<uint32_t>(ValueStack.size());
+    const uint32_t LocalStart =
+        Frame.VPos >= Frame.Locals ? Frame.VPos - Frame.Locals : 0U;
+    const uint32_t StackEnd = (Idx < FrameNum)
+                                  ? (Frames[Idx].VPos >= Frames[Idx].Locals
+                                         ? Frames[Idx].VPos - Frames[Idx].Locals
+                                         : 0U)
+                                  : ValueNum;
+    if (Frame.VPos <= ValueNum && LocalStart <= Frame.VPos) {
+      Info.Locals = ValueStack.subspan(LocalStart, Frame.VPos - LocalStart);
+    }
+    if (StackEnd <= ValueNum && Frame.VPos <= StackEnd) {
+      Info.Stack = ValueStack.subspan(Frame.VPos, StackEnd - Frame.VPos);
+    }
+    Result.push_back(Info);
+  }
+  return Result;
+}
+
+/// Collect the value types of the parameters and the locals of a function.
+std::vector<ValType> collectLocalTypes(const FunctionInstance *Func) noexcept {
+  std::vector<ValType> Types;
+  if (Func == nullptr) {
+    return Types;
+  }
+  const auto &Params = Func->getFuncType().getParamTypes();
+  Types.insert(Types.end(), Params.begin(), Params.end());
+  for (const auto &[Count, Type] : Func->getLocals()) {
+    Types.insert(Types.end(), Count, Type);
+  }
+  return Types;
+}
+
+/// `core ::= customsec(process-info)`
+/// `process-info ::= 0x0 executable-name:name`
+AST::CustomSection createCore(const Loader::Serializer &Ser,
+                              std::string_view ExecutableName) noexcept {
   AST::CustomSection Core;
   Core.setName("core");
   auto &Content = Core.getContent();
-  Content.insert(Content.begin(), {0x00, 0x00});
+  Content.push_back(0x00);
+  serializeName(Ser, ExecutableName, Content);
   return Core;
 }
 
-AST::CustomSection createCorestack(
-    Loader::Serializer &Ser, Span<const Runtime::StackManager::Frame> Frames,
-    Span<const Runtime::StackManager::Value> ValueStack, bool ForWasmgdb) {
+/// `coremodules ::= customsec(vec(coremodule))`
+/// `coremodule ::= 0x0 module-name:name`
+AST::CustomSection createCoreModules(const Loader::Serializer &Ser,
+                                     const IndexSpaces &Spaces) noexcept {
+  AST::CustomSection CoreModules;
+  CoreModules.setName("coremodules");
+  auto &Content = CoreModules.getContent();
+  const auto Modules = Spaces.getModules();
+  Ser.serializeU32(static_cast<uint32_t>(Modules.size()), Content);
+  for (const auto *Mod : Modules) {
+    Content.push_back(0x00);
+    serializeName(Ser, Mod->getModuleName(), Content);
+  }
+  return CoreModules;
+}
+
+/// `coreinstances ::= customsec(vec(coreinstance))`
+/// `coreinstance ::= 0x0 moduleidx:u32 memories:vec(u32) globals:vec(u32)`
+AST::CustomSection createCoreInstances(const Loader::Serializer &Ser,
+                                       const IndexSpaces &Spaces) noexcept {
+  AST::CustomSection CoreInstances;
+  CoreInstances.setName("coreinstances");
+  auto &Content = CoreInstances.getContent();
+  const auto &Memories = Spaces.getInstanceMemories();
+  const auto &Globals = Spaces.getInstanceGlobals();
+  Ser.serializeU32(static_cast<uint32_t>(Memories.size()), Content);
+  for (uint32_t I = 0; I < Memories.size(); ++I) {
+    Content.push_back(0x00);
+    Ser.serializeU32(I, Content);
+    Ser.serializeU32(static_cast<uint32_t>(Memories[I].size()), Content);
+    for (const auto Idx : Memories[I]) {
+      Ser.serializeU32(Idx, Content);
+    }
+    Ser.serializeU32(static_cast<uint32_t>(Globals[I].size()), Content);
+    for (const auto Idx : Globals[I]) {
+      Ser.serializeU32(Idx, Content);
+    }
+  }
+  return CoreInstances;
+}
+
+/// `corestack ::= customsec(thread-info vec(frame))`
+/// `thread-info ::= 0x0 thread-name:name`
+/// `frame ::= 0x0 instanceidx:u32 funcidx:u32 codeoffset:u32 locals:vec(value)
+///            stack:vec(value)`
+///
+/// The parser of wasmgdb reads the sizes of both vectors before the values and
+/// never reads the content of the operand stack vector, therefore the wasmgdb
+/// mode deliberately deviates from the grammar above and emits an empty
+/// operand stack. Such a coredump is only readable by wasmgdb, which is why
+/// this layout is selected by a dedicated option.
+AST::CustomSection createCoreStack(const Loader::Serializer &Ser,
+                                   Span<const FrameInfo> Frames,
+                                   bool ForWasmgdb) noexcept {
   AST::CustomSection CoreStack;
   CoreStack.setName("corestack");
   auto &Content = CoreStack.getContent();
-  // thread-info type 0x00 for wasmedbg
   Content.push_back(0x00);
-
-  // Thread name size
-  Content.push_back(0x04);
-
-  std::string ThreadName = "main";
-  Content.insert(Content.end(), ThreadName.begin(), ThreadName.end());
-  auto FramesSize = Frames.size() - 1;
-  Ser.serializeU32(static_cast<uint32_t>(FramesSize), Content);
-  for (size_t Idx = FramesSize; Idx > 0; Idx--) {
-    if (Frames[Idx].Module == nullptr) {
-      continue;
-    }
-    // frame type 0x00 for wasmedbg
+  serializeName(Ser, "main"sv, Content);
+  Ser.serializeU32(static_cast<uint32_t>(Frames.size()), Content);
+  for (const auto &Frame : Frames) {
     Content.push_back(0x00);
-    // TODO: fix main Funcidx is 0
-    auto Funcidx = Frames[Idx].From->getTargetIndex();
-    auto Codeoffset = Frames[Idx].From->getOffset();
-    uint32_t Lstart = Frames[Idx].VPos - Frames[Idx].Locals;
-    uint32_t Lend = Frames[Idx].VPos;
-    uint32_t Vstart = Frames[Idx].VPos;
-    uint32_t Vend = (Idx != FramesSize)
-                        ? Frames[Idx + 1].VPos - Frames[Idx + 1].Locals
-                        : static_cast<uint32_t>(ValueStack.size());
+    Ser.serializeU32(Frame.InstanceIdx, Content);
+    Ser.serializeU32(Frame.FuncIdx, Content);
+    Ser.serializeU32(Frame.CodeOffset, Content);
 
-    uint32_t Lsize = Lend - Lstart;
-    uint32_t Vsize = Vend - Vstart;
-    assuming(Lstart + Lsize <= ValueStack.size());
-    auto Locals = Span<const Runtime::StackManager::Value>(
-        ValueStack.begin() + Lstart, Lsize);
-    assuming(Vstart + Vsize <= ValueStack.size());
-    Span<const Runtime::StackManager::Value> Stacks;
-    if (!ForWasmgdb) {
-      Stacks = Span<const Runtime::StackManager::Value>(
-          ValueStack.begin() + Vstart, Vsize);
+    const auto LocalTypes = collectLocalTypes(Frame.Func);
+    const auto LocalNum = std::min(Frame.Locals.size(), LocalTypes.size());
+    const auto StackNum = ForWasmgdb ? 0U : Frame.Stack.size();
+    Ser.serializeU32(static_cast<uint32_t>(LocalNum), Content);
+    if (ForWasmgdb) {
+      Ser.serializeU32(static_cast<uint32_t>(StackNum), Content);
     }
-    Ser.serializeU32(Funcidx, Content);
-    Ser.serializeU32(Codeoffset, Content);
-    // locals size
-    Ser.serializeU32(Frames[Idx].Locals, Content);
-    // stack size
-    Ser.serializeU32(Vsize, Content);
-    for (auto &Iter : Locals) {
-      // 0x7F implies i32. i128 is not supported here, and wasmgdb does not
-      // support i64.
-      Content.push_back(0x7F);
-      auto Value = Iter.unwrap();
-      std::vector<Byte> ValueBytes(4);
-      std::memcpy(ValueBytes.data(), &Value, sizeof(int64_t));
-      Content.insert(Content.end(), ValueBytes.begin(), ValueBytes.end());
+    for (size_t I = 0; I < LocalNum; ++I) {
+      serializeValue(Ser, Frame.Locals[I], LocalTypes[I], ForWasmgdb, Content);
     }
     if (!ForWasmgdb) {
-      for (auto &Iter : Stacks) {
-        // 0x7F implies i32. i128 is not supported here, and wasmgdb does not
-        // support i64.
-        Content.push_back(0x7F);
-        auto Value = Iter.unwrap();
-        std::vector<Byte> ValueBytes(4);
-        std::memcpy(ValueBytes.data(), &Value, sizeof(int64_t));
-        Content.insert(Content.end(), ValueBytes.begin(), ValueBytes.end());
+      // The operand stack of the interpreter holds untyped values, the type of
+      // an entry cannot be recovered without replaying the validation of the
+      // function body. The depth is preserved and the entries are reported as
+      // missing values, which the format reserves for this purpose.
+      Ser.serializeU32(static_cast<uint32_t>(StackNum), Content);
+      for (size_t I = 0; I < StackNum; ++I) {
+        Content.push_back(ValueMissing);
       }
     }
   }
   return CoreStack;
 }
 
-// AST::DataSection
-// createData(Span<const Runtime::Instance::DataInstance *const> DataInstances)
-// {
-//   AST::DataSection DataSec;
-//   AST::DataSegment Seg;
-//   auto &Content = Seg.getData();
-//   for (auto &Data : DataInstances) {
-//     Content.insert(Content.end(), Data->getData().begin(),
-//                    Data->getData().end());
-//   }
-//   DataSec.getContent().push_back(Seg);
-//   return DataSec;
-// }
-AST::GlobalSection createGlobals(
-    Span<const Runtime::Instance::GlobalInstance *const> GlobalInstances) {
-  AST::GlobalSection Globals;
-  for (auto &Global : GlobalInstances) {
-    AST::GlobalSegment Seg;
-    Seg.getGlobalType() = Global->getGlobalType();
-    Seg.getExpr().getInstrs() = {
-        WasmEdge::AST::Instruction(WasmEdge::OpCode::End)};
-    Globals.getContent().push_back(Seg);
-  }
-  return Globals;
-}
-AST::MemorySection createMemory(
-    Span<const Runtime::Instance::MemoryInstance *const> MemoryInstances) {
+AST::MemorySection createMemory(const IndexSpaces &Spaces) noexcept {
   AST::MemorySection Memory;
   auto &Content = Memory.getContent();
-  if (MemoryInstances.size() == 0) {
-    return Memory;
+  for (const auto *Mem : Spaces.getMemories()) {
+    Content.push_back(Mem->getMemoryType());
   }
-  Content.push_back(MemoryInstances[0]->getMemoryType());
   return Memory;
 }
 
-AST::CustomSection createCoremodules(
-    Loader::Serializer &Ser,
-    Span<const Runtime::Instance::ModuleInstance *const> ModuleInstances) {
-  AST::CustomSection CoreModules;
-  CoreModules.setName("coremodules");
-  auto &Content = CoreModules.getContent();
-  Ser.serializeU32(static_cast<uint32_t>(ModuleInstances.size()), Content);
-  for (auto &Module : ModuleInstances) {
-    auto Name = Module->getModuleName();
-    Content.push_back(0x00);
-    Content.insert(Content.end(), Name.begin(), Name.end());
+/// The content of every linear memory is dumped into the data section. The
+/// parser of wasmgdb only reads the first data segment, therefore the whole
+/// memory is dumped as a single segment in the wasmgdb mode. Otherwise the runs
+/// of zeros are skipped to keep the coredump small.
+AST::DataSection createData(const IndexSpaces &Spaces,
+                            bool ForWasmgdb) noexcept {
+  static constexpr const uint64_t ChunkSize = UINT64_C(4096);
+  AST::DataSection Data;
+  auto &Content = Data.getContent();
+  const auto Memories = Spaces.getMemories();
+  for (uint32_t I = 0; I < Memories.size(); ++I) {
+    const auto *Mem = Memories[I];
+    const auto Size = Mem->getSize();
+    auto Bytes = Mem->getBytes(0, Size);
+    if (!Bytes) {
+      continue;
+    }
+    const bool Is64 = Mem->getMemoryType().getLimit().is64();
+    auto AddSegment = [&](uint64_t Offset, Span<const Byte> Chunk) {
+      AST::DataSegment Seg;
+      Seg.setMode(AST::DataSegment::DataMode::Active);
+      Seg.setIdx(I);
+      AST::Instruction OffsetInstr(Is64 ? OpCode::I64__const
+                                        : OpCode::I32__const);
+      OffsetInstr.setNum(static_cast<uint128_t>(Offset));
+      Seg.getExpr().getInstrs() = {OffsetInstr, AST::Instruction(OpCode::End)};
+      Seg.getData().assign(Chunk.begin(), Chunk.end());
+      Content.push_back(std::move(Seg));
+    };
+    if (ForWasmgdb) {
+      AddSegment(0, *Bytes);
+      continue;
+    }
+    for (uint64_t Begin = 0; Begin < Size; Begin += ChunkSize) {
+      const auto End = std::min(Begin + ChunkSize, Size);
+      const auto Chunk = Bytes->subspan(Begin, End - Begin);
+      auto *const First =
+          std::find_if(Chunk.begin(), Chunk.end(), [](Byte B) { return B; });
+      if (First == Chunk.end()) {
+        continue;
+      }
+      const auto Last =
+          std::find_if(Chunk.rbegin(), Chunk.rend(), [](Byte B) { return B; });
+      const auto Start = static_cast<uint64_t>(First - Chunk.begin());
+      const auto Stop = static_cast<uint64_t>(Chunk.rend() - Last);
+      AddSegment(Begin + Start, Chunk.subspan(Start, Stop - Start));
+    }
   }
-  return CoreModules;
+  return Data;
 }
 
-AST::CustomSection
-createCoreinstances(Span<const Runtime::Instance::ModuleInstance *const>) {
-  // TODO: Finish coreinstances
-  AST::CustomSection CoreInstances;
-  CoreInstances.setName("coreinstances");
-  auto &Content = CoreInstances.getContent();
-  Content.push_back(0x00);
-  return CoreInstances;
+/// The globals are dumped as constant and non-mutable globals holding their
+/// current values.
+AST::GlobalSection createGlobals(const IndexSpaces &Spaces) noexcept {
+  AST::GlobalSection Globals;
+  auto &Content = Globals.getContent();
+  for (const auto *Glob : Spaces.getGlobals()) {
+    const auto &Type = Glob->getGlobalType().getValType();
+    AST::GlobalSegment Seg;
+    Seg.getGlobalType() = AST::GlobalType(Type, ValMut::Const);
+    AST::Instruction Init(OpCode::Ref__null);
+    switch (Type.getCode()) {
+    case TypeCode::I32:
+      Init = AST::Instruction(OpCode::I32__const);
+      Init.setNum(Glob->getValue());
+      break;
+    case TypeCode::I64:
+      Init = AST::Instruction(OpCode::I64__const);
+      Init.setNum(Glob->getValue());
+      break;
+    case TypeCode::F32:
+      Init = AST::Instruction(OpCode::F32__const);
+      Init.setNum(Glob->getValue());
+      break;
+    case TypeCode::F64:
+      Init = AST::Instruction(OpCode::F64__const);
+      Init.setNum(Glob->getValue());
+      break;
+    case TypeCode::V128:
+      Init = AST::Instruction(OpCode::V128__const);
+      Init.setNum(Glob->getValue());
+      break;
+    default:
+      // A reference cannot be represented by a constant expression of a
+      // coredump, dump a null reference of the same type instead.
+      Init.setValType(Type);
+      break;
+    }
+    Seg.getExpr().getInstrs() = {Init, AST::Instruction(OpCode::End)};
+    Content.push_back(std::move(Seg));
+  }
+  return Globals;
+}
+
+} // namespace
+
+Expect<std::string> generateCoredump(const Runtime::StackManager &StackMgr,
+                                     AST::InstrView::iterator PC,
+                                     bool ForWasmgdb) noexcept {
+  spdlog::info("Generating coredump..."sv);
+
+  IndexSpaces Spaces;
+  FunctionResolver Resolver;
+  for (const auto &Frame : StackMgr.getFramesSpan()) {
+    Spaces.addModule(Frame.Module);
+    Resolver.addModule(Frame.Module);
+  }
+  Spaces.addModule(StackMgr.getModule());
+  Resolver.addModule(StackMgr.getModule());
+  if (Spaces.getModules().empty()) {
+    spdlog::error("Failed to generate coredump: no module instance found."sv);
+    return Unexpect(ErrCode::Value::IllegalPath);
+  }
+
+  const Loader::Serializer Ser;
+  AST::Module Module;
+  auto &Magic = Module.getMagic();
+  Magic.assign({0x00, 0x61, 0x73, 0x6D});
+  // The version must be 1 to be supported by wasmgdb.
+  auto &Version = Module.getVersion();
+  Version.assign({0x01, 0x00, 0x00, 0x00});
+
+  const auto Frames = collectFrames(StackMgr, PC, Spaces, Resolver);
+  auto &CustomSections = Module.getCustomSections();
+  CustomSections.push_back(
+      createCore(Ser, Spaces.getModules().front()->getModuleName()));
+  CustomSections.push_back(createCoreModules(Ser, Spaces));
+  CustomSections.push_back(createCoreInstances(Ser, Spaces));
+  CustomSections.push_back(createCoreStack(Ser, Frames, ForWasmgdb));
+  Module.getMemorySection() = createMemory(Spaces);
+  Module.getGlobalSection() = createGlobals(Spaces);
+  Module.getDataSection() = createData(Spaces, ForWasmgdb);
+  // The serializer emits the sections ordered by their start offsets, assign
+  // the offsets of a well-formed module to keep the section order valid.
+  Module.getMemorySection().setStartOffset(1);
+  Module.getGlobalSection().setStartOffset(2);
+  Module.getDataSection().setStartOffset(3);
+  for (auto &Sec : CustomSections) {
+    Sec.setStartOffset(4);
+  }
+
+  auto Res = Ser.serializeModule(Module);
+  if (!Res) {
+    spdlog::error("Failed to serialize coredump."sv);
+    return Unexpect(Res);
+  }
+
+  const std::string Path =
+      "coredump." + std::to_string(static_cast<uint64_t>(std::time(nullptr)));
+  std::ofstream File(Path, std::ios::out | std::ios::binary);
+  if (!File.is_open()) {
+    spdlog::error("Failed to open the coredump file {}."sv, Path);
+    return Unexpect(ErrCode::Value::IllegalPath);
+  }
+  File.write(reinterpret_cast<const char *>(Res->data()),
+             static_cast<std::streamsize>(Res->size()));
+  File.close();
+  if (File.fail()) {
+    spdlog::error("Failed to write the coredump file {}."sv, Path);
+    return Unexpect(ErrCode::Value::IllegalPath);
+  }
+  spdlog::info("Coredump generated at {}."sv, Path);
+  return Path;
 }
 
 } // namespace Coredump

--- a/lib/executor/engine/engine.cpp
+++ b/lib/executor/engine/engine.cpp
@@ -2366,12 +2366,12 @@ Expect<void> Executor::execute(Runtime::StackManager &StackMgr,
     __has_cpp_attribute(msvc::forceinline_calls)
     [[msvc::forceinline_calls]]
 #endif
-    EXPECTED_TRY(Dispatch().map_error([this, &StackMgr](auto E) {
+    EXPECTED_TRY(Dispatch().map_error([this, &StackMgr, PC](auto E) {
       StackTraceSize = interpreterStackTrace(StackMgr, StackTrace).size();
       if (Conf.getRuntimeConfigure().isEnableCoredump() &&
           E.getErrCodePhase() == WasmPhase::Execution) {
         Coredump::generateCoredump(
-            StackMgr, Conf.getRuntimeConfigure().isCoredumpWasmgdb());
+            StackMgr, PC, Conf.getRuntimeConfigure().isCoredumpWasmgdb());
       }
       return E;
     }));

--- a/test/driver/driverToolTest.cpp
+++ b/test/driver/driverToolTest.cpp
@@ -262,6 +262,14 @@ static const std::array<uint8_t, 44> ConsumerWasm{
     0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x03, 0x61, 0x64, 0x64,
     0x00, 0x00, 0x07, 0x07, 0x01, 0x03, 0x61, 0x64, 0x64, 0x00, 0x00};
 
+// trap.wasm: exports "_start" which traps on an integer division by zero.
+static const std::array<uint8_t, 53> TrapWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x04, 0x01,
+    0x60, 0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0x05, 0x03, 0x01, 0x00,
+    0x01, 0x07, 0x10, 0x02, 0x03, 0x6d, 0x65, 0x6d, 0x02, 0x00, 0x06,
+    0x5f, 0x73, 0x74, 0x61, 0x72, 0x74, 0x00, 0x00, 0x0a, 0x0a, 0x01,
+    0x08, 0x00, 0x41, 0x01, 0x41, 0x00, 0x6d, 0x1a, 0x0b};
+
 std::string simplePath() {
   static std::string Path;
   if (Path.empty()) {
@@ -304,6 +312,45 @@ std::string consumerPath() {
                            "consumer.wasm");
   }
   return Path;
+}
+
+std::string trapPath() {
+  static std::string Path;
+  if (Path.empty()) {
+    // The coredump is written into the working directory, hence the tests
+    // change it and the module must be addressed by an absolute path.
+    Path = std::filesystem::absolute(
+               writeWasmToFile(TrapWasm.data(), TrapWasm.size(), "trap.wasm"))
+               .string();
+  }
+  return Path;
+}
+
+// Run in a dedicated directory and report the number of the generated
+// coredumps, because the coredump is written into the working directory.
+size_t countCoredumpsOf(std::initializer_list<const char *> Args,
+                        const std::string &Name) {
+  const auto TempDir =
+      std::filesystem::temp_directory_path() /
+      std::filesystem::u8path("wasmedge-driver-coredump-" + Name);
+  std::error_code Error;
+  std::filesystem::remove_all(TempDir, Error);
+  if (!std::filesystem::create_directories(TempDir, Error)) {
+    return static_cast<size_t>(-1);
+  }
+  const auto Origin = std::filesystem::current_path();
+  std::filesystem::current_path(TempDir);
+  callRun(Args);
+  std::filesystem::current_path(Origin, Error);
+
+  size_t Count = 0;
+  for (const auto &Entry : std::filesystem::directory_iterator(TempDir)) {
+    if (Entry.path().filename().string().rfind("coredump.", 0) == 0) {
+      Count++;
+    }
+  }
+  std::filesystem::remove_all(TempDir, Error);
+  return Count;
 }
 
 std::string sectionsTestPath() {
@@ -977,6 +1024,41 @@ TEST(RunSubcommand, LinkedModules) {
   EXPECT_EQ(callRun({"--reactor", "--module", "provider:nonexist.wasm",
                      ConsPath.c_str(), "add", "1", "2"}),
             EXIT_FAILURE);
+}
+
+TEST(RunSubcommand, CoredumpRequiresInterpreter) {
+  std::string PathStr = trapPath();
+  const char *Path = PathStr.c_str();
+
+  // The interpreter is the default run mode, hence the coredump is generated.
+  EXPECT_EQ(countCoredumpsOf({"--enable-coredump", Path}, "default"), 1U);
+  EXPECT_EQ(countCoredumpsOf({"--coredump-for-wasmgdb", Path}, "wasmgdb"), 1U);
+  EXPECT_EQ(
+      countCoredumpsOf({"--run-mode=interpreter", "--enable-coredump", Path},
+                       "interpreter"),
+      1U);
+
+  // An explicitly requested run mode takes precedence over the coredump, so
+  // no coredump is generated and the run mode is kept.
+  EXPECT_EQ(
+      countCoredumpsOf({"--run-mode=jit", "--enable-coredump", Path}, "jit"),
+      0U);
+  EXPECT_EQ(
+      countCoredumpsOf({"--run-mode=aot", "--enable-coredump", Path}, "aot"),
+      0U);
+  EXPECT_EQ(
+      countCoredumpsOf({"--run-mode=lazyjit", "--coredump-for-wasmgdb", Path},
+                       "lazyjit"),
+      0U);
+
+  // The decision follows the requested run mode, not the effective one, hence
+  // it is deterministic on the builds without LLVM as well.
+  EXPECT_EQ(countCoredumpsOf({"--enable-jit", "--enable-coredump", Path},
+                             "deprecated-jit"),
+            0U);
+  EXPECT_EQ(countCoredumpsOf({"--force-interpreter", "--enable-coredump", Path},
+                             "deprecated-interpreter"),
+            1U);
 }
 
 TEST(RunSubcommand, GlobalFlags) {

--- a/test/executor/ExecutorTest.cpp
+++ b/test/executor/ExecutorTest.cpp
@@ -25,11 +25,13 @@
 #include <array>
 #include <chrono>
 #include <cstdint>
+#include <cstring>
 #include <filesystem>
 #include <functional>
 #include <map>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -306,30 +308,371 @@ TEST(VM, MultipleVM) {
   EXPECT_TRUE(Result2);
 }
 
-TEST(Coredump, generateCoredump) {
-  WasmEdge::Configure Conf;
-  Conf.getRuntimeConfigure().setEnableCoredump(true);
-  Conf.getRuntimeConfigure().setCoredumpWasmgdb(false);
-  WasmEdge::VM::VM VM(Conf);
-  std::array<WasmEdge::Byte, 70> Wasm{
-      0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x04, 0x01, 0x60,
-      0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0x05, 0x03, 0x01, 0x00, 0x01, 0x07,
-      0x1e, 0x02, 0x03, 0x6d, 0x65, 0x6d, 0x02, 0x00, 0x14, 0x61, 0x63, 0x63,
-      0x65, 0x73, 0x73, 0x5f, 0x6f, 0x75, 0x74, 0x5f, 0x6f, 0x66, 0x5f, 0x62,
-      0x6f, 0x75, 0x6e, 0x64, 0x73, 0x00, 0x00, 0x0a, 0x0d, 0x01, 0x0b, 0x00,
-      0x41, 0xf0, 0xa2, 0x04, 0x41, 0x00, 0x36, 0x02, 0x00, 0x0b};
-  ASSERT_TRUE(VM.loadWasm(Wasm));
-  ASSERT_TRUE(VM.validate());
-  ASSERT_TRUE(VM.instantiate());
-  VM.execute("access_out_of_bounds");
-  bool FindCoredump = false;
-  for (const auto &Entry : std::filesystem::directory_iterator("./")) {
-    if (Entry.path().string().find("coredump.") != std::string::npos) {
-      FindCoredump = true;
-      break;
+// Reader of the coredump custom section content.
+class CoredumpReader {
+public:
+  CoredumpReader(WasmEdge::Span<const WasmEdge::Byte> C) noexcept
+      : Content(C) {}
+
+  uint8_t readByte() noexcept {
+    if (Pos >= Content.size()) {
+      Failed = true;
+      return 0;
+    }
+    return Content[Pos++];
+  }
+
+  uint32_t readU32() noexcept {
+    uint32_t Result = 0;
+    uint32_t Shift = 0;
+    while (Pos < Content.size()) {
+      const uint8_t B = Content[Pos++];
+      Result |= static_cast<uint32_t>(B & 0x7FU) << Shift;
+      if ((B & 0x80U) == 0) {
+        return Result;
+      }
+      Shift += 7;
+    }
+    Failed = true;
+    return 0;
+  }
+
+  std::string readName() noexcept {
+    const uint32_t Size = readU32();
+    if (Pos + Size > Content.size()) {
+      Failed = true;
+      return {};
+    }
+    std::string Result(reinterpret_cast<const char *>(&Content[Pos]), Size);
+    Pos += Size;
+    return Result;
+  }
+
+  // Read a fixed width little endian integer of the wasmgdb dialect.
+  template <typename T> T readFixed() noexcept {
+    static_assert(std::is_integral_v<T>);
+    if (Pos + sizeof(T) > Content.size()) {
+      Failed = true;
+      return 0;
+    }
+    T Result = 0;
+    std::memcpy(&Result, &Content[Pos], sizeof(Result));
+    Pos += sizeof(T);
+    return Result;
+  }
+
+  int64_t readS64() noexcept {
+    int64_t Result = 0;
+    uint32_t Shift = 0;
+    while (Pos < Content.size()) {
+      const uint8_t B = Content[Pos++];
+      Result |= static_cast<int64_t>(B & 0x7FU) << Shift;
+      Shift += 7;
+      if ((B & 0x80U) == 0) {
+        if (Shift < 64 && (B & 0x40U) != 0) {
+          Result |= -(INT64_C(1) << Shift);
+        }
+        return Result;
+      }
+    }
+    Failed = true;
+    return 0;
+  }
+
+  // Read one `value` and return its type tag. The canonical encoding of the
+  // format uses LEB128 integers, wasmgdb expects fixed width integers.
+  uint8_t readValue(bool ForWasmgdb, int64_t &Out) noexcept {
+    const uint8_t Type = readByte();
+    switch (Type) {
+    case 0x01:
+      Out = 0;
+      return Type;
+    case 0x7F:
+      Out = ForWasmgdb ? readFixed<int32_t>() : readS64();
+      return Type;
+    case 0x7E:
+      Out = ForWasmgdb ? readFixed<int64_t>() : readS64();
+      return Type;
+    case 0x7D:
+      readFixed<int32_t>();
+      Out = 0;
+      return Type;
+    case 0x7C:
+      readFixed<int64_t>();
+      Out = 0;
+      return Type;
+    default:
+      Failed = true;
+      return Type;
     }
   }
-  EXPECT_TRUE(FindCoredump);
+
+  bool isFailed() const noexcept { return Failed; }
+  bool isEnd() const noexcept { return Pos == Content.size(); }
+
+private:
+  WasmEdge::Span<const WasmEdge::Byte> Content;
+  size_t Pos = 0;
+  bool Failed = false;
+};
+
+const AST::CustomSection *findCustomSection(const AST::Module &Mod,
+                                            std::string_view Name) noexcept {
+  for (const auto &Sec : Mod.getCustomSections()) {
+    if (Sec.getName() == Name) {
+      return &Sec;
+    }
+  }
+  return nullptr;
+}
+
+// Restore the working directory when leaving the scope.
+class ScopedWorkingDirectory {
+public:
+  ScopedWorkingDirectory(const std::filesystem::path &Path)
+      : Origin(std::filesystem::current_path()) {
+    std::filesystem::current_path(Path);
+  }
+  ~ScopedWorkingDirectory() {
+    std::error_code Error;
+    std::filesystem::current_path(Origin, Error);
+  }
+
+private:
+  std::filesystem::path Origin;
+};
+
+// (module
+//   (memory (export "mem") 1)
+//   (global $g (mut i32) (i32.const 42))
+//   (global $h f64 (f64.const 3.5))
+//   (func $inner (param i32) (result i32)
+//     (local i64)
+//     i32.const 7
+//     local.get 0
+//     i32.const 0
+//     i32.store
+//     drop
+//     local.get 0)
+//   (func (export "access_out_of_bounds") (result i32)
+//     i32.const 16
+//     i32.const 0xcafe
+//     i32.store
+//     i32.const 0x4522f0
+//     call $inner))
+std::array<WasmEdge::Byte, 147> CoredumpWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0a, 0x02, 0x60,
+    0x01, 0x7f, 0x01, 0x7f, 0x60, 0x00, 0x01, 0x7f, 0x03, 0x03, 0x02, 0x00,
+    0x01, 0x05, 0x03, 0x01, 0x00, 0x01, 0x06, 0x12, 0x02, 0x7f, 0x01, 0x41,
+    0x2a, 0x0b, 0x7c, 0x00, 0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0c,
+    0x40, 0x0b, 0x07, 0x1e, 0x02, 0x03, 0x6d, 0x65, 0x6d, 0x02, 0x00, 0x14,
+    0x61, 0x63, 0x63, 0x65, 0x73, 0x73, 0x5f, 0x6f, 0x75, 0x74, 0x5f, 0x6f,
+    0x66, 0x5f, 0x62, 0x6f, 0x75, 0x6e, 0x64, 0x73, 0x00, 0x01, 0x0a, 0x25,
+    0x02, 0x10, 0x01, 0x01, 0x7e, 0x41, 0x07, 0x20, 0x00, 0x41, 0x00, 0x36,
+    0x02, 0x00, 0x1a, 0x20, 0x00, 0x0b, 0x12, 0x00, 0x41, 0x10, 0x41, 0xfe,
+    0x95, 0x03, 0x36, 0x02, 0x00, 0x41, 0xf0, 0xc5, 0x94, 0x02, 0x10, 0x00,
+    0x0b, 0x00, 0x18, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x01, 0x08, 0x01, 0x00,
+    0x05, 0x69, 0x6e, 0x6e, 0x65, 0x72, 0x07, 0x07, 0x02, 0x00, 0x01, 0x67,
+    0x01, 0x01, 0x68};
+
+// Trap the module in an empty directory and parse the generated coredump.
+void runCoredump(bool ForWasmgdb, AST::Module &Output) {
+  const auto TempDir = std::filesystem::temp_directory_path() /
+                       std::filesystem::u8path("wasmedge-coredump-"s +
+                                               std::to_string(ForWasmgdb));
+  std::error_code Error;
+  std::filesystem::remove_all(TempDir, Error);
+  ASSERT_TRUE(std::filesystem::create_directories(TempDir, Error));
+
+  {
+    ScopedWorkingDirectory Guard(TempDir);
+    WasmEdge::Configure Conf;
+    Conf.getRuntimeConfigure().setEnableCoredump(true);
+    Conf.getRuntimeConfigure().setCoredumpWasmgdb(ForWasmgdb);
+    WasmEdge::VM::VM VM(Conf);
+    ASSERT_TRUE(VM.loadWasm(CoredumpWasm));
+    ASSERT_TRUE(VM.validate());
+    ASSERT_TRUE(VM.instantiate());
+    const auto Result = VM.execute("access_out_of_bounds"sv);
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+
+  std::vector<std::filesystem::path> Dumps;
+  for (const auto &Entry : std::filesystem::directory_iterator(TempDir)) {
+    if (Entry.path().filename().string().rfind("coredump."s, 0) == 0) {
+      Dumps.push_back(Entry.path());
+    }
+  }
+  ASSERT_EQ(Dumps.size(), 1U);
+
+  // The coredump must be a well-formed WASM module.
+  WasmEdge::Configure LoadConf;
+  WasmEdge::Loader::Loader LoadEngine(LoadConf);
+  auto Mod = LoadEngine.parseModule(Dumps[0].u8string());
+  ASSERT_TRUE(Mod);
+  Output = std::move(**Mod);
+  std::filesystem::remove_all(TempDir, Error);
+}
+
+TEST(Coredump, Sections) {
+  AST::Module Mod;
+  ASSERT_NO_FATAL_FAILURE(runCoredump(false, Mod));
+
+  ASSERT_EQ(Mod.getMemorySection().getContent().size(), 1U);
+  EXPECT_EQ(Mod.getMemorySection().getContent()[0].getLimit().getMin(), 1U);
+
+  // The runs of zeros of the linear memory are skipped, only the marker
+  // written by the module is dumped.
+  ASSERT_EQ(Mod.getDataSection().getContent().size(), 1U);
+  const auto &Seg = Mod.getDataSection().getContent()[0];
+  EXPECT_EQ(Seg.getMode(), AST::DataSegment::DataMode::Active);
+  EXPECT_EQ(Seg.getIdx(), 0U);
+  ASSERT_EQ(Seg.getExpr().getInstrs().size(), 2U);
+  EXPECT_EQ(Seg.getExpr().getInstrs()[0].getOpCode(), OpCode::I32__const);
+  EXPECT_EQ(Seg.getExpr().getInstrs()[0].getNum().get<int32_t>(), 16);
+  ASSERT_EQ(Seg.getData().size(), 2U);
+  EXPECT_EQ(Seg.getData()[0], 0xFE);
+  EXPECT_EQ(Seg.getData()[1], 0xCA);
+
+  // The globals are dumped as constant globals holding their current values.
+  ASSERT_EQ(Mod.getGlobalSection().getContent().size(), 2U);
+  const auto &GlobI32 = Mod.getGlobalSection().getContent()[0];
+  EXPECT_EQ(GlobI32.getGlobalType().getValMut(), ValMut::Const);
+  EXPECT_EQ(GlobI32.getGlobalType().getValType().getCode(), TypeCode::I32);
+  ASSERT_EQ(GlobI32.getExpr().getInstrs().size(), 2U);
+  EXPECT_EQ(GlobI32.getExpr().getInstrs()[0].getOpCode(), OpCode::I32__const);
+  EXPECT_EQ(GlobI32.getExpr().getInstrs()[0].getNum().get<int32_t>(), 42);
+  const auto &GlobF64 = Mod.getGlobalSection().getContent()[1];
+  EXPECT_EQ(GlobF64.getGlobalType().getValMut(), ValMut::Const);
+  ASSERT_EQ(GlobF64.getExpr().getInstrs().size(), 2U);
+  EXPECT_EQ(GlobF64.getExpr().getInstrs()[0].getOpCode(), OpCode::F64__const);
+  EXPECT_DOUBLE_EQ(GlobF64.getExpr().getInstrs()[0].getNum().get<double>(),
+                   3.5);
+
+  // core ::= customsec(0x0 executable-name:name)
+  const auto *Core = findCustomSection(Mod, "core"sv);
+  ASSERT_NE(Core, nullptr);
+  CoredumpReader CoreReader(Core->getContent());
+  EXPECT_EQ(CoreReader.readByte(), 0x00);
+  CoreReader.readName();
+  EXPECT_FALSE(CoreReader.isFailed());
+  EXPECT_TRUE(CoreReader.isEnd());
+
+  // coremodules ::= customsec(vec(0x0 module-name:name))
+  const auto *CoreModules = findCustomSection(Mod, "coremodules"sv);
+  ASSERT_NE(CoreModules, nullptr);
+  CoredumpReader ModuleReader(CoreModules->getContent());
+  ASSERT_EQ(ModuleReader.readU32(), 1U);
+  EXPECT_EQ(ModuleReader.readByte(), 0x00);
+  ModuleReader.readName();
+  EXPECT_FALSE(ModuleReader.isFailed());
+  EXPECT_TRUE(ModuleReader.isEnd());
+
+  // coreinstances ::= customsec(vec(0x0 moduleidx memories:vec globals:vec))
+  const auto *CoreInstances = findCustomSection(Mod, "coreinstances"sv);
+  ASSERT_NE(CoreInstances, nullptr);
+  CoredumpReader InstanceReader(CoreInstances->getContent());
+  ASSERT_EQ(InstanceReader.readU32(), 1U);
+  EXPECT_EQ(InstanceReader.readByte(), 0x00);
+  EXPECT_EQ(InstanceReader.readU32(), 0U);
+  ASSERT_EQ(InstanceReader.readU32(), 1U);
+  EXPECT_EQ(InstanceReader.readU32(), 0U);
+  ASSERT_EQ(InstanceReader.readU32(), 2U);
+  EXPECT_EQ(InstanceReader.readU32(), 0U);
+  EXPECT_EQ(InstanceReader.readU32(), 1U);
+  EXPECT_FALSE(InstanceReader.isFailed());
+  EXPECT_TRUE(InstanceReader.isEnd());
+}
+
+TEST(Coredump, StackFrames) {
+  AST::Module Mod;
+  ASSERT_NO_FATAL_FAILURE(runCoredump(false, Mod));
+
+  const auto *CoreStack = findCustomSection(Mod, "corestack"sv);
+  ASSERT_NE(CoreStack, nullptr);
+  CoredumpReader Reader(CoreStack->getContent());
+  EXPECT_EQ(Reader.readByte(), 0x00);
+  EXPECT_EQ(Reader.readName(), "main"s);
+
+  // The frames are listed from the youngest one to the oldest one, therefore
+  // the trapping `$inner` comes before its caller.
+  ASSERT_EQ(Reader.readU32(), 2U);
+
+  int64_t Value = 0;
+  EXPECT_EQ(Reader.readByte(), 0x00);
+  EXPECT_EQ(Reader.readU32(), 0U);
+  EXPECT_EQ(Reader.readU32(), 0U);
+  // The code offset is relative to the first instruction of the function body,
+  // the trapping `i32.store` of `$inner` follows three 2 byte instructions.
+  EXPECT_EQ(Reader.readU32(), 6U);
+  // `$inner` has one i32 parameter and one i64 local.
+  ASSERT_EQ(Reader.readU32(), 2U);
+  EXPECT_EQ(Reader.readValue(false, Value), 0x7F);
+  EXPECT_EQ(Value, INT64_C(0x4522f0));
+  EXPECT_EQ(Reader.readValue(false, Value), 0x7E);
+  EXPECT_EQ(Value, INT64_C(0));
+  // The operand stack values are untyped in the interpreter, hence they are
+  // dumped as missing values.
+  ASSERT_EQ(Reader.readU32(), 1U);
+  EXPECT_EQ(Reader.readValue(false, Value), 0x01);
+
+  EXPECT_EQ(Reader.readByte(), 0x00);
+  EXPECT_EQ(Reader.readU32(), 0U);
+  EXPECT_EQ(Reader.readU32(), 1U);
+  // The `call` of the caller follows a 2 byte, a 4 byte, a 3 byte and a 5 byte
+  // instruction.
+  EXPECT_EQ(Reader.readU32(), 14U);
+  EXPECT_EQ(Reader.readU32(), 0U);
+  EXPECT_EQ(Reader.readU32(), 0U);
+
+  EXPECT_FALSE(Reader.isFailed());
+  EXPECT_TRUE(Reader.isEnd());
+}
+
+TEST(Coredump, Wasmgdb) {
+  AST::Module Mod;
+  ASSERT_NO_FATAL_FAILURE(runCoredump(true, Mod));
+
+  // The wasmgdb parser only reads the first data segment and pads it with the
+  // offset, hence the whole memory must be dumped as a single segment.
+  ASSERT_EQ(Mod.getDataSection().getContent().size(), 1U);
+  const auto &Seg = Mod.getDataSection().getContent()[0];
+  EXPECT_EQ(Seg.getExpr().getInstrs()[0].getNum().get<int32_t>(), 0);
+  ASSERT_EQ(Seg.getData().size(), UINT32_C(65536));
+  EXPECT_EQ(Seg.getData()[16], 0xFE);
+  EXPECT_EQ(Seg.getData()[17], 0xCA);
+
+  const auto *CoreStack = findCustomSection(Mod, "corestack"sv);
+  ASSERT_NE(CoreStack, nullptr);
+  CoredumpReader Reader(CoreStack->getContent());
+  EXPECT_EQ(Reader.readByte(), 0x00);
+  EXPECT_EQ(Reader.readName(), "main"s);
+  ASSERT_EQ(Reader.readU32(), 2U);
+
+  // The wasmgdb parser expects both vector sizes before the values and never
+  // reads the operand stack, hence the operand stack must be empty.
+  int64_t Value = 0;
+  EXPECT_EQ(Reader.readByte(), 0x00);
+  EXPECT_EQ(Reader.readU32(), 0U);
+  EXPECT_EQ(Reader.readU32(), 0U);
+  EXPECT_EQ(Reader.readU32(), 6U);
+  ASSERT_EQ(Reader.readU32(), 2U);
+  EXPECT_EQ(Reader.readU32(), 0U);
+  EXPECT_EQ(Reader.readValue(true, Value), 0x7F);
+  EXPECT_EQ(Value, INT64_C(0x4522f0));
+  EXPECT_EQ(Reader.readValue(true, Value), 0x7E);
+  EXPECT_EQ(Value, INT64_C(0));
+
+  EXPECT_EQ(Reader.readByte(), 0x00);
+  EXPECT_EQ(Reader.readU32(), 0U);
+  EXPECT_EQ(Reader.readU32(), 1U);
+  EXPECT_EQ(Reader.readU32(), 14U);
+  EXPECT_EQ(Reader.readU32(), 0U);
+  EXPECT_EQ(Reader.readU32(), 0U);
+
+  EXPECT_FALSE(Reader.isFailed());
+  EXPECT_TRUE(Reader.isEnd());
 }
 
 } // namespace


### PR DESCRIPTION
## Description
This PR rewrites the generator to follow the WebAssembly tool-conventions `Coredump.md`, keeps a dedicated compatibility mode for the `wasmgdb` parser, and replaces the placeholder test with tests that parse the generated coredump back.

### What changed

- `include/executor/coredump.h`: added the missing `#pragma once` and reduced the public API to a single `generateCoredump(StackMgr, PC, ForWasmgdb) -> Expect<std::string>`.
- `lib/executor/coredump.cpp`: rewritten. Deduplicates module/memory/global instances by address for `coreinstances`, resolves the executing function of each frame by instruction pointer (correct for `call_indirect` and for the outermost frame), emits typed locals, dumps every linear memory, and emits globals as constant globals holding their current values.
- `lib/executor/engine/engine.cpp`: pass the trapping `PC` into the generator, and explicitly discard its result so a coredump failure cannot shadow the original trap.
- `lib/driver/runtimeTool.cpp`: `--coredump-for-wasmgdb` now enables coredump generation; previously it only selected the format and produced no file on its own. Because the coredump is produced by the interpreter only, and `--run-mode` is already documented in this function as the option with the highest precedence, an explicitly requested non-interpreter run mode is kept and the coredump is disabled with an actionable warning, instead of silently degrading the performance of the requested mode. The decision follows the requested run mode rather than the effective one, so it is deterministic on builds without LLVM.
- `include/loader/serialize.h`: expose `serializeS32/S64/F32/F64`, as suggested in the review of #3860.
- Tests: three coredump tests that parse the dump back and assert every section is fully consumed, plus `RunSubcommand.CoredumpRequiresInterpreter`, which covers eight run-mode/coredump combinations and asserts the number of generated coredump files.

### Related PR and Issues
Solved: #5205 #5162
Similar PR: #5206 #5164 #5260

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
<img width="704" height="333" alt="image" src="https://github.com/user-attachments/assets/16e47a51-49fb-4573-beb6-7d9f1a0bb2c4" />

We create a test WASM that has an out-of-bounds bug, and it is also stored in driverToolTest.cpp.
<img width="459" height="458" alt="image" src="https://github.com/user-attachments/assets/2329ac77-59be-494a-b641-df7d1e9e8f7b" />
After using wasmedge to run it with the enable coredump flag, it crashes and creates a coredump.
The following figure shows the coredump content and can be parsed by wasmgdb.
<img width="901" height="195" alt="image" src="https://github.com/user-attachments/assets/84c898d0-5d5e-46e7-a02e-cb7f3a753b13" />
<img width="448" height="91" alt="image" src="https://github.com/user-attachments/assets/24aacf1f-83fe-4e4d-9f59-e2ca7ba79b46" />

