### PR TITLE
fix(executor): correct return_call continuation for host tail calls

### DIFF
--- a/lib/executor/helper.cpp
+++ b/lib/executor/helper.cpp
@@ -155,9 +155,10 @@ Executor::enterFunction(Runtime::StackManager &StackMgr,
       StackMgr.push(std::move(R));
     }
 
-    // For host function case, the continuation will be the continuation from
-    // the popped frame.
-    return StackMgr.popFrame();
+    // A tail call pops the replaced caller's frame, whose `From` is one before
+    // its resume point, so step it forward one instruction for `runCallOp`.
+    const AST::InstrView::iterator Continuation = StackMgr.popFrame();
+    return IsTailCall ? Continuation + 1 : Continuation;
   } else if (Func.isCompiledFunction()) {
     // Compiled function case: Execute the function and jump to the
     // continuation.
@@ -242,9 +243,10 @@ Executor::enterFunction(Runtime::StackManager &StackMgr,
       StackMgr.push(Rets[I]);
     }
 
-    // For compiled function case, the continuation will be the continuation
-    // from the popped frame.
-    return StackMgr.popFrame();
+    // As in the host case, step a tail-call continuation forward one
+    // instruction for `runCallOp`.
+    const AST::InstrView::iterator Continuation = StackMgr.popFrame();
+    return IsTailCall ? Continuation + 1 : Continuation;
   } else {
     // WASM interpreter case: Jump to the start of the function body.
 

--- a/test/executor/ExecutorRegressionTest.cpp
+++ b/test/executor/ExecutorRegressionTest.cpp
@@ -52,6 +52,34 @@ private:
   Check *C = nullptr;
 };
 
+/// Host function that records its i32 argument and returns it incremented, so a
+/// caller can verify both the argument passed in and the value returned.
+class AddOne : public Runtime::HostFunction<AddOne> {
+public:
+  Expect<uint32_t> body(const Runtime::CallingFrame &, uint32_t Value) {
+    Args.push_back(Value);
+    return Value + 1;
+  }
+  Span<const uint32_t> getArgs() const noexcept { return Args; }
+
+private:
+  std::vector<uint32_t> Args;
+};
+
+/// Module that provides the "add_one" host function under the "host" namespace.
+class TailCallHostModule : public Runtime::Instance::ModuleInstance {
+public:
+  TailCallHostModule() : ModuleInstance("host") {
+    auto FP = std::make_unique<AddOne>();
+    F = FP.get();
+    addHostFunc("add_one", std::move(FP));
+  }
+  Span<const uint32_t> getArgs() const noexcept { return F->getArgs(); }
+
+private:
+  AddOne *F = nullptr;
+};
+
 /// After instantiation, read the exported table "t" at index 0 and verify the
 /// null reference has been normalized to an abstract heap type. This catches
 /// the root cause of #4757 without executing wasm that would segfault if the
@@ -611,6 +639,38 @@ std::array<WasmEdge::Byte, 97> StaleHandlerPileWasm{
     0x6a, 0x21, 0x00, 0x20, 0x00, 0x41, 0x03, 0x49, 0x0d, 0x00, 0x0b, 0x1f,
     0x40, 0x01, 0x00, 0x00, 0x00, 0x41, 0x07, 0x41, 0x08, 0x08, 0x01, 0x0b,
     0x0b};
+/// Binary Wasm module: a wasm function tail-calls an imported host function.
+/// $f2 has more params than the callee (the crashing shape) and $f1 has equal
+/// arity (the hanging shape); both return_call the host "add_one", whose
+/// result must propagate back to the exported caller.
+///
+/// (module
+///   (import "host" "add_one" (func $h (param i32) (result i32)))
+///   (func $f2 (param i32 i32) (result i32)
+///     local.get 0
+///     return_call $h)
+///   (func $f1 (param i32) (result i32)
+///     local.get 0
+///     return_call $h)
+///   (func (export "run_more") (result i32)
+///     i32.const 41
+///     i32.const 99
+///     call $f2)
+///   (func (export "run_eq") (result i32)
+///     i32.const 7
+///     call $f1))
+std::array<WasmEdge::Byte, 129> TailCallHostImportWasm{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x10, 0x03, 0x60,
+    0x01, 0x7f, 0x01, 0x7f, 0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x60, 0x00,
+    0x01, 0x7f, 0x02, 0x10, 0x01, 0x04, 0x68, 0x6f, 0x73, 0x74, 0x07, 0x61,
+    0x64, 0x64, 0x5f, 0x6f, 0x6e, 0x65, 0x00, 0x00, 0x03, 0x05, 0x04, 0x01,
+    0x00, 0x02, 0x02, 0x07, 0x15, 0x02, 0x08, 0x72, 0x75, 0x6e, 0x5f, 0x6d,
+    0x6f, 0x72, 0x65, 0x00, 0x03, 0x06, 0x72, 0x75, 0x6e, 0x5f, 0x65, 0x71,
+    0x00, 0x04, 0x0a, 0x20, 0x04, 0x06, 0x00, 0x20, 0x00, 0x12, 0x00, 0x0b,
+    0x06, 0x00, 0x20, 0x00, 0x12, 0x00, 0x0b, 0x09, 0x00, 0x41, 0x29, 0x41,
+    0xe3, 0x00, 0x10, 0x01, 0x0b, 0x06, 0x00, 0x41, 0x07, 0x10, 0x02, 0x0b,
+    0x00, 0x13, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x01, 0x0c, 0x03, 0x00, 0x01,
+    0x68, 0x01, 0x02, 0x66, 0x32, 0x02, 0x02, 0x66, 0x31};
 // clang-format on
 
 /// Regression test for ref.test on externalized nullable references.
@@ -1174,6 +1234,55 @@ TEST(ExecutorRegression, CallIndirectNonFuncTable) {
   auto Result = VM.validate();
   ASSERT_FALSE(Result);
   EXPECT_EQ(Result.error(), ErrCode::Value::TypeCheckFailed);
+}
+
+/// Regression test for return_call to an imported host function.
+///
+/// The bug: return_call to an imported host function popped the caller's frame
+/// but returned its continuation under the interpreter's `-1` convention while
+/// the host branch consumed it with the host convention, so execution resumed
+/// on the caller's call site instead of after it. Depending on the arity
+/// mismatch this crashed (caller has more params) or looped forever (equal
+/// arity), with a guest-controlled out-of-bounds access underneath.
+///
+/// The fix keeps the host branch returning after the caller's call site, so the
+/// host result propagates back to the exported caller as an ordinary return.
+TEST(ExecutorRegression, TailCallToHostImport) {
+  // --- Part 1: caller has more params than callee (was a crash) ---
+  {
+    Configure Conf;
+    TailCallHostModule HostMod;
+    VM::VM VM(Conf);
+    VM.registerModule(HostMod);
+    ASSERT_TRUE(VM.loadWasm(TailCallHostImportWasm));
+    ASSERT_TRUE(VM.validate());
+    ASSERT_TRUE(VM.instantiate());
+    auto Res = VM.execute("run_more");
+    ASSERT_TRUE(Res);
+    ASSERT_EQ(Res->size(), 1);
+    EXPECT_EQ(Res->at(0).first.get<uint32_t>(), 42);
+    auto Args = HostMod.getArgs();
+    ASSERT_EQ(Args.size(), 1);
+    EXPECT_EQ(Args[0], 41);
+  }
+
+  // --- Part 2: caller and callee have equal arity (was an infinite loop) ---
+  {
+    Configure Conf;
+    TailCallHostModule HostMod;
+    VM::VM VM(Conf);
+    VM.registerModule(HostMod);
+    ASSERT_TRUE(VM.loadWasm(TailCallHostImportWasm));
+    ASSERT_TRUE(VM.validate());
+    ASSERT_TRUE(VM.instantiate());
+    auto Res = VM.execute("run_eq");
+    ASSERT_TRUE(Res);
+    ASSERT_EQ(Res->size(), 1);
+    EXPECT_EQ(Res->at(0).first.get<uint32_t>(), 8);
+    auto Args = HostMod.getArgs();
+    ASSERT_EQ(Args.size(), 1);
+    EXPECT_EQ(Args[0], 7);
+  }
 }
 
 } // namespace


### PR DESCRIPTION
## Description

A return_call (tail call) to an imported host function corrupted the interpreter frame stack. The host branch of Executor::enterFunction popped the replaced caller's frame and returned its continuation under the interpreter's "one before the resume point" convention, while runCallOp consumed it under the host convention. Execution resumed on the caller's call site instead of after it, so depending on the arity mismatch the host process crashed (caller has more params than the callee) or looped forever at 100% CPU (equal arity), with a guest-controlled out-of-bounds read and write into host heap underneath. The module is well-formed, passes validation, and needs no flags on builds where the tail-call proposal is enabled by default.

Step the continuation forward one instruction for tail calls in the host and compiled-function branches so it agrees with runCallOp. The fix cannot live in pushFrame: its tail-call branch is shared with the wasm-interpreter callee path, which is already correct and consumes the continuation without the extra adjustment.

Add ExecutorRegression.TailCallToHostImport covering both the crashing and hanging shapes and asserting the host result propagates back to the exported caller.

Assisted-by: Claude (Anthropic)

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.

