### PR TITLE
fix: serialize: update serialization for instruction

### DIFF
--- a/lib/loader/serialize/serial_instruction.cpp
+++ b/lib/loader/serialize/serial_instruction.cpp
@@ -18,7 +18,15 @@ Serializer::serializeInstruction(const AST::Instruction &Instr,
     } else {
       serializeU32(Instr.getMemoryAlign(), OutVec);
     }
-    serializeU64(Instr.getMemoryOffset(), OutVec);
+    if (Conf.hasProposal(Proposal::Memory64)) {
+      serializeU64(Instr.getMemoryOffset(), OutVec);
+    } else {
+      if (Instr.getMemoryOffset() > std::numeric_limits<uint32_t>::max()) {
+        return logSerializeError(ErrCode::Value::IntegerTooLarge,
+                                ASTNodeAttr::Instruction);
+      }
+      serializeU32(static_cast<uint32_t>(Instr.getMemoryOffset()), OutVec);
+    }
     return {};
   };
 

--- a/test/loader/serializeInstructionTest.cpp
+++ b/test/loader/serializeInstructionTest.cpp
@@ -1150,6 +1150,10 @@ TEST(SerializeInstructionTest, SerializeMemoryInstruction) {
   std::vector<uint8_t> Output;
   std::vector<WasmEdge::AST::Instruction> Instructions;
 
+  WasmEdge::Configure ConfNoMemory64 = Conf;
+  ConfNoMemory64.removeProposal(WasmEdge::Proposal::Memory64);
+  WasmEdge::Loader::Serializer SerNoMemory64(ConfNoMemory64);
+
   // 11. Test memory instructions.
   //
   //   1.  Serialize memory_grow instruction.
@@ -1196,23 +1200,12 @@ TEST(SerializeInstructionTest, SerializeMemoryInstruction) {
   };
   EXPECT_EQ(Output, Expected);
 
-  I32Load.getMemoryAlign() = 0xFFFFFFFFU;
-  I32Load.getMemoryOffset() = 0xFFFFFFFEU;
+  I32Load.getMemoryAlign() = 0x00U;
+  I32Load.getMemoryOffset() = 0x100000000ULL;
   Instructions = {I32Load, End};
   Output = {};
-  EXPECT_TRUE(Ser.serializeSection(createCodeSec(Instructions), Output));
-  Expected = {
-      0x0AU,                             // Code section
-      0x0FU,                             // Content size = 15
-      0x01U,                             // Vector length = 1
-      0x0DU,                             // Code segment size = 13
-      0x00U,                             // Local vec(0)
-      0x28U,                             // OpCode I32__load.
-      0xFFU, 0xFFU, 0xFFU, 0xFFU, 0x0FU, // Align.
-      0xFEU, 0xFFU, 0xFFU, 0xFFU, 0x0FU, // Offset.
-      0x0BU                              // Expression End.
-  };
-  EXPECT_EQ(Output, Expected);
+  EXPECT_FALSE(SerNoMemory64.serializeSection(createCodeSec(Instructions),
+                                            Output));
 
   // memory.init x y encodes x (data segment index, SourceIndex) before y (memory
   // index, TargetIndex).  Using SourceIndex=5, TargetIndex=0 (non-multi-memory).


### PR DESCRIPTION
Summary

Fixes: #14131 — Fix a debug-only assertion in Cranelift alias analysis that assumed the observed_stores set could not grow during later instruction processing. Observations may be discovered after dead-store or idempotent-store rewrites, so the set must be monotonic (non-decreasing) rather than fixed-size.
Changes Made

Updated: the debug_assert! in [alias_analysis.rs](vscode-file://vscode-app/c:/Users/RuchitRathi/AppData/Local/Programs/Microsoft%20VS%20Code/e4c7e7b1d6/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to assert that observed_stores.len() only grows or stays the same (>=), not that it remains equal.
Added: a regression test at [issue-14131.clif](vscode-file://vscode-app/c:/Users/RuchitRathi/AppData/Local/Programs/Microsoft%20VS%20Code/e4c7e7b1d6/resources/app/out/vs/code/electron-browser/workbench/workbench.html) that reproduces the original assertion failure and verifies the fix.

Verification

Single reproducer: cargo +1.95.0 run -p cranelift-tools -- test cranelift/filetests/filetests/alias/issue-14131.clif (Passed)
Full alias suite: cargo +1.95.0 run -p cranelift-tools -- test cranelift/filetests/filetests/alias (40 tests passed)
Notes

Rationale: Additional store observations can appear after optimization rewrites; the invariant must allow monotonic growth.
Risk: Low — this changes a debug-only assertion and adds a regression test; no behavioral change in release builds.
