### PR TITLE
fix(loader): load native shared-library WASM only in AOT run mode

### DIFF
--- a/.github/workflows/reusable-build-on-macos.yml
+++ b/.github/workflows/reusable-build-on-macos.yml
@@ -166,12 +166,12 @@ jobs:
           wat2wasm examples/wasm/fibonacci.wat -o examples/wasm/fibonacci.wasm
           echo "./build/tools/wasmedge/wasmedgec examples/wasm/fibonacci.wasm fib_c.dylib"
           ./build/tools/wasmedge/wasmedgec examples/wasm/fibonacci.wasm fib_c.dylib
-          echo "./build/tools/wasmedge/wasmedge --reactor fib_c.dylib fib 20"
-          ./build/tools/wasmedge/wasmedge --reactor fib_c.dylib fib 20
+          echo "./build/tools/wasmedge/wasmedge --run-mode=aot --reactor fib_c.dylib fib 20"
+          ./build/tools/wasmedge/wasmedge --run-mode=aot --reactor fib_c.dylib fib 20
           echo "./build/tools/wasmedge/wasmedge compile examples/wasm/fibonacci.wasm fib_compile.dylib"
           ./build/tools/wasmedge/wasmedge compile examples/wasm/fibonacci.wasm fib_compile.dylib
-          echo "./build/tools/wasmedge/wasmedge --reactor fib_compile.dylib fib 20"
-          ./build/tools/wasmedge/wasmedge --reactor fib_compile.dylib fib 20
+          echo "./build/tools/wasmedge/wasmedge --run-mode=aot --reactor fib_compile.dylib fib 20"
+          ./build/tools/wasmedge/wasmedge --run-mode=aot --reactor fib_compile.dylib fib 20
       - name: Check symbol exposure
         run: |
           bash .github/scripts/check_symbols.sh

--- a/examples/capi/mandelbrot-set-in-threads/README.md
+++ b/examples/capi/mandelbrot-set-in-threads/README.md
@@ -85,7 +85,12 @@ WasmEdge_String MemoryName = WasmEdge_StringCreateByCString("memory");
 WasmEdge_ModuleInstanceAddMemory(HostModCxt, MemoryName, HostMemory);
 ```
 
-After the AOT-compiled WASM `mandelbrot.so` being made, you can load the file and instantiate the WASM module with `WasmEdge_VMRegisterModuleFromFile`.
+After the AOT-compiled WASM `mandelbrot.so` being made, you can load the file and instantiate the WASM module with `WasmEdge_VMRegisterModuleFromFile`. Loading a native shared library requires the AOT run mode, which must be set on the configure context before `WasmEdge_VMCreate`.
+
+```c
+WasmEdge_ConfigureSetRunMode(ConfCxt, WasmEdge_RunMode_AOT);
+WasmEdge_VMContext *VMCxt = WasmEdge_VMCreate(ConfCxt, NULL);
+```
 
 ```c
 WasmEdge_String ModName = WasmEdge_StringCreateByCString("mandelbrot");

--- a/examples/capi/mandelbrot-set-in-threads/main.cc
+++ b/examples/capi/mandelbrot-set-in-threads/main.cc
@@ -23,6 +23,7 @@ int main(int argc, char **argv) {
   WasmEdge_ConfigureAddProposal(ConfCxt, WasmEdge_Proposal_MultiMemories);
   WasmEdge_ConfigureRemoveProposal(ConfCxt, WasmEdge_Proposal_ReferenceTypes);
   WasmEdge_ConfigureAddProposal(ConfCxt, WasmEdge_Proposal_Threads);
+  WasmEdge_ConfigureSetRunMode(ConfCxt, WasmEdge_RunMode_AOT);
   WasmEdge_VMContext *VMCxt = WasmEdge_VMCreate(ConfCxt, NULL);
 
   WasmEdge_Result Res;

--- a/include/api/wasmedge/wasmedge_configure.h
+++ b/include/api/wasmedge/wasmedge_configure.h
@@ -166,7 +166,7 @@ WASMEDGE_CAPI_EXPORT extern uint64_t WasmEdge_ConfigureGetMaxMemoryPage(
 /// (default), JIT, or AOT. Only `WasmEdge_RunMode_AOT` will load AOT custom
 /// sections from universal WASM, or `dlopen` shared-library WASM artifacts;
 /// in the other modes, AOT data is ignored, and shared-library inputs are
-/// re-loaded as plain WASM after extracting their embedded bytes.
+/// rejected.
 ///
 /// This function is thread-safe.
 ///

--- a/lib/loader/loader.cpp
+++ b/lib/loader/loader.cpp
@@ -88,9 +88,17 @@ Loader::parseWasmUnit(const std::filesystem::path &FilePath) {
   case FileMgr::FileHeader::DLL:
   case FileMgr::FileHeader::MachO_32:
   case FileMgr::FileHeader::MachO_64: {
-    // Open the shared library long enough to validate its WasmEdge AOT
-    // version and extract the embedded WASM bytes. Whether the native
-    // handle stays alive depends on the configured RunMode.
+    if (Conf.getRuntimeConfigure().getRunMode() != RunMode::AOT) {
+      spdlog::error("Might an invalid wasm file"sv);
+      spdlog::error(ErrCode::Value::MalformedMagic);
+      spdlog::error(
+          "    The AOT compiled WASM shared library is only loadable in the "
+          "AOT run mode. Please use a normal WASM file, or set the run mode "
+          "to AOT."sv);
+      spdlog::error(ErrInfo::InfoFile(FilePath));
+      return Unexpect(ErrCode::Value::MalformedMagic);
+    }
+
     WASMType = InputType::SharedLibrary;
     FMgr.reset();
     std::shared_ptr<SharedLibrary> Library = std::make_shared<SharedLibrary>();
@@ -104,15 +112,7 @@ Loader::parseWasmUnit(const std::filesystem::path &FilePath) {
 
     EXPECTED_TRY(auto Code, Library->getWasm().map_error(ReportError));
 
-    if (Conf.getRuntimeConfigure().getRunMode() != RunMode::AOT) {
-      // Non-AOT mode: drop the native handle now and re-parse the embedded
-      // WASM bytes as plain WASM. No AOT function symbol from the shared
-      // library is resolved or called.
-      Library.reset();
-      return parseWasmUnit(Code);
-    }
-
-    // AOT mode: keep the library alive and load executable symbols.
+    // Keep the library alive and load executable symbols.
     EXPECTED_TRY(FMgr.setCode(Code).map_error(ReportError));
     EXPECTED_TRY(auto Unit, loadUnit().map_error(ReportError));
     if (auto Ptr = std::get_if<std::unique_ptr<AST::Module>>(&Unit);
@@ -152,8 +152,8 @@ Loader::parseWasmUnit(Span<const uint8_t> Code) {
     spdlog::error(ErrCode::Value::MalformedMagic);
     spdlog::error(
         "    The AOT compiled WASM shared library is not supported for loading "
-        "from memory. Please use the universal WASM binary or pure WASM, or "
-        "load the AOT compiled WASM shared library from file."sv);
+        "from memory. Please use a normal WASM file, or load the AOT compiled "
+        "WASM shared library from file in the AOT run mode."sv);
     return Unexpect(ErrCode::Value::MalformedMagic);
   default:
     break;

--- a/test/api/APIUnitTest.cpp
+++ b/test/api/APIUnitTest.cpp
@@ -1488,14 +1488,13 @@ TEST(APICoreTest, Compiler) {
 // on all platforms.
 #ifndef __riscv
 TEST(APICoreTest, RunModes) {
-  // Exercise the WasmEdge_RunMode behaviours and fallback paths.
+  // Exercise the WasmEdge_RunMode behaviours.
   //
-  // Compile fib to a native shared library (.so / .dylib / .dll) and load it
-  // under each RunMode. In Interpreter and JIT modes the loader extracts the
-  // embedded WASM bytes and dlcloses the library before any AOT function
-  // symbol is resolved; in AOT mode the existing dlopen-and-link behaviour is
-  // kept. Then verify that AOT mode on a plain .wasm with no AOT section
-  // falls back to interpreter execution with a warning.
+  // Compile fib to a native shared library (.so / .dylib / .dll). In
+  // Interpreter and JIT modes, loading a native shared-library artifact is
+  // rejected with MalformedMagic. In AOT mode, the library loads and its
+  // compiled native code runs. Then verify that AOT mode on a plain .wasm
+  // with no AOT section falls back to interpreter execution with a warning.
   WasmEdge_ConfigureContext *Conf = WasmEdge_ConfigureCreate();
   WasmEdge_ConfigureCompilerSetOutputFormat(
       Conf, WasmEdge_CompilerOutputFormat_Native);
@@ -1510,24 +1509,22 @@ TEST(APICoreTest, RunModes) {
   WasmEdge_Value P[1] = {WasmEdge_ValueGenI32(20)};
   WasmEdge_Value R[1] = {WasmEdge_ValueGenI32(0)};
 
-  // Interpreter mode: dlopen → extract embedded WASM bytes → dlclose →
-  // interpret.
+  // Interpreter mode: native shared-library artifacts are rejected.
   WasmEdge_ConfigureSetRunMode(Conf, WasmEdge_RunMode_Interpreter);
   WasmEdge_VMContext *VM = WasmEdge_VMCreate(Conf, nullptr);
   EXPECT_NE(VM, nullptr);
-  EXPECT_TRUE(WasmEdge_ResultOK(
+  EXPECT_TRUE(isErrMatch(
+      WasmEdge_ErrCode_MalformedMagic,
       WasmEdge_VMRunWasmFromFile(VM, SharedLibPath, FuncName, P, 1, R, 1)));
-  EXPECT_EQ(WasmEdge_ValueGetI32(R[0]), 10946);
   WasmEdge_VMDelete(VM);
 
-  // JIT mode: dlopen → extract bytes → dlclose → JIT-compile → run.
-  R[0] = WasmEdge_ValueGenI32(0);
+  // JIT mode: native shared-library artifacts are rejected.
   WasmEdge_ConfigureSetRunMode(Conf, WasmEdge_RunMode_JIT);
   VM = WasmEdge_VMCreate(Conf, nullptr);
   EXPECT_NE(VM, nullptr);
-  EXPECT_TRUE(WasmEdge_ResultOK(
+  EXPECT_TRUE(isErrMatch(
+      WasmEdge_ErrCode_MalformedMagic,
       WasmEdge_VMRunWasmFromFile(VM, SharedLibPath, FuncName, P, 1, R, 1)));
-  EXPECT_EQ(WasmEdge_ValueGetI32(R[0]), 10946);
   WasmEdge_VMDelete(VM);
 
   // AOT mode: keep library handle alive, run the embedded native code.

--- a/test/api/helper.cpp
+++ b/test/api/helper.cpp
@@ -52,6 +52,9 @@ WasmEdge_ConfigureContext *createConf(const Configure &Conf) {
       WasmEdge_ConfigureAddProposal(Cxt, static_cast<WasmEdge_Proposal>(I));
     }
   }
+  WasmEdge_ConfigureSetRunMode(
+      Cxt,
+      static_cast<WasmEdge_RunMode>(Conf.getRuntimeConfigure().getRunMode()));
   return Cxt;
 }
 

--- a/test/llvm/LLVMcoreTest.cpp
+++ b/test/llvm/LLVMcoreTest.cpp
@@ -33,6 +33,8 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <system_error>
+#include <thread>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -1027,6 +1029,81 @@ TEST(AOTMemory64, BoundsCheck) {
 
   VM.cleanup();
   EXPECT_NO_THROW(std::filesystem::remove(Path));
+}
+
+// Owns a uniquely named file under the system temporary directory and removes
+// it when the scope exits, including when an assertion returns early.
+class ScopedTempFile {
+public:
+  explicit ScopedTempFile(std::string_view Stem,
+                          std::string_view Extension = ""sv)
+      : Path(
+            std::filesystem::temp_directory_path() /
+            std::filesystem::u8path(std::string(Stem) + "-" +
+                                    std::to_string(std::hash<std::thread::id>{}(
+                                        std::this_thread::get_id())) +
+                                    std::string(Extension))) {}
+  ScopedTempFile(const ScopedTempFile &) = delete;
+  ScopedTempFile &operator=(const ScopedTempFile &) = delete;
+  ~ScopedTempFile() noexcept {
+    std::error_code EC;
+    std::filesystem::remove(Path, EC);
+  }
+
+  const std::filesystem::path &get() const noexcept { return Path; }
+
+private:
+  std::filesystem::path Path;
+};
+
+TEST(NativeRunMode, LoadSharedLibraryRequiresAOTMode) {
+  std::array<WasmEdge::Byte, 34> NativeRunModeWasm{
+      0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+      0x00, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x07, 0x05, 0x01, 0x01, 0x66,
+      0x00, 0x00, 0x0a, 0x06, 0x01, 0x04, 0x00, 0x41, 0x2a, 0x0b};
+
+  const ScopedTempFile Artifact("NativeRunModeTest", WASMEDGE_LIB_EXTENSION);
+  const auto &Path = Artifact.get();
+
+  {
+    WasmEdge::Configure Conf;
+    Conf.getCompilerConfigure().setOutputFormat(
+        CompilerConfigure::OutputFormat::Native);
+    Conf.getRuntimeConfigure().setRunMode(WasmEdge::RunMode::AOT);
+
+    WasmEdge::Loader::Loader Loader(Conf);
+    WasmEdge::Validator::Validator ValidatorEngine(Conf);
+    WasmEdge::LLVM::Compiler Compiler(Conf);
+    WasmEdge::LLVM::CodeGen CodeGen(Conf);
+
+    auto Module = Loader.parseModule(NativeRunModeWasm);
+    ASSERT_TRUE(Module);
+    ASSERT_TRUE(ValidatorEngine.validate(**Module));
+    auto Data = Compiler.compile(**Module);
+    ASSERT_TRUE(Data);
+    ASSERT_TRUE(CodeGen.codegen(NativeRunModeWasm, std::move(*Data), Path));
+  }
+
+  for (const auto Mode : {WasmEdge::RunMode::Interpreter,
+                          WasmEdge::RunMode::JIT, WasmEdge::RunMode::LazyJIT}) {
+    WasmEdge::Configure Conf;
+    Conf.getRuntimeConfigure().setRunMode(Mode);
+    WasmEdge::VM::VM VM(Conf);
+    auto Res = VM.loadWasm(Path);
+    EXPECT_FALSE(Res);
+    if (!Res) {
+      EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::MalformedMagic);
+    }
+    VM.cleanup();
+  }
+
+  {
+    WasmEdge::Configure Conf;
+    Conf.getRuntimeConfigure().setRunMode(WasmEdge::RunMode::AOT);
+    WasmEdge::VM::VM VM(Conf);
+    EXPECT_TRUE(VM.loadWasm(Path));
+    VM.cleanup();
+  }
 }
 
 } // namespace

--- a/test/loader/moduleTest.cpp
+++ b/test/loader/moduleTest.cpp
@@ -13,13 +13,48 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "common/filesystem.h"
 #include "loader/loader.h"
 
 #include <cstdint>
+#include <fstream>
+#include <functional>
 #include <gtest/gtest.h>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <thread>
+#include <utility>
 #include <vector>
 
 namespace {
+
+using namespace std::literals;
+
+// Owns a uniquely named file under the system temporary directory and removes
+// it when the scope exits, including when an assertion returns early.
+class ScopedTempFile {
+public:
+  explicit ScopedTempFile(std::string_view Stem,
+                          std::string_view Extension = ""sv)
+      : Path(
+            std::filesystem::temp_directory_path() /
+            std::filesystem::u8path(std::string(Stem) + "-" +
+                                    std::to_string(std::hash<std::thread::id>{}(
+                                        std::this_thread::get_id())) +
+                                    std::string(Extension))) {}
+  ScopedTempFile(const ScopedTempFile &) = delete;
+  ScopedTempFile &operator=(const ScopedTempFile &) = delete;
+  ~ScopedTempFile() noexcept {
+    std::error_code EC;
+    std::filesystem::remove(Path, EC);
+  }
+
+  const std::filesystem::path &get() const noexcept { return Path; }
+
+private:
+  std::filesystem::path Path;
+};
 
 WasmEdge::Configure Conf;
 WasmEdge::Loader::Loader Ldr(Conf);
@@ -217,6 +252,34 @@ TEST(ModuleTest, LoadDupSecModule) {
       0x0CU, 0x01U, 0x00U         // Datacount section duplicated
   };
   EXPECT_FALSE(Ldr.parseModule(Vec));
+}
+
+TEST(ModuleTest, LoadNativeLibraryMagicNotInAOTMode) {
+  const std::vector<std::pair<std::string, std::vector<uint8_t>>> Cases = {
+      {"elf", {0x7FU, 0x45U, 0x4CU, 0x46U}},
+      {"dll", {0x4DU, 0x5AU}},
+      {"macho32", {0xCEU, 0xFAU, 0xEDU, 0xFEU}},
+      {"macho64", {0xCFU, 0xFAU, 0xEDU, 0xFEU}}};
+
+  for (const auto &[Name, Magic] : Cases) {
+    const ScopedTempFile Artifact("wasmedgeLoaderNativeMagic-" + Name);
+    const auto &Path = Artifact.get();
+    {
+      std::ofstream Fout(Path, std::ios::out | std::ios::binary);
+      ASSERT_TRUE(Fout) << Name;
+      const std::vector<uint8_t> Junk(64, 0x00U);
+      Fout.write(reinterpret_cast<const char *>(Magic.data()),
+                 static_cast<std::streamsize>(Magic.size()));
+      Fout.write(reinterpret_cast<const char *>(Junk.data()),
+                 static_cast<std::streamsize>(Junk.size()));
+    }
+
+    auto Res = Ldr.parseModule(Path);
+    EXPECT_FALSE(Res) << Name;
+    if (!Res) {
+      EXPECT_EQ(Res.error(), WasmEdge::ErrCode::Value::MalformedMagic) << Name;
+    }
+  }
 }
 
 } // namespace

--- a/test/thread/ThreadTest.cpp
+++ b/test/thread/ThreadTest.cpp
@@ -235,6 +235,7 @@ TEST(AOTAsyncExecute, ThreadTest) {
   Conf.getCompilerConfigure().setInterruptible(true);
   Conf.getCompilerConfigure().setOutputFormat(
       WasmEdge::CompilerConfigure::OutputFormat::Native);
+  Conf.getRuntimeConfigure().setRunMode(WasmEdge::RunMode::AOT);
   const auto Path =
       std::filesystem::temp_directory_path() /
       std::filesystem::u8path("ThreadTest" WASMEDGE_LIB_EXTENSION);
@@ -289,6 +290,7 @@ TEST(AOTAsyncExecute, GasThreadTest) {
   Conf.getStatisticsConfigure().setTimeMeasuring(true);
   Conf.getCompilerConfigure().setOutputFormat(
       WasmEdge::CompilerConfigure::OutputFormat::Native);
+  Conf.getRuntimeConfigure().setRunMode(WasmEdge::RunMode::AOT);
   auto Path = std::filesystem::temp_directory_path() /
               std::filesystem::u8path("AOTGasTest" WASMEDGE_LIB_EXTENSION);
 


### PR DESCRIPTION
## Description

`Loader::parseWasmUnit(const std::filesystem::path &)` dispatches on the input file's
leading bytes. When the file carries ELF, Mach-O or PE magic, the loader passed the path
straight to `SharedLibrary::load()` — `dlopen()` on POSIX, `LoadLibraryExW()` on Windows —
and only afterwards checked the AOT binary version and the configured run mode.

Both calls run the module's initialisation code at load time: `DT_INIT` and `.init_array`
entries, `__attribute__((constructor))` functions, C++ static object constructors, and
`DllMain`. Releasing the handle afterwards does not unwind constructors that already ran,
so the ordering meant none of the later checks could take effect:

| Order | Step |
|-------|------|
| 1 | `dlopen()` / `LoadLibraryExW()` — initialisers run |
| 2 | `AOT::kBinaryVersion` comparison |
| 3 | `RunMode` comparison |
| 4 | `Library.reset()` and fall back to the embedded WASM |

Since the default run mode is `RunMode::Interpreter`, the check at step 3 never protected
the default configuration.

This PR moves the run-mode check ahead of the dynamic-loader call. Native shared-library
inputs are now accepted only under `RunMode::AOT`, which is opt-in and never selected
implicitly. In every other mode the file is rejected by magic with
`ErrCode::Value::MalformedMagic`, before any handle is opened.

The in-memory entry point `Loader::parseWasmUnit(Span<const uint8_t>)` already rejected
the same four magic values; the two sites now behave and read consistently.

### Breaking change

`wasmedge foo.so` under the default interpreter mode no longer works. Previously the
loader opened the file, extracted the embedded WASM through the `wasm.size` and
`wasm.code` symbols, closed the handle, and interpreted the extracted bytes. That
fallback is removed rather than reordered, because closing the handle never undid the
initialisers it was meant to contain.

Two supported replacements:

- pass `--run-mode=aot`, which is what a native artifact was built for; or
- compile with the WASM output format — `wasmedgec`'s default — which produces a normal
  `.wasm` file that loads in any run mode.

`.github/workflows/reusable-build-on-macos.yml` ran a native artifact without selecting
AOT and is updated accordingly.

### Also fixed: `createConf()` dropped the run mode

`test/api/helper.cpp`'s `createConf()` copied only proposals into the C configure
context, never the run mode. `test/api/APIAOTCoreTest.cpp` sets `RunMode::AOT`, but the
VM built through `createConf()` has always run at the default `Interpreter` — the AOT
spec suite has never actually executed in AOT mode, and passed only because the removed
fallback silently reinterpreted the artifact. This is a pre-existing bug that the loader
change exposes; `createConf()` now propagates the run mode.

### Known regression, not fixed here

`wasmedge parse`, `validate`, and `instantiate` no longer accept native artifacts, and
those subcommands do not register `--run-mode`, so there is no opt-in. Passing
`--run-mode=aot` before the subcommand is silently accepted but has no effect; passing it
after is rejected as `unknown option: run-mode`.

This is left as-is deliberately: `validate` in particular should not `dlopen` its input.
Adding `--run-mode` to those subcommands is a separate change if it is wanted.

### Scope

- `lib/loader/loader.cpp` — the guard, deletion of the unreachable non-AOT fallback, and
  wording alignment of the in-memory rejection.
- `test/loader/moduleTest.cpp` — all four magic values rejected with `MalformedMagic`
  outside AOT mode. No LLVM dependency.
- `test/llvm/LLVMcoreTest.cpp` — a real module compiled to a native artifact, refused
  under `Interpreter` and `JIT`, still accepted under `AOT`.
- `test/api/APIUnitTest.cpp`, `test/api/helper.cpp`, `test/thread/ThreadTest.cpp` —
  call sites that consumed the removed fallback.
- `include/api/wasmedge/wasmedge_configure.h` — the `WasmEdge_ConfigureSetRunMode` doc
  comment documented the removed behaviour.
- `examples/capi/mandelbrot-set-in-threads/main.cc` — builds its module natively and
  loads it without AOT.

No new `Configure` flag, C API setter, or CLI option; `RunMode::AOT` is the whole gate.
No new CMake test targets.

This contribution was developed with assistance from Claude (Anthropic), disclosed with
the `Assisted-by:` trailer on every commit and reviewed by a human before submission.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

Full suite, configured with `cmake -S . -B build -G Ninja -DWASMEDGE_BUILD_TESTS=ON`:

```
33/33 Test #33: wasmedgeVMTests ....................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 33

Total Test time (real) = 110.22 sec
```

`clang-format --dry-run --Werror` on all touched C++ files: clean, exit 0.

Manual CLI verification:

```
$ cc -shared -fPIC -o plain.wasm plain.c        # ELF magic, .wasm extension
$ wasmedge plain.wasm                            # and --run-mode=interpreter|jit|lazyjit
[error] Might an invalid wasm file
[error] malformed magic
[error]     The AOT compiled WASM shared library is only loadable in the AOT run
            mode. Please use a normal WASM file, or set the run mode to AOT.
exit=1

$ wasmedgec fibonacci.wasm fib_native.so         # native output
$ wasmedge --run-mode=aot --reactor fib_native.so fib 20
10946                                            # AOT path preserved
$ wasmedge --reactor fib_native.so fib 20        # default interpreter
exit=1                                           # correctly rejected

$ wasmedgec fibonacci.wasm fib_universal.wasm    # default WASM output
$ wasmedge --reactor fib_universal.wasm fib 20
10946                                            # normal path unaffected
```
