### PR TITLE
fix(executor): use correct atomic notify access width

### DIFF
--- a/include/executor/engine/atomic.ipp
+++ b/include/executor/engine/atomic.ipp
@@ -40,7 +40,7 @@ TypeT<T> Executor::runAtomicWaitOp(Runtime::StackManager &StackMgr,
             ErrInfo::InfoInstruction(Instr.getOpCode(), Instr.getOffset()));
         return E;
       })
-      .map([&](auto V) { RawAddress = emplaceAddr(V, AddrType); });
+      .map([&](auto V) { RawAddress = emplaceAddr(V, AddressType::I32); });
 }
 
 template <typename T, typename I>

--- a/lib/executor/engine/threadInstr.cpp
+++ b/lib/executor/engine/threadInstr.cpp
@@ -16,17 +16,15 @@ Executor::runAtomicNotifyOp(Runtime::StackManager &StackMgr,
   uint64_t Address = extractAddr(RawAddress, AddrType);
   EXPECTED_TRY(checkOffsetOverflow(MemInst, Instr, Address, sizeof(uint32_t)));
   Address += Instr.getMemoryOffset();
-  uint32_t Align =
-      AddrType == AddressType::I32 ? sizeof(uint32_t) : sizeof(uint64_t);
 
-  if (Address % Align != 0) {
+  if (Address % sizeof(uint32_t) != 0) {
     spdlog::error(ErrCode::Value::UnalignedAtomicAccess);
     spdlog::error(
         ErrInfo::InfoInstruction(Instr.getOpCode(), Instr.getOffset()));
     return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
-  uint64_t Count = extractAddr(RawCount, AddrType);
+  uint64_t Count = extractAddr(RawCount, AddressType::I32);
   EXPECTED_TRY(
       auto Total,
       atomicNotify(MemInst, Address, Count).map_error([&Instr](auto E) {
@@ -35,7 +33,7 @@ Executor::runAtomicNotifyOp(Runtime::StackManager &StackMgr,
             ErrInfo::InfoInstruction(Instr.getOpCode(), Instr.getOffset()));
         return E;
       }));
-  RawAddress = emplaceAddr(Total, AddrType);
+  RawAddress = emplaceAddr(Total, AddressType::I32);
   return {};
 }
 

--- a/lib/executor/engine/threadInstr.cpp
+++ b/lib/executor/engine/threadInstr.cpp
@@ -49,8 +49,7 @@ Executor::atomicNotify(Runtime::Instance::MemoryInstance &MemInst,
                        uint64_t Address, uint64_t Count) noexcept {
   // The error message should be handled by the caller, or the AOT mode will
   // produce the duplicated messages.
-  if (auto *AtomicObj = MemInst.getPointer<std::atomic<uint64_t> *>(Address);
-      !AtomicObj) {
+  if (!MemInst.checkAccessBound(Address, sizeof(uint32_t))) {
     return Unexpect(ErrCode::Value::MemoryOutOfBounds);
   }
 

--- a/lib/llvm/compiler/threadInstr.cpp
+++ b/lib/llvm/compiler/threadInstr.cpp
@@ -360,11 +360,13 @@ void FunctionCompiler::compileMemoryFence() noexcept {
 void FunctionCompiler::compileAtomicNotify(unsigned MemoryIndex,
                                            uint64_t MemoryOffset) noexcept {
   auto Count = Builder.createZExt(stackPop(), Context.Int64Ty);
-  auto Offset = Builder.createZExt(stackPop(), Context.Int64Ty);
+  auto Addr = Builder.createZExt(stackPop(), Context.Int64Ty);
+  auto Offset = Addr;
   if (MemoryOffset != 0) {
-    Offset = Builder.createAdd(Offset, LLContext.getInt64(MemoryOffset));
+    Offset = Builder.createAdd(Addr, LLContext.getInt64(MemoryOffset));
   }
   compileAtomicCheckOffsetAlignment(Offset, Context.Int32Ty);
+  boundsCheckMemory64(MemoryIndex, Addr, MemoryOffset, sizeof(uint32_t));
   stackPush(Builder.createTrunc(
       Builder.createCall(
           Context.getIntrinsic(
@@ -375,7 +377,7 @@ void FunctionCompiler::compileAtomicNotify(unsigned MemoryIndex,
                                           false)),
           {Context.getModuleInst(Builder, ModCtx),
            LLContext.getInt32(MemoryIndex), Offset, Count}),
-      Context.MemoryAddrTypes[MemoryIndex]));
+      Context.Int32Ty));
 }
 
 void FunctionCompiler::compileAtomicWait(unsigned MemoryIndex,
@@ -384,11 +386,13 @@ void FunctionCompiler::compileAtomicWait(unsigned MemoryIndex,
                                          uint32_t BitWidth) noexcept {
   auto Timeout = stackPop();
   auto ExpectedValue = Builder.createZExtOrTrunc(stackPop(), Context.Int64Ty);
-  auto Offset = Builder.createZExt(stackPop(), Context.Int64Ty);
+  auto Addr = Builder.createZExt(stackPop(), Context.Int64Ty);
+  auto Offset = Addr;
   if (MemoryOffset != 0) {
-    Offset = Builder.createAdd(Offset, LLContext.getInt64(MemoryOffset));
+    Offset = Builder.createAdd(Addr, LLContext.getInt64(MemoryOffset));
   }
   compileAtomicCheckOffsetAlignment(Offset, TargetType);
+  boundsCheckMemory64(MemoryIndex, Addr, MemoryOffset, BitWidth / 8);
   stackPush(Builder.createTrunc(
       Builder.createCall(
           Context.getIntrinsic(
@@ -401,7 +405,7 @@ void FunctionCompiler::compileAtomicWait(unsigned MemoryIndex,
           {Context.getModuleInst(Builder, ModCtx),
            LLContext.getInt32(MemoryIndex), Offset, ExpectedValue, Timeout,
            LLContext.getInt32(BitWidth)}),
-      Context.MemoryAddrTypes[MemoryIndex]));
+      Context.Int32Ty));
 }
 
 void FunctionCompiler::compileAtomicLoad(unsigned MemoryIndex,

--- a/test/thread/ThreadTest.cpp
+++ b/test/thread/ThreadTest.cpp
@@ -162,84 +162,157 @@ std::array<uint64_t, 4> Answers{
     UINT64_C(4446454406775736720),
     UINT64_C(9019442596657776185),
 };
-std::array<WasmEdge::Byte, 53> AtomicNotify32{
-    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x07, 0x01,
-    0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x05,
-    0x04, 0x01, 0x03, 0x01, 0x01, 0x07, 0x0a, 0x01, 0x06, 0x6e, 0x6f,
-    0x74, 0x69, 0x66, 0x79, 0x00, 0x00, 0x0a, 0x0c, 0x01, 0x0a, 0x00,
-    0x20, 0x00, 0x20, 0x01, 0xfe, 0x00, 0x02, 0x00, 0x0b,
+std::array<WasmEdge::Byte, 122> AtomicThreads32{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x15, 0x03, 0x60,
+    0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x60, 0x03, 0x7f, 0x7f, 0x7e, 0x01, 0x7f,
+    0x60, 0x03, 0x7f, 0x7e, 0x7e, 0x01, 0x7f, 0x03, 0x04, 0x03, 0x00, 0x01,
+    0x02, 0x05, 0x04, 0x01, 0x03, 0x01, 0x01, 0x07, 0x25, 0x04, 0x06, 0x6d,
+    0x65, 0x6d, 0x6f, 0x72, 0x79, 0x02, 0x00, 0x06, 0x6e, 0x6f, 0x74, 0x69,
+    0x66, 0x79, 0x00, 0x00, 0x06, 0x77, 0x61, 0x69, 0x74, 0x33, 0x32, 0x00,
+    0x01, 0x06, 0x77, 0x61, 0x69, 0x74, 0x36, 0x34, 0x00, 0x02, 0x0a, 0x26,
+    0x03, 0x0a, 0x00, 0x20, 0x00, 0x20, 0x01, 0xfe, 0x00, 0x02, 0x00, 0x0b,
+    0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x01, 0x02, 0x00,
+    0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x02, 0x03,
+    0x00, 0x0b,
 };
-std::array<WasmEdge::Byte, 111> AtomicNotify64{
-    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0e, 0x02, 0x60,
-    0x02, 0x7e, 0x7f, 0x01, 0x7f, 0x60, 0x03, 0x7e, 0x7f, 0x7e, 0x01, 0x7f,
-    0x03, 0x04, 0x03, 0x00, 0x00, 0x01, 0x05, 0x04, 0x01, 0x07, 0x01, 0x01,
-    0x07, 0x23, 0x03, 0x06, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79, 0x00, 0x00,
-    0x0d, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79, 0x2d, 0x6f, 0x66, 0x66, 0x73,
-    0x65, 0x74, 0x00, 0x01, 0x06, 0x77, 0x61, 0x69, 0x74, 0x33, 0x32, 0x00,
-    0x02, 0x0a, 0x24, 0x03, 0x0a, 0x00, 0x20, 0x00, 0x20, 0x01, 0xfe, 0x00,
-    0x02, 0x00, 0x0b, 0x0a, 0x00, 0x20, 0x00, 0x20, 0x01, 0xfe, 0x00, 0x02,
-    0x04, 0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x01,
-    0x02, 0x00, 0x0b,
+std::array<WasmEdge::Byte, 255> AtomicThreads64{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x1a, 0x04, 0x60,
+    0x02, 0x7e, 0x7f, 0x01, 0x7f, 0x60, 0x01, 0x7e, 0x01, 0x7f, 0x60, 0x03,
+    0x7e, 0x7f, 0x7e, 0x01, 0x7f, 0x60, 0x03, 0x7e, 0x7e, 0x7e, 0x01, 0x7f,
+    0x03, 0x08, 0x07, 0x00, 0x00, 0x01, 0x02, 0x02, 0x03, 0x03, 0x05, 0x04,
+    0x01, 0x07, 0x01, 0x01, 0x07, 0x6c, 0x08, 0x06, 0x6d, 0x65, 0x6d, 0x6f,
+    0x72, 0x79, 0x02, 0x00, 0x06, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79, 0x00,
+    0x00, 0x0d, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79, 0x2d, 0x6f, 0x66, 0x66,
+    0x73, 0x65, 0x74, 0x00, 0x01, 0x14, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79,
+    0x2d, 0x77, 0x72, 0x61, 0x70, 0x70, 0x65, 0x64, 0x2d, 0x63, 0x6f, 0x75,
+    0x6e, 0x74, 0x00, 0x02, 0x06, 0x77, 0x61, 0x69, 0x74, 0x33, 0x32, 0x00,
+    0x03, 0x0d, 0x77, 0x61, 0x69, 0x74, 0x33, 0x32, 0x2d, 0x6f, 0x66, 0x66,
+    0x73, 0x65, 0x74, 0x00, 0x04, 0x06, 0x77, 0x61, 0x69, 0x74, 0x36, 0x34,
+    0x00, 0x05, 0x0d, 0x77, 0x61, 0x69, 0x74, 0x36, 0x34, 0x2d, 0x6f, 0x66,
+    0x66, 0x73, 0x65, 0x74, 0x00, 0x06, 0x0a, 0x5b, 0x07, 0x0a, 0x00, 0x20,
+    0x00, 0x20, 0x01, 0xfe, 0x00, 0x02, 0x00, 0x0b, 0x0a, 0x00, 0x20, 0x00,
+    0x20, 0x01, 0xfe, 0x00, 0x02, 0x04, 0x0b, 0x0f, 0x00, 0x20, 0x00, 0x42,
+    0x81, 0x80, 0x80, 0x80, 0x20, 0xa7, 0xfe, 0x00, 0x02, 0x00, 0x0b, 0x0c,
+    0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x01, 0x02, 0x00, 0x0b,
+    0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x01, 0x02, 0x04,
+    0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x02, 0x03,
+    0x00, 0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x02,
+    0x03, 0x08, 0x0b,
 };
 
 using namespace std::literals;
 
-void runAtomicNotify32Test(WasmEdge::RunMode Mode) {
+constexpr uint32_t WaitOk = UINT32_C(0);
+constexpr uint32_t WaitNotEqual = UINT32_C(1);
+constexpr uint32_t WaitTimedOut = UINT32_C(2);
+
+const WasmEdge::ValType TyI32(WasmEdge::TypeCode::I32);
+const WasmEdge::ValType TyI64(WasmEdge::TypeCode::I64);
+
+void expectAtomicValue(WasmEdge::VM::VM &VM, std::string_view Func,
+                       std::initializer_list<WasmEdge::ValVariant> Params,
+                       std::initializer_list<WasmEdge::ValType> ParamTypes,
+                       uint32_t Want) {
+  auto Result = VM.execute(Func, Params, ParamTypes);
+  ASSERT_TRUE(Result);
+  ASSERT_EQ(Result->size(), 1U);
+  EXPECT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+  EXPECT_EQ((*Result)[0].first.get<uint32_t>(), Want);
+}
+
+void expectAtomicTrap(WasmEdge::VM::VM &VM, std::string_view Func,
+                      std::initializer_list<WasmEdge::ValVariant> Params,
+                      std::initializer_list<WasmEdge::ValType> ParamTypes,
+                      WasmEdge::ErrCode::Value Want) {
+  auto Result = VM.execute(Func, Params, ParamTypes);
+  ASSERT_FALSE(Result);
+  EXPECT_EQ(Result.error(), Want);
+}
+
+void registerWaiters(WasmEdge::Runtime::Instance::MemoryInstance &MemInst,
+                     uint64_t Address, size_t Count) {
+  std::unique_lock<std::mutex> Locker(MemInst.getWaiterMapMutex());
+  auto &WaiterMap = MemInst.getWaiterMap();
+  for (size_t I = 0; I < Count; ++I) {
+    WaiterMap.emplace(std::piecewise_construct, std::forward_as_tuple(Address),
+                      std::forward_as_tuple());
+  }
+}
+
+void runAtomicThreads32Test(WasmEdge::RunMode Mode) {
   WasmEdge::Configure Conf;
   Conf.addProposal(WasmEdge::Proposal::Threads);
   Conf.getRuntimeConfigure().setRunMode(Mode);
   WasmEdge::VM::VM VM(Conf);
-  ASSERT_TRUE(VM.loadWasm(AtomicNotify32));
+  ASSERT_TRUE(VM.loadWasm(AtomicThreads32));
   ASSERT_TRUE(VM.validate());
   ASSERT_TRUE(VM.instantiate());
 
   if (Mode == WasmEdge::RunMode::JIT) {
-    const auto *F = VM.getActiveModule()->findFuncExports("notify"sv);
-    ASSERT_NE(F, nullptr);
-    EXPECT_TRUE(F->isCompiledFunction());
+    for (const auto Name : {"notify"sv, "wait32"sv, "wait64"sv}) {
+      SCOPED_TRACE(Name);
+      const auto *F = VM.getActiveModule()->findFuncExports(Name);
+      ASSERT_NE(F, nullptr);
+      EXPECT_TRUE(F->isCompiledFunction());
+    }
   }
 
   for (const uint32_t Address : {UINT32_C(4), UINT32_C(65532)}) {
     SCOPED_TRACE(Address);
-    auto Result = VM.execute(
-        "notify",
-        std::initializer_list<WasmEdge::ValVariant>{Address, UINT32_C(1)},
-        {WasmEdge::ValType(WasmEdge::TypeCode::I32),
-         WasmEdge::ValType(WasmEdge::TypeCode::I32)});
-    ASSERT_TRUE(Result);
-    ASSERT_EQ(Result->size(), 1U);
-    EXPECT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
-    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(0));
+    expectAtomicValue(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI32, TyI32},
+                      UINT32_C(0));
   }
-
   for (const auto &[Address, Error] :
        {std::pair{UINT32_C(65533),
                   WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
         std::pair{UINT32_C(65536),
                   WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
     SCOPED_TRACE(Address);
-    auto Result = VM.execute(
-        "notify",
-        std::initializer_list<WasmEdge::ValVariant>{Address, UINT32_C(1)},
-        {WasmEdge::ValType(WasmEdge::TypeCode::I32),
-         WasmEdge::ValType(WasmEdge::TypeCode::I32)});
-    ASSERT_FALSE(Result);
-    EXPECT_EQ(Result.error(), Error);
+    expectAtomicTrap(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI32, TyI32},
+                     Error);
+  }
+
+  expectAtomicValue(VM, "wait32"sv, {UINT32_C(65532), UINT32_C(1), UINT64_C(0)},
+                    {TyI32, TyI32, TyI64}, WaitNotEqual);
+  expectAtomicValue(VM, "wait32"sv, {UINT32_C(0), UINT32_C(0), UINT64_C(0)},
+                    {TyI32, TyI32, TyI64}, WaitTimedOut);
+  for (const auto &[Address, Error] :
+       {std::pair{UINT32_C(65533),
+                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+        std::pair{UINT32_C(65536),
+                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+    SCOPED_TRACE(Address);
+    expectAtomicTrap(VM, "wait32"sv, {Address, UINT32_C(1), UINT64_C(0)},
+                     {TyI32, TyI32, TyI64}, Error);
+  }
+
+  expectAtomicValue(VM, "wait64"sv, {UINT32_C(65528), UINT64_C(1), UINT64_C(0)},
+                    {TyI32, TyI64, TyI64}, WaitNotEqual);
+  for (const auto &[Address, Error] :
+       {std::pair{UINT32_C(65532),
+                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+        std::pair{UINT32_C(65536),
+                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+    SCOPED_TRACE(Address);
+    expectAtomicTrap(VM, "wait64"sv, {Address, UINT64_C(1), UINT64_C(0)},
+                     {TyI32, TyI64, TyI64}, Error);
   }
 }
 
-void runAtomicNotify64Test(WasmEdge::RunMode Mode) {
+void runAtomicThreads64Test(WasmEdge::RunMode Mode) {
   WasmEdge::Configure Conf;
   Conf.addProposal(WasmEdge::Proposal::Threads);
   Conf.addProposal(WasmEdge::Proposal::Memory64);
   Conf.getRuntimeConfigure().setRunMode(Mode);
   WasmEdge::VM::VM VM(Conf);
-  ASSERT_TRUE(VM.loadWasm(AtomicNotify64));
+  ASSERT_TRUE(VM.loadWasm(AtomicThreads64));
   ASSERT_TRUE(VM.validate());
   ASSERT_TRUE(VM.instantiate());
 
   if (Mode == WasmEdge::RunMode::JIT) {
-    for (const auto Name : {"notify"sv, "notify-offset"sv, "wait32"sv}) {
+    for (const auto Name : {"notify"sv, "notify-offset"sv, "wait32"sv,
+                            "wait32-offset"sv, "wait64"sv, "wait64-offset"sv}) {
+      SCOPED_TRACE(Name);
       const auto *F = VM.getActiveModule()->findFuncExports(Name);
       ASSERT_NE(F, nullptr);
       EXPECT_TRUE(F->isCompiledFunction());
@@ -248,64 +321,92 @@ void runAtomicNotify64Test(WasmEdge::RunMode Mode) {
 
   for (const uint64_t Address : {UINT64_C(4), UINT64_C(65532)}) {
     SCOPED_TRACE(Address);
-    auto Result = VM.execute(
-        "notify",
-        std::initializer_list<WasmEdge::ValVariant>{Address, UINT32_C(1)},
-        {WasmEdge::ValType(WasmEdge::TypeCode::I64),
-         WasmEdge::ValType(WasmEdge::TypeCode::I32)});
-    ASSERT_TRUE(Result);
-    ASSERT_EQ(Result->size(), 1U);
-    EXPECT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
-    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(0));
+    expectAtomicValue(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI64, TyI32},
+                      UINT32_C(0));
   }
-
   for (const auto &[Address, Error] :
        {std::pair{UINT64_C(65533),
                   WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
         std::pair{UINT64_C(65536),
                   WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
     SCOPED_TRACE(Address);
-    auto Result = VM.execute(
-        "notify",
-        std::initializer_list<WasmEdge::ValVariant>{Address, UINT32_C(1)},
-        {WasmEdge::ValType(WasmEdge::TypeCode::I64),
-         WasmEdge::ValType(WasmEdge::TypeCode::I32)});
-    ASSERT_FALSE(Result);
-    EXPECT_EQ(Result.error(), Error);
+    expectAtomicTrap(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI64, TyI32},
+                     Error);
   }
 
-  auto OverflowResult =
-      VM.execute("notify-offset",
-                 std::initializer_list<WasmEdge::ValVariant>{
-                     UINT64_C(0xFFFFFFFFFFFFFFFC), UINT32_C(1)},
-                 {WasmEdge::ValType(WasmEdge::TypeCode::I64),
-                  WasmEdge::ValType(WasmEdge::TypeCode::I32)});
-  ASSERT_FALSE(OverflowResult);
-  EXPECT_EQ(OverflowResult.error(),
-            WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  expectAtomicValue(VM, "notify-offset"sv, {UINT64_C(65528), UINT32_C(1)},
+                    {TyI64, TyI32}, UINT32_C(0));
+  for (const uint64_t Address :
+       {UINT64_C(65532), UINT64_C(0xFFFFFFFFFFFFFFFC)}) {
+    SCOPED_TRACE(Address);
+    expectAtomicTrap(VM, "notify-offset"sv, {Address, UINT32_C(1)},
+                     {TyI64, TyI32},
+                     WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
 
-  auto WaitResult = VM.execute("wait32",
-                               std::initializer_list<WasmEdge::ValVariant>{
-                                   UINT64_C(0), UINT32_C(1), UINT64_C(0)},
-                               {WasmEdge::ValType(WasmEdge::TypeCode::I64),
-                                WasmEdge::ValType(WasmEdge::TypeCode::I32),
-                                WasmEdge::ValType(WasmEdge::TypeCode::I64)});
-  ASSERT_TRUE(WaitResult);
-  ASSERT_EQ(WaitResult->size(), 1U);
-  EXPECT_EQ((*WaitResult)[0].second.getCode(), WasmEdge::TypeCode::I32);
-  EXPECT_EQ((*WaitResult)[0].first.get<uint32_t>(), UINT32_C(1));
+  expectAtomicValue(VM, "wait32"sv, {UINT64_C(65532), UINT32_C(1), UINT64_C(0)},
+                    {TyI64, TyI32, TyI64}, WaitNotEqual);
+  expectAtomicValue(VM, "wait32"sv, {UINT64_C(0), UINT32_C(0), UINT64_C(0)},
+                    {TyI64, TyI32, TyI64}, WaitTimedOut);
+  for (const auto &[Address, Error] :
+       {std::pair{UINT64_C(65533),
+                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+        std::pair{UINT64_C(65536),
+                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+    SCOPED_TRACE(Address);
+    expectAtomicTrap(VM, "wait32"sv, {Address, UINT32_C(1), UINT64_C(0)},
+                     {TyI64, TyI32, TyI64}, Error);
+  }
+  expectAtomicValue(VM, "wait32-offset"sv,
+                    {UINT64_C(65528), UINT32_C(1), UINT64_C(0)},
+                    {TyI64, TyI32, TyI64}, WaitNotEqual);
+  for (const uint64_t Address :
+       {UINT64_C(65532), UINT64_C(0xFFFFFFFFFFFFFFFC)}) {
+    SCOPED_TRACE(Address);
+    expectAtomicTrap(VM, "wait32-offset"sv, {Address, UINT32_C(1), UINT64_C(0)},
+                     {TyI64, TyI32, TyI64},
+                     WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+
+  expectAtomicValue(VM, "wait64"sv, {UINT64_C(65528), UINT64_C(1), UINT64_C(0)},
+                    {TyI64, TyI64, TyI64}, WaitNotEqual);
+  for (const auto &[Address, Error] :
+       {std::pair{UINT64_C(65532),
+                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+        std::pair{UINT64_C(65536),
+                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+    SCOPED_TRACE(Address);
+    expectAtomicTrap(VM, "wait64"sv, {Address, UINT64_C(1), UINT64_C(0)},
+                     {TyI64, TyI64, TyI64}, Error);
+  }
+  expectAtomicValue(VM, "wait64-offset"sv,
+                    {UINT64_C(65520), UINT64_C(1), UINT64_C(0)},
+                    {TyI64, TyI64, TyI64}, WaitNotEqual);
+  for (const uint64_t Address :
+       {UINT64_C(65528), UINT64_C(0xFFFFFFFFFFFFFFF8)}) {
+    SCOPED_TRACE(Address);
+    expectAtomicTrap(VM, "wait64-offset"sv, {Address, UINT64_C(1), UINT64_C(0)},
+                     {TyI64, TyI64, TyI64},
+                     WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+
+  auto *MemInst = VM.getActiveModule()->findMemoryExports("memory"sv);
+  ASSERT_NE(MemInst, nullptr);
+  registerWaiters(*MemInst, UINT64_C(8), 2);
+  expectAtomicValue(VM, "notify-wrapped-count"sv, {UINT64_C(8)}, {TyI64},
+                    UINT32_C(1));
 }
 
-TEST(AtomicNotify, BoundaryInterpreter) {
-  runAtomicNotify32Test(WasmEdge::RunMode::Interpreter);
-  runAtomicNotify64Test(WasmEdge::RunMode::Interpreter);
+TEST(AtomicWaitNotify, BoundaryInterpreter) {
+  runAtomicThreads32Test(WasmEdge::RunMode::Interpreter);
+  runAtomicThreads64Test(WasmEdge::RunMode::Interpreter);
 }
 
 #ifdef WASMEDGE_USE_LLVM
 
-TEST(AtomicNotify, BoundaryJIT) {
-  runAtomicNotify32Test(WasmEdge::RunMode::JIT);
-  runAtomicNotify64Test(WasmEdge::RunMode::JIT);
+TEST(AtomicWaitNotify, BoundaryJIT) {
+  runAtomicThreads32Test(WasmEdge::RunMode::JIT);
+  runAtomicThreads64Test(WasmEdge::RunMode::JIT);
 }
 
 #endif

--- a/test/thread/ThreadTest.cpp
+++ b/test/thread/ThreadTest.cpp
@@ -162,263 +162,282 @@ std::array<uint64_t, 4> Answers{
     UINT64_C(4446454406775736720),
     UINT64_C(9019442596657776185),
 };
+// (module
+//   (memory (export "memory") 1 1 shared)
+//   (func (export "notify") (param i32 i32) (result i32)
+//     local.get 0 local.get 1 memory.atomic.notify)
+//   (func (export "wait32") (param i32 i32 i64) (result i32)
+//     local.get 0 local.get 1 local.get 2 memory.atomic.wait32)
+//   (func (export "wait64") (param i32 i64 i64) (result i32)
+//     local.get 0 local.get 1 local.get 2 memory.atomic.wait64))
+std::array<WasmEdge::Byte, 122> AtomicThreads32{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x15, 0x03, 0x60,
+    0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x60, 0x03, 0x7f, 0x7f, 0x7e, 0x01, 0x7f,
+    0x60, 0x03, 0x7f, 0x7e, 0x7e, 0x01, 0x7f, 0x03, 0x04, 0x03, 0x00, 0x01,
+    0x02, 0x05, 0x04, 0x01, 0x03, 0x01, 0x01, 0x07, 0x25, 0x04, 0x06, 0x6d,
+    0x65, 0x6d, 0x6f, 0x72, 0x79, 0x02, 0x00, 0x06, 0x6e, 0x6f, 0x74, 0x69,
+    0x66, 0x79, 0x00, 0x00, 0x06, 0x77, 0x61, 0x69, 0x74, 0x33, 0x32, 0x00,
+    0x01, 0x06, 0x77, 0x61, 0x69, 0x74, 0x36, 0x34, 0x00, 0x02, 0x0a, 0x26,
+    0x03, 0x0a, 0x00, 0x20, 0x00, 0x20, 0x01, 0xfe, 0x00, 0x02, 0x00, 0x0b,
+    0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x01, 0x02, 0x00,
+    0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x02, 0x03,
+    0x00, 0x0b,
+};
+// The same module on a 64-bit shared memory, plus memarg offset variants and
+// a notify whose count is produced by i32.wrap_i64.
+//
+// (module
+//   (memory (export "memory") i64 1 1 shared)
+//   (func (export "notify") (param i64 i32) (result i32)
+//     local.get 0 local.get 1 memory.atomic.notify)
+//   (func (export "notify-offset") (param i64 i32) (result i32)
+//     local.get 0 local.get 1 memory.atomic.notify offset=4)
+//   (func (export "notify-wrapped-count") (param i64) (result i32)
+//     local.get 0 i64.const 0x0000000200000001 i32.wrap_i64
+//     memory.atomic.notify)
+//   (func (export "wait32") (param i64 i32 i64) (result i32)
+//     local.get 0 local.get 1 local.get 2 memory.atomic.wait32)
+//   (func (export "wait32-offset") (param i64 i32 i64) (result i32)
+//     local.get 0 local.get 1 local.get 2 memory.atomic.wait32 offset=4)
+//   (func (export "wait64") (param i64 i64 i64) (result i32)
+//     local.get 0 local.get 1 local.get 2 memory.atomic.wait64)
+//   (func (export "wait64-offset") (param i64 i64 i64) (result i32)
+//     local.get 0 local.get 1 local.get 2 memory.atomic.wait64 offset=8))
+std::array<WasmEdge::Byte, 255> AtomicThreads64{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x1a, 0x04, 0x60,
+    0x02, 0x7e, 0x7f, 0x01, 0x7f, 0x60, 0x01, 0x7e, 0x01, 0x7f, 0x60, 0x03,
+    0x7e, 0x7f, 0x7e, 0x01, 0x7f, 0x60, 0x03, 0x7e, 0x7e, 0x7e, 0x01, 0x7f,
+    0x03, 0x08, 0x07, 0x00, 0x00, 0x01, 0x02, 0x02, 0x03, 0x03, 0x05, 0x04,
+    0x01, 0x07, 0x01, 0x01, 0x07, 0x6c, 0x08, 0x06, 0x6d, 0x65, 0x6d, 0x6f,
+    0x72, 0x79, 0x02, 0x00, 0x06, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79, 0x00,
+    0x00, 0x0d, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79, 0x2d, 0x6f, 0x66, 0x66,
+    0x73, 0x65, 0x74, 0x00, 0x01, 0x14, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79,
+    0x2d, 0x77, 0x72, 0x61, 0x70, 0x70, 0x65, 0x64, 0x2d, 0x63, 0x6f, 0x75,
+    0x6e, 0x74, 0x00, 0x02, 0x06, 0x77, 0x61, 0x69, 0x74, 0x33, 0x32, 0x00,
+    0x03, 0x0d, 0x77, 0x61, 0x69, 0x74, 0x33, 0x32, 0x2d, 0x6f, 0x66, 0x66,
+    0x73, 0x65, 0x74, 0x00, 0x04, 0x06, 0x77, 0x61, 0x69, 0x74, 0x36, 0x34,
+    0x00, 0x05, 0x0d, 0x77, 0x61, 0x69, 0x74, 0x36, 0x34, 0x2d, 0x6f, 0x66,
+    0x66, 0x73, 0x65, 0x74, 0x00, 0x06, 0x0a, 0x5b, 0x07, 0x0a, 0x00, 0x20,
+    0x00, 0x20, 0x01, 0xfe, 0x00, 0x02, 0x00, 0x0b, 0x0a, 0x00, 0x20, 0x00,
+    0x20, 0x01, 0xfe, 0x00, 0x02, 0x04, 0x0b, 0x0f, 0x00, 0x20, 0x00, 0x42,
+    0x81, 0x80, 0x80, 0x80, 0x20, 0xa7, 0xfe, 0x00, 0x02, 0x00, 0x0b, 0x0c,
+    0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x01, 0x02, 0x00, 0x0b,
+    0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x01, 0x02, 0x04,
+    0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x02, 0x03,
+    0x00, 0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x02,
+    0x03, 0x08, 0x0b,
+};
 
 using namespace std::literals;
 
-class AtomicWaitNotify : public ::testing::Test {
-protected:
-  static inline const std::array<WasmEdge::Byte, 122> Memory32Wasm{
-      0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x15, 0x03, 0x60,
-      0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x60, 0x03, 0x7f, 0x7f, 0x7e, 0x01, 0x7f,
-      0x60, 0x03, 0x7f, 0x7e, 0x7e, 0x01, 0x7f, 0x03, 0x04, 0x03, 0x00, 0x01,
-      0x02, 0x05, 0x04, 0x01, 0x03, 0x01, 0x01, 0x07, 0x25, 0x04, 0x06, 0x6d,
-      0x65, 0x6d, 0x6f, 0x72, 0x79, 0x02, 0x00, 0x06, 0x6e, 0x6f, 0x74, 0x69,
-      0x66, 0x79, 0x00, 0x00, 0x06, 0x77, 0x61, 0x69, 0x74, 0x33, 0x32, 0x00,
-      0x01, 0x06, 0x77, 0x61, 0x69, 0x74, 0x36, 0x34, 0x00, 0x02, 0x0a, 0x26,
-      0x03, 0x0a, 0x00, 0x20, 0x00, 0x20, 0x01, 0xfe, 0x00, 0x02, 0x00, 0x0b,
-      0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x01, 0x02, 0x00,
-      0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x02, 0x03,
-      0x00, 0x0b,
-  };
-  static inline const std::array<WasmEdge::Byte, 255> Memory64Wasm{
-      0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x1a, 0x04, 0x60,
-      0x02, 0x7e, 0x7f, 0x01, 0x7f, 0x60, 0x01, 0x7e, 0x01, 0x7f, 0x60, 0x03,
-      0x7e, 0x7f, 0x7e, 0x01, 0x7f, 0x60, 0x03, 0x7e, 0x7e, 0x7e, 0x01, 0x7f,
-      0x03, 0x08, 0x07, 0x00, 0x00, 0x01, 0x02, 0x02, 0x03, 0x03, 0x05, 0x04,
-      0x01, 0x07, 0x01, 0x01, 0x07, 0x6c, 0x08, 0x06, 0x6d, 0x65, 0x6d, 0x6f,
-      0x72, 0x79, 0x02, 0x00, 0x06, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79, 0x00,
-      0x00, 0x0d, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79, 0x2d, 0x6f, 0x66, 0x66,
-      0x73, 0x65, 0x74, 0x00, 0x01, 0x14, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79,
-      0x2d, 0x77, 0x72, 0x61, 0x70, 0x70, 0x65, 0x64, 0x2d, 0x63, 0x6f, 0x75,
-      0x6e, 0x74, 0x00, 0x02, 0x06, 0x77, 0x61, 0x69, 0x74, 0x33, 0x32, 0x00,
-      0x03, 0x0d, 0x77, 0x61, 0x69, 0x74, 0x33, 0x32, 0x2d, 0x6f, 0x66, 0x66,
-      0x73, 0x65, 0x74, 0x00, 0x04, 0x06, 0x77, 0x61, 0x69, 0x74, 0x36, 0x34,
-      0x00, 0x05, 0x0d, 0x77, 0x61, 0x69, 0x74, 0x36, 0x34, 0x2d, 0x6f, 0x66,
-      0x66, 0x73, 0x65, 0x74, 0x00, 0x06, 0x0a, 0x5b, 0x07, 0x0a, 0x00, 0x20,
-      0x00, 0x20, 0x01, 0xfe, 0x00, 0x02, 0x00, 0x0b, 0x0a, 0x00, 0x20, 0x00,
-      0x20, 0x01, 0xfe, 0x00, 0x02, 0x04, 0x0b, 0x0f, 0x00, 0x20, 0x00, 0x42,
-      0x81, 0x80, 0x80, 0x80, 0x20, 0xa7, 0xfe, 0x00, 0x02, 0x00, 0x0b, 0x0c,
-      0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x01, 0x02, 0x00, 0x0b,
-      0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x01, 0x02, 0x04,
-      0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x02, 0x03,
-      0x00, 0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x02,
-      0x03, 0x08, 0x0b,
-  };
+void expectAtomicValue(WasmEdge::VM::VM &VM, std::string_view Func,
+                       std::initializer_list<WasmEdge::ValVariant> Params,
+                       std::initializer_list<WasmEdge::ValType> ParamTypes,
+                       uint32_t Want) {
+  auto Result = VM.execute(Func, Params, ParamTypes);
+  ASSERT_TRUE(Result);
+  ASSERT_EQ(Result->size(), 1U);
+  EXPECT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+  EXPECT_EQ((*Result)[0].first.get<uint32_t>(), Want);
+}
 
-  static constexpr uint32_t WaitNotEqual = UINT32_C(1);
-  static constexpr uint32_t WaitTimedOut = UINT32_C(2);
+void expectAtomicTrap(WasmEdge::VM::VM &VM, std::string_view Func,
+                      std::initializer_list<WasmEdge::ValVariant> Params,
+                      std::initializer_list<WasmEdge::ValType> ParamTypes,
+                      WasmEdge::ErrCode::Value Want) {
+  auto Result = VM.execute(Func, Params, ParamTypes);
+  ASSERT_FALSE(Result);
+  EXPECT_EQ(Result.error(), Want);
+}
 
-  const WasmEdge::ValType TyI32{WasmEdge::TypeCode::I32};
-  const WasmEdge::ValType TyI64{WasmEdge::TypeCode::I64};
-
-  static void
-  expectAtomicValue(WasmEdge::VM::VM &VM, std::string_view Func,
-                    std::initializer_list<WasmEdge::ValVariant> Params,
-                    std::initializer_list<WasmEdge::ValType> ParamTypes,
-                    uint32_t Want) {
-    auto Result = VM.execute(Func, Params, ParamTypes);
-    ASSERT_TRUE(Result);
-    ASSERT_EQ(Result->size(), 1U);
-    EXPECT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
-    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), Want);
+void registerWaiters(WasmEdge::Runtime::Instance::MemoryInstance &MemInst,
+                     uint64_t Address, size_t Count) {
+  std::unique_lock<std::mutex> Locker(MemInst.getWaiterMapMutex());
+  auto &WaiterMap = MemInst.getWaiterMap();
+  for (size_t I = 0; I < Count; ++I) {
+    WaiterMap.emplace(std::piecewise_construct, std::forward_as_tuple(Address),
+                      std::forward_as_tuple());
   }
+}
 
-  static void
-  expectAtomicTrap(WasmEdge::VM::VM &VM, std::string_view Func,
-                   std::initializer_list<WasmEdge::ValVariant> Params,
-                   std::initializer_list<WasmEdge::ValType> ParamTypes,
-                   WasmEdge::ErrCode::Value Want) {
-    auto Result = VM.execute(Func, Params, ParamTypes);
-    ASSERT_FALSE(Result);
-    EXPECT_EQ(Result.error(), Want);
-  }
+void runAtomicThreads32Test(WasmEdge::RunMode Mode) {
+  const WasmEdge::ValType TyI32(WasmEdge::TypeCode::I32);
+  const WasmEdge::ValType TyI64(WasmEdge::TypeCode::I64);
+  constexpr uint32_t WaitNotEqual = UINT32_C(1);
+  constexpr uint32_t WaitTimedOut = UINT32_C(2);
 
-  static void
-  registerWaiters(WasmEdge::Runtime::Instance::MemoryInstance &MemInst,
-                  uint64_t Address, size_t Count) {
-    std::unique_lock<std::mutex> Locker(MemInst.getWaiterMapMutex());
-    auto &WaiterMap = MemInst.getWaiterMap();
-    for (size_t I = 0; I < Count; ++I) {
-      WaiterMap.emplace(std::piecewise_construct,
-                        std::forward_as_tuple(Address),
-                        std::forward_as_tuple());
+  WasmEdge::Configure Conf;
+  Conf.addProposal(WasmEdge::Proposal::Threads);
+  Conf.getRuntimeConfigure().setRunMode(Mode);
+  WasmEdge::VM::VM VM(Conf);
+  ASSERT_TRUE(VM.loadWasm(AtomicThreads32));
+  ASSERT_TRUE(VM.validate());
+  ASSERT_TRUE(VM.instantiate());
+
+  if (Mode == WasmEdge::RunMode::JIT) {
+    for (const auto Name : {"notify"sv, "wait32"sv, "wait64"sv}) {
+      SCOPED_TRACE(Name);
+      const auto *F = VM.getActiveModule()->findFuncExports(Name);
+      ASSERT_NE(F, nullptr);
+      EXPECT_TRUE(F->isCompiledFunction());
     }
   }
 
-  void runMemory32Cases(WasmEdge::RunMode Mode) {
-    WasmEdge::Configure Conf;
-    Conf.addProposal(WasmEdge::Proposal::Threads);
-    Conf.getRuntimeConfigure().setRunMode(Mode);
-    WasmEdge::VM::VM VM(Conf);
-    ASSERT_TRUE(VM.loadWasm(Memory32Wasm));
-    ASSERT_TRUE(VM.validate());
-    ASSERT_TRUE(VM.instantiate());
+  for (const uint32_t Address : {UINT32_C(4), UINT32_C(65532)}) {
+    SCOPED_TRACE(Address);
+    expectAtomicValue(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI32, TyI32},
+                      UINT32_C(0));
+  }
+  for (const auto &[Address, Error] :
+       {std::pair{UINT32_C(65533),
+                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+        std::pair{UINT32_C(65536),
+                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+    SCOPED_TRACE(Address);
+    expectAtomicTrap(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI32, TyI32},
+                     Error);
+  }
 
-    if (Mode == WasmEdge::RunMode::JIT) {
-      for (const auto Name : {"notify"sv, "wait32"sv, "wait64"sv}) {
-        SCOPED_TRACE(Name);
-        const auto *F = VM.getActiveModule()->findFuncExports(Name);
-        ASSERT_NE(F, nullptr);
-        EXPECT_TRUE(F->isCompiledFunction());
-      }
-    }
+  expectAtomicValue(VM, "wait32"sv, {UINT32_C(65532), UINT32_C(1), UINT64_C(0)},
+                    {TyI32, TyI32, TyI64}, WaitNotEqual);
+  expectAtomicValue(VM, "wait32"sv, {UINT32_C(0), UINT32_C(0), UINT64_C(0)},
+                    {TyI32, TyI32, TyI64}, WaitTimedOut);
+  for (const auto &[Address, Error] :
+       {std::pair{UINT32_C(65533),
+                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+        std::pair{UINT32_C(65536),
+                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+    SCOPED_TRACE(Address);
+    expectAtomicTrap(VM, "wait32"sv, {Address, UINT32_C(1), UINT64_C(0)},
+                     {TyI32, TyI32, TyI64}, Error);
+  }
 
-    for (const uint32_t Address : {UINT32_C(4), UINT32_C(65532)}) {
-      SCOPED_TRACE(Address);
-      expectAtomicValue(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI32, TyI32},
-                        UINT32_C(0));
-    }
-    for (const auto &[Address, Error] :
-         {std::pair{UINT32_C(65533),
-                    WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-          std::pair{UINT32_C(65536),
-                    WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-      SCOPED_TRACE(Address);
-      expectAtomicTrap(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI32, TyI32},
-                       Error);
-    }
+  expectAtomicValue(VM, "wait64"sv, {UINT32_C(65528), UINT64_C(1), UINT64_C(0)},
+                    {TyI32, TyI64, TyI64}, WaitNotEqual);
+  for (const auto &[Address, Error] :
+       {std::pair{UINT32_C(65532),
+                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+        std::pair{UINT32_C(65536),
+                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+    SCOPED_TRACE(Address);
+    expectAtomicTrap(VM, "wait64"sv, {Address, UINT64_C(1), UINT64_C(0)},
+                     {TyI32, TyI64, TyI64}, Error);
+  }
+}
 
-    expectAtomicValue(VM, "wait32"sv,
-                      {UINT32_C(65532), UINT32_C(1), UINT64_C(0)},
-                      {TyI32, TyI32, TyI64}, WaitNotEqual);
-    expectAtomicValue(VM, "wait32"sv, {UINT32_C(0), UINT32_C(0), UINT64_C(0)},
-                      {TyI32, TyI32, TyI64}, WaitTimedOut);
-    for (const auto &[Address, Error] :
-         {std::pair{UINT32_C(65533),
-                    WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-          std::pair{UINT32_C(65536),
-                    WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-      SCOPED_TRACE(Address);
-      expectAtomicTrap(VM, "wait32"sv, {Address, UINT32_C(1), UINT64_C(0)},
-                       {TyI32, TyI32, TyI64}, Error);
-    }
+void runAtomicThreads64Test(WasmEdge::RunMode Mode) {
+  const WasmEdge::ValType TyI32(WasmEdge::TypeCode::I32);
+  const WasmEdge::ValType TyI64(WasmEdge::TypeCode::I64);
+  constexpr uint32_t WaitNotEqual = UINT32_C(1);
+  constexpr uint32_t WaitTimedOut = UINT32_C(2);
 
-    expectAtomicValue(VM, "wait64"sv,
-                      {UINT32_C(65528), UINT64_C(1), UINT64_C(0)},
-                      {TyI32, TyI64, TyI64}, WaitNotEqual);
-    for (const auto &[Address, Error] :
-         {std::pair{UINT32_C(65532),
-                    WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-          std::pair{UINT32_C(65536),
-                    WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-      SCOPED_TRACE(Address);
-      expectAtomicTrap(VM, "wait64"sv, {Address, UINT64_C(1), UINT64_C(0)},
-                       {TyI32, TyI64, TyI64}, Error);
+  WasmEdge::Configure Conf;
+  Conf.addProposal(WasmEdge::Proposal::Threads);
+  Conf.addProposal(WasmEdge::Proposal::Memory64);
+  Conf.getRuntimeConfigure().setRunMode(Mode);
+  WasmEdge::VM::VM VM(Conf);
+  ASSERT_TRUE(VM.loadWasm(AtomicThreads64));
+  ASSERT_TRUE(VM.validate());
+  ASSERT_TRUE(VM.instantiate());
+
+  if (Mode == WasmEdge::RunMode::JIT) {
+    for (const auto Name : {"notify"sv, "notify-offset"sv, "wait32"sv,
+                            "wait32-offset"sv, "wait64"sv, "wait64-offset"sv}) {
+      SCOPED_TRACE(Name);
+      const auto *F = VM.getActiveModule()->findFuncExports(Name);
+      ASSERT_NE(F, nullptr);
+      EXPECT_TRUE(F->isCompiledFunction());
     }
   }
 
-  void runMemory64Cases(WasmEdge::RunMode Mode) {
-    WasmEdge::Configure Conf;
-    Conf.addProposal(WasmEdge::Proposal::Threads);
-    Conf.addProposal(WasmEdge::Proposal::Memory64);
-    Conf.getRuntimeConfigure().setRunMode(Mode);
-    WasmEdge::VM::VM VM(Conf);
-    ASSERT_TRUE(VM.loadWasm(Memory64Wasm));
-    ASSERT_TRUE(VM.validate());
-    ASSERT_TRUE(VM.instantiate());
-
-    if (Mode == WasmEdge::RunMode::JIT) {
-      for (const auto Name :
-           {"notify"sv, "notify-offset"sv, "wait32"sv, "wait32-offset"sv,
-            "wait64"sv, "wait64-offset"sv}) {
-        SCOPED_TRACE(Name);
-        const auto *F = VM.getActiveModule()->findFuncExports(Name);
-        ASSERT_NE(F, nullptr);
-        EXPECT_TRUE(F->isCompiledFunction());
-      }
-    }
-
-    for (const uint64_t Address : {UINT64_C(4), UINT64_C(65532)}) {
-      SCOPED_TRACE(Address);
-      expectAtomicValue(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI64, TyI32},
-                        UINT32_C(0));
-    }
-    for (const auto &[Address, Error] :
-         {std::pair{UINT64_C(65533),
-                    WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-          std::pair{UINT64_C(65536),
-                    WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-      SCOPED_TRACE(Address);
-      expectAtomicTrap(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI64, TyI32},
-                       Error);
-    }
-
-    expectAtomicValue(VM, "notify-offset"sv, {UINT64_C(65528), UINT32_C(1)},
-                      {TyI64, TyI32}, UINT32_C(0));
-    for (const uint64_t Address :
-         {UINT64_C(65532), UINT64_C(0xFFFFFFFFFFFFFFFC)}) {
-      SCOPED_TRACE(Address);
-      expectAtomicTrap(VM, "notify-offset"sv, {Address, UINT32_C(1)},
-                       {TyI64, TyI32},
-                       WasmEdge::ErrCode::Value::MemoryOutOfBounds);
-    }
-
-    expectAtomicValue(VM, "wait32"sv,
-                      {UINT64_C(65532), UINT32_C(1), UINT64_C(0)},
-                      {TyI64, TyI32, TyI64}, WaitNotEqual);
-    expectAtomicValue(VM, "wait32"sv, {UINT64_C(0), UINT32_C(0), UINT64_C(0)},
-                      {TyI64, TyI32, TyI64}, WaitTimedOut);
-    for (const auto &[Address, Error] :
-         {std::pair{UINT64_C(65533),
-                    WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-          std::pair{UINT64_C(65536),
-                    WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-      SCOPED_TRACE(Address);
-      expectAtomicTrap(VM, "wait32"sv, {Address, UINT32_C(1), UINT64_C(0)},
-                       {TyI64, TyI32, TyI64}, Error);
-    }
-    expectAtomicValue(VM, "wait32-offset"sv,
-                      {UINT64_C(65528), UINT32_C(1), UINT64_C(0)},
-                      {TyI64, TyI32, TyI64}, WaitNotEqual);
-    for (const uint64_t Address :
-         {UINT64_C(65532), UINT64_C(0xFFFFFFFFFFFFFFFC)}) {
-      SCOPED_TRACE(Address);
-      expectAtomicTrap(
-          VM, "wait32-offset"sv, {Address, UINT32_C(1), UINT64_C(0)},
-          {TyI64, TyI32, TyI64}, WasmEdge::ErrCode::Value::MemoryOutOfBounds);
-    }
-
-    expectAtomicValue(VM, "wait64"sv,
-                      {UINT64_C(65528), UINT64_C(1), UINT64_C(0)},
-                      {TyI64, TyI64, TyI64}, WaitNotEqual);
-    for (const auto &[Address, Error] :
-         {std::pair{UINT64_C(65532),
-                    WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-          std::pair{UINT64_C(65536),
-                    WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-      SCOPED_TRACE(Address);
-      expectAtomicTrap(VM, "wait64"sv, {Address, UINT64_C(1), UINT64_C(0)},
-                       {TyI64, TyI64, TyI64}, Error);
-    }
-    expectAtomicValue(VM, "wait64-offset"sv,
-                      {UINT64_C(65520), UINT64_C(1), UINT64_C(0)},
-                      {TyI64, TyI64, TyI64}, WaitNotEqual);
-    for (const uint64_t Address :
-         {UINT64_C(65528), UINT64_C(0xFFFFFFFFFFFFFFF8)}) {
-      SCOPED_TRACE(Address);
-      expectAtomicTrap(
-          VM, "wait64-offset"sv, {Address, UINT64_C(1), UINT64_C(0)},
-          {TyI64, TyI64, TyI64}, WasmEdge::ErrCode::Value::MemoryOutOfBounds);
-    }
-
-    auto *MemInst = VM.getActiveModule()->findMemoryExports("memory"sv);
-    ASSERT_NE(MemInst, nullptr);
-    registerWaiters(*MemInst, UINT64_C(8), 2);
-    expectAtomicValue(VM, "notify-wrapped-count"sv, {UINT64_C(8)}, {TyI64},
-                      UINT32_C(1));
+  for (const uint64_t Address : {UINT64_C(4), UINT64_C(65532)}) {
+    SCOPED_TRACE(Address);
+    expectAtomicValue(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI64, TyI32},
+                      UINT32_C(0));
   }
-};
+  for (const auto &[Address, Error] :
+       {std::pair{UINT64_C(65533),
+                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+        std::pair{UINT64_C(65536),
+                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+    SCOPED_TRACE(Address);
+    expectAtomicTrap(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI64, TyI32},
+                     Error);
+  }
 
-TEST_F(AtomicWaitNotify, BoundaryInterpreter) {
-  runMemory32Cases(WasmEdge::RunMode::Interpreter);
-  runMemory64Cases(WasmEdge::RunMode::Interpreter);
+  expectAtomicValue(VM, "notify-offset"sv, {UINT64_C(65528), UINT32_C(1)},
+                    {TyI64, TyI32}, UINT32_C(0));
+  for (const uint64_t Address :
+       {UINT64_C(65532), UINT64_C(0xFFFFFFFFFFFFFFFC)}) {
+    SCOPED_TRACE(Address);
+    expectAtomicTrap(VM, "notify-offset"sv, {Address, UINT32_C(1)},
+                     {TyI64, TyI32},
+                     WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+
+  expectAtomicValue(VM, "wait32"sv, {UINT64_C(65532), UINT32_C(1), UINT64_C(0)},
+                    {TyI64, TyI32, TyI64}, WaitNotEqual);
+  expectAtomicValue(VM, "wait32"sv, {UINT64_C(0), UINT32_C(0), UINT64_C(0)},
+                    {TyI64, TyI32, TyI64}, WaitTimedOut);
+  for (const auto &[Address, Error] :
+       {std::pair{UINT64_C(65533),
+                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+        std::pair{UINT64_C(65536),
+                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+    SCOPED_TRACE(Address);
+    expectAtomicTrap(VM, "wait32"sv, {Address, UINT32_C(1), UINT64_C(0)},
+                     {TyI64, TyI32, TyI64}, Error);
+  }
+  expectAtomicValue(VM, "wait32-offset"sv,
+                    {UINT64_C(65528), UINT32_C(1), UINT64_C(0)},
+                    {TyI64, TyI32, TyI64}, WaitNotEqual);
+  for (const uint64_t Address :
+       {UINT64_C(65532), UINT64_C(0xFFFFFFFFFFFFFFFC)}) {
+    SCOPED_TRACE(Address);
+    expectAtomicTrap(VM, "wait32-offset"sv, {Address, UINT32_C(1), UINT64_C(0)},
+                     {TyI64, TyI32, TyI64},
+                     WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+
+  expectAtomicValue(VM, "wait64"sv, {UINT64_C(65528), UINT64_C(1), UINT64_C(0)},
+                    {TyI64, TyI64, TyI64}, WaitNotEqual);
+  for (const auto &[Address, Error] :
+       {std::pair{UINT64_C(65532),
+                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+        std::pair{UINT64_C(65536),
+                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+    SCOPED_TRACE(Address);
+    expectAtomicTrap(VM, "wait64"sv, {Address, UINT64_C(1), UINT64_C(0)},
+                     {TyI64, TyI64, TyI64}, Error);
+  }
+  expectAtomicValue(VM, "wait64-offset"sv,
+                    {UINT64_C(65520), UINT64_C(1), UINT64_C(0)},
+                    {TyI64, TyI64, TyI64}, WaitNotEqual);
+  for (const uint64_t Address :
+       {UINT64_C(65528), UINT64_C(0xFFFFFFFFFFFFFFF8)}) {
+    SCOPED_TRACE(Address);
+    expectAtomicTrap(VM, "wait64-offset"sv, {Address, UINT64_C(1), UINT64_C(0)},
+                     {TyI64, TyI64, TyI64},
+                     WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+
+  auto *MemInst = VM.getActiveModule()->findMemoryExports("memory"sv);
+  ASSERT_NE(MemInst, nullptr);
+  registerWaiters(*MemInst, UINT64_C(8), 2);
+  expectAtomicValue(VM, "notify-wrapped-count"sv, {UINT64_C(8)}, {TyI64},
+                    UINT32_C(1));
+}
+
+TEST(AtomicWaitNotify, BoundaryInterpreter) {
+  runAtomicThreads32Test(WasmEdge::RunMode::Interpreter);
+  runAtomicThreads64Test(WasmEdge::RunMode::Interpreter);
 }
 
 #ifdef WASMEDGE_USE_LLVM
 
-TEST_F(AtomicWaitNotify, BoundaryJIT) {
-  runMemory32Cases(WasmEdge::RunMode::JIT);
-  runMemory64Cases(WasmEdge::RunMode::JIT);
+TEST(AtomicWaitNotify, BoundaryJIT) {
+  runAtomicThreads32Test(WasmEdge::RunMode::JIT);
+  runAtomicThreads64Test(WasmEdge::RunMode::JIT);
 }
 
 #endif

--- a/test/thread/ThreadTest.cpp
+++ b/test/thread/ThreadTest.cpp
@@ -162,8 +162,48 @@ std::array<uint64_t, 4> Answers{
     UINT64_C(4446454406775736720),
     UINT64_C(9019442596657776185),
 };
+std::array<WasmEdge::Byte, 50> AtomicNotify{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x06,
+    0x01, 0x60, 0x01, 0x7f, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00,
+    0x05, 0x04, 0x01, 0x03, 0x01, 0x01, 0x07, 0x08, 0x01, 0x04,
+    0x74, 0x65, 0x73, 0x74, 0x00, 0x00, 0x0a, 0x0c, 0x01, 0x0a,
+    0x00, 0x20, 0x00, 0x41, 0x00, 0xfe, 0x00, 0x02, 0x00, 0x0b,
+};
 
 using namespace std::literals;
+
+void runAtomicNotifyTest(WasmEdge::RunMode Mode) {
+  WasmEdge::Configure Conf;
+  Conf.addProposal(WasmEdge::Proposal::Threads);
+  Conf.getRuntimeConfigure().setRunMode(Mode);
+  WasmEdge::VM::VM VM(Conf);
+  ASSERT_TRUE(VM.loadWasm(AtomicNotify));
+  ASSERT_TRUE(VM.validate());
+  ASSERT_TRUE(VM.instantiate());
+
+  for (const uint32_t Address : {UINT32_C(65528), UINT32_C(65532)}) {
+    SCOPED_TRACE(Address);
+    auto Result = VM.execute(
+        "test", std::initializer_list<WasmEdge::ValVariant>{Address},
+        {WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ(Result->size(), 1U);
+    EXPECT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(0));
+  }
+}
+
+TEST(AtomicNotify, BoundaryInterpreter) {
+  runAtomicNotifyTest(WasmEdge::RunMode::Interpreter);
+}
+
+#ifdef WASMEDGE_USE_LLVM
+
+TEST(AtomicNotify, BoundaryJIT) {
+  runAtomicNotifyTest(WasmEdge::RunMode::JIT);
+}
+
+#endif
 
 TEST(AsyncExecute, ThreadTest) {
   WasmEdge::Configure Conf;

--- a/test/thread/ThreadTest.cpp
+++ b/test/thread/ThreadTest.cpp
@@ -162,44 +162,151 @@ std::array<uint64_t, 4> Answers{
     UINT64_C(4446454406775736720),
     UINT64_C(9019442596657776185),
 };
-std::array<WasmEdge::Byte, 50> AtomicNotify{
-    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x06,
-    0x01, 0x60, 0x01, 0x7f, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00,
-    0x05, 0x04, 0x01, 0x03, 0x01, 0x01, 0x07, 0x08, 0x01, 0x04,
-    0x74, 0x65, 0x73, 0x74, 0x00, 0x00, 0x0a, 0x0c, 0x01, 0x0a,
-    0x00, 0x20, 0x00, 0x41, 0x00, 0xfe, 0x00, 0x02, 0x00, 0x0b,
+std::array<WasmEdge::Byte, 53> AtomicNotify32{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x07, 0x01,
+    0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x05,
+    0x04, 0x01, 0x03, 0x01, 0x01, 0x07, 0x0a, 0x01, 0x06, 0x6e, 0x6f,
+    0x74, 0x69, 0x66, 0x79, 0x00, 0x00, 0x0a, 0x0c, 0x01, 0x0a, 0x00,
+    0x20, 0x00, 0x20, 0x01, 0xfe, 0x00, 0x02, 0x00, 0x0b,
+};
+std::array<WasmEdge::Byte, 111> AtomicNotify64{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0e, 0x02, 0x60,
+    0x02, 0x7e, 0x7f, 0x01, 0x7f, 0x60, 0x03, 0x7e, 0x7f, 0x7e, 0x01, 0x7f,
+    0x03, 0x04, 0x03, 0x00, 0x00, 0x01, 0x05, 0x04, 0x01, 0x07, 0x01, 0x01,
+    0x07, 0x23, 0x03, 0x06, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79, 0x00, 0x00,
+    0x0d, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79, 0x2d, 0x6f, 0x66, 0x66, 0x73,
+    0x65, 0x74, 0x00, 0x01, 0x06, 0x77, 0x61, 0x69, 0x74, 0x33, 0x32, 0x00,
+    0x02, 0x0a, 0x24, 0x03, 0x0a, 0x00, 0x20, 0x00, 0x20, 0x01, 0xfe, 0x00,
+    0x02, 0x00, 0x0b, 0x0a, 0x00, 0x20, 0x00, 0x20, 0x01, 0xfe, 0x00, 0x02,
+    0x04, 0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x01,
+    0x02, 0x00, 0x0b,
 };
 
 using namespace std::literals;
 
-void runAtomicNotifyTest(WasmEdge::RunMode Mode) {
+void runAtomicNotify32Test(WasmEdge::RunMode Mode) {
   WasmEdge::Configure Conf;
   Conf.addProposal(WasmEdge::Proposal::Threads);
   Conf.getRuntimeConfigure().setRunMode(Mode);
   WasmEdge::VM::VM VM(Conf);
-  ASSERT_TRUE(VM.loadWasm(AtomicNotify));
+  ASSERT_TRUE(VM.loadWasm(AtomicNotify32));
   ASSERT_TRUE(VM.validate());
   ASSERT_TRUE(VM.instantiate());
 
-  for (const uint32_t Address : {UINT32_C(65528), UINT32_C(65532)}) {
+  if (Mode == WasmEdge::RunMode::JIT) {
+    const auto *F = VM.getActiveModule()->findFuncExports("notify"sv);
+    ASSERT_NE(F, nullptr);
+    EXPECT_TRUE(F->isCompiledFunction());
+  }
+
+  for (const uint32_t Address : {UINT32_C(4), UINT32_C(65532)}) {
     SCOPED_TRACE(Address);
-    auto Result =
-        VM.execute("test", std::initializer_list<WasmEdge::ValVariant>{Address},
-                   {WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    auto Result = VM.execute(
+        "notify",
+        std::initializer_list<WasmEdge::ValVariant>{Address, UINT32_C(1)},
+        {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+         WasmEdge::ValType(WasmEdge::TypeCode::I32)});
     ASSERT_TRUE(Result);
     ASSERT_EQ(Result->size(), 1U);
     EXPECT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
     EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(0));
   }
+
+  for (const auto &[Address, Error] :
+       {std::pair{UINT32_C(65533),
+                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+        std::pair{UINT32_C(65536),
+                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+    SCOPED_TRACE(Address);
+    auto Result = VM.execute(
+        "notify",
+        std::initializer_list<WasmEdge::ValVariant>{Address, UINT32_C(1)},
+        {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+         WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), Error);
+  }
+}
+
+void runAtomicNotify64Test(WasmEdge::RunMode Mode) {
+  WasmEdge::Configure Conf;
+  Conf.addProposal(WasmEdge::Proposal::Threads);
+  Conf.addProposal(WasmEdge::Proposal::Memory64);
+  Conf.getRuntimeConfigure().setRunMode(Mode);
+  WasmEdge::VM::VM VM(Conf);
+  ASSERT_TRUE(VM.loadWasm(AtomicNotify64));
+  ASSERT_TRUE(VM.validate());
+  ASSERT_TRUE(VM.instantiate());
+
+  if (Mode == WasmEdge::RunMode::JIT) {
+    for (const auto Name : {"notify"sv, "notify-offset"sv, "wait32"sv}) {
+      const auto *F = VM.getActiveModule()->findFuncExports(Name);
+      ASSERT_NE(F, nullptr);
+      EXPECT_TRUE(F->isCompiledFunction());
+    }
+  }
+
+  for (const uint64_t Address : {UINT64_C(4), UINT64_C(65532)}) {
+    SCOPED_TRACE(Address);
+    auto Result = VM.execute(
+        "notify",
+        std::initializer_list<WasmEdge::ValVariant>{Address, UINT32_C(1)},
+        {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+         WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ(Result->size(), 1U);
+    EXPECT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(0));
+  }
+
+  for (const auto &[Address, Error] :
+       {std::pair{UINT64_C(65533),
+                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+        std::pair{UINT64_C(65536),
+                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+    SCOPED_TRACE(Address);
+    auto Result = VM.execute(
+        "notify",
+        std::initializer_list<WasmEdge::ValVariant>{Address, UINT32_C(1)},
+        {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+         WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), Error);
+  }
+
+  auto OverflowResult =
+      VM.execute("notify-offset",
+                 std::initializer_list<WasmEdge::ValVariant>{
+                     UINT64_C(0xFFFFFFFFFFFFFFFC), UINT32_C(1)},
+                 {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                  WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+  ASSERT_FALSE(OverflowResult);
+  EXPECT_EQ(OverflowResult.error(),
+            WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+
+  auto WaitResult = VM.execute("wait32",
+                               std::initializer_list<WasmEdge::ValVariant>{
+                                   UINT64_C(0), UINT32_C(1), UINT64_C(0)},
+                               {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                                WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                                WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+  ASSERT_TRUE(WaitResult);
+  ASSERT_EQ(WaitResult->size(), 1U);
+  EXPECT_EQ((*WaitResult)[0].second.getCode(), WasmEdge::TypeCode::I32);
+  EXPECT_EQ((*WaitResult)[0].first.get<uint32_t>(), UINT32_C(1));
 }
 
 TEST(AtomicNotify, BoundaryInterpreter) {
-  runAtomicNotifyTest(WasmEdge::RunMode::Interpreter);
+  runAtomicNotify32Test(WasmEdge::RunMode::Interpreter);
+  runAtomicNotify64Test(WasmEdge::RunMode::Interpreter);
 }
 
 #ifdef WASMEDGE_USE_LLVM
 
-TEST(AtomicNotify, BoundaryJIT) { runAtomicNotifyTest(WasmEdge::RunMode::JIT); }
+TEST(AtomicNotify, BoundaryJIT) {
+  runAtomicNotify32Test(WasmEdge::RunMode::JIT);
+  runAtomicNotify64Test(WasmEdge::RunMode::JIT);
+}
 
 #endif
 

--- a/test/thread/ThreadTest.cpp
+++ b/test/thread/ThreadTest.cpp
@@ -162,251 +162,263 @@ std::array<uint64_t, 4> Answers{
     UINT64_C(4446454406775736720),
     UINT64_C(9019442596657776185),
 };
-std::array<WasmEdge::Byte, 122> AtomicThreads32{
-    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x15, 0x03, 0x60,
-    0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x60, 0x03, 0x7f, 0x7f, 0x7e, 0x01, 0x7f,
-    0x60, 0x03, 0x7f, 0x7e, 0x7e, 0x01, 0x7f, 0x03, 0x04, 0x03, 0x00, 0x01,
-    0x02, 0x05, 0x04, 0x01, 0x03, 0x01, 0x01, 0x07, 0x25, 0x04, 0x06, 0x6d,
-    0x65, 0x6d, 0x6f, 0x72, 0x79, 0x02, 0x00, 0x06, 0x6e, 0x6f, 0x74, 0x69,
-    0x66, 0x79, 0x00, 0x00, 0x06, 0x77, 0x61, 0x69, 0x74, 0x33, 0x32, 0x00,
-    0x01, 0x06, 0x77, 0x61, 0x69, 0x74, 0x36, 0x34, 0x00, 0x02, 0x0a, 0x26,
-    0x03, 0x0a, 0x00, 0x20, 0x00, 0x20, 0x01, 0xfe, 0x00, 0x02, 0x00, 0x0b,
-    0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x01, 0x02, 0x00,
-    0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x02, 0x03,
-    0x00, 0x0b,
-};
-std::array<WasmEdge::Byte, 255> AtomicThreads64{
-    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x1a, 0x04, 0x60,
-    0x02, 0x7e, 0x7f, 0x01, 0x7f, 0x60, 0x01, 0x7e, 0x01, 0x7f, 0x60, 0x03,
-    0x7e, 0x7f, 0x7e, 0x01, 0x7f, 0x60, 0x03, 0x7e, 0x7e, 0x7e, 0x01, 0x7f,
-    0x03, 0x08, 0x07, 0x00, 0x00, 0x01, 0x02, 0x02, 0x03, 0x03, 0x05, 0x04,
-    0x01, 0x07, 0x01, 0x01, 0x07, 0x6c, 0x08, 0x06, 0x6d, 0x65, 0x6d, 0x6f,
-    0x72, 0x79, 0x02, 0x00, 0x06, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79, 0x00,
-    0x00, 0x0d, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79, 0x2d, 0x6f, 0x66, 0x66,
-    0x73, 0x65, 0x74, 0x00, 0x01, 0x14, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79,
-    0x2d, 0x77, 0x72, 0x61, 0x70, 0x70, 0x65, 0x64, 0x2d, 0x63, 0x6f, 0x75,
-    0x6e, 0x74, 0x00, 0x02, 0x06, 0x77, 0x61, 0x69, 0x74, 0x33, 0x32, 0x00,
-    0x03, 0x0d, 0x77, 0x61, 0x69, 0x74, 0x33, 0x32, 0x2d, 0x6f, 0x66, 0x66,
-    0x73, 0x65, 0x74, 0x00, 0x04, 0x06, 0x77, 0x61, 0x69, 0x74, 0x36, 0x34,
-    0x00, 0x05, 0x0d, 0x77, 0x61, 0x69, 0x74, 0x36, 0x34, 0x2d, 0x6f, 0x66,
-    0x66, 0x73, 0x65, 0x74, 0x00, 0x06, 0x0a, 0x5b, 0x07, 0x0a, 0x00, 0x20,
-    0x00, 0x20, 0x01, 0xfe, 0x00, 0x02, 0x00, 0x0b, 0x0a, 0x00, 0x20, 0x00,
-    0x20, 0x01, 0xfe, 0x00, 0x02, 0x04, 0x0b, 0x0f, 0x00, 0x20, 0x00, 0x42,
-    0x81, 0x80, 0x80, 0x80, 0x20, 0xa7, 0xfe, 0x00, 0x02, 0x00, 0x0b, 0x0c,
-    0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x01, 0x02, 0x00, 0x0b,
-    0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x01, 0x02, 0x04,
-    0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x02, 0x03,
-    0x00, 0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x02,
-    0x03, 0x08, 0x0b,
-};
 
 using namespace std::literals;
 
-constexpr uint32_t WaitOk = UINT32_C(0);
-constexpr uint32_t WaitNotEqual = UINT32_C(1);
-constexpr uint32_t WaitTimedOut = UINT32_C(2);
+class AtomicWaitNotify : public ::testing::Test {
+protected:
+  static inline const std::array<WasmEdge::Byte, 122> Memory32Wasm{
+      0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x15, 0x03, 0x60,
+      0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x60, 0x03, 0x7f, 0x7f, 0x7e, 0x01, 0x7f,
+      0x60, 0x03, 0x7f, 0x7e, 0x7e, 0x01, 0x7f, 0x03, 0x04, 0x03, 0x00, 0x01,
+      0x02, 0x05, 0x04, 0x01, 0x03, 0x01, 0x01, 0x07, 0x25, 0x04, 0x06, 0x6d,
+      0x65, 0x6d, 0x6f, 0x72, 0x79, 0x02, 0x00, 0x06, 0x6e, 0x6f, 0x74, 0x69,
+      0x66, 0x79, 0x00, 0x00, 0x06, 0x77, 0x61, 0x69, 0x74, 0x33, 0x32, 0x00,
+      0x01, 0x06, 0x77, 0x61, 0x69, 0x74, 0x36, 0x34, 0x00, 0x02, 0x0a, 0x26,
+      0x03, 0x0a, 0x00, 0x20, 0x00, 0x20, 0x01, 0xfe, 0x00, 0x02, 0x00, 0x0b,
+      0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x01, 0x02, 0x00,
+      0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x02, 0x03,
+      0x00, 0x0b,
+  };
+  static inline const std::array<WasmEdge::Byte, 255> Memory64Wasm{
+      0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x1a, 0x04, 0x60,
+      0x02, 0x7e, 0x7f, 0x01, 0x7f, 0x60, 0x01, 0x7e, 0x01, 0x7f, 0x60, 0x03,
+      0x7e, 0x7f, 0x7e, 0x01, 0x7f, 0x60, 0x03, 0x7e, 0x7e, 0x7e, 0x01, 0x7f,
+      0x03, 0x08, 0x07, 0x00, 0x00, 0x01, 0x02, 0x02, 0x03, 0x03, 0x05, 0x04,
+      0x01, 0x07, 0x01, 0x01, 0x07, 0x6c, 0x08, 0x06, 0x6d, 0x65, 0x6d, 0x6f,
+      0x72, 0x79, 0x02, 0x00, 0x06, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79, 0x00,
+      0x00, 0x0d, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79, 0x2d, 0x6f, 0x66, 0x66,
+      0x73, 0x65, 0x74, 0x00, 0x01, 0x14, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x79,
+      0x2d, 0x77, 0x72, 0x61, 0x70, 0x70, 0x65, 0x64, 0x2d, 0x63, 0x6f, 0x75,
+      0x6e, 0x74, 0x00, 0x02, 0x06, 0x77, 0x61, 0x69, 0x74, 0x33, 0x32, 0x00,
+      0x03, 0x0d, 0x77, 0x61, 0x69, 0x74, 0x33, 0x32, 0x2d, 0x6f, 0x66, 0x66,
+      0x73, 0x65, 0x74, 0x00, 0x04, 0x06, 0x77, 0x61, 0x69, 0x74, 0x36, 0x34,
+      0x00, 0x05, 0x0d, 0x77, 0x61, 0x69, 0x74, 0x36, 0x34, 0x2d, 0x6f, 0x66,
+      0x66, 0x73, 0x65, 0x74, 0x00, 0x06, 0x0a, 0x5b, 0x07, 0x0a, 0x00, 0x20,
+      0x00, 0x20, 0x01, 0xfe, 0x00, 0x02, 0x00, 0x0b, 0x0a, 0x00, 0x20, 0x00,
+      0x20, 0x01, 0xfe, 0x00, 0x02, 0x04, 0x0b, 0x0f, 0x00, 0x20, 0x00, 0x42,
+      0x81, 0x80, 0x80, 0x80, 0x20, 0xa7, 0xfe, 0x00, 0x02, 0x00, 0x0b, 0x0c,
+      0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x01, 0x02, 0x00, 0x0b,
+      0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x01, 0x02, 0x04,
+      0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x02, 0x03,
+      0x00, 0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x02,
+      0x03, 0x08, 0x0b,
+  };
 
-const WasmEdge::ValType TyI32(WasmEdge::TypeCode::I32);
-const WasmEdge::ValType TyI64(WasmEdge::TypeCode::I64);
+  static constexpr uint32_t WaitNotEqual = UINT32_C(1);
+  static constexpr uint32_t WaitTimedOut = UINT32_C(2);
 
-void expectAtomicValue(WasmEdge::VM::VM &VM, std::string_view Func,
-                       std::initializer_list<WasmEdge::ValVariant> Params,
-                       std::initializer_list<WasmEdge::ValType> ParamTypes,
-                       uint32_t Want) {
-  auto Result = VM.execute(Func, Params, ParamTypes);
-  ASSERT_TRUE(Result);
-  ASSERT_EQ(Result->size(), 1U);
-  EXPECT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
-  EXPECT_EQ((*Result)[0].first.get<uint32_t>(), Want);
-}
+  const WasmEdge::ValType TyI32{WasmEdge::TypeCode::I32};
+  const WasmEdge::ValType TyI64{WasmEdge::TypeCode::I64};
 
-void expectAtomicTrap(WasmEdge::VM::VM &VM, std::string_view Func,
-                      std::initializer_list<WasmEdge::ValVariant> Params,
-                      std::initializer_list<WasmEdge::ValType> ParamTypes,
-                      WasmEdge::ErrCode::Value Want) {
-  auto Result = VM.execute(Func, Params, ParamTypes);
-  ASSERT_FALSE(Result);
-  EXPECT_EQ(Result.error(), Want);
-}
-
-void registerWaiters(WasmEdge::Runtime::Instance::MemoryInstance &MemInst,
-                     uint64_t Address, size_t Count) {
-  std::unique_lock<std::mutex> Locker(MemInst.getWaiterMapMutex());
-  auto &WaiterMap = MemInst.getWaiterMap();
-  for (size_t I = 0; I < Count; ++I) {
-    WaiterMap.emplace(std::piecewise_construct, std::forward_as_tuple(Address),
-                      std::forward_as_tuple());
+  static void
+  expectAtomicValue(WasmEdge::VM::VM &VM, std::string_view Func,
+                    std::initializer_list<WasmEdge::ValVariant> Params,
+                    std::initializer_list<WasmEdge::ValType> ParamTypes,
+                    uint32_t Want) {
+    auto Result = VM.execute(Func, Params, ParamTypes);
+    ASSERT_TRUE(Result);
+    ASSERT_EQ(Result->size(), 1U);
+    EXPECT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), Want);
   }
-}
 
-void runAtomicThreads32Test(WasmEdge::RunMode Mode) {
-  WasmEdge::Configure Conf;
-  Conf.addProposal(WasmEdge::Proposal::Threads);
-  Conf.getRuntimeConfigure().setRunMode(Mode);
-  WasmEdge::VM::VM VM(Conf);
-  ASSERT_TRUE(VM.loadWasm(AtomicThreads32));
-  ASSERT_TRUE(VM.validate());
-  ASSERT_TRUE(VM.instantiate());
+  static void
+  expectAtomicTrap(WasmEdge::VM::VM &VM, std::string_view Func,
+                   std::initializer_list<WasmEdge::ValVariant> Params,
+                   std::initializer_list<WasmEdge::ValType> ParamTypes,
+                   WasmEdge::ErrCode::Value Want) {
+    auto Result = VM.execute(Func, Params, ParamTypes);
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), Want);
+  }
 
-  if (Mode == WasmEdge::RunMode::JIT) {
-    for (const auto Name : {"notify"sv, "wait32"sv, "wait64"sv}) {
-      SCOPED_TRACE(Name);
-      const auto *F = VM.getActiveModule()->findFuncExports(Name);
-      ASSERT_NE(F, nullptr);
-      EXPECT_TRUE(F->isCompiledFunction());
+  static void
+  registerWaiters(WasmEdge::Runtime::Instance::MemoryInstance &MemInst,
+                  uint64_t Address, size_t Count) {
+    std::unique_lock<std::mutex> Locker(MemInst.getWaiterMapMutex());
+    auto &WaiterMap = MemInst.getWaiterMap();
+    for (size_t I = 0; I < Count; ++I) {
+      WaiterMap.emplace(std::piecewise_construct,
+                        std::forward_as_tuple(Address),
+                        std::forward_as_tuple());
     }
   }
 
-  for (const uint32_t Address : {UINT32_C(4), UINT32_C(65532)}) {
-    SCOPED_TRACE(Address);
-    expectAtomicValue(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI32, TyI32},
-                      UINT32_C(0));
-  }
-  for (const auto &[Address, Error] :
-       {std::pair{UINT32_C(65533),
-                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-        std::pair{UINT32_C(65536),
-                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI32, TyI32},
-                     Error);
-  }
+  void runMemory32Cases(WasmEdge::RunMode Mode) {
+    WasmEdge::Configure Conf;
+    Conf.addProposal(WasmEdge::Proposal::Threads);
+    Conf.getRuntimeConfigure().setRunMode(Mode);
+    WasmEdge::VM::VM VM(Conf);
+    ASSERT_TRUE(VM.loadWasm(Memory32Wasm));
+    ASSERT_TRUE(VM.validate());
+    ASSERT_TRUE(VM.instantiate());
 
-  expectAtomicValue(VM, "wait32"sv, {UINT32_C(65532), UINT32_C(1), UINT64_C(0)},
-                    {TyI32, TyI32, TyI64}, WaitNotEqual);
-  expectAtomicValue(VM, "wait32"sv, {UINT32_C(0), UINT32_C(0), UINT64_C(0)},
-                    {TyI32, TyI32, TyI64}, WaitTimedOut);
-  for (const auto &[Address, Error] :
-       {std::pair{UINT32_C(65533),
-                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-        std::pair{UINT32_C(65536),
-                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "wait32"sv, {Address, UINT32_C(1), UINT64_C(0)},
-                     {TyI32, TyI32, TyI64}, Error);
-  }
+    if (Mode == WasmEdge::RunMode::JIT) {
+      for (const auto Name : {"notify"sv, "wait32"sv, "wait64"sv}) {
+        SCOPED_TRACE(Name);
+        const auto *F = VM.getActiveModule()->findFuncExports(Name);
+        ASSERT_NE(F, nullptr);
+        EXPECT_TRUE(F->isCompiledFunction());
+      }
+    }
 
-  expectAtomicValue(VM, "wait64"sv, {UINT32_C(65528), UINT64_C(1), UINT64_C(0)},
-                    {TyI32, TyI64, TyI64}, WaitNotEqual);
-  for (const auto &[Address, Error] :
-       {std::pair{UINT32_C(65532),
-                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-        std::pair{UINT32_C(65536),
-                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "wait64"sv, {Address, UINT64_C(1), UINT64_C(0)},
-                     {TyI32, TyI64, TyI64}, Error);
-  }
-}
+    for (const uint32_t Address : {UINT32_C(4), UINT32_C(65532)}) {
+      SCOPED_TRACE(Address);
+      expectAtomicValue(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI32, TyI32},
+                        UINT32_C(0));
+    }
+    for (const auto &[Address, Error] :
+         {std::pair{UINT32_C(65533),
+                    WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+          std::pair{UINT32_C(65536),
+                    WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+      SCOPED_TRACE(Address);
+      expectAtomicTrap(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI32, TyI32},
+                       Error);
+    }
 
-void runAtomicThreads64Test(WasmEdge::RunMode Mode) {
-  WasmEdge::Configure Conf;
-  Conf.addProposal(WasmEdge::Proposal::Threads);
-  Conf.addProposal(WasmEdge::Proposal::Memory64);
-  Conf.getRuntimeConfigure().setRunMode(Mode);
-  WasmEdge::VM::VM VM(Conf);
-  ASSERT_TRUE(VM.loadWasm(AtomicThreads64));
-  ASSERT_TRUE(VM.validate());
-  ASSERT_TRUE(VM.instantiate());
+    expectAtomicValue(VM, "wait32"sv,
+                      {UINT32_C(65532), UINT32_C(1), UINT64_C(0)},
+                      {TyI32, TyI32, TyI64}, WaitNotEqual);
+    expectAtomicValue(VM, "wait32"sv, {UINT32_C(0), UINT32_C(0), UINT64_C(0)},
+                      {TyI32, TyI32, TyI64}, WaitTimedOut);
+    for (const auto &[Address, Error] :
+         {std::pair{UINT32_C(65533),
+                    WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+          std::pair{UINT32_C(65536),
+                    WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+      SCOPED_TRACE(Address);
+      expectAtomicTrap(VM, "wait32"sv, {Address, UINT32_C(1), UINT64_C(0)},
+                       {TyI32, TyI32, TyI64}, Error);
+    }
 
-  if (Mode == WasmEdge::RunMode::JIT) {
-    for (const auto Name : {"notify"sv, "notify-offset"sv, "wait32"sv,
-                            "wait32-offset"sv, "wait64"sv, "wait64-offset"sv}) {
-      SCOPED_TRACE(Name);
-      const auto *F = VM.getActiveModule()->findFuncExports(Name);
-      ASSERT_NE(F, nullptr);
-      EXPECT_TRUE(F->isCompiledFunction());
+    expectAtomicValue(VM, "wait64"sv,
+                      {UINT32_C(65528), UINT64_C(1), UINT64_C(0)},
+                      {TyI32, TyI64, TyI64}, WaitNotEqual);
+    for (const auto &[Address, Error] :
+         {std::pair{UINT32_C(65532),
+                    WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+          std::pair{UINT32_C(65536),
+                    WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+      SCOPED_TRACE(Address);
+      expectAtomicTrap(VM, "wait64"sv, {Address, UINT64_C(1), UINT64_C(0)},
+                       {TyI32, TyI64, TyI64}, Error);
     }
   }
 
-  for (const uint64_t Address : {UINT64_C(4), UINT64_C(65532)}) {
-    SCOPED_TRACE(Address);
-    expectAtomicValue(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI64, TyI32},
-                      UINT32_C(0));
-  }
-  for (const auto &[Address, Error] :
-       {std::pair{UINT64_C(65533),
-                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-        std::pair{UINT64_C(65536),
-                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI64, TyI32},
-                     Error);
-  }
+  void runMemory64Cases(WasmEdge::RunMode Mode) {
+    WasmEdge::Configure Conf;
+    Conf.addProposal(WasmEdge::Proposal::Threads);
+    Conf.addProposal(WasmEdge::Proposal::Memory64);
+    Conf.getRuntimeConfigure().setRunMode(Mode);
+    WasmEdge::VM::VM VM(Conf);
+    ASSERT_TRUE(VM.loadWasm(Memory64Wasm));
+    ASSERT_TRUE(VM.validate());
+    ASSERT_TRUE(VM.instantiate());
 
-  expectAtomicValue(VM, "notify-offset"sv, {UINT64_C(65528), UINT32_C(1)},
-                    {TyI64, TyI32}, UINT32_C(0));
-  for (const uint64_t Address :
-       {UINT64_C(65532), UINT64_C(0xFFFFFFFFFFFFFFFC)}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "notify-offset"sv, {Address, UINT32_C(1)},
-                     {TyI64, TyI32},
-                     WasmEdge::ErrCode::Value::MemoryOutOfBounds);
-  }
+    if (Mode == WasmEdge::RunMode::JIT) {
+      for (const auto Name :
+           {"notify"sv, "notify-offset"sv, "wait32"sv, "wait32-offset"sv,
+            "wait64"sv, "wait64-offset"sv}) {
+        SCOPED_TRACE(Name);
+        const auto *F = VM.getActiveModule()->findFuncExports(Name);
+        ASSERT_NE(F, nullptr);
+        EXPECT_TRUE(F->isCompiledFunction());
+      }
+    }
 
-  expectAtomicValue(VM, "wait32"sv, {UINT64_C(65532), UINT32_C(1), UINT64_C(0)},
-                    {TyI64, TyI32, TyI64}, WaitNotEqual);
-  expectAtomicValue(VM, "wait32"sv, {UINT64_C(0), UINT32_C(0), UINT64_C(0)},
-                    {TyI64, TyI32, TyI64}, WaitTimedOut);
-  for (const auto &[Address, Error] :
-       {std::pair{UINT64_C(65533),
-                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-        std::pair{UINT64_C(65536),
-                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "wait32"sv, {Address, UINT32_C(1), UINT64_C(0)},
-                     {TyI64, TyI32, TyI64}, Error);
-  }
-  expectAtomicValue(VM, "wait32-offset"sv,
-                    {UINT64_C(65528), UINT32_C(1), UINT64_C(0)},
-                    {TyI64, TyI32, TyI64}, WaitNotEqual);
-  for (const uint64_t Address :
-       {UINT64_C(65532), UINT64_C(0xFFFFFFFFFFFFFFFC)}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "wait32-offset"sv, {Address, UINT32_C(1), UINT64_C(0)},
-                     {TyI64, TyI32, TyI64},
-                     WasmEdge::ErrCode::Value::MemoryOutOfBounds);
-  }
+    for (const uint64_t Address : {UINT64_C(4), UINT64_C(65532)}) {
+      SCOPED_TRACE(Address);
+      expectAtomicValue(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI64, TyI32},
+                        UINT32_C(0));
+    }
+    for (const auto &[Address, Error] :
+         {std::pair{UINT64_C(65533),
+                    WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+          std::pair{UINT64_C(65536),
+                    WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+      SCOPED_TRACE(Address);
+      expectAtomicTrap(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI64, TyI32},
+                       Error);
+    }
 
-  expectAtomicValue(VM, "wait64"sv, {UINT64_C(65528), UINT64_C(1), UINT64_C(0)},
-                    {TyI64, TyI64, TyI64}, WaitNotEqual);
-  for (const auto &[Address, Error] :
-       {std::pair{UINT64_C(65532),
-                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-        std::pair{UINT64_C(65536),
-                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "wait64"sv, {Address, UINT64_C(1), UINT64_C(0)},
-                     {TyI64, TyI64, TyI64}, Error);
-  }
-  expectAtomicValue(VM, "wait64-offset"sv,
-                    {UINT64_C(65520), UINT64_C(1), UINT64_C(0)},
-                    {TyI64, TyI64, TyI64}, WaitNotEqual);
-  for (const uint64_t Address :
-       {UINT64_C(65528), UINT64_C(0xFFFFFFFFFFFFFFF8)}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "wait64-offset"sv, {Address, UINT64_C(1), UINT64_C(0)},
-                     {TyI64, TyI64, TyI64},
-                     WasmEdge::ErrCode::Value::MemoryOutOfBounds);
-  }
+    expectAtomicValue(VM, "notify-offset"sv, {UINT64_C(65528), UINT32_C(1)},
+                      {TyI64, TyI32}, UINT32_C(0));
+    for (const uint64_t Address :
+         {UINT64_C(65532), UINT64_C(0xFFFFFFFFFFFFFFFC)}) {
+      SCOPED_TRACE(Address);
+      expectAtomicTrap(VM, "notify-offset"sv, {Address, UINT32_C(1)},
+                       {TyI64, TyI32},
+                       WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+    }
 
-  auto *MemInst = VM.getActiveModule()->findMemoryExports("memory"sv);
-  ASSERT_NE(MemInst, nullptr);
-  registerWaiters(*MemInst, UINT64_C(8), 2);
-  expectAtomicValue(VM, "notify-wrapped-count"sv, {UINT64_C(8)}, {TyI64},
-                    UINT32_C(1));
-}
+    expectAtomicValue(VM, "wait32"sv,
+                      {UINT64_C(65532), UINT32_C(1), UINT64_C(0)},
+                      {TyI64, TyI32, TyI64}, WaitNotEqual);
+    expectAtomicValue(VM, "wait32"sv, {UINT64_C(0), UINT32_C(0), UINT64_C(0)},
+                      {TyI64, TyI32, TyI64}, WaitTimedOut);
+    for (const auto &[Address, Error] :
+         {std::pair{UINT64_C(65533),
+                    WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+          std::pair{UINT64_C(65536),
+                    WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+      SCOPED_TRACE(Address);
+      expectAtomicTrap(VM, "wait32"sv, {Address, UINT32_C(1), UINT64_C(0)},
+                       {TyI64, TyI32, TyI64}, Error);
+    }
+    expectAtomicValue(VM, "wait32-offset"sv,
+                      {UINT64_C(65528), UINT32_C(1), UINT64_C(0)},
+                      {TyI64, TyI32, TyI64}, WaitNotEqual);
+    for (const uint64_t Address :
+         {UINT64_C(65532), UINT64_C(0xFFFFFFFFFFFFFFFC)}) {
+      SCOPED_TRACE(Address);
+      expectAtomicTrap(
+          VM, "wait32-offset"sv, {Address, UINT32_C(1), UINT64_C(0)},
+          {TyI64, TyI32, TyI64}, WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+    }
 
-TEST(AtomicWaitNotify, BoundaryInterpreter) {
-  runAtomicThreads32Test(WasmEdge::RunMode::Interpreter);
-  runAtomicThreads64Test(WasmEdge::RunMode::Interpreter);
+    expectAtomicValue(VM, "wait64"sv,
+                      {UINT64_C(65528), UINT64_C(1), UINT64_C(0)},
+                      {TyI64, TyI64, TyI64}, WaitNotEqual);
+    for (const auto &[Address, Error] :
+         {std::pair{UINT64_C(65532),
+                    WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
+          std::pair{UINT64_C(65536),
+                    WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
+      SCOPED_TRACE(Address);
+      expectAtomicTrap(VM, "wait64"sv, {Address, UINT64_C(1), UINT64_C(0)},
+                       {TyI64, TyI64, TyI64}, Error);
+    }
+    expectAtomicValue(VM, "wait64-offset"sv,
+                      {UINT64_C(65520), UINT64_C(1), UINT64_C(0)},
+                      {TyI64, TyI64, TyI64}, WaitNotEqual);
+    for (const uint64_t Address :
+         {UINT64_C(65528), UINT64_C(0xFFFFFFFFFFFFFFF8)}) {
+      SCOPED_TRACE(Address);
+      expectAtomicTrap(
+          VM, "wait64-offset"sv, {Address, UINT64_C(1), UINT64_C(0)},
+          {TyI64, TyI64, TyI64}, WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+    }
+
+    auto *MemInst = VM.getActiveModule()->findMemoryExports("memory"sv);
+    ASSERT_NE(MemInst, nullptr);
+    registerWaiters(*MemInst, UINT64_C(8), 2);
+    expectAtomicValue(VM, "notify-wrapped-count"sv, {UINT64_C(8)}, {TyI64},
+                      UINT32_C(1));
+  }
+};
+
+TEST_F(AtomicWaitNotify, BoundaryInterpreter) {
+  runMemory32Cases(WasmEdge::RunMode::Interpreter);
+  runMemory64Cases(WasmEdge::RunMode::Interpreter);
 }
 
 #ifdef WASMEDGE_USE_LLVM
 
-TEST(AtomicWaitNotify, BoundaryJIT) {
-  runAtomicThreads32Test(WasmEdge::RunMode::JIT);
-  runAtomicThreads64Test(WasmEdge::RunMode::JIT);
+TEST_F(AtomicWaitNotify, BoundaryJIT) {
+  runMemory32Cases(WasmEdge::RunMode::JIT);
+  runMemory64Cases(WasmEdge::RunMode::JIT);
 }
 
 #endif

--- a/test/thread/ThreadTest.cpp
+++ b/test/thread/ThreadTest.cpp
@@ -24,6 +24,7 @@
 
 #include <fstream>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -162,14 +163,6 @@ std::array<uint64_t, 4> Answers{
     UINT64_C(4446454406775736720),
     UINT64_C(9019442596657776185),
 };
-// (module
-//   (memory (export "memory") 1 1 shared)
-//   (func (export "notify") (param i32 i32) (result i32)
-//     local.get 0 local.get 1 memory.atomic.notify)
-//   (func (export "wait32") (param i32 i32 i64) (result i32)
-//     local.get 0 local.get 1 local.get 2 memory.atomic.wait32)
-//   (func (export "wait64") (param i32 i64 i64) (result i32)
-//     local.get 0 local.get 1 local.get 2 memory.atomic.wait64))
 std::array<WasmEdge::Byte, 122> AtomicThreads32{
     0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x15, 0x03, 0x60,
     0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x60, 0x03, 0x7f, 0x7f, 0x7e, 0x01, 0x7f,
@@ -183,26 +176,6 @@ std::array<WasmEdge::Byte, 122> AtomicThreads32{
     0x0b, 0x0c, 0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02, 0xfe, 0x02, 0x03,
     0x00, 0x0b,
 };
-// The same module on a 64-bit shared memory, plus memarg offset variants and
-// a notify whose count is produced by i32.wrap_i64.
-//
-// (module
-//   (memory (export "memory") i64 1 1 shared)
-//   (func (export "notify") (param i64 i32) (result i32)
-//     local.get 0 local.get 1 memory.atomic.notify)
-//   (func (export "notify-offset") (param i64 i32) (result i32)
-//     local.get 0 local.get 1 memory.atomic.notify offset=4)
-//   (func (export "notify-wrapped-count") (param i64) (result i32)
-//     local.get 0 i64.const 0x0000000200000001 i32.wrap_i64
-//     memory.atomic.notify)
-//   (func (export "wait32") (param i64 i32 i64) (result i32)
-//     local.get 0 local.get 1 local.get 2 memory.atomic.wait32)
-//   (func (export "wait32-offset") (param i64 i32 i64) (result i32)
-//     local.get 0 local.get 1 local.get 2 memory.atomic.wait32 offset=4)
-//   (func (export "wait64") (param i64 i64 i64) (result i32)
-//     local.get 0 local.get 1 local.get 2 memory.atomic.wait64)
-//   (func (export "wait64-offset") (param i64 i64 i64) (result i32)
-//     local.get 0 local.get 1 local.get 2 memory.atomic.wait64 offset=8))
 std::array<WasmEdge::Byte, 255> AtomicThreads64{
     0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x1a, 0x04, 0x60,
     0x02, 0x7e, 0x7f, 0x01, 0x7f, 0x60, 0x01, 0x7e, 0x01, 0x7f, 0x60, 0x03,
@@ -230,217 +203,359 @@ std::array<WasmEdge::Byte, 255> AtomicThreads64{
 
 using namespace std::literals;
 
-void expectAtomicValue(WasmEdge::VM::VM &VM, std::string_view Func,
-                       std::initializer_list<WasmEdge::ValVariant> Params,
-                       std::initializer_list<WasmEdge::ValType> ParamTypes,
-                       uint32_t Want) {
-  auto Result = VM.execute(Func, Params, ParamTypes);
-  ASSERT_TRUE(Result);
-  ASSERT_EQ(Result->size(), 1U);
-  EXPECT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
-  EXPECT_EQ((*Result)[0].first.get<uint32_t>(), Want);
-}
-
-void expectAtomicTrap(WasmEdge::VM::VM &VM, std::string_view Func,
-                      std::initializer_list<WasmEdge::ValVariant> Params,
-                      std::initializer_list<WasmEdge::ValType> ParamTypes,
-                      WasmEdge::ErrCode::Value Want) {
-  auto Result = VM.execute(Func, Params, ParamTypes);
-  ASSERT_FALSE(Result);
-  EXPECT_EQ(Result.error(), Want);
-}
-
-void registerWaiters(WasmEdge::Runtime::Instance::MemoryInstance &MemInst,
-                     uint64_t Address, size_t Count) {
-  std::unique_lock<std::mutex> Locker(MemInst.getWaiterMapMutex());
-  auto &WaiterMap = MemInst.getWaiterMap();
-  for (size_t I = 0; I < Count; ++I) {
-    WaiterMap.emplace(std::piecewise_construct, std::forward_as_tuple(Address),
-                      std::forward_as_tuple());
-  }
-}
-
-void runAtomicThreads32Test(WasmEdge::RunMode Mode) {
-  const WasmEdge::ValType TyI32(WasmEdge::TypeCode::I32);
-  const WasmEdge::ValType TyI64(WasmEdge::TypeCode::I64);
-  constexpr uint32_t WaitNotEqual = UINT32_C(1);
-  constexpr uint32_t WaitTimedOut = UINT32_C(2);
-
+TEST(AtomicWaitNotify, Memory32) {
   WasmEdge::Configure Conf;
   Conf.addProposal(WasmEdge::Proposal::Threads);
-  Conf.getRuntimeConfigure().setRunMode(Mode);
   WasmEdge::VM::VM VM(Conf);
   ASSERT_TRUE(VM.loadWasm(AtomicThreads32));
   ASSERT_TRUE(VM.validate());
   ASSERT_TRUE(VM.instantiate());
-
-  if (Mode == WasmEdge::RunMode::JIT) {
-    for (const auto Name : {"notify"sv, "wait32"sv, "wait64"sv}) {
-      SCOPED_TRACE(Name);
-      const auto *F = VM.getActiveModule()->findFuncExports(Name);
-      ASSERT_NE(F, nullptr);
-      EXPECT_TRUE(F->isCompiledFunction());
-    }
+  {
+    auto Result = VM.execute(
+        "notify",
+        std::initializer_list<WasmEdge::ValVariant>{UINT32_C(4), UINT32_C(1)},
+        {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+         WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(0));
   }
-
-  for (const uint32_t Address : {UINT32_C(4), UINT32_C(65532)}) {
-    SCOPED_TRACE(Address);
-    expectAtomicValue(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI32, TyI32},
-                      UINT32_C(0));
+  {
+    auto Result = VM.execute("notify",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65532), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(0));
   }
-  for (const auto &[Address, Error] :
-       {std::pair{UINT32_C(65533),
-                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-        std::pair{UINT32_C(65536),
-                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI32, TyI32},
-                     Error);
+  {
+    auto Result = VM.execute("notify",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65533), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
   }
-
-  expectAtomicValue(VM, "wait32"sv, {UINT32_C(65532), UINT32_C(1), UINT64_C(0)},
-                    {TyI32, TyI32, TyI64}, WaitNotEqual);
-  expectAtomicValue(VM, "wait32"sv, {UINT32_C(0), UINT32_C(0), UINT64_C(0)},
-                    {TyI32, TyI32, TyI64}, WaitTimedOut);
-  for (const auto &[Address, Error] :
-       {std::pair{UINT32_C(65533),
-                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-        std::pair{UINT32_C(65536),
-                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "wait32"sv, {Address, UINT32_C(1), UINT64_C(0)},
-                     {TyI32, TyI32, TyI64}, Error);
+  {
+    auto Result = VM.execute("notify",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65536), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
   }
-
-  expectAtomicValue(VM, "wait64"sv, {UINT32_C(65528), UINT64_C(1), UINT64_C(0)},
-                    {TyI32, TyI64, TyI64}, WaitNotEqual);
-  for (const auto &[Address, Error] :
-       {std::pair{UINT32_C(65532),
-                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-        std::pair{UINT32_C(65536),
-                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "wait64"sv, {Address, UINT64_C(1), UINT64_C(0)},
-                     {TyI32, TyI64, TyI64}, Error);
+  {
+    auto Result = VM.execute("wait32",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65532), UINT32_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(1));
+  }
+  {
+    auto Result = VM.execute("wait32",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(0), UINT32_C(0), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(2));
+  }
+  {
+    auto Result = VM.execute("wait32",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65533), UINT32_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
+  }
+  {
+    auto Result = VM.execute("wait32",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65536), UINT32_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  {
+    auto Result = VM.execute("wait64",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65528), UINT64_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(1));
+  }
+  {
+    auto Result = VM.execute("wait64",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65532), UINT64_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
+  }
+  {
+    auto Result = VM.execute("wait64",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65536), UINT64_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
   }
 }
 
-void runAtomicThreads64Test(WasmEdge::RunMode Mode) {
-  const WasmEdge::ValType TyI32(WasmEdge::TypeCode::I32);
-  const WasmEdge::ValType TyI64(WasmEdge::TypeCode::I64);
-  constexpr uint32_t WaitNotEqual = UINT32_C(1);
-  constexpr uint32_t WaitTimedOut = UINT32_C(2);
-
+TEST(AtomicWaitNotify, Memory64) {
   WasmEdge::Configure Conf;
   Conf.addProposal(WasmEdge::Proposal::Threads);
   Conf.addProposal(WasmEdge::Proposal::Memory64);
-  Conf.getRuntimeConfigure().setRunMode(Mode);
   WasmEdge::VM::VM VM(Conf);
   ASSERT_TRUE(VM.loadWasm(AtomicThreads64));
   ASSERT_TRUE(VM.validate());
   ASSERT_TRUE(VM.instantiate());
-
-  if (Mode == WasmEdge::RunMode::JIT) {
-    for (const auto Name : {"notify"sv, "notify-offset"sv, "wait32"sv,
-                            "wait32-offset"sv, "wait64"sv, "wait64-offset"sv}) {
-      SCOPED_TRACE(Name);
-      const auto *F = VM.getActiveModule()->findFuncExports(Name);
-      ASSERT_NE(F, nullptr);
-      EXPECT_TRUE(F->isCompiledFunction());
-    }
+  {
+    auto Result = VM.execute(
+        "notify",
+        std::initializer_list<WasmEdge::ValVariant>{UINT64_C(4), UINT32_C(1)},
+        {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+         WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(0));
   }
-
-  for (const uint64_t Address : {UINT64_C(4), UINT64_C(65532)}) {
-    SCOPED_TRACE(Address);
-    expectAtomicValue(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI64, TyI32},
-                      UINT32_C(0));
+  {
+    auto Result = VM.execute("notify",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65532), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(0));
   }
-  for (const auto &[Address, Error] :
-       {std::pair{UINT64_C(65533),
-                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-        std::pair{UINT64_C(65536),
-                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "notify"sv, {Address, UINT32_C(1)}, {TyI64, TyI32},
-                     Error);
+  {
+    auto Result = VM.execute("notify",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65533), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
   }
-
-  expectAtomicValue(VM, "notify-offset"sv, {UINT64_C(65528), UINT32_C(1)},
-                    {TyI64, TyI32}, UINT32_C(0));
-  for (const uint64_t Address :
-       {UINT64_C(65532), UINT64_C(0xFFFFFFFFFFFFFFFC)}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "notify-offset"sv, {Address, UINT32_C(1)},
-                     {TyI64, TyI32},
-                     WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  {
+    auto Result = VM.execute("notify",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65536), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
   }
-
-  expectAtomicValue(VM, "wait32"sv, {UINT64_C(65532), UINT32_C(1), UINT64_C(0)},
-                    {TyI64, TyI32, TyI64}, WaitNotEqual);
-  expectAtomicValue(VM, "wait32"sv, {UINT64_C(0), UINT32_C(0), UINT64_C(0)},
-                    {TyI64, TyI32, TyI64}, WaitTimedOut);
-  for (const auto &[Address, Error] :
-       {std::pair{UINT64_C(65533),
-                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-        std::pair{UINT64_C(65536),
-                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "wait32"sv, {Address, UINT32_C(1), UINT64_C(0)},
-                     {TyI64, TyI32, TyI64}, Error);
+  {
+    auto Result = VM.execute("notify-offset",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65528), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(0));
   }
-  expectAtomicValue(VM, "wait32-offset"sv,
-                    {UINT64_C(65528), UINT32_C(1), UINT64_C(0)},
-                    {TyI64, TyI32, TyI64}, WaitNotEqual);
-  for (const uint64_t Address :
-       {UINT64_C(65532), UINT64_C(0xFFFFFFFFFFFFFFFC)}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "wait32-offset"sv, {Address, UINT32_C(1), UINT64_C(0)},
-                     {TyI64, TyI32, TyI64},
-                     WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  {
+    auto Result = VM.execute("notify-offset",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65532), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
   }
-
-  expectAtomicValue(VM, "wait64"sv, {UINT64_C(65528), UINT64_C(1), UINT64_C(0)},
-                    {TyI64, TyI64, TyI64}, WaitNotEqual);
-  for (const auto &[Address, Error] :
-       {std::pair{UINT64_C(65532),
-                  WasmEdge::ErrCode::Value::UnalignedAtomicAccess},
-        std::pair{UINT64_C(65536),
-                  WasmEdge::ErrCode::Value::MemoryOutOfBounds}}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "wait64"sv, {Address, UINT64_C(1), UINT64_C(0)},
-                     {TyI64, TyI64, TyI64}, Error);
+  {
+    auto Result = VM.execute("notify-offset",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(0xFFFFFFFFFFFFFFFC), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
   }
-  expectAtomicValue(VM, "wait64-offset"sv,
-                    {UINT64_C(65520), UINT64_C(1), UINT64_C(0)},
-                    {TyI64, TyI64, TyI64}, WaitNotEqual);
-  for (const uint64_t Address :
-       {UINT64_C(65528), UINT64_C(0xFFFFFFFFFFFFFFF8)}) {
-    SCOPED_TRACE(Address);
-    expectAtomicTrap(VM, "wait64-offset"sv, {Address, UINT64_C(1), UINT64_C(0)},
-                     {TyI64, TyI64, TyI64},
-                     WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  {
+    auto Result = VM.execute("wait32",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65532), UINT32_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(1));
   }
-
-  auto *MemInst = VM.getActiveModule()->findMemoryExports("memory"sv);
+  {
+    auto Result = VM.execute("wait32",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(0), UINT32_C(0), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(2));
+  }
+  {
+    auto Result = VM.execute("wait32",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65533), UINT32_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
+  }
+  {
+    auto Result = VM.execute("wait32",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65536), UINT32_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  {
+    auto Result = VM.execute("wait32-offset",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65528), UINT32_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(1));
+  }
+  {
+    auto Result = VM.execute("wait32-offset",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65532), UINT32_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  {
+    auto Result =
+        VM.execute("wait32-offset",
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       UINT64_C(0xFFFFFFFFFFFFFFFC), UINT32_C(1), UINT64_C(0)},
+                   {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                    WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                    WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  {
+    auto Result = VM.execute("wait64",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65528), UINT64_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(1));
+  }
+  {
+    auto Result = VM.execute("wait64",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65532), UINT64_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
+  }
+  {
+    auto Result = VM.execute("wait64",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65536), UINT64_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  {
+    auto Result = VM.execute("wait64-offset",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65520), UINT64_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(1));
+  }
+  {
+    auto Result = VM.execute("wait64-offset",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65528), UINT64_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  {
+    auto Result =
+        VM.execute("wait64-offset",
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       UINT64_C(0xFFFFFFFFFFFFFFF8), UINT64_C(1), UINT64_C(0)},
+                   {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                    WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                    WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  auto *MemInst = VM.getActiveModule()->findMemoryExports("memory");
   ASSERT_NE(MemInst, nullptr);
-  registerWaiters(*MemInst, UINT64_C(8), 2);
-  expectAtomicValue(VM, "notify-wrapped-count"sv, {UINT64_C(8)}, {TyI64},
-                    UINT32_C(1));
+  {
+    std::unique_lock<std::mutex> Locker(MemInst->getWaiterMapMutex());
+    auto &WaiterMap = MemInst->getWaiterMap();
+    WaiterMap.emplace(std::piecewise_construct,
+                      std::forward_as_tuple(UINT64_C(8)),
+                      std::forward_as_tuple());
+    WaiterMap.emplace(std::piecewise_construct,
+                      std::forward_as_tuple(UINT64_C(8)),
+                      std::forward_as_tuple());
+  }
+  {
+    auto Result =
+        VM.execute("notify-wrapped-count",
+                   std::initializer_list<WasmEdge::ValVariant>{UINT64_C(8)},
+                   {WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(1));
+  }
 }
-
-TEST(AtomicWaitNotify, BoundaryInterpreter) {
-  runAtomicThreads32Test(WasmEdge::RunMode::Interpreter);
-  runAtomicThreads64Test(WasmEdge::RunMode::Interpreter);
-}
-
-#ifdef WASMEDGE_USE_LLVM
-
-TEST(AtomicWaitNotify, BoundaryJIT) {
-  runAtomicThreads32Test(WasmEdge::RunMode::JIT);
-  runAtomicThreads64Test(WasmEdge::RunMode::JIT);
-}
-
-#endif
 
 TEST(AsyncExecute, ThreadTest) {
   WasmEdge::Configure Conf;
@@ -506,6 +621,410 @@ TEST(AsyncExecute, GasThreadTest) {
 }
 
 #ifdef WASMEDGE_USE_LLVM
+
+TEST(AtomicWaitNotifyJIT, Memory32) {
+  WasmEdge::Configure Conf;
+  Conf.addProposal(WasmEdge::Proposal::Threads);
+  Conf.getRuntimeConfigure().setRunMode(WasmEdge::RunMode::JIT);
+  WasmEdge::VM::VM VM(Conf);
+  ASSERT_TRUE(VM.loadWasm(AtomicThreads32));
+  ASSERT_TRUE(VM.validate());
+  ASSERT_TRUE(VM.instantiate());
+  {
+    const auto *FuncInst = VM.getActiveModule()->findFuncExports("notify");
+    ASSERT_NE(FuncInst, nullptr);
+    EXPECT_TRUE(FuncInst->isCompiledFunction());
+  }
+  {
+    const auto *FuncInst = VM.getActiveModule()->findFuncExports("wait32");
+    ASSERT_NE(FuncInst, nullptr);
+    EXPECT_TRUE(FuncInst->isCompiledFunction());
+  }
+  {
+    const auto *FuncInst = VM.getActiveModule()->findFuncExports("wait64");
+    ASSERT_NE(FuncInst, nullptr);
+    EXPECT_TRUE(FuncInst->isCompiledFunction());
+  }
+  {
+    auto Result = VM.execute(
+        "notify",
+        std::initializer_list<WasmEdge::ValVariant>{UINT32_C(4), UINT32_C(1)},
+        {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+         WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(0));
+  }
+  {
+    auto Result = VM.execute("notify",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65532), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(0));
+  }
+  {
+    auto Result = VM.execute("notify",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65533), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
+  }
+  {
+    auto Result = VM.execute("notify",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65536), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  {
+    auto Result = VM.execute("wait32",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65532), UINT32_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(1));
+  }
+  {
+    auto Result = VM.execute("wait32",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(0), UINT32_C(0), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(2));
+  }
+  {
+    auto Result = VM.execute("wait32",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65533), UINT32_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
+  }
+  {
+    auto Result = VM.execute("wait32",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65536), UINT32_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  {
+    auto Result = VM.execute("wait64",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65528), UINT64_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(1));
+  }
+  {
+    auto Result = VM.execute("wait64",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65532), UINT64_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
+  }
+  {
+    auto Result = VM.execute("wait64",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT32_C(65536), UINT64_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+}
+
+TEST(AtomicWaitNotifyJIT, Memory64) {
+  WasmEdge::Configure Conf;
+  Conf.addProposal(WasmEdge::Proposal::Threads);
+  Conf.addProposal(WasmEdge::Proposal::Memory64);
+  Conf.getRuntimeConfigure().setRunMode(WasmEdge::RunMode::JIT);
+  WasmEdge::VM::VM VM(Conf);
+  ASSERT_TRUE(VM.loadWasm(AtomicThreads64));
+  ASSERT_TRUE(VM.validate());
+  ASSERT_TRUE(VM.instantiate());
+  {
+    const auto *FuncInst = VM.getActiveModule()->findFuncExports("notify");
+    ASSERT_NE(FuncInst, nullptr);
+    EXPECT_TRUE(FuncInst->isCompiledFunction());
+  }
+  {
+    const auto *FuncInst =
+        VM.getActiveModule()->findFuncExports("notify-offset");
+    ASSERT_NE(FuncInst, nullptr);
+    EXPECT_TRUE(FuncInst->isCompiledFunction());
+  }
+  {
+    const auto *FuncInst = VM.getActiveModule()->findFuncExports("wait32");
+    ASSERT_NE(FuncInst, nullptr);
+    EXPECT_TRUE(FuncInst->isCompiledFunction());
+  }
+  {
+    const auto *FuncInst =
+        VM.getActiveModule()->findFuncExports("wait32-offset");
+    ASSERT_NE(FuncInst, nullptr);
+    EXPECT_TRUE(FuncInst->isCompiledFunction());
+  }
+  {
+    const auto *FuncInst = VM.getActiveModule()->findFuncExports("wait64");
+    ASSERT_NE(FuncInst, nullptr);
+    EXPECT_TRUE(FuncInst->isCompiledFunction());
+  }
+  {
+    const auto *FuncInst =
+        VM.getActiveModule()->findFuncExports("wait64-offset");
+    ASSERT_NE(FuncInst, nullptr);
+    EXPECT_TRUE(FuncInst->isCompiledFunction());
+  }
+  {
+    auto Result = VM.execute(
+        "notify",
+        std::initializer_list<WasmEdge::ValVariant>{UINT64_C(4), UINT32_C(1)},
+        {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+         WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(0));
+  }
+  {
+    auto Result = VM.execute("notify",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65532), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(0));
+  }
+  {
+    auto Result = VM.execute("notify",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65533), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
+  }
+  {
+    auto Result = VM.execute("notify",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65536), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  {
+    auto Result = VM.execute("notify-offset",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65528), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(0));
+  }
+  {
+    auto Result = VM.execute("notify-offset",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65532), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  {
+    auto Result = VM.execute("notify-offset",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(0xFFFFFFFFFFFFFFFC), UINT32_C(1)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  {
+    auto Result = VM.execute("wait32",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65532), UINT32_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(1));
+  }
+  {
+    auto Result = VM.execute("wait32",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(0), UINT32_C(0), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(2));
+  }
+  {
+    auto Result = VM.execute("wait32",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65533), UINT32_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
+  }
+  {
+    auto Result = VM.execute("wait32",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65536), UINT32_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  {
+    auto Result = VM.execute("wait32-offset",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65528), UINT32_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(1));
+  }
+  {
+    auto Result = VM.execute("wait32-offset",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65532), UINT32_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  {
+    auto Result =
+        VM.execute("wait32-offset",
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       UINT64_C(0xFFFFFFFFFFFFFFFC), UINT32_C(1), UINT64_C(0)},
+                   {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                    WasmEdge::ValType(WasmEdge::TypeCode::I32),
+                    WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  {
+    auto Result = VM.execute("wait64",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65528), UINT64_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(1));
+  }
+  {
+    auto Result = VM.execute("wait64",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65532), UINT64_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::UnalignedAtomicAccess);
+  }
+  {
+    auto Result = VM.execute("wait64",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65536), UINT64_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  {
+    auto Result = VM.execute("wait64-offset",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65520), UINT64_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(1));
+  }
+  {
+    auto Result = VM.execute("wait64-offset",
+                             std::initializer_list<WasmEdge::ValVariant>{
+                                 UINT64_C(65528), UINT64_C(1), UINT64_C(0)},
+                             {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                              WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  {
+    auto Result =
+        VM.execute("wait64-offset",
+                   std::initializer_list<WasmEdge::ValVariant>{
+                       UINT64_C(0xFFFFFFFFFFFFFFF8), UINT64_C(1), UINT64_C(0)},
+                   {WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                    WasmEdge::ValType(WasmEdge::TypeCode::I64),
+                    WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_FALSE(Result);
+    EXPECT_EQ(Result.error(), WasmEdge::ErrCode::Value::MemoryOutOfBounds);
+  }
+  auto *MemInst = VM.getActiveModule()->findMemoryExports("memory");
+  ASSERT_NE(MemInst, nullptr);
+  {
+    std::unique_lock<std::mutex> Locker(MemInst->getWaiterMapMutex());
+    auto &WaiterMap = MemInst->getWaiterMap();
+    WaiterMap.emplace(std::piecewise_construct,
+                      std::forward_as_tuple(UINT64_C(8)),
+                      std::forward_as_tuple());
+    WaiterMap.emplace(std::piecewise_construct,
+                      std::forward_as_tuple(UINT64_C(8)),
+                      std::forward_as_tuple());
+  }
+  {
+    auto Result =
+        VM.execute("notify-wrapped-count",
+                   std::initializer_list<WasmEdge::ValVariant>{UINT64_C(8)},
+                   {WasmEdge::ValType(WasmEdge::TypeCode::I64)});
+    ASSERT_TRUE(Result);
+    ASSERT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
+    EXPECT_EQ((*Result)[0].first.get<uint32_t>(), UINT32_C(1));
+  }
+}
 
 TEST(AOTAsyncExecute, ThreadTest) {
   WasmEdge::Configure Conf;

--- a/test/thread/ThreadTest.cpp
+++ b/test/thread/ThreadTest.cpp
@@ -183,9 +183,9 @@ void runAtomicNotifyTest(WasmEdge::RunMode Mode) {
 
   for (const uint32_t Address : {UINT32_C(65528), UINT32_C(65532)}) {
     SCOPED_TRACE(Address);
-    auto Result = VM.execute(
-        "test", std::initializer_list<WasmEdge::ValVariant>{Address},
-        {WasmEdge::ValType(WasmEdge::TypeCode::I32)});
+    auto Result =
+        VM.execute("test", std::initializer_list<WasmEdge::ValVariant>{Address},
+                   {WasmEdge::ValType(WasmEdge::TypeCode::I32)});
     ASSERT_TRUE(Result);
     ASSERT_EQ(Result->size(), 1U);
     EXPECT_EQ((*Result)[0].second.getCode(), WasmEdge::TypeCode::I32);
@@ -199,9 +199,7 @@ TEST(AtomicNotify, BoundaryInterpreter) {
 
 #ifdef WASMEDGE_USE_LLVM
 
-TEST(AtomicNotify, BoundaryJIT) {
-  runAtomicNotifyTest(WasmEdge::RunMode::JIT);
-}
+TEST(AtomicNotify, BoundaryJIT) { runAtomicNotifyTest(WasmEdge::RunMode::JIT); }
 
 #endif
 


### PR DESCRIPTION
Fixes #5303.

`memory.atomic.notify` has a four-byte access width, but `atomicNotify()` previously checked the address using `std::atomic<uint64_t>`, requiring eight available bytes. This caused the final valid four-byte memory location to incorrectly trap with `MemoryOutOfBounds`.

This change:

- validates the address using the specified four-byte access width
- permits notification at the final valid four-byte address
- adds regression coverage for addresses `65528` and `65532`
- covers interpreter and LLVM JIT execution

This contribution was developed with assistance from Cursor (GPT-5.6 Sol).

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

Commands:

```sh
cmake --build build-llvm --target wasmedgeThreadTests -j$(nproc)
./build-llvm/test/thread/wasmedgeThreadTests --gtest_filter='AtomicNotify.*'
ctest --test-dir build-llvm -R '^wasmedgeThreadTests$' --output-on-failure
```

Results:

```text
[==========] Running 2 tests from 1 test suite.
[ RUN      ] AtomicNotify.BoundaryInterpreter
[       OK ] AtomicNotify.BoundaryInterpreter
[ RUN      ] AtomicNotify.BoundaryJIT
[       OK ] AtomicNotify.BoundaryJIT
[  PASSED  ] 2 tests.

1/1 Test #14: wasmedgeThreadTests .............. Passed
100% tests passed, 0 tests failed out of 1
```

Additional validation:

```text
clang-format 22.1.8: passed
commitlint: passed
```