### PR TITLE
fix(api): return NULL from WasmEdge_FunctionInstanceGetData for non-host functions

### DIFF
--- a/include/api/wasmedge/wasmedge_instance.h
+++ b/include/api/wasmedge/wasmedge_instance.h
@@ -685,11 +685,14 @@ WasmEdge_FunctionInstanceCreateBinding(
 
 /// Get the function data field of the function instance.
 ///
-/// The function data is passed during FunctionInstance creation.
+/// The function data is the `Data` argument of the
+/// `WasmEdge_FunctionInstanceCreate()` or
+/// `WasmEdge_FunctionInstanceCreateBinding()` calls.
 ///
 /// \param Cxt the WasmEdge_FunctionInstanceContext.
 ///
-/// \returns pointer to Data, NULL if failed.
+/// \returns pointer to Data, NULL if the function instance is not created by
+/// the C API.
 WASMEDGE_CAPI_EXPORT extern const void *WasmEdge_FunctionInstanceGetData(
     const WasmEdge_FunctionInstanceContext *Cxt) WASMEDGE_CAPI_NOEXCEPT;
 

--- a/lib/api/wasmedge.cpp
+++ b/lib/api/wasmedge.cpp
@@ -2743,9 +2743,11 @@ WasmEdge_FunctionInstanceGetFunctionType(
 
 WASMEDGE_CAPI_EXPORT extern const void *WasmEdge_FunctionInstanceGetData(
     const WasmEdge_FunctionInstanceContext *Cxt) noexcept {
-  if (Cxt) {
-    return reinterpret_cast<CAPIHostFunc *>(&fromFuncCxt(Cxt)->getHostFunc())
-        ->getData();
+  if (Cxt && fromFuncCxt(Cxt)->isHostFunction()) {
+    if (auto *HostFunc =
+            dynamic_cast<CAPIHostFunc *>(&fromFuncCxt(Cxt)->getHostFunc())) {
+      return HostFunc->getData();
+    }
   }
   return nullptr;
 }

--- a/test/api/APIUnitTest.cpp
+++ b/test/api/APIUnitTest.cpp
@@ -2292,6 +2292,60 @@ TEST(APICoreTest, Instance) {
   WasmEdge_FunctionInstanceDelete(FuncCxt);
   EXPECT_TRUE(true);
 
+  // Get the host function data from a function instance.
+  uint32_t HostData = 0U;
+  FuncType = WasmEdge_FunctionTypeCreate(Param, 2, Result, 1);
+  FuncCxt = WasmEdge_FunctionInstanceCreate(FuncType, externAdd, &HostData, 0);
+  EXPECT_NE(FuncCxt, nullptr);
+  EXPECT_EQ(WasmEdge_FunctionInstanceGetData(FuncCxt), &HostData);
+  WasmEdge_FunctionInstanceDelete(FuncCxt);
+  FuncCxt = WasmEdge_FunctionInstanceCreateBinding(
+      FuncType, externWrap, reinterpret_cast<void *>(externAdd), &HostData, 0);
+  EXPECT_NE(FuncCxt, nullptr);
+  EXPECT_EQ(WasmEdge_FunctionInstanceGetData(FuncCxt), &HostData);
+  WasmEdge_FunctionInstanceDelete(FuncCxt);
+  FuncCxt = WasmEdge_FunctionInstanceCreate(FuncType, externAdd, nullptr, 0);
+  EXPECT_NE(FuncCxt, nullptr);
+  EXPECT_EQ(WasmEdge_FunctionInstanceGetData(FuncCxt), nullptr);
+  WasmEdge_FunctionInstanceDelete(FuncCxt);
+  WasmEdge_FunctionTypeDelete(FuncType);
+  EXPECT_EQ(WasmEdge_FunctionInstanceGetData(nullptr), nullptr);
+
+  // Get the host function data from the function instances not created by
+  // the C API.
+  hexToFile(TestWasm, TPath);
+  WasmEdge_ConfigureContext *Conf = WasmEdge_ConfigureCreate();
+  WasmEdge_StoreContext *Store = WasmEdge_StoreCreate();
+  WasmEdge_ModuleInstanceContext *HostMod = createExternModule("extern");
+  EXPECT_NE(HostMod, nullptr);
+  EXPECT_TRUE(registerModule(Conf, Store, HostMod));
+  WasmEdge_ASTModuleContext *Mod = loadModule(Conf, TPath);
+  EXPECT_NE(Mod, nullptr);
+  EXPECT_TRUE(validateModule(Conf, Mod));
+  WasmEdge_ModuleInstanceContext *ModCxt = instantiateModule(Conf, Store, Mod);
+  EXPECT_NE(ModCxt, nullptr);
+  WasmEdge_ASTModuleDelete(Mod);
+  WasmEdge_String WasmFuncName = WasmEdge_StringCreateByCString("func-mul-2");
+  WasmEdge_FunctionInstanceContext *WasmFuncCxt =
+      WasmEdge_ModuleInstanceFindFunction(ModCxt, WasmFuncName);
+  WasmEdge_StringDelete(WasmFuncName);
+  EXPECT_NE(WasmFuncCxt, nullptr);
+  EXPECT_EQ(WasmEdge_FunctionInstanceGetData(WasmFuncCxt), nullptr);
+  WasmEdge_ModuleInstanceContext *WasiMod =
+      WasmEdge_ModuleInstanceCreateWASI(nullptr, 0, nullptr, 0, nullptr, 0);
+  EXPECT_NE(WasiMod, nullptr);
+  WasmEdge_String WasiFuncName = WasmEdge_StringCreateByCString("proc_exit");
+  WasmEdge_FunctionInstanceContext *WasiFuncCxt =
+      WasmEdge_ModuleInstanceFindFunction(WasiMod, WasiFuncName);
+  WasmEdge_StringDelete(WasiFuncName);
+  EXPECT_NE(WasiFuncCxt, nullptr);
+  EXPECT_EQ(WasmEdge_FunctionInstanceGetData(WasiFuncCxt), nullptr);
+  WasmEdge_ModuleInstanceDelete(ModCxt);
+  WasmEdge_ModuleInstanceDelete(HostMod);
+  WasmEdge_ModuleInstanceDelete(WasiMod);
+  WasmEdge_StoreDelete(Store);
+  WasmEdge_ConfigureDelete(Conf);
+
   // Table instance
   WasmEdge_LimitContext *TabLim;
   WasmEdge_TableInstanceContext *TabCxt;


### PR DESCRIPTION
## Description

Fixes #5311

`WasmEdge_FunctionInstanceGetData` dereferenced the `std::get_if` result
without checking the variant. Calling it on a WASM exported function
crashed instead of returning NULL as documented.

- Check `isHostFunction()` and downcast with `dynamic_cast`, so the host
  functions not created by the C API (e.g. WASI) also return NULL.
- Clarify the NULL semantics in the header.
- Cover the data round-trip and the NULL cases in `APICoreTest.Instance`.
  The new cases crash on the unfixed code.

This contribution was developed with assistance from Claude Fable 5 (Anthropic).

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

Repro from the issue (macOS arm64):

Before:

```
Func=0x100b99340
Segmentation fault: 11 (EXC_BAD_ACCESS in WasmEdge_FunctionInstanceGetData + 8)
```

After:

```
Func=0x7b4c05ec0
data=0x0
exit code: 0
```

Local test run:

```
$ ctest -R "wasmedgeAPI" --output-on-failure
1/3 Test #10: wasmedgeAPIUnitTests .............   Passed
2/3 Test #11: wasmedgeAPIVMCoreTests ...........   Passed
3/3 Test #12: wasmedgeAPIStepsCoreTests ........   Passed
100% tests passed out of 3

$ ./wasmedgeAPIUnitTests
[==========] 25 tests from 1 test suite ran. (10 ms total)
[  PASSED  ] 25 tests.
```

The new cases crash with the unfixed `lib/api/wasmedge.cpp`, which confirms
the regression coverage. `clang-format`, `lineguard`, and `commitlint` pass.
