### PR TITLE
fix(wasi): trap on remaining misaligned WASI socket pointers

### DIFF
--- a/lib/host/wasi/wasifunc.cpp
+++ b/lib/host/wasi/wasifunc.cpp
@@ -2201,11 +2201,11 @@ Expect<uint32_t> WasiSockSendV1::body(const Runtime::CallingFrame &Frame,
                                       uint32_t /* Out */ SoDataLenPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_ciovec_t>(SiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(SoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   // Check memory instance from module.
@@ -2275,15 +2275,15 @@ Expect<uint32_t> WasiSockSendToV1::body(const Runtime::CallingFrame &Frame,
                                         uint32_t /* Out */ SoDataLenPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   if (unlikely(isMisaligned<__wasi_ciovec_t>(SiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(SoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   // Check memory instance from module.
@@ -2441,13 +2441,13 @@ Expect<uint32_t> WasiSockGetAddrinfo::body(
   // true)
 
   if (unlikely(isMisaligned<__wasi_addrinfo_t>(HintsPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
   if (unlikely(isMisaligned<uint8_t_ptr>(ResPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
   if (unlikely(isMisaligned<__wasi_size_t>(ResLengthPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   // Check memory instance from module.
@@ -3156,11 +3156,11 @@ Expect<uint32_t> WasiSockSendV2::body(const Runtime::CallingFrame &Frame,
                                       uint32_t /* Out */ SoDataLenPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_ciovec_t>(SiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(SoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   // Check memory instance from module.
@@ -3230,15 +3230,15 @@ Expect<uint32_t> WasiSockSendToV2::body(const Runtime::CallingFrame &Frame,
                                         uint32_t /* Out */ SoDataLenPtr) {
   // Alignment checks
   if (unlikely(isMisaligned<__wasi_ciovec_t>(SiDataPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   if (unlikely(isMisaligned<__wasi_address_t>(AddressPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   if (unlikely(isMisaligned<__wasi_size_t>(SoDataLenPtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   // Check memory instance from module.
@@ -3343,7 +3343,7 @@ Expect<uint32_t> WasiSockGetOpt::body(const Runtime::CallingFrame &Frame,
   // no alignment requirement for FlagPtr as it's a byte array
 
   if (unlikely(isMisaligned<uint32_t>(FlagSizePtr))) {
-    return __WASI_ERRNO_ADDRNOTAVAIL;
+    return Unexpect(ErrCode::Value::UnalignedAtomicAccess);
   }
 
   auto *MemInst = Frame.getMemoryByIndex(0);

--- a/test/host/wasi/wasi.cpp
+++ b/test/host/wasi/wasi.cpp
@@ -5250,26 +5250,26 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_ciovec_t) * 2);
 
       // Test misaligned SiDataPtr
-      EXPECT_TRUE(WasiSockSend.run(CallFrame,
-                                   std::initializer_list<WasmEdge::ValVariant>{
-                                       static_cast<int32_t>(3), // dummy fd
-                                       MisalignedSiDataPtr,
-                                       static_cast<uint32_t>(1), // SiDataLen
-                                       static_cast<uint32_t>(0), // SiFlags
-                                       AlignedSoDataLenPtr},
-                                   Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      ExpectUnalignedTrap(
+          WasiSockSend.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               static_cast<int32_t>(3), // dummy fd
+                               MisalignedSiDataPtr,
+                               static_cast<uint32_t>(1), // SiDataLen
+                               static_cast<uint32_t>(0), // SiFlags
+                               AlignedSoDataLenPtr},
+                           Errno));
 
       // Test misaligned SoDataLenPtr
-      EXPECT_TRUE(WasiSockSend.run(CallFrame,
-                                   std::initializer_list<WasmEdge::ValVariant>{
-                                       static_cast<int32_t>(3), // dummy fd
-                                       AlignedSiDataPtr,
-                                       static_cast<uint32_t>(1), // SiDataLen
-                                       static_cast<uint32_t>(0), // SiFlags
-                                       MisalignedSoDataLenPtr},
-                                   Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      ExpectUnalignedTrap(
+          WasiSockSend.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               static_cast<int32_t>(3), // dummy fd
+                               AlignedSiDataPtr,
+                               static_cast<uint32_t>(1), // SiDataLen
+                               static_cast<uint32_t>(0), // SiFlags
+                               MisalignedSoDataLenPtr},
+                           Errno));
 
       // Test properly aligned parameters (should pass alignment but fail on
       // invalid fd)
@@ -5369,7 +5369,7 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_size_t) * 4);
 
       // Test misaligned AddressPtr
-      EXPECT_TRUE(
+      ExpectUnalignedTrap(
           WasiSockSendTo.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  static_cast<int32_t>(3), // dummy fd
@@ -5380,10 +5380,9 @@ TEST(WasiTest, PointerAlignment) {
                                  static_cast<uint32_t>(0),   // SiFlags
                                  AlignedSoDataLenPtr},
                              Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
 
       // Test misaligned SiDataPtr
-      EXPECT_TRUE(
+      ExpectUnalignedTrap(
           WasiSockSendTo.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  static_cast<int32_t>(3), // dummy fd
@@ -5394,10 +5393,9 @@ TEST(WasiTest, PointerAlignment) {
                                  static_cast<uint32_t>(0),   // SiFlags
                                  AlignedSoDataLenPtr},
                              Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
 
       // Test misaligned SoDataLenPtr
-      EXPECT_TRUE(
+      ExpectUnalignedTrap(
           WasiSockSendTo.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  static_cast<int32_t>(3), // dummy fd
@@ -5408,7 +5406,6 @@ TEST(WasiTest, PointerAlignment) {
                                  static_cast<uint32_t>(0),   // SiFlags
                                  MisalignedSoDataLenPtr},
                              Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
 
       // Test properly aligned parameters (should pass alignment but fail on
       // invalid fd)
@@ -5440,7 +5437,7 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_size_t) * 4);
 
       // Test misaligned HintsPtr alignment
-      EXPECT_TRUE(
+      ExpectUnalignedTrap(
           WasiSockGetAddrinfo.run(CallFrame,
                                   std::initializer_list<WasmEdge::ValVariant>{
                                       static_cast<uint32_t>(0), // NodePtr
@@ -5451,10 +5448,9 @@ TEST(WasiTest, PointerAlignment) {
                                       static_cast<uint32_t>(1), // MaxResLength
                                       AlignedResLengthPtr},
                                   Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
 
-      // Test misaligned HintsPtr
-      EXPECT_TRUE(
+      // Test misaligned ResPtr
+      ExpectUnalignedTrap(
           WasiSockGetAddrinfo.run(CallFrame,
                                   std::initializer_list<WasmEdge::ValVariant>{
                                       static_cast<uint32_t>(0), // NodePtr
@@ -5465,10 +5461,9 @@ TEST(WasiTest, PointerAlignment) {
                                       static_cast<uint32_t>(1), // MaxResLength
                                       AlignedResLengthPtr},
                                   Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
 
       // Test misaligned ResLengthPtr
-      EXPECT_TRUE(
+      ExpectUnalignedTrap(
           WasiSockGetAddrinfo.run(CallFrame,
                                   std::initializer_list<WasmEdge::ValVariant>{
                                       static_cast<uint32_t>(0), // NodePtr
@@ -5479,7 +5474,6 @@ TEST(WasiTest, PointerAlignment) {
                                       static_cast<uint32_t>(1), // MaxResLength
                                       MisalignedResLengthPtr},
                                   Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
 
       // Test properly aligned parameters (should pass alignment but fail on
       // other validations)
@@ -5777,26 +5771,26 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_size_t) * 3);
 
       // Test misaligned SiDataPtr
-      EXPECT_TRUE(WasiSockSend.run(CallFrame,
-                                   std::initializer_list<WasmEdge::ValVariant>{
-                                       static_cast<int32_t>(3), // dummy fd
-                                       MisalignedSiDataPtr,
-                                       static_cast<uint32_t>(1), // SiDataLen
-                                       static_cast<uint32_t>(0), // SiFlags
-                                       AlignedSoDataLenPtr},
-                                   Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      ExpectUnalignedTrap(
+          WasiSockSend.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               static_cast<int32_t>(3), // dummy fd
+                               MisalignedSiDataPtr,
+                               static_cast<uint32_t>(1), // SiDataLen
+                               static_cast<uint32_t>(0), // SiFlags
+                               AlignedSoDataLenPtr},
+                           Errno));
 
       // Test misaligned SoDataLenPtr
-      EXPECT_TRUE(WasiSockSend.run(CallFrame,
-                                   std::initializer_list<WasmEdge::ValVariant>{
-                                       static_cast<int32_t>(3), // dummy fd
-                                       AlignedSiDataPtr,
-                                       static_cast<uint32_t>(1), // SiDataLen
-                                       static_cast<uint32_t>(0), // SiFlags
-                                       MisalignedSoDataLenPtr},
-                                   Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+      ExpectUnalignedTrap(
+          WasiSockSend.run(CallFrame,
+                           std::initializer_list<WasmEdge::ValVariant>{
+                               static_cast<int32_t>(3), // dummy fd
+                               AlignedSiDataPtr,
+                               static_cast<uint32_t>(1), // SiDataLen
+                               static_cast<uint32_t>(0), // SiFlags
+                               MisalignedSoDataLenPtr},
+                           Errno));
 
       // Test properly aligned parameters (should pass alignment but fail on
       // invalid fd)
@@ -5826,7 +5820,7 @@ TEST(WasiTest, PointerAlignment) {
           static_cast<uint32_t>(alignof(__wasi_size_t) * 4);
 
       // Test misaligned SiDataPtr
-      EXPECT_TRUE(
+      ExpectUnalignedTrap(
           WasiSockSendTo.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  static_cast<int32_t>(3), // dummy fd
@@ -5837,10 +5831,9 @@ TEST(WasiTest, PointerAlignment) {
                                  static_cast<uint32_t>(0),   // SiFlags
                                  AlignedSoDataLenPtr},
                              Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
 
       // Test misaligned AddressPtr
-      EXPECT_TRUE(
+      ExpectUnalignedTrap(
           WasiSockSendTo.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  static_cast<int32_t>(3), // dummy fd
@@ -5851,10 +5844,9 @@ TEST(WasiTest, PointerAlignment) {
                                  static_cast<uint32_t>(0),   // SiFlags
                                  AlignedSoDataLenPtr},
                              Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
 
       // Test misaligned SoDataLenPtr
-      EXPECT_TRUE(
+      ExpectUnalignedTrap(
           WasiSockSendTo.run(CallFrame,
                              std::initializer_list<WasmEdge::ValVariant>{
                                  static_cast<int32_t>(3), // dummy fd
@@ -5865,7 +5857,6 @@ TEST(WasiTest, PointerAlignment) {
                                  static_cast<uint32_t>(0),   // SiFlags
                                  MisalignedSoDataLenPtr},
                              Errno));
-      EXPECT_EQ(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
 
       // Test properly aligned parameters (should pass alignment but fail on
       // invalid fd)
@@ -5880,6 +5871,33 @@ TEST(WasiTest, PointerAlignment) {
                                  static_cast<uint32_t>(0),   // SiFlags
                                  AlignedSoDataLenPtr},
                              Errno));
+      EXPECT_NE(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
+    }
+
+    {
+      WasmEdge::Host::WasiSockGetOpt WasiSockGetOpt(Env);
+      const uint32_t MisalignedFlagSizePtr = alignof(uint32_t) - 1;
+      const uint32_t AlignedFlagSizePtr =
+          static_cast<uint32_t>(alignof(uint32_t) * 4);
+      const uint32_t FlagPtr = 64;
+
+      ExpectUnalignedTrap(WasiSockGetOpt.run(
+          CallFrame,
+          std::initializer_list<WasmEdge::ValVariant>{
+              static_cast<int32_t>(3),
+              static_cast<uint32_t>(__WASI_SOCK_OPT_LEVEL_SOL_SOCKET),
+              static_cast<uint32_t>(__WASI_SOCK_OPT_SO_TYPE), FlagPtr,
+              MisalignedFlagSizePtr},
+          Errno));
+
+      EXPECT_TRUE(WasiSockGetOpt.run(
+          CallFrame,
+          std::initializer_list<WasmEdge::ValVariant>{
+              static_cast<int32_t>(3),
+              static_cast<uint32_t>(__WASI_SOCK_OPT_LEVEL_SOL_SOCKET),
+              static_cast<uint32_t>(__WASI_SOCK_OPT_SO_TYPE), FlagPtr,
+              AlignedFlagSizePtr},
+          Errno));
       EXPECT_NE(Errno[0].get<int32_t>(), __WASI_ERRNO_ADDRNOTAVAIL);
     }
 


### PR DESCRIPTION
## Description

This PR is a follow-up to #5301 and completes the remaining WASI typed guest pointer alignment updates.

closes: #4960 

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

Unit tests:

```console
cmake --build build-lfx-repro --target wasiTests wasmedge wasmedgec \
  -j$(sysctl -n hw.logicalcpu)
./build-lfx-repro/test/host/wasi/wasiTests \
  --gtest_filter=WasiTest.PointerAlignment
./build-lfx-repro/test/host/wasi/wasiTests
```

Results:
<img width="887" height="386" alt="image" src="https://github.com/user-attachments/assets/03a00ad5-bf7c-4f34-8d33-7a8b2d7c38a1" />

Local checks:

```console
lineguard --config .lineguardrc -r \
  lib/host/wasi/wasifunc.cpp \
  test/host/wasi/wasi.cpp
```

Both checks passed. The affected ranges also passed `clang-format --dry-run -Werror`.

CLI smoke tests covered 6 representative misaligned pointer cases across Interpreter, JIT, and AOT:

| Scope | Cases | Interpreter | JIT | AOT compile | AOT run |
|---|---:|---:|---:|---:|---:|
| Socket send paths | 4 | 134 | 134 | 0 | 134 |
| Address resolution and socket options | 2 | 134 | 134 | 0 | 134 |

All cases trapped before guest `proc_exit`. AOT compilation succeeded, and the trap occurred when each AOT module was executed.

Final source audit:

```console
alignment checks: 75
trap returns: 75
alignment checks returning __WASI_ERRNO_ADDRNOTAVAIL: 0
```

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
