### PR TITLE
fix(loader): check the size bound before allocating the read buffer

### DIFF
--- a/lib/loader/filemgr.cpp
+++ b/lib/loader/filemgr.cpp
@@ -82,8 +82,13 @@ Expect<Byte> FileMgr::readByte() {
 
 // Read bytes. See "include/loader/filemgr.h".
 Expect<std::vector<Byte>> FileMgr::readBytes(size_t SizeToRead) {
+  if (unlikely(Status != ErrCode::Value::Success)) {
+    return Unexpect(Status);
+  }
   // Set the flag to the start offset.
   LastPos = Pos;
+  // Check whether reading exceeds the data boundary before allocating.
+  EXPECTED_TRY(testRead(SizeToRead));
   // Read bytes into vector.
   std::vector<Byte> Buf(SizeToRead);
   EXPECTED_TRY(readBytes(Buf));

--- a/test/component/ComponentLoaderTest.cpp
+++ b/test/component/ComponentLoaderTest.cpp
@@ -586,6 +586,26 @@ TEST(ComponentLoaderTest, ValueSection) {
   EXPECT_EQ(Sec.getContent()[0].getData()[0], 0x01);
 }
 
+TEST(ComponentLoaderTest, ValueSectionLengthExceedsInput) {
+  WasmEdge::Configure Conf;
+  Conf.addProposal(WasmEdge::Proposal::Component);
+  WasmEdge::Loader::Loader Loader(Conf);
+
+  // Value section declaring a value whose length exceeds the input:
+  //   0x0c = value section id (12), 0x00 = content size,
+  //   0x01 = vec count (1 value), 0x20 = valtype (type index 32),
+  //   0xffffffff0e = len (0xefffffff bytes).
+  std::vector<uint8_t> Vec = {
+      0x00, 0x61, 0x73, 0x6d, 0x0d, 0x00, 0x01, 0x00, // preamble
+      0x0c, 0x00, 0x01, 0x20,                         // value section
+      0xff, 0xff, 0xff, 0xff, 0x0e,                   // value length
+  };
+
+  auto Res = Loader.parseWasmUnit(Vec);
+  ASSERT_FALSE(Res);
+  EXPECT_EQ(Res.error().getEnum(), WasmEdge::ErrCode::Value::UnexpectedEnd);
+}
+
 TEST(ComponentLoaderTest, MalformedResultList) {
   WasmEdge::Configure Conf;
   Conf.addProposal(WasmEdge::Proposal::Component);

--- a/test/loader/filemgrTest.cpp
+++ b/test/loader/filemgrTest.cpp
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <cstdint>
 #include <gtest/gtest.h>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -928,6 +929,16 @@ TEST(FileManagerTest, Vector__PeekByte) {
   Mgr.readByte();
   ASSERT_FALSE(PeekByte = Mgr.peekByte());
   EXPECT_EQ(10U, Mgr.getOffset());
+}
+
+TEST(FileManagerTest, Vector__ReadBytesOutOfBounds) {
+  // 19. Test unsigned char list reading in the out-of-bounds case.
+  WasmEdge::Expect<std::vector<uint8_t>> ReadBytes;
+  ASSERT_TRUE(Mgr.setCode(std::vector<uint8_t>{0x00, 0xFF, 0x1F, 0x2E}));
+  EXPECT_EQ(0U, Mgr.getOffset());
+  ASSERT_FALSE(ReadBytes = Mgr.readBytes(std::numeric_limits<size_t>::max()));
+  EXPECT_EQ(WasmEdge::ErrCode::Value::UnexpectedEnd, ReadBytes.error());
+  EXPECT_EQ(4U, Mgr.getOffset());
 }
 
 } // namespace


### PR DESCRIPTION
## Description

FileMgr::readBytes(size_t) constructed the std::vector<Byte> before any boundary check, so a length larger than the input was allocated and zero-filled first, and only rejected afterwards by testRead().

The component value section passes its len field straight through, which let a 17-byte input request 0xEFFFFFFF bytes and peak at 3.77 GiB before the load failed. Reported by ClusterFuzz against the wasmedge-fuzzcomponent target.

Run testRead() before the allocation so an out-of-bounds length is rejected without allocating, for that call site and every other one.

Assisted-by: Claude (Anthropic)

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
