### PR TITLE
refactor(loader): switch the component loaders on their enumerators

### DIFF
--- a/include/loader/loader.h
+++ b/include/loader/loader.h
@@ -433,7 +433,7 @@ private:
   Expect<void> loadSection(AST::Component::ExportSection &Sec);
   Expect<void> loadSection(AST::Component::ValueSection &Sec);
   // core:instance and instance
-  Expect<void> loadCoreInstance(AST::Component::CoreInstance &Instance);
+  Expect<void> loadInstance(AST::Component::CoreInstance &Instance);
   Expect<void> loadInstance(AST::Component::Instance &Instance);
   // core:sort and sort
   Expect<void> loadCoreSort(AST::Component::Sort &Sort);
@@ -441,7 +441,7 @@ private:
   Expect<void> loadSortIndex(AST::Component::SortIndex &SortIdx,
                              const bool IsCore = false);
   // core:alias and alias
-  Expect<void> loadCoreAlias(AST::Component::CoreAlias &Alias);
+  Expect<void> loadAlias(AST::Component::CoreAlias &Alias);
   Expect<void> loadAlias(AST::Component::Alias &Alias);
   // core:deftype and deftype
   Expect<void> loadType(AST::Component::CoreDefType &Ty);

--- a/lib/loader/ast/component/component_alias.cpp
+++ b/lib/loader/ast/component/component_alias.cpp
@@ -6,7 +6,7 @@
 namespace WasmEdge {
 namespace Loader {
 
-Expect<void> Loader::loadCoreAlias(AST::Component::CoreAlias &Alias) {
+Expect<void> Loader::loadAlias(AST::Component::CoreAlias &Alias) {
   auto ReportError = [this](auto E) {
     return logLoadError(E, FMgr.getLastOffset(), ASTNodeAttr::Comp_Alias);
   };
@@ -41,15 +41,16 @@ Expect<void> Loader::loadAlias(AST::Component::Alias &Alias) {
 
   EXPECTED_TRY(loadSort(Alias.getSort()).map_error(ReportError));
   EXPECTED_TRY(uint8_t Flag, FMgr.readByte().map_error(ReportError));
-  switch (Flag) {
-  case 0x00:
-  case 0x01: {
+  const auto Target = static_cast<AST::Component::Alias::TargetType>(Flag);
+  switch (Target) {
+  case AST::Component::Alias::TargetType::Export:
+  case AST::Component::Alias::TargetType::CoreExport: {
     EXPECTED_TRY(uint32_t Idx, FMgr.readU32().map_error(ReportError));
     EXPECTED_TRY(std::string Name, FMgr.readName().map_error(ReportError));
     Alias.setExport(Idx, Name);
     break;
   }
-  case 0x02: {
+  case AST::Component::Alias::TargetType::Outer: {
     if (!Alias.getSort().isOuterAliasSort()) {
       return logLoadError(ErrCode::Value::MalformedSort, FMgr.getLastOffset(),
                           ASTNodeAttr::Comp_Alias);
@@ -63,7 +64,7 @@ Expect<void> Loader::loadAlias(AST::Component::Alias &Alias) {
     return logLoadError(ErrCode::Value::MalformedAliasTarget,
                         FMgr.getLastOffset(), ASTNodeAttr::Comp_Alias);
   }
-  Alias.setTargetType(static_cast<AST::Component::Alias::TargetType>(Flag));
+  Alias.setTargetType(Target);
   return {};
 }
 

--- a/lib/loader/ast/component/component_canonical.cpp
+++ b/lib/loader/ast/component/component_canonical.cpp
@@ -326,16 +326,17 @@ Expect<void> Loader::loadCanonicalOption(AST::Component::CanonOpt &Opt) {
   //            | 0x07 f:<core:funcidx> => (callback f) 🔀
 
   EXPECTED_TRY(uint8_t Flag, FMgr.readByte().map_error(ReportError));
-  switch (Flag) {
-  case 0x00:
-  case 0x01:
-  case 0x02:
-  case 0x06:
+  const auto Code = static_cast<ComponentCanonOptCode>(Flag);
+  switch (Code) {
+  case ComponentCanonOptCode::Encode_UTF8:
+  case ComponentCanonOptCode::Encode_UTF16:
+  case ComponentCanonOptCode::Encode_Latin1:
+  case ComponentCanonOptCode::Async:
     break;
-  case 0x03:
-  case 0x04:
-  case 0x05:
-  case 0x07: {
+  case ComponentCanonOptCode::Memory:
+  case ComponentCanonOptCode::Realloc:
+  case ComponentCanonOptCode::PostReturn:
+  case ComponentCanonOptCode::Callback: {
     EXPECTED_TRY(uint32_t Idx, FMgr.readU32().map_error(ReportError));
     Opt.setIndex(Idx);
     break;
@@ -343,7 +344,7 @@ Expect<void> Loader::loadCanonicalOption(AST::Component::CanonOpt &Opt) {
   default:
     return ReportError(ErrCode::Value::UnknownCanonicalOption);
   }
-  Opt.setCode(static_cast<ComponentCanonOptCode>(Flag));
+  Opt.setCode(Code);
   return {};
 }
 

--- a/lib/loader/ast/component/component_declarator.cpp
+++ b/lib/loader/ast/component/component_declarator.cpp
@@ -66,7 +66,7 @@ Expect<void> Loader::loadDecl(AST::Component::CoreModuleDecl &Decl) {
   }
   case 0x02: {
     AST::Component::CoreAlias Alias;
-    EXPECTED_TRY(loadCoreAlias(Alias).map_error(ReportError));
+    EXPECTED_TRY(loadAlias(Alias).map_error(ReportError));
     Decl.setAlias(std::move(Alias));
     return {};
   }

--- a/lib/loader/ast/component/component_descriptor.cpp
+++ b/lib/loader/ast/component/component_descriptor.cpp
@@ -71,8 +71,8 @@ Expect<void> Loader::loadDesc(AST::Component::ExternDesc &Desc) {
   //              | 0x01                       => (sub resource)
 
   EXPECTED_TRY(uint8_t Flag, FMgr.readByte().map_error(ReportError));
-  switch (Flag) {
-  case 0x00: {
+  switch (static_cast<AST::Component::ExternDesc::DescType>(Flag)) {
+  case AST::Component::ExternDesc::DescType::CoreType: {
     EXPECTED_TRY(uint8_t B, FMgr.readByte().map_error(ReportError));
     if (B != 0x11U) {
       return ReportError(ErrCode::Value::IntegerTooLong);
@@ -81,12 +81,12 @@ Expect<void> Loader::loadDesc(AST::Component::ExternDesc &Desc) {
     Desc.setCoreTypeIdx(Idx);
     return {};
   }
-  case 0x01: {
+  case AST::Component::ExternDesc::DescType::FuncType: {
     EXPECTED_TRY(uint32_t Idx, FMgr.readU32().map_error(ReportError));
     Desc.setFuncTypeIdx(Idx);
     return {};
   }
-  case 0x02: {
+  case AST::Component::ExternDesc::DescType::ValueBound: {
     EXPECTED_TRY(uint8_t B, FMgr.readByte().map_error(ReportError));
     if (B == 0x00) {
       EXPECTED_TRY(uint32_t Idx, FMgr.readU32().map_error(ReportError));
@@ -100,7 +100,7 @@ Expect<void> Loader::loadDesc(AST::Component::ExternDesc &Desc) {
     }
     return {};
   }
-  case 0x03: {
+  case AST::Component::ExternDesc::DescType::TypeBound: {
     EXPECTED_TRY(uint8_t B, FMgr.readByte().map_error(ReportError));
     if (B == 0x00) {
       EXPECTED_TRY(uint32_t Idx, FMgr.readU32().map_error(ReportError));
@@ -112,12 +112,12 @@ Expect<void> Loader::loadDesc(AST::Component::ExternDesc &Desc) {
     }
     return {};
   }
-  case 0x04: {
+  case AST::Component::ExternDesc::DescType::ComponentType: {
     EXPECTED_TRY(uint32_t Idx, FMgr.readU32().map_error(ReportError));
     Desc.setComponentTypeIdx(Idx);
     return {};
   }
-  case 0x05: {
+  case AST::Component::ExternDesc::DescType::InstanceType: {
     EXPECTED_TRY(uint32_t Idx, FMgr.readU32().map_error(ReportError));
     Desc.setInstanceTypeIdx(Idx);
     return {};

--- a/lib/loader/ast/component/component_instance.cpp
+++ b/lib/loader/ast/component/component_instance.cpp
@@ -6,7 +6,7 @@
 namespace WasmEdge {
 namespace Loader {
 
-Expect<void> Loader::loadCoreInstance(AST::Component::CoreInstance &Instance) {
+Expect<void> Loader::loadInstance(AST::Component::CoreInstance &Instance) {
   auto ReportError = [this](auto E) {
     return logLoadError(E, FMgr.getLastOffset(),
                         ASTNodeAttr::Comp_CoreInstance);

--- a/lib/loader/ast/component/component_section.cpp
+++ b/lib/loader/ast/component/component_section.cpp
@@ -43,7 +43,7 @@ Expect<void> Loader::loadSection(AST::Component::CoreInstanceSection &Sec) {
   return loadSectionContent(Sec, [this, &Sec]() {
     return loadSectionContentVec(
         Sec, [this](AST::Component::CoreInstance &Instance) {
-          return loadCoreInstance(Instance);
+          return loadInstance(Instance);
         });
   });
 }

--- a/lib/loader/ast/component/component_sort.cpp
+++ b/lib/loader/ast/component/component_sort.cpp
@@ -32,16 +32,18 @@ Expect<void> Loader::loadSort(AST::Component::Sort &Sort) {
   EXPECTED_TRY(auto Flag, FMgr.readByte().map_error([this](auto E) {
     return logLoadError(E, FMgr.getLastOffset(), ASTNodeAttr::Comp_Sort);
   }));
-  switch (Flag) {
-  case 0x00:
+  if (Flag == 0x00) {
     return loadCoreSort(Sort);
-  case 0x01:
-  case 0x02:
-  case 0x03:
-  case 0x04:
-  case 0x05:
+  }
+  const auto Type = static_cast<AST::Component::Sort::SortType>(Flag);
+  switch (Type) {
+  case AST::Component::Sort::SortType::Func:
+  case AST::Component::Sort::SortType::Value:
+  case AST::Component::Sort::SortType::Type:
+  case AST::Component::Sort::SortType::Component:
+  case AST::Component::Sort::SortType::Instance:
     Sort.setIsCore(false);
-    Sort.setSortType(static_cast<AST::Component::Sort::SortType>(Flag));
+    Sort.setSortType(Type);
     return {};
   default:
     return logLoadError(ErrCode::Value::MalformedSort, FMgr.getLastOffset(),
@@ -61,17 +63,18 @@ Expect<void> Loader::loadCoreSort(AST::Component::Sort &Sort) {
   EXPECTED_TRY(auto Flag, FMgr.readByte().map_error([this](auto E) {
     return logLoadError(E, FMgr.getLastOffset(), ASTNodeAttr::Comp_Sort);
   }));
-  switch (Flag) {
-  case 0x00:
-  case 0x01:
-  case 0x02:
-  case 0x03:
-  case 0x04:
-  case 0x10:
-  case 0x11:
-  case 0x12:
+  const auto Type = static_cast<AST::Component::Sort::CoreSortType>(Flag);
+  switch (Type) {
+  case AST::Component::Sort::CoreSortType::Func:
+  case AST::Component::Sort::CoreSortType::Table:
+  case AST::Component::Sort::CoreSortType::Memory:
+  case AST::Component::Sort::CoreSortType::Global:
+  case AST::Component::Sort::CoreSortType::Tag:
+  case AST::Component::Sort::CoreSortType::Type:
+  case AST::Component::Sort::CoreSortType::Module:
+  case AST::Component::Sort::CoreSortType::Instance:
     Sort.setIsCore(true);
-    Sort.setCoreSortType(static_cast<AST::Component::Sort::CoreSortType>(Flag));
+    Sort.setCoreSortType(Type);
     return {};
   default:
     return logLoadError(ErrCode::Value::MalformedSort, FMgr.getLastOffset(),

--- a/lib/loader/ast/component/component_type.cpp
+++ b/lib/loader/ast/component/component_type.cpp
@@ -3,8 +3,6 @@
 
 #include "loader/loader.h"
 
-using namespace std::literals;
-
 namespace WasmEdge {
 namespace Loader {
 
@@ -166,7 +164,8 @@ Expect<void> Loader::loadType(AST::Component::DefValType &Ty, uint8_t Code) {
   //              | 0x65 t?:<valtype>?         => (future t?) 🔀
   //              | 0x63 k:<valtype> v:<valtype> => (map k v) 🗺️
 
-  switch (static_cast<ComponentTypeCode>(Code)) {
+  const auto TC = static_cast<ComponentTypeCode>(Code);
+  switch (TC) {
   case ComponentTypeCode::Bool:
   case ComponentTypeCode::S8:
   case ComponentTypeCode::U8:
@@ -181,7 +180,7 @@ Expect<void> Loader::loadType(AST::Component::DefValType &Ty, uint8_t Code) {
   case ComponentTypeCode::Char:
   case ComponentTypeCode::String:
   case ComponentTypeCode::ErrContext:
-    Ty.setPrimValType(static_cast<AST::Component::PrimValType>(Code));
+    Ty.setPrimValType(static_cast<AST::Component::PrimValType>(TC));
     return {};
   case ComponentTypeCode::Record: {
     AST::Component::RecordTy RTy;
@@ -198,7 +197,8 @@ Expect<void> Loader::loadType(AST::Component::DefValType &Ty, uint8_t Code) {
   case ComponentTypeCode::List:
   case ComponentTypeCode::ListLen: {
     AST::Component::ListTy LTy;
-    EXPECTED_TRY(loadType(LTy, Code == 0x67).map_error(ReportError));
+    EXPECTED_TRY(
+        loadType(LTy, TC == ComponentTypeCode::ListLen).map_error(ReportError));
     Ty.setList(std::move(LTy));
     return {};
   }

--- a/lib/loader/ast/component/component_valtype.cpp
+++ b/lib/loader/ast/component/component_valtype.cpp
@@ -60,24 +60,23 @@ Expect<void> Loader::loadType(ComponentValType &Ty) {
       return logLoadError(ErrCode::Value::MalformedValType,
                           FMgr.getLastOffset(), ASTNodeAttr::Comp_ValueType);
     }
-    AST::Component::PrimValType PVT = static_cast<AST::Component::PrimValType>(
-        static_cast<uint8_t>(Val & INT64_C(0x7F)));
-    switch (PVT) {
-    case AST::Component::PrimValType::Bool:
-    case AST::Component::PrimValType::S8:
-    case AST::Component::PrimValType::U8:
-    case AST::Component::PrimValType::S16:
-    case AST::Component::PrimValType::U16:
-    case AST::Component::PrimValType::S32:
-    case AST::Component::PrimValType::U32:
-    case AST::Component::PrimValType::S64:
-    case AST::Component::PrimValType::U64:
-    case AST::Component::PrimValType::F32:
-    case AST::Component::PrimValType::F64:
-    case AST::Component::PrimValType::Char:
-    case AST::Component::PrimValType::String:
-    case AST::Component::PrimValType::ErrorContext:
-      Ty.setCode(static_cast<ComponentTypeCode>(PVT));
+    const auto Code = static_cast<ComponentTypeCode>(Val & INT64_C(0x7F));
+    switch (Code) {
+    case ComponentTypeCode::Bool:
+    case ComponentTypeCode::S8:
+    case ComponentTypeCode::U8:
+    case ComponentTypeCode::S16:
+    case ComponentTypeCode::U16:
+    case ComponentTypeCode::S32:
+    case ComponentTypeCode::U32:
+    case ComponentTypeCode::S64:
+    case ComponentTypeCode::U64:
+    case ComponentTypeCode::F32:
+    case ComponentTypeCode::F64:
+    case ComponentTypeCode::Char:
+    case ComponentTypeCode::String:
+    case ComponentTypeCode::ErrContext:
+      Ty.setCode(Code);
       break;
     default:
       return logLoadError(ErrCode::Value::MalformedValType,


### PR DESCRIPTION
## Description

Cast each byte of a canonical option, an extern descriptor, an alias target, and a sort to its enumeration once and switch on the enumerators, as the canonical loader already does, instead of matching raw byte literals and casting at the end. Decode a primitive value type as its ComponentTypeCode rather than through a PrimValType round trip, name the list-with-length code by its enumerator, and overload loadAlias and loadInstance over the core and component forms like loadType does.

Assisted-by: Claude Fable 5.1 <noreply@anthropic.com>

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
