### PR TITLE
fix(wasi_crypto): take over the buffer when SecretVec is built from a vector rvalue

### DIFF
--- a/plugins/wasi_crypto/utils/secret_vec.h
+++ b/plugins/wasi_crypto/utils/secret_vec.h
@@ -23,6 +23,7 @@
 
 #include <climits>
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 namespace WasmEdge {
@@ -39,6 +40,10 @@ public:
 
   SecretVec(Span<const uint8_t> Data) noexcept
       : Data(Data.begin(), Data.end()) {}
+
+  /// Take over the buffer instead of copying it through `Span`, so that only
+  /// one copy of the content exists and it is the cleansed one.
+  SecretVec(std::vector<uint8_t> &&Data) noexcept : Data(std::move(Data)) {}
 
   SecretVec(size_t Size) noexcept : Data(Size) {}
 

--- a/plugins/wasi_crypto/utils/secret_vec.h
+++ b/plugins/wasi_crypto/utils/secret_vec.h
@@ -35,8 +35,8 @@ class SecretVec {
 public:
   SecretVec(const SecretVec &) = default;
 
-  /// Wipe the replaced content before releasing it, which the defaulted
-  /// assignment operators do not do.
+  /// Assigning over a live vector releases its buffer, so wipe the replaced
+  /// content first.
   SecretVec &operator=(const SecretVec &Rhs) {
     if (this != &Rhs) {
       cleanse();
@@ -45,10 +45,11 @@ public:
     return *this;
   }
 
+  /// The wiped buffer is handed to `Rhs`, which releases it on destruction.
   SecretVec &operator=(SecretVec &&Rhs) noexcept {
     if (this != &Rhs) {
       cleanse();
-      Data = std::move(Rhs.Data);
+      Data.swap(Rhs.Data);
     }
     return *this;
   }

--- a/plugins/wasi_crypto/utils/secret_vec.h
+++ b/plugins/wasi_crypto/utils/secret_vec.h
@@ -34,8 +34,25 @@ namespace WasiCrypto {
 class SecretVec {
 public:
   SecretVec(const SecretVec &) = default;
-  SecretVec &operator=(const SecretVec &) = default;
-  SecretVec &operator=(SecretVec &&) noexcept = default;
+
+  /// Wipe the replaced content before releasing it, which the defaulted
+  /// assignment operators do not do.
+  SecretVec &operator=(const SecretVec &Rhs) {
+    if (this != &Rhs) {
+      cleanse();
+      Data = Rhs.Data;
+    }
+    return *this;
+  }
+
+  SecretVec &operator=(SecretVec &&Rhs) noexcept {
+    if (this != &Rhs) {
+      cleanse();
+      Data = std::move(Rhs.Data);
+    }
+    return *this;
+  }
+
   SecretVec(SecretVec &&) noexcept = default;
 
   SecretVec(Span<const uint8_t> Data) noexcept
@@ -47,7 +64,7 @@ public:
 
   SecretVec(size_t Size) noexcept : Data(Size) {}
 
-  ~SecretVec() noexcept { OPENSSL_cleanse(Data.data(), Data.size()); }
+  ~SecretVec() noexcept { cleanse(); }
 
   auto begin() noexcept { return Data.begin(); }
   auto begin() const noexcept { return Data.begin(); }
@@ -76,6 +93,8 @@ public:
   }
 
 private:
+  void cleanse() noexcept { OPENSSL_cleanse(Data.data(), Data.size()); }
+
   std::vector<uint8_t> Data;
 };
 

--- a/test/plugins/wasi_crypto/CMakeLists.txt
+++ b/test/plugins/wasi_crypto/CMakeLists.txt
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
+set(OPENSSL_USE_STATIC_LIBS ON)
+find_package(OpenSSL REQUIRED)
+
 wasmedge_add_executable(wasiCryptoTests
   aeads.cpp
   asymmetric.cpp
@@ -32,6 +35,7 @@ target_include_directories(wasiCryptoTests
 target_link_libraries(wasiCryptoTests
   PRIVATE
   ${GTEST_BOTH_LIBRARIES}
+  OpenSSL::Crypto
 )
 # Link to the WasmEdge library
 if(WASMEDGE_LINK_PLUGINS_STATIC)

--- a/test/plugins/wasi_crypto/common.cpp
+++ b/test/plugins/wasi_crypto/common.cpp
@@ -147,30 +147,34 @@ TEST(SecretVecTest, CopyFromLvalueVector) {
   EXPECT_TRUE(std::equal(Secret.begin(), Secret.end(), Data.begin()));
 }
 
-TEST(SecretVecTest, MoveAssignTransfersBuffer) {
+TEST(SecretVecTest, MoveAssignWipesReplacedBuffer) {
   SecretVec Secret(std::vector<uint8_t>(32, uint8_t{0xAB}));
   SecretVec Other(std::vector<uint8_t>(64, uint8_t{0xCD}));
-  const uint8_t *const Buffer = Other.data();
+  const uint8_t *const Taken = Other.data();
+  const uint8_t *const Replaced = Secret.data();
 
   Secret = std::move(Other);
 
-  EXPECT_EQ(Secret.data(), Buffer);
+  EXPECT_EQ(Secret.data(), Taken);
   EXPECT_EQ(Secret.size(), 64U);
+
+  // The replaced buffer is handed to `Other`, where it stays a live vector of
+  // the original size and its content can be read back.
+  EXPECT_EQ(Other.data(), Replaced);
+  ASSERT_EQ(Other.size(), 32U);
+  EXPECT_TRUE(std::all_of(Other.begin(), Other.end(),
+                          [](uint8_t Byte) { return Byte == 0; }));
 }
 
-TEST(SecretVecTest, CopyAssignWipesReplacedContent) {
+TEST(SecretVecTest, CopyAssignReplacesContent) {
   SecretVec Secret(std::vector<uint8_t>(32, uint8_t{0xAB}));
-  const uint8_t *const Buffer = Secret.data();
   const SecretVec Other(std::vector<uint8_t>(8, uint8_t{0xCD}));
 
   Secret = Other;
 
-  if (Secret.data() != Buffer) {
-    GTEST_SKIP() << "the assignment reallocated, the replaced buffer is gone";
-  }
   ASSERT_EQ(Secret.size(), 8U);
-  EXPECT_TRUE(std::all_of(Buffer + Secret.size(), Buffer + 32,
-                          [](uint8_t Byte) { return Byte == 0; }));
+  EXPECT_TRUE(std::all_of(Secret.begin(), Secret.end(),
+                          [](uint8_t Byte) { return Byte == 0xCD; }));
 }
 
 TEST(SecretVecTest, SelfAssignKeepsContent) {

--- a/test/plugins/wasi_crypto/common.cpp
+++ b/test/plugins/wasi_crypto/common.cpp
@@ -3,6 +3,7 @@
 
 #include "common/func.h"
 #include "helper.h"
+#include "utils/secret_vec.h"
 
 namespace {
 template <typename T, typename M>
@@ -122,6 +123,28 @@ TEST_F(WasiCryptoTest, Options) {
     // Close options.
     WASI_CRYPTO_EXPECT_TRUE(optionsClose(KxOptionsHandle));
   }
+}
+
+TEST(SecretVecTest, MoveFromVector) {
+  std::vector<uint8_t> Data(32, uint8_t{0xAB});
+  const uint8_t *const Buffer = Data.data();
+
+  SecretVec Secret(std::move(Data));
+
+  EXPECT_EQ(Secret.data(), Buffer);
+  EXPECT_EQ(Secret.size(), 32U);
+}
+
+TEST(SecretVecTest, CopyFromLvalueVector) {
+  std::vector<uint8_t> Data(32, uint8_t{0xAB});
+  const uint8_t *const Buffer = Data.data();
+
+  SecretVec Secret(Data);
+
+  EXPECT_EQ(Data.size(), 32U);
+  EXPECT_EQ(Data.data(), Buffer);
+  EXPECT_NE(Secret.data(), Buffer);
+  EXPECT_TRUE(std::equal(Secret.begin(), Secret.end(), Data.begin()));
 }
 
 } // namespace WasiCrypto

--- a/test/plugins/wasi_crypto/common.cpp
+++ b/test/plugins/wasi_crypto/common.cpp
@@ -147,6 +147,43 @@ TEST(SecretVecTest, CopyFromLvalueVector) {
   EXPECT_TRUE(std::equal(Secret.begin(), Secret.end(), Data.begin()));
 }
 
+TEST(SecretVecTest, MoveAssignTransfersBuffer) {
+  SecretVec Secret(std::vector<uint8_t>(32, uint8_t{0xAB}));
+  SecretVec Other(std::vector<uint8_t>(64, uint8_t{0xCD}));
+  const uint8_t *const Buffer = Other.data();
+
+  Secret = std::move(Other);
+
+  EXPECT_EQ(Secret.data(), Buffer);
+  EXPECT_EQ(Secret.size(), 64U);
+}
+
+TEST(SecretVecTest, CopyAssignWipesReplacedContent) {
+  SecretVec Secret(std::vector<uint8_t>(32, uint8_t{0xAB}));
+  const uint8_t *const Buffer = Secret.data();
+  const SecretVec Other(std::vector<uint8_t>(8, uint8_t{0xCD}));
+
+  Secret = Other;
+
+  if (Secret.data() != Buffer) {
+    GTEST_SKIP() << "the assignment reallocated, the replaced buffer is gone";
+  }
+  ASSERT_EQ(Secret.size(), 8U);
+  EXPECT_TRUE(std::all_of(Buffer + Secret.size(), Buffer + 32,
+                          [](uint8_t Byte) { return Byte == 0; }));
+}
+
+TEST(SecretVecTest, SelfAssignKeepsContent) {
+  SecretVec Secret(std::vector<uint8_t>(32, uint8_t{0xAB}));
+  SecretVec &Alias = Secret;
+
+  Secret = Alias;
+
+  EXPECT_EQ(Secret.size(), 32U);
+  EXPECT_TRUE(std::all_of(Secret.begin(), Secret.end(),
+                          [](uint8_t Byte) { return Byte == 0xAB; }));
+}
+
 } // namespace WasiCrypto
 } // namespace Host
 } // namespace WasmEdge


### PR DESCRIPTION
## Description

Fixes #5324.

`SecretVec` had no `std::vector<uint8_t>&&` constructor, so a vector rvalue fell through to `SecretVec(Span<const uint8_t>)` and got copied. The `std::move` at the call site did nothing, and the source buffer was freed without `OPENSSL_cleanse`. The new constructor is an exact match for a vector rvalue, so it beats the conversion to `Span` with no ambiguity; lvalues keep copying as before.

Nothing was leaking. Everything currently reaching that overload is public data, and every secret path already returns `SecretVec`. So this removes one copy per export and closes the trap: exports reach `ArrayOutput` through a generic forwarding lambda, so the return type of `exportData` alone decides whether the bytes get cleansed.

## Assignment

The appendix item from the issue. Copy and move assignment were defaulted, so assigning over a live `SecretVec` released the old buffer uncleansed. Both are now hand written.

Move assignment wipes the destination and then swaps, so the wiped buffer is handed back to `Rhs` where a test can read it. Copy assignment delegates to it:

```cpp
inline SecretVec &SecretVec::operator=(const SecretVec &Rhs) {
  return *this = SecretVec(Rhs);
}
```

That leaves a single `cleanse()` on the assignment path rather than one per operator, and it is the one `MoveAssignWipesReplacedBuffer` pins down: delete it and that test fails. Copying first also makes self assignment safe without a `this != &Rhs` guard.

It has to be defined after the class. Constructing a `SecretVec` in an in-class body makes the compiler test the `SecretVec(Span<const uint8_t>)` candidate, which instantiates `is_compatible_range_v<const uint8_t, const SecretVec &>` before `data()` is declared further down the class. The trait resolves false and stays cached, so every later `SecretVec` to `Span` conversion in the translation unit fails to compile. The comment on the declaration records this.

## Correction to the issue

I claimed no CMake change was needed. That was wrong. `wasiCryptoTests` never constructed a `SecretVec` in its own translation units, so the target does not link `OpenSSL::Crypto` and the new cases fail on `_OPENSSL_cleanse`. The test `CMakeLists.txt` now mirrors the plugin's own two lines. No new test target.

## Tests

Five cases in the existing `test/plugins/wasi_crypto/common.cpp`: move from a vector rvalue, copy from an lvalue, move assignment wiping the buffer it replaces, copy assignment replacing the content, self assignment preserving it. `MoveFromVector` is the regression test and fails on the unfixed header exactly as reported in the issue.

## Test Evidence

macOS arm64, OpenSSL 3.5, `-DWASMEDGE_PLUGIN_WASI_CRYPTO=ON -DWASMEDGE_BUILD_TESTS=ON`.

```
[       OK ] SecretVecTest.MoveFromVector (0 ms)
[       OK ] SecretVecTest.CopyFromLvalueVector (0 ms)
[       OK ] SecretVecTest.MoveAssignWipesReplacedBuffer (0 ms)
[       OK ] SecretVecTest.CopyAssignReplacesContent (0 ms)
[       OK ] SecretVecTest.SelfAssignKeepsContent (0 ms)

[==========] 24 tests from 2 test suites ran. (1271 ms total)
[  PASSED  ] 24 tests.
```

Removing the `cleanse()` from move assignment and rebuilding gives 4 passed, 1 failed on `MoveAssignWipesReplacedBuffer`.

`clang-format` 22.1.8, `lineguard` 0.1.7 and `codespell` 2.4.1 are clean.

## Checklist

- [x] **DCO Signed-off**: commits are signed off (`git commit -s`).
- [x] **Commit Messages**: follow Conventional Commits.
- [x] **Coding Style**: `clang-format` clean.
- [x] **Local Tests Passed**: 24/24 `wasiCryptoTests` pass, output above.
