### PR TITLE
fix(llvm): map the Os and Oz levels to O2 with size attributes on LLVM 23

### DIFF
--- a/lib/llvm/compiler.cpp
+++ b/lib/llvm/compiler.cpp
@@ -43,10 +43,16 @@ toLLVMLevel(WasmEdge::CompilerConfigure::OptimizationLevel Level) noexcept {
     return "default<O2>";
   case OL::O3:
     return "default<O3>";
+#if LLVM_VERSION_MAJOR >= 23
+  case OL::Os:
+  case OL::Oz:
+    return "default<O2>";
+#else
   case OL::Os:
     return "default<Os>";
   case OL::Oz:
     return "default<Oz>";
+#endif
   default:
     assumingUnreachable();
   }
@@ -144,6 +150,29 @@ Expect<void> Compiler::optimize(LLVM::Module &LLModule,
       LLVMRelocPIC, LLVMCodeModelDefault);
 
 #if LLVM_VERSION_MAJOR >= 13
+#if LLVM_VERSION_MAJOR >= 23
+  {
+    using OL = CompilerConfigure::OptimizationLevel;
+    const auto Level = Conf.getCompilerConfigure().getOptimizationLevel();
+    if (Level == OL::Os || Level == OL::Oz) {
+      auto LLContext = LLModule.getContext();
+      const auto OptSize = LLVM::Attribute::createEnum(
+          LLContext, LLVM::Core::OptimizeForSize, 0);
+      const auto MinSize =
+          LLVM::Attribute::createEnum(LLContext, LLVM::Core::MinSize, 0);
+      for (auto Fn = LLModule.getFirstFunction(); Fn;
+           Fn = Fn.getNextFunction()) {
+        if (Fn.isDeclaration()) {
+          continue;
+        }
+        Fn.addFnAttr(OptSize);
+        if (Level == OL::Oz) {
+          Fn.addFnAttr(MinSize);
+        }
+      }
+    }
+  }
+#endif
   auto PBO = LLVM::PassBuilderOptions::create();
   if (auto Error = PBO.runPasses(
           LLModule,

--- a/lib/llvm/llvm.h
+++ b/lib/llvm/llvm.h
@@ -154,9 +154,11 @@ public:
 #endif
 
   static inline unsigned int Cold = 0;
+  static inline unsigned int MinSize = 0;
   static inline unsigned int NoAlias = 0;
   static inline unsigned int NoInline = 0;
   static inline unsigned int NoReturn = 0;
+  static inline unsigned int OptimizeForSize = 0;
   static inline unsigned int ReadOnly = 0;
   static inline unsigned int StrictFP = 0;
   static inline unsigned int UWTable = 0;
@@ -246,9 +248,11 @@ private:
 #endif
 
     Cold = getEnumAttributeKind("cold"sv);
+    MinSize = getEnumAttributeKind("minsize"sv);
     NoAlias = getEnumAttributeKind("noalias"sv);
     NoInline = getEnumAttributeKind("noinline"sv);
     NoReturn = getEnumAttributeKind("noreturn"sv);
+    OptimizeForSize = getEnumAttributeKind("optsize"sv);
     ReadOnly = getEnumAttributeKind("readonly"sv);
     StrictFP = getEnumAttributeKind("strictfp"sv);
     UWTable = getEnumAttributeKind("uwtable"sv);
@@ -346,6 +350,7 @@ public:
 
   const char *getTarget() noexcept { return LLVMGetTarget(Ref); }
   void setTarget(const char *Triple) noexcept { LLVMSetTarget(Ref, Triple); }
+  Context getContext() const noexcept { return LLVMGetModuleContext(Ref); }
   inline Value addFunction(Type Ty, LLVMLinkage Linkage,
                            const char *Name = "") noexcept;
   inline Value addGlobal(Type Ty, bool IsConstant, LLVMLinkage Linkage,
@@ -818,6 +823,7 @@ public:
   Value getNextParam() noexcept { return LLVMGetNextParam(Ref); }
   Value getNextGlobal() noexcept { return LLVMGetNextGlobal(Ref); }
   Value getNextFunction() noexcept { return LLVMGetNextFunction(Ref); }
+  bool isDeclaration() const noexcept { return LLVMIsDeclaration(Ref) != 0; }
   unsigned int countBasicBlocks() noexcept { return LLVMCountBasicBlocks(Ref); }
 
   Type getType() const noexcept { return LLVMTypeOf(Ref); }

--- a/test/driver/CMakeLists.txt
+++ b/test/driver/CMakeLists.txt
@@ -15,3 +15,13 @@ target_link_libraries(wasmedgeDriverToolTests
   ${GTEST_BOTH_LIBRARIES}
   wasmedgeDriver
 )
+
+if(WASMEDGE_USE_LLVM)
+  find_package(LLVM QUIET HINTS "${LLVM_CMAKE_PATH}" "${LLVM_DIR}")
+  if(LLVM_FOUND)
+    target_compile_definitions(wasmedgeDriverToolTests
+      PRIVATE
+      WASMEDGE_LLVM_VERSION_MAJOR=${LLVM_VERSION_MAJOR}
+    )
+  endif()
+endif()

--- a/test/driver/driverToolTest.cpp
+++ b/test/driver/driverToolTest.cpp
@@ -11,6 +11,7 @@
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
+#include <iterator>
 #include <string>
 #if !WASMEDGE_OS_WINDOWS
 #include <unistd.h>
@@ -799,6 +800,35 @@ TEST(CompileSubcommand, CompilerSpecificFlags) {
   EXPECT_EQ(callCompile({"--optimize", "z", Path, Output.c_str()}),
             EXIT_SUCCESS);
   std::filesystem::remove(Output.c_str());
+
+#if defined(WASMEDGE_LLVM_VERSION_MAJOR) && WASMEDGE_LLVM_VERSION_MAJOR >= 23
+  auto ReadOptimizedIR = []() {
+    std::ifstream Ifs("wasm-opt.ll");
+    return std::string(std::istreambuf_iterator<char>(Ifs),
+                       std::istreambuf_iterator<char>());
+  };
+  auto RemoveDumpedIR = []() {
+    std::filesystem::remove("wasm.ll");
+    std::filesystem::remove("wasm-opt.ll");
+  };
+
+  RemoveDumpedIR();
+  EXPECT_EQ(callCompile({"--optimize", "s", "--dump", Path, Output.c_str()}),
+            EXIT_SUCCESS);
+  std::filesystem::remove(Output.c_str());
+  const std::string IROptSize = ReadOptimizedIR();
+  EXPECT_NE(IROptSize.find("optsize"), std::string::npos);
+  EXPECT_EQ(IROptSize.find("minsize"), std::string::npos);
+  RemoveDumpedIR();
+
+  EXPECT_EQ(callCompile({"--optimize", "z", "--dump", Path, Output.c_str()}),
+            EXIT_SUCCESS);
+  std::filesystem::remove(Output.c_str());
+  const std::string IRMinSize = ReadOptimizedIR();
+  EXPECT_NE(IRMinSize.find("optsize"), std::string::npos);
+  EXPECT_NE(IRMinSize.find("minsize"), std::string::npos);
+  RemoveDumpedIR();
+#endif
 
   EXPECT_EQ(callCompile({"--optimize", "invalid", Path, Output.c_str()}),
             EXIT_SUCCESS);


### PR DESCRIPTION
## Description

The `macOS 15 (arm64)` job on master started failing in `wasmedgeDriverToolTests` once Homebrew rolled out LLVM 23.1.0 (e.g. [this run](https://github.com/WasmEdge/WasmEdge/actions/runs/33854387706/job/100964463119)): LLVM 23 removed the `Os`/`Oz` aliases from the default pass pipeline, so `--optimize s`/`z` aborted the whole process with:

```
LLVM ERROR: The optimization level "Os" is no longer supported. Use O2 in conjunction with the optsize attribute instead.
```

Following the upstream guidance (and matching how clang lowers `-Os`/`-Oz`), on LLVM >= 23 the compiler now runs the `default<O2>` pipeline and marks every defined function `optsize` for Os, plus `minsize` for Oz. Older LLVM versions keep the previous pipeline strings, so their behavior is unchanged.

Changes:

- `lib/llvm/compiler.cpp`: map Os/Oz to the `default<O2>` pipeline on LLVM >= 23 and apply `optsize`/`minsize` function attributes in `Compiler::optimize()`.
- `lib/llvm/llvm.h`: add the `MinSize`/`OptimizeForSize` attribute kinds, `Module::getContext()`, and `Value::isDeclaration()` wrappers.

This is the same approach taken by crystal-lang/crystal#16983 for the identical breakage.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

This contribution was developed with assistance from GitHub Copilot CLI (Claude Fable 5).

## Test Evidence

With Homebrew LLVM 23.1.0 on macOS 15 (arm64), which reproduced the CI crash before this fix:

```
$ llvm-config --version
23.1.0

$ ./build/test/driver/wasmedgeDriverToolTests
[==========] Running 44 tests from 6 test suites.
[       OK ] CompileSubcommand.ErrorHandling (0 ms)
[       OK ] CompileSubcommand.ValidAndInvalidModules (17 ms)
[       OK ] CompileSubcommand.ProposalFlags (44 ms)
[       OK ] CompileSubcommand.CompilerSpecificFlags (140 ms)
[       OK ] CompileSubcommand.OutputFormat (17 ms)
[==========] 44 tests from 6 test suites ran. (249 ms total)
[  PASSED  ] 44 tests.
```

IR dump verification (`wasmedgec --dump`): `--optimize s` emits `optsize` and `--optimize z` emits `minsize optsize` on all defined functions:

```
attributes #0 = { optsize strictfp uwtable "no-stack-arg-probe" }
attributes #0 = { minsize optsize strictfp uwtable "no-stack-arg-probe" }
```

`clang-format --dry-run -Werror` and `lineguard` pass on the modified files.