### PR TITLE
refactor(validator): simplify the component validator's helpers

### DIFF
--- a/include/ast/component/canonical.h
+++ b/include/ast/component/canonical.h
@@ -18,6 +18,7 @@
 #include "common/span.h"
 
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 namespace WasmEdge {
@@ -164,6 +165,15 @@ public:
   void setContextType(const ValType T) noexcept { CtxType = T; }
 
   Span<const CanonOpt> getOptions() const noexcept { return Opts; }
+  /// True when the definition carries the option OptCode.
+  bool hasOption(ComponentCanonOptCode OptCode) const noexcept {
+    for (const auto &Opt : Opts) {
+      if (Opt.getCode() == OptCode) {
+        return true;
+      }
+    }
+    return false;
+  }
   void setOptions(std::vector<CanonOpt> &&List) noexcept {
     Opts = std::move(List);
   }
@@ -175,6 +185,70 @@ public:
   void setResultList(const ComponentValType &VT) noexcept {
     ResultList.clear();
     ResultList.emplace_back(VT);
+  }
+
+  /// The core function type of the canonical built-in Code, as the Explainer's
+  /// synopsis tables give it, with AddrType for the address type of the memory
+  /// the definition names, or of the table for thread.new-indirect.
+  /// context.get and context.set take the context slot type, and task.return
+  /// the lowered results, so their callers form those types themselves.
+  static std::pair<std::vector<ValType>, std::vector<ValType>>
+  getBuiltinCoreFuncType(ComponentCanonOpCode Code,
+                         const ValType &AddrType) noexcept {
+    const ValType I32(TypeCode::I32);
+    const ValType I64(TypeCode::I64);
+    switch (Code) {
+    case ComponentCanonOpCode::Backpressure__inc:
+    case ComponentCanonOpCode::Backpressure__dec:
+    case ComponentCanonOpCode::Task__cancel:
+      return {{}, {}};
+    case ComponentCanonOpCode::Yield:
+    case ComponentCanonOpCode::Waitable_set__new:
+    case ComponentCanonOpCode::Thread__index:
+    case ComponentCanonOpCode::Thread__suspend:
+      return {{}, {I32}};
+    case ComponentCanonOpCode::Waitable_set__wait:
+    case ComponentCanonOpCode::Waitable_set__poll:
+      return {{I32, AddrType}, {I32}};
+    case ComponentCanonOpCode::Waitable_set__drop:
+    case ComponentCanonOpCode::Subtask__drop:
+    case ComponentCanonOpCode::Stream__drop_readable:
+    case ComponentCanonOpCode::Stream__drop_writable:
+    case ComponentCanonOpCode::Future__drop_readable:
+    case ComponentCanonOpCode::Future__drop_writable:
+    case ComponentCanonOpCode::Error_context__drop:
+    case ComponentCanonOpCode::Thread__resume_later:
+      return {{I32}, {}};
+    case ComponentCanonOpCode::Waitable__join:
+      return {{I32, I32}, {}};
+    case ComponentCanonOpCode::Subtask__cancel:
+    case ComponentCanonOpCode::Stream__cancel_read:
+    case ComponentCanonOpCode::Stream__cancel_write:
+    case ComponentCanonOpCode::Future__cancel_read:
+    case ComponentCanonOpCode::Future__cancel_write:
+    case ComponentCanonOpCode::Thread__yield_then_resume:
+    case ComponentCanonOpCode::Thread__suspend_then_resume:
+    case ComponentCanonOpCode::Thread__yield_then_promote:
+    case ComponentCanonOpCode::Thread__suspend_then_promote:
+      return {{I32}, {I32}};
+    case ComponentCanonOpCode::Stream__new:
+    case ComponentCanonOpCode::Future__new:
+      return {{}, {I64}};
+    case ComponentCanonOpCode::Stream__read:
+    case ComponentCanonOpCode::Stream__write:
+      return {{I32, AddrType, AddrType}, {AddrType}};
+    case ComponentCanonOpCode::Future__read:
+    case ComponentCanonOpCode::Future__write:
+      return {{I32, AddrType}, {I32}};
+    case ComponentCanonOpCode::Error_context__new:
+      return {{AddrType, AddrType}, {I32}};
+    case ComponentCanonOpCode::Error_context__debug_message:
+      return {{I32, AddrType}, {}};
+    case ComponentCanonOpCode::Thread__new_indirect:
+      return {{AddrType, I32}, {I32}};
+    default:
+      assumingUnreachable();
+    }
   }
 
 private:

--- a/include/ast/component/descriptor.h
+++ b/include/ast/component/descriptor.h
@@ -63,19 +63,22 @@ public:
     Type.emplace<TagType>(std::move(TT));
   }
 
-  bool isFunc() const noexcept {
-    return std::holds_alternative<uint32_t>(Type);
+  /// The kind of core extern the descriptor describes.
+  ExternalType getExternalType() const noexcept {
+    if (std::holds_alternative<TableType>(Type)) {
+      return ExternalType::Table;
+    }
+    if (std::holds_alternative<MemoryType>(Type)) {
+      return ExternalType::Memory;
+    }
+    if (std::holds_alternative<GlobalType>(Type)) {
+      return ExternalType::Global;
+    }
+    if (std::holds_alternative<TagType>(Type)) {
+      return ExternalType::Tag;
+    }
+    return ExternalType::Function;
   }
-  bool isTable() const noexcept {
-    return std::holds_alternative<TableType>(Type);
-  }
-  bool isMemory() const noexcept {
-    return std::holds_alternative<MemoryType>(Type);
-  }
-  bool isGlobal() const noexcept {
-    return std::holds_alternative<GlobalType>(Type);
-  }
-  bool isTag() const noexcept { return std::holds_alternative<TagType>(Type); }
 
 private:
   std::variant<uint32_t, TableType, MemoryType, GlobalType, TagType> Type;

--- a/include/ast/type.h
+++ b/include/ast/type.h
@@ -453,6 +453,21 @@ public:
     return false;
   }
 
+  /// Matcher: Match two limits.
+  static bool matchLimit(const Limit &Exp, const Limit &Got) noexcept {
+    if (Exp.getAddrType() != Got.getAddrType() ||
+        Exp.isShared() != Got.isShared()) {
+      return false;
+    }
+    if (Got.getMin() < Exp.getMin()) {
+      return false;
+    }
+    if (Exp.hasMax()) {
+      return Got.hasMax() && Got.getMax() <= Exp.getMax();
+    }
+    return true;
+  }
+
 private:
   /// Matcher: Helper for checking the equivalence of two defined types.
   static bool isDefTypeEqual(Span<const SubType *const> LHSList,

--- a/include/validator/component_context.h
+++ b/include/validator/component_context.h
@@ -41,19 +41,15 @@ class Context {
 public:
   explicit Context(TypeSystem &Types) noexcept : Types(Types) {}
 
-  /// The type system these index spaces resolve against.
-  TypeSystem &types() noexcept { return Types; }
-
   // ==========================================================================
-  // The scope stack. Scopes stay in the arena after they pop; an unbalanced
-  // exit on an error path is harmless because validate() resets the stack.
+  // The scope stack. Scopes stay owned after they pop; validate() resets it.
   // ==========================================================================
 
-  Scope &enterScope(Scope::Kind K) noexcept {
+  Scope &enterScope(ScopeKind K) noexcept {
     const Scope *Parent = Stack.empty() ? nullptr : Stack.back();
-    ScopeArena.emplace_back(K, Parent);
-    Stack.push_back(&ScopeArena.back());
-    return ScopeArena.back();
+    OwnedScopes.emplace_back(K, Parent);
+    Stack.push_back(&OwnedScopes.back());
+    return OwnedScopes.back();
   }
 
   void exitScope() noexcept {
@@ -70,12 +66,7 @@ public:
     return *Stack.back();
   }
 
-  uint32_t depth() const noexcept {
-    return static_cast<uint32_t>(Stack.size());
-  }
-
-  /// The scope Levels hops up from the current one. Returns nullptr if Levels
-  /// is out of range.
+  /// The scope Levels hops up from the current one; nullptr if out of range.
   Scope *scopeUp(uint32_t Levels) noexcept {
     if (Levels >= Stack.size()) {
       return nullptr;
@@ -83,8 +74,7 @@ public:
     return Stack[Stack.size() - 1 - Levels];
   }
 
-  /// The scope one level inside the outer-alias target (Levels > 0): if it is
-  /// a real component, the alias crosses a component boundary.
+  /// The scope inside the outer-alias target; a component there is a crossing.
   const Scope *scopeInsideTarget(uint32_t Levels) const noexcept {
     if (Levels == 0 || Levels > Stack.size()) {
       return nullptr;
@@ -105,23 +95,18 @@ public:
   Expect<const CoreShape *> buildCoreShape(const AST::Module &Mod) noexcept;
 
   // ==========================================================================
-  // Naming: grammar, strong uniqueness, `implements`, annotated plainnames,
-  // and the named-types rule. This is the only writer of NameSide.
+  // Naming checks and the named-types rule; the only writer of NameSide.
   // ==========================================================================
 
-  /// Extern-name grammar and position checks. An export rejects the
-  /// import-only dep, url, and hash names.
+  /// Extern-name grammar checks; an export rejects the import-only name kinds.
   Expect<ExternName> parseExternName(std::string_view Name,
                                      bool IsImport) const noexcept;
   /// Build the comparison record for a parsed name.
   NameRecord makeNameRecord(const ExternName &Name) const noexcept;
-  /// Append N to Names, or diagnose the clash. An exact duplicate is always
-  /// a name conflict, a strong-uniqueness one names the declarator side.
+  /// Append N to Names, or diagnose the clash (exact or strong-uniqueness).
   Expect<void> addUniqueName(std::vector<NameRecord> &Names,
                              const NameRecord &N, bool IsImport) const noexcept;
-  /// The name attributes. Each kind may appear at most once. An
-  /// `implements` value must be an interface name, and the annotated name
-  /// must be plain and instance-typed.
+  /// Name attributes: each kind at most once, on a plain, instance-typed name.
   Expect<void> checkNameAttributes(const ExternName &CN,
                                    Span<const std::string> Impls,
                                    Span<const std::string> ExtIds,
@@ -134,25 +119,21 @@ public:
   /// Track plain resource labels for later annotated-name checks.
   void recordResourceLabel(const ExternName &Name, const ExternInfo &Info,
                            bool IsImport) noexcept;
-  /// Named-types rule. A preceding import or export must introduce every
-  /// flags, enum, record, variant, or resource that an extern refers to.
+  /// Named-types rule: an earlier extern must introduce each named type used.
   Expect<void> checkNamedTypesRule(const ExternInfo &Info,
                                    bool IsImport) noexcept;
 
   // ==========================================================================
-  // Declaring an import or an export. The export path is split so name
-  // errors precede ascription errors, so the checks above stay callable.
+  // Declaring an import or an export; name errors precede ascription errors.
   // ==========================================================================
 
-  /// Check an import's name and define the (already resolved) entity it
-  /// introduces.
+  /// Check an import's name and define the resolved entity it introduces.
   Expect<ExternInfo>
   defineImport(std::string_view Name, const ExternInfo &Resolved,
                Span<const std::string> Impls = {},
                Span<const std::string> ExtIds = {},
                Span<const std::string> VSuffixes = {}) noexcept;
-  /// Check and record the name of an export. defineExport then defines the
-  /// entity, with its optional ascription.
+  /// Check and record an export's name; defineExport then defines the entity.
   Expect<ExternName>
   registerExportName(std::string_view Name, bool IsInstance,
                      Span<const std::string> Impls = {},
@@ -163,66 +144,58 @@ public:
   defineExport(const ExternName &CN, const ExternInfo &Inferred,
                const std::optional<ExternInfo> &Ascribed) noexcept;
 
-  /// Mint fresh identities for the resources that the own declarations of an
-  /// instance shape introduced. The current scope owns them.
+  /// Mint fresh identities for the resources Inst declares; top() owns them.
   const Shape *freshenDeclaredResources(const Shape *Inst,
                                         bool FromImport) noexcept {
     return Types.freshenDeclaredResources(Inst, top(), FromImport);
   }
 
   // ==========================================================================
-  // Canonical options. The flattening they parameterize lives on
-  // TypeSystem; these resolve core index spaces, so they live here.
+  // Canonical options. They resolve core index spaces, so they live here.
   // ==========================================================================
 
-  /// True iff the canonical definition carries the given option.
-  static bool hasOption(const AST::Component::Canonical &Canon,
-                        ComponentCanonOptCode Code) noexcept;
-  /// True iff the canonical `memory` option selects a 64-bit memory.
-  bool canonMemoryIs64(const AST::Component::Canonical &Canon) const noexcept;
   /// The index type of the selected canonical memory.
-  ValType canonPtrType(const AST::Component::Canonical &Canon) const noexcept {
-    return ValType(canonMemoryIs64(Canon) ? TypeCode::I64 : TypeCode::I32);
-  }
-  /// canonopt structural rules: duplicates, index validity, the referenced
-  /// core function signatures, and the per-site option whitelist.
+  ValType
+  getCanonPtrType(const AST::Component::Canonical &Canon) const noexcept;
+  /// canonopt rules: duplicates, indices, core signatures, per-site whitelist.
   Expect<void> checkOptions(const AST::Component::Canonical &Canon,
                             bool IsLift) const noexcept;
+  /// The memory and realloc options a definition (What) needs.
+  Expect<void> requireOptions(const AST::Component::Canonical &Canon,
+                              bool NeedMemory, bool NeedRealloc,
+                              std::string_view What) const noexcept;
 
   // ==========================================================================
   // Instantiation.
   // ==========================================================================
 
-  /// Match args against CI.Imports, then produce the instance's export view
-  /// with substituted and freshened resource ids.
+  /// Match args against CI.Imports and produce the freshened export view.
   Expect<const Shape *> instantiateComponentShape(
       const Shape &CI,
       Span<const AST::Component::InstantiateArg<AST::Component::SortIndex>>
           Args) noexcept;
 
-  /// Core-module code sections deferred to the end of the root component,
-  /// each with the checker state captured at its definition.
+  /// Core-module code sections deferred to the end of the root component.
   std::vector<std::pair<const AST::Module *, FormChecker>> DeferredModules;
 
   void reset() noexcept {
     DeferredModules.clear();
     Stack.clear();
-    ScopeArena.clear();
+    OwnedScopes.clear();
     Types.reset();
   }
 
 private:
-  // Named-types rule. introduceExternTypes both checks (false if a referenced
-  // type was not introduced first) and records what it introduces.
+  // Named-types rule: introduceExternTypes checks (false if unmet) and records.
   bool introduceExternTypes(const ExternInfo &Info, bool IsImport) noexcept;
-  bool isValTypeIntroduced(const QualValType &Q, bool IsImport) noexcept;
-  bool isTypeEntryIntroduced(const TypeEntry &E, bool IsImport) noexcept;
+  bool isIntroduced(const QualValType &Q, bool IsImport) noexcept;
+  bool isIntroduced(const TypeEntry &E, bool IsImport) noexcept;
   // The immediate components of the type. The extern names the type itself.
   bool areInnerTypesIntroduced(const TypeEntry &E, bool IsImport) noexcept;
 
   TypeSystem &Types;
   std::vector<Scope *> Stack;
-  std::deque<Scope> ScopeArena;
+  std::deque<Scope> OwnedScopes;
 };
 
 } // namespace Component

--- a/include/validator/component_name.h
+++ b/include/validator/component_name.h
@@ -13,8 +13,6 @@ namespace Validator {
 namespace Component {
 
 /// A parsed extern name of a component import or export.
-/// exportname ::= <plainname> | <interfacename>
-/// importname ::= <exportname> | <depname> | <urlname> | <hashname>
 class ExternName {
 public:
   enum class Kind : uint8_t {
@@ -30,8 +28,7 @@ public:
     Integrity
   };
 
-  /// Fragments of the parsed name, all views into the input. The kind decides
-  /// which ones are set. The rest stay empty.
+  /// Fragments as views into the input; the kind decides which are set.
   struct Detail {
     std::string_view Resource;     // Constructor, Method, Static
     std::string_view Method;       // Method, Static
@@ -44,8 +41,7 @@ public:
     std::string_view Integrity;    // LockedDep, Url, Integrity
   };
 
-  /// Returns true if Input is a valid kebab-case label per the Component Model
-  /// spec: `label ::= <first-fragment> ( '-' <fragment> )*`
+  /// Returns true if Input is a label: <first-fragment> ( '-' <fragment> )*.
   static bool isKebabString(std::string_view Input) noexcept;
 
   /// Parses Name into this object, which stays Invalid on failure.
@@ -53,41 +49,30 @@ public:
 
   Kind getKind() const noexcept { return NameKind; }
   std::string_view getOriginalName() const noexcept { return OriName; }
-  /// The name with its annotation stripped; empty unless the name carries a
-  /// `[constructor]`, `[method]`, or `[static]` tag.
+  /// The name without its annotation tag; empty when the name carries none.
   std::string_view getNoTagName() const noexcept { return NoTagName; }
   const Detail &getDetail() const noexcept { return NameDetail; }
-  /// 🔗 The `versionsuffix` attribute. The name has to carry an
-  /// `interfaceversion` in `canonversion` form, and the two concatenated
-  /// have to be a valid semver.
+  /// The `versionsuffix` attribute: canonversion plus Suffix must be a semver.
   Expect<void> checkVersionSuffix(std::string_view Suffix) const noexcept;
 
 private:
-  // pkgpath ::= <namespace> <words>
-  struct PkgPath {
-    std::string_view Namespace;
-    std::string_view Package;
-  };
-
   // Cursor primitives, all consuming from Rest.
   bool tryRead(std::string_view Prefix) noexcept;
   bool readUntil(char Delim, std::string_view &Output) noexcept;
   std::string_view readLabelChars() noexcept;
 
-  // One member per production. Each one consumes the rest of the input after
-  // its leading tag, then fills in NameKind and Detail.
+  // One member per production, consuming the rest after its leading tag.
   Expect<void> parsePlainName() noexcept;
   Expect<void> parseUnlockedDep() noexcept;
   Expect<void> parseLockedDep() noexcept;
   Expect<void> parseUrlName() noexcept;
   Expect<void> parseHashName() noexcept;
   Expect<void> parseInterfaceName() noexcept;
-  Expect<PkgPath> parsePkgPath(std::string_view StopChars) noexcept;
+  Expect<void> parsePkgPath(std::string_view StopChars) noexcept;
   Expect<std::string_view> parseIntegrityBody() noexcept;
   Expect<std::string_view> parseIntegritySuffix() noexcept;
 
-  // Grammar checks over an explicit substring. A semver scanner returns its
-  // granular code unlogged, and the caller picks the diagnostic.
+  // Grammar checks over a substring; the semver scanners stay unlogged.
   Expect<void> checkWordsLabel(std::string_view Label,
                                std::string_view What) const noexcept;
   Expect<void> checkVersionRange(std::string_view Body) const noexcept;

--- a/include/validator/component_types.h
+++ b/include/validator/component_types.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -46,9 +47,19 @@ struct Shape;
 // Core-level views.
 // ===========================================================================
 
-/// Resolved core:importdesc / core export type. Kind discriminates. For
-/// Kind == Tag, Func holds the tag signature.
+/// Resolved core extern type: Kind discriminates, a Tag's signature is Func.
 struct CoreExternInfo {
+  CoreExternInfo() noexcept = default;
+  /// A function, or the signature of a tag when K is Tag.
+  CoreExternInfo(ExternalType K, const AST::SubType *ST) noexcept
+      : Kind(K), Func(ST) {}
+  explicit CoreExternInfo(const AST::TableType *TT) noexcept
+      : Kind(ExternalType::Table), Table(TT) {}
+  explicit CoreExternInfo(const AST::MemoryType *MT) noexcept
+      : Kind(ExternalType::Memory), Memory(MT) {}
+  explicit CoreExternInfo(const AST::GlobalType *GT) noexcept
+      : Kind(ExternalType::Global), Global(GT) {}
+
   ExternalType Kind = ExternalType::Function;
   const AST::SubType *Func = nullptr;
   const AST::TableType *Table = nullptr;
@@ -56,8 +67,7 @@ struct CoreExternInfo {
   const AST::GlobalType *Global = nullptr;
 };
 
-/// Core module or core instance: ordered imports and named exports (an
-/// instance has no imports).
+/// Core module or instance: ordered imports (none for an instance) and exports.
 struct CoreShape {
   std::vector<std::tuple<std::string, std::string, CoreExternInfo>> Imports;
   std::map<std::string, CoreExternInfo, std::less<>> Exports;
@@ -73,8 +83,7 @@ struct CoreTypeEntry {
 // Resource identity remapping.
 // ===========================================================================
 
-/// Remap of the resource ids a view was written against to the ids it
-/// denotes here. An absent id maps to itself.
+/// Remap of a view's resource ids to those meant here; an absent id is itself.
 struct ResourceMap {
   std::unordered_map<uint32_t, uint32_t> Map;
 
@@ -88,8 +97,7 @@ struct ResourceMap {
 // Component-level views.
 // ===========================================================================
 
-/// A valtype together with the scope its type indices resolve in and the
-/// remap table in effect for resource identities reached through it.
+/// A valtype with the scope its indices resolve in and the remap in effect.
 struct QualValType {
   ComponentValType VT{};
   const Scope *Home = nullptr;
@@ -103,46 +111,51 @@ struct FuncInfo {
   const ResourceMap *Remap = nullptr;
 };
 
-/// Entry of the type index space. DT is null for `(sub resource)` bounds;
-/// ResourceId is set iff this is a resource, and is already remapped.
+/// Type index entry: DT null for resource bounds, ResourceId set iff resource.
 struct TypeEntry {
+  TypeEntry() noexcept = default;
+  TypeEntry(const AST::Component::DefType *Def, const Scope *Owner) noexcept
+      : DT(Def), Home(Owner) {}
+
   const AST::Component::DefType *DT = nullptr;
   const Scope *Home = nullptr;
   const ResourceMap *Remap = nullptr;
-  // Instancetype / componenttype shape. Two fields, not one: a type entry has
-  // no sort tag, so which one is set is the discriminator.
+  // Instancetype or componenttype shape; which one is set discriminates.
   const Shape *Inst = nullptr;
   const Shape *Comp = nullptr;
   std::optional<uint32_t> ResourceId;
-  // Naming identity for resources: re-exports mint a fresh NameId while
-  // keeping ResourceId, so matching and the named-types rule can differ.
+  // Resource naming identity; a re-export mints a new one but keeps ResourceId.
   std::optional<uint32_t> NameId;
+
+  /// The defvaltype or functype definition this entry holds, else nullptr.
+  const AST::Component::DefValType *getDefValType() const noexcept {
+    return DT != nullptr && DT->isDefValType() ? &DT->getDefValType() : nullptr;
+  }
+  const AST::Component::FuncType *getFuncType() const noexcept {
+    return DT != nullptr && DT->isFuncType() ? &DT->getFuncType() : nullptr;
+  }
+  bool isResource() const noexcept { return ResourceId.has_value(); }
 };
 
-/// The class of an extern, named as the binary descriptor tag reads it. A
-/// sortidx entity has no descriptor, but the same six classes.
+/// The class of an extern, named as the binary descriptor tag reads it.
 using ExternKind = AST::Component::ExternDesc::DescType;
 
-/// Resolved externdesc: the typed identity of an import/export/entity.
-/// Exactly one member is live, selected by K.
+/// Resolved externdesc; exactly one member is live, selected by Kind.
 struct ExternInfo {
-  ExternKind K = ExternKind::FuncType;
+  ExternKind Kind = ExternKind::FuncType;
   const CoreShape *CoreMod = nullptr;
   FuncInfo Func;
   QualValType Value;
   TypeEntry Type;
-  // Instance and component externs share one field: K discriminates. The type
-  // is qualified so that the member may carry the same name.
+  // Instance and component externs share this field; Kind discriminates.
   const Component::Shape *Shape = nullptr;
 };
 
-/// Component or instance: ordered imports (an instance has none) and named
-/// exports. DeclScope owns the resource ids the shape binds.
+/// Component or instance externs; DeclScope owns the resource ids it binds.
 struct Shape {
   std::vector<std::pair<std::string, ExternInfo>> Imports;
   std::map<std::string, ExternInfo, std::less<>> Exports;
-  // Export names in declaration order (introduction order matters for the
-  // named-types rule).
+  // Export names in declaration order, as the named-types rule needs.
   std::vector<std::string> ExportOrder;
   const Scope *DeclScope = nullptr;
 };
@@ -153,8 +166,7 @@ struct ValueEntry {
   bool Consumed = false;
 };
 
-/// Entry of the session-global resource registry. The vector index is the
-/// resource identity.
+/// Entry of the resource registry; the vector index is the resource identity.
 struct ResourceEntry {
   const AST::Component::ResourceType *RT = nullptr;
   const Scope *Origin = nullptr;
@@ -178,17 +190,18 @@ struct NameRecord {
 // Scope: one per component / componenttype / instancetype / moduletype.
 // ===========================================================================
 
+/// The four constructs that open a scope.
+enum class ScopeKind : uint8_t {
+  Component,
+  ComponentType,
+  InstanceType,
+  ModuleType
+};
+
 struct Scope {
-  enum class Kind : uint8_t {
-    Component,
-    ComponentType,
-    InstanceType,
-    ModuleType
-  };
+  Scope(ScopeKind K, const Scope *P) noexcept : Kind(K), Parent(P) {}
 
-  Scope(Kind K, const Scope *P) noexcept : K(K), Parent(P) {}
-
-  Kind K;
+  ScopeKind Kind;
   const Scope *Parent;
 
   // Core index spaces.
@@ -208,35 +221,30 @@ struct Scope {
   std::vector<const Shape *> Components;
   std::vector<const Shape *> Instances;
 
-  /// Naming state of one side. Imports and exports are checked separately, so
-  /// every member exists once per side.
+  /// Naming state of one side; imports and exports are checked separately.
   struct NameSide {
     std::vector<NameRecord> Names;
-    // Plain resource label -> resource id, for
-    // [constructor]/[method]/[static] name checks.
+    // Plain resource label -> id, for [constructor]/[method]/[static] checks.
     std::unordered_map<std::string, uint32_t> ResourceLabels;
     std::unordered_map<uint32_t, std::string> ResourceNames;
     // Resource ids introduced by preceding imports/exports (nameability).
     std::unordered_set<uint32_t> NamedResources;
-    // Composite defined types introduced by preceding imports/exports, with
-    // the scope their inner indices resolve in.
+    // Introduced composite types with the scope their inner indices resolve in.
     std::unordered_map<const AST::Component::DefType *, const Scope *>
         NamedTypes;
-    // Naming identities of introduced types: local references must name the
-    // introduced identity, not merely a structurally identical definition.
+    // Naming identities of introduced types; local references must name one.
     std::unordered_set<uint32_t> NamedIds;
   };
   NameSide ImportSide;
   NameSide ExportSide;
 
-  // All context.get and context.set built-ins of one component share one
-  // type, so writes with one type never pair with reads of another.
+  // The one type every context.get and context.set of this component share.
   std::optional<ValType> ContextType;
 
-  NameSide &nameSide(bool IsImport) noexcept {
+  NameSide &getNameSide(bool IsImport) noexcept {
     return IsImport ? ImportSide : ExportSide;
   }
-  const NameSide &nameSide(bool IsImport) const noexcept {
+  const NameSide &getNameSide(bool IsImport) const noexcept {
     return IsImport ? ImportSide : ExportSide;
   }
 
@@ -264,21 +272,53 @@ struct Scope {
   const AST::SubType *getCoreFunc(uint32_t Idx) const noexcept {
     return Idx < CoreFuncs.size() ? CoreFuncs[Idx] : nullptr;
   }
-};
 
-/// Normalized value type: a primitive code or a composite defvaltype with its
-/// resolution frame.
-struct NormalVal {
-  ComponentTypeCode Prim = ComponentTypeCode::TypeIndex;
-  const AST::Component::DefValType *DVT = nullptr;
-  const Scope *Home = nullptr;
-  const ResourceMap *Remap = nullptr;
-  bool Valid = false;
+  // Index-space registration: one entry per definition, in binary order.
+  void addCoreModule(const CoreShape *Mod) noexcept {
+    CoreModules.push_back(Mod);
+  }
+  void addCoreInstance(const CoreShape *Inst) noexcept {
+    CoreInstances.push_back(Inst);
+  }
+  void addCoreType(const CoreTypeEntry &Entry) noexcept {
+    CoreTypes.push_back(Entry);
+  }
+  void addCoreFunc(const AST::SubType *Func) noexcept {
+    CoreFuncs.push_back(Func);
+  }
+  /// A resolved core extern enters the index space of its kind.
+  void addCoreExtern(const CoreExternInfo &Ext) noexcept {
+    switch (Ext.Kind) {
+    case ExternalType::Function:
+      CoreFuncs.push_back(Ext.Func);
+      break;
+    case ExternalType::Table:
+      CoreTables.push_back(Ext.Table);
+      break;
+    case ExternalType::Memory:
+      CoreMemories.push_back(Ext.Memory);
+      break;
+    case ExternalType::Global:
+      CoreGlobals.push_back(Ext.Global);
+      break;
+    case ExternalType::Tag:
+      CoreTags.push_back(Ext.Func);
+      break;
+    }
+  }
+  void addType(const TypeEntry &Entry) noexcept { Types.push_back(Entry); }
+  void addFunc(const FuncInfo &Func) noexcept { Funcs.push_back(Func); }
+  void addValue(const QualValType &Type) noexcept {
+    Values.push_back({Type, false});
+  }
+  void addInstance(const Shape *Inst) noexcept { Instances.push_back(Inst); }
+  void addComponent(const Shape *Comp) noexcept { Components.push_back(Comp); }
+  /// Consume the value at Idx, which the caller has bounds-checked, once.
+  Expect<void> consumeValue(uint32_t Idx) noexcept;
 };
 
 // ===========================================================================
-// The type system: arenas, the resource registry, and every operation that
-// is a pure function of a type view.
+// The type system: owned storage, the resource registry, and type operations.
 // ===========================================================================
 
 class TypeSystem {
@@ -287,12 +327,12 @@ public:
   // Resource registry: index is the identity.
   // -------------------------------------------------------------------------
 
-  uint32_t newNameId() noexcept { return NextNameId++; }
+  uint32_t nextNameId() noexcept { return NextNameId++; }
 
   uint32_t addResource(const AST::Component::ResourceType *RT,
                        const Scope *Origin, bool FromImport) noexcept {
     uint32_t Id = static_cast<uint32_t>(Resources.size());
-    Resources.push_back({RT, Origin, FromImport, newNameId()});
+    Resources.push_back({RT, Origin, FromImport, nextNameId()});
     return Id;
   }
 
@@ -302,11 +342,10 @@ public:
   }
 
   // -------------------------------------------------------------------------
-  // Arenas for synthesized views.
+  // Storage the type system owns. Every view holds raw pointers into it.
   // -------------------------------------------------------------------------
 
-  /// Compose two remaps, Inner first, into one memoized table. This is safe
-  /// only because a leaf table is filled before anything composes it.
+  /// Compose two remaps, Inner first; a leaf table is filled before composed.
   const ResourceMap *composeRemap(const ResourceMap *Outer,
                                   const ResourceMap *Inner) noexcept {
     if (Outer == nullptr) {
@@ -320,9 +359,8 @@ public:
     if (It != RemapCompose.end()) {
       return It->second;
     }
-    auto *Node = &RemapArena.emplace_back();
-    // What Inner moves lands on its Outer image. What only Outer knows keeps
-    // that image. Everything else is already identity in both.
+    auto *Node = &OwnedRemaps.emplace_back();
+    // Inner's moves land on their Outer image; Outer-only entries keep theirs.
     for (const auto &[From, To] : Inner->Map) {
       Node->Map.emplace(From, Outer->apply(To));
     }
@@ -338,34 +376,67 @@ public:
     return M != nullptr ? M->apply(Id) : Id;
   }
 
-  CoreShape *newCoreShape() noexcept { return &CoreShapeArena.emplace_back(); }
-  Shape *newShape() noexcept { return &ShapeArena.emplace_back(); }
-  ResourceMap *newResourceMap() noexcept { return &RemapArena.emplace_back(); }
+  CoreShape *addCoreShape() noexcept { return &OwnedCoreShapes.emplace_back(); }
+  Shape *addShape() noexcept { return &OwnedShapes.emplace_back(); }
+  ResourceMap *addResourceMap() noexcept { return &OwnedRemaps.emplace_back(); }
 
-  /// Synthesize a core function type owned by the universe (canon lower and
-  /// the resource built-ins produce core funcs with no AST-backed type).
-  const AST::SubType *makeCoreFuncType(Span<const ValType> Params,
-                                       Span<const ValType> Results) noexcept {
-    SynthCoreTypes.push_back(
+  /// An owned core function type for canon lower and resource built-in funcs.
+  const AST::SubType *addCoreFuncType(Span<const ValType> Params,
+                                      Span<const ValType> Results) noexcept {
+    OwnedCoreTypes.push_back(
         std::make_unique<AST::SubType>(AST::FunctionType(Params, Results)));
-    return SynthCoreTypes.back().get();
+    return OwnedCoreTypes.back().get();
   }
 
   // -------------------------------------------------------------------------
-  // Normalization: the shared substrate of every walk below.
+  // Resolution: the shared substrate of every walk below.
   // -------------------------------------------------------------------------
 
-  /// Resolve through type-index and prim-alias indirections.
-  NormalVal normalizeValType(const QualValType &Q) noexcept;
-  NormalVal normalizeEntry(const TypeEntry &E) const noexcept;
-  /// Resolve a valtype's type index to its entry (nullptr for primitives or
-  /// out-of-bounds). Composes the view's remap into Storage.
+  /// Resolve a valtype's type index to its entry in Storage, nullptr if none.
   const TypeEntry *resolveQualType(const QualValType &Q,
                                    TypeEntry &Storage) noexcept;
+  /// The primitive a valtype denotes through aliases; nullopt for composites.
+  std::optional<AST::Component::PrimValType>
+  resolvePrimValType(const QualValType &Q) noexcept;
   /// Effective resource id behind an own/borrow handle index.
   std::optional<uint32_t> resolveResourceId(const Scope *Home,
                                             const ResourceMap *Remap,
                                             uint32_t Idx) const noexcept;
+
+  /// Calls Func on each nested value type; stream and future payloads excluded.
+  template <typename F>
+  void forEachValType(const AST::Component::DefValType &D, F &&Func) const {
+    if (D.isRecordTy()) {
+      for (const auto &LT : D.getRecord().LabelTypes) {
+        Func(LT.getValType());
+      }
+    } else if (D.isVariantTy()) {
+      for (const auto &[Label, Ty] : D.getVariant().Cases) {
+        if (Ty.has_value()) {
+          Func(*Ty);
+        }
+      }
+    } else if (D.isListTy()) {
+      Func(D.getList().ValTy);
+    } else if (D.isTupleTy()) {
+      for (const auto &Ty : D.getTuple().Types) {
+        Func(Ty);
+      }
+    } else if (D.isMapTy()) {
+      Func(D.getMap().KeyTy);
+      Func(D.getMap().ValTy);
+    } else if (D.isOptionTy()) {
+      Func(D.getOption().ValTy);
+    } else if (D.isResultTy()) {
+      const auto &R = D.getResult();
+      if (R.ValTy.has_value()) {
+        Func(*R.ValTy);
+      }
+      if (R.ErrTy.has_value()) {
+        Func(*R.ErrTy);
+      }
+    }
+  }
 
   // -------------------------------------------------------------------------
   // Resource-id walks.
@@ -386,10 +457,10 @@ public:
   // -------------------------------------------------------------------------
 
   static inline constexpr const uint64_t MaxTypeSize = 1000000;
-  uint64_t sizeOfExtern(const ExternInfo &Info) noexcept;
-  uint64_t depthOfExtern(const ExternInfo &Info) noexcept;
-  Expect<void> checkTypeSize(uint64_t Size) const noexcept;
-  Expect<void> checkTypeDepth(uint64_t Depth) const noexcept;
+  /// The reference engine bounds value-type nesting at 100.
+  static inline constexpr const uint64_t MaxTypeDepth = 100;
+  uint64_t getTypeSize(const ExternInfo &Info) noexcept;
+  uint64_t getTypeDepth(const ExternInfo &Info) noexcept;
   /// Both limits over one extern, the pairing every call site needs.
   Expect<void> checkTypeLimits(const ExternInfo &Info) noexcept;
 
@@ -400,62 +471,55 @@ public:
   static inline constexpr const uint32_t MaxFlatParams = 16;
   static inline constexpr const uint32_t MaxFlatAsyncParams = 4;
   static inline constexpr const uint32_t MaxFlatResults = 1;
-  /// Ceiling kept while flattening: past the largest limit above, every
-  /// consumer replaces the list, so more entries cannot change an outcome.
+  /// Flattening ceiling; past the largest limit every consumer replaces it.
   static inline constexpr const uint32_t MaxFlatExpand = MaxFlatParams + 1;
   /// Thread-local slots addressable by context.get/context.set.
   static inline constexpr const uint32_t MaxContextSlots = 2;
   /// Elements a fixed-length list may declare, as the reference validator.
   static inline constexpr const uint32_t MaxFixedListElems = 1U << 30;
 
-  /// Appends the flat core types of Q to Out, false on an invalid type. Ptr
-  /// is the index type of the selected canonical memory.
+  /// Appends Q's flat core types to Out, false if invalid; Ptr indexes memory.
   bool flattenValType(const QualValType &Q, std::vector<ValType> &Out,
                       const ValType &Ptr) noexcept;
   /// True iff the type transitively contains a list or string.
   bool needsMemory(const QualValType &Q) noexcept;
-  /// Flatten a function type into its core signature. The flags report which
-  /// side transitively needs a memory.
+  /// Flatten a function type; the flags report which side needs a memory.
   Expect<AST::FunctionType> flattenFuncType(const FuncInfo &FI,
                                             const ValType &Ptr,
                                             bool &ParamsNeedMemory,
                                             bool &ResultsNeedMemory) noexcept;
 
   // -------------------------------------------------------------------------
-  // Instantiation-time substitution. The instantiation itself lives on
-  // Context, which reads the index spaces to match the arguments.
+  // Instantiation-time substitution; the instantiation itself lives on Context.
   // -------------------------------------------------------------------------
 
-  /// Rebuild an instance view with fresh ids for the resources its own
-  /// declarations introduced. Origin owns them.
+  /// Rebuild an instance view with fresh Origin-owned ids for its resources.
   const Shape *freshenDeclaredResources(const Shape *Inst, const Scope &Origin,
                                         bool FromImport) noexcept;
-  /// The export view an instantiation produces: CI's exports rebuilt against
-  /// the combined substitution + freshening table.
+  /// The export view an instantiation produces: CI's exports rebuilt via Node.
   const Shape *rebuildInstanceExports(const Shape &CI,
                                       const ResourceMap *Node) noexcept;
 
   void reset() noexcept {
     NextNameId = 0;
     Resources.clear();
-    CoreShapeArena.clear();
-    ShapeArena.clear();
-    RemapArena.clear();
+    OwnedCoreShapes.clear();
+    OwnedShapes.clear();
+    OwnedRemaps.clear();
     RemapCompose.clear();
-    SynthCoreTypes.clear();
+    OwnedCoreTypes.clear();
     TypeSizeMemo.clear();
     TypeDepthMemo.clear();
   }
 
 private:
-  void collectNormalValResources(const NormalVal &N,
-                                 std::unordered_set<uint32_t> &Out) noexcept;
-  uint64_t sizeOfValType(const QualValType &Q) noexcept;
-  uint64_t sizeOfNormalVal(const NormalVal &N) noexcept;
-  uint64_t depthOfValType(const QualValType &Q) noexcept;
-  uint64_t depthOfNormalVal(const NormalVal &N) noexcept;
-  // Memo that keeps shape identity within one rebuild. This is per-rebuild
-  // state, so the code threads it rather than stores it.
+  void collectResources(const TypeEntry &E,
+                        std::unordered_set<uint32_t> &Out) noexcept;
+  uint64_t getTypeSize(const QualValType &Q) noexcept;
+  uint64_t getTypeSize(const TypeEntry &E) noexcept;
+  uint64_t getTypeDepth(const QualValType &Q) noexcept;
+  uint64_t getTypeDepth(const TypeEntry &E) noexcept;
+  // Memo keeping shape identity within one rebuild; threaded, never stored.
   using ShapeMemo = std::unordered_map<const Shape *, const Shape *>;
   ExternInfo rebuildExtern(const ExternInfo &E, const ResourceMap *Node,
                            ShapeMemo &Memo) noexcept;
@@ -466,20 +530,19 @@ private:
 
   uint32_t NextNameId = 0;
   std::vector<ResourceEntry> Resources;
-  std::deque<CoreShape> CoreShapeArena;
-  std::deque<Shape> ShapeArena;
-  std::deque<ResourceMap> RemapArena;
+  std::deque<CoreShape> OwnedCoreShapes;
+  std::deque<Shape> OwnedShapes;
+  std::deque<ResourceMap> OwnedRemaps;
   std::map<std::pair<const ResourceMap *, const ResourceMap *>,
            const ResourceMap *>
       RemapCompose;
-  std::vector<std::unique_ptr<AST::SubType>> SynthCoreTypes;
+  std::vector<std::unique_ptr<AST::SubType>> OwnedCoreTypes;
   std::unordered_map<const void *, uint64_t> TypeSizeMemo;
   std::unordered_map<const void *, uint64_t> TypeDepthMemo;
 };
 
 // ===========================================================================
-// The subtype relation. One matcher serves one match, and the caller then
-// reads its resource substitution and its failure reason.
+// The subtype relation; one matcher per match, then read substitution/reason.
 // ===========================================================================
 
 class Matcher {
@@ -488,15 +551,13 @@ public:
 
   /// MVP subtype relation: structural equality modulo resource identity.
   bool matchValType(const QualValType &Sub, const QualValType &Sup) noexcept;
-  bool matchNormalVal(const NormalVal &NSub, const NormalVal &NSup) noexcept;
+  bool matchValType(const TypeEntry &Sub, const TypeEntry &Sup) noexcept;
   bool matchExtern(const ExternInfo &Sub, const ExternInfo &Sup) noexcept;
-  /// Core externs carry no resource identity, so this needs neither the
-  /// substitution nor the failure reason.
+  /// Core externs carry no resource identity, so no substitution or reason.
   bool matchCoreExtern(const CoreExternInfo &Sub,
                        const CoreExternInfo &Sup) const noexcept;
 
-  /// Most specific reason the innermost failing matcher recorded. A site
-  /// falls back to its own generic mismatch code.
+  /// Most specific reason recorded; a site falls back to its own mismatch code.
   ErrCode::Value getFailCode() const noexcept { return FailCode; }
   /// Supertype-side abstract resource ids bound to subtype ids by the match.
   const ResourceMap &getSubst() const noexcept { return Subst; }
@@ -504,12 +565,11 @@ public:
 private:
   bool matchFunc(const FuncInfo &Sub, const FuncInfo &Sup) noexcept;
   bool matchTypeEntry(const TypeEntry &Sub, const TypeEntry &Sup) noexcept;
-  // Instances match on exports only. Components also match imports
-  // contravariantly, so the two relations stay separate.
+  // Instances match on exports only; components match imports contravariantly.
   bool matchInstanceShape(const Shape &Sub, const Shape &Sup) noexcept;
   bool matchComponentShape(const Shape &Sub, const Shape &Sup) noexcept;
-  bool matchCoreFuncType(const AST::SubType *Sub,
-                         const AST::SubType *Sup) const noexcept;
+  bool matchPrimValType(AST::Component::PrimValType Sub,
+                        AST::Component::PrimValType Sup) noexcept;
   // Drop a leaf reason. A nested failure reports its position instead.
   void clearLeafFailCode() noexcept;
 

--- a/include/validator/component_value_decode.h
+++ b/include/validator/component_value_decode.h
@@ -19,6 +19,7 @@
 #include "ast/component/type.h"
 #include "common/errcode.h"
 #include "common/types.h"
+#include "validator/component_types.h"
 
 #include <cmath>
 #include <cstring>
@@ -29,15 +30,11 @@ namespace WasmEdge {
 namespace Validator {
 namespace Component {
 
-using AST::Component::DefValType;
-using AST::Component::PrimValType;
-
-/// Decoder over the payload bytes of one value definition. The resolver maps
-/// a type index to its defined value type, or nullptr.
-template <typename ResolverT> class ValueDecoder {
+/// Decoder over one value definition's payload, resolving types in its scope.
+class ValueDecoder {
 public:
-  ValueDecoder(Span<const Byte> D, ResolverT &&R) noexcept
-      : Data(D), Resolve(std::forward<ResolverT>(R)) {}
+  ValueDecoder(Span<const Byte> D, const Scope &S) noexcept
+      : Data(D), Types(S) {}
 
   Expect<ComponentValVariant> decode(const ComponentValType &Ty) noexcept {
     EXPECTED_TRY(auto V, decodeVal(Ty));
@@ -82,8 +79,7 @@ private:
       EXPECTED_TRY(auto B, readByte());
       Result |= static_cast<uint64_t>(B & 0x7FU) << Shift;
       if ((B & 0x80U) == 0) {
-        // On the final byte, every bit above the value width must repeat the
-        // sign bit.
+        // On the final byte, every bit above the value width repeats the sign.
         const uint32_t Rest = MaxBits - Shift;
         if (Rest <= 7) {
           const uint8_t Mask =
@@ -107,57 +103,60 @@ private:
 
   Expect<ComponentValVariant> decodeVal(const ComponentValType &Ty) noexcept {
     if (Ty.isPrimValType()) {
-      return decodePrim(static_cast<PrimValType>(Ty.getCode()));
+      return decodePrim(static_cast<AST::Component::PrimValType>(Ty.getCode()));
     }
-    const DefValType *D = Resolve(Ty.getTypeIndex());
+    const auto *Entry = Types.getType(Ty.getTypeIndex());
+    const AST::Component::DefValType *D =
+        Entry != nullptr ? Entry->getDefValType() : nullptr;
     if (D == nullptr) {
       return Unexpect(ErrCode::Value::ComponentMalformedValue);
     }
     return decodeDef(*D);
   }
 
-  Expect<ComponentValVariant> decodePrim(PrimValType P) noexcept {
+  Expect<ComponentValVariant>
+  decodePrim(AST::Component::PrimValType P) noexcept {
     switch (P) {
-    case PrimValType::Bool: {
+    case AST::Component::PrimValType::Bool: {
       EXPECTED_TRY(auto B, readByte());
       if (B > 1) {
         return Unexpect(ErrCode::Value::ComponentMalformedValue);
       }
       return ComponentValVariant{B != 0};
     }
-    case PrimValType::U8: {
+    case AST::Component::PrimValType::U8: {
       EXPECTED_TRY(auto B, readByte());
       return ComponentValVariant{static_cast<uint8_t>(B)};
     }
-    case PrimValType::S8: {
+    case AST::Component::PrimValType::S8: {
       EXPECTED_TRY(auto B, readByte());
       return ComponentValVariant{static_cast<int8_t>(B)};
     }
-    case PrimValType::U16: {
+    case AST::Component::PrimValType::U16: {
       EXPECTED_TRY(auto V, readULEB(16));
       return ComponentValVariant{static_cast<uint16_t>(V)};
     }
-    case PrimValType::S16: {
+    case AST::Component::PrimValType::S16: {
       EXPECTED_TRY(auto V, readSLEB(16));
       return ComponentValVariant{static_cast<int16_t>(V)};
     }
-    case PrimValType::U32: {
+    case AST::Component::PrimValType::U32: {
       EXPECTED_TRY(auto V, readULEB(32));
       return ComponentValVariant{static_cast<uint32_t>(V)};
     }
-    case PrimValType::S32: {
+    case AST::Component::PrimValType::S32: {
       EXPECTED_TRY(auto V, readSLEB(32));
       return ComponentValVariant{static_cast<int32_t>(V)};
     }
-    case PrimValType::U64: {
+    case AST::Component::PrimValType::U64: {
       EXPECTED_TRY(auto V, readULEB(64));
       return ComponentValVariant{V};
     }
-    case PrimValType::S64: {
+    case AST::Component::PrimValType::S64: {
       EXPECTED_TRY(auto V, readSLEB(64));
       return ComponentValVariant{V};
     }
-    case PrimValType::F32: {
+    case AST::Component::PrimValType::F32: {
       uint32_t Bits = 0;
       for (uint32_t I = 0; I < 4; ++I) {
         EXPECTED_TRY(auto B, readByte());
@@ -170,7 +169,7 @@ private:
       }
       return ComponentValVariant{F};
     }
-    case PrimValType::F64: {
+    case AST::Component::PrimValType::F64: {
       uint64_t Bits = 0;
       for (uint32_t I = 0; I < 8; ++I) {
         EXPECTED_TRY(auto B, readByte());
@@ -183,11 +182,11 @@ private:
       }
       return ComponentValVariant{D};
     }
-    case PrimValType::Char: {
+    case AST::Component::PrimValType::Char: {
       EXPECTED_TRY(auto CP, readUtf8Scalar());
       return ComponentValVariant{CP};
     }
-    case PrimValType::String: {
+    case AST::Component::PrimValType::String: {
       EXPECTED_TRY(auto Len, readULEB(32));
       if (Len > Data.size() - Off) {
         return Unexpect(ErrCode::Value::ComponentMalformedValue);
@@ -247,7 +246,8 @@ private:
     return CP;
   }
 
-  Expect<ComponentValVariant> decodeDef(const DefValType &D) noexcept {
+  Expect<ComponentValVariant>
+  decodeDef(const AST::Component::DefValType &D) noexcept {
     if (D.isPrimValType()) {
       return decodePrim(D.getPrimValType());
     }
@@ -365,7 +365,7 @@ private:
   }
 
   Span<const Byte> Data;
-  ResolverT Resolve;
+  const Scope &Types;
   size_t Off = 0;
 };
 

--- a/include/validator/validator.h
+++ b/include/validator/validator.h
@@ -118,8 +118,7 @@ private:
                         Component::Shape &Out) noexcept;
   Expect<void> validate(const AST::Component::Export &Ex,
                         Component::Shape &Out) noexcept;
-  // Resolve + validate descriptors into typed views. Sub-resource type
-  // bounds allocate a fresh abstract resource id (import- or export-side).
+  // Resolve descriptors into typed views; a sub-resource bound gets a fresh id.
   Expect<void> validate(const AST::Component::CoreImportDesc &Desc,
                         Component::CoreExternInfo &Out) noexcept;
   Expect<void> validate(const AST::Component::ExternDesc &Desc, bool IsImport,

--- a/lib/executor/instantiate/import.cpp
+++ b/lib/executor/instantiate/import.cpp
@@ -34,22 +34,6 @@ auto logUnknownError(std::string_view ModName, std::string_view ExtName,
   return Unexpect(ErrCode::Value::UnknownImport);
 }
 
-bool matchLimit(const AST::Limit &Exp, const AST::Limit &Got) {
-  if (Exp.getAddrType() != Got.getAddrType()) {
-    return false;
-  }
-  if (Exp.isShared() != Got.isShared()) {
-    return false;
-  }
-  if ((Got.getMin() < Exp.getMin()) || (Exp.hasMax() && !Got.hasMax())) {
-    return false;
-  }
-  if (Exp.hasMax() && Got.hasMax() && Got.getMax() > Exp.getMax()) {
-    return false;
-  }
-  return true;
-}
-
 Expect<void>
 checkImportMatched(std::string_view ModName, std::string_view ExtName,
                    const ExternalType ExtType,
@@ -241,7 +225,7 @@ Expect<void> Executor::instantiate(
           !AST::TypeMatcher::matchType(
               ImpModInst->getTypeList(), ImpType.getRefType(),
               ModInst.getTypeList(), TabType.getRefType()) ||
-          !matchLimit(TabLim, ImpLim)) {
+          !AST::TypeMatcher::matchLimit(TabLim, ImpLim)) {
         return logMatchError(ModName, ExtName, ExtType, TabType.getRefType(),
                              TabLim.hasMax(), TabLim.getMin(), TabLim.getMax(),
                              ImpType.getRefType(), ImpLim.hasMax(),
@@ -259,7 +243,7 @@ Expect<void> Executor::instantiate(
       // description.
       auto *ImpInst = ImpModInst->findMemoryExports(ExtName);
       const auto &ImpLim = ImpInst->getMemoryType().getLimit();
-      if (!matchLimit(MemLim, ImpLim)) {
+      if (!AST::TypeMatcher::matchLimit(MemLim, ImpLim)) {
         return logMatchError(ModName, ExtName, ExtType, MemLim.hasMax(),
                              MemLim.getMin(), MemLim.getMax(), ImpLim.hasMax(),
                              ImpLim.getMin(), ImpLim.getMax());

--- a/lib/validator/component_canon.cpp
+++ b/lib/validator/component_canon.cpp
@@ -18,8 +18,7 @@ namespace Validator {
 
 using namespace std::literals;
 
-// canon ::= lift | lower | resource.* | async built-in. One switch covers
-// every opcode; checks shared between opcodes are lambdas over this scope.
+// canon ::= lift | lower | resource.* | async built-in, one switch per opcode.
 Expect<void>
 Validator::validate(const AST::Component::Canonical &Canon) noexcept {
   auto &S = CompCtx.top();
@@ -29,16 +28,18 @@ Validator::validate(const AST::Component::Canonical &Canon) noexcept {
   // Defines the core function a canonical definition lowers to.
   auto PushCoreFunc = [&](std::vector<ValType> Params,
                           std::vector<ValType> Results) -> Expect<void> {
-    S.CoreFuncs.push_back(CompTypes.makeCoreFuncType(Params, Results));
+    S.addCoreFunc(CompTypes.addCoreFuncType(Params, Results));
     return {};
   };
-
-  auto HasOpt = [&Canon](ComponentCanonOptCode Code) noexcept {
-    return Component::Context::hasOption(Canon, Code);
+  // A built-in takes its core type from the shared table, keyed on Addr.
+  auto PushBuiltin = [&](const ValType &Addr) -> Expect<void> {
+    auto [Params, Results] = AST::Component::Canonical::getBuiltinCoreFuncType(
+        Canon.getOpCode(), Addr);
+    return PushCoreFunc(std::move(Params), std::move(Results));
   };
 
   // The resource built-ins take no options and name a resource type.
-  auto ResourceEntryAt =
+  auto GetResourceEntry =
       [&](std::string_view What) -> Expect<const Component::TypeEntry *> {
     if (!Canon.getOptions().empty()) {
       spdlog::error(ErrCode::Value::CanonOptionOnBuiltin);
@@ -52,7 +53,7 @@ Validator::validate(const AST::Component::Canonical &Canon) noexcept {
                     Canon.getIndex());
       return Unexpect(ErrCode::Value::ComponentTypeIndexOutOfBounds);
     }
-    if (!Entry->ResourceId.has_value()) {
+    if (!Entry->isResource()) {
       spdlog::error(ErrCode::Value::ComponentNotResourceType);
       spdlog::error("    {} type index {} is not a resource."sv, What,
                     Canon.getIndex());
@@ -61,10 +62,9 @@ Validator::validate(const AST::Component::Canonical &Canon) noexcept {
     return Entry;
   };
 
-  // resource.new / resource.rep additionally need the resource to be defined
-  // here, and derive their core signature from its representation.
+  // resource.new / resource.rep need a locally-defined resource and its rep.
   auto LocalResourceRep = [&](std::string_view What) -> Expect<ValType> {
-    EXPECTED_TRY(const auto *Entry, ResourceEntryAt(What));
+    EXPECTED_TRY(const auto *Entry, GetResourceEntry(What));
     const auto &Res = CompTypes.getResource(*Entry->ResourceId);
     if (Res.RT == nullptr || Res.Origin != &S) {
       spdlog::error(ErrCode::Value::ComponentNotLocalResource);
@@ -78,10 +78,9 @@ Validator::validate(const AST::Component::Canonical &Canon) noexcept {
   auto CheckTypeImmediate =
       [&](bool WantStream) -> Expect<const Component::TypeEntry *> {
     const auto *Entry = S.getType(Canon.getIndex());
-    const bool Ok = Entry != nullptr && Entry->DT != nullptr &&
-                    Entry->DT->isDefValType() &&
-                    (WantStream ? Entry->DT->getDefValType().isStreamTy()
-                                : Entry->DT->getDefValType().isFutureTy());
+    const auto *Def = Entry != nullptr ? Entry->getDefValType() : nullptr;
+    const bool Ok =
+        Def != nullptr && (WantStream ? Def->isStreamTy() : Def->isFutureTy());
     if (!Ok) {
       spdlog::error(ErrCode::Value::InvalidTypeReference);
       spdlog::error("    Built-in type index {} does not refer to a {} "
@@ -92,29 +91,16 @@ Validator::validate(const AST::Component::Canonical &Canon) noexcept {
     return Entry;
   };
 
-  // The option-bearing built-ins are all lowerings, so post-return and
-  // callback are rejected; memory and realloc are required only where the
-  // Explainer's built-in table demands them.
+  // Option-bearing built-ins are lowerings: no post-return or callback.
   auto BuiltinOptions = [&](bool NeedMemory, bool NeedRealloc) -> Expect<void> {
     EXPECTED_TRY(CompCtx.checkOptions(Canon, false));
-    if (NeedMemory && !HasOpt(ComponentCanonOptCode::Memory)) {
-      spdlog::error(ErrCode::Value::CanonMemoryRequired);
-      spdlog::error("    this canonical built-in requires the memory "
-                    "option."sv);
-      return Unexpect(ErrCode::Value::CanonMemoryRequired);
-    }
-    if (NeedRealloc && !HasOpt(ComponentCanonOptCode::Realloc)) {
-      spdlog::error(ErrCode::Value::CanonReallocRequired);
-      spdlog::error("    this canonical built-in requires the realloc "
-                    "option."sv);
-      return Unexpect(ErrCode::Value::CanonReallocRequired);
-    }
-    return {};
+    return CompCtx.requireOptions(Canon, NeedMemory, NeedRealloc,
+                                  "this canonical built-in"sv);
   };
 
   // Built-ins the spec restricts to synchronous use.
   auto RequireSync = [&]() -> Expect<void> {
-    if (HasOpt(ComponentCanonOptCode::Async)) {
+    if (Canon.hasOption(ComponentCanonOptCode::Async)) {
       spdlog::error(ErrCode::Value::CanonAsyncOnBuiltin);
       spdlog::error("    this canonical built-in is always synchronous."sv);
       return Unexpect(ErrCode::Value::CanonAsyncOnBuiltin);
@@ -133,34 +119,34 @@ Validator::validate(const AST::Component::Canonical &Canon) noexcept {
                     Canon.getTargetIndex());
       return Unexpect(ErrCode::Value::ComponentTypeIndexOutOfBounds);
     }
-    if (Entry->DT == nullptr || !Entry->DT->isFuncType()) {
+    if (Entry->getFuncType() == nullptr) {
       spdlog::error(ErrCode::Value::ComponentNotFunctionType);
       spdlog::error("    canon lift type index {} is not a function type."sv,
                     Canon.getTargetIndex());
       return Unexpect(ErrCode::Value::ComponentNotFunctionType);
     }
-    const Component::FuncInfo FI{&Entry->DT->getFuncType(), Entry->Home,
+    const Component::FuncInfo FI{Entry->getFuncType(), Entry->Home,
                                  Entry->Remap};
     EXPECTED_TRY(CompCtx.checkOptions(Canon, true));
-    const bool AsyncOpt = HasOpt(ComponentCanonOptCode::Async);
+    const bool AsyncOpt = Canon.hasOption(ComponentCanonOptCode::Async);
     if (AsyncOpt && !FI.FT->isAsync()) {
       spdlog::error(ErrCode::Value::CanonAsyncRequiresAsyncType);
       spdlog::error("    canon lift with `async` needs `(func async ...)`."sv);
       return Unexpect(ErrCode::Value::CanonAsyncRequiresAsyncType);
     }
-    if (HasOpt(ComponentCanonOptCode::Callback) && !AsyncOpt) {
+    if (Canon.hasOption(ComponentCanonOptCode::Callback) && !AsyncOpt) {
       spdlog::error(ErrCode::Value::CanonCallbackRequiresAsync);
       spdlog::error("    the `callback` option requires the `async` option."sv);
       return Unexpect(ErrCode::Value::CanonCallbackRequiresAsync);
     }
-    if (AsyncOpt && HasOpt(ComponentCanonOptCode::PostReturn)) {
+    if (AsyncOpt && Canon.hasOption(ComponentCanonOptCode::PostReturn)) {
       spdlog::error(ErrCode::Value::CanonPostReturnWithAsync);
       spdlog::error("    cannot specify post-return function in combination "
                     "with async."sv);
       return Unexpect(ErrCode::Value::CanonPostReturnWithAsync);
     }
 
-    const ValType Ptr = CompCtx.canonPtrType(Canon);
+    const ValType Ptr = CompCtx.getCanonPtrType(Canon);
     EXPECTED_TRY(auto Sig, CompTypes.flattenFuncType(FI, Ptr, ParamsNeedMemory,
                                                      ResultsNeedMemory));
     const bool ParamsIndirect =
@@ -171,29 +157,20 @@ Validator::validate(const AST::Component::Canonical &Canon) noexcept {
       Sig.getParamTypes().assign(1, Ptr);
     }
     if (AsyncOpt) {
-      // Async lift. The core function returns the packed callback code, or
-      // nothing when stackful. The results flow through task.return.
+      // Async lift returns the packed callback code, or nothing when stackful.
       Sig.getReturnTypes().clear();
-      if (HasOpt(ComponentCanonOptCode::Callback)) {
+      if (Canon.hasOption(ComponentCanonOptCode::Callback)) {
         Sig.getReturnTypes().push_back(I32V);
       }
     } else if (ResultsIndirect) {
       Sig.getReturnTypes().assign(1, Ptr);
     }
     // Required options: lifting params lowers them into the callee's memory.
-    if ((ParamsNeedMemory || ParamsIndirect ||
-         (!AsyncOpt && (ResultsNeedMemory || ResultsIndirect))) &&
-        !HasOpt(ComponentCanonOptCode::Memory)) {
-      spdlog::error(ErrCode::Value::CanonMemoryRequired);
-      spdlog::error("    canon lift requires the memory option."sv);
-      return Unexpect(ErrCode::Value::CanonMemoryRequired);
-    }
-    if ((ParamsNeedMemory || ParamsIndirect) &&
-        !HasOpt(ComponentCanonOptCode::Realloc)) {
-      spdlog::error(ErrCode::Value::CanonReallocRequired);
-      spdlog::error("    canon lift requires the realloc option."sv);
-      return Unexpect(ErrCode::Value::CanonReallocRequired);
-    }
+    EXPECTED_TRY(CompCtx.requireOptions(
+        Canon,
+        ParamsNeedMemory || ParamsIndirect ||
+            (!AsyncOpt && (ResultsNeedMemory || ResultsIndirect)),
+        ParamsNeedMemory || ParamsIndirect, "canon lift"sv));
 
     // The callee must have exactly the flattened core type.
     const auto *Callee = S.getCoreFunc(Canon.getIndex());
@@ -242,7 +219,7 @@ Validator::validate(const AST::Component::Canonical &Canon) noexcept {
       }
     }
 
-    S.Funcs.push_back(FI);
+    S.addFunc(FI);
     return {};
   }
 
@@ -255,7 +232,7 @@ Validator::validate(const AST::Component::Canonical &Canon) noexcept {
       return Unexpect(ErrCode::Value::ComponentFunctionIndexOutOfBounds);
     }
     EXPECTED_TRY(CompCtx.checkOptions(Canon, false));
-    const bool AsyncOpt = HasOpt(ComponentCanonOptCode::Async);
+    const bool AsyncOpt = Canon.hasOption(ComponentCanonOptCode::Async);
     if (FI->FT == nullptr) {
       spdlog::error(ErrCode::Value::InvalidTypeReference);
       return Unexpect(ErrCode::Value::InvalidTypeReference);
@@ -266,7 +243,7 @@ Validator::validate(const AST::Component::Canonical &Canon) noexcept {
       return Unexpect(ErrCode::Value::CanonAsyncRequiresAsyncType);
     }
 
-    const ValType Ptr = CompCtx.canonPtrType(Canon);
+    const ValType Ptr = CompCtx.getCanonPtrType(Canon);
     EXPECTED_TRY(auto Sig, CompTypes.flattenFuncType(*FI, Ptr, ParamsNeedMemory,
                                                      ResultsNeedMemory));
     const bool ParamsIndirect =
@@ -289,18 +266,10 @@ Validator::validate(const AST::Component::Canonical &Canon) noexcept {
       // Async lower: the core function returns the packed subtask state.
       Sig.getReturnTypes().assign(1, I32V);
     }
-    if ((ParamsNeedMemory || ResultsNeedMemory || ParamsIndirect ||
-         ResultsIndirect) &&
-        !HasOpt(ComponentCanonOptCode::Memory)) {
-      spdlog::error(ErrCode::Value::CanonMemoryRequired);
-      spdlog::error("    canon lower requires the memory option."sv);
-      return Unexpect(ErrCode::Value::CanonMemoryRequired);
-    }
-    if (ResultsNeedMemory && !HasOpt(ComponentCanonOptCode::Realloc)) {
-      spdlog::error(ErrCode::Value::CanonReallocRequired);
-      spdlog::error("    canon lower requires the realloc option."sv);
-      return Unexpect(ErrCode::Value::CanonReallocRequired);
-    }
+    EXPECTED_TRY(CompCtx.requireOptions(Canon,
+                                        ParamsNeedMemory || ResultsNeedMemory ||
+                                            ParamsIndirect || ResultsIndirect,
+                                        ResultsNeedMemory, "canon lower"sv));
     return PushCoreFunc(Sig.getParamTypes(), Sig.getReturnTypes());
   }
 
@@ -313,27 +282,25 @@ Validator::validate(const AST::Component::Canonical &Canon) noexcept {
     return PushCoreFunc({I32V}, {Rep});
   }
   case ComponentCanonOpCode::Resource__drop:
-    EXPECTED_TRY(ResourceEntryAt("resource.drop"sv));
+    EXPECTED_TRY(GetResourceEntry("resource.drop"sv));
     return PushCoreFunc({I32V}, {});
 
-  // Async built-ins: type immediates and the core signatures derived from the
-  // Explainer's canonical built-in tables.
+  // Async built-ins take their core signatures from the shared table.
   case ComponentCanonOpCode::Backpressure__inc:
   case ComponentCanonOpCode::Backpressure__dec:
-    return PushCoreFunc({}, {});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Thread__index:
-    return PushCoreFunc({}, {I32V});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Task__return: {
-    // The declared results lower as the core parameters. The caller owns the
-    // storage they are read from, so task.return never reallocates.
+    // The results lower as the core parameters; task.return never reallocates.
     EXPECTED_TRY(CompCtx.checkOptions(Canon, false));
-    if (HasOpt(ComponentCanonOptCode::Realloc)) {
+    if (Canon.hasOption(ComponentCanonOptCode::Realloc)) {
       spdlog::error(ErrCode::Value::CanonReallocOnBuiltin);
       spdlog::error("    realloc cannot be specified for task.return."sv);
       return Unexpect(ErrCode::Value::CanonReallocOnBuiltin);
     }
     EXPECTED_TRY(RequireSync());
-    const ValType Ptr = CompCtx.canonPtrType(Canon);
+    const ValType Ptr = CompCtx.getCanonPtrType(Canon);
     std::vector<ValType> Params;
     for (const auto &R : Canon.getResultList()) {
       const Component::QualValType Q{R.getValType(), &S, nullptr};
@@ -347,21 +314,17 @@ Validator::validate(const AST::Component::Canonical &Canon) noexcept {
       Params.assign(1, Ptr);
       ParamsNeedMemory = true;
     }
-    if (ParamsNeedMemory && !HasOpt(ComponentCanonOptCode::Memory)) {
-      spdlog::error(ErrCode::Value::CanonMemoryRequired);
-      spdlog::error("    task.return requires the memory option."sv);
-      return Unexpect(ErrCode::Value::CanonMemoryRequired);
-    }
+    EXPECTED_TRY(CompCtx.requireOptions(Canon, ParamsNeedMemory, false,
+                                        "task.return"sv));
     return PushCoreFunc(std::move(Params), {});
   }
   case ComponentCanonOpCode::Task__cancel:
-    return PushCoreFunc({}, {});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Context__get:
   case ComponentCanonOpCode::Context__set: {
     const bool IsGet = Canon.getOpCode() == ComponentCanonOpCode::Context__get;
     const std::string_view Name = IsGet ? "context.get"sv : "context.set"sv;
-    // The spec restricts the thread-local slot to be less than 2. The loader
-    // stores the slot immediate as the constant value, not as an index.
+    // The slot immediate is stored as the constant value, not as an index.
     if (Canon.getConstVal() >= Component::TypeSystem::MaxContextSlots) {
       spdlog::error(ErrCode::Value::ComponentContextSlotOutOfBounds);
       spdlog::error(
@@ -396,69 +359,69 @@ Validator::validate(const AST::Component::Canonical &Canon) noexcept {
     return PushCoreFunc({Ty}, {});
   }
   case ComponentCanonOpCode::Yield:
-    return PushCoreFunc({}, {I32V});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Subtask__cancel:
-    return PushCoreFunc({I32V}, {I32V});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Subtask__drop:
-    return PushCoreFunc({I32V}, {});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Stream__new:
     EXPECTED_TRY(CheckTypeImmediate(true));
-    return PushCoreFunc({}, {I64V});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Stream__read:
   case ComponentCanonOpCode::Stream__write: {
     EXPECTED_TRY(const auto *Entry, CheckTypeImmediate(true));
-    const auto &Elem = Entry->DT->getDefValType().getStream().ValTy;
+    const auto &Elem = Entry->getDefValType()->getStream().ValTy;
     // Reading a payload that allocates needs realloc; writing never does.
     const bool NeedRealloc =
         Canon.getOpCode() == ComponentCanonOpCode::Stream__read &&
         Elem.has_value() &&
         CompTypes.needsMemory({*Elem, Entry->Home, Entry->Remap});
     EXPECTED_TRY(BuiltinOptions(Elem.has_value(), NeedRealloc));
-    return PushCoreFunc({I32V, I32V, I32V}, {I32V});
+    return PushBuiltin(CompCtx.getCanonPtrType(Canon));
   }
   case ComponentCanonOpCode::Stream__cancel_read:
   case ComponentCanonOpCode::Stream__cancel_write:
     EXPECTED_TRY(CheckTypeImmediate(true));
-    return PushCoreFunc({I32V}, {I32V});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Stream__drop_readable:
   case ComponentCanonOpCode::Stream__drop_writable:
     EXPECTED_TRY(CheckTypeImmediate(true));
-    return PushCoreFunc({I32V}, {});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Future__new:
     EXPECTED_TRY(CheckTypeImmediate(false));
-    return PushCoreFunc({}, {I64V});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Future__read:
   case ComponentCanonOpCode::Future__write: {
     EXPECTED_TRY(const auto *Entry, CheckTypeImmediate(false));
-    const auto &Elem = Entry->DT->getDefValType().getFuture().ValTy;
+    const auto &Elem = Entry->getDefValType()->getFuture().ValTy;
     // Reading a payload that allocates needs realloc; writing never does.
     const bool NeedRealloc =
         Canon.getOpCode() == ComponentCanonOpCode::Future__read &&
         Elem.has_value() &&
         CompTypes.needsMemory({*Elem, Entry->Home, Entry->Remap});
     EXPECTED_TRY(BuiltinOptions(Elem.has_value(), NeedRealloc));
-    return PushCoreFunc({I32V, I32V}, {I32V});
+    return PushBuiltin(CompCtx.getCanonPtrType(Canon));
   }
   case ComponentCanonOpCode::Future__cancel_read:
   case ComponentCanonOpCode::Future__cancel_write:
     EXPECTED_TRY(CheckTypeImmediate(false));
-    return PushCoreFunc({I32V}, {I32V});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Future__drop_readable:
   case ComponentCanonOpCode::Future__drop_writable:
     EXPECTED_TRY(CheckTypeImmediate(false));
-    return PushCoreFunc({I32V}, {});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Error_context__new:
     EXPECTED_TRY(BuiltinOptions(true, false));
     EXPECTED_TRY(RequireSync());
-    return PushCoreFunc({I32V, I32V}, {I32V});
+    return PushBuiltin(CompCtx.getCanonPtrType(Canon));
   case ComponentCanonOpCode::Error_context__debug_message:
     EXPECTED_TRY(BuiltinOptions(true, true));
     EXPECTED_TRY(RequireSync());
-    return PushCoreFunc({I32V, I32V}, {});
+    return PushBuiltin(CompCtx.getCanonPtrType(Canon));
   case ComponentCanonOpCode::Error_context__drop:
-    return PushCoreFunc({I32V}, {});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Waitable_set__new:
-    return PushCoreFunc({}, {I32V});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Waitable_set__wait:
   case ComponentCanonOpCode::Waitable_set__poll: {
     if (Canon.getIndex() >= S.CoreMemories.size()) {
@@ -472,15 +435,14 @@ Validator::validate(const AST::Component::Canonical &Canon) noexcept {
     const ValType Addr =
         ValType(Mem != nullptr && Mem->getLimit().is64() ? TypeCode::I64
                                                          : TypeCode::I32);
-    return PushCoreFunc({I32V, Addr}, {I32V});
+    return PushBuiltin(Addr);
   }
   case ComponentCanonOpCode::Waitable_set__drop:
-    return PushCoreFunc({I32V}, {});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Waitable__join:
-    return PushCoreFunc({I32V, I32V}, {});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Thread__new_indirect: {
-    // The type immediate must be a core (func (param i32)) shape and the
-    // target a core table.
+    // The start type must be (func (param i32)) and the target a core table.
     const auto *CT = S.getCoreType(Canon.getIndex());
     const bool TypeOk =
         CT != nullptr && CT->Func != nullptr &&
@@ -500,17 +462,21 @@ Validator::validate(const AST::Component::Canonical &Canon) noexcept {
                     Canon.getTargetIndex());
       return Unexpect(ErrCode::Value::DefTypeIndexOutOfBounds);
     }
-    return PushCoreFunc({I32V, I32V}, {I32V});
+    // The thread index carries the address type of the table.
+    const auto *Tab = S.CoreTables[Canon.getTargetIndex()];
+    return PushBuiltin(ValType(Tab != nullptr && Tab->getLimit().is64()
+                                   ? TypeCode::I64
+                                   : TypeCode::I32));
   }
   case ComponentCanonOpCode::Thread__resume_later:
-    return PushCoreFunc({I32V}, {});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Thread__suspend:
-    return PushCoreFunc({}, {I32V});
+    return PushBuiltin(I32V);
   case ComponentCanonOpCode::Thread__suspend_then_resume:
   case ComponentCanonOpCode::Thread__yield_then_resume:
   case ComponentCanonOpCode::Thread__suspend_then_promote:
   case ComponentCanonOpCode::Thread__yield_then_promote:
-    return PushCoreFunc({I32V}, {I32V});
+    return PushBuiltin(I32V);
   default:
     spdlog::error(ErrCode::Value::ComponentNotImplValidator);
     spdlog::error("    canonical built-in {} is not supported yet."sv,

--- a/lib/validator/component_context.cpp
+++ b/lib/validator/component_context.cpp
@@ -30,24 +30,24 @@ using namespace std::literals;
 
 void Context::defineExtern(const ExternInfo &Info) noexcept {
   auto &S = top();
-  switch (Info.K) {
+  switch (Info.Kind) {
   case ExternKind::CoreType:
-    S.CoreModules.push_back(Info.CoreMod);
+    S.addCoreModule(Info.CoreMod);
     break;
   case ExternKind::FuncType:
-    S.Funcs.push_back(Info.Func);
+    S.addFunc(Info.Func);
     break;
   case ExternKind::ValueBound:
-    S.Values.push_back({Info.Value, false});
+    S.addValue(Info.Value);
     break;
   case ExternKind::TypeBound:
-    S.Types.push_back(Info.Type);
+    S.addType(Info.Type);
     break;
   case ExternKind::InstanceType:
-    S.Instances.push_back(Info.Shape);
+    S.addInstance(Info.Shape);
     break;
   case ExternKind::ComponentType:
-    S.Components.push_back(Info.Shape);
+    S.addComponent(Info.Shape);
     break;
   }
 }
@@ -67,7 +67,7 @@ Context::resolveSortIndex(const AST::Component::SortIndex &SI) noexcept {
                       Idx, S.CoreModules.size());
         return Unexpect(ErrCode::Value::DefTypeIndexOutOfBounds);
       }
-      Info.K = ExternKind::CoreType;
+      Info.Kind = ExternKind::CoreType;
       Info.CoreMod = Mod;
       return Info;
     }
@@ -85,7 +85,7 @@ Context::resolveSortIndex(const AST::Component::SortIndex &SI) noexcept {
                     S.Funcs.size());
       return Unexpect(ErrCode::Value::DefTypeIndexOutOfBounds);
     }
-    Info.K = ExternKind::FuncType;
+    Info.Kind = ExternKind::FuncType;
     Info.Func = *F;
     return Info;
   }
@@ -96,7 +96,7 @@ Context::resolveSortIndex(const AST::Component::SortIndex &SI) noexcept {
                     S.Values.size());
       return Unexpect(ErrCode::Value::DefTypeIndexOutOfBounds);
     }
-    Info.K = ExternKind::ValueBound;
+    Info.Kind = ExternKind::ValueBound;
     Info.Value = S.Values[Idx].Type;
     return Info;
   }
@@ -108,7 +108,7 @@ Context::resolveSortIndex(const AST::Component::SortIndex &SI) noexcept {
                     S.Types.size());
       return Unexpect(ErrCode::Value::ComponentTypeIndexOutOfBounds);
     }
-    Info.K = ExternKind::TypeBound;
+    Info.Kind = ExternKind::TypeBound;
     Info.Type = *E;
     return Info;
   }
@@ -120,7 +120,7 @@ Context::resolveSortIndex(const AST::Component::SortIndex &SI) noexcept {
                     S.Components.size());
       return Unexpect(ErrCode::Value::DefTypeIndexOutOfBounds);
     }
-    Info.K = ExternKind::ComponentType;
+    Info.Kind = ExternKind::ComponentType;
     Info.Shape = C;
     return Info;
   }
@@ -132,7 +132,7 @@ Context::resolveSortIndex(const AST::Component::SortIndex &SI) noexcept {
                     S.Instances.size());
       return Unexpect(ErrCode::Value::DefTypeIndexOutOfBounds);
     }
-    Info.K = ExternKind::InstanceType;
+    Info.Kind = ExternKind::InstanceType;
     Info.Shape = I;
     return Info;
   }
@@ -142,14 +142,13 @@ Context::resolveSortIndex(const AST::Component::SortIndex &SI) noexcept {
   }
 }
 
-// External view of an inline core module: its imports in order and the
-// resolved types of its exports.
+// External view of an inline core module: its imports and export types.
 Expect<const CoreShape *>
 Context::buildCoreShape(const AST::Module &Mod) noexcept {
-  auto *Info = Types.newCoreShape();
+  auto *Info = Types.addCoreShape();
   const auto &ModTypes = Mod.getTypeSection().getContent();
 
-  auto TypeAt = [&ModTypes](uint32_t Idx) noexcept -> const AST::SubType * {
+  auto GetSubType = [&ModTypes](uint32_t Idx) noexcept -> const AST::SubType * {
     return Idx < ModTypes.size() ? &ModTypes[Idx] : nullptr;
   };
 
@@ -159,28 +158,25 @@ Context::buildCoreShape(const AST::Module &Mod) noexcept {
     CoreExternInfo Ext;
     switch (Imp.getExternalType()) {
     case ExternalType::Function:
-      Ext = {ExternalType::Function, TypeAt(Imp.getExternalFuncTypeIdx()),
-             nullptr, nullptr, nullptr};
+      Ext = CoreExternInfo(ExternalType::Function,
+                           GetSubType(Imp.getExternalFuncTypeIdx()));
       Funcs.push_back(Ext);
       break;
     case ExternalType::Table:
-      Ext = {ExternalType::Table, nullptr, &Imp.getExternalTableType(), nullptr,
-             nullptr};
+      Ext = CoreExternInfo(&Imp.getExternalTableType());
       Tables.push_back(Ext);
       break;
     case ExternalType::Memory:
-      Ext = {ExternalType::Memory, nullptr, nullptr,
-             &Imp.getExternalMemoryType(), nullptr};
+      Ext = CoreExternInfo(&Imp.getExternalMemoryType());
       Memories.push_back(Ext);
       break;
     case ExternalType::Global:
-      Ext = {ExternalType::Global, nullptr, nullptr, nullptr,
-             &Imp.getExternalGlobalType()};
+      Ext = CoreExternInfo(&Imp.getExternalGlobalType());
       Globals.push_back(Ext);
       break;
     case ExternalType::Tag:
-      Ext = {ExternalType::Tag, TypeAt(Imp.getExternalTagType().getTypeIdx()),
-             nullptr, nullptr, nullptr};
+      Ext = CoreExternInfo(ExternalType::Tag,
+                           GetSubType(Imp.getExternalTagType().getTypeIdx()));
       Tags.push_back(Ext);
       break;
     default:
@@ -198,23 +194,19 @@ Context::buildCoreShape(const AST::Module &Mod) noexcept {
                                std::string(Imp.getExternalName()), Ext);
   }
   for (const auto TIdx : Mod.getFunctionSection().getContent()) {
-    Funcs.push_back(
-        {ExternalType::Function, TypeAt(TIdx), nullptr, nullptr, nullptr});
+    Funcs.emplace_back(ExternalType::Function, GetSubType(TIdx));
   }
   for (const auto &Seg : Mod.getTableSection().getContent()) {
-    Tables.push_back(
-        {ExternalType::Table, nullptr, &Seg.getTableType(), nullptr, nullptr});
+    Tables.emplace_back(&Seg.getTableType());
   }
   for (const auto &MT : Mod.getMemorySection().getContent()) {
-    Memories.push_back({ExternalType::Memory, nullptr, nullptr, &MT, nullptr});
+    Memories.emplace_back(&MT);
   }
   for (const auto &Seg : Mod.getGlobalSection().getContent()) {
-    Globals.push_back({ExternalType::Global, nullptr, nullptr, nullptr,
-                       &Seg.getGlobalType()});
+    Globals.emplace_back(&Seg.getGlobalType());
   }
   for (const auto &TT : Mod.getTagSection().getContent()) {
-    Tags.push_back({ExternalType::Tag, TypeAt(TT.getTypeIdx()), nullptr,
-                    nullptr, nullptr});
+    Tags.emplace_back(ExternalType::Tag, GetSubType(TT.getTypeIdx()));
   }
 
   for (const auto &Exp : Mod.getExportSection().getContent()) {
@@ -263,28 +255,20 @@ Context::buildCoreShape(const AST::Module &Mod) noexcept {
 // Canonical options.
 // ---------------------------------------------------------------------------
 
-bool Context::hasOption(const AST::Component::Canonical &Canon,
-                        ComponentCanonOptCode Code) noexcept {
-  for (const auto &Opt : Canon.getOptions()) {
-    if (Opt.getCode() == Code) {
-      return true;
-    }
-  }
-  return false;
-}
-
-bool Context::canonMemoryIs64(
+ValType Context::getCanonPtrType(
     const AST::Component::Canonical &Canon) const noexcept {
   for (const auto &Opt : Canon.getOptions()) {
     if (Opt.getCode() == ComponentCanonOptCode::Memory) {
       const uint32_t Idx = Opt.getIndex();
       if (Idx < top().CoreMemories.size()) {
         const auto *Mem = top().CoreMemories[Idx];
-        return Mem != nullptr && Mem->getLimit().is64();
+        return ValType(Mem != nullptr && Mem->getLimit().is64()
+                           ? TypeCode::I64
+                           : TypeCode::I32);
       }
     }
   }
-  return false;
+  return ValType(TypeCode::I32);
 }
 
 Expect<void> Context::checkOptions(const AST::Component::Canonical &Canon,
@@ -294,7 +278,7 @@ Expect<void> Context::checkOptions(const AST::Component::Canonical &Canon,
   bool SeenEncoding = false, SeenMemory = false, SeenRealloc = false,
        SeenPostReturn = false, SeenAsync = false, SeenCallback = false;
   // The pointer width of realloc follows the selected memory.
-  const ValType Ptr = canonPtrType(Canon);
+  const ValType Ptr = getCanonPtrType(Canon);
   for (const auto &Opt : Canon.getOptions()) {
     switch (Opt.getCode()) {
     case ComponentCanonOptCode::Encode_UTF8:
@@ -338,8 +322,7 @@ Expect<void> Context::checkOptions(const AST::Component::Canonical &Canon,
             Opt.getIndex());
         return Unexpect(ErrCode::Value::InvalidIndex);
       }
-      // realloc must have type [ptr ptr ptr ptr] -> [ptr], where ptr is the
-      // index type of the selected memory.
+      // realloc has type [ptr ptr ptr ptr] -> [ptr] for the selected memory.
       const std::vector<ValType> ReallocParams(4, Ptr);
       const std::vector<ValType> ReallocResults(1, Ptr);
       const auto &CT = Func->getCompositeType();
@@ -420,6 +403,22 @@ Expect<void> Context::checkOptions(const AST::Component::Canonical &Canon,
   return {};
 }
 
+Expect<void> Context::requireOptions(const AST::Component::Canonical &Canon,
+                                     bool NeedMemory, bool NeedRealloc,
+                                     std::string_view What) const noexcept {
+  if (NeedMemory && !Canon.hasOption(ComponentCanonOptCode::Memory)) {
+    spdlog::error(ErrCode::Value::CanonMemoryRequired);
+    spdlog::error("    {} requires the memory option."sv, What);
+    return Unexpect(ErrCode::Value::CanonMemoryRequired);
+  }
+  if (NeedRealloc && !Canon.hasOption(ComponentCanonOptCode::Realloc)) {
+    spdlog::error(ErrCode::Value::CanonReallocRequired);
+    spdlog::error("    {} requires the realloc option."sv, What);
+    return Unexpect(ErrCode::Value::CanonReallocRequired);
+  }
+  return {};
+}
+
 // ---------------------------------------------------------------------------
 // Name grammar and strong uniqueness.
 // ---------------------------------------------------------------------------
@@ -483,8 +482,7 @@ NameRecord Context::makeNameRecord(const ExternName &Name) const noexcept {
     R.StrippedExact = std::string(Name.getOriginalName());
     break;
   }
-  // Case-folding models the acronym rule, which applies only to labels and
-  // interface names. Dep, url, and integrity names compare exactly.
+  // Dep, url, and integrity names compare exactly; the rest case-fold.
   switch (Name.getKind()) {
   case ExternName::Kind::LockedDep:
   case ExternName::Kind::UnlockedDep:
@@ -505,16 +503,15 @@ NameRecord Context::makeNameRecord(const ExternName &Name) const noexcept {
 Expect<void> Context::addUniqueName(std::vector<NameRecord> &Names,
                                     const NameRecord &N,
                                     bool IsImport) const noexcept {
-  // A strong-uniqueness violation inside a declarator carries a side-specific
-  // code. An exact duplicate is a plain name conflict everywhere.
+  // Declarator clashes carry their own code; exact duplicates never do.
   const auto SideCode = IsImport ? ErrCode::Value::ComponentImportNameConflict
                                  : ErrCode::Value::ComponentExportNameConflict;
   const auto ConflictCode =
-      top().K == Scope::Kind::Component
+      top().Kind == ScopeKind::Component
           ? SideCode
           : (IsImport ? ErrCode::Value::ComponentDeclImportNameConflict
                       : ErrCode::Value::ComponentDeclExportNameConflict);
-  auto reportClash = [&](ErrCode::Value Code) noexcept {
+  auto ReportClash = [&](ErrCode::Value Code) noexcept {
     spdlog::error(Code);
     spdlog::error("    {} name '{}' is not strongly-unique."sv,
                   IsImport ? "Import"sv : "Export"sv, N.Original);
@@ -522,16 +519,15 @@ Expect<void> Context::addUniqueName(std::vector<NameRecord> &Names,
   };
   for (const auto &E : Names) {
     if (E.Original == N.Original) {
-      return reportClash(SideCode);
+      return ReportClash(SideCode);
     }
     if (E.Stripped == N.Stripped) {
-      // `l` and `[constructor]l` (for the *same* label) are the one
-      // strongly-unique annotated pair.
+      // `l` and `[constructor]l` of the same label are the one allowed pair.
       const bool CtorException = ((E.IsConstructor && N.IsPlainLabel) ||
                                   (N.IsConstructor && E.IsPlainLabel)) &&
                                  E.StrippedExact == N.StrippedExact;
       if (!CtorException) {
-        return reportClash(ConflictCode);
+        return ReportClash(ConflictCode);
       }
       continue;
     }
@@ -540,7 +536,7 @@ Expect<void> Context::addUniqueName(std::vector<NameRecord> &Names,
          E.DottedFirst == N.StrippedExact) ||
         (E.IsPlainLabel && N.IsDottedSame &&
          N.DottedFirst == E.StrippedExact)) {
-      return reportClash(ConflictCode);
+      return ReportClash(ConflictCode);
     }
   }
   Names.push_back(N);
@@ -615,15 +611,14 @@ Context::defineImport(std::string_view Name, const ExternInfo &Resolved,
                       Span<const std::string> Impls,
                       Span<const std::string> ExtIds,
                       Span<const std::string> VSuffixes) noexcept {
-  // Each instance import mints fresh identities for the resources the
-  // instance type itself declares (two imports of one shape differ).
+  // Each instance import mints fresh identities for its declared resources.
   ExternInfo Info = Resolved;
-  if (Info.K == ExternKind::InstanceType) {
+  if (Info.Kind == ExternKind::InstanceType) {
     Info.Shape = freshenDeclaredResources(Info.Shape, true);
   }
   EXPECTED_TRY(ExternName CN, parseExternName(Name, true));
   EXPECTED_TRY(checkNameAttributes(CN, Impls, ExtIds, VSuffixes,
-                                   Info.K == ExternKind::InstanceType));
+                                   Info.Kind == ExternKind::InstanceType));
   EXPECTED_TRY(addUniqueName(top().ImportSide.Names, makeNameRecord(CN), true));
   defineExtern(Info);
   EXPECTED_TRY(checkNamedTypesRule(Info, true));
@@ -660,12 +655,11 @@ Context::defineExport(const ExternName &CN, const ExternInfo &Inferred,
     }
     Result = *Ascribed;
   }
-  // An export of a type re-introduces it under a fresh naming identity. The
-  // underlying resource or structural identity stays, for matching.
-  if (Result.K == ExternKind::TypeBound) {
-    Result.Type.NameId = Types.newNameId();
+  // An export of a type re-introduces it under a fresh naming identity.
+  if (Result.Kind == ExternKind::TypeBound) {
+    Result.Type.NameId = Types.nextNameId();
   }
-  if (Result.K == ExternKind::InstanceType) {
+  if (Result.Kind == ExternKind::InstanceType) {
     Result.Shape = freshenDeclaredResources(Result.Shape, false);
   }
   defineExtern(Result);
@@ -687,7 +681,7 @@ Expect<void> Context::checkAnnotatedName(const ExternName &Name,
       Kind != ExternName::Kind::Method && Kind != ExternName::Kind::Static) {
     return {};
   }
-  if (Info.K != ExternKind::FuncType || Info.Func.FT == nullptr) {
+  if (Info.Kind != ExternKind::FuncType || Info.Func.FT == nullptr) {
     spdlog::error(ErrCode::Value::ComponentIsNotFunc);
     spdlog::error(
         "    Annotated name '{}' is only allowed on function imports/exports."sv,
@@ -696,11 +690,10 @@ Expect<void> Context::checkAnnotatedName(const ExternName &Name,
   }
   const std::string_view ResourceLabel = Name.getDetail().Resource;
   auto &S = top();
-  const auto &Labels = S.nameSide(IsImport).ResourceLabels;
-  const auto &Names = S.nameSide(IsImport).ResourceNames;
+  const auto &Labels = S.getNameSide(IsImport).ResourceLabels;
+  const auto &Names = S.getNameSide(IsImport).ResourceNames;
   const auto &FT = *Info.Func.FT;
-  // The resource reached through the signature must carry a name on this side
-  // which matches the annotation's first label.
+  // The signature's resource must be named here as the annotation's label.
   auto CheckTarget = [&](uint32_t Target) noexcept -> Expect<void> {
     auto NameIt = Names.find(Target);
     if (NameIt == Names.end()) {
@@ -719,17 +712,16 @@ Expect<void> Context::checkAnnotatedName(const ExternName &Name,
     return {};
   };
 
-  // Resolve a valtype to an own or borrow of a resource. Id filters when the
-  // caller sets it.
+  // Resolve a valtype to the resource behind its own or borrow handle.
   auto HandleOf = [this](const QualValType &Q,
                          bool WantOwn) noexcept -> std::optional<uint32_t> {
     TypeEntry Storage;
     const auto *Entry = Types.resolveQualType(Q, Storage);
-    if (Entry == nullptr || Entry->DT == nullptr ||
-        !Entry->DT->isDefValType()) {
+    const auto *Def = Entry != nullptr ? Entry->getDefValType() : nullptr;
+    if (Def == nullptr) {
       return std::nullopt;
     }
-    const auto &DVT = Entry->DT->getDefValType();
+    const auto &DVT = *Def;
     uint32_t HandleIdx = 0;
     if (WantOwn && DVT.isOwnTy()) {
       HandleIdx = DVT.getOwn().Idx;
@@ -739,7 +731,7 @@ Expect<void> Context::checkAnnotatedName(const ExternName &Name,
       return std::nullopt;
     }
     const auto *Res = Entry->Home->getType(HandleIdx);
-    if (Res == nullptr || !Res->ResourceId.has_value()) {
+    if (Res == nullptr || !Res->isResource()) {
       return std::nullopt;
     }
     return Types.applyRemap(Entry->Remap, *Res->ResourceId);
@@ -760,10 +752,9 @@ Expect<void> Context::checkAnnotatedName(const ExternName &Name,
       // Unwrap (result (own T) e?).
       TypeEntry Storage;
       const auto *Entry = Types.resolveQualType(Q, Storage);
-      if (Entry != nullptr && Entry->DT != nullptr &&
-          Entry->DT->isDefValType() &&
-          Entry->DT->getDefValType().isResultTy()) {
-        const auto &Res = Entry->DT->getDefValType().getResult();
+      const auto *Def = Entry != nullptr ? Entry->getDefValType() : nullptr;
+      if (Def != nullptr && Def->isResultTy()) {
+        const auto &Res = Def->getResult();
         if (Res.ValTy.has_value()) {
           Target = HandleOf({*Res.ValTy, Entry->Home, Entry->Remap}, true);
         }
@@ -818,22 +809,20 @@ void Context::recordResourceLabel(const ExternName &Name,
                                   const ExternInfo &Info,
                                   bool IsImport) noexcept {
   if (Name.getKind() == ExternName::Kind::Label &&
-      Info.K == ExternKind::TypeBound && Info.Type.ResourceId.has_value()) {
+      Info.Kind == ExternKind::TypeBound && Info.Type.isResource()) {
     auto &S = top();
-    auto &Labels = S.nameSide(IsImport).ResourceLabels;
-    auto &Names = S.nameSide(IsImport).ResourceNames;
+    auto &Labels = S.getNameSide(IsImport).ResourceLabels;
+    auto &Names = S.getNameSide(IsImport).ResourceNames;
     Labels.emplace(std::string(Name.getOriginalName()), *Info.Type.ResourceId);
     Names.emplace(*Info.Type.ResourceId, std::string(Name.getOriginalName()));
   }
 }
 
 // ---------------------------------------------------------------------------
-// The named-types rule. Flags, enums, records, variants, and resources are
-// never anonymous. Tuples, lists, options, and results can be.
+// The named-types rule: flags, enums, records, variants, resources are named.
 // ---------------------------------------------------------------------------
 
-bool Context::isValTypeIntroduced(const QualValType &Q,
-                                  bool IsImport) noexcept {
+bool Context::isIntroduced(const QualValType &Q, bool IsImport) noexcept {
   if (Q.VT.isPrimValType() || Q.Home == nullptr) {
     return true;
   }
@@ -842,28 +831,27 @@ bool Context::isValTypeIntroduced(const QualValType &Q,
   if (Entry == nullptr) {
     return true;
   }
-  return isTypeEntryIntroduced(*Entry, IsImport);
+  return isIntroduced(*Entry, IsImport);
 }
 
-bool Context::isTypeEntryIntroduced(const TypeEntry &E,
-                                    bool IsImport) noexcept {
+bool Context::isIntroduced(const TypeEntry &E, bool IsImport) noexcept {
   auto &S = top();
-  const auto &NamedTys = S.nameSide(IsImport).NamedTypes;
-  const auto &NamedRes = S.nameSide(IsImport).NamedResources;
-  if (E.ResourceId.has_value()) {
+  const auto &NamedTys = S.getNameSide(IsImport).NamedTypes;
+  const auto &NamedRes = S.getNameSide(IsImport).NamedResources;
+  if (E.isResource()) {
     return E.NameId.has_value() && NamedRes.count(*E.NameId) != 0;
   }
-  if (E.DT == nullptr || !E.DT->isDefValType()) {
+  const auto *Def = E.getDefValType();
+  if (Def == nullptr) {
     return true;
   }
-  const auto &D = E.DT->getDefValType();
+  const auto &D = *Def;
   if (D.isPrimValType()) {
     return true;
   }
-  // A local reference must name the introduced identity. A foreign entry
-  // accepts a structurally equal named type.
+  // Local: the introduced identity. Foreign: a structurally equal named type.
   if (D.isFlagsTy() || D.isEnumTy() || D.isRecordTy() || D.isVariantTy()) {
-    const auto &NamedIds = S.nameSide(IsImport).NamedIds;
+    const auto &NamedIds = S.getNameSide(IsImport).NamedIds;
     if (E.Home == &S) {
       return E.NameId.has_value() && NamedIds.count(*E.NameId) != 0;
     }
@@ -879,8 +867,7 @@ bool Context::isTypeEntryIntroduced(const TypeEntry &E,
         Probe.DT = Named;
         Probe.Home = Home;
         Matcher M(Types);
-        if (M.matchNormalVal(Types.normalizeEntry(E),
-                             Types.normalizeEntry(Probe))) {
+        if (M.matchValType(E, Probe)) {
           return true;
         }
       }
@@ -888,30 +875,8 @@ bool Context::isTypeEntryIntroduced(const TypeEntry &E,
     return false;
   }
   auto Sub = [&](const ComponentValType &VT) noexcept {
-    return isValTypeIntroduced({VT, E.Home, E.Remap}, IsImport);
+    return isIntroduced({VT, E.Home, E.Remap}, IsImport);
   };
-  if (D.isTupleTy()) {
-    for (const auto &Ty : D.getTuple().Types) {
-      if (!Sub(Ty)) {
-        return false;
-      }
-    }
-    return true;
-  }
-  if (D.isListTy()) {
-    return Sub(D.getList().ValTy);
-  }
-  if (D.isMapTy()) {
-    return Sub(D.getMap().KeyTy) && Sub(D.getMap().ValTy);
-  }
-  if (D.isOptionTy()) {
-    return Sub(D.getOption().ValTy);
-  }
-  if (D.isResultTy()) {
-    const auto &R = D.getResult();
-    return (!R.ValTy.has_value() || Sub(*R.ValTy)) &&
-           (!R.ErrTy.has_value() || Sub(*R.ErrTy));
-  }
   if (D.isStreamTy() || D.isFutureTy()) {
     const auto &Elem =
         D.isStreamTy() ? D.getStream().ValTy : D.getFuture().ValTy;
@@ -920,7 +885,7 @@ bool Context::isTypeEntryIntroduced(const TypeEntry &E,
   if (D.isOwnTy() || D.isBorrowTy()) {
     const uint32_t Idx = D.isOwnTy() ? D.getOwn().Idx : D.getBorrow().Idx;
     const auto *Res = E.Home->getType(Idx);
-    if (Res == nullptr || !Res->ResourceId.has_value()) {
+    if (Res == nullptr || !Res->isResource()) {
       return true;
     }
     const uint32_t Eff = Types.applyRemap(E.Remap, *Res->ResourceId);
@@ -930,14 +895,16 @@ bool Context::isTypeEntryIntroduced(const TypeEntry &E,
             : Res->NameId.value_or(Types.getResource(Eff).NameId);
     return NamedRes.count(NameId) != 0;
   }
-  return true;
+  bool All = true;
+  Types.forEachValType(
+      D, [&](const ComponentValType &VT) noexcept { All = All && Sub(VT); });
+  return All;
 }
 
-// Checks the type being introduced itself: its immediate components must be
-// named, while the type itself is exempt (the extern names it).
+// The introduced type is exempt; its immediate components must be named.
 bool Context::areInnerTypesIntroduced(const TypeEntry &E,
                                       bool IsImport) noexcept {
-  if (E.ResourceId.has_value()) {
+  if (E.isResource()) {
     return true;
   }
   if (E.Comp != nullptr) {
@@ -951,81 +918,40 @@ bool Context::areInnerTypesIntroduced(const TypeEntry &E,
     }
     return true;
   }
-  if (E.DT == nullptr) {
-    return true;
-  }
-  if (E.DT->isFuncType()) {
-    const auto &FT = E.DT->getFuncType();
-    for (const auto &P : FT.getParamList()) {
-      if (!isValTypeIntroduced({P.getValType(), E.Home, E.Remap}, IsImport)) {
+  if (const auto *FT = E.getFuncType()) {
+    for (const auto &P : FT->getParamList()) {
+      if (!isIntroduced({P.getValType(), E.Home, E.Remap}, IsImport)) {
         return false;
       }
     }
-    for (const auto &R : FT.getResultList()) {
-      if (!isValTypeIntroduced({R.getValType(), E.Home, E.Remap}, IsImport)) {
+    for (const auto &R : FT->getResultList()) {
+      if (!isIntroduced({R.getValType(), E.Home, E.Remap}, IsImport)) {
         return false;
       }
     }
     return true;
   }
-  if (!E.DT->isDefValType()) {
+  const auto *Def = E.getDefValType();
+  if (Def == nullptr) {
     return true;
   }
-  const auto &D = E.DT->getDefValType();
+  const auto &D = *Def;
   if (D.isPrimValType() || D.isFlagsTy() || D.isEnumTy()) {
     return true;
   }
   auto Sub = [&](const ComponentValType &VT) noexcept {
-    return isValTypeIntroduced({VT, E.Home, E.Remap}, IsImport);
+    return isIntroduced({VT, E.Home, E.Remap}, IsImport);
   };
-  if (D.isRecordTy()) {
-    for (const auto &LT : D.getRecord().LabelTypes) {
-      if (!Sub(LT.getValType())) {
-        return false;
-      }
-    }
-    return true;
-  }
-  if (D.isVariantTy()) {
-    for (const auto &[Label, Ty] : D.getVariant().Cases) {
-      if (Ty.has_value() && !Sub(*Ty)) {
-        return false;
-      }
-    }
-    return true;
-  }
-  if (D.isTupleTy()) {
-    for (const auto &Ty : D.getTuple().Types) {
-      if (!Sub(Ty)) {
-        return false;
-      }
-    }
-    return true;
-  }
-  if (D.isListTy()) {
-    return Sub(D.getList().ValTy);
-  }
-  if (D.isMapTy()) {
-    return Sub(D.getMap().KeyTy) && Sub(D.getMap().ValTy);
-  }
-  if (D.isOptionTy()) {
-    return Sub(D.getOption().ValTy);
-  }
-  if (D.isResultTy()) {
-    const auto &R = D.getResult();
-    return (!R.ValTy.has_value() || Sub(*R.ValTy)) &&
-           (!R.ErrTy.has_value() || Sub(*R.ErrTy));
-  }
   if (D.isStreamTy() || D.isFutureTy()) {
     const auto &Elem =
         D.isStreamTy() ? D.getStream().ValTy : D.getFuture().ValTy;
     return !Elem.has_value() || Sub(*Elem);
   }
   if (D.isOwnTy() || D.isBorrowTy()) {
-    const auto &NamedRes = top().nameSide(IsImport).NamedResources;
+    const auto &NamedRes = top().getNameSide(IsImport).NamedResources;
     const uint32_t Idx = D.isOwnTy() ? D.getOwn().Idx : D.getBorrow().Idx;
     const auto *Res = E.Home->getType(Idx);
-    if (Res == nullptr || !Res->ResourceId.has_value()) {
+    if (Res == nullptr || !Res->isResource()) {
       return true;
     }
     const uint32_t Eff = Types.applyRemap(E.Remap, *Res->ResourceId);
@@ -1035,15 +961,17 @@ bool Context::areInnerTypesIntroduced(const TypeEntry &E,
             : Res->NameId.value_or(Types.getResource(Eff).NameId);
     return NamedRes.count(NameId) != 0;
   }
-  return true;
+  bool All = true;
+  Types.forEachValType(
+      D, [&](const ComponentValType &VT) noexcept { All = All && Sub(VT); });
+  return All;
 }
 
-// Validate and register an extern for the named-types rule. An instance
-// extern recurses and introduces its exports in declaration order.
+// Validate and register an extern for the named-types rule.
 bool Context::introduceExternTypes(const ExternInfo &Info,
                                    bool IsImport) noexcept {
   auto &S = top();
-  switch (Info.K) {
+  switch (Info.Kind) {
   case ExternKind::CoreType:
   case ExternKind::ComponentType:
     return true;
@@ -1052,14 +980,14 @@ bool Context::introduceExternTypes(const ExternInfo &Info,
       return false;
     }
     // Introduce: imported types are usable by exports as well.
-    if (Info.Type.ResourceId.has_value() && Info.Type.NameId.has_value()) {
+    if (Info.Type.isResource() && Info.Type.NameId.has_value()) {
       if (IsImport) {
         S.ImportSide.NamedResources.insert(*Info.Type.NameId);
         S.ExportSide.NamedResources.insert(*Info.Type.NameId);
       } else {
         S.ExportSide.NamedResources.insert(*Info.Type.NameId);
       }
-    } else if (Info.Type.DT != nullptr && Info.Type.DT->isDefValType()) {
+    } else if (Info.Type.getDefValType() != nullptr) {
       if (IsImport) {
         S.ImportSide.NamedTypes.emplace(Info.Type.DT, Info.Type.Home);
         S.ExportSide.NamedTypes.emplace(Info.Type.DT, Info.Type.Home);
@@ -1104,37 +1032,36 @@ bool Context::introduceExternTypes(const ExternInfo &Info,
       return true;
     }
     for (const auto &P : Info.Func.FT->getParamList()) {
-      if (!isValTypeIntroduced(
-              {P.getValType(), Info.Func.Home, Info.Func.Remap}, IsImport)) {
+      if (!isIntroduced({P.getValType(), Info.Func.Home, Info.Func.Remap},
+                        IsImport)) {
         return false;
       }
     }
     for (const auto &R : Info.Func.FT->getResultList()) {
-      if (!isValTypeIntroduced(
-              {R.getValType(), Info.Func.Home, Info.Func.Remap}, IsImport)) {
+      if (!isIntroduced({R.getValType(), Info.Func.Home, Info.Func.Remap},
+                        IsImport)) {
         return false;
       }
     }
     return true;
   }
   case ExternKind::ValueBound:
-    return isValTypeIntroduced(Info.Value, IsImport);
+    return isIntroduced(Info.Value, IsImport);
   }
   return true;
 }
 
 Expect<void> Context::checkNamedTypesRule(const ExternInfo &Info,
                                           bool IsImport) noexcept {
-  // Instance-type declarations do not enforce the named-types rule. An
-  // import or an export checks their shapes again.
-  if (top().K == Scope::Kind::InstanceType) {
+  // Instance-type declarations do not enforce the named-types rule.
+  if (top().Kind == ScopeKind::InstanceType) {
     return {};
   }
   if (introduceExternTypes(Info, IsImport)) {
     return {};
   }
   ErrCode::Value Code;
-  switch (Info.K) {
+  switch (Info.Kind) {
   case ExternKind::FuncType:
     Code = IsImport ? ErrCode::Value::ComponentFuncNotValidImport
                     : ErrCode::Value::ComponentFuncNotValidExport;
@@ -1178,12 +1105,7 @@ Expect<const Shape *> Context::instantiateComponentShape(
     if (!Arg.getIndex().getSort().isCore() &&
         Arg.getIndex().getSort().getSortType() ==
             AST::Component::Sort::SortType::Value) {
-      auto &VE = top().Values[Arg.getIndex().getIdx()];
-      if (VE.Consumed) {
-        spdlog::error(ErrCode::Value::ComponentValueAlreadyConsumed);
-        return Unexpect(ErrCode::Value::ComponentValueAlreadyConsumed);
-      }
-      VE.Consumed = true;
+      EXPECTED_TRY(top().consumeValue(Arg.getIndex().getIdx()));
     }
   }
   // Match every import. The matcher accumulates the resource substitution.
@@ -1212,7 +1134,7 @@ Expect<const Shape *> Context::instantiateComponentShape(
   for (const auto &[Name, E] : CI.Exports) {
     Types.collectResources(E, Reachable);
   }
-  auto *Node = Types.newResourceMap();
+  auto *Node = Types.addResourceMap();
   Node->Map = M.getSubst().Map;
   for (const uint32_t Id : Reachable) {
     if (Node->Map.count(Id) != 0) {
@@ -1221,15 +1143,14 @@ Expect<const Shape *> Context::instantiateComponentShape(
     const auto &Entry = Types.getResource(Id);
     if (!Entry.FromImport && CI.DeclScope != nullptr &&
         Types.originatesIn(Id, *CI.DeclScope)) {
-      // Freshened ids carry no definition body: the fresh resource belongs to
-      // the created instance, so it is never canon-local here.
+      // A fresh resource belongs to the created instance: no definition body.
       Node->Map.emplace(Id, Types.addResource(nullptr, &top(), false));
     }
   }
 
   const auto *Result = Types.rebuildInstanceExports(CI, Node);
   ExternInfo Probe;
-  Probe.K = ExternKind::InstanceType;
+  Probe.Kind = ExternKind::InstanceType;
   Probe.Shape = Result;
   EXPECTED_TRY(Types.checkTypeLimits(Probe));
   return Result;

--- a/lib/validator/component_name.cpp
+++ b/lib/validator/component_name.cpp
@@ -15,13 +15,7 @@ namespace Component {
 
 using namespace std::literals;
 
-// label          ::= <first-fragment> ( '-' <fragment> )*
-// first-fragment ::= <first-word> | <first-acronym>
-// first-word     ::= [a-z] [0-9a-z]*
-// first-acronym  ::= [A-Z] [0-9A-Z]*
-// fragment       ::= <word> | <acronym>
-// word           ::= [0-9a-z]+
-// acronym        ::= [0-9A-Z]+
+// label ::= <first-fragment> ( '-' <fragment> )*, each a word or an acronym.
 bool ExternName::isKebabString(std::string_view Input) noexcept {
   bool IsFirstPart = true;
   bool Uppercase = false;
@@ -127,10 +121,7 @@ std::string_view ExternName::readLabelChars() noexcept {
   return Output;
 }
 
-// plainname ::= <label>
-//             | '[constructor]' <label>
-//             | '[method]' <label> '.' <label>
-//             | '[static]' <label> '.' <label>
+// plainname ::= <label> | '[constructor|method|static]' <label> ('.' <label>)?
 Expect<void> ExternName::parsePlainName() noexcept {
   if (tryRead("[constructor]"sv)) {
     if (!isKebabString(Rest)) {
@@ -145,9 +136,8 @@ Expect<void> ExternName::parsePlainName() noexcept {
     return {};
   }
 
-  // Once a '[method]' or '[static]' tag matched, the name must contain a
-  // '.' separating two kebab labels.
-  auto readResourceAndLabel = [this](std::string_view &Resource,
+  // A '[method]' or '[static]' name needs a '.' between two kebab labels.
+  auto ReadResourceAndLabel = [this](std::string_view &Resource,
                                      std::string_view &Label) -> Expect<void> {
     NoTagName = Rest;
     if (!readUntil('.', Resource)) {
@@ -173,7 +163,7 @@ Expect<void> ExternName::parsePlainName() noexcept {
 
   if (tryRead("[method]"sv)) {
     std::string_view Resource, Label;
-    EXPECTED_TRY(readResourceAndLabel(Resource, Label));
+    EXPECTED_TRY(ReadResourceAndLabel(Resource, Label));
     NameDetail.Resource = Resource;
     NameDetail.Method = Label;
     NameKind = Kind::Method;
@@ -182,7 +172,7 @@ Expect<void> ExternName::parsePlainName() noexcept {
 
   if (tryRead("[static]"sv)) {
     std::string_view Resource, Label;
-    EXPECTED_TRY(readResourceAndLabel(Resource, Label));
+    EXPECTED_TRY(ReadResourceAndLabel(Resource, Label));
     NameDetail.Resource = Resource;
     NameDetail.Method = Label;
     NameKind = Kind::Static;
@@ -205,10 +195,7 @@ Expect<void> ExternName::parsePlainName() noexcept {
   return {};
 }
 
-// depname      ::= 'unlocked-dep=<' <pkgnamequery> '>'
-// pkgnamequery ::= <pkgpath> <verrange>?
-// verrange     ::= '@*' | '@{' <verlower> '}' | '@{' <verupper> '}'
-//                | '@{' <verlower> ' ' <verupper> '}'
+// depname ::= 'unlocked-dep=<' <pkgpath> <verrange>? '>'
 Expect<void> ExternName::parseUnlockedDep() noexcept {
   if (!tryRead("<"sv)) {
     spdlog::error(ErrCode::Value::NameExpectedOpenAngle);
@@ -216,7 +203,7 @@ Expect<void> ExternName::parseUnlockedDep() noexcept {
     return Unexpect(ErrCode::Value::NameExpectedOpenAngle);
   }
 
-  EXPECTED_TRY(auto Path, parsePkgPath("@>"sv));
+  EXPECTED_TRY(parsePkgPath("@>"sv));
 
   std::string_view VersionRange;
   if (!Rest.empty() && Rest[0] == '@') {
@@ -256,15 +243,12 @@ Expect<void> ExternName::parseUnlockedDep() noexcept {
     return Unexpect(ErrCode::Value::NameTrailingCharacters);
   }
 
-  NameDetail.Namespace = Path.Namespace;
-  NameDetail.Package = Path.Package;
   NameDetail.VersionRange = VersionRange;
   NameKind = Kind::UnlockedDep;
   return {};
 }
 
 // depname ::= 'locked-dep=<' <pkgname> '>' ( ',' <hashname> )?
-// pkgname ::= <pkgpath> ( '@' <valid semver> )?
 Expect<void> ExternName::parseLockedDep() noexcept {
   if (!tryRead("<"sv)) {
     spdlog::error(ErrCode::Value::NameExpectedOpenAngle);
@@ -272,7 +256,7 @@ Expect<void> ExternName::parseLockedDep() noexcept {
     return Unexpect(ErrCode::Value::NameExpectedOpenAngle);
   }
 
-  EXPECTED_TRY(auto Path, parsePkgPath("@>"sv));
+  EXPECTED_TRY(parsePkgPath("@>"sv));
 
   std::string_view Version;
   if (!Rest.empty() && Rest[0] == '@') {
@@ -303,16 +287,13 @@ Expect<void> ExternName::parseLockedDep() noexcept {
 
   EXPECTED_TRY(auto Integrity, parseIntegritySuffix());
 
-  NameDetail.Namespace = Path.Namespace;
-  NameDetail.Package = Path.Package;
   NameDetail.Version = Version;
   NameDetail.Integrity = Integrity;
   NameKind = Kind::LockedDep;
   return {};
 }
 
-// urlname     ::= 'url=<' <nonbrackets> '>' ( ',' <hashname> )?
-// nonbrackets ::= [^<>]*
+// urlname ::= 'url=<' <nonbrackets> '>' ( ',' <hashname> )?
 Expect<void> ExternName::parseUrlName() noexcept {
   if (!tryRead("<"sv)) {
     spdlog::error(ErrCode::Value::NameExpectedOpenAngle);
@@ -358,10 +339,7 @@ Expect<void> ExternName::parseHashName() noexcept {
   return {};
 }
 
-// interfacename    ::= <namespace> <label> <projection> <interfaceversion>?
-// namespace        ::= <words> ':'
-// projection       ::= '/' <label>
-// interfaceversion ::= '@' <valid semver> | '@' <canonversion>
+// interfacename ::= <words> ':' <label> '/' <label> <interfaceversion>?
 Expect<void> ExternName::parseInterfaceName() noexcept {
   size_t ColonPos = Rest.find(':');
   std::string_view Namespace = Rest.substr(0, ColonPos);
@@ -371,8 +349,7 @@ Expect<void> ExternName::parseInterfaceName() noexcept {
   std::string_view Package = readLabelChars();
   EXPECTED_TRY(checkWordsLabel(Package, "package"sv));
 
-  // Nested namespaces (`a:b:c/d`) are feature-gated. Only a projection can
-  // follow the package name.
+  // Nested namespaces (`a:b:c/d`) are feature-gated; only a projection follows.
   if (Rest.empty() || Rest[0] != '/') {
     spdlog::error(ErrCode::Value::NameExpectedSlashAfterPackage);
     spdlog::error("    Component name: expected `/` after package name"sv);
@@ -388,8 +365,7 @@ Expect<void> ExternName::parseInterfaceName() noexcept {
     return Unexpect(ErrCode::Value::ComponentNameNotKebab);
   }
 
-  // Nested projections (`a:b/c/d`) are feature-gated. Only a version can
-  // follow the projection label.
+  // Nested projections (`a:b/c/d`) are feature-gated; only a version follows.
   if (!Rest.empty() && Rest[0] != '@') {
     spdlog::error(ErrCode::Value::NameTrailingCharacters);
     spdlog::error(
@@ -419,14 +395,12 @@ Expect<void> ExternName::parseInterfaceName() noexcept {
   return {};
 }
 
-// Parses 'namespace:package', stopping at the delimiters in StopChars.
-Expect<ExternName::PkgPath>
-ExternName::parsePkgPath(std::string_view StopChars) noexcept {
+// Parses 'namespace:package' into NameDetail, stopping at StopChars.
+Expect<void> ExternName::parsePkgPath(std::string_view StopChars) noexcept {
   size_t ColonPos = Rest.find(':');
   size_t StopPos = Rest.find_first_of(StopChars);
   if (ColonPos == Rest.npos || (StopPos != Rest.npos && StopPos < ColonPos)) {
-    // No namespace delimiter: diagnose the leading label run. This catches
-    // inputs like `<`, `<>`, or a stray label without `:`.
+    // No namespace delimiter: diagnose the leading label run first.
     std::string_view Label = readLabelChars();
     EXPECTED_TRY(checkWordsLabel(Label, "namespace"sv));
     spdlog::error(ErrCode::Value::ComponentInvalidName);
@@ -450,11 +424,12 @@ ExternName::parsePkgPath(std::string_view StopChars) noexcept {
     return Unexpect(ErrCode::Value::NameExpectedCloseAngle);
   }
 
-  return PkgPath{Namespace, Package};
+  NameDetail.Namespace = Namespace;
+  NameDetail.Package = Package;
+  return {};
 }
 
-// Parses the `<integrity-metadata> '>'` body, which must end the name, and
-// returns the metadata.
+// Parses the `<integrity-metadata> '>'` body, which must end the name.
 Expect<std::string_view> ExternName::parseIntegrityBody() noexcept {
   std::string_view Data;
   if (!readUntil('>', Data)) {
@@ -472,8 +447,7 @@ Expect<std::string_view> ExternName::parseIntegrityBody() noexcept {
   return Data;
 }
 
-// Parse the optional ',' <hashname> suffix. An exhausted input gives no
-// integrity metadata.
+// Parses the optional ',' <hashname> suffix; an exhausted input yields none.
 Expect<std::string_view> ExternName::parseIntegritySuffix() noexcept {
   if (Rest.empty()) {
     return std::string_view{};
@@ -492,9 +466,7 @@ Expect<std::string_view> ExternName::parseIntegritySuffix() noexcept {
   return parseIntegrityBody();
 }
 
-// words ::= <first-word> ( '-' <word> )*
-// Validate a namespace or package label. A non-kebab label is "not in kebab
-// case". A kebab label with uppercase is "not lowercase".
+// words ::= <first-word> ( '-' <word> )*: a kebab label that is all lowercase.
 Expect<void> ExternName::checkWordsLabel(std::string_view Label,
                                          std::string_view What) const noexcept {
   if (!isKebabString(Label)) {
@@ -516,8 +488,6 @@ Expect<void> ExternName::checkWordsLabel(std::string_view Label,
 }
 
 // verrange body ::= <verlower> | <verupper> | <verlower> ' ' <verupper>
-// verlower      ::= '>=' <valid semver>
-// verupper      ::= '<' <valid semver>
 Expect<void>
 ExternName::checkVersionRange(std::string_view Body) const noexcept {
   if (Body.substr(0, 2) == ">="sv) {
@@ -571,7 +541,7 @@ ExternName::checkVersionRange(std::string_view Body) const noexcept {
   return Unexpect(ErrCode::Value::NameExpectedVersionRangeOp);
 }
 
-// semversuffix ::= [0-9A-Za-z.+-]* 🔗
+// semversuffix ::= [0-9A-Za-z.+-]*
 Expect<void>
 ExternName::checkVersionSuffix(std::string_view Suffix) const noexcept {
   for (char C : Suffix) {
@@ -600,9 +570,7 @@ ExternName::checkVersionSuffix(std::string_view Suffix) const noexcept {
   return {};
 }
 
-// canonversion ::= [1-9] [0-9]*
-//                | '0.' [1-9] [0-9]*
-//                | '0.0.' [1-9] [0-9]*
+// canonversion ::= [1-9] [0-9]* | '0.' [1-9] [0-9]* | '0.0.' [1-9] [0-9]*
 bool ExternName::isCanonVersion(std::string_view V) const noexcept {
   if (V.substr(0, 4) == "0.0."sv) {
     V.remove_prefix(4);
@@ -620,8 +588,7 @@ bool ExternName::isCanonVersion(std::string_view V) const noexcept {
   return true;
 }
 
-// MAJOR.MINOR.PATCH[-prerelease][+build] per semver.org 2.0. The unlogged
-// granular code reaches an interface version, but not a dep or range bound.
+// Scans MAJOR.MINOR.PATCH[-prerelease][+build] per semver.org 2.0, unlogged.
 Expect<void> ExternName::scanSemver(std::string_view V) const noexcept {
   if (V.empty()) {
     return Unexpect(ErrCode::Value::NameEmptyString);
@@ -675,8 +642,7 @@ Expect<void> ExternName::scanSemver(std::string_view V) const noexcept {
   return scanSemverIdentifiers(V, false);
 }
 
-// Scans a dot-separated pre-release or build identifier list. Identifiers are
-// [0-9A-Za-z-]+ and, for pre-release, numeric ones have no leading zeros.
+// Scans a dot-separated identifier list, rejecting leading zeros when asked.
 Expect<void>
 ExternName::scanSemverIdentifiers(std::string_view Idents,
                                   bool CheckLeadingZeros) const noexcept {
@@ -708,15 +674,11 @@ ExternName::scanSemverIdentifiers(std::string_view Idents,
   }
 }
 
-// integrity-metadata ::= *WSP hash-with-options *(1*WSP hash-with-options) *WSP
-// hash-with-options  ::= hash-expression *("?" option-expression)
-// hash-expression    ::= hash-algorithm "-" base64-value
-// hash-algorithm     ::= "sha256" / "sha384" / "sha512"
+// integrity-metadata ::= WSP-separated (sha256|sha384|sha512) '-' base64-value.
 Expect<void>
 ExternName::checkIntegrityMetadata(std::string_view Input) const noexcept {
-  // base64-value ::= [A-Za-z0-9+/]+ ( '=' | '==' )?
-  // Non-empty, with `=` padding only at the end.
-  auto isBase64 = [](std::string_view S) noexcept {
+  // base64-value ::= [A-Za-z0-9+/]+ ( '=' | '==' )?, padded only at the end.
+  auto IsBase64 = [](std::string_view S) noexcept {
     if (S.empty()) {
       return false;
     }
@@ -779,7 +741,7 @@ ExternName::checkIntegrityMetadata(std::string_view Input) const noexcept {
                     Algo);
       return Unexpect(ErrCode::Value::NameUnknownHashAlgorithm);
     }
-    if (!isBase64(HashExpr.substr(DashPos + 1))) {
+    if (!IsBase64(HashExpr.substr(DashPos + 1))) {
       spdlog::error(ErrCode::Value::NameInvalidBase64);
       spdlog::error("    Component name: hash value is not valid base64"sv);
       return Unexpect(ErrCode::Value::NameInvalidBase64);

--- a/lib/validator/component_type.cpp
+++ b/lib/validator/component_type.cpp
@@ -54,8 +54,7 @@ Expect<void> checkLabel(std::string_view Label,
 
 } // namespace
 
-// valtype ::= i:<typeidx> | pvt:<primvaltype>. A type index must refer to a
-// defvaltype entry in the current scope.
+// valtype ::= i:<typeidx> | pvt:<primvaltype>; the index must be a defvaltype.
 Expect<void> Validator::validate(const ComponentValType &VT) noexcept {
   if (VT.isPrimValType()) {
     return {};
@@ -67,7 +66,7 @@ Expect<void> Validator::validate(const ComponentValType &VT) noexcept {
                   VT.getTypeIndex(), CompCtx.top().Types.size());
     return Unexpect(ErrCode::Value::ComponentTypeIndexOutOfBounds);
   }
-  if (Entry->DT == nullptr || !Entry->DT->isDefValType()) {
+  if (Entry->getDefValType() == nullptr) {
     spdlog::error(ErrCode::Value::NotADefinedType);
     spdlog::error("    Value type index {} does not refer to a value type."sv,
                   VT.getTypeIndex());
@@ -199,7 +198,7 @@ Validator::validate(const AST::Component::DefValType &DVT) noexcept {
                     Idx, CompCtx.top().Types.size());
       return Unexpect(ErrCode::Value::ComponentTypeIndexOutOfBounds);
     }
-    if (!Entry->ResourceId.has_value()) {
+    if (!Entry->isResource()) {
       spdlog::error(ErrCode::Value::ComponentNotResourceType);
       spdlog::error(
           "    own/borrow type index {} does not refer to a resource type."sv,
@@ -243,8 +242,7 @@ Validator::validate(const AST::Component::DefValType &DVT) noexcept {
     return {};
   }
   if (DVT.isMapTy()) {
-    // keytype ::= bool | s8 | u8 | s16 | u16 | s32 | u32 | s64 | u64 | char
-    //           | string
+    // keytype ::= bool | s8 .. u64 | char | string.
     const auto &Map = DVT.getMap();
     switch (Map.KeyTy.getCode()) {
     case ComponentTypeCode::Bool:
@@ -309,7 +307,7 @@ Expect<void> Validator::validate(const AST::Component::FuncType &FT) noexcept {
 
 Expect<void>
 Validator::validate(const AST::Component::ResourceType &RT) noexcept {
-  if (CompCtx.top().K != Component::Scope::Kind::Component) {
+  if (CompCtx.top().Kind != Component::ScopeKind::Component) {
     spdlog::error(ErrCode::Value::ComponentResourceOutsideComponent);
     spdlog::error(
         "    Resource types cannot be defined in component or instance types."sv);
@@ -345,28 +343,24 @@ Validator::validate(const AST::Component::ResourceType &RT) noexcept {
   return {};
 }
 
-// core:deftype ::= rectype | moduletype. Rectypes push one core:type entry
-// per subtype; moduletypes are validated in their own scope.
+// core:deftype ::= rectype | moduletype; rectypes push one entry per subtype.
 Expect<void>
 Validator::validate(const AST::Component::CoreDefType &DType) noexcept {
   if (DType.isRecType()) {
     auto &S = CompCtx.top();
     const auto STypes = DType.getSubTypes();
     const uint32_t BaseIdx = static_cast<uint32_t>(S.CoreTypes.size());
-    // The group enters the core:type space as a whole, so that its members may
-    // reference each other, and every member then validates against it.
+    // The whole group is added first so its members may reference each other.
     for (const auto &ST : STypes) {
-      S.CoreTypes.push_back({&ST, nullptr});
+      S.addCoreType({&ST, nullptr});
     }
-    // A module type occupies a core:type index but is not a subtype, so it
-    // reaches the core subtype rules as a null entry.
+    // A module type occupies a core:type index but is a null subtype entry.
     std::vector<const AST::SubType *> TypeVec;
     TypeVec.reserve(S.CoreTypes.size());
     for (const auto &Entry : S.CoreTypes) {
       TypeVec.push_back(Entry.Func);
     }
-    // Concrete indices resolve against the component core:type space, which
-    // the core FormChecker cannot see.
+    // Concrete indices resolve against the component core:type space.
     auto CheckIdx = [&S](uint32_t Idx) -> Expect<void> {
       const auto *Entry = S.getCoreType(Idx);
       if (Entry == nullptr) {
@@ -387,8 +381,7 @@ Validator::validate(const AST::Component::CoreDefType &DType) noexcept {
       }
       return {};
     };
-    // Depth memoization for the core subtype hierarchy checks. The core
-    // validator resizes it on demand.
+    // Depth memoization for the core subtype hierarchy checks.
     std::vector<uint32_t> SubTypeDepthMap;
     for (uint32_t I = 0; I < STypes.size(); ++I) {
       const auto &CT = STypes[I].getCompositeType();
@@ -411,9 +404,9 @@ Validator::validate(const AST::Component::CoreDefType &DType) noexcept {
     }
     return {};
   }
-  auto *Shape = CompTypes.newCoreShape();
+  auto *Shape = CompTypes.addCoreShape();
   EXPECTED_TRY(validate(DType.getModuleType(), *Shape));
-  CompCtx.top().CoreTypes.push_back({nullptr, Shape});
+  CompCtx.top().addCoreType({nullptr, Shape});
   return {};
 }
 
@@ -422,46 +415,54 @@ Validator::validate(const AST::Component::DefType &DType) noexcept {
   if (DType.isDefValType()) {
     EXPECTED_TRY(validate(DType.getDefValType()));
     auto &S = CompCtx.top();
-    S.Types.push_back(
-        {&DType, &S, nullptr, nullptr, nullptr, {}, CompTypes.newNameId()});
+    Component::TypeEntry Entry{&DType, &S};
+    Entry.NameId = CompTypes.nextNameId();
+    S.addType(Entry);
   } else if (DType.isFuncType()) {
     EXPECTED_TRY(validate(DType.getFuncType()));
     auto &S = CompCtx.top();
-    S.Types.push_back({&DType, &S, nullptr, nullptr, nullptr, {}, {}});
+    S.addType({&DType, &S});
   } else if (DType.isResourceType()) {
     EXPECTED_TRY(validate(DType.getResourceType()));
     auto &S = CompCtx.top();
     const uint32_t Id =
         CompTypes.addResource(&DType.getResourceType(), &S, false);
-    S.Types.push_back({&DType, &S, nullptr, nullptr, nullptr, Id,
-                       CompTypes.getResource(Id).NameId});
+    Component::TypeEntry Entry{&DType, &S};
+    Entry.ResourceId = Id;
+    Entry.NameId = CompTypes.getResource(Id).NameId;
+    S.addType(Entry);
   } else if (DType.isInstanceType()) {
-    auto *Shape = CompTypes.newShape();
+    auto *Shape = CompTypes.addShape();
     EXPECTED_TRY(validate(DType.getInstanceType(), *Shape));
     auto &S = CompCtx.top();
-    S.Types.push_back({&DType, &S, nullptr, Shape, nullptr, {}, {}});
+    Component::TypeEntry Entry{&DType, &S};
+    Entry.Inst = Shape;
+    S.addType(Entry);
   } else if (DType.isComponentType()) {
-    auto *Shape = CompTypes.newShape();
+    auto *Shape = CompTypes.addShape();
     EXPECTED_TRY(validate(DType.getComponentType(), *Shape));
     auto &S = CompCtx.top();
-    S.Types.push_back({&DType, &S, nullptr, nullptr, Shape, {}, {}});
+    Component::TypeEntry Entry{&DType, &S};
+    Entry.Comp = Shape;
+    S.addType(Entry);
   }
   // Effective type-size limit on the freshly defined entry.
   {
     auto &S = CompCtx.top();
     Component::ExternInfo Probe;
-    Probe.K = Component::ExternKind::TypeBound;
+    Probe.Kind = Component::ExternKind::TypeBound;
     Probe.Type = S.Types.back();
     EXPECTED_TRY(CompTypes.checkTypeLimits(Probe));
   }
   return {};
 }
 
-// core:importdesc inside moduletype declarations. A func or tag type index
-// resolves in the own core type space of the moduletype.
+// core:importdesc in a moduletype; type indices resolve in its own core space.
 Expect<void> Validator::validate(const AST::Component::CoreImportDesc &Desc,
                                  Component::CoreExternInfo &Out) noexcept {
-  if (Desc.isFunc()) {
+  Out.Kind = Desc.getExternalType();
+  switch (Out.Kind) {
+  case ExternalType::Function: {
     const auto *Entry = CompCtx.top().getCoreType(Desc.getTypeIndex());
     if (Entry == nullptr) {
       spdlog::error(ErrCode::Value::ComponentTypeIndexOutOfBounds);
@@ -475,21 +476,25 @@ Expect<void> Validator::validate(const AST::Component::CoreImportDesc &Desc,
                     Desc.getTypeIndex());
       return Unexpect(ErrCode::Value::InvalidTypeReference);
     }
-    Out.Kind = ExternalType::Function;
     Out.Func = Entry->Func;
-  } else if (Desc.isTable()) {
+    break;
+  }
+  case ExternalType::Table: {
     EXPECTED_TRY(validate(Desc.getTableType()));
-    Out.Kind = ExternalType::Table;
     Out.Table = &Desc.getTableType();
-  } else if (Desc.isMemory()) {
+    break;
+  }
+  case ExternalType::Memory: {
     EXPECTED_TRY(validate(Desc.getMemoryType()));
-    Out.Kind = ExternalType::Memory;
     Out.Memory = &Desc.getMemoryType();
-  } else if (Desc.isGlobal()) {
+    break;
+  }
+  case ExternalType::Global: {
     EXPECTED_TRY(validate(Desc.getGlobalType()));
-    Out.Kind = ExternalType::Global;
     Out.Global = &Desc.getGlobalType();
-  } else if (Desc.isTag()) {
+    break;
+  }
+  case ExternalType::Tag: {
     const uint32_t Idx = Desc.getTagType().getTypeIdx();
     const auto *Entry = CompCtx.top().getCoreType(Idx);
     if (Entry == nullptr) {
@@ -506,18 +511,18 @@ Expect<void> Validator::validate(const AST::Component::CoreImportDesc &Desc,
       spdlog::error("    Tag types must be function types without results."sv);
       return Unexpect(ErrCode::Value::InvalidTagResultType);
     }
-    Out.Kind = ExternalType::Tag;
     Out.Func = Entry->Func;
+    break;
+  }
   }
   return {};
 }
 
-// moduletype ::= 0x50 md*:vec(<core:moduledecl>). Runs in a ModuleType scope
-// whose core type space is local to the declaration body.
+// moduletype ::= 0x50 md*:vec(<core:moduledecl>), in its own ModuleType scope.
 Expect<void>
 Validator::validate(Span<const AST::Component::CoreModuleDecl> Decls,
                     Component::CoreShape &Out) noexcept {
-  CompCtx.enterScope(Component::Scope::Kind::ModuleType);
+  CompCtx.enterScope(Component::ScopeKind::ModuleType);
   for (const auto &Decl : Decls) {
     if (Decl.isImport()) {
       const auto &Imp = Decl.getImport();
@@ -564,8 +569,7 @@ Validator::validate(Span<const AST::Component::CoreModuleDecl> Decls,
   return {};
 }
 
-// core:alias inside moduletype declarations. The grammar fixes it to an outer
-// alias of the core type sort. The MVP also rejects an alias of a module type.
+// core:alias in a moduletype: an outer alias of a non-module core type.
 Expect<void>
 Validator::validate(const AST::Component::CoreAlias &Alias) noexcept {
   const auto *Target = CompCtx.scopeUp(Alias.getComponentJump());
@@ -587,13 +591,13 @@ Validator::validate(const AST::Component::CoreAlias &Alias) noexcept {
     spdlog::error("    Module types cannot be aliased into module types."sv);
     return Unexpect(ErrCode::Value::InvalidTypeReference);
   }
-  CompCtx.top().CoreTypes.push_back(*Entry);
+  CompCtx.top().addCoreType(*Entry);
   return {};
 }
 
 Expect<void> Validator::validate(const AST::Component::InstanceType &IT,
                                  Component::Shape &Out) noexcept {
-  auto &S = CompCtx.enterScope(Component::Scope::Kind::InstanceType);
+  auto &S = CompCtx.enterScope(Component::ScopeKind::InstanceType);
   Out.DeclScope = &S;
   for (const auto &Decl : IT.getDecl()) {
     const auto Before = Out.Exports.size();
@@ -608,7 +612,7 @@ Expect<void> Validator::validate(const AST::Component::InstanceType &IT,
 
 Expect<void> Validator::validate(const AST::Component::ComponentType &CT,
                                  Component::Shape &Out) noexcept {
-  auto &S = CompCtx.enterScope(Component::Scope::Kind::ComponentType);
+  auto &S = CompCtx.enterScope(Component::ScopeKind::ComponentType);
   Out.DeclScope = &S;
   for (const auto &Decl : CT.getDecl()) {
     EXPECTED_TRY(validate(Decl, Out));
@@ -644,7 +648,7 @@ Expect<void> Validator::validate(const AST::Component::InstanceDecl &Decl,
     // The descriptor is checked before the export name.
     Component::ExternInfo Info;
     EXPECTED_TRY(validate(ED.getExternDesc(), false, Info));
-    if (Info.K == Component::ExternKind::InstanceType) {
+    if (Info.Kind == Component::ExternKind::InstanceType) {
       Info.Shape = CompCtx.freshenDeclaredResources(Info.Shape, false);
     }
     EXPECTED_TRY(Component::ExternName CN,
@@ -656,7 +660,7 @@ Expect<void> Validator::validate(const AST::Component::InstanceDecl &Decl,
     EXPECTED_TRY(CompCtx.checkAnnotatedName(CN, Info, false));
     EXPECTED_TRY(CompCtx.checkNameAttributes(
         CN, ED.getImplements(), ED.getExternalIds(), ED.getVersionSuffixes(),
-        Info.K == Component::ExternKind::InstanceType));
+        Info.Kind == Component::ExternKind::InstanceType));
     CompCtx.recordResourceLabel(CN, Info, false);
     Exports.emplace(std::string(ED.getName()), Info);
     return {};
@@ -680,14 +684,13 @@ Expect<void> Validator::validate(const AST::Component::ComponentDecl &Decl,
   return validate(Decl.getInstance(), Out.Exports);
 }
 
-// externdesc resolution: bounds/kind checks plus entity typing. Sub-resource
-// type bounds allocate a fresh abstract id in the current scope.
+// externdesc resolution; a (sub resource) bound allocates a fresh resource id.
 Expect<void> Validator::validate(const AST::Component::ExternDesc &Desc,
                                  bool IsImport,
                                  Component::ExternInfo &Out) noexcept {
-  Out.K = Desc.getDescType();
+  Out.Kind = Desc.getDescType();
   auto &S = CompCtx.top();
-  switch (Out.K) {
+  switch (Out.Kind) {
   case AST::Component::ExternDesc::DescType::CoreType: {
     const auto *Entry = S.getCoreType(Desc.getTypeIndex());
     if (Entry == nullptr) {
@@ -715,7 +718,7 @@ Expect<void> Validator::validate(const AST::Component::ExternDesc &Desc,
                     Desc.getTypeIndex(), S.Types.size());
       return Unexpect(ErrCode::Value::ComponentTypeIndexOutOfBounds);
     }
-    if (Entry->DT == nullptr || !Entry->DT->isFuncType()) {
+    if (Entry->getFuncType() == nullptr) {
       const auto Code = IsImport ? ErrCode::Value::ComponentUnknownFunctionType
                                  : ErrCode::Value::ComponentNotFunctionType;
       spdlog::error(Code);
@@ -723,7 +726,7 @@ Expect<void> Validator::validate(const AST::Component::ExternDesc &Desc,
                     Desc.getTypeIndex());
       return Unexpect(Code);
     }
-    Out.Func = {&Entry->DT->getFuncType(), Entry->Home, Entry->Remap};
+    Out.Func = {Entry->getFuncType(), Entry->Home, Entry->Remap};
     return {};
   }
   case AST::Component::ExternDesc::DescType::ValueBound: {
@@ -753,18 +756,16 @@ Expect<void> Validator::validate(const AST::Component::ExternDesc &Desc,
       }
       Out.Type = *Entry;
       // The created index carries a fresh naming identity.
-      Out.Type.NameId = CompTypes.newNameId();
+      Out.Type.NameId = CompTypes.nextNameId();
       return {};
     }
     // (sub resource): fresh abstract resource type.
     const uint32_t Id = CompTypes.addResource(nullptr, &S, IsImport);
-    Out.Type = {nullptr,
-                &S,
-                nullptr,
-                nullptr,
-                nullptr,
-                Id,
-                CompTypes.getResource(Id).NameId};
+    Component::TypeEntry Bound;
+    Bound.Home = &S;
+    Bound.ResourceId = Id;
+    Bound.NameId = CompTypes.getResource(Id).NameId;
+    Out.Type = Bound;
     return {};
   }
   case AST::Component::ExternDesc::DescType::ComponentType: {

--- a/lib/validator/component_types.cpp
+++ b/lib/validator/component_types.cpp
@@ -22,7 +22,21 @@ namespace Component {
 using namespace std::literals;
 
 // ---------------------------------------------------------------------------
-// Type view normalization.
+// Scope.
+// ---------------------------------------------------------------------------
+
+Expect<void> Scope::consumeValue(uint32_t Idx) noexcept {
+  auto &Entry = Values[Idx];
+  if (Entry.Consumed) {
+    spdlog::error(ErrCode::Value::ComponentValueAlreadyConsumed);
+    return Unexpect(ErrCode::Value::ComponentValueAlreadyConsumed);
+  }
+  Entry.Consumed = true;
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// Type view resolution.
 // ---------------------------------------------------------------------------
 
 const TypeEntry *TypeSystem::resolveQualType(const QualValType &Q,
@@ -35,7 +49,7 @@ const TypeEntry *TypeSystem::resolveQualType(const QualValType &Q,
     return nullptr;
   }
   Storage = *Entry;
-  if (Entry->ResourceId.has_value()) {
+  if (Entry->isResource()) {
     Storage.ResourceId = applyRemap(Q.Remap, *Entry->ResourceId);
   }
   Storage.Remap = composeRemap(Q.Remap, Entry->Remap);
@@ -49,35 +63,25 @@ TypeSystem::resolveResourceId(const Scope *Home, const ResourceMap *Remap,
     return std::nullopt;
   }
   const auto *Entry = Home->getType(Idx);
-  if (Entry == nullptr || !Entry->ResourceId.has_value()) {
+  if (Entry == nullptr || !Entry->isResource()) {
     return std::nullopt;
   }
   return applyRemap(Remap, *Entry->ResourceId);
 }
 
-// Resolves through type-index and prim-alias indirections.
-NormalVal TypeSystem::normalizeValType(const QualValType &Q) noexcept {
+// The primitive behind a valtype, through prim-alias indirections.
+std::optional<AST::Component::PrimValType>
+TypeSystem::resolvePrimValType(const QualValType &Q) noexcept {
   if (Q.VT.isPrimValType()) {
-    return {Q.VT.getCode(), nullptr, nullptr, nullptr, true};
+    return static_cast<AST::Component::PrimValType>(Q.VT.getCode());
   }
   TypeEntry Storage;
   const auto *Entry = resolveQualType(Q, Storage);
-  if (Entry == nullptr) {
-    return {};
+  const auto *Def = Entry != nullptr ? Entry->getDefValType() : nullptr;
+  if (Def == nullptr || !Def->isPrimValType()) {
+    return std::nullopt;
   }
-  return normalizeEntry(*Entry);
-}
-
-NormalVal TypeSystem::normalizeEntry(const TypeEntry &E) const noexcept {
-  if (E.DT == nullptr || !E.DT->isDefValType()) {
-    return {};
-  }
-  const auto &DVT = E.DT->getDefValType();
-  if (DVT.isPrimValType()) {
-    return {static_cast<ComponentTypeCode>(DVT.getPrimValType()), nullptr,
-            nullptr, nullptr, true};
-  }
-  return {ComponentTypeCode::TypeIndex, &DVT, E.Home, E.Remap, true};
+  return Def->getPrimValType();
 }
 
 // ---------------------------------------------------------------------------
@@ -85,123 +89,64 @@ NormalVal TypeSystem::normalizeEntry(const TypeEntry &E) const noexcept {
 // ---------------------------------------------------------------------------
 
 bool TypeSystem::containsBorrow(const QualValType &Q) noexcept {
-  const auto N = normalizeValType(Q);
-  if (!N.Valid || N.DVT == nullptr) {
+  TypeEntry Storage;
+  const auto *Entry = resolveQualType(Q, Storage);
+  const auto *Def = Entry != nullptr ? Entry->getDefValType() : nullptr;
+  if (Def == nullptr || Def->isPrimValType()) {
     return false;
   }
-  const auto &D = *N.DVT;
-  auto Sub = [&](const ComponentValType &VT) noexcept {
-    return containsBorrow({VT, N.Home, N.Remap});
-  };
+  const auto &D = *Def;
   if (D.isBorrowTy()) {
     return true;
   }
-  if (D.isRecordTy()) {
-    for (const auto &LT : D.getRecord().LabelTypes) {
-      if (Sub(LT.getValType())) {
-        return true;
-      }
-    }
-    return false;
-  }
-  if (D.isVariantTy()) {
-    for (const auto &[Label, Ty] : D.getVariant().Cases) {
-      if (Ty.has_value() && Sub(*Ty)) {
-        return true;
-      }
-    }
-    return false;
-  }
-  if (D.isListTy()) {
-    return Sub(D.getList().ValTy);
-  }
-  if (D.isTupleTy()) {
-    for (const auto &Ty : D.getTuple().Types) {
-      if (Sub(Ty)) {
-        return true;
-      }
-    }
-    return false;
-  }
-  if (D.isMapTy()) {
-    return Sub(D.getMap().KeyTy) || Sub(D.getMap().ValTy);
-  }
-  if (D.isOptionTy()) {
-    return Sub(D.getOption().ValTy);
-  }
-  if (D.isResultTy()) {
-    const auto &R = D.getResult();
-    return (R.ValTy.has_value() && Sub(*R.ValTy)) ||
-           (R.ErrTy.has_value() && Sub(*R.ErrTy));
-  }
-  // stream and future do not recurse: their element type is borrow-free by
-  // construction, since defining one rejects a borrow in its payload.
-  return false;
+  // Stream and future payloads are borrow-free, so the containers suffice.
+  bool Found = false;
+  forEachValType(D, [&](const ComponentValType &VT) noexcept {
+    Found = Found || containsBorrow({VT, Entry->Home, Entry->Remap});
+  });
+  return Found;
 }
 
 void TypeSystem::collectResources(const QualValType &Q,
                                   std::unordered_set<uint32_t> &Out) noexcept {
-  collectNormalValResources(normalizeValType(Q), Out);
+  TypeEntry Storage;
+  if (const auto *Entry = resolveQualType(Q, Storage)) {
+    collectResources(*Entry, Out);
+  }
 }
 
-void TypeSystem::collectNormalValResources(
-    const NormalVal &N, std::unordered_set<uint32_t> &Out) noexcept {
-  if (!N.Valid || N.DVT == nullptr) {
+void TypeSystem::collectResources(const TypeEntry &E,
+                                  std::unordered_set<uint32_t> &Out) noexcept {
+  const auto *Def = E.getDefValType();
+  if (Def == nullptr || Def->isPrimValType()) {
     return;
   }
-  const auto &D = *N.DVT;
+  const auto &D = *Def;
   auto Sub = [&](const ComponentValType &VT) noexcept {
-    collectResources({VT, N.Home, N.Remap}, Out);
+    collectResources({VT, E.Home, E.Remap}, Out);
   };
   if (D.isOwnTy() || D.isBorrowTy()) {
     const uint32_t Idx = D.isOwnTy() ? D.getOwn().Idx : D.getBorrow().Idx;
-    if (auto Id = resolveResourceId(N.Home, N.Remap, Idx)) {
+    if (auto Id = resolveResourceId(E.Home, E.Remap, Idx)) {
       Out.insert(*Id);
     }
     return;
   }
-  if (D.isRecordTy()) {
-    for (const auto &LT : D.getRecord().LabelTypes) {
-      Sub(LT.getValType());
+  // A stream or future payload can reach a resource too.
+  if (D.isStreamTy() || D.isFutureTy()) {
+    const auto &Elem =
+        D.isStreamTy() ? D.getStream().ValTy : D.getFuture().ValTy;
+    if (Elem.has_value()) {
+      Sub(*Elem);
     }
-  } else if (D.isVariantTy()) {
-    for (const auto &[Label, Ty] : D.getVariant().Cases) {
-      if (Ty.has_value()) {
-        Sub(*Ty);
-      }
-    }
-  } else if (D.isListTy()) {
-    Sub(D.getList().ValTy);
-  } else if (D.isTupleTy()) {
-    for (const auto &Ty : D.getTuple().Types) {
-      Sub(Ty);
-    }
-  } else if (D.isMapTy()) {
-    Sub(D.getMap().KeyTy);
-    Sub(D.getMap().ValTy);
-  } else if (D.isOptionTy()) {
-    Sub(D.getOption().ValTy);
-  } else if (D.isResultTy()) {
-    if (D.getResult().ValTy.has_value()) {
-      Sub(*D.getResult().ValTy);
-    }
-    if (D.getResult().ErrTy.has_value()) {
-      Sub(*D.getResult().ErrTy);
-    }
-  } else if (D.isStreamTy()) {
-    if (D.getStream().ValTy.has_value()) {
-      Sub(*D.getStream().ValTy);
-    }
-  } else if (D.isFutureTy()) {
-    if (D.getFuture().ValTy.has_value()) {
-      Sub(*D.getFuture().ValTy);
-    }
+    return;
   }
+  forEachValType(D, Sub);
 }
 
 void TypeSystem::collectResources(const ExternInfo &Info,
                                   std::unordered_set<uint32_t> &Out) noexcept {
-  switch (Info.K) {
+  switch (Info.Kind) {
   case ExternKind::CoreType:
     return;
   case ExternKind::FuncType: {
@@ -221,7 +166,7 @@ void TypeSystem::collectResources(const ExternInfo &Info,
     return;
   case ExternKind::TypeBound: {
     const auto &E = Info.Type;
-    if (E.ResourceId.has_value()) {
+    if (E.isResource()) {
       Out.insert(*E.ResourceId);
       return;
     }
@@ -240,15 +185,15 @@ void TypeSystem::collectResources(const ExternInfo &Info,
       }
       return;
     }
-    if (E.DT != nullptr && E.DT->isDefValType()) {
-      collectNormalValResources(normalizeEntry(E), Out);
+    if (E.getDefValType() != nullptr) {
+      collectResources(E, Out);
       return;
     }
-    if (E.DT != nullptr && E.DT->isFuncType()) {
-      for (const auto &P : E.DT->getFuncType().getParamList()) {
+    if (const auto *FT = E.getFuncType()) {
+      for (const auto &P : FT->getParamList()) {
         collectResources({P.getValType(), E.Home, E.Remap}, Out);
       }
-      for (const auto &R : E.DT->getFuncType().getResultList()) {
+      for (const auto &R : FT->getResultList()) {
         collectResources({R.getValType(), E.Home, E.Remap}, Out);
       }
     }
@@ -283,67 +228,46 @@ bool TypeSystem::originatesIn(uint32_t Id, const Scope &S) const noexcept {
 // Effective type-size and nesting-depth limits.
 // ---------------------------------------------------------------------------
 
-// Effective size of a value type. This is the metric of the spec limit, and
-// it is memoized per node.
-uint64_t TypeSystem::sizeOfValType(const QualValType &Q) noexcept {
-  return sizeOfNormalVal(normalizeValType(Q));
+// Effective size of a value type (the spec limit metric), memoized per node.
+uint64_t TypeSystem::getTypeSize(const QualValType &Q) noexcept {
+  TypeEntry Storage;
+  const auto *Entry = resolveQualType(Q, Storage);
+  return Entry != nullptr ? getTypeSize(*Entry) : 1;
 }
 
-uint64_t TypeSystem::sizeOfNormalVal(const NormalVal &N) noexcept {
-  if (!N.Valid || N.DVT == nullptr) {
+uint64_t TypeSystem::getTypeSize(const TypeEntry &E) noexcept {
+  const auto *Def = E.getDefValType();
+  if (Def == nullptr || Def->isPrimValType()) {
     return 1;
   }
-  auto It = TypeSizeMemo.find(N.DVT);
+  auto It = TypeSizeMemo.find(Def);
   if (It != TypeSizeMemo.end()) {
     return It->second;
   }
-  TypeSizeMemo.emplace(N.DVT, 1); // Break cycles defensively.
-  const auto &D = *N.DVT;
+  TypeSizeMemo.emplace(Def, 1); // Break cycles defensively.
+  const auto &D = *Def;
   uint64_t Size = 1;
-  auto Add = [&](const ComponentValType &VT) noexcept {
-    Size += sizeOfValType({VT, N.Home, N.Remap});
-  };
-  if (D.isRecordTy()) {
-    for (const auto &LT : D.getRecord().LabelTypes) {
-      Add(LT.getValType());
-    }
-  } else if (D.isVariantTy()) {
+  // A payload-less variant case and every flags or enum label count one.
+  if (D.isVariantTy()) {
     for (const auto &[Label, Ty] : D.getVariant().Cases) {
-      if (Ty.has_value()) {
-        Add(*Ty);
-      } else {
+      if (!Ty.has_value()) {
         Size += 1;
       }
-    }
-  } else if (D.isListTy()) {
-    Add(D.getList().ValTy);
-  } else if (D.isTupleTy()) {
-    for (const auto &Ty : D.getTuple().Types) {
-      Add(Ty);
-    }
-  } else if (D.isMapTy()) {
-    Add(D.getMap().KeyTy);
-    Add(D.getMap().ValTy);
-  } else if (D.isOptionTy()) {
-    Add(D.getOption().ValTy);
-  } else if (D.isResultTy()) {
-    if (D.getResult().ValTy.has_value()) {
-      Add(*D.getResult().ValTy);
-    }
-    if (D.getResult().ErrTy.has_value()) {
-      Add(*D.getResult().ErrTy);
     }
   } else if (D.isFlagsTy()) {
     Size += D.getFlags().Labels.size();
   } else if (D.isEnumTy()) {
     Size += D.getEnum().Labels.size();
   }
-  TypeSizeMemo[N.DVT] = Size;
+  forEachValType(D, [&](const ComponentValType &VT) noexcept {
+    Size += getTypeSize({VT, E.Home, E.Remap});
+  });
+  TypeSizeMemo[Def] = Size;
   return Size;
 }
 
-uint64_t TypeSystem::sizeOfExtern(const ExternInfo &Info) noexcept {
-  switch (Info.K) {
+uint64_t TypeSystem::getTypeSize(const ExternInfo &Info) noexcept {
+  switch (Info.Kind) {
   case ExternKind::CoreType:
     return Info.CoreMod != nullptr
                ? 1 + Info.CoreMod->Imports.size() + Info.CoreMod->Exports.size()
@@ -358,19 +282,19 @@ uint64_t TypeSystem::sizeOfExtern(const ExternInfo &Info) noexcept {
     }
     uint64_t Size = 1;
     for (const auto &P : Info.Func.FT->getParamList()) {
-      Size += sizeOfValType({P.getValType(), Info.Func.Home, Info.Func.Remap});
+      Size += getTypeSize({P.getValType(), Info.Func.Home, Info.Func.Remap});
     }
     for (const auto &R : Info.Func.FT->getResultList()) {
-      Size += sizeOfValType({R.getValType(), Info.Func.Home, Info.Func.Remap});
+      Size += getTypeSize({R.getValType(), Info.Func.Home, Info.Func.Remap});
     }
     TypeSizeMemo.emplace(Info.Func.FT, Size);
     return Size;
   }
   case ExternKind::ValueBound:
-    return 1 + sizeOfValType(Info.Value);
+    return 1 + getTypeSize(Info.Value);
   case ExternKind::TypeBound: {
     const auto &E = Info.Type;
-    if (E.ResourceId.has_value()) {
+    if (E.isResource()) {
       return 1;
     }
     if (E.Inst != nullptr || E.Comp != nullptr) {
@@ -384,27 +308,27 @@ uint64_t TypeSystem::sizeOfExtern(const ExternInfo &Info) noexcept {
       uint64_t Size = 1;
       if (E.Inst != nullptr) {
         for (const auto &[Name, Sub] : E.Inst->Exports) {
-          Size += 1 + sizeOfExtern(Sub);
+          Size += 1 + getTypeSize(Sub);
         }
       } else {
         for (const auto &[Name, Sub] : E.Comp->Imports) {
-          Size += 1 + sizeOfExtern(Sub);
+          Size += 1 + getTypeSize(Sub);
         }
         for (const auto &[Name, Sub] : E.Comp->Exports) {
-          Size += 1 + sizeOfExtern(Sub);
+          Size += 1 + getTypeSize(Sub);
         }
       }
       TypeSizeMemo[Key] = Size;
       return Size;
     }
-    if (E.DT != nullptr && E.DT->isDefValType()) {
-      return sizeOfNormalVal(normalizeEntry(E));
+    if (E.getDefValType() != nullptr) {
+      return getTypeSize(E);
     }
-    if (E.DT != nullptr && E.DT->isFuncType()) {
+    if (E.getFuncType() != nullptr) {
       ExternInfo FI;
-      FI.K = ExternKind::FuncType;
-      FI.Func = {&E.DT->getFuncType(), E.Home, E.Remap};
-      return sizeOfExtern(FI);
+      FI.Kind = ExternKind::FuncType;
+      FI.Func = {E.getFuncType(), E.Home, E.Remap};
+      return getTypeSize(FI);
     }
     return 1;
   }
@@ -421,10 +345,10 @@ uint64_t TypeSystem::sizeOfExtern(const ExternInfo &Info) noexcept {
     TypeSizeMemo.emplace(Info.Shape, 1);
     uint64_t Size = 1;
     for (const auto &[Name, Sub] : Info.Shape->Imports) {
-      Size += 1 + sizeOfExtern(Sub);
+      Size += 1 + getTypeSize(Sub);
     }
     for (const auto &[Name, Sub] : Info.Shape->Exports) {
-      Size += 1 + sizeOfExtern(Sub);
+      Size += 1 + getTypeSize(Sub);
     }
     TypeSizeMemo[Info.Shape] = Size;
     return Size;
@@ -433,72 +357,45 @@ uint64_t TypeSystem::sizeOfExtern(const ExternInfo &Info) noexcept {
   return 1;
 }
 
-// Depth of a value type: leaves count 1, wrappers add 1. Guards the recursive
-// canonical-ABI walkers.
-uint64_t TypeSystem::depthOfValType(const QualValType &Q) noexcept {
-  return depthOfNormalVal(normalizeValType(Q));
+// Depth of a value type: leaves count 1, wrappers add 1.
+uint64_t TypeSystem::getTypeDepth(const QualValType &Q) noexcept {
+  TypeEntry Storage;
+  const auto *Entry = resolveQualType(Q, Storage);
+  return Entry != nullptr ? getTypeDepth(*Entry) : 1;
 }
 
-uint64_t TypeSystem::depthOfNormalVal(const NormalVal &N) noexcept {
-  if (!N.Valid || N.DVT == nullptr) {
+uint64_t TypeSystem::getTypeDepth(const TypeEntry &E) noexcept {
+  const auto *Def = E.getDefValType();
+  if (Def == nullptr || Def->isPrimValType()) {
     return 1;
   }
-  auto It = TypeDepthMemo.find(N.DVT);
+  auto It = TypeDepthMemo.find(Def);
   if (It != TypeDepthMemo.end()) {
     return It->second;
   }
-  TypeDepthMemo.emplace(N.DVT, 1); // Break cycles defensively.
-  const auto &D = *N.DVT;
+  TypeDepthMemo.emplace(Def, 1); // Break cycles defensively.
+  const auto &D = *Def;
   uint64_t Max = 0;
-  auto Sub = [&](const ComponentValType &VT) noexcept {
-    Max = std::max(Max, depthOfValType({VT, N.Home, N.Remap}));
-  };
-  if (D.isRecordTy()) {
-    for (const auto &LT : D.getRecord().LabelTypes) {
-      Sub(LT.getValType());
-    }
-  } else if (D.isVariantTy()) {
-    for (const auto &[Name, VT] : D.getVariant().Cases) {
-      if (VT.has_value()) {
-        Sub(*VT);
-      }
-    }
-  } else if (D.isListTy()) {
-    Sub(D.getList().ValTy);
-  } else if (D.isTupleTy()) {
-    for (const auto &VT : D.getTuple().Types) {
-      Sub(VT);
-    }
-  } else if (D.isMapTy()) {
-    Sub(D.getMap().KeyTy);
-    Sub(D.getMap().ValTy);
-  } else if (D.isOptionTy()) {
-    Sub(D.getOption().ValTy);
-  } else if (D.isResultTy()) {
-    if (D.getResult().ValTy.has_value()) {
-      Sub(*D.getResult().ValTy);
-    }
-    if (D.getResult().ErrTy.has_value()) {
-      Sub(*D.getResult().ErrTy);
-    }
-  }
+  forEachValType(D, [&](const ComponentValType &VT) noexcept {
+    Max = std::max(Max, getTypeDepth({VT, E.Home, E.Remap}));
+  });
   const uint64_t Depth = Max + 1;
-  TypeDepthMemo[N.DVT] = Depth;
+  TypeDepthMemo[Def] = Depth;
   return Depth;
 }
 
-uint64_t TypeSystem::depthOfExtern(const ExternInfo &Info) noexcept {
+uint64_t TypeSystem::getTypeDepth(const ExternInfo &Info) noexcept {
   uint64_t Max = 0;
-  switch (Info.K) {
+  switch (Info.Kind) {
   case ExternKind::FuncType:
     if (Info.Func.FT != nullptr) {
       for (const auto &P : Info.Func.FT->getParamList()) {
-        Max = std::max(Max, depthOfValType({P.getValType(), Info.Func.Home,
-                                            Info.Func.Remap}));
+        Max = std::max(Max, getTypeDepth({P.getValType(), Info.Func.Home,
+                                          Info.Func.Remap}));
       }
       for (const auto &R : Info.Func.FT->getResultList()) {
-        Max = std::max(Max, depthOfValType({R.getValType(), Info.Func.Home,
-                                            Info.Func.Remap}));
+        Max = std::max(Max, getTypeDepth({R.getValType(), Info.Func.Home,
+                                          Info.Func.Remap}));
       }
     }
     break;
@@ -506,27 +403,26 @@ uint64_t TypeSystem::depthOfExtern(const ExternInfo &Info) noexcept {
     const auto &E = Info.Type;
     if (E.Inst != nullptr || E.Comp != nullptr) {
       ExternInfo Probe;
-      Probe.K = E.Inst != nullptr ? ExternKind::InstanceType
-                                  : ExternKind::ComponentType;
+      Probe.Kind = E.Inst != nullptr ? ExternKind::InstanceType
+                                     : ExternKind::ComponentType;
       Probe.Shape = E.Inst != nullptr ? E.Inst : E.Comp;
-      Max = depthOfExtern(Probe);
-    } else if (E.DT != nullptr && E.DT->isDefValType()) {
-      Max = depthOfNormalVal(normalizeEntry(E));
-    } else if (E.DT != nullptr && E.DT->isFuncType()) {
+      Max = getTypeDepth(Probe);
+    } else if (E.getDefValType() != nullptr) {
+      Max = getTypeDepth(E);
+    } else if (E.getFuncType() != nullptr) {
       ExternInfo Probe;
-      Probe.K = ExternKind::FuncType;
-      Probe.Func = {&E.DT->getFuncType(), E.Home, E.Remap};
-      Max = depthOfExtern(Probe);
+      Probe.Kind = ExternKind::FuncType;
+      Probe.Func = {E.getFuncType(), E.Home, E.Remap};
+      Max = getTypeDepth(Probe);
     }
     break;
   }
   case ExternKind::ValueBound:
-    Max = depthOfValType(Info.Value);
+    Max = getTypeDepth(Info.Value);
     break;
   case ExternKind::InstanceType:
   case ExternKind::ComponentType: {
-    // A shape is one nesting level of its own. Instances carry no imports, so
-    // one walk covers both shapes.
+    // A shape is one nesting level; one walk covers both shapes.
     if (Info.Shape == nullptr) {
       return 1;
     }
@@ -536,10 +432,10 @@ uint64_t TypeSystem::depthOfExtern(const ExternInfo &Info) noexcept {
     }
     TypeDepthMemo.emplace(Info.Shape, 1); // Break cycles defensively.
     for (const auto &[Name, E] : Info.Shape->Imports) {
-      Max = std::max(Max, depthOfExtern(E));
+      Max = std::max(Max, getTypeDepth(E));
     }
     for (const auto &[Name, E] : Info.Shape->Exports) {
-      Max = std::max(Max, depthOfExtern(E));
+      Max = std::max(Max, getTypeDepth(E));
     }
     TypeDepthMemo[Info.Shape] = Max + 1;
     return Max + 1;
@@ -551,19 +447,16 @@ uint64_t TypeSystem::depthOfExtern(const ExternInfo &Info) noexcept {
   return Max;
 }
 
-Expect<void> TypeSystem::checkTypeSize(uint64_t Size) const noexcept {
+Expect<void> TypeSystem::checkTypeLimits(const ExternInfo &Info) noexcept {
+  const uint64_t Size = getTypeSize(Info);
   if (Size >= MaxTypeSize) {
     spdlog::error(ErrCode::Value::ComponentTypeSizeLimit);
     spdlog::error("    Effective type size {} exceeds the limit of {}."sv, Size,
                   MaxTypeSize);
     return Unexpect(ErrCode::Value::ComponentTypeSizeLimit);
   }
-  return {};
-}
-
-Expect<void> TypeSystem::checkTypeDepth(uint64_t Depth) const noexcept {
-  // The reference engine bounds value-type nesting at 100.
-  if (Depth > 100) {
+  const uint64_t Depth = getTypeDepth(Info);
+  if (Depth > MaxTypeDepth) {
     spdlog::error(ErrCode::Value::ComponentTypeNestingDepth);
     spdlog::error("    Value type nesting depth {} exceeds the limit."sv,
                   Depth);
@@ -572,63 +465,58 @@ Expect<void> TypeSystem::checkTypeDepth(uint64_t Depth) const noexcept {
   return {};
 }
 
-Expect<void> TypeSystem::checkTypeLimits(const ExternInfo &Info) noexcept {
-  EXPECTED_TRY(checkTypeSize(sizeOfExtern(Info)));
-  EXPECTED_TRY(checkTypeDepth(depthOfExtern(Info)));
-  return {};
-}
-
 // ---------------------------------------------------------------------------
 // Canonical ABI flattening (spec `flatten_functype`).
 // ---------------------------------------------------------------------------
 
-// Spec flatten_type: appends the flat core types of Q. Returns false for
-// types that cannot be flattened (async-gated ones).
+// Spec flatten_type: appends the flat core types of Q; false if unflattenable.
 bool TypeSystem::flattenValType(const QualValType &Q, std::vector<ValType> &Out,
                                 const ValType &Ptr) noexcept {
   if (Out.size() > MaxFlatExpand) {
     return true;
   }
-  const auto N = normalizeValType(Q);
-  if (!N.Valid) {
-    return false;
-  }
-  if (N.DVT == nullptr) {
-    switch (N.Prim) {
-    case ComponentTypeCode::Bool:
-    case ComponentTypeCode::S8:
-    case ComponentTypeCode::U8:
-    case ComponentTypeCode::S16:
-    case ComponentTypeCode::U16:
-    case ComponentTypeCode::S32:
-    case ComponentTypeCode::U32:
-    case ComponentTypeCode::Char:
+  if (const auto Prim = resolvePrimValType(Q)) {
+    switch (*Prim) {
+    case AST::Component::PrimValType::Bool:
+    case AST::Component::PrimValType::S8:
+    case AST::Component::PrimValType::U8:
+    case AST::Component::PrimValType::S16:
+    case AST::Component::PrimValType::U16:
+    case AST::Component::PrimValType::S32:
+    case AST::Component::PrimValType::U32:
+    case AST::Component::PrimValType::Char:
       Out.push_back(ValType(TypeCode::I32));
       return true;
-    case ComponentTypeCode::S64:
-    case ComponentTypeCode::U64:
+    case AST::Component::PrimValType::S64:
+    case AST::Component::PrimValType::U64:
       Out.push_back(ValType(TypeCode::I64));
       return true;
-    case ComponentTypeCode::F32:
+    case AST::Component::PrimValType::F32:
       Out.push_back(ValType(TypeCode::F32));
       return true;
-    case ComponentTypeCode::F64:
+    case AST::Component::PrimValType::F64:
       Out.push_back(ValType(TypeCode::F64));
       return true;
-    case ComponentTypeCode::String:
+    case AST::Component::PrimValType::String:
       Out.push_back(Ptr);
       Out.push_back(Ptr);
       return true;
-    case ComponentTypeCode::ErrContext:
+    case AST::Component::PrimValType::ErrorContext:
       Out.push_back(ValType(TypeCode::I32));
       return true;
     default:
       return false;
     }
   }
-  const auto &D = *N.DVT;
+  TypeEntry Storage;
+  const auto *Entry = resolveQualType(Q, Storage);
+  const auto *Def = Entry != nullptr ? Entry->getDefValType() : nullptr;
+  if (Def == nullptr) {
+    return false;
+  }
+  const auto &D = *Def;
   auto Sub = [&](const ComponentValType &VT) noexcept {
-    return flattenValType({VT, N.Home, N.Remap}, Out, Ptr);
+    return flattenValType({VT, Entry->Home, Entry->Remap}, Out, Ptr);
   };
   if (D.isRecordTy()) {
     for (const auto &LT : D.getRecord().LabelTypes) {
@@ -649,8 +537,7 @@ bool TypeSystem::flattenValType(const QualValType &Q, std::vector<ValType> &Out,
   if (D.isListTy()) {
     const auto &L = D.getList();
     if (L.Len.has_value()) {
-      // Fixed-length lists flatten to Len copies of the element. Every copy
-      // widens Out, so the ceiling also bounds the iteration count.
+      // Fixed-length lists flatten to Len copies of the element.
       for (uint32_t I = 0; I < *L.Len && Out.size() <= MaxFlatExpand; ++I) {
         if (!Sub(L.ValTy)) {
           return false;
@@ -710,7 +597,7 @@ bool TypeSystem::flattenValType(const QualValType &Q, std::vector<ValType> &Out,
     for (const auto &Payload : Payloads) {
       std::vector<ValType> Flat;
       for (const auto &Ty : Payload) {
-        if (!flattenValType({Ty, N.Home, N.Remap}, Flat, Ptr)) {
+        if (!flattenValType({Ty, Entry->Home, Entry->Remap}, Flat, Ptr)) {
           return false;
         }
       }
@@ -729,59 +616,26 @@ bool TypeSystem::flattenValType(const QualValType &Q, std::vector<ValType> &Out,
   return false;
 }
 
-// True iff the type transitively contains a list or string (drives the memory
-// / realloc option requirements).
+// True iff the type transitively contains a list, map, or string.
 bool TypeSystem::needsMemory(const QualValType &Q) noexcept {
-  const auto N = normalizeValType(Q);
-  if (!N.Valid) {
+  if (const auto Prim = resolvePrimValType(Q)) {
+    return *Prim == AST::Component::PrimValType::String;
+  }
+  TypeEntry Storage;
+  const auto *Entry = resolveQualType(Q, Storage);
+  const auto *Def = Entry != nullptr ? Entry->getDefValType() : nullptr;
+  if (Def == nullptr) {
     return false;
   }
-  if (N.DVT == nullptr) {
-    return N.Prim == ComponentTypeCode::String;
-  }
-  const auto &D = *N.DVT;
-  auto Sub = [&](const ComponentValType &VT) noexcept {
-    return needsMemory({VT, N.Home, N.Remap});
-  };
-  if (D.isListTy()) {
+  const auto &D = *Def;
+  if (D.isListTy() || D.isMapTy()) {
     return true;
   }
-  if (D.isRecordTy()) {
-    for (const auto &LT : D.getRecord().LabelTypes) {
-      if (Sub(LT.getValType())) {
-        return true;
-      }
-    }
-    return false;
-  }
-  if (D.isVariantTy()) {
-    for (const auto &[Label, Ty] : D.getVariant().Cases) {
-      if (Ty.has_value() && Sub(*Ty)) {
-        return true;
-      }
-    }
-    return false;
-  }
-  if (D.isTupleTy()) {
-    for (const auto &Ty : D.getTuple().Types) {
-      if (Sub(Ty)) {
-        return true;
-      }
-    }
-    return false;
-  }
-  if (D.isMapTy()) {
-    return true;
-  }
-  if (D.isOptionTy()) {
-    return Sub(D.getOption().ValTy);
-  }
-  if (D.isResultTy()) {
-    const auto &R = D.getResult();
-    return (R.ValTy.has_value() && Sub(*R.ValTy)) ||
-           (R.ErrTy.has_value() && Sub(*R.ErrTy));
-  }
-  return false;
+  bool Found = false;
+  forEachValType(D, [&](const ComponentValType &VT) noexcept {
+    Found = Found || needsMemory({VT, Entry->Home, Entry->Remap});
+  });
+  return Found;
 }
 
 Expect<AST::FunctionType>
@@ -818,13 +672,12 @@ TypeSystem::flattenFuncType(const FuncInfo &FI, const ValType &Ptr,
 // Instantiation-time substitution.
 // ---------------------------------------------------------------------------
 
-// Rebuild a view across an instantiation boundary. Node is the combined
-// substitution and freshening, and Memo keeps shape identity.
+// Rebuild a view across an instantiation boundary under the Node remap.
 ExternInfo TypeSystem::rebuildExtern(const ExternInfo &E,
                                      const ResourceMap *Node,
                                      ShapeMemo &Memo) noexcept {
   ExternInfo R = E;
-  switch (E.K) {
+  switch (E.Kind) {
   case ExternKind::CoreType:
     break;
   case ExternKind::FuncType:
@@ -848,7 +701,7 @@ TypeEntry TypeSystem::rebuildTypeEntry(const TypeEntry &E,
                                        const ResourceMap *Node,
                                        ShapeMemo &Memo) noexcept {
   TypeEntry R = E;
-  if (E.ResourceId.has_value()) {
+  if (E.isResource()) {
     R.ResourceId = Node->apply(*E.ResourceId);
     if (*R.ResourceId != *E.ResourceId) {
       R.NameId = getResource(*R.ResourceId).NameId;
@@ -864,8 +717,7 @@ TypeEntry TypeSystem::rebuildTypeEntry(const TypeEntry &E,
   return R;
 }
 
-// One walk for both shapes: instances have no imports, components no
-// declaration order, so each loop is a no-op for the other kind.
+// One walk for both shapes; each loop is a no-op for the other kind.
 const Shape *TypeSystem::rebuildShape(const Shape *S, const ResourceMap *Node,
                                       ShapeMemo &Memo) noexcept {
   if (S == nullptr) {
@@ -875,7 +727,7 @@ const Shape *TypeSystem::rebuildShape(const Shape *S, const ResourceMap *Node,
   if (It != Memo.end()) {
     return It->second;
   }
-  auto *R = newShape();
+  auto *R = addShape();
   Memo.emplace(S, R);
   R->DeclScope = S->DeclScope;
   R->ExportOrder = S->ExportOrder;
@@ -891,18 +743,17 @@ const Shape *TypeSystem::rebuildShape(const Shape *S, const ResourceMap *Node,
 const Shape *TypeSystem::freshenDeclaredResources(const Shape *Inst,
                                                   const Scope &Origin,
                                                   bool FromImport) noexcept {
-  // Only declaration-built shapes carry their own declared resources. The
-  // resources of a concrete instance belong to the enclosing component.
+  // Only declaration-built shapes carry their own declared resources.
   if (Inst == nullptr || Inst->DeclScope == nullptr ||
-      Inst->DeclScope->K != Scope::Kind::InstanceType) {
+      Inst->DeclScope->Kind != ScopeKind::InstanceType) {
     return Inst;
   }
   std::unordered_set<uint32_t> Ids;
   ExternInfo Probe;
-  Probe.K = ExternKind::InstanceType;
+  Probe.Kind = ExternKind::InstanceType;
   Probe.Shape = Inst;
   collectResources(Probe, Ids);
-  auto *Node = newResourceMap();
+  auto *Node = addResourceMap();
   for (const uint32_t Id : Ids) {
     if (originatesIn(Id, *Inst->DeclScope)) {
       Node->Map.emplace(Id, addResource(nullptr, &Origin, FromImport));
@@ -919,7 +770,7 @@ const Shape *
 TypeSystem::rebuildInstanceExports(const Shape &CI,
                                    const ResourceMap *Node) noexcept {
   ShapeMemo Memo;
-  auto *Result = newShape();
+  auto *Result = addShape();
   Result->DeclScope = CI.DeclScope;
   for (const auto &[Name, E] : CI.Exports) {
     Result->Exports.emplace(Name, rebuildExtern(E, Node, Memo));
@@ -934,36 +785,48 @@ TypeSystem::rebuildInstanceExports(const Shape &CI,
 
 bool Matcher::matchValType(const QualValType &Sub,
                            const QualValType &Sup) noexcept {
-  return matchNormalVal(Types.normalizeValType(Sub),
-                        Types.normalizeValType(Sup));
+  const auto PSub = Types.resolvePrimValType(Sub);
+  const auto PSup = Types.resolvePrimValType(Sup);
+  if (PSub.has_value() || PSup.has_value()) {
+    return PSub.has_value() && PSup.has_value() &&
+           matchPrimValType(*PSub, *PSup);
+  }
+  TypeEntry SubStorage, SupStorage;
+  const auto *SubEntry = Types.resolveQualType(Sub, SubStorage);
+  const auto *SupEntry = Types.resolveQualType(Sup, SupStorage);
+  return SubEntry != nullptr && SupEntry != nullptr &&
+         matchValType(*SubEntry, *SupEntry);
 }
 
-bool Matcher::matchNormalVal(const NormalVal &NSub,
-                             const NormalVal &NSup) noexcept {
-  if (!NSub.Valid || !NSup.Valid) {
-    return false;
-  }
-  if (NSub.DVT == nullptr && NSup.DVT == nullptr) {
-    if (NSub.Prim != NSup.Prim) {
-      // Only a class-level difference names the primitive. A
-      // scalar-against-scalar mismatch keeps the positional diagnostic.
-      if ((NSub.Prim == ComponentTypeCode::String) !=
-          (NSup.Prim == ComponentTypeCode::String)) {
-        FailCode = ErrCode::Value::ComponentPrimitiveMismatch;
-      }
-      return false;
+bool Matcher::matchPrimValType(AST::Component::PrimValType Sub,
+                               AST::Component::PrimValType Sup) noexcept {
+  if (Sub != Sup) {
+    // Only a class-level difference names the primitive.
+    if ((Sub == AST::Component::PrimValType::String) !=
+        (Sup == AST::Component::PrimValType::String)) {
+      FailCode = ErrCode::Value::ComponentPrimitiveMismatch;
     }
-    return true;
-  }
-  if (NSub.DVT == nullptr || NSup.DVT == nullptr) {
     return false;
   }
-  const auto &A = *NSub.DVT;
-  const auto &B = *NSup.DVT;
+  return true;
+}
+
+bool Matcher::matchValType(const TypeEntry &Sub,
+                           const TypeEntry &Sup) noexcept {
+  const auto *ADef = Sub.getDefValType();
+  const auto *BDef = Sup.getDefValType();
+  if (ADef == nullptr || BDef == nullptr) {
+    return false;
+  }
+  if (ADef->isPrimValType() || BDef->isPrimValType()) {
+    return ADef->isPrimValType() && BDef->isPrimValType() &&
+           matchPrimValType(ADef->getPrimValType(), BDef->getPrimValType());
+  }
+  const auto &A = *ADef;
+  const auto &B = *BDef;
   auto MatchSub = [&](const ComponentValType &VA,
                       const ComponentValType &VB) noexcept {
-    return matchValType({VA, NSub.Home, NSub.Remap},
-                        {VB, NSup.Home, NSup.Remap});
+    return matchValType({VA, Sub.Home, Sub.Remap}, {VB, Sup.Home, Sup.Remap});
   };
   auto MatchOpt = [&](const std::optional<ComponentValType> &VA,
                       const std::optional<ComponentValType> &VB) noexcept {
@@ -1065,8 +928,8 @@ bool Matcher::matchNormalVal(const NormalVal &NSub,
   if ((A.isOwnTy() && B.isOwnTy()) || (A.isBorrowTy() && B.isBorrowTy())) {
     const uint32_t IA = A.isOwnTy() ? A.getOwn().Idx : A.getBorrow().Idx;
     const uint32_t IB = B.isOwnTy() ? B.getOwn().Idx : B.getBorrow().Idx;
-    const auto RA = Types.resolveResourceId(NSub.Home, NSub.Remap, IA);
-    const auto RB = Types.resolveResourceId(NSup.Home, NSup.Remap, IB);
+    const auto RA = Types.resolveResourceId(Sub.Home, Sub.Remap, IA);
+    const auto RB = Types.resolveResourceId(Sup.Home, Sup.Remap, IB);
     if (!RA.has_value() || !RB.has_value()) {
       return false;
     }
@@ -1122,8 +985,8 @@ bool Matcher::matchFunc(const FuncInfo &Sub, const FuncInfo &Sup) noexcept {
 bool Matcher::matchTypeEntry(const TypeEntry &Sub,
                              const TypeEntry &Sup) noexcept {
   // Abstract resource supertype: binds (or re-checks) the substitution.
-  if (Sup.ResourceId.has_value() && Sup.DT == nullptr) {
-    if (!Sub.ResourceId.has_value()) {
+  if (Sup.isResource() && Sup.DT == nullptr) {
+    if (!Sub.isResource()) {
       FailCode = ErrCode::Value::ComponentExpectedResource;
       return false;
     }
@@ -1132,15 +995,14 @@ bool Matcher::matchTypeEntry(const TypeEntry &Sub,
       FailCode = ErrCode::Value::ComponentResourceMismatch;
       return false;
     }
-    // Abstract-to-abstract bindings work in both directions (component
-    // shapes are matched contravariantly on imports).
+    // Abstract-to-abstract bindings work in both directions.
     if (Sub.DT == nullptr) {
       Subst.Map.emplace(*Sub.ResourceId, *Sup.ResourceId);
     }
     return true;
   }
-  if (Sup.ResourceId.has_value()) {
-    if (!Sub.ResourceId.has_value()) {
+  if (Sup.isResource()) {
+    if (!Sub.isResource()) {
       FailCode = ErrCode::Value::ComponentExpectedResource;
       return false;
     }
@@ -1151,8 +1013,8 @@ bool Matcher::matchTypeEntry(const TypeEntry &Sub,
     }
     return *Sub.ResourceId == SupId;
   }
-  if (Sub.ResourceId.has_value()) {
-    if (Sup.DT != nullptr && Sup.DT->isDefValType()) {
+  if (Sub.isResource()) {
+    if (Sup.getDefValType() != nullptr) {
       FailCode = ErrCode::Value::ComponentExpectedDefinedType;
     }
     return false;
@@ -1163,27 +1025,20 @@ bool Matcher::matchTypeEntry(const TypeEntry &Sub,
   if (Sup.Comp != nullptr) {
     return Sub.Comp != nullptr && matchComponentShape(*Sub.Comp, *Sup.Comp);
   }
-  if (Sup.DT == nullptr || Sub.DT == nullptr) {
-    return false;
-  }
-  if (Sup.DT->isFuncType()) {
-    if (!Sub.DT->isFuncType()) {
+  if (Sup.getFuncType() != nullptr) {
+    if (Sub.getFuncType() == nullptr) {
       return false;
     }
-    return matchFunc({&Sub.DT->getFuncType(), Sub.Home, Sub.Remap},
-                     {&Sup.DT->getFuncType(), Sup.Home, Sup.Remap});
+    return matchFunc({Sub.getFuncType(), Sub.Home, Sub.Remap},
+                     {Sup.getFuncType(), Sup.Home, Sup.Remap});
   }
-  if (Sup.DT->isDefValType()) {
-    if (!Sub.DT->isDefValType()) {
-      return false;
-    }
-    return matchNormalVal(Types.normalizeEntry(Sub), Types.normalizeEntry(Sup));
+  if (Sup.getDefValType() != nullptr) {
+    return matchValType(Sub, Sup);
   }
   return false;
 }
 
-// Positional diagnostics ("type mismatch in instance export") beat leaf
-// reasons when the failure is nested inside an instance/component shape.
+// Positional diagnostics beat leaf reasons nested inside a shape.
 void Matcher::clearLeafFailCode() noexcept {
   switch (FailCode) {
   case ErrCode::Value::InstanceMissingExpectedExport:
@@ -1201,8 +1056,7 @@ void Matcher::clearLeafFailCode() noexcept {
 }
 
 bool Matcher::matchInstanceShape(const Shape &Sub, const Shape &Sup) noexcept {
-  // Walk expected exports in declaration order: abstract resources must
-  // bind before the functions that reference them.
+  // Declaration order: abstract resources bind before their functions.
   auto MatchOne = [&](const std::string &Name,
                       const ExternInfo &SupE) noexcept {
     auto It = Sub.Exports.find(Name);
@@ -1234,8 +1088,7 @@ bool Matcher::matchInstanceShape(const Shape &Sub, const Shape &Sup) noexcept {
 }
 
 bool Matcher::matchComponentShape(const Shape &Sub, const Shape &Sup) noexcept {
-  // Imports contravariant: everything Sub requires, Sup must require
-  // compatibly (so args satisfying Sup satisfy Sub).
+  // Imports are contravariant: whatever Sub requires, Sup must require.
   for (const auto &[Name, SubImp] : Sub.Imports) {
     const ExternInfo *SupImp = nullptr;
     for (const auto &[SupName, E] : Sup.Imports) {
@@ -1270,15 +1123,15 @@ bool Matcher::matchComponentShape(const Shape &Sub, const Shape &Sup) noexcept {
 
 bool Matcher::matchExtern(const ExternInfo &Sub,
                           const ExternInfo &Sup) noexcept {
-  if (Sub.K != Sup.K) {
-    if (Sup.K == ExternKind::FuncType) {
+  if (Sub.Kind != Sup.Kind) {
+    if (Sup.Kind == ExternKind::FuncType) {
       FailCode = ErrCode::Value::ComponentExpectedFunc;
-    } else if (Sup.K == ExternKind::ComponentType) {
+    } else if (Sup.Kind == ExternKind::ComponentType) {
       FailCode = ErrCode::Value::ComponentExpectedComponent;
     }
     return false;
   }
-  switch (Sup.K) {
+  switch (Sup.Kind) {
   case ExternKind::CoreType: {
     if (Sub.CoreMod == nullptr || Sup.CoreMod == nullptr) {
       return false;
@@ -1316,8 +1169,7 @@ bool Matcher::matchExtern(const ExternInfo &Sub,
     if (matchFunc(Sub.Func, Sup.Func)) {
       return true;
     }
-    // A value-leaf reason stays internal to a function signature. The
-    // diagnostic names the parameter or result position instead.
+    // A value-leaf reason stays internal to a function signature.
     if (FailCode == ErrCode::Value::ComponentPrimitiveMismatch ||
         FailCode == ErrCode::Value::ComponentEnumMismatch ||
         FailCode == ErrCode::Value::ComponentExpectedNoOkType ||
@@ -1340,48 +1192,34 @@ bool Matcher::matchExtern(const ExternInfo &Sub,
   return false;
 }
 
-bool Matcher::matchCoreFuncType(const AST::SubType *Sub,
-                                const AST::SubType *Sup) const noexcept {
-  if (Sub == nullptr || Sup == nullptr) {
-    return false;
-  }
-  const auto &CA = Sub->getCompositeType();
-  const auto &CB = Sup->getCompositeType();
-  if (!CA.isFunc() || !CB.isFunc()) {
-    return false;
-  }
-  return CA.getFuncType().getParamTypes() == CB.getFuncType().getParamTypes() &&
-         CA.getFuncType().getReturnTypes() == CB.getFuncType().getReturnTypes();
-}
-
 bool Matcher::matchCoreExtern(const CoreExternInfo &Sub,
                               const CoreExternInfo &Sup) const noexcept {
   if (Sub.Kind != Sup.Kind) {
     return false;
   }
-  auto MatchLimits = [](const AST::Limit &LA, const AST::Limit &LB) noexcept {
-    if (LA.is64() != LB.is64() || LA.isShared() != LB.isShared()) {
-      return false;
-    }
-    if (LA.getMin() < LB.getMin()) {
-      return false;
-    }
-    if (LB.hasMax()) {
-      return LA.hasMax() && LA.getMax() <= LB.getMax();
-    }
-    return true;
-  };
   switch (Sup.Kind) {
   case ExternalType::Function:
-  case ExternalType::Tag:
-    return matchCoreFuncType(Sub.Func, Sup.Func);
+  case ExternalType::Tag: {
+    if (Sub.Func == nullptr || Sup.Func == nullptr) {
+      return false;
+    }
+    const auto &CA = Sub.Func->getCompositeType();
+    const auto &CB = Sup.Func->getCompositeType();
+    return CA.isFunc() && CB.isFunc() &&
+           CA.getFuncType().getParamTypes() ==
+               CB.getFuncType().getParamTypes() &&
+           CA.getFuncType().getReturnTypes() ==
+               CB.getFuncType().getReturnTypes();
+  }
   case ExternalType::Table:
     return Sub.Table != nullptr && Sup.Table != nullptr &&
            Sub.Table->getRefType() == Sup.Table->getRefType() &&
-           MatchLimits(Sub.Table->getLimit(), Sup.Table->getLimit());
+           AST::TypeMatcher::matchLimit(Sup.Table->getLimit(),
+                                        Sub.Table->getLimit());
   case ExternalType::Memory:
     return Sub.Memory != nullptr && Sup.Memory != nullptr &&
-           MatchLimits(Sub.Memory->getLimit(), Sup.Memory->getLimit());
+           AST::TypeMatcher::matchLimit(Sup.Memory->getLimit(),
+                                        Sub.Memory->getLimit());
   case ExternalType::Global:
     return Sub.Global != nullptr && Sup.Global != nullptr &&
            Sub.Global->getValType() == Sup.Global->getValType() &&

--- a/lib/validator/component_validator.cpp
+++ b/lib/validator/component_validator.cpp
@@ -25,9 +25,8 @@ using namespace std::literals;
 Expect<void>
 Validator::validate(const AST::Component::Component &Comp) noexcept {
   CompCtx.reset();
-  EXPECTED_TRY(validate(Comp, *CompTypes.newShape()));
-  // Deferred function-body validation of all nested core modules, resumed
-  // on the checker state captured at each definition.
+  EXPECTED_TRY(validate(Comp, *CompTypes.addShape()));
+  // Deferred function-body validation on the checker state saved per module.
   for (auto &[Mod, Saved] : CompCtx.DeferredModules) {
     Checker = std::move(Saved);
     EXPECTED_TRY(validate(Mod->getCodeSection()).map_error([](auto E) {
@@ -45,9 +44,8 @@ Validator::validate(const AST::Component::Component &Comp) noexcept {
 
 Expect<void> Validator::validate(const AST::Component::Component &Comp,
                                  Component::Shape &Out) noexcept {
-  // Walk the sections in binary order, in a fresh scope. The index spaces
-  // grow as definitions validate, so a reference sees only earlier entries.
-  auto &S = CompCtx.enterScope(Component::Scope::Kind::Component);
+  // Walk the sections in binary order; a reference sees only earlier entries.
+  auto &S = CompCtx.enterScope(Component::ScopeKind::Component);
   Out.DeclScope = &S;
 
   auto ReportError = [](auto E) {
@@ -87,8 +85,7 @@ Expect<void> Validator::validate(const AST::Component::Component &Comp,
 
 Expect<void>
 Validator::validate(const AST::Component::CoreModuleSection &ModSec) noexcept {
-  // Validate the sections except the function bodies, which defer to the end
-  // of the root component, matching the reference validator's ordering.
+  // Validate every section but the function bodies, which defer to the end.
   const auto &Mod = ModSec.getContent();
   Checker.reset(true);
   auto ReportError = [](ASTNodeAttr Attr) {
@@ -139,7 +136,7 @@ Validator::validate(const AST::Component::CoreModuleSection &ModSec) noexcept {
   }
   CompCtx.DeferredModules.emplace_back(&Mod, Checker);
   EXPECTED_TRY(const auto *Shape, CompCtx.buildCoreShape(Mod));
-  CompCtx.top().CoreModules.push_back(Shape);
+  CompCtx.top().addCoreModule(Shape);
   return {};
 }
 
@@ -216,8 +213,7 @@ Validator::validate(const AST::Component::CoreInstance &Inst) noexcept {
         ErrCode::Value Code = ErrCode::Value::ArgTypeMismatch;
         switch (Required.Kind) {
         case ExternalType::Function:
-          // The message prints the expected signature; a trivial one is
-          // reported as `expected: (func)`.
+          // A trivial expected signature is reported as `expected: (func)`.
           if (Required.Func != nullptr &&
               Required.Func->getCompositeType().isFunc() &&
               Required.Func->getCompositeType()
@@ -264,15 +260,14 @@ Validator::validate(const AST::Component::CoreInstance &Inst) noexcept {
       }
     }
     // The new core instance exposes the module's exports.
-    auto *Result = CompTypes.newCoreShape();
+    auto *Result = CompTypes.addCoreShape();
     Result->Exports = Mod->Exports;
-    S.CoreInstances.push_back(Result);
+    S.addCoreInstance(Result);
     return {};
   }
 
-  // Inline exports: project current index-space entries into a fresh
-  // core instance.
-  auto *Result = CompTypes.newCoreShape();
+  // Inline exports project index-space entries into a fresh core instance.
+  auto *Result = CompTypes.addCoreShape();
   for (const auto &Exp : Inst.getInlineExports()) {
     const auto &SI = Exp.getSortIdx();
     const uint32_t Idx = SI.getIdx();
@@ -289,7 +284,7 @@ Validator::validate(const AST::Component::CoreInstance &Inst) noexcept {
         spdlog::error("    Core function index {} out of bounds."sv, Idx);
         return Unexpect(ErrCode::Value::DefTypeIndexOutOfBounds);
       }
-      Ext = {ExternalType::Function, F, nullptr, nullptr, nullptr};
+      Ext = Component::CoreExternInfo(ExternalType::Function, F);
       break;
     }
     case AST::Component::Sort::CoreSortType::Table: {
@@ -298,7 +293,7 @@ Validator::validate(const AST::Component::CoreInstance &Inst) noexcept {
         spdlog::error("    Core table index {} out of bounds."sv, Idx);
         return Unexpect(ErrCode::Value::DefTypeIndexOutOfBounds);
       }
-      Ext = {ExternalType::Table, nullptr, S.CoreTables[Idx], nullptr, nullptr};
+      Ext = Component::CoreExternInfo(S.CoreTables[Idx]);
       break;
     }
     case AST::Component::Sort::CoreSortType::Memory: {
@@ -307,8 +302,7 @@ Validator::validate(const AST::Component::CoreInstance &Inst) noexcept {
         spdlog::error("    Core memory index {} out of bounds."sv, Idx);
         return Unexpect(ErrCode::Value::DefTypeIndexOutOfBounds);
       }
-      Ext = {ExternalType::Memory, nullptr, nullptr, S.CoreMemories[Idx],
-             nullptr};
+      Ext = Component::CoreExternInfo(S.CoreMemories[Idx]);
       break;
     }
     case AST::Component::Sort::CoreSortType::Global: {
@@ -317,8 +311,7 @@ Validator::validate(const AST::Component::CoreInstance &Inst) noexcept {
         spdlog::error("    Core global index {} out of bounds."sv, Idx);
         return Unexpect(ErrCode::Value::DefTypeIndexOutOfBounds);
       }
-      Ext = {ExternalType::Global, nullptr, nullptr, nullptr,
-             S.CoreGlobals[Idx]};
+      Ext = Component::CoreExternInfo(S.CoreGlobals[Idx]);
       break;
     }
     case AST::Component::Sort::CoreSortType::Tag: {
@@ -327,7 +320,7 @@ Validator::validate(const AST::Component::CoreInstance &Inst) noexcept {
         spdlog::error("    Core tag index {} out of bounds."sv, Idx);
         return Unexpect(ErrCode::Value::UnknownCoreTag);
       }
-      Ext = {ExternalType::Tag, S.CoreTags[Idx], nullptr, nullptr, nullptr};
+      Ext = Component::CoreExternInfo(ExternalType::Tag, S.CoreTags[Idx]);
       break;
     }
     default:
@@ -343,7 +336,7 @@ Validator::validate(const AST::Component::CoreInstance &Inst) noexcept {
       return Unexpect(ErrCode::Value::DupExportName);
     }
   }
-  S.CoreInstances.push_back(Result);
+  S.addCoreInstance(Result);
   return {};
 }
 
@@ -360,12 +353,12 @@ Validator::validate(const AST::Component::CoreTypeSection &TypeSec) noexcept {
 
 Expect<void>
 Validator::validate(const AST::Component::ComponentSection &CompSec) noexcept {
-  auto *Shape = CompTypes.newShape();
+  auto *Shape = CompTypes.addShape();
   EXPECTED_TRY(validate(CompSec.getContent(), *Shape).map_error([](auto E) {
     spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Sec_Component));
     return E;
   }));
-  CompCtx.top().Components.push_back(Shape);
+  CompCtx.top().addComponent(Shape);
   return {};
 }
 
@@ -393,12 +386,12 @@ Validator::validate(const AST::Component::Instance &Inst) noexcept {
     }
     EXPECTED_TRY(const auto *Result, CompCtx.instantiateComponentShape(
                                          *CI, Inst.getInstantiateArgs()));
-    CompCtx.top().Instances.push_back(Result);
+    CompCtx.top().addInstance(Result);
     return {};
   }
 
   // Inline exports. Index validity is checked before the export name.
-  auto *Result = CompTypes.newShape();
+  auto *Result = CompTypes.addShape();
   Result->DeclScope = &S;
   std::vector<Component::NameRecord> Names;
   for (const auto &Exp : Inst.getInlineExports()) {
@@ -420,27 +413,21 @@ Validator::validate(const AST::Component::Instance &Inst) noexcept {
     EXPECTED_TRY(CompCtx.checkAnnotatedName(CN, Info, false));
     EXPECTED_TRY(CompCtx.checkNameAttributes(
         CN, Exp.getImplements(), Exp.getExternalIds(), Exp.getVersionSuffixes(),
-        Info.K == Component::ExternKind::InstanceType));
+        Info.Kind == Component::ExternKind::InstanceType));
     if (!Exp.getSortIdx().getSort().isCore() &&
         Exp.getSortIdx().getSort().getSortType() ==
             AST::Component::Sort::SortType::Value) {
-      auto &VE = CompCtx.top().Values[Exp.getSortIdx().getIdx()];
-      if (VE.Consumed) {
-        spdlog::error(ErrCode::Value::ComponentValueAlreadyConsumed);
-        return Unexpect(ErrCode::Value::ComponentValueAlreadyConsumed);
-      }
-      VE.Consumed = true;
+      EXPECTED_TRY(CompCtx.top().consumeValue(Exp.getSortIdx().getIdx()));
     }
     Result->Exports.emplace(std::string(Exp.getName()), Info);
     Result->ExportOrder.emplace_back(Exp.getName());
   }
-  // An inline instance nests the shapes it re-exports, so it is bounded like
-  // any other declared type.
+  // An inline instance nests re-exported shapes, so it is bounded like a type.
   Component::ExternInfo Probe;
-  Probe.K = Component::ExternKind::InstanceType;
+  Probe.Kind = Component::ExternKind::InstanceType;
   Probe.Shape = Result;
   EXPECTED_TRY(CompTypes.checkTypeLimits(Probe));
-  CompCtx.top().Instances.push_back(Result);
+  CompCtx.top().addInstance(Result);
   return {};
 }
 
@@ -458,8 +445,8 @@ Validator::validate(const AST::Component::AliasSection &AliasSec) noexcept {
 Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
   auto &S = CompCtx.top();
   const auto &Sort = Alias.getSort();
-  const bool InTypeDecl = S.K == Component::Scope::Kind::ComponentType ||
-                          S.K == Component::Scope::Kind::InstanceType;
+  const bool InTypeDecl = S.Kind == Component::ScopeKind::ComponentType ||
+                          S.Kind == Component::ScopeKind::InstanceType;
 
   switch (Alias.getTargetType()) {
   case AST::Component::Alias::TargetType::Export: {
@@ -490,7 +477,7 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
     if (WantCoreModule) {
       // Core-module exports of component instances.
       if (It == Inst->Exports.end() ||
-          It->second.K != Component::ExternKind::CoreType) {
+          It->second.Kind != Component::ExternKind::CoreType) {
         spdlog::error(ErrCode::Value::ComponentExportNotAModule);
         spdlog::error("    Export '{}' of instance {} is not a core module."sv,
                       Name, InstIdx);
@@ -508,15 +495,15 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
     const auto ST = Sort.getSortType();
     const auto &Info = It->second;
     const bool KindOk = (ST == AST::Component::Sort::SortType::Func &&
-                         Info.K == Component::ExternKind::FuncType) ||
+                         Info.Kind == Component::ExternKind::FuncType) ||
                         (ST == AST::Component::Sort::SortType::Value &&
-                         Info.K == Component::ExternKind::ValueBound) ||
+                         Info.Kind == Component::ExternKind::ValueBound) ||
                         (ST == AST::Component::Sort::SortType::Type &&
-                         Info.K == Component::ExternKind::TypeBound) ||
+                         Info.Kind == Component::ExternKind::TypeBound) ||
                         (ST == AST::Component::Sort::SortType::Component &&
-                         Info.K == Component::ExternKind::ComponentType) ||
+                         Info.Kind == Component::ExternKind::ComponentType) ||
                         (ST == AST::Component::Sort::SortType::Instance &&
-                         Info.K == Component::ExternKind::InstanceType);
+                         Info.Kind == Component::ExternKind::InstanceType);
     if (!KindOk) {
       spdlog::error(ErrCode::Value::ComponentUnknownExport);
       spdlog::error("    Export '{}' of instance {} does not match the "
@@ -558,26 +545,17 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
       return Unexpect(Code);
     }
     const auto &Ext = It->second;
-    auto KindMatches = [&](ExternalType ET,
-                           AST::Component::Sort::CoreSortType Want) noexcept {
-      return Ext.Kind == ET && CS == Want;
-    };
-    if (KindMatches(ExternalType::Function,
-                    AST::Component::Sort::CoreSortType::Func)) {
-      S.CoreFuncs.push_back(Ext.Func);
-    } else if (KindMatches(ExternalType::Table,
-                           AST::Component::Sort::CoreSortType::Table)) {
-      S.CoreTables.push_back(Ext.Table);
-    } else if (KindMatches(ExternalType::Memory,
-                           AST::Component::Sort::CoreSortType::Memory)) {
-      S.CoreMemories.push_back(Ext.Memory);
-    } else if (KindMatches(ExternalType::Global,
-                           AST::Component::Sort::CoreSortType::Global)) {
-      S.CoreGlobals.push_back(Ext.Global);
-    } else if (KindMatches(ExternalType::Tag,
-                           AST::Component::Sort::CoreSortType::Tag)) {
-      S.CoreTags.push_back(Ext.Func);
-    } else {
+    const bool KindOk = (CS == AST::Component::Sort::CoreSortType::Func &&
+                         Ext.Kind == ExternalType::Function) ||
+                        (CS == AST::Component::Sort::CoreSortType::Table &&
+                         Ext.Kind == ExternalType::Table) ||
+                        (CS == AST::Component::Sort::CoreSortType::Memory &&
+                         Ext.Kind == ExternalType::Memory) ||
+                        (CS == AST::Component::Sort::CoreSortType::Global &&
+                         Ext.Kind == ExternalType::Global) ||
+                        (CS == AST::Component::Sort::CoreSortType::Tag &&
+                         Ext.Kind == ExternalType::Tag);
+    if (!KindOk) {
       const auto Code = CS == AST::Component::Sort::CoreSortType::Tag
                             ? ErrCode::Value::UnknownCoreTag
                             : ErrCode::Value::InvalidTypeReference;
@@ -586,6 +564,7 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
                     Name);
       return Unexpect(Code);
     }
+    S.addCoreExtern(Ext);
     return {};
   }
   case AST::Component::Alias::TargetType::Outer: {
@@ -612,7 +591,7 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
                         Idx);
           return Unexpect(ErrCode::Value::DefTypeIndexOutOfBounds);
         }
-        S.CoreModules.push_back(Mod);
+        S.addCoreModule(Mod);
         return {};
       }
       case AST::Component::Sort::CoreSortType::Type: {
@@ -622,7 +601,7 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
           spdlog::error("    Aliased core type index {} out of bounds."sv, Idx);
           return Unexpect(ErrCode::Value::ComponentTypeIndexOutOfBounds);
         }
-        S.CoreTypes.push_back(*Entry);
+        S.addCoreType(*Entry);
         return {};
       }
       default:
@@ -640,13 +619,13 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
         spdlog::error("    Aliased type index {} out of bounds."sv, Idx);
         return Unexpect(ErrCode::Value::ComponentTypeIndexOutOfBounds);
       }
-      // A type that crosses a component boundary must carry no free resource
-      // identity. A free identity leaks generativity.
+      // A type crossing a component boundary must carry no free resource id.
       const auto *Inside = CompCtx.scopeInsideTarget(Ct);
-      if (Inside != nullptr && Inside->K == Component::Scope::Kind::Component) {
+      if (Inside != nullptr &&
+          Inside->Kind == Component::ScopeKind::Component) {
         std::unordered_set<uint32_t> Ids;
         Component::ExternInfo Probe;
-        Probe.K = Component::ExternKind::TypeBound;
+        Probe.Kind = Component::ExternKind::TypeBound;
         Probe.Type = *Entry;
         CompTypes.collectResources(Probe, Ids);
         // Ids bound by the aliased type itself are not free.
@@ -671,7 +650,7 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
           return Unexpect(ErrCode::Value::ComponentAliasResourceLeak);
         }
       }
-      S.Types.push_back(*Entry);
+      S.addType(*Entry);
       return {};
     }
     case AST::Component::Sort::SortType::Component: {
@@ -687,7 +666,7 @@ Expect<void> Validator::validate(const AST::Component::Alias &Alias) noexcept {
         spdlog::error("    Aliased component index {} out of bounds."sv, Idx);
         return Unexpect(ErrCode::Value::DefTypeIndexOutOfBounds);
       }
-      S.Components.push_back(Comp);
+      S.addComponent(Comp);
       return {};
     }
     default:
@@ -756,13 +735,12 @@ Validator::validate(const AST::Component::StartSection &StartSec) noexcept {
       spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Sec_Start));
       return Unexpect(ErrCode::Value::InvalidIndex);
     }
-    if (S.Values[ValIdx].Consumed) {
-      spdlog::error(ErrCode::Value::ComponentValueAlreadyConsumed);
+    EXPECTED_TRY(S.consumeValue(ValIdx).map_error([ValIdx](auto E) {
       spdlog::error("    Start argument value {} was already consumed."sv,
                     ValIdx);
       spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Sec_Start));
-      return Unexpect(ErrCode::Value::ComponentValueAlreadyConsumed);
-    }
+      return E;
+    }));
     if (!Component::Matcher(CompTypes).matchValType(
             S.Values[ValIdx].Type,
             {Params[I].getValType(), FI->Home, FI->Remap})) {
@@ -771,7 +749,6 @@ Validator::validate(const AST::Component::StartSection &StartSec) noexcept {
       spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Sec_Start));
       return Unexpect(ErrCode::Value::ArgTypeMismatch);
     }
-    S.Values[ValIdx].Consumed = true;
   }
   const auto Results = FI->FT->getResultList();
   if (Start.getResult() != Results.size()) {
@@ -782,7 +759,7 @@ Validator::validate(const AST::Component::StartSection &StartSec) noexcept {
     return Unexpect(ErrCode::Value::ArgTypeMismatch);
   }
   for (const auto &R : Results) {
-    S.Values.push_back({{R.getValType(), FI->Home, FI->Remap}, false});
+    S.addValue({R.getValType(), FI->Home, FI->Remap});
   }
   return {};
 }
@@ -824,8 +801,7 @@ Expect<void> Validator::validate(const AST::Component::ExportSection &ExpSec,
 Expect<void> Validator::validate(const AST::Component::Export &Ex,
                                  Component::Shape &Out) noexcept {
   auto &S = CompCtx.top();
-  // The index bounds are diagnosed before the export name. A valid name
-  // upgrades a bounds error to a per-sort code.
+  // Index bounds are diagnosed before the name; a valid name refines the code.
   {
     const auto &SI = Ex.getSortIndex();
     Component::ExternName CN;
@@ -875,16 +851,13 @@ Expect<void> Validator::validate(const AST::Component::Export &Ex,
   if (!Ex.getSortIndex().getSort().isCore() &&
       Ex.getSortIndex().getSort().getSortType() ==
           AST::Component::Sort::SortType::Value) {
-    auto &VE = S.Values[Ex.getSortIndex().getIdx()];
-    if (VE.Consumed) {
-      spdlog::error(ErrCode::Value::ComponentValueAlreadyConsumed);
-      spdlog::error("    Exported value {} was already consumed."sv,
-                    Ex.getSortIndex().getIdx());
-      return Unexpect(ErrCode::Value::ComponentValueAlreadyConsumed);
-    }
-    VE.Consumed = true;
+    const uint32_t ValIdx = Ex.getSortIndex().getIdx();
+    EXPECTED_TRY(S.consumeValue(ValIdx).map_error([ValIdx](auto E) {
+      spdlog::error("    Exported value {} was already consumed."sv, ValIdx);
+      return E;
+    }));
     // Exported values must not transitively contain borrow handles.
-    if (CompTypes.containsBorrow(VE.Type)) {
+    if (CompTypes.containsBorrow(S.Values[ValIdx].Type)) {
       spdlog::error(ErrCode::Value::InvalidTypeReference);
       spdlog::error("    Exported value types cannot contain borrows."sv);
       return Unexpect(ErrCode::Value::InvalidTypeReference);
@@ -893,7 +866,7 @@ Expect<void> Validator::validate(const AST::Component::Export &Ex,
   EXPECTED_TRY(
       Component::ExternName CN,
       CompCtx.registerExportName(
-          Ex.getName(), Inferred.K == Component::ExternKind::InstanceType,
+          Ex.getName(), Inferred.Kind == Component::ExternKind::InstanceType,
           Ex.getImplements(), Ex.getExternalIds(), Ex.getVersionSuffixes()));
   std::optional<Component::ExternInfo> Ascribed;
   if (Ex.getDesc().has_value()) {
@@ -901,7 +874,7 @@ Expect<void> Validator::validate(const AST::Component::Export &Ex,
   }
   EXPECTED_TRY(auto Result, CompCtx.defineExport(CN, Inferred, Ascribed));
   // The re-exported value index is born consumed.
-  if (Result.K == Component::ExternKind::ValueBound) {
+  if (Result.Kind == Component::ExternKind::ValueBound) {
     CompCtx.top().Values.back().Consumed = true;
   }
   Out.Exports.emplace(std::string(Ex.getName()), Result);
@@ -915,15 +888,7 @@ Validator::validate(const AST::Component::ValueSection &ValSec) noexcept {
       spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Comp_Sec_Value));
       return E;
     }));
-    auto Resolver = [this](uint32_t Idx) -> const AST::Component::DefValType * {
-      const auto *Entry = CompCtx.top().getType(Idx);
-      return Entry != nullptr && Entry->DT != nullptr &&
-                     Entry->DT->isDefValType()
-                 ? &Entry->DT->getDefValType()
-                 : nullptr;
-    };
-    Component::ValueDecoder<decltype(Resolver)> Decoder(Value.getData(),
-                                                        std::move(Resolver));
+    Component::ValueDecoder Decoder(Value.getData(), CompCtx.top());
     auto Decoded = Decoder.decode(Value.getType());
     if (!Decoded) {
       spdlog::error(ErrCode::Value::ComponentMalformedValue);
@@ -932,8 +897,7 @@ Validator::validate(const AST::Component::ValueSection &ValSec) noexcept {
       return Unexpect(ErrCode::Value::ComponentMalformedValue);
     }
     Value.setDecoded(std::move(*Decoded));
-    CompCtx.top().Values.push_back(
-        {{Value.getType(), &CompCtx.top(), nullptr}, false});
+    CompCtx.top().addValue({Value.getType(), &CompCtx.top(), nullptr});
   }
   return {};
 }

--- a/test/component/ComponentLoaderTest.cpp
+++ b/test/component/ComponentLoaderTest.cpp
@@ -193,7 +193,7 @@ TEST(ComponentNameParserTest, KebabLabel) {
 TEST(ComponentNameParserTest, StronglyUniqueBasicCases) {
   Validator::Component::TypeSystem Types;
   Validator::Component::Context Ctx{Types};
-  Ctx.enterScope(Validator::Component::Scope::Kind::Component);
+  Ctx.enterScope(Validator::Component::ScopeKind::Component);
   std::vector<Validator::Component::NameRecord> Names;
 
   auto add = [&](std::string_view S) -> bool {
@@ -220,7 +220,7 @@ TEST(ComponentNameParserTest, StronglyUniqueBasicCases) {
 TEST(ComponentNameParserTest, StronglyUnique) {
   Validator::Component::TypeSystem Types;
   Validator::Component::Context Ctx{Types};
-  Ctx.enterScope(Validator::Component::Scope::Kind::Component);
+  Ctx.enterScope(Validator::Component::ScopeKind::Component);
   std::vector<Validator::Component::NameRecord> Names;
 
   auto add = [&](std::string_view S) -> bool {
@@ -246,7 +246,7 @@ TEST(ComponentNameParserTest, StronglyUniqueExportBasicCases) {
   // name sets (Explainer §Import and Export Definitions).
   Validator::Component::TypeSystem Types;
   Validator::Component::Context Ctx{Types};
-  Ctx.enterScope(Validator::Component::Scope::Kind::Component);
+  Ctx.enterScope(Validator::Component::ScopeKind::Component);
   std::vector<Validator::Component::NameRecord> Names;
 
   auto add = [&](std::string_view S) -> bool {
@@ -273,7 +273,7 @@ TEST(ComponentNameParserTest, StronglyUniqueExportBasicCases) {
 TEST(ComponentNameParserTest, StronglyUniqueExport) {
   Validator::Component::TypeSystem Types;
   Validator::Component::Context Ctx{Types};
-  Ctx.enterScope(Validator::Component::Scope::Kind::Component);
+  Ctx.enterScope(Validator::Component::ScopeKind::Component);
   std::vector<Validator::Component::NameRecord> Names;
 
   auto add = [&](std::string_view S) -> bool {
@@ -298,7 +298,7 @@ TEST(ComponentNameParserTest, StronglyUniqueImportExportIndependence) {
   // and an export sharing a name is not a strong-uniqueness violation.
   Validator::Component::TypeSystem Types;
   Validator::Component::Context Ctx{Types};
-  Ctx.enterScope(Validator::Component::Scope::Kind::Component);
+  Ctx.enterScope(Validator::Component::ScopeKind::Component);
   std::vector<Validator::Component::NameRecord> Imports, Exports;
 
   auto add = [&Ctx](std::vector<Validator::Component::NameRecord> &Names,
@@ -511,7 +511,7 @@ TEST(ComponentNameParserTest, SpecExamples) {
 TEST(ComponentNameParserTest, StronglyUniqueWithNewKinds) {
   Validator::Component::TypeSystem Types;
   Validator::Component::Context Ctx{Types};
-  Ctx.enterScope(Validator::Component::Scope::Kind::Component);
+  Ctx.enterScope(Validator::Component::ScopeKind::Component);
   std::vector<Validator::Component::NameRecord> Names;
 
   auto add = [&](std::string_view S) -> bool {

--- a/test/component/ComponentValidatorTest.cpp
+++ b/test/component/ComponentValidatorTest.cpp
@@ -3070,12 +3070,13 @@ TEST(ComponentValidatorTest, FutureOfOwnPasses) {
 // =============================================================================
 
 // Helper: decode a `val(t)` payload for a primitive type. No type index can
-// appear in these payloads, so the resolver always fails.
+// appear in these payloads, so an empty scope resolves none.
 inline Expect<ComponentValVariant> decodePrimValue(std::vector<Byte> Data,
                                                    ComponentTypeCode Code) {
+  const Validator::Component::Scope Empty(
+      Validator::Component::ScopeKind::Component, nullptr);
   Validator::Component::ValueDecoder Dec(
-      Span<const Byte>(Data.data(), Data.size()),
-      [](uint32_t) -> const AST::Component::DefValType * { return nullptr; });
+      Span<const Byte>(Data.data(), Data.size()), Empty);
   return Dec.decode(ComponentValType(Code));
 }
 
@@ -3719,6 +3720,22 @@ TEST(ComponentValidatorTest, AsyncFuncSatisfiesAsyncImport) {
   auto Comp = makeAsyncArgComponent(true, true);
   Validator::Validator V(Conf);
   ASSERT_TRUE(V.validate(Comp));
+}
+
+TEST(ComponentValidatorTest, BuiltinCoreFuncTypeFollowsAddressType) {
+  const ValType I32(TypeCode::I32);
+  const ValType I64(TypeCode::I64);
+  const auto Read64 = AST::Component::Canonical::getBuiltinCoreFuncType(
+      ComponentCanonOpCode::Stream__read, I64);
+  EXPECT_EQ(Read64.first, (std::vector<ValType>{I32, I64, I64}));
+  EXPECT_EQ(Read64.second, (std::vector<ValType>{I64}));
+  const auto Wait32 = AST::Component::Canonical::getBuiltinCoreFuncType(
+      ComponentCanonOpCode::Waitable_set__wait, I32);
+  EXPECT_EQ(Wait32.first, (std::vector<ValType>{I32, I32}));
+  EXPECT_EQ(Wait32.second, (std::vector<ValType>{I32}));
+  const auto NewIndirect64 = AST::Component::Canonical::getBuiltinCoreFuncType(
+      ComponentCanonOpCode::Thread__new_indirect, I64);
+  EXPECT_EQ(NewIndirect64.first, (std::vector<ValType>{I64, I32}));
 }
 
 } // namespace


### PR DESCRIPTION
## Description

Fold the helpers that were named by their argument type into overloads of one name (getTypeSize, getTypeDepth, collectResources, isIntroduced), drop the NormalVal intermediate so that the walkers run on the TypeEntry a valtype resolves to and TypeSystem::resolvePrimValType answers the primitive where one matters, and walk nested value types through TypeSystem::forEachValType instead of six copies of the record / variant / list / tuple / map / option / result case chain.

Move the accessors onto the objects they read: Canonical::hasOption replaces Context::hasOption, CoreImportDesc::getExternalType replaces its five is* predicates, TypeEntry answers getDefValType / getFuncType / isResource, Limit::matches carries the limits relation for both the executor's import matching and the validator's core-extern matching, and Context::requireOptions spells the memory and realloc requirements once. Scope gains add* per index space, addCoreExtern, and consumeValue, so the validator drives it the way it drives FormChecker instead of pushing into its vectors, and CoreExternInfo gets one constructor per kind. The single-use canonMemoryIs64, checkTypeSize, checkTypeDepth, and matchCoreFuncType are inlined into their only callers, and the unused Context accessors go.

Name the owning storage Owned* like ModuleInstance::OwnedFuncInsts, the factories add*, the discriminators Kind (with a namespace-level ScopeKind), the accessors get* (getCanonPtrType, getTypeSize), and the lambdas UpperCamel; ExternName::parsePkgPath writes NameDetail itself, and the value decoder spells AST::Component::PrimValType and DefValType instead of using-declarations.

Assisted-by: Claude Fable 5.1 <noreply@anthropic.com>

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence
<!-- Paste your test output screenshot or logs here -->

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
