### PR TITLE
ci: upgrade Debian static build to Bookworm

### DIFF
--- a/.github/workflows/reusable-build-on-debian-static.yml
+++ b/.github/workflows/reusable-build-on-debian-static.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Ensure git safe directory
         run: |
           git config --global --add safe.directory $(pwd)
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
+        with:
+          image: docker.io/tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          platforms: arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Build WasmEdge

--- a/utils/docker/Dockerfile.debian-static
+++ b/utils/docker/Dockerfile.debian-static
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1.5-labs
 
-ARG XX_VERSION=1.2.1
-ARG DEBIAN_VERSION=bullseye
-ARG LLVM_VERSION=16
+ARG XX_VERSION=1.9.0
+ARG DEBIAN_VERSION=bookworm
+ARG LLVM_VERSION=23
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 FROM --platform=$BUILDPLATFORM debian:${DEBIAN_VERSION} AS base
@@ -10,7 +10,7 @@ COPY --from=xx / /
 
 # Install host dependencies
 RUN apt-get update -y && apt-get install --no-install-recommends -y \
-    lsb-release software-properties-common curl wget gnupg \
+    lsb-release ca-certificates curl wget gnupg \
     cmake ninja-build git clang xz-utils
 
 # Set up llvm's apt repo
@@ -18,7 +18,7 @@ ARG LLVM_VERSION
 RUN /bin/bash <<EOT
     set -ex
     curl -sSfL https://apt.llvm.org/llvm-snapshot.gpg.key > /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-    add-apt-repository "deb http://apt.llvm.org/$(lsb_release -sc)/  llvm-toolchain-$(lsb_release -sc)-${LLVM_VERSION} main"
+    echo "deb http://apt.llvm.org/$(lsb_release -sc)/ llvm-toolchain-$(lsb_release -sc)-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm.list
     apt-get update -y
 EOT
 
@@ -47,7 +47,7 @@ EOT
 RUN xx-apt-get install --no-install-recommends -y \
     xx-cxx-essentials \
     liblld-${LLVM_VERSION}-dev libpolly-${LLVM_VERSION}-dev \
-    libncurses5-dev zlib1g-dev
+    libncurses-dev zlib1g-dev libzstd-dev
 
 # Make a cmake toolchain file
 RUN cat <<EOT > /toolchain.cmake


### PR DESCRIPTION
## Description

- Upgrade the static Debian build base from Bullseye to Bookworm.
- Update the cross-compilation helper to `tonistiigi/xx:1.9.0` and configure the LLVM 23 Bookworm package source directly.
- Install required certificate and static-link dependencies.
- Register a digest-pinned ARM64 QEMU binfmt handler before Buildx so ARM64 package maintainer scripts can run.
- Preserve the rolling `debian:testing` reusable workflow.

This contribution was developed with assistance from OpenCode.

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [ ] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [ ] **Coding Style**: Run `clang-format` on your code to ensure they meet the coding style guidelines.
- [ ] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

```text
git diff --check origin/master..HEAD
# passed

docker buildx bake -f utils/docker/docker-bake.debian-static.hcl --print
# passed; includes linux/amd64 and linux/arm64

ARM64 binfmt image
# docker.io/tonistiigi/binfmt pinned to sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
```

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.