### PR TITLE
ci: bump lineguard to 0.2.0

### DIFF
--- a/.github/workflows/misc-linters.yml
+++ b/.github/workflows/misc-linters.yml
@@ -57,7 +57,7 @@ jobs:
           git config --global --add safe.directory $(pwd)
       - name: Install lineguard
         run: |
-          cargo install lineguard@0.1.7
+          cargo install lineguard@0.2.0
       - name: Run lineguard
         run: |
           lineguard --config .lineguardrc --verbose -r . || { echo "Lineguard found issues"; exit 1; }

--- a/.lineguardrc
+++ b/.lineguardrc
@@ -1,7 +1,8 @@
 file_extensions = ["rs", "toml", "md", "yml", "yaml", "cpp", "hpp", "c", "h", "sh", "ipp", "cmake", "txt", "py", "wxs", "spdx"]
 ignore_patterns = [
     "**/.git/**",
-    "thirdparty/",
+    "thirdparty",
+    "utils/corpus",
 ]
 [checks]
 newline_ending = true


### PR DESCRIPTION
## Description

Bump lineguard from 0.1.7 to 0.2.0. Fix the `.lineguardrc` ignore patterns: 0.2.0 matches paths with `glob::Pattern`, so trailing-slash patterns never match. Drop the trailing slash from `thirdparty` and add `utils/corpus` to exclude the non-UTF-8 fuzz corpus.

This contribution was developed with assistance from GitHub Copilot CLI (GPT-6 Astra).

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines. (Not applicable: no C/C++ changes.)
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

`lineguard --config .lineguardrc -r .` exited 0. The fixed ignore patterns exclude `thirdparty` (16 files) and `utils/corpus` (14 files); the 13 non-UTF-8 corpus warnings are gone.

```text
lineguard 0.2.0: ✓ All files passed lint checks!
  Files checked: 1089 (was 1119)
commitlint: passed
git diff --check: passed
```

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.

