### PR TITLE
fix: make the sources compile as C++20

### DIFF
--- a/include/common/filesystem.h
+++ b/include/common/filesystem.h
@@ -9,7 +9,7 @@
 ///
 /// \file
 /// This file contains std::filesystem linkage handling for various
-/// compilers.
+/// compilers and the UTF-8 path conversion helpers.
 ///
 //===----------------------------------------------------------------------===//
 #pragma once
@@ -51,3 +51,29 @@ namespace filesystem = experimental::filesystem;
 #endif
 
 #undef EXPERIMENTAL
+
+#include <string>
+#include <string_view>
+
+namespace WasmEdge {
+
+/// Build a path from UTF-8 encoded text.
+inline std::filesystem::path u8path(std::string_view Source) {
+#if defined(__cpp_lib_char8_t)
+  return std::filesystem::path(std::u8string(Source.begin(), Source.end()));
+#else
+  return std::filesystem::u8path(Source);
+#endif
+}
+
+/// Return the UTF-8 encoded text of a path.
+inline std::string u8string(const std::filesystem::path &Path) {
+#if defined(__cpp_lib_char8_t)
+  const auto Str = Path.u8string();
+  return std::string(Str.begin(), Str.end());
+#else
+  return Path.u8string();
+#endif
+}
+
+} // namespace WasmEdge

--- a/include/common/spdlog.h
+++ b/include/common/spdlog.h
@@ -59,7 +59,7 @@ struct fmt::formatter<std::filesystem::path>
     auto Quoted = fmt::memory_buffer();
     auto Iter = std::back_inserter(Quoted);
     *Iter++ = Delimiter;
-    for (const auto C : Path.u8string()) {
+    for (const auto C : WasmEdge::u8string(Path)) {
       if (C == Delimiter || C == Escape) {
         *Iter++ = Escape;
       }

--- a/include/experimental/span.hpp
+++ b/include/experimental/span.hpp
@@ -43,7 +43,7 @@ template <class T> constexpr auto to_address(const T &p) noexcept {
   if constexpr (detail::defined_to_address<T>::value) {
     return pointer_traits<T>::to_address(p);
   } else {
-    return to_address(p.operator->());
+    return cxx20::to_address(p.operator->());
   }
 }
 
@@ -77,7 +77,7 @@ static inline constexpr bool is_compatible_element_v =
     is_compatible_element<T, U>::value;
 template <class T, class It>
 static inline constexpr bool is_compatible_iterator_v = is_compatible_element_v<
-    T, remove_pointer_t<decltype(to_address(declval<It>()))>>;
+    T, remove_pointer_t<decltype(cxx20::to_address(declval<It>()))>>;
 template <class T, class R>
 static inline constexpr bool is_compatible_range_v = is_compatible_element_v<
     T, typename contiguous_range_element<remove_cv_t<R>>::type>;
@@ -146,10 +146,10 @@ struct span : public detail::span_storage<T, Extent> {
   template <class It,
             enable_if_t<detail::is_compatible_iterator_v<T, It>> * = nullptr>
   constexpr span(It first, size_t count) noexcept
-      : base(to_address(first), count) {}
+      : base(cxx20::to_address(first), count) {}
   template <class It, enable_if_t<detail::is_compatible_iterator_v<T, It>>>
   constexpr span(It first, It last) noexcept
-      : base(to_address(first), last - first) {}
+      : base(cxx20::to_address(first), last - first) {}
   template <size_t N>
   constexpr span(T (&arr)[N]) noexcept : base(std::data(arr), N) {}
   template <class U, size_t N,
@@ -230,7 +230,7 @@ struct span : public detail::span_storage<T, Extent> {
 
 template <class It, class EndOrSize>
 span(It, EndOrSize)
-    -> span<remove_pointer_t<decltype(to_address(declval<It>()))>>;
+    -> span<remove_pointer_t<decltype(cxx20::to_address(declval<It>()))>>;
 template <class T, size_t N> span(T (&)[N]) -> span<T, N>;
 template <class T, size_t N> span(array<T, N> &) -> span<T, N>;
 template <class T, size_t N> span(const array<T, N> &) -> span<const T, N>;

--- a/lib/aot/cache.cpp
+++ b/lib/aot/cache.cpp
@@ -6,6 +6,7 @@
 #include "aot/blake3.h"
 #include "common/config.h"
 #include "common/defines.h"
+#include "common/filesystem.h"
 #include "common/hexstr.h"
 #include "system/path.h"
 
@@ -20,7 +21,7 @@ namespace {
 std::filesystem::path getRoot(Cache::StorageScope Scope) {
   switch (Scope) {
   case Cache::StorageScope::Global:
-    return std::filesystem::u8path(kCacheRoot);
+    return u8path(kCacheRoot);
   case Cache::StorageScope::Local: {
     if (const auto Home = Path::home(); !Home.empty()) {
       return Home / "cache"sv;
@@ -38,7 +39,7 @@ Expect<std::filesystem::path> Cache::getPath(Span<const Byte> Data,
                                              std::string_view Key) {
   auto Root = getRoot(Scope);
   if (!Key.empty()) {
-    Root /= std::filesystem::u8path(Key);
+    Root /= u8path(Key);
   }
 
   Blake3 Hasher;
@@ -54,7 +55,7 @@ Expect<std::filesystem::path> Cache::getPath(Span<const Byte> Data,
 void Cache::clear(Cache::StorageScope Scope, std::string_view Key) {
   auto Root = getRoot(Scope);
   if (!Key.empty()) {
-    Root /= std::filesystem::u8path(Key);
+    Root /= u8path(Key);
   }
   std::error_code ErrCode;
   std::filesystem::remove_all(Root, ErrCode);

--- a/lib/driver/compilerTool.cpp
+++ b/lib/driver/compilerTool.cpp
@@ -56,9 +56,9 @@ int Compiler([[maybe_unused]] struct DriverCompilerOptions &Opt) noexcept {
   Conf.getRuntimeConfigure().setRunMode(WasmEdge::RunMode::Interpreter);
 
   std::filesystem::path InputPath =
-      std::filesystem::absolute(std::filesystem::u8path(Opt.WasmName.value()));
+      std::filesystem::absolute(u8path(Opt.WasmName.value()));
   std::filesystem::path OutputPath =
-      std::filesystem::absolute(std::filesystem::u8path(Opt.SoName.value()));
+      std::filesystem::absolute(u8path(Opt.SoName.value()));
   Loader::Loader Loader(Conf);
 
   std::vector<Byte> Data;
@@ -113,7 +113,7 @@ int Compiler([[maybe_unused]] struct DriverCompilerOptions &Opt) noexcept {
     if (Opt.ConfGenericBinary.value()) {
       Conf.getCompilerConfigure().setGenericBinary(true);
     }
-    if (OutputPath.extension().u8string() == WASMEDGE_LIB_EXTENSION) {
+    if (u8string(OutputPath.extension()) == WASMEDGE_LIB_EXTENSION) {
       Conf.getCompilerConfigure().setOutputFormat(
           CompilerConfigure::OutputFormat::Native);
     }

--- a/lib/driver/instantiateTool.cpp
+++ b/lib/driver/instantiateTool.cpp
@@ -34,8 +34,7 @@ int InstantiateTool(struct DriverToolOptions &Opt) noexcept {
     spdlog::error("No input wasm file provided."sv);
     return EXIT_FAILURE;
   }
-  const auto InputPath =
-      std::filesystem::absolute(std::filesystem::u8path(Opt.SoName.value()));
+  const auto InputPath = std::filesystem::absolute(u8path(Opt.SoName.value()));
 
   VM::VM VM(Conf);
 
@@ -47,16 +46,15 @@ int InstantiateTool(struct DriverToolOptions &Opt) noexcept {
       return EXIT_FAILURE;
     }
     auto Name = ModEntry.substr(0, Pos);
-    auto Path = std::filesystem::absolute(
-        std::filesystem::u8path(ModEntry.substr(Pos + 1)));
+    auto Path = std::filesystem::absolute(u8path(ModEntry.substr(Pos + 1)));
     if (auto Result = VM.registerModule(Name, Path); !Result) {
       spdlog::error("Failed to register module \"{}\" from: {}"sv, Name,
-                    Path.u8string());
+                    u8string(Path));
       return EXIT_FAILURE;
     }
   }
 
-  if (auto Result = VM.loadWasm(InputPath.u8string()); !Result) {
+  if (auto Result = VM.loadWasm(u8string(InputPath)); !Result) {
     return EXIT_FAILURE;
   }
   if (auto Result = VM.validate(); !Result) {

--- a/lib/driver/parseTool.cpp
+++ b/lib/driver/parseTool.cpp
@@ -126,8 +126,7 @@ int ParseTool(struct DriverToolOptions &Opt) noexcept {
   std::ios::sync_with_stdio(false);
 
   Configure Conf = createConfigure(Opt);
-  const auto InputPath =
-      std::filesystem::absolute(std::filesystem::u8path(Opt.SoName.value()));
+  const auto InputPath = std::filesystem::absolute(u8path(Opt.SoName.value()));
 
   Loader::Loader Loader(Conf);
   auto Res = Loader.parseModule(InputPath);

--- a/lib/driver/runtimeTool.cpp
+++ b/lib/driver/runtimeTool.cpp
@@ -443,8 +443,7 @@ int Tool(struct DriverToolOptions &Opt) noexcept {
   }
 
   Conf.addHostRegistration(HostRegistration::Wasi);
-  const auto InputPath =
-      std::filesystem::absolute(std::filesystem::u8path(Opt.SoName.value()));
+  const auto InputPath = std::filesystem::absolute(u8path(Opt.SoName.value()));
 
   // Create VM and get WASI module instance.
   VM::VM VM(Conf);
@@ -459,17 +458,16 @@ int Tool(struct DriverToolOptions &Opt) noexcept {
       return EXIT_FAILURE;
     }
     auto Name = ModEntry.substr(0, Pos);
-    auto Path = std::filesystem::absolute(
-        std::filesystem::u8path(ModEntry.substr(Pos + 1)));
+    auto Path = std::filesystem::absolute(u8path(ModEntry.substr(Pos + 1)));
     if (auto Result = VM.registerModule(Name, Path); !Result) {
       spdlog::error("Failed to register module \"{}\" from: {}"sv, Name,
-                    Path.u8string());
+                    u8string(Path));
       return EXIT_FAILURE;
     }
   }
 
   // Load, validate, and instantiate WASM or Component.
-  if (auto Result = VM.loadWasm(InputPath.u8string()); !Result) {
+  if (auto Result = VM.loadWasm(u8string(InputPath)); !Result) {
     return EXIT_FAILURE;
   }
   if (auto Result = VM.validate(); !Result) {
@@ -508,11 +506,10 @@ int Tool(struct DriverToolOptions &Opt) noexcept {
   bool EnterCommandMode = !Opt.Reactor.value() && HasValidCommandModStartFunc();
 
   // Initialize WASI module.
-  WasiMod->init(Opt.Dir.value(),
-                InputPath.filename()
-                    .replace_extension(std::filesystem::u8path("wasm"sv))
-                    .u8string(),
-                Opt.Args.value(), Opt.Env.value());
+  WasiMod->init(
+      Opt.Dir.value(),
+      u8string(InputPath.filename().replace_extension(u8path("wasm"sv))),
+      Opt.Args.value(), Opt.Env.value());
 
   if (EnterCommandMode) {
     // command mode

--- a/lib/driver/validateTool.cpp
+++ b/lib/driver/validateTool.cpp
@@ -21,14 +21,13 @@ int ValidateTool(struct DriverToolOptions &Opt) noexcept {
   Configure Conf = createConfigure(Opt);
 
   Conf.addHostRegistration(HostRegistration::Wasi);
-  const auto InputPath =
-      std::filesystem::absolute(std::filesystem::u8path(Opt.SoName.value()));
+  const auto InputPath = std::filesystem::absolute(u8path(Opt.SoName.value()));
 
   // Create VM and get WASI module instance.
   VM::VM VM(Conf);
 
   // Load, validate, WASM or Component.
-  if (auto Result = VM.loadWasm(InputPath.u8string()); !Result) {
+  if (auto Result = VM.loadWasm(u8string(InputPath)); !Result) {
     return EXIT_FAILURE;
   }
 

--- a/lib/host/wasi/inode-win.cpp
+++ b/lib/host/wasi/inode-win.cpp
@@ -5,6 +5,7 @@
 #if WASMEDGE_OS_WINDOWS
 
 #include "common/errcode.h"
+#include "common/filesystem.h"
 #include "common/variant.h"
 #include "host/wasi/clock.h"
 #include "host/wasi/environ.h"
@@ -289,7 +290,7 @@ getRelativePath(HANDLE_ Handle, std::string_view Path) noexcept {
   EXPECTED_TRY(auto FullPath, getHandlePath(Handle));
 
   // Append the paths together
-  FullPath /= std::filesystem::u8path(Path);
+  FullPath /= u8path(Path);
   return FullPath;
 }
 
@@ -583,7 +584,7 @@ WasiExpect<void> FindHolder::doLoadDirent() noexcept {
   const std::filesystem::path Filename(
       std::wstring_view(Info.FileName, Info.FileNameLength / sizeof(wchar_t)));
 
-  std::string UTF8FileName = Filename.u8string();
+  std::string UTF8FileName = u8string(Filename);
   resizeBuffer(sizeof(__wasi_dirent_t) + UTF8FileName.size());
   __wasi_dirent_t *const Dirent =
       reinterpret_cast<__wasi_dirent_t *>(getBuffer().data());
@@ -651,7 +652,7 @@ WasiExpect<void> FindHolder::doLoadDirent() noexcept {
     return WasiUnexpect(detail::fromLastError(GetLastError()));
   }
 
-  std::string UTF8FileName = Filename.u8string();
+  std::string UTF8FileName = u8string(Filename);
   resizeBuffer(sizeof(__wasi_dirent_t) + UTF8FileName.size());
   __wasi_dirent_t *const Dirent =
       reinterpret_cast<__wasi_dirent_t *>(getBuffer().data());
@@ -690,7 +691,7 @@ WasiExpect<INode> INode::open(std::string Path, __wasi_oflags_t OpenFlags,
   EXPECTED_TRY(auto Pack, getOpenFlags(OpenFlags, FdFlags, VFSFlags));
   const auto [AttributeFlags, AccessFlags, CreationDisposition] = Pack;
   const DWORD_ ShareFlags = FILE_SHARE_VALID_FLAGS_;
-  const auto FullPath = std::filesystem::u8path(Path);
+  const auto FullPath = u8path(Path);
 
   INode Result(FullPath, AccessFlags, ShareFlags, CreationDisposition,
                AttributeFlags);
@@ -1388,7 +1389,7 @@ WasiExpect<void> INode::pathReadlink(std::string Path, Span<char> Buffer,
     return WasiUnexpect(__WASI_ERRNO_NOSYS);
   }
 
-  const auto U8Data = std::filesystem::path{Data}.u8string();
+  const auto U8Data = u8string(std::filesystem::path{Data});
   NRead = static_cast<uint32_t>(std::min(Buffer.size(), U8Data.size()));
   std::copy_n(U8Data.begin(), NRead, Buffer.begin());
 
@@ -1472,7 +1473,7 @@ WasiExpect<void> INode::pathSymlink(std::string OldPath,
     return WasiUnexpect(__WASI_ERRNO_EXIST);
   }
 
-  const std::filesystem::path OldU8Path = std::filesystem::u8path(OldPath);
+  const std::filesystem::path OldU8Path = u8path(OldPath);
 
   DWORD_ TargetType = SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE_;
   if (OldU8Path.filename().empty()) {

--- a/lib/llvm/codegen.cpp
+++ b/lib/llvm/codegen.cpp
@@ -5,6 +5,7 @@
 
 #include "aot/version.h"
 #include "common/defines.h"
+#include "common/filesystem.h"
 #include "common/hash.h"
 #include "data.h"
 #include "llvm.h"
@@ -193,7 +194,7 @@ Expect<void> outputNativeLibrary(const std::filesystem::path &OutputPath,
     ObjectName = createTemp(OPath);
     if (ObjectName.empty()) {
       // TODO:return error
-      spdlog::error("so file creation failed:{}"sv, OPath.u8string());
+      spdlog::error("so file creation failed:{}"sv, u8string(OPath));
       return Unexpect(ErrCode::Value::IllegalPath);
     }
     std::ofstream OS(ObjectName, std::ios_base::binary);
@@ -237,19 +238,19 @@ Expect<void> outputNativeLibrary(const std::filesystem::path &OutputPath,
 #endif
           "-dylib", "-demangle", "-macosx_version_min", OSVersion.c_str(),
           "-syslibroot", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
-          ObjectName.u8string().c_str(), "-o", OutputPath.u8string().c_str()},
+          u8string(ObjectName).c_str(), "-o", u8string(OutputPath).c_str()},
 #elif WASMEDGE_OS_LINUX
   LinkResult = lld::elf::link(
       std::initializer_list<const char *>{"ld.lld", "--eh-frame-hdr",
                                           "--shared", "--gc-sections",
                                           "--discard-all", ObjectName.c_str(),
-                                          "-o", OutputPath.u8string().c_str()},
+                                          "-o", u8string(OutputPath).c_str()},
 #elif WASMEDGE_OS_WINDOWS
   LinkResult = lld::coff::link(
       std::initializer_list<const char *>{
           "lld-link", "-dll", "-base:0", "-nologo",
-          ObjectName.u8string().c_str(),
-          ("-out:" + OutputPath.u8string()).c_str()},
+          u8string(ObjectName).c_str(),
+          ("-out:" + u8string(OutputPath)).c_str()},
 #endif
 
 #if LLVM_VERSION_MAJOR >= 14
@@ -287,7 +288,7 @@ Expect<void> outputNativeLibrary(const std::filesystem::path &OutputPath,
       spdlog::error("codesign error on fork:{}"sv, std::strerror(errno));
     } else if (PID == 0) {
       execlp("/usr/bin/codesign", "codesign", "-s", "-",
-             OutputPath.u8string().c_str(), nullptr);
+             u8string(OutputPath).c_str(), nullptr);
       std::exit(256);
     } else {
       int ChildStat;
@@ -314,7 +315,7 @@ Expect<void> outputWasmLibrary(LLVM::Context LLContext,
     SharedObjectName = createTemp(SOPath);
     if (SharedObjectName.empty()) {
       // TODO:return error
-      spdlog::error("so file creation failed:{}"sv, SOPath.u8string());
+      spdlog::error("so file creation failed:{}"sv, u8string(SOPath));
       return Unexpect(ErrCode::Value::IllegalPath);
     }
     std::ofstream OS(SharedObjectName, std::ios_base::binary);
@@ -326,7 +327,7 @@ Expect<void> outputWasmLibrary(LLVM::Context LLContext,
 
   LLVM::MemoryBuffer SOFile;
   if (auto [Res, ErrorMessage] =
-          LLVM::MemoryBuffer::getFile(SharedObjectName.u8string().c_str());
+          LLVM::MemoryBuffer::getFile(u8string(SharedObjectName).c_str());
       unlikely(ErrorMessage)) {
     spdlog::error("object file open error:{}"sv, ErrorMessage.string_view());
     return Unexpect(ErrCode::Value::IllegalPath);

--- a/lib/loader/serialize/serial_section.cpp
+++ b/lib/loader/serialize/serial_section.cpp
@@ -62,7 +62,7 @@ void Serializer::serializeSection(const AST::ImportSection &Sec,
   // Import section: 0x02 + size:u32 + content:vec(importdesc).
   serializeSectionContent(
       Sec, 0x02U, OutVec,
-      [=](const AST::ImportDesc &R, std::vector<uint8_t> &V) {
+      [this](const AST::ImportDesc &R, std::vector<uint8_t> &V) {
         serializeDesc(R, V);
       });
 }
@@ -71,9 +71,10 @@ void Serializer::serializeSection(const AST::ImportSection &Sec,
 void Serializer::serializeSection(const AST::FunctionSection &Sec,
                                   std::vector<uint8_t> &OutVec) const noexcept {
   // Function section: 0x03 + size:u32 + content:vec(u32).
-  serializeSectionContent(
-      Sec, 0x03U, OutVec,
-      [=](const uint32_t &R, std::vector<uint8_t> &V) { serializeU32(R, V); });
+  serializeSectionContent(Sec, 0x03U, OutVec,
+                          [this](const uint32_t &R, std::vector<uint8_t> &V) {
+                            serializeU32(R, V);
+                          });
 }
 
 // Serialize table section. See "include/loader/serialize.h".
@@ -82,7 +83,7 @@ void Serializer::serializeSection(const AST::TableSection &Sec,
   // Table section: 0x04 + size:u32 + content:vec(table).
   serializeSectionContent(
       Sec, 0x04U, OutVec,
-      [=](const AST::TableSegment &R, std::vector<uint8_t> &V) {
+      [this](const AST::TableSegment &R, std::vector<uint8_t> &V) {
         serializeSegment(R, V);
       });
 }
@@ -93,7 +94,7 @@ void Serializer::serializeSection(const AST::MemorySection &Sec,
   // Memory section: 0x05 + size:u32 + content:vec(memorytype).
   serializeSectionContent(
       Sec, 0x05U, OutVec,
-      [=](const AST::MemoryType &R, std::vector<uint8_t> &V) {
+      [this](const AST::MemoryType &R, std::vector<uint8_t> &V) {
         serializeType(R, V);
       });
 }
@@ -104,7 +105,7 @@ void Serializer::serializeSection(const AST::GlobalSection &Sec,
   // Global section: 0x06 + size:u32 + content:vec(global).
   serializeSectionContent(
       Sec, 0x06U, OutVec,
-      [=](const AST::GlobalSegment &R, std::vector<uint8_t> &V) {
+      [this](const AST::GlobalSegment &R, std::vector<uint8_t> &V) {
         serializeSegment(R, V);
       });
 }
@@ -115,7 +116,7 @@ void Serializer::serializeSection(const AST::ExportSection &Sec,
   // Export section: 0x07 + size:u32 + content:vec(exportdesc).
   serializeSectionContent(
       Sec, 0x07U, OutVec,
-      [=](const AST::ExportDesc &R, std::vector<uint8_t> &V) {
+      [this](const AST::ExportDesc &R, std::vector<uint8_t> &V) {
         serializeDesc(R, V);
       });
 }
@@ -142,7 +143,7 @@ void Serializer::serializeSection(const AST::ElementSection &Sec,
   // Element section: 0x09 + size:u32 + content:vec(elemseg).
   serializeSectionContent(
       Sec, 0x09U, OutVec,
-      [=](const AST::ElementSegment &R, std::vector<uint8_t> &V) {
+      [this](const AST::ElementSegment &R, std::vector<uint8_t> &V) {
         serializeSegment(R, V);
       });
 }
@@ -153,7 +154,7 @@ void Serializer::serializeSection(const AST::CodeSection &Sec,
   // Code section: 0x0A + size:u32 + content:vec(codeseg).
   serializeSectionContent(
       Sec, 0x0AU, OutVec,
-      [=](const AST::CodeSegment &R, std::vector<uint8_t> &V) {
+      [this](const AST::CodeSegment &R, std::vector<uint8_t> &V) {
         serializeSegment(R, V);
       });
 }
@@ -164,7 +165,7 @@ void Serializer::serializeSection(const AST::DataSection &Sec,
   // Data section: 0x0B + size:u32 + content:vec(dataseg).
   serializeSectionContent(
       Sec, 0x0BU, OutVec,
-      [=](const AST::DataSegment &R, std::vector<uint8_t> &V) {
+      [this](const AST::DataSegment &R, std::vector<uint8_t> &V) {
         serializeSegment(R, V);
       });
 }
@@ -189,10 +190,11 @@ void Serializer::serializeSection(const AST::DataCountSection &Sec,
 void Serializer::serializeSection(const AST::TagSection &Sec,
                                   std::vector<uint8_t> &OutVec) const noexcept {
   // Tag section: 0x0D + size:u32 + content:vec(tagtype)
-  serializeSectionContent(Sec, 0x0DU, OutVec,
-                          [=](const AST::TagType &R, std::vector<uint8_t> &V) {
-                            serializeType(R, V);
-                          });
+  serializeSectionContent(
+      Sec, 0x0DU, OutVec,
+      [this](const AST::TagType &R, std::vector<uint8_t> &V) {
+        serializeType(R, V);
+      });
 }
 
 } // namespace Loader

--- a/lib/plugin/plugin.cpp
+++ b/lib/plugin/plugin.cpp
@@ -3,6 +3,7 @@
 
 #include "plugin/plugin.h"
 #include "common/errcode.h"
+#include "common/filesystem.h"
 #include "common/version.h"
 #include "wasmedge/wasmedge.h"
 
@@ -264,11 +265,11 @@ std::vector<std::filesystem::path> Plugin::getDefaultPluginPaths() noexcept {
     std::string_view ExtraEnvStr = ExtraEnv;
     for (auto Sep = ExtraEnvStr.find(':'); Sep != std::string_view::npos;
          Sep = ExtraEnvStr.find(':')) {
-      Result.push_back(std::filesystem::u8path(ExtraEnvStr.substr(0, Sep)));
+      Result.push_back(u8path(ExtraEnvStr.substr(0, Sep)));
       const auto Next = ExtraEnvStr.find_first_not_of(':', Sep);
       ExtraEnvStr = ExtraEnvStr.substr(Next);
     }
-    Result.push_back(std::filesystem::u8path(ExtraEnvStr));
+    Result.push_back(u8path(ExtraEnvStr));
   }
 
   // Plugin directory for the WasmEdge installation.
@@ -283,9 +284,7 @@ std::vector<std::filesystem::path> Plugin::getDefaultPluginPaths() noexcept {
           "within the object. dli_fname is null."sv);
       return std::vector<std::filesystem::path>();
     }
-    auto LibPath = std::filesystem::u8path(DLInfo.dli_fname)
-                       .parent_path()
-                       .lexically_normal();
+    auto LibPath = u8path(DLInfo.dli_fname).parent_path().lexically_normal();
     const auto UsrStr = "/usr"sv;
     const auto LibStr = "/lib"sv;
     const auto &PathStr = LibPath.native();
@@ -297,12 +296,11 @@ std::vector<std::filesystem::path> Plugin::getDefaultPluginPaths() noexcept {
       // Plug-in path will be in "LIB_PATH/wasmedge".
       // If the installation path is under "/usr/lib" or "/usr/lib64", the
       // traced library path will be "/lib" or "/lib64".
-      Result.push_back(LibPath / std::filesystem::u8path("wasmedge"sv));
+      Result.push_back(LibPath / u8path("wasmedge"sv));
     } else {
       // The installation path of the WasmEdge library is not under "/usr", such
       // as "$HOME/.wasmedge". Plug-in path will be in "LIB_PATH/../plugin".
-      Result.push_back(LibPath / std::filesystem::u8path(".."sv) /
-                       std::filesystem::u8path("plugin"sv));
+      Result.push_back(LibPath / u8path(".."sv) / u8path("plugin"sv));
     }
   } else {
     spdlog::error(ErrCode::Value::NonNullRequired);
@@ -323,7 +321,7 @@ std::vector<std::filesystem::path> Plugin::getDefaultPluginPaths() noexcept {
   // Local home plugin directory.
   std::filesystem::path Home;
   if (const auto HomeEnv = ::getenv("USERPROFILE")) {
-    Home = std::filesystem::u8path(HomeEnv);
+    Home = u8path(HomeEnv);
   } else {
 #if NTDDI_VERSION >= NTDDI_VISTA
     wchar_t *Path = nullptr;
@@ -342,8 +340,7 @@ std::vector<std::filesystem::path> Plugin::getDefaultPluginPaths() noexcept {
     }
 #endif
   }
-  Result.push_back(Home / std::filesystem::u8path(".wasmedge"sv) /
-                   std::filesystem::u8path("plugin"sv));
+  Result.push_back(Home / u8path(".wasmedge"sv) / u8path("plugin"sv));
 #endif
 
   return Result;
@@ -360,13 +357,13 @@ WASMEDGE_EXPORT bool Plugin::load(const std::filesystem::path &Path) noexcept {
                Error)) {
         const auto &EntryPath = Entry.path();
         if (Entry.is_regular_file(Error) &&
-            EntryPath.extension().u8string() == WASMEDGE_LIB_EXTENSION) {
+            u8string(EntryPath.extension()) == WASMEDGE_LIB_EXTENSION) {
           Result |= loadFile(EntryPath);
         }
       }
       return Result;
     } else if (std::filesystem::is_regular_file(Status) &&
-               Path.extension().u8string() == WASMEDGE_LIB_EXTENSION) {
+               u8string(Path.extension()) == WASMEDGE_LIB_EXTENSION) {
       return loadFile(Path);
     }
   }
@@ -418,7 +415,7 @@ bool Plugin::loadFile(const std::filesystem::path &Path) noexcept {
 
   // A library already loaded in this process stays available: report success
   // without re-dlopen'ing or re-registering it.
-  const std::string FileKey = Path.u8string();
+  const std::string FileKey = u8string(Path);
   if (LoadedFiles.find(FileKey) != LoadedFiles.end()) {
     return true;
   }

--- a/lib/system/path.cpp
+++ b/lib/system/path.cpp
@@ -5,6 +5,7 @@
 
 #include "common/config.h"
 #include "common/defines.h"
+#include "common/filesystem.h"
 #include <string_view>
 
 #if defined(HAVE_PWD_H)
@@ -23,7 +24,7 @@ std::filesystem::path Path::home() noexcept {
 #if defined(HAVE_PWD_H)
   {
     const struct passwd *PassWd = getpwuid(getuid());
-    Home = std::filesystem::u8path(PassWd->pw_dir);
+    Home = u8path(PassWd->pw_dir);
   }
 #elif WASMEDGE_OS_WINDOWS
   {
@@ -48,7 +49,7 @@ std::filesystem::path Path::home() noexcept {
   }
 #endif
   if (!Home.empty()) {
-    return Home / std::filesystem::u8path(".wasmedge"sv);
+    return Home / u8path(".wasmedge"sv);
   }
   return {};
 }

--- a/plugins/wasi_nn/GGML/core/ggml_core.cpp
+++ b/plugins/wasi_nn/GGML/core/ggml_core.cpp
@@ -3,6 +3,7 @@
 
 #include "ggml_core.h"
 #include "GGML/utils.h"
+#include "common/filesystem.h"
 #include "common/types.h"
 #include "host/wasi/vfs_io.h"
 #include "wasinnenv.h"
@@ -135,8 +136,7 @@ Expect<ErrNo> load(WasiNNEnvironment &Env, WASINN::Graph &G,
   LOG_DEBUG(GraphRef.EnableDebugLog, "load: handling model path...Done"sv)
 
   // Check if the model exists.
-  if (!std::filesystem::exists(
-          std::filesystem::u8path(GraphRef.Params.model.path))) {
+  if (!std::filesystem::exists(u8path(GraphRef.Params.model.path))) {
     RET_ERROR(ErrNo::ModelNotFound, "load: model file not found."sv)
   }
   GraphRef.Params.model = GraphRef.Params.model;

--- a/plugins/wasi_nn/wasinn_bitnet.cpp
+++ b/plugins/wasi_nn/wasinn_bitnet.cpp
@@ -1,4 +1,5 @@
 #include "wasinn_bitnet.h"
+#include "common/filesystem.h"
 #include "wasinnenv.h"
 #include <cstdint>
 
@@ -1958,8 +1959,7 @@ Expect<ErrNo> load(WasiNNEnvironment &, WASINN::Graph &G,
   LOG_DEBUG(GraphRef.EnableDebugLog, "load: handling model path...Done"sv)
 
   // Check if the model exists.
-  if (!std::filesystem::exists(
-          std::filesystem::u8path(GraphRef.Params.model))) {
+  if (!std::filesystem::exists(u8path(GraphRef.Params.model))) {
     RET_ERROR(ErrNo::ModelNotFound,
               "load: Model file not found at path: '{}'."sv,
               GraphRef.Params.model)

--- a/plugins/wasi_nn/wasinn_piper.cpp
+++ b/plugins/wasi_nn/wasinn_piper.cpp
@@ -3,6 +3,7 @@
 
 #include "wasinn_piper.h"
 #include "common/errcode.h"
+#include "common/filesystem.h"
 #include "common/span.h"
 #include "wasinnenv.h"
 #include "wasinntypes.h"
@@ -165,7 +166,7 @@ WASINN::ErrNo parseRunConfig(RunConfig &RunConfig,
   }
   // Verify model file exists
   if (ModelPath) {
-    auto Path = std::filesystem::u8path(ModelPath.value());
+    auto Path = u8path(ModelPath.value());
     if (!std::filesystem::exists(Path)) {
       spdlog::error("[WASI-NN] Piper backend: Model file doesn't exist"sv);
       return WASINN::ErrNo::InvalidArgument;
@@ -183,8 +184,7 @@ WASINN::ErrNo parseRunConfig(RunConfig &RunConfig,
     return Err;
   }
   if (ModelConfigPath) {
-    RunConfig.ModelConfigPath =
-        std::filesystem::u8path(ModelConfigPath.value());
+    RunConfig.ModelConfigPath = u8path(ModelConfigPath.value());
   } else {
     RunConfig.ModelConfigPath = RunConfig.ModelPath;
     RunConfig.ModelConfigPath += ".json";
@@ -206,7 +206,7 @@ WASINN::ErrNo parseRunConfig(RunConfig &RunConfig,
       return Err;
     }
     if (Path) {
-      RunConfig.ESpeakDataPath = std::filesystem::u8path(Path.value());
+      RunConfig.ESpeakDataPath = u8path(Path.value());
     }
   }
   if (auto Err =

--- a/plugins/wasi_nn/wasinnenv.cpp
+++ b/plugins/wasi_nn/wasinnenv.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "wasinnenv.h"
+#include "common/filesystem.h"
 #include "wasinnmodule.h"
 #include "wasinntypes.h"
 
@@ -137,7 +138,7 @@ WasiNNEnvironment::WasiNNEnvironment() noexcept {
       } else {
         for (const std::string &P : Paths) {
           std::vector<uint8_t> Model;
-          if (load(std::filesystem::u8path(P), Model)) {
+          if (load(u8path(P), Model)) {
             Models.push_back(std::move(Model));
           }
         }

--- a/test/aot/AOTCacheTest.cpp
+++ b/test/aot/AOTCacheTest.cpp
@@ -31,7 +31,7 @@ TEST(CacheTest, GlobalEmpty) {
       {}, WasmEdge::AOT::Cache::StorageScope::Global);
   EXPECT_TRUE(Path);
   auto Root = *Path;
-  while (Root.filename().u8string() != "wasmedge"sv) {
+  while (WasmEdge::u8string(Root.filename()) != "wasmedge"sv) {
     ASSERT_TRUE(Root.has_parent_path());
     Root = Root.parent_path();
   }
@@ -39,7 +39,7 @@ TEST(CacheTest, GlobalEmpty) {
   const auto Part = std::filesystem::proximate(*Path, Root, ErrCode);
   EXPECT_FALSE(ErrCode);
   EXPECT_EQ(
-      Part.u8string(),
+      WasmEdge::u8string(Part),
       "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"s);
 }
 
@@ -48,7 +48,7 @@ TEST(CacheTest, LocalEmpty) {
       {}, WasmEdge::AOT::Cache::StorageScope::Local);
   EXPECT_TRUE(Path);
   auto Root = *Path;
-  while (Root.filename().u8string() != ".wasmedge"sv) {
+  while (WasmEdge::u8string(Root.filename()) != ".wasmedge"sv) {
     ASSERT_TRUE(Root.has_parent_path());
     Root = Root.parent_path();
   }
@@ -57,7 +57,7 @@ TEST(CacheTest, LocalEmpty) {
   const auto Part = std::filesystem::proximate(*Path, Root, ErrCode);
   EXPECT_FALSE(ErrCode);
   EXPECT_EQ(
-      Part.u8string(),
+      WasmEdge::u8string(Part),
       "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"s);
 }
 
@@ -66,7 +66,7 @@ TEST(CacheTest, GlobalKey) {
       {}, WasmEdge::AOT::Cache::StorageScope::Global, "key"s);
   EXPECT_TRUE(Path);
   auto Root = *Path;
-  while (Root.filename().u8string() != "wasmedge"sv) {
+  while (WasmEdge::u8string(Root.filename()) != "wasmedge"sv) {
     ASSERT_TRUE(Root.has_parent_path());
     Root = Root.parent_path();
   }
@@ -74,9 +74,9 @@ TEST(CacheTest, GlobalKey) {
   const auto Part = std::filesystem::proximate(*Path, Root, ErrCode);
   EXPECT_FALSE(ErrCode);
   EXPECT_EQ(
-      Part.filename().u8string(),
+      WasmEdge::u8string(Part.filename()),
       "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"s);
-  EXPECT_EQ(Part.parent_path().filename().u8string(), "key"s);
+  EXPECT_EQ(WasmEdge::u8string(Part.parent_path().filename()), "key"s);
 }
 
 TEST(CacheTest, LocalKey) {
@@ -84,8 +84,8 @@ TEST(CacheTest, LocalKey) {
       {}, WasmEdge::AOT::Cache::StorageScope::Local, "key"s);
   EXPECT_TRUE(Path);
   auto Root = *Path;
-  while (Root.filename().u8string() != ".wasmedge"sv &&
-         Root.filename().u8string() != "wasmedge"sv) {
+  while (WasmEdge::u8string(Root.filename()) != ".wasmedge"sv &&
+         WasmEdge::u8string(Root.filename()) != "wasmedge"sv) {
     ASSERT_TRUE(Root.has_parent_path());
     Root = Root.parent_path();
   }
@@ -94,9 +94,9 @@ TEST(CacheTest, LocalKey) {
   const auto Part = std::filesystem::proximate(*Path, Root, ErrCode);
   EXPECT_FALSE(ErrCode);
   EXPECT_EQ(
-      Part.filename().u8string(),
+      WasmEdge::u8string(Part.filename()),
       "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"s);
-  EXPECT_EQ(Part.parent_path().filename().u8string(), "key"s);
+  EXPECT_EQ(WasmEdge::u8string(Part.parent_path().filename()), "key"s);
 }
 
 } // namespace

--- a/test/api/APIAOTCoreTest.cpp
+++ b/test/api/APIAOTCoreTest.cpp
@@ -14,6 +14,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "common/filesystem.h"
 #include "helper.h"
 #include "hostfunc_c.h"
 #include "wasmedge/wasmedge.h"
@@ -35,7 +36,7 @@
 namespace {
 using namespace std::literals;
 using namespace WasmEdge;
-static SpecTest T(std::filesystem::u8path("../spec/testSuites"sv));
+static SpecTest T(u8path("../spec/testSuites"sv));
 
 // Parameterized testing class.
 class CoreCompileTest : public testing::TestWithParam<std::string> {};
@@ -71,9 +72,9 @@ TEST_P(CoreCompileTest, TestSuites) {
       WasmEdge_CompilerDelete(CompilerCxt);
     }
     Expect<std::string> compile(const std::string &FileName) {
-      auto Path = std::filesystem::u8path(FileName);
-      Path.replace_extension(std::filesystem::u8path(WASMEDGE_LIB_EXTENSION));
-      const auto SOPath = Path.u8string();
+      auto Path = u8path(FileName);
+      Path.replace_extension(u8path(WASMEDGE_LIB_EXTENSION));
+      const auto SOPath = u8string(Path);
       WasmEdge_Result Res = WasmEdge_CompilerCompile(
           CompilerCxt, FileName.c_str(), SOPath.c_str());
       if (!WasmEdge_ResultOK(Res)) {

--- a/test/api/APIStepsCoreTest.cpp
+++ b/test/api/APIStepsCoreTest.cpp
@@ -14,6 +14,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "common/filesystem.h"
 #include "helper.h"
 #include "hostfunc_c.h"
 #include "wasmedge/wasmedge.h"
@@ -34,7 +35,7 @@ namespace {
 
 using namespace std::literals;
 using namespace WasmEdge;
-static SpecTest T(std::filesystem::u8path("../spec/testSuites"sv));
+static SpecTest T(u8path("../spec/testSuites"sv));
 
 // Parameterized testing class.
 class CoreTest : public testing::TestWithParam<std::string> {};

--- a/test/api/APIUnitTest.cpp
+++ b/test/api/APIUnitTest.cpp
@@ -282,7 +282,7 @@ std::vector<uint8_t> ConsumerWasm = {
     0x01, 0x08, 0x00, 0x20, 0x00, 0x20, 0x01, 0x10, 0x00, 0x0b};
 
 void hexToFile(cxx20::span<const uint8_t> Wasm, const char *Path) {
-  std::ofstream TFile(std::filesystem::u8path(Path), std::ios_base::binary);
+  std::ofstream TFile(WasmEdge::u8path(Path), std::ios_base::binary);
   TFile.write(reinterpret_cast<const char *>(Wasm.data()),
               static_cast<std::streamsize>(Wasm.size()));
   TFile.close();
@@ -1435,7 +1435,7 @@ TEST(APICoreTest, Compiler) {
 
   // Compile file for shared library output format from buffer
   std::error_code EC;
-  auto TPathFS = std::filesystem::u8path(TPath);
+  auto TPathFS = WasmEdge::u8path(TPath);
   size_t FileSize = std::filesystem::file_size(TPathFS, EC);
   EXPECT_FALSE(EC);
   std::ifstream Fin(TPathFS, std::ios::in | std::ios::binary);

--- a/test/api/APIVMCoreTest.cpp
+++ b/test/api/APIVMCoreTest.cpp
@@ -14,6 +14,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "common/filesystem.h"
 #include "helper.h"
 #include "hostfunc_c.h"
 #include "wasmedge/wasmedge.h"
@@ -33,7 +34,7 @@
 namespace {
 using namespace std::literals;
 using namespace WasmEdge;
-static SpecTest T(std::filesystem::u8path("../spec/testSuites"sv));
+static SpecTest T(u8path("../spec/testSuites"sv));
 
 // Parameterized testing class.
 class CoreTest : public testing::TestWithParam<std::string> {};

--- a/test/driver/driverToolTest.cpp
+++ b/test/driver/driverToolTest.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "common/defines.h"
+#include "common/filesystem.h"
 #include "driver/tool.h"
 #include "driver/unitool.h"
 #include "po/argument_parser.h"
@@ -331,9 +332,8 @@ std::string trapPath() {
 // coredumps, because the coredump is written into the working directory.
 size_t countCoredumpsOf(std::initializer_list<const char *> Args,
                         const std::string &Name) {
-  const auto TempDir =
-      std::filesystem::temp_directory_path() /
-      std::filesystem::u8path("wasmedge-driver-coredump-" + Name);
+  const auto TempDir = std::filesystem::temp_directory_path() /
+                       WasmEdge::u8path("wasmedge-driver-coredump-" + Name);
   std::error_code Error;
   std::filesystem::remove_all(TempDir, Error);
   if (!std::filesystem::create_directories(TempDir, Error)) {

--- a/test/executor/ExecutorTest.cpp
+++ b/test/executor/ExecutorTest.cpp
@@ -14,6 +14,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "common/filesystem.h"
 #include "common/spdlog.h"
 #include "vm/vm.h"
 
@@ -40,7 +41,7 @@ namespace {
 
 using namespace std::literals;
 using namespace WasmEdge;
-static SpecTest T(std::filesystem::u8path("../spec/testSuites"sv));
+static SpecTest T(u8path("../spec/testSuites"sv));
 
 // Parameterized testing class.
 class CoreTest : public testing::TestWithParam<std::string> {};
@@ -477,9 +478,9 @@ std::array<WasmEdge::Byte, 147> CoredumpWasm{
 
 // Trap the module in an empty directory and parse the generated coredump.
 void runCoredump(bool ForWasmgdb, AST::Module &Output) {
-  const auto TempDir = std::filesystem::temp_directory_path() /
-                       std::filesystem::u8path("wasmedge-coredump-"s +
-                                               std::to_string(ForWasmgdb));
+  const auto TempDir =
+      std::filesystem::temp_directory_path() /
+      u8path("wasmedge-coredump-"s + std::to_string(ForWasmgdb));
   std::error_code Error;
   std::filesystem::remove_all(TempDir, Error);
   ASSERT_TRUE(std::filesystem::create_directories(TempDir, Error));
@@ -509,7 +510,7 @@ void runCoredump(bool ForWasmgdb, AST::Module &Output) {
   // The coredump must be a well-formed WASM module.
   WasmEdge::Configure LoadConf;
   WasmEdge::Loader::Loader LoadEngine(LoadConf);
-  auto Mod = LoadEngine.parseModule(Dumps[0].u8string());
+  auto Mod = LoadEngine.parseModule(u8string(Dumps[0]));
   ASSERT_TRUE(Mod);
   Output = std::move(**Mod);
   std::filesystem::remove_all(TempDir, Error);

--- a/test/externref/ExternrefTest.cpp
+++ b/test/externref/ExternrefTest.cpp
@@ -126,7 +126,7 @@ std::vector<uint8_t> ExternConvertWasm = {
     0x01, 0x04, 0x01, 0x00, 0x01, 0x30, 0x04, 0x04, 0x01, 0x00, 0x01, 0x30};
 
 void HexToFile(cxx20::span<const uint8_t> Wasm, const char *Path) {
-  std::ofstream TFile(std::filesystem::u8path(Path), std::ios_base::binary);
+  std::ofstream TFile(WasmEdge::u8path(Path), std::ios_base::binary);
   TFile.write(reinterpret_cast<const char *>(Wasm.data()),
               static_cast<std::streamsize>(Wasm.size()));
   TFile.close();

--- a/test/host/wasi/wasi.cpp
+++ b/test/host/wasi/wasi.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "common/defines.h"
+#include "common/filesystem.h"
 #include "common/types.h"
 #include "host/wasi/wasibase.h"
 #include "host/wasi/wasifunc.h"
@@ -4261,7 +4262,7 @@ namespace {
 namespace fs = std::filesystem;
 int openFileForWrite(const fs::path &Filename) {
   int Fd = -1;
-  const std::string PathStr = Filename.u8string();
+  const std::string PathStr = WasmEdge::u8string(Filename);
 #if WASMEDGE_OS_WINDOWS
   if (_sopen_s(&Fd, PathStr.c_str(),
                _O_WRONLY | _O_CREAT | _O_TRUNC | _O_BINARY, _SH_DENYNO,
@@ -4276,7 +4277,7 @@ int openFileForWrite(const fs::path &Filename) {
 
 int openFileForRead(const fs::path &Filename) {
   int Fd = -1;
-  const std::string PathStr = Filename.u8string();
+  const std::string PathStr = WasmEdge::u8string(Filename);
 #if WASMEDGE_OS_WINDOWS
   if (_sopen_s(&Fd, PathStr.c_str(), _O_RDONLY | _O_BINARY, _SH_DENYNO, 0) !=
       0) {
@@ -4331,7 +4332,7 @@ TEST(WasiTest, CustomFds) {
   WasmEdge::Runtime::CallingFrame CallFrame(nullptr, &Mod);
 
   std::array<WasmEdge::ValVariant, 1> Errno;
-  const fs::path TempPath = fs::u8path("wasi_custom_fd_test.tmp");
+  const fs::path TempPath = WasmEdge::u8path("wasi_custom_fd_test.tmp");
 
   auto SetupTestFile = [&](const std::string_view &TestString,
                            bool ForRead) -> int {
@@ -4520,7 +4521,7 @@ TEST(WasiTest, PointerAlignment) {
   std::array<WasmEdge::ValVariant, 1> Errno;
 
   // CustomFds pointer alignment tests
-  const fs::path TempPath = fs::u8path("wasi_custom_fd_test.tmp");
+  const fs::path TempPath = WasmEdge::u8path("wasi_custom_fd_test.tmp");
 
   // Test WasiFdFdstatGet alignment checks
   {

--- a/test/llvm/LLVMcoreTest.cpp
+++ b/test/llvm/LLVMcoreTest.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "common/defines.h"
+#include "common/filesystem.h"
 #include "common/spdlog.h"
 #include "executor/executor.h"
 #include "loader/loader.h"
@@ -47,7 +48,7 @@ namespace {
 
 using namespace std::literals;
 using namespace WasmEdge;
-static SpecTest T(std::filesystem::u8path("../spec/testSuites"sv));
+static SpecTest T(u8path("../spec/testSuites"sv));
 
 // Parameterized testing class.
 class NativeCoreTest : public testing::TestWithParam<std::string> {};
@@ -994,9 +995,9 @@ TEST_P(NativeCoreTest, TestSuites) {
       CopyConf.getCompilerConfigure().setDumpIR(true);
       WasmEdge::LLVM::Compiler Compiler(CopyConf);
       WasmEdge::LLVM::CodeGen CodeGen(CopyConf);
-      auto Path = std::filesystem::u8path(FileName);
-      Path.replace_extension(std::filesystem::u8path(WASMEDGE_LIB_EXTENSION));
-      const auto SOPath = Path.u8string();
+      auto Path = u8path(FileName);
+      Path.replace_extension(u8path(WASMEDGE_LIB_EXTENSION));
+      const auto SOPath = u8string(Path);
       std::vector<WasmEdge::Byte> Data;
       std::unique_ptr<WasmEdge::AST::Module> Module;
       return Loader.loadFile(FileName)
@@ -1168,9 +1169,9 @@ TEST_P(CustomWasmCoreTest, TestSuites) {
       CopyConf.getCompilerConfigure().setDumpIR(true);
       WasmEdge::LLVM::Compiler Compiler(CopyConf);
       WasmEdge::LLVM::CodeGen CodeGen(CopyConf);
-      auto Path = std::filesystem::u8path(FileName);
-      Path.replace_extension(std::filesystem::u8path(".aot.wasm"));
-      const auto SOPath = Path.u8string();
+      auto Path = u8path(FileName);
+      Path.replace_extension(u8path(".aot.wasm"));
+      const auto SOPath = u8string(Path);
       std::vector<WasmEdge::Byte> Data;
       std::unique_ptr<WasmEdge::AST::Module> Module;
       return Loader.loadFile(FileName)
@@ -1604,7 +1605,7 @@ TEST(AsyncRunWsmFile, NativeInterruptTest) {
   WasmEdge::LLVM::Compiler Compiler(Conf);
   WasmEdge::LLVM::CodeGen CodeGen(Conf);
   auto Path = std::filesystem::temp_directory_path() /
-              std::filesystem::u8path("AOTcoreTest" WASMEDGE_LIB_EXTENSION);
+              u8path("AOTcoreTest" WASMEDGE_LIB_EXTENSION);
   auto Module = *Loader.parseModule(AsyncWasm);
   ASSERT_TRUE(ValidatorEngine.validate(*Module));
   auto Data = Compiler.compile(*Module);
@@ -1646,7 +1647,7 @@ TEST(AsyncExecute, NativeInterruptTest) {
   WasmEdge::LLVM::Compiler Compiler(Conf);
   WasmEdge::LLVM::CodeGen CodeGen(Conf);
   auto Path = std::filesystem::temp_directory_path() /
-              std::filesystem::u8path("AOTcoreTest" WASMEDGE_LIB_EXTENSION);
+              u8path("AOTcoreTest" WASMEDGE_LIB_EXTENSION);
   auto Module = *Loader.parseModule(AsyncWasm);
   ASSERT_TRUE(ValidatorEngine.validate(*Module));
   auto Data = Compiler.compile(*Module);
@@ -1690,8 +1691,8 @@ TEST(AsyncRunWsmFile, CustomWasmInterruptTest) {
   WasmEdge::Validator::Validator ValidatorEngine(Conf);
   WasmEdge::LLVM::Compiler Compiler(Conf);
   WasmEdge::LLVM::CodeGen CodeGen(Conf);
-  auto Path = std::filesystem::temp_directory_path() /
-              std::filesystem::u8path("AOTcoreTest.aot.wasm");
+  auto Path =
+      std::filesystem::temp_directory_path() / u8path("AOTcoreTest.aot.wasm");
   auto Module = *Loader.parseModule(AsyncWasm);
   ASSERT_TRUE(ValidatorEngine.validate(*Module));
   auto Data = Compiler.compile(*Module);
@@ -1732,8 +1733,8 @@ TEST(AsyncExecute, CustomWasmInterruptTest) {
   WasmEdge::Validator::Validator ValidatorEngine(Conf);
   WasmEdge::LLVM::Compiler Compiler(Conf);
   WasmEdge::LLVM::CodeGen CodeGen(Conf);
-  auto Path = std::filesystem::temp_directory_path() /
-              std::filesystem::u8path("AOTcoreTest.aot.wasm");
+  auto Path =
+      std::filesystem::temp_directory_path() / u8path("AOTcoreTest.aot.wasm");
   auto Module = *Loader.parseModule(AsyncWasm);
   ASSERT_TRUE(ValidatorEngine.validate(*Module));
   auto Data = Compiler.compile(*Module);
@@ -1820,7 +1821,7 @@ TEST(SIMDNaN, F32x4MaxNaNHandling) {
   WasmEdge::LLVM::CodeGen CodeGen(Conf);
 
   auto Path = std::filesystem::temp_directory_path() /
-              std::filesystem::u8path("SIMDNaNTest" WASMEDGE_LIB_EXTENSION);
+              u8path("SIMDNaNTest" WASMEDGE_LIB_EXTENSION);
 
   auto Module = *Loader.parseModule(SIMDNaNTestWasm);
   ASSERT_TRUE(ValidatorEngine.validate(*Module));
@@ -1893,7 +1894,7 @@ TEST(AOTMemory64, BoundsCheck) {
   WasmEdge::LLVM::CodeGen CodeGen(Conf);
 
   auto Path = std::filesystem::temp_directory_path() /
-              std::filesystem::u8path("AOTMemory64Test" WASMEDGE_LIB_EXTENSION);
+              u8path("AOTMemory64Test" WASMEDGE_LIB_EXTENSION);
 
   auto Module = *Loader.parseModule(Memory64Wasm);
   ASSERT_TRUE(ValidatorEngine.validate(*Module));
@@ -1953,12 +1954,11 @@ class ScopedTempFile {
 public:
   explicit ScopedTempFile(std::string_view Stem,
                           std::string_view Extension = ""sv)
-      : Path(
-            std::filesystem::temp_directory_path() /
-            std::filesystem::u8path(std::string(Stem) + "-" +
-                                    std::to_string(std::hash<std::thread::id>{}(
-                                        std::this_thread::get_id())) +
-                                    std::string(Extension))) {}
+      : Path(std::filesystem::temp_directory_path() /
+             u8path(std::string(Stem) + "-" +
+                    std::to_string(std::hash<std::thread::id>{}(
+                        std::this_thread::get_id())) +
+                    std::string(Extension))) {}
   ScopedTempFile(const ScopedTempFile &) = delete;
   ScopedTempFile &operator=(const ScopedTempFile &) = delete;
   ~ScopedTempFile() noexcept {

--- a/test/loader/moduleTest.cpp
+++ b/test/loader/moduleTest.cpp
@@ -37,12 +37,11 @@ class ScopedTempFile {
 public:
   explicit ScopedTempFile(std::string_view Stem,
                           std::string_view Extension = ""sv)
-      : Path(
-            std::filesystem::temp_directory_path() /
-            std::filesystem::u8path(std::string(Stem) + "-" +
-                                    std::to_string(std::hash<std::thread::id>{}(
-                                        std::this_thread::get_id())) +
-                                    std::string(Extension))) {}
+      : Path(std::filesystem::temp_directory_path() /
+             WasmEdge::u8path(std::string(Stem) + "-" +
+                              std::to_string(std::hash<std::thread::id>{}(
+                                  std::this_thread::get_id())) +
+                              std::string(Extension))) {}
   ScopedTempFile(const ScopedTempFile &) = delete;
   ScopedTempFile &operator=(const ScopedTempFile &) = delete;
   ~ScopedTempFile() noexcept {

--- a/test/mixcall/mixcallTest.cpp
+++ b/test/mixcall/mixcallTest.cpp
@@ -76,7 +76,7 @@ std::vector<uint8_t> Module2Wasm = {
     0x31};
 
 void HexToFile(cxx20::span<const uint8_t> Wasm, const char *Path) {
-  std::ofstream TFile(std::filesystem::u8path(Path), std::ios_base::binary);
+  std::ofstream TFile(WasmEdge::u8path(Path), std::ios_base::binary);
   TFile.write(reinterpret_cast<const char *>(Wasm.data()),
               static_cast<std::streamsize>(Wasm.size()));
   TFile.close();

--- a/test/plugins/unittest/unittest_cpp.cpp
+++ b/test/plugins/unittest/unittest_cpp.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "common/defines.h"
+#include "common/filesystem.h"
 #include "plugin/plugin.h"
 #include "runtime/callingframe.h"
 #include "runtime/instance/module.h"
@@ -18,9 +19,9 @@ namespace {
 
 std::unique_ptr<WasmEdge::Runtime::Instance::ModuleInstance> createModuleC() {
   using namespace std::literals::string_view_literals;
-  WasmEdge::Plugin::Plugin::load(std::filesystem::u8path(
-      "./" WASMEDGE_LIB_PREFIX
-      "wasmedgePluginTestModuleC" WASMEDGE_LIB_EXTENSION));
+  WasmEdge::Plugin::Plugin::load(
+      WasmEdge::u8path("./" WASMEDGE_LIB_PREFIX
+                       "wasmedgePluginTestModuleC" WASMEDGE_LIB_EXTENSION));
   if (const auto *Plugin =
           WasmEdge::Plugin::Plugin::find("wasmedge_plugintest_c"sv)) {
     if (const auto *Module =
@@ -33,9 +34,9 @@ std::unique_ptr<WasmEdge::Runtime::Instance::ModuleInstance> createModuleC() {
 
 std::unique_ptr<WasmEdge::Runtime::Instance::ModuleInstance> createModuleCPP() {
   using namespace std::literals::string_view_literals;
-  WasmEdge::Plugin::Plugin::load(std::filesystem::u8path(
-      "./" WASMEDGE_LIB_PREFIX
-      "wasmedgePluginTestModuleCPP" WASMEDGE_LIB_EXTENSION));
+  WasmEdge::Plugin::Plugin::load(
+      WasmEdge::u8path("./" WASMEDGE_LIB_PREFIX
+                       "wasmedgePluginTestModuleCPP" WASMEDGE_LIB_EXTENSION));
   if (const auto *Plugin =
           WasmEdge::Plugin::Plugin::find("wasmedge_plugintest_cpp"sv)) {
     WasmEdge::PO::ArgumentParser Parser;

--- a/test/plugins/wasi_crypto/helper.h
+++ b/test/plugins/wasi_crypto/helper.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "asymmetric_common/module.h"
+#include "common/filesystem.h"
 #include "common/module.h"
 #include "ctx.h"
 #include "helper.h"
@@ -73,9 +74,9 @@ public:
     MemInst = Mod.findMemoryExports("memory");
 
     using namespace std::literals::string_view_literals;
-    Plugin::Plugin::load(std::filesystem::u8path(
-        "../../../plugins/wasi_crypto/" WASMEDGE_LIB_PREFIX
-        "wasmedgePluginWasiCrypto" WASMEDGE_LIB_EXTENSION));
+    Plugin::Plugin::load(
+        WasmEdge::u8path("../../../plugins/wasi_crypto/" WASMEDGE_LIB_PREFIX
+                         "wasmedgePluginWasiCrypto" WASMEDGE_LIB_EXTENSION));
     if (const auto *Plugin = WasmEdge::Plugin::Plugin::find("wasi_crypto"sv)) {
       if (const auto *Module =
               Plugin->findModule("wasi_crypto_asymmetric_common"sv)) {

--- a/test/plugins/wasi_nn/wasi_nn.cpp
+++ b/test/plugins/wasi_nn/wasi_nn.cpp
@@ -5,6 +5,7 @@
 #include "wasinnfunc.h"
 #include "wasinnmodule.h"
 
+#include "common/filesystem.h"
 #include "common/types.h"
 #include "runtime/callingframe.h"
 #include "runtime/instance/module.h"
@@ -58,8 +59,8 @@ inline std::unique_ptr<T> dynamicPointerCast(std::unique_ptr<U> &&R) noexcept {
 std::unique_ptr<WasmEdge::Host::WasiNNModule>
 createModule(std::string_view NNRPCURI = "") {
   WasmEdge::Plugin::Plugin::load(
-      std::filesystem::u8path("../../../plugins/wasi_nn/" WASMEDGE_LIB_PREFIX
-                              "wasmedgePluginWasiNN" WASMEDGE_LIB_EXTENSION));
+      WasmEdge::u8path("../../../plugins/wasi_nn/" WASMEDGE_LIB_PREFIX
+                       "wasmedgePluginWasiNN" WASMEDGE_LIB_EXTENSION));
   if (const auto *Plugin = WasmEdge::Plugin::Plugin::find("wasi_nn"sv)) {
     WasmEdge::PO::ArgumentParser Parser;
     Plugin->registerOptions(Parser);

--- a/test/plugins/wasm_bpf/simple_map_test.cpp
+++ b/test/plugins/wasm_bpf/simple_map_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "common/defines.h"
+#include "common/filesystem.h"
 #include "executor/executor.h"
 #include "func-attach-bpf-program.h"
 #include "func-bpf-map-fd-by-name.h"
@@ -24,8 +25,8 @@ namespace {
 WasmEdge::Runtime::Instance::ModuleInstance *createModule() {
   using namespace std::literals::string_view_literals;
   WasmEdge::Plugin::Plugin::load(
-      std::filesystem::u8path("../../../plugins/wasm_bpf/" WASMEDGE_LIB_PREFIX
-                              "wasmedgePluginWasmBpf" WASMEDGE_LIB_EXTENSION));
+      WasmEdge::u8path("../../../plugins/wasm_bpf/" WASMEDGE_LIB_PREFIX
+                       "wasmedgePluginWasmBpf" WASMEDGE_LIB_EXTENSION));
   if (const auto *Plugin = WasmEdge::Plugin::Plugin::find("wasm_bpf"sv)) {
     if (const auto *Module = Plugin->findModule("wasm_bpf"sv)) {
       return Module->create().release();

--- a/test/plugins/wasm_bpf/simple_ringbuf_test.cpp
+++ b/test/plugins/wasm_bpf/simple_ringbuf_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "common/defines.h"
+#include "common/filesystem.h"
 #include "executor/executor.h"
 #include "func-attach-bpf-program.h"
 #include "func-bpf-buffer-poll.h"
@@ -20,8 +21,8 @@ namespace {
 WasmEdge::Runtime::Instance::ModuleInstance *createModule() {
   using namespace std::literals::string_view_literals;
   WasmEdge::Plugin::Plugin::load(
-      std::filesystem::u8path("../../../plugins/wasm_bpf/" WASMEDGE_LIB_PREFIX
-                              "wasmedgePluginWasmBpf" WASMEDGE_LIB_EXTENSION));
+      WasmEdge::u8path("../../../plugins/wasm_bpf/" WASMEDGE_LIB_PREFIX
+                       "wasmedgePluginWasmBpf" WASMEDGE_LIB_EXTENSION));
   if (const auto *Plugin = WasmEdge::Plugin::Plugin::find("wasm_bpf"sv)) {
     if (const auto *Module = Plugin->findModule("wasm_bpf"sv)) {
       return Module->create().release();

--- a/test/plugins/wasm_bpf/wasm_bpf.cpp
+++ b/test/plugins/wasm_bpf/wasm_bpf.cpp
@@ -3,6 +3,7 @@
 
 #include "ast/type.h"
 #include "common/defines.h"
+#include "common/filesystem.h"
 #include "executor/executor.h"
 #include "func-attach-bpf-program.h"
 #include "func-bpf-buffer-poll.h"
@@ -42,8 +43,8 @@ inline std::unique_ptr<T> dynamicPointerCast(std::unique_ptr<U> &&R) noexcept {
 std::unique_ptr<WasmEdge::Host::WasmBpfModule> createModule() {
   using namespace std::literals::string_view_literals;
   WasmEdge::Plugin::Plugin::load(
-      std::filesystem::u8path("../../../plugins/wasm_bpf/" WASMEDGE_LIB_PREFIX
-                              "wasmedgePluginWasmBpf" WASMEDGE_LIB_EXTENSION));
+      WasmEdge::u8path("../../../plugins/wasm_bpf/" WASMEDGE_LIB_PREFIX
+                       "wasmedgePluginWasmBpf" WASMEDGE_LIB_EXTENSION));
   if (const auto *Plugin = WasmEdge::Plugin::Plugin::find("wasm_bpf"sv)) {
     if (const auto *Module = Plugin->findModule("wasm_bpf"sv)) {
       return dynamicPointerCast<WasmEdge::Host::WasmBpfModule>(

--- a/test/plugins/wasmedge_ffmpeg/utils.h
+++ b/test/plugins/wasmedge_ffmpeg/utils.h
@@ -7,6 +7,7 @@
 #include "avfilter/module.h"
 #include "avformat/module.h"
 #include "avutil/module.h"
+#include "common/filesystem.h"
 #include "swresample/module.h"
 #include "swscale/module.h"
 
@@ -76,7 +77,7 @@ public:
     MemInst = Mod.findMemoryExports("memory");
 
     using namespace std::literals::string_view_literals;
-    WasmEdge::Plugin::Plugin::load(std::filesystem::u8path(
+    WasmEdge::Plugin::Plugin::load(WasmEdge::u8path(
         "../../../plugins/wasmedge_ffmpeg/" WASMEDGE_LIB_PREFIX
         "wasmedgePluginWasmEdgeFFmpeg" WASMEDGE_LIB_EXTENSION));
     if (const auto *Plugin =

--- a/test/plugins/wasmedge_image/wasmedge_image.cpp
+++ b/test/plugins/wasmedge_image/wasmedge_image.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "common/defines.h"
+#include "common/filesystem.h"
 #include "image_module.h"
 #include "runtime/callingframe.h"
 #include "runtime/instance/module.h"
@@ -30,9 +31,9 @@ inline std::unique_ptr<T> dynamicPointerCast(std::unique_ptr<U> &&R) noexcept {
 
 std::unique_ptr<WasmEdge::Host::WasmEdgeImageModule> createModule() {
   using namespace std::literals::string_view_literals;
-  WasmEdge::Plugin::Plugin::load(std::filesystem::u8path(
-      "../../../plugins/wasmedge_image/" WASMEDGE_LIB_PREFIX
-      "wasmedgePluginWasmEdgeImage" WASMEDGE_LIB_EXTENSION));
+  WasmEdge::Plugin::Plugin::load(
+      WasmEdge::u8path("../../../plugins/wasmedge_image/" WASMEDGE_LIB_PREFIX
+                       "wasmedgePluginWasmEdgeImage" WASMEDGE_LIB_EXTENSION));
   if (const auto *Plugin = WasmEdge::Plugin::Plugin::find("wasmedge_image"sv)) {
     if (const auto *Module = Plugin->findModule("wasmedge_image"sv)) {
       return dynamicPointerCast<WasmEdge::Host::WasmEdgeImageModule>(

--- a/test/plugins/wasmedge_opencvmini/wasmedge_opencvmini.cpp
+++ b/test/plugins/wasmedge_opencvmini/wasmedge_opencvmini.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "common/defines.h"
+#include "common/filesystem.h"
 #include "opencvmini_module.h"
 #include "runtime/callingframe.h"
 #include "runtime/instance/module.h"
@@ -30,7 +31,7 @@ inline std::unique_ptr<T> dynamicPointerCast(std::unique_ptr<U> &&R) noexcept {
 
 std::unique_ptr<WasmEdge::Host::WasmEdgeOpenCVMiniModule> createModule() {
   using namespace std::literals::string_view_literals;
-  WasmEdge::Plugin::Plugin::load(std::filesystem::u8path(
+  WasmEdge::Plugin::Plugin::load(WasmEdge::u8path(
       "../../../plugins/wasmedge_opencvmini/" WASMEDGE_LIB_PREFIX
       "wasmedgePluginWasmEdgeOpenCVMini" WASMEDGE_LIB_EXTENSION));
   if (const auto *Plugin =

--- a/test/plugins/wasmedge_stablediffusion/wasmedge_stablediffusion.cpp
+++ b/test/plugins/wasmedge_stablediffusion/wasmedge_stablediffusion.cpp
@@ -1,4 +1,5 @@
 #include "common/defines.h"
+#include "common/filesystem.h"
 #include "runtime/instance/module.h"
 #include "sd_func.h"
 #include "sd_module.h"
@@ -27,7 +28,7 @@ inline std::unique_ptr<T> dynamicPointerCast(std::unique_ptr<U> &&R) noexcept {
 
 std::unique_ptr<WasmEdge::Host::SDModule> createModule() {
   using namespace std::literals::string_view_literals;
-  WasmEdge::Plugin::Plugin::load(std::filesystem::u8path(
+  WasmEdge::Plugin::Plugin::load(WasmEdge::u8path(
       "../../../plugins/wasmedge_stablediffusion/" WASMEDGE_LIB_PREFIX
       "wasmedgePluginWasmEdgeStableDiffusion" WASMEDGE_LIB_EXTENSION));
   if (const auto *Plugin =

--- a/test/plugins/wasmedge_tensorflow/wasmedge_tensorflow.cpp
+++ b/test/plugins/wasmedge_tensorflow/wasmedge_tensorflow.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "common/defines.h"
+#include "common/filesystem.h"
 #include "runtime/instance/module.h"
 #include "tensorflow_func.h"
 #include "tensorflow_module.h"
@@ -28,7 +29,7 @@ inline std::unique_ptr<T> dynamicPointerCast(std::unique_ptr<U> &&R) noexcept {
 
 std::unique_ptr<WasmEdge::Host::WasmEdgeTensorflowModule> createModule() {
   using namespace std::literals::string_view_literals;
-  WasmEdge::Plugin::Plugin::load(std::filesystem::u8path(
+  WasmEdge::Plugin::Plugin::load(WasmEdge::u8path(
       "../../../plugins/wasmedge_tensorflow/" WASMEDGE_LIB_PREFIX
       "wasmedgePluginWasmEdgeTensorflow" WASMEDGE_LIB_EXTENSION));
   if (const auto *Plugin =

--- a/test/plugins/wasmedge_tensorflowlite/wasmedge_tensorflowlite.cpp
+++ b/test/plugins/wasmedge_tensorflowlite/wasmedge_tensorflowlite.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "common/defines.h"
+#include "common/filesystem.h"
 #include "runtime/instance/module.h"
 #include "tensorflowlite_func.h"
 #include "tensorflowlite_module.h"
@@ -28,7 +29,7 @@ inline std::unique_ptr<T> dynamicPointerCast(std::unique_ptr<U> &&R) noexcept {
 
 std::unique_ptr<WasmEdge::Host::WasmEdgeTensorflowLiteModule> createModule() {
   using namespace std::literals::string_view_literals;
-  WasmEdge::Plugin::Plugin::load(std::filesystem::u8path(
+  WasmEdge::Plugin::Plugin::load(WasmEdge::u8path(
       "../../../plugins/wasmedge_tensorflowlite/" WASMEDGE_LIB_PREFIX
       "wasmedgePluginWasmEdgeTensorflowLite" WASMEDGE_LIB_EXTENSION));
   if (const auto *Plugin =

--- a/test/plugins/wasmedge_zlib/wasmedge_zlib.cpp
+++ b/test/plugins/wasmedge_zlib/wasmedge_zlib.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The WasmEdge Authors
 
 #include "common/defines.h"
+#include "common/filesystem.h"
 #include "host/wasi/wasimodule.h"
 #include "runtime/instance/module.h"
 #include "zlibfunc.h"
@@ -39,9 +40,9 @@ inline std::unique_ptr<T> dynamicPointerCast(std::unique_ptr<U> &&R) noexcept {
 
 std::unique_ptr<WasmEdge::Host::WasmEdgeZlibModule> createModule() {
   using namespace std::literals::string_view_literals;
-  WasmEdge::Plugin::Plugin::load(std::filesystem::u8path(
-      "../../../plugins/wasmedge_zlib/" WASMEDGE_LIB_PREFIX
-      "wasmedgePluginWasmEdgeZlib" WASMEDGE_LIB_EXTENSION));
+  WasmEdge::Plugin::Plugin::load(
+      WasmEdge::u8path("../../../plugins/wasmedge_zlib/" WASMEDGE_LIB_PREFIX
+                       "wasmedgePluginWasmEdgeZlib" WASMEDGE_LIB_EXTENSION));
   if (const auto *Plugin = WasmEdge::Plugin::Plugin::find("wasmedge_zlib"sv)) {
     if (const auto *Module = Plugin->findModule("wasmedge_zlib"sv)) {
       return dynamicPointerCast<WasmEdge::Host::WasmEdgeZlibModule>(

--- a/test/spec/spectest.cpp
+++ b/test/spec/spectest.cpp
@@ -16,6 +16,7 @@
 
 #include "spectest.h"
 #include "common/errcode.h"
+#include "common/filesystem.h"
 #include "common/hash.h"
 #include "common/spdlog.h"
 
@@ -381,7 +382,7 @@ std::vector<std::string> SpecTest::enumerate(const SpecTest::TestMode Mode,
       for (const auto &Subdir :
            std::filesystem::directory_iterator(ProposalRoot)) {
         const auto SubdirPath = Subdir.path();
-        const auto UnitName = SubdirPath.filename().u8string();
+        const auto UnitName = u8string(SubdirPath.filename());
         const auto UnitJson = UnitName + ".json"s;
         if (std::filesystem::is_regular_file(SubdirPath / UnitJson)) {
           Cases.push_back(std::string(Proposal.Path) + ' ' + UnitName);
@@ -951,7 +952,7 @@ void SpecTest::processCommands(ContextHandle Ctx, std::string_view Proposal,
         }
         std::string_view FileName = Cmd["filename"];
         const auto FilePath =
-            (TestsuiteRoot / Proposal / UnitName / FileName).u8string();
+            u8string(TestsuiteRoot / Proposal / UnitName / FileName);
         const uint64_t LineNumber = Cmd["line"];
         // Reset the flag for each module command to avoid stale state
         // from prior test entries.
@@ -999,7 +1000,7 @@ void SpecTest::processCommands(ContextHandle Ctx, std::string_view Proposal,
         std::string_view ASTName;
         std::string_view FileName = Cmd["filename"];
         const auto FilePath =
-            (TestsuiteRoot / Proposal / UnitName / FileName).u8string();
+            u8string(TestsuiteRoot / Proposal / UnitName / FileName);
         const uint64_t LineNumber = Cmd["line"];
         if (IsComponent &&
             !checkComponentSupported(UnitName, WasmPhase::Loading)) {
@@ -1099,7 +1100,7 @@ void SpecTest::processCommands(ContextHandle Ctx, std::string_view Proposal,
         }
         const std::string_view Name = Cmd["filename"];
         const auto Filename =
-            (TestsuiteRoot / Proposal / UnitName / Name).u8string();
+            u8string(TestsuiteRoot / Proposal / UnitName / Name);
         const std::string_view Text = Cmd["text"];
         TrapLoad(Filename, std::string(Text));
         return;
@@ -1112,7 +1113,7 @@ void SpecTest::processCommands(ContextHandle Ctx, std::string_view Proposal,
         }
         const std::string_view Name = Cmd["filename"];
         const auto Filename =
-            (TestsuiteRoot / Proposal / UnitName / Name).u8string();
+            u8string(TestsuiteRoot / Proposal / UnitName / Name);
         const std::string_view Text = Cmd["text"];
         TrapValidate(Filename, std::string(Text));
         return;
@@ -1121,7 +1122,7 @@ void SpecTest::processCommands(ContextHandle Ctx, std::string_view Proposal,
       case CommandID::AssertUninstantiable: {
         const std::string_view Name = Cmd["filename"];
         const auto Filename =
-            (TestsuiteRoot / Proposal / UnitName / Name).u8string();
+            u8string(TestsuiteRoot / Proposal / UnitName / Name);
         const std::string_view Text = Cmd["text"];
         TrapInstantiate(Filename, std::string(Text));
         return;

--- a/test/thread/ThreadTest.cpp
+++ b/test/thread/ThreadTest.cpp
@@ -12,6 +12,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "common/filesystem.h"
 #include "common/spdlog.h"
 #include "vm/vm.h"
 
@@ -236,9 +237,8 @@ TEST(AOTAsyncExecute, ThreadTest) {
   Conf.getCompilerConfigure().setOutputFormat(
       WasmEdge::CompilerConfigure::OutputFormat::Native);
   Conf.getRuntimeConfigure().setRunMode(WasmEdge::RunMode::AOT);
-  const auto Path =
-      std::filesystem::temp_directory_path() /
-      std::filesystem::u8path("ThreadTest" WASMEDGE_LIB_EXTENSION);
+  const auto Path = std::filesystem::temp_directory_path() /
+                    WasmEdge::u8path("ThreadTest" WASMEDGE_LIB_EXTENSION);
   {
     WasmEdge::Loader::Loader Loader(Conf);
     WasmEdge::Validator::Validator ValidatorEngine(Conf);
@@ -292,7 +292,7 @@ TEST(AOTAsyncExecute, GasThreadTest) {
       WasmEdge::CompilerConfigure::OutputFormat::Native);
   Conf.getRuntimeConfigure().setRunMode(WasmEdge::RunMode::AOT);
   auto Path = std::filesystem::temp_directory_path() /
-              std::filesystem::u8path("AOTGasTest" WASMEDGE_LIB_EXTENSION);
+              WasmEdge::u8path("AOTGasTest" WASMEDGE_LIB_EXTENSION);
 
   {
     WasmEdge::Loader::Loader Loader(Conf);


### PR DESCRIPTION
## Description

Make the sources compile as both C++17 and C++20. Building every target with
`cxx_std_20` (Clang and GCC, `-Werror`) exposed three incompatibilities; the
first one surfaces as soon as a dependency such as the system `blake3` package
exports `cxx_std_20` (#5337).

- `cxx20::span` called `to_address` unqualified inside
  `namespace cxx20 { using namespace std; }`, which is ambiguous with
  `std::to_address` through ADL for iterators such as
  `std::vector::iterator`. Qualify the calls with `cxx20::`.
- The section serializer lambdas captured `this` implicitly with `[=]`,
  which C++20 deprecates; capture `this` explicitly (`[=, this]` is not valid
  C++17).
- `std::filesystem::u8path` is deprecated and `path::u8string()` returns
  `std::u8string` in C++20. Add `WasmEdge::u8path()` and
  `WasmEdge::u8string()` to `common/filesystem.h`, which keep the UTF-8
  semantics on both standards, and move every call site in the runtime, the
  plug-ins, and the tests to them. Under C++17 they forward to the standard
  library, so the behavior is unchanged.

This contribution was developed with assistance from GitHub Copilot CLI
(Claude Fable 5.1).

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

Every target forced to `cxx_std_20` through a `CMAKE_PROJECT_INCLUDE` file that
links an INTERFACE target with `target_compile_features(... cxx_std_20)`:

```
# macOS arm64, AppleClang
$ grep -o -- '-std=[a-z+0-9]*' build-cxx20/build.ninja | sort | uniq -c
 207 -std=c++20
   1 -std=gnu11
$ cmake --build build-cxx20        # 0 errors, 0 warnings
$ (cd build-cxx20 && ctest -E "APIAOTCoreTests|LLVMCoreTests" -j8)
100% tests passed out of 34

# Ubuntu 24.04 arm64, GCC 13.3, LLVM 18
    209 -std=c++20
$ cmake --build build-cxx20        # 0 errors
$ ctest -E "APIAOTCoreTests|LLVMCoreTests" -j6
100% tests passed, 0 tests failed out of 34
```

Before the change the same build fails with 58 errors
(`call to 'to_address' is ambiguous`, `'u8path<...>' is deprecated`,
`invalid operands ... 'std::u8string' and 'basic_string_view<char>'`) plus
`implicit capture of 'this' with a capture default of '=' is deprecated`.

Default C++17 build on macOS:

```
$ cmake --build build               # 0 errors, 0 warnings
$ (cd build && ctest -E "APIAOTCoreTests|LLVMCoreTests" -j4)
100% tests passed out of 34
```

`wasmedgeAPIAOTCoreTests` was excluded from the local runs because it exceeds
the default ctest timeout on this machine. `clang-format` (22.1.8),
`lineguard`, and `commitlint` pass.

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
