### PR TITLE
fix(allocator): include config.h so WASMEDGE_ALLOCATOR_IS_STABLE is correct

### DIFF
--- a/include/system/allocator.h
+++ b/include/system/allocator.h
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
+#include "common/config.h"
 #include "common/defines.h"
 #include <cstdint>
 

--- a/test/instance/MemInstanceTest.cpp
+++ b/test/instance/MemInstanceTest.cpp
@@ -16,6 +16,7 @@
 #include "common/spdlog.h"
 #include "common/types.h"
 #include "runtime/instance/memory.h"
+#include "system/allocator.h"
 #include "vm/vm.h"
 
 #include <array>
@@ -64,6 +65,28 @@ TEST(MemInstanceTest, Limit__Pages) {
   MemInst Inst6(WasmEdge::AST::MemoryType(1),
                 Conf.getRuntimeConfigure().getMaxMemoryPage());
   ASSERT_FALSE(Inst6.growPage(0xFFFFFFFF));
+}
+
+// ---------------------------------------------------------------------------
+// Allocator stability regression test.
+// ---------------------------------------------------------------------------
+
+TEST(MemInstanceTest, DataPtrStabilityMatchesAllocator) {
+  // WASMEDGE_ALLOCATOR_IS_STABLE tells the AOT/JIT code generator whether the
+  // linear memory base pointer may be cached directly in the module context.
+  // It is computed in "system/allocator.h" from HAVE_MMAP, which is only
+  // defined by the generated "common/config.h"; when that header is not
+  // included the macro silently degrades to 0 and every compiled memory access
+  // reloads the base pointer through an extra indirection. Assert the macro
+  // against what Allocator::resize() actually does instead of recomputing the
+  // platform predicate, so the two can never drift apart again.
+  using MemInst = WasmEdge::Runtime::Instance::MemoryInstance;
+
+  MemInst Inst(WasmEdge::AST::MemoryType(1));
+  uint8_t *const BeforeGrow = Inst.getDataPtr();
+  ASSERT_FALSE(BeforeGrow == nullptr);
+  ASSERT_TRUE(Inst.growPage(1));
+  EXPECT_EQ(Inst.getDataPtr() == BeforeGrow, WASMEDGE_ALLOCATOR_IS_STABLE != 0);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Refs #4744.

`include/system/allocator.h` derives `WASMEDGE_ALLOCATOR_IS_STABLE` from `HAVE_MMAP`, but `HAVE_MMAP` only exists in the generated `common/config.h`, which that header never includes. The macro is 0 on x86_64 Linux and macOS, so `getMemory()` takes the two-load path and the linear-memory base pointer is reloaded before every store.

The same predicate answers 0 in the header and 1 inside `allocator.cpp`, which includes `config.h` two lines earlier. `&&` binds tighter than `||`, so only the x86_64 arm depended on it. Dead since e71133e2.

Stores stay `volatile`, so the guard-page mechanism from #4848 is untouched. This is not a competing patch to that PR.

Two notes: the 32767 cliff in #4744 is a separate page-split store reproducible in plain C, hence `Refs` not `Closes`. And the macro selects the `ModuleContext` ABI while the AOT cache key is `blake3(wasm)` with no version, so `AOT::kBinaryVersion` likely needs 3 to 4. Your call.

## Checklist

- [X] **DCO Signed-off**
- [X] **Commit Messages**: Conventional Commit format
- [X] **Coding Style**: `clang-format` clean
- [X] **Local Tests Passed**: see below
- [X] **AI Disclosure**: AI-assisted, disclosed here.
- [X] **Human-in-the-loop**: I reviewed every line of this diff before submitting.

## Test Evidence

Correctness gate, interpreter / JIT / AOT: in-bounds round-trip returns 42, OOB store still traps.

Codegen: base reloads in the reproducer loop go from 8 to 0.

Timing, best of 3:

```
reproducer                 1.26s -> 0.55s   2.29x
variable-address fill                       1.43x
load-only control                           1.06x
```

The load-only control is flat as expected, a volatile load does not block hoisting, only a volatile store does.
