### PR TITLE
fix(wasi_nn): pin the OpenVINO CPU inference precision to f32

### DIFF
--- a/plugins/wasi_nn/wasinn_openvino.cpp
+++ b/plugins/wasi_nn/wasinn_openvino.cpp
@@ -120,8 +120,11 @@ Expect<WASINN::ErrNo> setInput(WASINN::WasiNNEnvironment &Env, WASINN::Graph &G,
       return WASINN::ErrNo::InvalidArgument;
     }
 
-    ov::CompiledModel CompiledModel =
-        Env.OpenVINOCore.compile_model(GraphRef.OpenVINOModel, Device);
+    // Without an explicit hint OpenVINO infers in bf16 or f16 on CPUs that
+    // support them, so the same F32 model would produce host-dependent output.
+    ov::CompiledModel CompiledModel = Env.OpenVINOCore.compile_model(
+        GraphRef.OpenVINOModel, Device,
+        ov::hint::inference_precision(ov::element::f32));
     CxtRef.OpenVINOInferRequest = CompiledModel.create_infer_request();
     CxtRef.OpenVINOInferRequest.set_input_tensor(Index, InputTensor);
   } catch (const std::exception &EX) {


### PR DESCRIPTION
## Description

WASI-NN OpenVINO CI jobs have been failing at random across multiple
targets, including ubuntu* variants since June 2026.

After checking the detailed log, the failed test belongs to the fourth
predicted class of the MobileNet fixture flipping from 926 to 923.

Log from previous CI results:

```text
/__w/WasmEdge/WasmEdge/test/plugins/wasi_nn/wasi_nn.cpp:566: Failure
Expected equality of these values:
  SortedIndex[I]
    Which is: 923
  CorrectClasses[I]
    Which is: 926

[  FAILED  ] WasiNNTest.OpenVINOBackend (216 ms)
```

Refer to: https://github.com/WasmEdge/WasmEdge/actions/runs/34601703104/job/103271038985

After checking the documents from the OpenVINO, the OpenVINO backend
compiles models withoutan inference precision hint. The default
execution mode will try to apply the optimization based on the
hardware architecture.

Which means it will try to enable bf16 on x86 hosts with AVX512\_BF16
and enable f16 on arm hosts with native half-precision support.

With this feature, the behavior may change from the previous F32
output.

By passing `ov::hint::inference_precision(ov::element::f32)` to
`ov::Core::compile_model`. The backend will only accept F32
tensors, always infers in f32. And ensure that the output will
no longer depends on the host CPU.

This contribution was developed with assistance from GitHub Copilot CLI
(Claude Fable 5.1).

## Checklist

Before submitting this PR, please ensure the following:

- [x] **DCO Signed-off**: All commits are signed-off (`git commit -s`). CI workflows will only be approved if DCO check is passed.
- [x] **Commit Messages**: Run `commitlint` on your commit messages to ensure they meet the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standards.
- [x] **Coding Style**: Run `clang-format` on your code to ensure it meets the coding style guidelines.
- [x] **Local Tests Passed**: Provide a screenshot or logs below to prove that you have passed the test suites locally.

If you are using AI-assisted tools, please ensure the following:

- [x] **AI Disclosure**: Disclose it using the `Assisted-by:` trailer in your commits and note it in the PR description. Please refer to the CONTRIBUTING.md/AGENTS.md files for the detailed format.
- [x] **Human-in-the-loop**: Submitting commits, issues, and PRs without human verification is forbidden.

## Test Evidence

macOS arm64, AppleClang 21, Homebrew `openvino` 2026.3.1, with the CI
plugin job configuration (`-DCMAKE_BUILD_TYPE=Release
-DWASMEDGE_BUILD_TESTS=ON -DWASMEDGE_BUILD_TOOLS=OFF
-DWASMEDGE_USE_LLVM=OFF -DWASMEDGE_PLUGIN_WASI_NN_BACKEND=OpenVINO`).
The Arm CPU takes the f16 path, so the tie resolves differently than on
the bf16 runners, but the assertion fails on master before the fix:

```text
$ ./wasiNNTests --gtest_filter=WasiNNTest.OpenVINOBackend
[ RUN      ] WasiNNTest.OpenVINOBackend
test/plugins/wasi_nn/wasi_nn.cpp:566: Failure
Expected equality of these values:
  SortedIndex[I]
    Which is: 567
  CorrectClasses[I]
    Which is: 926

test/plugins/wasi_nn/wasi_nn.cpp:566: Failure
Expected equality of these values:
  SortedIndex[I]
    Which is: 926
  CorrectClasses[I]
    Which is: 567

[  FAILED  ] WasiNNTest.OpenVINOBackend (492 ms)
```

Running the same fixtures through the OpenVINO Python API shows the
precision hint is what moves the near tie (`p` lists the probabilities of
the top six classes):

```text
default hint:      <Type: 'float16'> top6=[963, 762, 909, 567, 926, 923] p=[0.7153, 0.0692, 0.037, 0.0156, 0.0151, 0.0148]
f32 hint:          <Type: 'float32'> top6=[963, 762, 909, 926, 567, 923] p=[0.7113, 0.0707, 0.0364, 0.0155, 0.0153, 0.0147]
```

With the fix, the full build has no warnings and the whole `wasiNNTests`
suite passes:

```text
$ cmake --build build-openvino
$ ./wasiNNTests
[==========] Running 12 tests from 2 test suites.
[ RUN      ] WasiNNTest.OpenVINOBackend
[       OK ] WasiNNTest.OpenVINOBackend (442 ms)
...
[==========] 12 tests from 2 test suites ran. (443 ms total)
[  PASSED  ] 12 tests.
```

`clang-format`, `lineguard`, and `commitlint` pass.

---

> **Important:** This PR will be automatically closed if the above requirements are not met.
> **Tip:** If you want to run CI jobs on GitHub, you can create a PR to your own forked repository to trigger the workflows.
